### PR TITLE
Added support Solaris distributions.

### DIFF
--- a/chef/lib/chef/platform.rb
+++ b/chef/lib/chef/platform.rb
@@ -182,6 +182,30 @@ class Chef
             }
           },
           :solaris  => {},
+          :openindiana => {
+            :default => {
+              :service => Chef::Provider::Service::Solaris,
+              :package => Chef::Provider::Package::Solaris,
+              :cron => Chef::Provider::Cron::Solaris,
+              :group => Chef::Provider::Group::Usermod
+            }
+          },
+          :opensolaris => {
+            :default => {
+              :service => Chef::Provider::Service::Solaris,
+              :package => Chef::Provider::Package::Solaris,
+              :cron => Chef::Provider::Cron::Solaris,
+              :group => Chef::Provider::Group::Usermod
+            }
+          },
+          :nexentacore => {
+            :default => {
+              :service => Chef::Provider::Service::Solaris,
+              :package => Chef::Provider::Package::Solaris,
+              :cron => Chef::Provider::Cron::Solaris,
+              :group => Chef::Provider::Group::Usermod
+            }
+          },
           :solaris2 => {
             :default => {
               :service => Chef::Provider::Service::Solaris,


### PR DESCRIPTION
Added platform support for the following Solaris distributions:

Solaris, Solaris Express, OpenIndiana, OpenSolaris, and Nexenta.

Matches Ohai detection for these distributions add via:  https://github.com/opscode/ohai/pull/25
