### PR TITLE
[CHEF-2833] Portage package provider doesn't behave as it should

### DIFF
--- a/chef/lib/chef/provider/package/portage.rb
+++ b/chef/lib/chef/provider/package/portage.rb
@@ -41,9 +41,12 @@ class Chef
             end
           end.compact
 
-          if versions.size > 1 && !category
+          if versions.size > 1
             atoms = versions.map {|v| v.first }.sort
-            raise Chef::Exceptions::Package, "Multiple packages found for #{@new_resource.package_name}: #{atoms.join(" ")}. Specify a category."
+            categories = atoms.map {|v| v.split('/')[0] }.uniq
+            if !category && categories.size > 1
+              raise Chef::Exceptions::Package, "Multiple packages found for #{@new_resource.package_name}: #{atoms.join(" ")}. Specify a category."
+            end
           elsif versions.size == 1
             @current_resource.version(versions.first.last)
             Chef::Log.debug("#{@new_resource} current version #{$1}")

--- a/chef/spec/unit/provider/package/portage_spec.rb
+++ b/chef/spec/unit/provider/package/portage_spec.rb
@@ -87,6 +87,13 @@ describe Chef::Provider::Package::Portage, "load_current_resource" do
       @provider.load_current_resource
       @provider.current_resource.version.should be_nil
     end
+
+    it "should return a current resource with a nil version if a category is not specified and multiple packages from the same category are found" do
+      ::Dir.stub!(:[]).with("/var/db/pkg/*/git-*").and_return(["/var/db/pkg/dev-util/git-1.0.0", "/var/db/pkg/dev-util/git-1.0.1"])
+      @provider = Chef::Provider::Package::Portage.new(@new_resource_without_category, @run_context)
+      @provider.load_current_resource
+      @provider.current_resource.version.should be_nil
+    end
   end
 
   describe "once the state of the package is known" do


### PR DESCRIPTION
If I have two versions of the same ebuild, Chef#pacakge fails when I specify the category of the package, but it shouldn't.

http://tickets.opscode.com/browse/CHEF-2833
