### PR TITLE
CHEF-1917 -  Resource references in notifications are not resolved when the resource is declared in a ruby block

### DIFF
--- a/chef/lib/chef/runner.rb
+++ b/chef/lib/chef/runner.rb
@@ -50,6 +50,10 @@ class Chef
     # Determine the appropriate provider for the given resource, then
     # execute it.
     def run_action(resource, action)
+      # Try to resolve lazy/forward references in notifications again to handle
+      # the case where the resource was defined lazily (ie. in a ruby_block)
+      resource.resolve_notification_references
+
       resource.run_action(action)
 
       # Execute any immediate and queue up any delayed notifications

--- a/chef/spec/unit/runner_spec.rb
+++ b/chef/spec/unit/runner_spec.rb
@@ -278,4 +278,22 @@ describe Chef::Runner do
     not_if_called_times.should == 2
   end
 
+  it "should resolve resource references in notifications when resources are defined lazily" do
+    @first_resource.action = :nothing
+
+    lazy_resources = lambda {
+      last_resource = Chef::Resource::Cat.new("peanut", @run_context)
+      @run_context.resource_collection << last_resource
+      last_resource.notifies(:purr, @first_resource.to_s, :delayed)
+      last_resource.action = :purr
+    }
+    second_resource = Chef::Resource::RubyBlock.new("myblock", @run_context)
+    @run_context.resource_collection << second_resource
+    second_resource.block { lazy_resources.call }
+
+    @runner.converge
+
+    @first_resource.should be_updated
+  end
+
 end


### PR DESCRIPTION
Fix for CHEF-1917.
