### PR TITLE
Patch for blank versions in zypper provider

### DIFF
--- a/chef/lib/chef/provider/package/zypper.rb
+++ b/chef/lib/chef/provider/package/zypper.rb
@@ -86,7 +86,7 @@ class Chef
         end
 
         def install_package(name, version)
-          if version
+          if !version.to_s.strip.empty?
             run_command(
               :command => "zypper -n --no-gpg-checks install -l  #{name}=#{version}"
             )
@@ -98,7 +98,7 @@ class Chef
         end
 
         def upgrade_package(name, version)
-          if version
+          if !version.to_s.strip.empty?
             run_command(
               :command => "zypper -n --no-gpg-checks install -l #{name}=#{version}"
             )
@@ -110,7 +110,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          if version
+          if !version.to_s.strip.empty?
             run_command(
               :command => "zypper -n --no-gpg-checks remove  #{name}=#{version}"
             )


### PR DESCRIPTION
When using the apache2 cookbook on SUSE I noticed that zypper was failing because a blank version (an empty string, specifically) was being passed into methods that check only on the base of truthiness.  As a result commands like this were executed:

```
zypper -n --no-gpg-checks install -l  package_name=
```

Rather than:

```
zypper -n --no-gpg-checks install -l  package_name
```

The extra = causes the first command to error.  I browsed over your [How to Contribute](http://wiki.opscode.com/display/chef/How+to+Contribute) and honestly it's more than I care to do.  Feel free to re-write the patch if you prefer.
