### PR TITLE
[CHEF-2808] Fix for "can't convert Array into String" in dirname

### DIFF
--- a/chef/lib/chef/knife/bootstrap.rb
+++ b/chef/lib/chef/knife/bootstrap.rb
@@ -115,7 +115,7 @@ class Chef
           bootstrap_files << File.join(File.dirname(__FILE__), 'bootstrap', "#{config[:distro]}.erb")
           bootstrap_files << File.join(@@chef_config_dir, "bootstrap", "#{config[:distro]}.erb")
           bootstrap_files << File.join(ENV['HOME'], '.chef', 'bootstrap', "#{config[:distro]}.erb")
-          bootstrap_files << Gem.find_files(File.join("chef","knife","bootstrap","#{config[:distro]}.erb"))
+          bootstrap_files += Gem.find_files(File.join("chef","knife","bootstrap","#{config[:distro]}.erb"))
           bootstrap_files.flatten!
         end
 


### PR DESCRIPTION
I was getting "can't convert Array into String" @ chef-0.10.4/lib/chef/knife/bootstrap.rb:122:in `dirname' when using non-standard bootstrap template. Obviously enough, Gem.find_files returns an Array and not a String.

Ticket: http://tickets.opscode.com/browse/CHEF-2808
