### PR TITLE
Chef 1979

### DIFF
--- a/chef/lib/chef/knife/status.rb
+++ b/chef/lib/chef/knife/status.rb
@@ -74,6 +74,7 @@ class Chef
             end
             line_parts << platform
           end
+          line_parts << fqdn if fqdn
           line_parts << ipaddress if ipaddress
           line_parts << run_list if run_list
 


### PR DESCRIPTION
Knife status now handle better when some node attributes are not set.

Example output :

<pre>
$ knife status
6 minutes ago, vm-debian1.fotolia.loc, debian 5.0.7, 10.11.11.201.
5 minutes ago, chefserver.fotolia.loc, freebsd 8.1-RELEASE.
</pre>
