### PR TITLE
[Chef 2690] :timeout option for not_if stops entire chef run rather than triggering "execute" command

### DIFF
--- a/chef/lib/chef/resource/conditional.rb
+++ b/chef/lib/chef/resource/conditional.rb
@@ -75,6 +75,7 @@ class Chef
       def evaluate_command
         shell_out(@command, @command_opts).status.success?
       rescue Chef::Exceptions::CommandTimeout
+        Chef::Log.warn "Command '#{@command}' timed out"
         false
       end
 

--- a/chef/spec/unit/resource/conditional_spec.rb
+++ b/chef/spec/unit/resource/conditional_spec.rb
@@ -57,6 +57,11 @@ describe Chef::Resource::Conditional do
       it 'indicates that resource convergence should not continue' do
         @conditional.continue?.should be_false
       end
+
+      it 'should log a warning' do
+        Chef::Log.should_receive(:warn).with("Command 'false' timed out")
+        @conditional.continue?
+      end
     end
 
     describe "after running a block that returns a truthy value" do
@@ -110,6 +115,11 @@ describe Chef::Resource::Conditional do
 
       it 'indicates that resource convergence should continue' do
         @conditional.continue?.should be_true
+      end
+
+      it 'should log a warning' do
+        Chef::Log.should_receive(:warn).with("Command 'false' timed out")
+        @conditional.continue?
       end
     end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2690
