### PR TITLE
Allow for cookbook version

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_install.rb
+++ b/chef/lib/chef/knife/cookbook_site_install.rb
@@ -116,6 +116,8 @@ class Chef
             exit 1
           end
           name_args.first
+        else
+          name_args.first
         end
       end
 


### PR DESCRIPTION
Based on Steven Danna's pull request: https://github.com/opscode/chef/pull/128

Cookbook site install allows a version to be specified. The logic for handling the version from name_args is already in chef/lib/chef/knife/cookbook_site_download, so all we have to do is make sure we don't error out before passing the version along.

Addition: Preserved the user notification that the installation of multiple cookbooks is not yet possible.
