### PR TITLE
Fix remote_directory to remove symlinked directories correctly with the purge option

### DIFF
--- a/chef/lib/chef/provider/remote_directory.rb
+++ b/chef/lib/chef/provider/remote_directory.rb
@@ -57,7 +57,7 @@ class Chef
       def purge_unmanaged_files(unmanaged_files)
         if @new_resource.purge
           unmanaged_files.sort.reverse.each do |f|
-            if ::File.directory?(f)
+            if ::File.directory?(f) && !::File.symlink?(f)
               Dir::rmdir(f)
               Chef::Log.debug("#{@new_resource} removed directory #{f}")
             else

--- a/chef/spec/unit/provider/remote_directory_spec.rb
+++ b/chef/spec/unit/provider/remote_directory_spec.rb
@@ -128,6 +128,21 @@ describe Chef::Provider::RemoteDirectory do
         ::File.exist?(@destination_dir + '/a/multiply/nested/baz.txt').should be_false
         ::File.exist?(@destination_dir + '/a/multiply/nested/directory/qux.txt').should be_false
       end
+
+      it "removes directory symlinks properly" do
+        symlinked_dir_path = @destination_dir + '/symlinked_dir'
+        @provider.action_create
+
+        Dir.mktmpdir do |tmp_dir|
+          FileUtils.ln_s(tmp_dir, symlinked_dir_path)
+          ::File.exist?(symlinked_dir_path).should be_true
+
+          @provider.action_create
+
+          ::File.exist?(symlinked_dir_path).should be_false
+          ::File.exist?(tmp_dir).should be_true
+        end
+      end
     end
 
     describe "with overwrite disabled" do


### PR DESCRIPTION
Currently chef tries to purge symlinked directories using Dir::rmdir which explodes because the symlink is not a directory. This fixes it.
