### PR TITLE
[Chef-2715]: Provide alternate chef-client location

### DIFF
--- a/chef/lib/chef/knife/core/bootstrap_context.rb
+++ b/chef/lib/chef/knife/core/bootstrap_context.rb
@@ -79,8 +79,8 @@ CONFIG
           client_rb
         end
 
-        def start_chef
-          s = "/usr/bin/chef-client -j /etc/chef/first-boot.json"
+        def start_chef(client='/usr/bin/chef-client')
+          s = "#{client} -j /etc/chef/first-boot.json"
           s << " -E #{bootstrap_environment}" if chef_version.to_f != 0.9 # only use the -E option on Chef 0.10+
           s
         end

--- a/chef/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/chef/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -79,6 +79,11 @@ EXPECTED
     it "starts chef in the configured environment" do
       @context.start_chef.should == '/usr/bin/chef-client -j /etc/chef/first-boot.json -E prodtastic'
     end
+
+    it "uses alternate chef-client location if specified" do
+      @context.start_chef('/usr/local/bin/chef-client').should == '/usr/local/bin/chef-client -j /etc/chef/first-boot.json -E prodtastic'
+    end
+
   end
 
   describe "when installing a prerelease version of chef" do


### PR DESCRIPTION
Hi,

Here's a patch for http://tickets.opscode.com/browse/CHEF-2715

I merged with the upstream master so my old changes for python appear in the pull request but the diff is clean.

Thanks

--Gilles
