### PR TITLE
add -i option to knife ssh documentation

### DIFF
--- a/chef/distro/common/markdown/man1/knife-ssh.mkd
+++ b/chef/distro/common/markdown/man1/knife-ssh.mkd
@@ -15,6 +15,8 @@ __knife__ __ssh QUERY COMMAND__ _(options)_
     The ssh password
   * `-x`, `--ssh-user USERNAME    `:
     The ssh username
+  * `-i`, `--identity-file IDENTITY_FILE`:
+    The SSH identity file used for authentication
 
 ## DESCRIPTION
 


### PR DESCRIPTION
It's missing!
