### PR TITLE
CHEF-1849: Generic Debian bootstrap

### DIFF
--- a/chef/lib/chef/knife/bootstrap/debian-apt.erb
+++ b/chef/lib/chef/knife/bootstrap/debian-apt.erb
@@ -1,0 +1,33 @@
+bash -c '
+if [ ! -f /usr/bin/chef-client ]; then
+  apt-get install -y lsb-release
+  echo "chef	chef/chef_server_url	string	<%= Chef::Config[:chef_server_url] %>" | debconf-set-selections 
+  [ -f /etc/apt/sources.list.d/opscode.list ] || echo "deb http://apt.opscode.com $(lsb_release -sc) main" > /etc/apt/sources.list.d/opscode.list
+  wget -O- http://apt.opscode.com/packages@opscode.com.gpg.key | apt-key add -
+  apt-get update
+  apt-get install -y chef
+fi
+
+<% unless Chef::Config[:validation_client_name] == "chef-validator" -%>
+[  `grep -qx "validation_client_name \"<%= Chef::Config[:validation_client_name] %>\"" /etc/chef/client.rb` ] || echo "validation_client_name \"<%= Chef::Config[:validation_client_name] %>\"" >> /etc/chef/client.rb
+<% end -%>
+
+(
+cat <<'EOP'
+<%= IO.read(Chef::Config[:validation_key]) %>
+EOP
+) > /tmp/validation.pem
+awk NF /tmp/validation.pem > /etc/chef/validation.pem
+rm /tmp/validation.pem
+
+<% if @config[:chef_node_name] %>
+[ `grep -qx "node_name \"<%= @config[:chef_node_name] %>\"" /etc/chef/client.rb` ] || echo "node_name \"<%= @config[:chef_node_name] %>\"" >> /etc/chef/client.rb
+<% end -%> 
+
+(
+cat <<'EOP'
+<%= { "run_list" => @run_list }.to_json %>
+EOP
+) > /etc/chef/first-boot.json
+
+/usr/bin/chef-client -j /etc/chef/first-boot.json'


### PR DESCRIPTION
Added generic Debian APT based bootstrap. Essentially same bootstrap as ubuntu10.04-apt, but this one pulls lsb-release package first and uses lsb_release to create a proper apt sources.list.
