### PR TITLE
fixes for rubygems1.8 [CHEF-2790]

### DIFF
--- a/chef/lib/chef/provider/package/rubygems.rb
+++ b/chef/lib/chef/provider/package/rubygems.rb
@@ -74,7 +74,11 @@ class Chef
           # === Returns
           # [Gem::Specification]  an array of Gem::Specification objects
           def installed_versions(gem_dep)
-            gem_source_index.search(gem_dep)
+            if gem_dep.respond_to?(:matching_specs)
+              gem_dep.matching_specs
+            else 
+              gem_source_index.search(gem_dep)
+            end
           end
 
           ##


### PR DESCRIPTION
See ticket; this fixes deprecation warnings for rubygems 1.8 users.

Please also apply to chef 0.9. Let me know if you have any concerns or questions.
