### PR TITLE
Make chef work on Rubinius

### DIFF
--- a/chef/lib/chef/version_class.rb
+++ b/chef/lib/chef/version_class.rb
@@ -21,7 +21,7 @@ class Chef
     attr_reader :major, :minor, :patch
 
     def initialize(str="")
-      @major, @minor, @patch = parse(str)
+      parse(str)
     end
 
     def inspect


### PR DESCRIPTION
This removes unsupported (and suspect) behavior on Rubinius. Namely, what the return value of an masgn is. #parse sets the ivars, so #initialize doesn't need to. This appears to be a simple oversight.

This works around a bug in Rubinius which is slated to be fixed also.
