### PR TITLE
Add cssh support for knife ssh 

### DIFF
--- a/chef/distro/common/html/knife-ssh.1.html
+++ b/chef/distro/common/html/knife-ssh.1.html
@@ -121,6 +121,7 @@ subset of the connected hosts in parallel
 <dt><strong>screen</strong>(1)</dt><dd>Runs ssh interactively inside <code>screen</code>. ~/.screenrc will be sourced
 if it exists.</dd>
 <dt class="flush"><strong>tmux</strong>(1)</dt><dd>Runs ssh interactively inside tmux.</dd>
+<dt class="flush"><strong>cssh</strong>(1)</dt><dd>Launches a cssh session.</dd>
 <dt><code>macterm</code> (Mac OS X only)</dt><dd>Opens a Terminal.app window and creates a tab for each ssh session.
 You must install the rb-appscript gem before you can use this
 option.</dd>

--- a/chef/distro/common/man/man1/knife-ssh.1
+++ b/chef/distro/common/man/man1/knife-ssh.1
@@ -58,6 +58,10 @@ Runs ssh interactively inside \fBscreen\fR\. ~/\.screenrc will be sourced if it 
 Runs ssh interactively inside tmux\.
 .
 .TP
+\fBcssh\fR(1)
+Launches a cssh session\.
+.
+.TP
 \fBmacterm\fR (Mac OS X only)
 Opens a Terminal\.app window and creates a tab for each ssh session\. You must install the rb\-appscript gem before you can use this option\.
 .

--- a/chef/distro/common/markdown/man1/knife-ssh.mkd
+++ b/chef/distro/common/markdown/man1/knife-ssh.mkd
@@ -41,6 +41,8 @@ The available multiplexers are:
     if it exists.
   * __tmux__(1):
     Runs ssh interactively inside tmux.
+  * __cssh__(1):
+    Launches a cssh session.
   * `macterm` (Mac OS X only):
     Opens a Terminal.app window and creates a tab for each ssh session.
     You must install the rb-appscript gem before you can use this

--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -248,6 +248,11 @@ class Chef
         exec("screen -c #{tf.path}")
       end
 
+
+      def cssh
+        exec "cssh "+session.servers_for.map {|server| server.user ? "#{server.user}@#{server.host}" : server.host}.join(" ")
+      end
+
       def tmux
         ssh_dest = lambda do |server|
           prefix = server.user ? "#{server.user}@" : ""
@@ -316,6 +321,8 @@ class Chef
           tmux
         when "macterm"
           macterm
+        when "cssh"
+          cssh
         else
           ssh_command(@name_args[1..-1].join(" "))
         end


### PR DESCRIPTION
Knife ssh "_:_" interactive is great for some things, but sometimes it would be nice to have a more complete terminal experience for each machine you are dealing with. The various terminal multiplexers are nice as well, but they don't (afaik) send keystrokes to a configurable subset of the connected windows. 
