### PR TITLE
If vendor_path is empty, the first vendor operation removes it and causes failure

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_vendor.rb
+++ b/chef/lib/chef/knife/cookbook_site_vendor.rb
@@ -104,6 +104,7 @@ class Chef
           Chef::Mixin::Command.run_command(:command => "git checkout #{config[:branch_default]}", :cwd => vendor_path)
           Chef::Log.info("Merging changes from #{name_args[0]} version #{download.version}.")
 
+          Dir.mkdir(vendor_path) unless File.directory?(vendor_path)
           Dir.chdir(vendor_path) do
             if system("git merge #{branch_name}")
               Chef::Log.info("Cookbook #{name_args[0]} version #{download.version} successfully vendored!")


### PR DESCRIPTION
I decided to start with an "empty" chef repo.  I added my .knife directory and proceeded to attempt to vendor the apache2 cookbook. The first error I got was:

ERROR: /Users/bstevens/chef2/.chef/../cookbooks/ doesn't exist!.  Make sure you have cookbook_path configured correctly

So, I created a "cookbooks" directory.  Then I got this:

INFO: Downloading apache2 from the cookbooks site at version 0.99.2
INFO: Cookbook saved: /Users/bstevens/chef2/cookbooks/apache2.tar.gz
INFO: Checking out the master branch.
INFO: Checking the status of the vendor branch.
INFO: Creating vendor branch.
INFO: Removing pre-existing version.
INFO: Uncompressing apache2 version 0.99.2.
INFO: Adding changes.
INFO: Committing changes.
INFO: Creating tag chef-vendor-apache2-0.99.2.
INFO: Checking out the master branch.
INFO: Merging changes from apache2 version 0.99.2.
/Users/bstevens/apps/ruby/1.9.2/lib/ruby/gems/1.9.1/gems/chef-0.9.12/lib/chef/knife/cookbook_site_vendor.rb:102:in `chdir': No such file or directory - /Users/bstevens/chef2/cookbooks (Errno::ENOENT)
    from /Users/bstevens/apps/ruby/1.9.2/lib/ruby/gems/1.9.1/gems/chef-0.9.12/lib/chef/knife/cookbook_site_vendor.rb:102:in`run'
    from /Users/bstevens/apps/ruby/1.9.2/lib/ruby/gems/1.9.1/gems/chef-0.9.12/lib/chef/knife.rb:127:in `run'
    from /Users/bstevens/apps/ruby/1.9.2/lib/ruby/gems/1.9.1/gems/chef-0.9.12/lib/chef/application/knife.rb:121:in`run'
    from /Users/bstevens/apps/ruby/1.9.2/lib/ruby/gems/1.9.1/gems/chef-0.9.12/bin/knife:25:in `<top (required)>'
    from /Users/bstevens/apps/ruby/current/bin/knife:19:in`load'
    from /Users/bstevens/apps/ruby/current/bin/knife:19:in `<main>'

I'll try to summarize.  I have an empty chef repo.  I add a .knife directory with config files, and commit.  Then I try to "knife cookbook site vendor apache2".  It bombs because it sees the "cookbooks" directory doesn't exist, so I create it.  Then...  The vendor process creates a chef-vendor-apache2 branch and checks it out.  It unpacks the apache2 cookbook in there and commits it in the branch.  Then...  It checks out the master branch right be before it attempts to merge the vendor branch into the master.  Unfortunately the "cookbooks" directory hadn't been previously committed [in the master branch], so it's first occurrence is in the vendor branch.  When the master branch is then checked [back] out, the cookbooks directory no longer exists.

So, I added this small change and it works.

Obviously this is a somewhat unique situation, but I don't think it would be "unheard of", and I don't see how the change would affect anything else.

Thoughts?
