### PR TITLE
CHEF-2516: resolve NameError in Shef::SoloSession#rebuild_context

### DIFF
--- a/chef/lib/chef/shef/shef_session.rb
+++ b/chef/lib/chef/shef/shef_session.rb
@@ -161,10 +161,11 @@ module Shef
     end
 
     def rebuild_context
+      @run_status = Chef::RunStatus.new(@node)
       Chef::Cookbook::FileVendor.on_create { |manifest| Chef::Cookbook::FileSystemFileVendor.new(manifest, Chef::Config[:cookbook_path]) }
       @run_context = Chef::RunContext.new(@node, Chef::CookbookCollection.new(Chef::CookbookLoader.new(Chef::Config[:cookbook_path])))
       @run_context.load(Chef::RunList::RunListExpansionFromDisk.new("_default", []))
-      run_status.run_context = run_context
+      @run_status.run_context = run_context
     end
 
     private


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2516

When attempting to run shef in solo mode (--solo) I get a NameError exception raised. Here's an example:

```
vagrant@solo-tester> shef --solo --config ./solo.rb -j ./dna.json
loading configuration: ./solo.rb
Session type: solo
Loading...[Thu, 04 Aug 2011 05:03:02 +0000] INFO: Run List is []
[Thu, 04 Aug 2011 05:03:02 +0000] INFO: Run List expands to []
epic fail!

/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef/shef_session.rb:168:in `rebuild_context': undefined local variable or method `run_status' for #<Shef::SoloSession:0xb734792c> (NameError)
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef/shef_session.rb:54:in `reset!'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef/shef_session.rb:96:in `loading'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef/shef_session.rb:49:in `reset!'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef.rb:122:in `session'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef.rb:131:in `init'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/lib/chef/shef.rb:62:in `start'
    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-0.10.2/bin/shef:34
    from /opt/vagrant_ruby/bin/shef:19:in `load'
    from /opt/vagrant_ruby/bin/shef:19
```

It looks like [Shef::SoloSession#rebuild_context](https://github.com/opscode/chef/blob/f4591b56cb74c8f1939704fea8ede51056feb4c4/chef/lib/chef/shef/shef_session.rb#L163) never defines run_status. However, [Shef::ClientSession#rebuild_context](https://github.com/opscode/chef/blob/f4591b56cb74c8f1939704fea8ede51056feb4c4/chef/lib/chef/shef/shef_session.rb#L190) looks better.
