### PR TITLE
allow to call data_bag from recipe with symbolic name

### DIFF
--- a/chef/lib/chef/data_bag.rb
+++ b/chef/lib/chef/data_bag.rb
@@ -159,7 +159,7 @@ class Chef
           raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{Chef::Config[:data_bag_path]}' is invalid"
         end
 
-        Dir.glob(File.join(Chef::Config[:data_bag_path], name, "*.json")).inject({}) do |bag, f|
+        Dir.glob(File.join(Chef::Config[:data_bag_path], "#{name}", "*.json")).inject({}) do |bag, f|
           item = JSON.parse(IO.read(f))
           bag[item['id']] = item
           bag

--- a/chef/spec/unit/data_bag_spec.rb
+++ b/chef/spec/unit/data_bag_spec.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,7 +61,7 @@ describe Chef::DataBag do
 
     %w{
       name
-    }.each do |t| 
+    }.each do |t|
       it "should match '#{t}'" do
         @deserial.send(t.to_sym).should == @data_bag.send(t.to_sym)
       end
@@ -104,6 +104,12 @@ describe Chef::DataBag do
         File.should_receive(:directory?).with('/var/chef/data_bags').and_return(true)
         Dir.should_receive(:glob).with('/var/chef/data_bags/foo/*.json').and_return([])
         Chef::DataBag.load('foo')
+      end
+
+      it "should get the data bag from the data_bag_path by symbolic name" do
+        File.should_receive(:directory?).with('/var/chef/data_bags').and_return(true)
+        Dir.should_receive(:glob).with('/var/chef/data_bags/foo/*.json').and_return([])
+        Chef::DataBag.load(:foo)
       end
 
       it "should return the data bag" do


### PR DESCRIPTION
data_bag(:user) did not work without this fix with chef-solo, data bag name should be provided as a string. Now both options are supported:

data_bag(:users) or data_bag("users")
