### PR TITLE
Support for invalid url's in remote_file

### DIFF
--- a/chef/lib/chef/resource/remote_file.rb
+++ b/chef/lib/chef/resource/remote_file.rb
@@ -75,7 +75,14 @@ class Chef
       def absolute_uri?(source)
         URI.parse(source).absolute?
       rescue URI::InvalidURIError
-        false
+				# we do a simple check if the source starts with http://
+				# in case if we are dealing with a specification invalid url, like
+				# some_invalid_url.google.com but for practical purposes they are just as valid
+				if source.strip.start_with?("http://")
+					true
+				else
+					false
+				end
       end
 
     end

--- a/chef/spec/unit/resource/remote_file_spec.rb
+++ b/chef/spec/unit/resource/remote_file_spec.rb
@@ -38,6 +38,12 @@ describe Chef::Resource::RemoteFile do
     Chef::Platform.find_provider(:noplatform, 'noversion', @resource).should == Chef::Provider::RemoteFile
   end
 
+  it "says its provider is RemoteFile when the source is an absolute URI, even if URI is specification invalid" do
+    @resource.source("http://some_invalid_subdomain.google.com/robots.txt")
+    @resource.provider.should == Chef::Provider::RemoteFile
+    Chef::Platform.find_provider(:noplatform, 'noversion', @resource).should == Chef::Provider::RemoteFile
+  end
+
   it "says its provider is CookbookFile when the source is a relative URI" do
     @resource.source('seattle.txt')
     @resource.provider.should == Chef::Provider::CookbookFile


### PR DESCRIPTION
Remote file currently thinks url like

```
some_invalid_url.google.com/somefile.txt
```

as a local file because it's specification invalid. This patch overrides that by doing a simple http:// prefix check if url is specification invalid.
