### PR TITLE
Fixed typo in chef-solr Rakefile

### DIFF
--- a/chef-solr/Rakefile
+++ b/chef-solr/Rakefile
@@ -39,12 +39,12 @@ end
 
 desc "Install the gem"
 task :install => :package do
-  sh %{gem install pkg/#{chef-solr}-#{Chef::Solr::VERSION} --no-rdoc --no-ri}
+  sh %{gem install pkg/chef-solr-#{Chef::Solr::VERSION} --no-rdoc --no-ri}
 end
 
 desc "Uninstall the gem"
 task :uninstall do
-  sh %{gem uninstall #{chef-solr} -x -v #{Chef::Solr::VERSION} }
+  sh %{gem uninstall chef-solr -x -v #{Chef::Solr::VERSION} }
 end
 
 require 'rdoc/task'


### PR DESCRIPTION
Fixed typo in chef-solr Rakefile, which affected top-level `rake install` task. (http://tickets.opscode.com/browse/CHEF-2712)
