### PR TITLE
[CHEF-1248] Allow loading knife commands installed as gems

### DIFF
--- a/chef/lib/chef/knife.rb
+++ b/chef/lib/chef/knife.rb
@@ -28,9 +28,19 @@ class Chef
     include Mixlib::CLI
     extend Chef::Mixin::ConvertToClassName
 
+    begin
+      require 'rubygems'
+      files = Gem.find_files 'chef/knife/*.rb'
+      files.map! do |file|
+        file[/(#{Regexp.escape File.join('chef', 'knife', '')}.*\.rb)/, 1]
+      end.uniq!
+    rescue LoadError
+      files = Dir[File.expand_path(File.join(File.dirname(__FILE__), 'knife', '*.rb'))]
+      files.map! { |knife_file| knife_file[/#{CHEF_ROOT}#{Regexp.escape(File::SEPARATOR)}(.*)\.rb/,1] }
+    end
+
     # The "require paths" of the core knife subcommands bundled with chef
-    DEFAULT_SUBCOMMAND_FILES = Dir[File.expand_path(File.join(File.dirname(__FILE__), 'knife', '*.rb'))]
-    DEFAULT_SUBCOMMAND_FILES.map! { |knife_file| knife_file[/#{CHEF_ROOT}#{Regexp.escape(File::SEPARATOR)}(.*)\.rb/,1] }
+    DEFAULT_SUBCOMMAND_FILES = files
 
     attr_accessor :name_args
 


### PR DESCRIPTION
The attached commit allows a knife command from a gem living in chef/knife/*.rb to be loaded automatically with knife.

This works where rubygems is not available by falling back to the dir glob in chef/knife.  This partially fixes CHEF-1248.

With this patch I can ship a knife command inside a gem and have it automatically loaded:

```
$ gem contents --no-prefix ssvm | grep knife
lib/chef/knife/bootstrap/ssvm-gems.erb
lib/chef/knife/ssvm_create.rb
lib/chef/knife/ssvm_delete.rb
lib/chef/knife/ssvm_reboot.rb
$ ruby -Ilib bin/knife ssvm
FATAL: Cannot find sub command for: 'ssvm'
Available ssvm subcommands: (for details, knife SUB-COMMAND --help)

** SSVM COMMANDS **
knife ssvm create HOST [RUN LIST ...]
knife ssvm delete HOST
knife ssvm reboot HOST
```
