### PR TITLE
Support 303 "See Other" redirects

### DIFF
--- a/chef/lib/chef/rest.rb
+++ b/chef/lib/chef/rest.rb
@@ -386,7 +386,7 @@ class Chef
     private
 
     def redirected_to(response)
-      if response.kind_of?(Net::HTTPFound) || response.kind_of?(Net::HTTPMovedPermanently)
+      if response.kind_of?(Net::HTTPFound) || response.kind_of?(Net::HTTPMovedPermanently) || response.kind_of?(Net::HTTPSeeOther)
         response['location']
       else
         nil


### PR DESCRIPTION
It's an issue for files from launchpad like http://launchpad.net/graphite/0.9/0.9.9/+download/whisper-0.9.9.tar.gz
