### PR TITLE
CHEF-2854

### DIFF
--- a/chef/lib/chef/mixin/command/unix.rb
+++ b/chef/lib/chef/mixin/command/unix.rb
@@ -86,8 +86,8 @@ class Chef
                 Process.uid = args[:user]
               end
 
-              ENV.clear if Chef::Config[:base_shell_environment]
-              (Chef::Config[:base_shell_environment] || {}).merge(args[:environment]).each do |key,value|
+              ENV.clear if Chef::Config[:override_shell_environment]
+              (Chef::Config[:override_shell_environment] || {}).merge(args[:environment]).each do |key,value|
                 ENV[key] = value
               end
 

--- a/chef/lib/chef/mixin/shell_out.rb
+++ b/chef/lib/chef/mixin/shell_out.rb
@@ -26,8 +26,8 @@ class Chef
         cmd = Mixlib::ShellOut.new(*command_args)
         class << cmd
           def set_environment
-            ENV.clear if Chef::Config[:base_shell_environment]
-            (Chef::Config[:base_shell_environment] || {}).merge(environment).each do |env_var,value|
+            ENV.clear if Chef::Config[:override_shell_environment]
+            (Chef::Config[:override_shell_environment] || {}).merge(environment).each do |env_var,value|
               ENV[env_var] = value
             end
           end

--- a/chef/spec/unit/mixin/command_spec.rb
+++ b/chef/spec/unit/mixin/command_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Mixin::Command do
       end
 
       it "should respect base_shell_environment when defined" do
-        Chef::Config[:base_shell_environment] = {"CHEF" => "1"}
+        Chef::Config[:override_shell_environment] = {"CHEF" => "1"}
         popen4("env") do |pid, stdin, stdout, stderr|
           stdout.read.strip.should == "CHEF=1\nLC_ALL=C"
         end

--- a/chef/spec/unit/mixin/shell_out_spec.rb
+++ b/chef/spec/unit/mixin/shell_out_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Mixin::ShellOut do
 
   describe "set_environment" do
     it "should respect base_shell_environment when defined" do
-      Chef::Config[:base_shell_environment] = {"CHEF" => "1"}
+      Chef::Config[:override_shell_environment] = {"CHEF" => "1"}
       shell_out("env").stdout.strip.should == "CHEF=1\nLC_ALL=C"
     end
   end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2854

This defines a new config setting base_shell_environment that allows one to define a known environment for all external processes chef launches (service, execute resources or only_if, not_if conditions).
