### PR TITLE
CHEF-2566

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_install.rb
+++ b/chef/lib/chef/knife/cookbook_site_install.rb
@@ -129,7 +129,7 @@ class Chef
 
       def extract_cookbook(upstream_file, version)
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
-        shell_out!("tar zxvf #{upstream_file}", :cwd => @install_path)
+        shell_out!("tar zxvf '#{upstream_file}'", :cwd => @install_path)
       end
 
       def clear_existing_files(cookbook_path)


### PR DESCRIPTION
1. It's not acceptable to have absolute cookbook_path values in the $HOME/.chef/knife.rb
2. external arguments for shell commands must be escaped 
