### PR TITLE
PATH issue for groupadd/useradd

### DIFF
--- a/chef-expander/lib/chef/expander/version.rb
+++ b/chef-expander/lib/chef/expander/version.rb
@@ -23,7 +23,7 @@ require 'open3'
 module Chef
   module Expander
 
-    VERSION = "0.10.0.rc.2"
+    VERSION = "0.10.0"
 
     def self.version
       @rev ||= begin

--- a/chef-server-api/Gemfile.lock
+++ b/chef-server-api/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../chef
   specs:
-    chef (0.10.0.rc.2)
+    chef (0.10.0)
       bunny (>= 0.6.0)
       erubis
       highline
@@ -21,8 +21,8 @@ PATH
 PATH
   remote: ../chef-solr
   specs:
-    chef-solr (0.10.0.rc.2)
-      chef (= 0.10.0.rc.2)
+    chef-solr (0.10.0)
+      chef (= 0.10.0)
 
 GEM
   remote: http://rubygems.org/

--- a/chef-server-api/lib/chef-server-api/version.rb
+++ b/chef-server-api/lib/chef-server-api/version.rb
@@ -1,3 +1,3 @@
 module ChefServerApi
-  VERSION = '0.10.0.rc.2'
+  VERSION = '0.10.0'
 end

--- a/chef-server-webui/lib/chef-server-webui/version.rb
+++ b/chef-server-webui/lib/chef-server-webui/version.rb
@@ -1,3 +1,3 @@
 module ChefServerWebui
-  VERSION = '0.10.0.rc.2'
+  VERSION = '0.10.0'
 end

--- a/chef-server/lib/chef-server/version.rb
+++ b/chef-server/lib/chef-server/version.rb
@@ -17,5 +17,5 @@
 #
 
 module ChefServer
-  VERSION = '0.10.0.rc.2'
+  VERSION = '0.10.0'
 end

--- a/chef-solr/lib/chef/solr/version.rb
+++ b/chef-solr/lib/chef/solr/version.rb
@@ -1,6 +1,6 @@
 class Chef
   class Solr
-    VERSION = '0.10.0.rc.2'
+    VERSION = '0.10.0'
 
     # Solr Schema. Used to detect incompatibilities between installed solr and
     # chef-solr versions.

