### PR TITLE
Allow for cookbook version with evaluation of the second argument

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_install.rb
+++ b/chef/lib/chef/knife/cookbook_site_install.rb
@@ -110,10 +110,11 @@ class Chef
         if name_args.empty?
           ui.error("please specify a cookbook to download and install")
           exit 1
-        elsif name_args.size > 1
-          ui.error("Installing multiple cookbooks at once is not supported")
-          exit 1
-        else
+        elsif name_args.size >= 2
+          unless name_args.last.match(/^[0-9]/)
+            ui.error("Installing multiple cookbooks at once is not supported")
+            exit 1
+          end
           name_args.first
         end
       end


### PR DESCRIPTION
Based on Steven Danna's https://github.com/opscode/chef/pull/128

Cookbook site install allows a version to be specified. The logic for handling the version from name_args is already in chef/lib/chef/knife/cookbook_site_download, so all we have to do is make sure we don't error out before passing the version along.

Did some slight adjustments to preserve the user notification that the installation of multiple cookbooks is not yet possible.
