### PR TITLE
bugfix for loading role json

### DIFF
--- a/chef/lib/chef/role.rb
+++ b/chef/lib/chef/role.rb
@@ -310,7 +310,7 @@ class Chef
       rb_file = File.join(Chef::Config[:role_path], "#{name}.rb")
 
       if File.exists?(js_file) || force == "json"
-        Chef::JSONCompat.from_json(IO.read(js_file))
+        json_create Chef::JSONCompat.from_json(IO.read(js_file))
       elsif File.exists?(rb_file) || force == "ruby"
         role = Chef::Role.new
         role.name(name)


### PR DESCRIPTION
Chef::Role.from_file was returning a Hash instead of a Role object. I found it while tracking down an exception I got: https://gist.github.com/916842
