### PR TITLE
Allow for the path to chef-client to be configured when running knife bootstrap

### DIFF
--- a/chef/lib/chef/knife/core/bootstrap_context.rb
+++ b/chef/lib/chef/knife/core/bootstrap_context.rb
@@ -80,7 +80,8 @@ CONFIG
         end
 
         def start_chef
-          s = "/usr/bin/chef-client -j /etc/chef/first-boot.json"
+          client_path = @chef_config[:chef_client_path] || '/usr/bin/env chef-client'
+          s = "#{client_path} -j /etc/chef/first-boot.json"
           s << " -E #{bootstrap_environment}" if chef_version.to_f != 0.9 # only use the -E option on Chef 0.10+
           s
         end


### PR DESCRIPTION
We are using the knife bootstrap functionality, but our chef-client executable was not stored in /usr/bin.  Because of this, we could not use the start_chef bootstrap command.

This patch makes the following changes:
1.  It allows for the user to specify a chef config variable that will define the explicit path to the chef-client executable
2.  It loads the chef-client from /usr/bin/env client-config rather than /usr/bin/client-config to look for the client according to the environment path rather than forcing /usr/bin
