### PR TITLE
Escape git clone repository and destination

### DIFF
--- a/chef/lib/chef/provider/git.rb
+++ b/chef/lib/chef/provider/git.rb
@@ -21,6 +21,7 @@ require 'chef/log'
 require 'chef/provider'
 require 'chef/mixin/shell_out'
 require 'fileutils'
+require 'shellwords'
 
 class Chef
   class Provider
@@ -120,7 +121,7 @@ class Chef
 
         Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
 
-        clone_cmd = "git clone #{args.join(' ')} '#{@new_resource.repository}' '#{@new_resource.destination}'"
+        clone_cmd = "git clone #{args.join(' ')} #{@new_resource.repository} #{Shellwords.escape @new_resource.destination}"
         shell_out!(clone_cmd, run_options(:log_level => :info))
       end
 

--- a/chef/spec/unit/provider/git_spec.rb
+++ b/chef/spec/unit/provider/git_spec.rb
@@ -135,7 +135,7 @@ SHAS
   it "runs a clone command with default git options" do
     @resource.user "deployNinja"
     @resource.ssh_wrapper "do_it_this_way.sh"
-    expected_cmd = "git clone  'git://github.com/opscode/chef.git' '/my/deploy/dir'"
+    expected_cmd = "git clone  git://github.com/opscode/chef.git /my/deploy/dir"
     @provider.should_receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
                                                 :environment =>{"GIT_SSH"=>"do_it_this_way.sh"}, :log_level => :info, :log_tag => "git[web2.0 app]", :live_stream => STDOUT)
     @provider.clone
@@ -145,7 +145,7 @@ SHAS
     @resource.user "deployNinja"
     @resource.destination "/Application Support/with/space"
     @resource.ssh_wrapper "do_it_this_way.sh"
-    expected_cmd = "git clone  'git://github.com/opscode/chef.git' '/Application Support/with/space'"
+    expected_cmd = "git clone  git://github.com/opscode/chef.git /Application\\ Support/with/space"
     @provider.should_receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
                                                 :environment =>{"GIT_SSH"=>"do_it_this_way.sh"}, :log_level => :info, :log_tag => "git[web2.0 app]", :live_stream => STDOUT)
     @provider.clone
@@ -153,14 +153,14 @@ SHAS
 
   it "compiles a clone command using --depth for shallow cloning" do
     @resource.depth 5
-    expected_cmd = "git clone --depth 5 'git://github.com/opscode/chef.git' '/my/deploy/dir'"
+    expected_cmd = 'git clone --depth 5 git://github.com/opscode/chef.git /my/deploy/dir'
     @provider.should_receive(:shell_out!).with(expected_cmd, {:log_level => :info, :log_tag => "git[web2.0 app]", :live_stream => STDOUT})
     @provider.clone
   end
 
   it "compiles a clone command with a remote other than ``origin''" do
     @resource.remote "opscode"
-    expected_cmd = "git clone -o opscode 'git://github.com/opscode/chef.git' '/my/deploy/dir'"
+    expected_cmd = 'git clone -o opscode git://github.com/opscode/chef.git /my/deploy/dir'
     @provider.should_receive(:shell_out!).with(expected_cmd, {:log_level => :info, :log_tag => "git[web2.0 app]", :live_stream => STDOUT})
     @provider.clone
   end


### PR DESCRIPTION
Escape destination path in the git clone command.
Fixes `Too many arguments.` error for destinations with spaces.

(this pull request replaces https://github.com/opscode/chef/pull/236)

@btm:
I've signed the CLA and I am listed as a approved contributor. I added a test case and fixed other tests that compare generated git commands.
