### PR TITLE
Fixed error occurred when Solrizer parses invalid JSON

### DIFF
--- a/chef-expander/lib/chef/expander/solrizer.rb
+++ b/chef-expander/lib/chef/expander/solrizer.rb
@@ -108,6 +108,7 @@ module Chef
         Yajl::Parser.parse(serialized_object)
       rescue Yajl::ParseError
         log.error { "cannot index object because it is invalid JSON: #{serialized_object}" }
+        nil
       end
 
       def run

--- a/chef-expander/spec/unit/solrizer_spec.rb
+++ b/chef-expander/spec/unit/solrizer_spec.rb
@@ -28,6 +28,22 @@ require 'rexml/document'
 describe Expander::Solrizer do
   SEP = "__=__"
 
+  describe "when created with invalid JSON" do
+    before do
+      @log_stream = StringIO.new
+      Expander::Solrizer::LOGGER.init(@log_stream)
+      @solrizer = Expander::Solrizer.new('{!"action":"delete"}') { :no_op }
+    end
+
+    it "logs error info" do
+      @log_stream.string.should =~ /invalid JSON/
+    end
+
+    it "skips invalid request" do
+      @solrizer.action.should == "skip"
+    end
+  end
+
   describe "when created with an add request" do
     before do
       @now = Time.now.utc.to_i


### PR DESCRIPTION
Since log always returns `true`, parse generates error when invalid JSON string passed

```
undefined method `[]' for true:TrueClass" 
```
