### PR TITLE
Config option to allow for knifing a knew host with a 

### DIFF
--- a/chef/lib/chef/config.rb
+++ b/chef/lib/chef/config.rb
@@ -204,6 +204,7 @@ class Chef
     client_key "/etc/chef/client.pem"
     validation_key "/etc/chef/validation.pem"
     validation_client_name "chef-validator"
+    data_bag_keyfile "/etc/chef/encrypted_data_bag_secret"
     web_ui_client_name "chef-webui"
     web_ui_key "/etc/chef/webui.pem"
     web_ui_admin_user_name  "admin"

--- a/chef/lib/chef/knife/configure.rb
+++ b/chef/lib/chef/knife/configure.rb
@@ -23,6 +23,8 @@ class Chef
     class Configure < Knife
       attr_reader :chef_server, :new_client_name, :admin_client_name, :admin_client_key
       attr_reader :chef_repo, :new_client_key, :validation_client_name, :validation_key
+      attr_reader :data_bag_keyfile
+
 
       deps do
         require 'ohai'

--- a/chef/lib/chef/knife/core/bootstrap_context.rb
+++ b/chef/lib/chef/knife/core/bootstrap_context.rb
@@ -50,6 +50,10 @@ class Chef
           IO.read(@chef_config[:validation_key])
         end
 
+        def data_bag_keyfile
+          IO.read(@chef_config[:data_bag_keyfile])
+        end
+
         def encrypted_data_bag_secret
           IO.read(@chef_config[:encrypted_data_bag_secret])
         end


### PR DESCRIPTION
My testing copy of .chef/knife.rb normally sets it this way, to use a local version (per chef config):
data_bag_keyfile         "#{current_dir}/data_bag_key"

More info in the mailing list post at http://lists.opscode.com/sympa/arc/chef/2011-11/msg00071.html.
