### PR TITLE
Chef 1868

### DIFF
--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -1,5 +1,5 @@
 bash -c '
-rpm -Uvh http://download.fedora.redhat.com/pub/epel/5/i386/epel-release-5-3.noarch.rpm
+rpm -Uvh http://download.fedora.redhat.com/pub/epel/5/i386/epel-release-5-4.noarch.rpm
 rpm -Uvh http://download.elff.bravenet.com/5/i386/elff-release-5-3.noarch.rpm
 
 yum install -q -y ruby ruby-devel gcc gcc-c++ automake autoconf rubygems make


### PR DESCRIPTION
Updated the EPEL repo URL in the knife bootstrap for Centos distro (was a 5-3 URL which no longer exists on the download.fedora.redhat.com site...updated to the 5-4 URL which does exist).
