### PR TITLE
Add support for git submodules to the rake update task.

### DIFF
--- a/chef/lib/chef/tasks/chef_repo.rake
+++ b/chef/lib/chef/tasks/chef_repo.rake
@@ -52,6 +52,8 @@ task :update do
     end
     if pull
       sh %{git pull} 
+      sh %{git submodule init}
+      sh %{git submodule update}
     else
       puts "* Skipping git pull, no origin specified"
     end


### PR DESCRIPTION
There doesn't seem to be a downside to calling these needlessly, and it's nice to have the support for submodules.
