### PR TITLE
CHEF-2493 - Fixing deploy resource to handle new additional_remotes git option.

### DIFF
--- a/chef/lib/chef/resource/deploy.rb
+++ b/chef/lib/chef/resource/deploy.rb
@@ -73,6 +73,7 @@ class Chef
         @svn_force_export = false
         @provider = Chef::Provider::Deploy::Timestamped
         @allowed_actions.push(:force_deploy, :deploy, :rollback)
+        @additional_remotes = Hash[]
       end
 
       # where the checked out/cloned code goes
@@ -364,6 +365,14 @@ class Chef
       def after_restart(arg=nil, &block)
         arg ||= block
         set_or_return(:after_restart, arg, :kind_of => [Proc, String])
+      end
+      
+      def additional_remotes(arg=nil)
+        set_or_return(
+          :additional_remotes,
+          arg,
+          :kind_of => Hash
+        )
       end
 
     end


### PR DESCRIPTION
This patch adds the additional_remotes method to the deploy resource which is now available on the git resource. Without it, deploy resources will throw an exception regardless of whether they specify additional remotes.

Broken by this merge: https://github.com/opscode/chef/commit/6760ea2deb67cf9fbd2478d5835d9dd70b49cae5
See also: http://tickets.opscode.com/browse/CHEF-2379
