### PR TITLE
[CHEF-2105] regression of non-master branch option for knife cookbook site install

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_install.rb
+++ b/chef/lib/chef/knife/cookbook_site_install.rb
@@ -44,7 +44,7 @@ class Chef
         :description => "A colon-separated path to look for cookbooks in",
         :proc => lambda { |o| o.split(":") }
 
-      option :branch_default,
+      option :default_branch,
         :short => "-B BRANCH",
         :long => "--branch BRANCH",
         :description => "Default branch to work with",

--- a/chef/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/chef/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -34,6 +34,7 @@ class Chef
         @repo_path = repo_path
         @ui = ui
         @default_branch = 'master'
+        apply_opts(opts)
       end
 
       def sanity_check
@@ -133,8 +134,6 @@ class Chef
           case option.to_s
           when 'default_branch'
             @default_branch = value
-          else
-            raise ArgumentError, "invalid option `#{option}' passed to CookbookRepo.new()"
           end
         end
       end

--- a/chef/spec/unit/knife/core/cookbook_scm_repo_spec.rb
+++ b/chef/spec/unit/knife/core/cookbook_scm_repo_spec.rb
@@ -166,4 +166,15 @@ DIRTY
       @cookbook_repo.finalize_updates_to("apache2", "1.2.3").should be_true
     end
   end
+
+  describe "when a custom default branch is specified" do
+    before do
+      @cookbook_repo = Chef::Knife::CookbookSCMRepo.new(@repo_path, @ui, :default_branch => 'develop')
+    end
+
+    it "resets to default state by checking out the default branch" do
+      @cookbook_repo.should_receive(:shell_out!).with('git checkout develop', :cwd => @repo_path)
+      @cookbook_repo.reset_to_default_state
+    end
+  end
 end


### PR DESCRIPTION
As per [2105](http://tickets.opscode.com/browse/CHEF-2105), it looks like the ability to specify a non-master branch with

```
knife cookbook site [vendor|install] foobar --branch develop
```

was broken just before 0.10.0 with commit 3f8b3bb3b4ff0ec4fd4dee927e16cb296649df92. This small patch fixes the problem but is rather naive -- I'd like feedback from @danielsdeleo on how he meant for the missing `apply_opts` call that was to blame to be used: lots of knife options in addition to `default_branch` get passed in from the `config` object in `cookbook_site_install.rb`, so the `ArgumentError` clause either goes away or gets ugly...

Also the added spec would still pass without the option name change in `cookbook_site_install.rb` even though it wouldn't actually work correctly -- I haven't been able to find existing specs for the cookbook site install command itself where I might add a spec for the option, so would appreciate a point if there is a good place for that, this is my first real foray into Chef source.
