### PR TITLE
mount support for fuse filesystems in chef

### DIFF
--- a/chef/spec/unit/solr_query_spec.rb
+++ b/chef/spec/unit/solr_query_spec.rb
@@ -155,6 +155,7 @@ describe Chef::SolrQuery do
     it "reindexes Chef::ApiClient, Chef::Node, and Chef::Role objects, reporting the results as a hash" do
       @solr.should_receive(:delete_database).with("chunky_bacon")
       @solr.should_receive(:reindex_all).with(Chef::ApiClient).and_return(true)
+      @solr.should_receive(:reindex_all).with(Chef::Environment).and_return(true)
       @solr.should_receive(:reindex_all).with(Chef::Node).and_return(true)
       @solr.should_receive(:reindex_all).with(Chef::Role).and_return(true)
       Chef::DataBag.stub!(:cdb_list).and_return([])


### PR DESCRIPTION
to mount a fuse filesystem you pass the type of the filesystem in the origin string as:
mount -t fuse s3fs#bucket_name /mnt/bucket -o rw,.....

and chef does not have the support, so I just included a condition for that. I think the conditions could be summarized in two, but I just followed the code style.

if you have any questions, please feel free to ask me

thank you
