### PR TITLE
Fixes [CHEF-2795] - Knife plugin loader rejects gems with 'chef' in their name

### DIFF
--- a/chef/lib/chef/knife/core/subcommand_loader.rb
+++ b/chef/lib/chef/knife/core/subcommand_loader.rb
@@ -21,8 +21,8 @@ class Chef
   class Knife
     class SubcommandLoader
 
-      CHEF_FILE_IN_GEM = /chef-[\d]+\.[\d]+\.[\d]+/
-      CURRENT_CHEF_GEM = /chef-#{Regexp.escape(Chef::VERSION)}/
+      CHEF_FILE_IN_GEM = /^chef-[\d]+\.[\d]+\.[\d]+/
+      CURRENT_CHEF_GEM = /^chef-#{Regexp.escape(Chef::VERSION)}/
 
       attr_reader :chef_config_dir
       attr_reader :env


### PR DESCRIPTION
See http://tickets.opscode.com/browse/CHEF-2795

The knife/core/subcommand_loader.rb file has to avoid loading plugins from alternate versions of chef.

To do so, the method `from_old_gem?(path)` uses the following regexp:

```
CHEF_FILE_IN_GEM = /chef-[\d]+\.[\d]+\.[\d]+/
CURRENT_CHEF_GEM = /chef-#{Regexp.escape(Chef::VERSION)}/
```

Unfortunately, that precludes any gem containing the word 'chef' from being loaded (in particular, the cluster_chef tools.

Fix is to anchor the regexp:

```
CHEF_FILE_IN_GEM = /^chef-[\d]+\.[\d]+\.[\d]+/
CURRENT_CHEF_GEM = /^chef-#{Regexp.escape(Chef::VERSION)}/
```
