### PR TITLE
CHEF-1896: Support for ssh gateway in knife ssh and knife bootstrap

### DIFF
--- a/chef/lib/chef/knife/bootstrap.rb
+++ b/chef/lib/chef/knife/bootstrap.rb
@@ -56,7 +56,8 @@ class Chef
       option :ssh_gateway,
         :short => "-G GATEWAY",
         :long => "--ssh-gateway GATEWAY",
-        :description => "The ssh gateway"
+        :description => "The ssh gateway",
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway] = key }
 
       option :identity_file,
         :short => "-i IDENTITY_FILE",
@@ -182,7 +183,7 @@ class Chef
         ssh.config[:ssh_user] = config[:ssh_user]
         ssh.config[:ssh_password] = config[:ssh_password]
         ssh.config[:ssh_port] = Chef::Config[:knife][:ssh_port] || config[:ssh_port]
-        ssh.config[:ssh_gateway] = config[:ssh_gateway]
+        ssh.config[:ssh_gateway] = Chef::Config[:knife][:ssh_gateway] || config[:ssh_gateway]
         ssh.config[:identity_file] = config[:identity_file]
         ssh.config[:manual] = true
         ssh.config[:no_host_key_verify] = config[:no_host_key_verify]

--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -74,7 +74,8 @@ class Chef
       option :ssh_gateway,
         :short => "-G GATEWAY",
         :long => "--ssh-gateway GATEWAY",
-        :description => "The ssh gateway"
+        :description => "The ssh gateway",
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gatewa] = key }
 
       option :identity_file,
         :short => "-i IDENTITY_FILE",
@@ -122,6 +123,7 @@ class Chef
       end
 
       def session_from_list(list)
+        config[:ssh_gateway] ||= Chef::Config[:knife][:ssh_gateway]
         if config[:ssh_gateway]
           gw_host, gw_user = config[:ssh_gateway].split('@').reverse
           gw_host, gw_port = gw_host.split(':')


### PR DESCRIPTION
A follow-on to abecciu's pull request. Starting from abecciu:CHEF-1896, I added the support for configuration in knife.rb per schisamo's request, thus the ssh gateway host is now configurable via

  knife[:ssh_gateway] = "user@somehost"
