### PR TITLE
chef-expander does not respect config.solr_url value

### DIFF
--- a/chef-expander/lib/chef/expander/solrizer.rb
+++ b/chef-expander/lib/chef/expander/solrizer.rb
@@ -251,7 +251,8 @@ module Chef
       end
 
       def solr_url
-        'http://127.0.0.1:8983/solr/update'
+        base_url = Expander.config.solr_url || 'http://127.0.0.1:8983'
+        "#{base_url}/solr/update"
       end
 
       def indexed_object


### PR DESCRIPTION
Currently there is no way to configure chef-expander to use other then default Solr URL. This patch should fix the problem
