### PR TITLE
Chef 2540

### DIFF
--- a/chef/lib/chef/run_list.rb
+++ b/chef/lib/chef/run_list.rb
@@ -72,13 +72,14 @@ class Chef
       if other.kind_of?(Chef::RunList)
         other.run_list_items == @run_list_items
       else
-        return false unless other.respond_to?(:size) && (other.size == @run_list_items.size)
         if other.kind_of?(String)
           other_run_list_items = [ coerce_to_run_list_item(other) ]        
-        else
+        else          
           other_run_list_items = other.dup
         end
-
+        return false unless other.respond_to?(:size) && (other.size == @run_list_items.size)
+        return false unless other.respond_to?(:map!)
+        
         other_run_list_items.map! { |item| coerce_to_run_list_item(item) }
         other_run_list_items == @run_list_items
       end


### PR DESCRIPTION
fix CHEF-2540 - add test for string, and for the presence of a map! function before trying to use the "other"
