### PR TITLE
[CHEF-1902] fixes rescue error when erubis error has no line number

### DIFF
--- a/chef/lib/chef/mixin/template.rb
+++ b/chef/lib/chef/mixin/template.rb
@@ -71,10 +71,15 @@ class Chef
         
         def source_listing
           @source_listing ||= begin
-            line_index = line_number - 1
-            beginning_line = line_index <= SOURCE_CONTEXT_WINDOW ? 0 : line_index - SOURCE_CONTEXT_WINDOW
-            source_size = SOURCE_CONTEXT_WINDOW * 2 + 1
             lines = @template.split(/\n/)
+            if line_number
+              line_index = line_number - 1
+              beginning_line = line_index <= SOURCE_CONTEXT_WINDOW ? 0 : line_index - SOURCE_CONTEXT_WINDOW
+              source_size = SOURCE_CONTEXT_WINDOW * 2 + 1
+            else
+              beginning_line = 0
+              source_size    = lines.length
+            end
             contextual_lines = lines[beginning_line, source_size]
             output = []
             contextual_lines.each_with_index do |line, index|


### PR DESCRIPTION
If erubis isn't sure what line caused the error, then `line_number` is nil; this makes the rescue block fails with its own error and sadness follows confusion. Made `source_listing` dump all lines in this case -- it's probably an omitted 'end' or other full-template error
