### PR TITLE
Remove statement about build-essential dependecies in apt vs. gem bootstrap

### DIFF
--- a/chef/distro/common/markdown/man1/knife-bootstrap.mkd
+++ b/chef/distro/common/markdown/man1/knife-bootstrap.mkd
@@ -57,11 +57,7 @@ target node (FQDN). The following distros are supported:
 * ubuntu10.04-apt
 
 The gems installations will use RubyGems 1.3.6 and Chef installed as a
-gem. The apt installation will use the Opscode APT repository. The
-RubyGems installation requires installing gems with native extensions,
-so development related packages (ruby-dev, build-essential) are
-installed. These are not installed with the apt installation, as native
-extensions are already compiled in the required packages.
+gem. The apt installation will use the Opscode APT repository.
 
 In addition to handling the software installation, these bootstrap
 templates do the following:


### PR DESCRIPTION
Current versions of chef packages in the Opscode APT repository depend on rubygems which in turn depends on build-essential.
