### PR TITLE
A possible fix for CHEF-2573, which breaks knife ssh tmux on newer versions of tmux

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -272,7 +272,7 @@ class Chef
           end.join(" \\; ")
         end
 
-        tmux_name = "'knife ssh #{@name_args[0]}'"
+        tmux_name = "'knife ssh #{@name_args[0].gsub(/:/,' ')}'"
         begin
           server = session.servers_for.first
           cmd = ["tmux new-session -d -s #{tmux_name}",


### PR DESCRIPTION
Strips out colons from the generated session names as a quick fix for tmux >= 1.5 which does not allow colons in session names
