### PR TITLE
Auto-generate a GIT_SSH wrapper from a ssh_key attribute

### DIFF
--- a/chef/chef.gemspec
+++ b/chef/chef.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-log", ">= 1.2.0"
   s.add_dependency "mixlib-authentication", ">= 1.1.0"
   s.add_dependency "ohai", ">= 0.5.7"
+  s.add_dependency "git-ssh-wrapper", ">= 0.0.1"
 
   s.add_dependency "rest-client", ">= 1.0.4", "< 1.7.0"
   s.add_dependency "bunny", ">= 0.6.0"

--- a/chef/lib/chef/client.rb
+++ b/chef/lib/chef/client.rb
@@ -34,6 +34,7 @@ require 'chef/cookbook/file_system_file_vendor'
 require 'chef/cookbook/remote_file_vendor'
 require 'chef/version'
 require 'ohai'
+require 'git-ssh-wrapper'
 
 class Chef
   # == Chef::Client

--- a/chef/lib/chef/provider/git.rb
+++ b/chef/lib/chef/provider/git.rb
@@ -194,6 +194,7 @@ class Chef
         run_opts[:user] = @new_resource.user if @new_resource.user
         run_opts[:group] = @new_resource.group if @new_resource.group
         run_opts[:environment] = {"GIT_SSH" => @new_resource.ssh_wrapper} if @new_resource.ssh_wrapper
+        run_opts[:environment] = {"GIT_SSH" => generate_GIT_SSH(@new_resource.ssh_key)} if @new_resource.ssh_key
         run_opts
       end
       
@@ -228,6 +229,10 @@ class Chef
           raise Chef::Exceptions::UnresolvableGitReference, msg
         end
         $1
+      end
+
+      def generate_GIT_SSH(private_key)
+        GitSSHWrapper.new(:private_key => private_key).git_ssh[/^GIT_SSH='(.+)'$/, 1]
       end
       
     end

--- a/chef/lib/chef/resource/scm.rb
+++ b/chef/lib/chef/resource/scm.rb
@@ -31,6 +31,7 @@ class Chef
         @revision = "HEAD"
         @remote = "origin"
         @ssh_wrapper = nil
+        @ssh_key_path = nil
         @depth = nil
         @allowed_actions.push(:checkout, :export, :sync, :diff, :log)
       end
@@ -136,6 +137,14 @@ class Chef
       def ssh_wrapper(arg=nil)
         set_or_return(
           :ssh_wrapper,
+          arg,
+          :kind_of => String
+        )
+      end
+
+      def ssh_key(arg=nil)
+        set_or_return(
+          :ssh_key,
           arg,
           :kind_of => String
         )

--- a/chef/spec/unit/provider/git_spec.rb
+++ b/chef/spec/unit/provider/git_spec.rb
@@ -166,6 +166,20 @@ describe Chef::Provider::Git do
     @provider.should_receive(:run_command).with(:command => expected_cmd)
     @provider.clone
   end
+
+  it "compiles a clone command with an ssh key" do
+    #mock out GitSSHWrapper stuff
+    wrapper = GitSSHWrapper.new(:private_key => 'KEY DATA')
+    GitSSHWrapper.stub(:new).and_return(wrapper)
+    wrapper.stub(:git_ssh).and_return("GIT_SSH='/path/to/wrapper.sh'")
+
+    #chef specific test
+    @resource.ssh_key "KEY DATA"
+    expected_cmd = 'git clone  git://github.com/opscode/chef.git /my/deploy/dir'
+    @provider.should_receive(:run_command).with(:command => expected_cmd,
+                                                :environment => {"GIT_SSH"=>"/path/to/wrapper.sh"})
+    @provider.clone
+  end
   
   it "runs a checkout command with default options" do
     expected_cmd = 'git checkout -b deploy d35af14d41ae22b19da05d7d03a0bafc321b244c'


### PR DESCRIPTION
I added an ssh_key attribute to the scm resource that will use the git-ssh-wrapper gem to auto-generate the necessary temp files for the GIT_SSH wrapper. It would allow you to have the following resource:

```
git "/srv/foo" do
  repository 'git@github.com:foo/bar.git'
  reference 'master'
  ssh_key node[:deploy_key]
  action :sync
end
```

This patch is pretty rough, i'm looking for feedback on how i can improve on this to get it merged in the future.
