### PR TITLE
Add Ruby Enterprise Edition Ubuntu knife bootstrap target

### DIFF
--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-ree.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-ree.erb
@@ -1,0 +1,37 @@
+bash -c '
+<%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+
+if [ ! -f /usr/bin/chef-client ]; then
+  wget <%= "--proxy=on " if knife_config[:bootstrap_proxy] %>http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise_1.8.7-2011.03_amd64_ubuntu10.04.deb
+  dpkg -i ruby-enterprise_1.8.7-2011.03_amd64_ubuntu10.04.deb 
+  gem install rubygems-update -v 1.3.7
+  update_rubygems
+  apt-get install -y build-essential
+  gem install ohai --no-rdoc --no-ri --verbose
+  gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
+  ln -sf /usr/local/bin/chef-client /usr/bin/chef-client
+fi
+
+mkdir -p /etc/chef
+
+(
+cat <<'EOP'
+<%= validation_key %>
+EOP
+) > /tmp/validation.pem
+awk NF /tmp/validation.pem > /etc/chef/validation.pem
+rm /tmp/validation.pem
+
+(
+cat <<'EOP'
+<%= config_content %>
+EOP
+) > /etc/chef/client.rb
+
+(
+cat <<'EOP'
+<%= { "run_list" => @run_list }.to_json %>
+EOP
+) > /etc/chef/first-boot.json
+
+<%= start_chef %>'


### PR DESCRIPTION
As we're still on Ruby 1.8.7, we find the Ruby Enterprise Edition packages that Phusion provide allow us to update Rubygems while still using a 'packaged' Ruby.

As such I created a bootstrap to install REE on an Ubuntu Lucid system and then use that to install chef rather than risk having multiple Ruby versions on a system without using RVM.

It downgrades to Rubygems 1.3.7, as that seems to, well, work for everything.

I hope you find this useful!
