### PR TITLE
Escape git destination path (fixes destinations with spaces).

### DIFF
--- a/chef/lib/chef/provider/git.rb
+++ b/chef/lib/chef/provider/git.rb
@@ -120,7 +120,7 @@ class Chef
 
         Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
 
-        clone_cmd = "git clone #{args.join(' ')} #{@new_resource.repository} #{@new_resource.destination}"
+        clone_cmd = "git clone #{args.join(' ')} #{@new_resource.repository} '#{@new_resource.destination}'"
         shell_out!(clone_cmd, run_options(:log_level => :info))
       end
 


### PR DESCRIPTION
Escape destination path in the git clone command.
This fixes `Too many arguments.` error for destinations with spaces. 
