### PR TITLE
[CHEF-2894] - use same values for initialize as knife cookbook create

### DIFF
--- a/chef/lib/chef/cookbook/metadata.rb
+++ b/chef/lib/chef/cookbook/metadata.rb
@@ -91,7 +91,7 @@ class Chef
       #
       # === Returns
       # metadata<Chef::Cookbook::Metadata>
-      def initialize(cookbook=nil, maintainer='Your Name', maintainer_email='youremail@example.com', license='Apache v2.0')
+      def initialize(cookbook=nil, maintainer='YOUR_COMPANY_NAME', maintainer_email='YOUR_EMAIL', license='none')
         @cookbook = cookbook
         @name = cookbook ? cookbook.name : ""
         @long_description = ""


### PR DESCRIPTION
Fixes CHEF-2894. Using the same default values as `knife cookbook create` means that if the values are not present in the metadata we're not making decisions for the user, particularly the license.
