### PR TITLE
Fixes CHEF-2573 by removing colon from tmux name

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -272,7 +272,7 @@ class Chef
           end.join(" \\; ")
         end
 
-        tmux_name = "'knife ssh #{@name_args[0]}'"
+        tmux_name = "'knife ssh #{@name_args[0].gsub(/:/,' ')}'"
         begin
           server = session.servers_for.first
           cmd = ["tmux new-session -d -s #{tmux_name}",


### PR DESCRIPTION
Replaces all colons from the generated session names with spaces as a quick
fix for tmux >= 1.5 which does not allow colons in session names

http://tickets.opscode.com/browse/CHEF-2573

(now on a topic branch instead of master)