--- a/chef/distro/common/html/chef-client.8.html
+++ b/chef/distro/common/html/chef-client.8.html
@@ -131,7 +131,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-client(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-expander.8.html
+++ b/chef/distro/common/html/chef-expander.8.html
@@ -154,7 +154,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-expander(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-expanderctl.8.html
+++ b/chef/distro/common/html/chef-expanderctl.8.html
@@ -136,7 +136,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-expanderctl(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-server-webui.8.html
+++ b/chef/distro/common/html/chef-server-webui.8.html
@@ -175,7 +175,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-server-webui(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-server.8.html
+++ b/chef/distro/common/html/chef-server.8.html
@@ -172,7 +172,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-server(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-solo.8.html
+++ b/chef/distro/common/html/chef-solo.8.html
@@ -181,7 +181,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-solo(8)</li>
   </ol>

--- a/chef/distro/common/html/chef-solr.8.html
+++ b/chef/distro/common/html/chef-solr.8.html
@@ -153,7 +153,7 @@ found in /usr/share/common-licenses/Apache-2.0.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>chef-solr(8)</li>
   </ol>

--- a/chef/distro/common/html/knife-bootstrap.1.html
+++ b/chef/distro/common/html/knife-bootstrap.1.html
@@ -231,7 +231,7 @@ to other users via the process list using tools such as <span class="man-ref">ps
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-bootrap(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-client.1.html
+++ b/chef/distro/common/html/knife-client.1.html
@@ -209,7 +209,7 @@ setting up a host for management with Chef.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-client(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-configure.1.html
+++ b/chef/distro/common/html/knife-configure.1.html
@@ -160,7 +160,7 @@ may need to modify that setting after copying to a remote host.</p></li>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-configure(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-cookbook-site.1.html
+++ b/chef/distro/common/html/knife-cookbook-site.1.html
@@ -229,7 +229,7 @@ configuration file.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-cookbook-site(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-cookbook.1.html
+++ b/chef/distro/common/html/knife-cookbook.1.html
@@ -363,7 +363,7 @@ cookbook.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-cookbook(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-data-bag.1.html
+++ b/chef/distro/common/html/knife-data-bag.1.html
@@ -224,7 +224,7 @@ encryption keys.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-data-bag(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-environment.1.html
+++ b/chef/distro/common/html/knife-environment.1.html
@@ -257,7 +257,7 @@ override_attributes "aws_s3_bucket" =&gt; "production"
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-environment(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-exec.1.html
+++ b/chef/distro/common/html/knife-exec.1.html
@@ -124,7 +124,7 @@ commands available.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-exec(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-index.1.html
+++ b/chef/distro/common/html/knife-index.1.html
@@ -115,7 +115,7 @@ time for all objects to be indexed and available for search.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-index(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-node.1.html
+++ b/chef/distro/common/html/knife-node.1.html
@@ -260,7 +260,7 @@ run list, the correct syntax is "role[ROLE_NAME]"</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-node(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-recipe.1.html
+++ b/chef/distro/common/html/knife-recipe.1.html
@@ -82,7 +82,7 @@
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-recipe(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-role.1.html
+++ b/chef/distro/common/html/knife-role.1.html
@@ -190,7 +190,7 @@ run_list.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-role(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-search.1.html
+++ b/chef/distro/common/html/knife-search.1.html
@@ -133,7 +133,7 @@ query syntax. The following data types are indexed for search:
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-search(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-ssh.1.html
+++ b/chef/distro/common/html/knife-ssh.1.html
@@ -146,7 +146,7 @@ option.</dd>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-ssh(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-status.1.html
+++ b/chef/distro/common/html/knife-status.1.html
@@ -118,7 +118,7 @@ may not be publicly reachable.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-status(1)</li>
   </ol>

--- a/chef/distro/common/html/knife-tag.1.html
+++ b/chef/distro/common/html/knife-tag.1.html
@@ -127,7 +127,7 @@
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife-tag(1)</li>
   </ol>

--- a/chef/distro/common/html/knife.1.html
+++ b/chef/distro/common/html/knife.1.html
@@ -285,7 +285,7 @@ data editing entirely.</dd>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>knife(1)</li>
   </ol>

--- a/chef/distro/common/html/shef.1.html
+++ b/chef/distro/common/html/shef.1.html
@@ -273,7 +273,7 @@ and may become out of sync with the behavior of those libraries.</p>
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>Chef 0.10.0.rc.2</li>
+    <li class='tl'>Chef 0.10.0</li>
     <li class='tc'>April 2011</li>
     <li class='tr'>shef(1)</li>
   </ol>

--- a/chef/distro/common/man/man1/knife-bootstrap.1
+++ b/chef/distro/common/man/man1/knife-bootstrap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-BOOTRAP" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-BOOTRAP" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-bootrap\fR \- Install Chef Client on a remote host

--- a/chef/distro/common/man/man1/knife-client.1
+++ b/chef/distro/common/man/man1/knife-client.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-CLIENT" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-CLIENT" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-client\fR \- Manage Chef API Clients

--- a/chef/distro/common/man/man1/knife-configure.1
+++ b/chef/distro/common/man/man1/knife-configure.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-CONFIGURE" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-CONFIGURE" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-configure\fR \- Generate configuration files for knife or Chef Client

--- a/chef/distro/common/man/man1/knife-cookbook-site.1
+++ b/chef/distro/common/man/man1/knife-cookbook-site.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-COOKBOOK\-SITE" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-COOKBOOK\-SITE" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-cookbook\-site\fR \- Install and update open source cookbooks

--- a/chef/distro/common/man/man1/knife-cookbook.1
+++ b/chef/distro/common/man/man1/knife-cookbook.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-COOKBOOK" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-COOKBOOK" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-cookbook\fR \- upload and manage chef cookbooks

--- a/chef/distro/common/man/man1/knife-data-bag.1
+++ b/chef/distro/common/man/man1/knife-data-bag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-DATA\-BAG" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-DATA\-BAG" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-data\-bag\fR \- Store arbitrary data on a Chef Server

--- a/chef/distro/common/man/man1/knife-environment.1
+++ b/chef/distro/common/man/man1/knife-environment.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-ENVIRONMENT" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-ENVIRONMENT" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-environment\fR \- Define cookbook policies for the environments in your infrastructure

--- a/chef/distro/common/man/man1/knife-exec.1
+++ b/chef/distro/common/man/man1/knife-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-EXEC" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-EXEC" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-exec\fR \- Run user scripts using the Chef API DSL

--- a/chef/distro/common/man/man1/knife-index.1
+++ b/chef/distro/common/man/man1/knife-index.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-INDEX" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-INDEX" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-index\fR \- Rebuild the search index on a Chef Server

--- a/chef/distro/common/man/man1/knife-node.1
+++ b/chef/distro/common/man/man1/knife-node.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-NODE" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-NODE" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-node\fR \- Manage the hosts in your infrastructure

--- a/chef/distro/common/man/man1/knife-role.1
+++ b/chef/distro/common/man/man1/knife-role.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-ROLE" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-ROLE" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-role\fR \- Group common configuration settings

--- a/chef/distro/common/man/man1/knife-search.1
+++ b/chef/distro/common/man/man1/knife-search.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-SEARCH" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-SEARCH" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-search\fR \- Find objects on a Chef Server by query

--- a/chef/distro/common/man/man1/knife-ssh.1
+++ b/chef/distro/common/man/man1/knife-ssh.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-SSH" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-SSH" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-ssh\fR \- Run a command or interactive session on multiple remote hosts

--- a/chef/distro/common/man/man1/knife-status.1
+++ b/chef/distro/common/man/man1/knife-status.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-STATUS" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-STATUS" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-status\fR \- Display status information for the nodes in your infrastructure

--- a/chef/distro/common/man/man1/knife-tag.1
+++ b/chef/distro/common/man/man1/knife-tag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE\-TAG" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE\-TAG" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\-tag\fR \- Apply tags to nodes on a Chef Server

--- a/chef/distro/common/man/man1/knife.1
+++ b/chef/distro/common/man/man1/knife.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KNIFE" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "KNIFE" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBknife\fR \- Chef Server API client utility

--- a/chef/distro/common/man/man1/shef.1
+++ b/chef/distro/common/man/man1/shef.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "SHEF" "1" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "SHEF" "1" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBshef\fR \- Interactive Chef Console

--- a/chef/distro/common/man/man8/chef-client.8
+++ b/chef/distro/common/man/man8/chef-client.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-CLIENT" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-CLIENT" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-client\fR \- Runs a client node connecting to a chef\-server\.

--- a/chef/distro/common/man/man8/chef-expander.8
+++ b/chef/distro/common/man/man8/chef-expander.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-EXPANDER" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-EXPANDER" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-expander\fR \- fetches messages from RabbitMQ, processes, and loads into chef\-solr

--- a/chef/distro/common/man/man8/chef-expanderctl.8
+++ b/chef/distro/common/man/man8/chef-expanderctl.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-EXPANDERCTL" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-EXPANDERCTL" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-expanderctl\fR \- management program for chef\-expander

--- a/chef/distro/common/man/man8/chef-server-webui.8
+++ b/chef/distro/common/man/man8/chef-server-webui.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-SERVER\-WEBUI" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-SERVER\-WEBUI" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-server\-webui\fR \- Start the Chef Server merb application slice providing Web User Interface (Management Console)\.

--- a/chef/distro/common/man/man8/chef-server.8
+++ b/chef/distro/common/man/man8/chef-server.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-SERVER" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-SERVER" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-server\fR \- Start the Chef Server merb application slice\.

--- a/chef/distro/common/man/man8/chef-solo.8
+++ b/chef/distro/common/man/man8/chef-solo.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-SOLO" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-SOLO" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-solo\fR \- Runs chef in solo mode against a specified cookbook location\.

--- a/chef/distro/common/man/man8/chef-solr.8
+++ b/chef/distro/common/man/man8/chef-solr.8
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "CHEF\-SOLR" "8" "April 2011" "Chef 0.10.0.rc.2" "Chef Manual"
+.TH "CHEF\-SOLR" "8" "April 2011" "Chef 0.10.0" "Chef Manual"
 .
 .SH "NAME"
 \fBchef\-solr\fR \- Runs as Chef\'s search server

--- a/chef/lib/chef/version.rb
+++ b/chef/lib/chef/version.rb
@@ -17,7 +17,7 @@
 
 class Chef
   CHEF_ROOT = File.dirname(File.expand_path(File.dirname(__FILE__)))
-  VERSION = '0.10.0.rc.2'
+  VERSION = '0.10.0'
 end
 
 # NOTE: the Chef::Version class is defined in version_class.rb


### PR DESCRIPTION
By default, /usr/sbin/ and /sbin are not in the path on RHEL5/CentOS5. This causes breakage on bootstrap runs that call any command in those paths by exporting it prior to calling chef-client.
