### PR TITLE
Fixed misnamed event variable.  Was breaking delete links in Firefox 6.

### DIFF
--- a/chef-server-webui/public/javascripts/chef.js
+++ b/chef-server-webui/public/javascripts/chef.js
@@ -116,7 +116,7 @@ $(document).ready(function(){
   });
 
   // livequery hidden form for link_to ajax magic
-  $(document.body).delegate('a[method]', 'click', function(e){
+  $(document.body).delegate('a[method]', 'click', function(event){
     var $this = $(this);
     var message = $this.attr('confirm'), method = $this.attr('method');
 


### PR DESCRIPTION
Super small change here.  Javascript error was occurring when trying to delete a node in chef-ui, preventing those links from working in Firefox 6.
