### PR TITLE
[CHEF-2388] - remove ruby-libs, use rubygems 1.7.2 for CentOS

### DIFF
--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -3,12 +3,13 @@ if [ ! -f /usr/bin/chef-client ]; then
   rpm -Uvh http://download.fedora.redhat.com/pub/epel/5/i386/epel-release-5-4.noarch.rpm
   wget -O /etc/yum.repos.d/aegis.repo http://rpm.aegisco.com/aegisco/el5/aegisco.repo
 
+  yum remove -y ruby ruby-libs
   yum install -y ruby-1.8.7.334-2.el5 ruby-devel-1.8.7.334-2.el5 gcc gcc-c++ automake autoconf make
 
   cd /tmp
-  wget http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz
-  tar zxf rubygems-1.3.7.tgz
-  cd rubygems-1.3.7
+  wget http://production.cf.rubygems.org/rubygems/rubygems-1.7.2.tgz
+  tar zxf rubygems-1.7.2.tgz
+  cd rubygems-1.7.2
   ruby setup.rb --no-format-executable
 fi
 


### PR DESCRIPTION
fix for chef-2388 - remove ruby-libs which causes conflicts, use rubygems-1.7.2 as required by chef 0.10 with centos5-gems distro bootstrap
