### PR TITLE
[FIX] Rescue correct exception when "node.fqdn" is not defined

### DIFF
--- a/chef/lib/chef/shef.rb
+++ b/chef/lib/chef/shef.rb
@@ -144,7 +144,7 @@ module Shef
 
   def self.greeting
     " #{Etc.getlogin}@#{Shef.session.node.fqdn}"
-  rescue NameError
+  rescue NameError, ArgumentError
     ""
   end
 


### PR DESCRIPTION
When `node.fqdn` is not defined, the exception raised is "ArgumentError" (`Attribute fqdn is not defined`).

Should probably use `node.hostname` when `node.fqdn` is undefined, in the end.
