### PR TITLE
CHEF-2395: Collating multiline knife ssh output

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -154,7 +154,16 @@ class Chef
         end
       end
 
+      def print_all(lines_hash)
+        lines_hash.each do |host, lines|
+          ui.msg(ui.color(host, :cyan) + "\n")
+          ui.msg(lines)
+          ui.msg(ui.color("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=", :yellow) + "\n")
+        end
+      end
+
       def ssh_command(command, subsession=nil)
+        mylines = Hash.new()
         subsession ||= session
         command = fixup_sudo(command)
         subsession.open_channel do |ch|
@@ -162,14 +171,20 @@ class Chef
           ch.exec command do |ch, success|
             raise ArgumentError, "Cannot execute #{command}" unless success
             ch.on_data do |ichannel, data|
-              print_data(ichannel[:host], data)
               if data =~ /^knife sudo password: /
                 ichannel.send_data("#{get_password}\n")
+              end
+
+              if mylines.has_key?(ichannel[:host])
+                mylines[ichannel[:host]] += data
+              else
+                mylines[ichannel[:host]] = data
               end
             end
           end
         end
         session.loop
+        print_all(mylines)
       end
 
       def get_password


### PR DESCRIPTION
- returns all ssh output as a group related to the remote host
- hosts are separated by a divider for easy visual scanning. I dig the yellow ymmv.
- when running commands that use RHEL/CentOS style "service X restart"
  commands or similar, the "[ OK ]" or "[ FAIL ]" status is on a
  single line
- uses the sweet sweet ui.msg
- Previous print method is still there, in case anyone is using it downstream
