### PR TITLE
The ssh_attribute is never read from the config file

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -44,8 +44,7 @@ class Chef
       option :attribute,
         :short => "-a ATTR",
         :long => "--attribute ATTR",
-        :description => "The attribute to use for opening the connection - default is fqdn",
-        :default => "fqdn"
+        :description => "The attribute to use for opening the connection - default is fqdn"
 
       option :manual,
         :short => "-m",


### PR DESCRIPTION
This fixes it by not setting the default value here. Instead, it relies on the `configure_attribute` function
