### PR TITLE
Add 'additional_remotes' property to 'git' resource

### DIFF
--- a/chef/lib/chef/resource/git.rb
+++ b/chef/lib/chef/resource/git.rb
@@ -26,6 +26,15 @@ class Chef
         super
         @resource_name = :git
         @provider = Chef::Provider::Git
+        @additional_remotes = Hash[]
+      end
+
+      def additional_remotes(arg=nil)
+        set_or_return(
+          :additional_remotes,
+          arg,
+          :kind_of => Hash
+        )
       end
 
       alias :branch :revision

--- a/features/data/cookbooks/scm/metadata.rb
+++ b/features/data/cookbooks/scm/metadata.rb
@@ -6,3 +6,4 @@ license 'Apache v2.0'
 long_description "SCM integration/acceptance test recipes"
 
 recipe "scm::git", "git awesome"
+recipe "scm::git-remotes", "git awesome repos"

--- a/features/provider/scm/git.feature
+++ b/features/provider/scm/git.feature
@@ -13,6 +13,19 @@ Feature: Git
      Then the run should exit '0'
       And a file named 'gitchef/.git' should exist
       And a file named 'gitchef/what_revision_am_i' should exist
-  
-  
-  
+
+  Scenario: Clone a git repo with additional repositories
+    Given a test git repo in the temp directory
+      And a validated node
+      And it includes the recipe 'scm::git-remotes'
+     When I run the chef-client
+     Then the run should exit '0'
+      And a remote repository named 'hi' should exist in 'gitchef2'
+      And a remote repository named 'lo' should exist in 'gitchef2'
+      And a remote repository named 'waugh' should exist in 'gitchef2'
+     When I remove the remote repository named 'lo' from 'gitchef2'
+      And I run the chef-client again
+     Then the run should exit '0'
+      And a remote repository named 'hi' should exist in 'gitchef2'
+      And a remote repository named 'lo' should exist in 'gitchef2'
+      And a remote repository named 'waugh' should exist in 'gitchef2'

--- a/features/steps/deploy_steps.rb
+++ b/features/steps/deploy_steps.rb
@@ -1,5 +1,6 @@
 require 'chef/shell_out'
-
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
 
 # Given /^I have a clone of typo in the data\/tmp dir$/ do
 #   cmd = "git clone #{datadir}/typo.bundle #{tmpdir}/gitrepo/typo"
@@ -26,6 +27,10 @@ Given /^a test git repo in the temp directory$/ do
   test_git_repo_tarball_filename = "#{datadir}/test_git_repo.tar.gz"
   cmd = Chef::ShellOut.new("tar xzvf #{test_git_repo_tarball_filename} -C #{tmpdir}")
   cmd.run_command.exitstatus.should == 0
+end
+
+When /^I remove the remote repository named '(.+)' from '(.+)'$/ do |remote_name, repository_dir|
+  shell_out!("git remote rm #{remote_name}", Hash[:cwd => File.join(tmpdir, repository_dir)])
 end
 
 Then /^I should hear about it$/ do
@@ -81,4 +86,8 @@ Then /^the second chef run should have skipped deployment$/ do
   expected_deploy = "#{tmpdir}/deploy/releases/62c9979f6694612d9659259f8a68d71048ae9a5b"
   Then "'stdout' should not have 'INFO: Already deployed app at #{expected_deploy}.  Rolling back to it - use action :force_deploy to re-checkout this revision.'"
 end
-  
+
+Then /^a remote repository named '(.*)' should exist in '(.*)'$/ do |remote_name, repository_dir|
+  remotes = shell_out!('git remote', Hash[:cwd => File.join(tmpdir, repository_dir)]).stdout.split(/\s/)
+  remotes.should include remote_name
+end


### PR DESCRIPTION
additional_remotes allows you to add one or more remote repositories to your git directory using the "git remote add" command.  Use it like so:

git "/target_dir" do
   repository "git@github.com:opscode/chef.git"
   additional_remotes["jkeiser"] = "git@github.com:jkeiser-oc/chef.git"
   action :sync
end
