### PR TITLE
Allow for cookbook version

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_install.rb
+++ b/chef/lib/chef/knife/cookbook_site_install.rb
@@ -108,14 +108,15 @@ class Chef
 
       def parse_name_args!
         if name_args.empty?
-          ui.error("please specify a cookbook to download and install")
+          ui.error("Please specify a cookbook to download and install.")
           exit 1
-        elsif name_args.size > 1
-          ui.error("Installing multiple cookbooks at once is not supported")
-          exit 1
-        else
-          name_args.first
+        elsif name_args.size >= 2
+          unless name_args.last.match(/^(\d+)(\.\d+){1,2}$/) and name_args.size == 2
+            ui.error("Installing multiple cookbooks at once is not supported.")
+            exit 1
+          end
         end
+        name_args.first
       end
 
       def download_cookbook_to(download_path)


### PR DESCRIPTION
Cookbook site install allows a version to be specified.  The logic for handling the version from name_args is already in chef/lib/chef/knife/cookbook_site_download, so all we have to do is make sure we don't error out before passing the version along.
