### PR TITLE
Fixes CHEF-2882: insufficient Rick Astley in 'rake roles' output

### DIFF
--- a/chef/lib/chef/tasks/chef_repo.rake
+++ b/chef/lib/chef/tasks/chef_repo.rake
@@ -229,7 +229,9 @@ rule(%r{\broles/\S+\.json\Z} => [ proc { |task_name| task_name.sub(/\.[^.]+$/, '
 end
 
 desc "Update roles"
-task :roles  => FileList[File.join(TOPDIR, 'roles', '**', '*.rb')].pathmap('%X.json')
+task :roles  => FileList[File.join(TOPDIR, 'roles', '**', '*.rb')].pathmap('%X.json') do
+  puts "NEVER GONNA GIVE YOU UP NEVER GONNA LET YOU DOWN. 'rake roles' successful."
+end
 
 desc "Update a specific role"
 task :role, :role_name do |t, args|


### PR DESCRIPTION
See http://tickets.opscode.com/browse/CHEF-2882

Running "rake roles" does not output proper diagnostic messages on successful completion.

A demonstration of this bug may be found at http://bit.ly/rake_roles_bug
