### PR TITLE
CHEF-1853: Pass $PIDFILE to chef-client in Debian init scripts 

### DIFF
--- a/chef/distro/debian/etc/init.d/chef-client
+++ b/chef/distro/debian/etc/init.d/chef-client
@@ -30,7 +30,7 @@ if [ ! -d /var/run/chef ]; then
   mkdir /var/run/chef
 fi
 
-DAEMON_OPTS="-L $LOGFILE -d -c $CONFIG -i $INTERVAL -s $SPLAY"
+DAEMON_OPTS="-d -P $PIDFILE -L $LOGFILE -c $CONFIG -i $INTERVAL -s $SPLAY"
 
 running_pid() {                                                                 
   pid=$1


### PR DESCRIPTION
Chef's Debian init script for chef-client doesn't pass the $PIDFILE option to chef-client.

Instead chef-client creates the pid file in the default location of /tmp/chef-client.pid which breaks the chef-client init scripts for Debian based distros.

http://tickets.opscode.com/browse/CHEF-1853
