### PR TITLE
0.10 service/arch: support multiple lines and background form when declaring DAEMONS

### DIFF
--- a/chef/lib/chef/provider/service/arch.rb
+++ b/chef/lib/chef/provider/service/arch.rb
@@ -39,7 +39,7 @@ class Chef::Provider::Service::Arch < Chef::Provider::Service::Init
   end
 
   # Get list of all daemons from the file '/etc/rc.conf'.
-  # Mutiple lines are support. Example
+  # Mutiple lines and background form are supported. Example:
   #   DAEMONS=(\
   #     foobar \
   #     @example \


### PR DESCRIPTION
Add support multiple lines and background form when declaring DAEMONS
