### PR TITLE
The ssh_attribute is never read from the config file

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -115,7 +115,7 @@ class Chef
                  @action_nodes.each do |item|
                    i = format_for_display(item)[config[:attribute]]
                    if i.nil?
-                     ui.msg("#{item} does not have attribute #{config[:attribute]}")
+                     ui.msg("\"#{item}\" does not have attribute \"#{config[:attribute]}\"")
                    else
                      r.push(i) unless i.nil?
                    end


### PR DESCRIPTION
This fixes it by not setting the default value here. Instead, it relies on the `configure_attribute` function
