### PR TITLE
Implementation of feature request CHEF-2959

### DIFF
--- a/chef/lib/chef/provider/package/apt.rb
+++ b/chef/lib/chef/provider/package/apt.rb
@@ -37,6 +37,14 @@ class Chef
           @current_resource
         end
 
+        def force_yes
+          if @new_resource.respond_to?("force_yes")
+            @new_resource.force_yes
+          else
+            false
+          end
+        end
+
         def check_package_state(package)
           Chef::Log.debug("#{@new_resource} checking package status for #{package}")
           installed = false
@@ -85,8 +93,13 @@ class Chef
         def install_package(name, version)
           package_name = "#{name}=#{version}"
           package_name = name if @is_virtual_package
+          if force_yes
+            force_yes_flag = "--force-yes"
+          else
+            force_yes_flag = ""
+          end
           run_command_with_systems_locale(
-            :command => "apt-get -q -y#{expand_options(@new_resource.options)} install #{package_name}",
+            :command => "apt-get -q -y#{expand_options(@new_resource.options)} install #{package_name} #{force_yes_flag}",
             :environment => {
               "DEBIAN_FRONTEND" => "noninteractive"
             }

--- a/chef/lib/chef/resource/apt_package.rb
+++ b/chef/lib/chef/resource/apt_package.rb
@@ -28,6 +28,14 @@ class Chef
         @resource_name = :apt_package
         @provider = Chef::Provider::Package::Apt
       end
+
+      def force_yes(arg=nil)
+        set_or_return(
+          :force_yes,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
+        )
+      end
       
     end
   end


### PR DESCRIPTION
Without this patch the apt --force-yes must be specified via
a resource option.  This makes your package declration platform
dependent.

This commit allows you to set the flag via an explicit attribute
instead of a resource option.  This helps cookbooks be more
platform agnostic.
