### PR TITLE
[CHEF-1398] Add check for bad RunListItems

### DIFF
--- a/chef/lib/chef/run_list/run_list_item.rb
+++ b/chef/lib/chef/run_list/run_list_item.rb
@@ -21,6 +21,7 @@ class Chef
       QUALIFIED_RECIPE             = %r{^recipe\[([^\]@]+)(@([0-9]+(\.[0-9]+){1,2}))?\]$}
       QUALIFIED_ROLE               = %r{^role\[([^\]]+)\]$}
       VERSIONED_UNQUALIFIED_RECIPE = %r{^([^@]+)(@([0-9]+(\.[0-9]+){1,2}))$}
+      FALSE_FRIEND                 = %r{[\[\]]}
 
       attr_reader :name, :type, :version
 
@@ -51,6 +52,12 @@ class Chef
             @type = :recipe
             @name = match[1]
             @version = match[3] if match[3]
+          elsif match = FALSE_FRIEND.match(item)
+            # Recipe[recipe_name]
+            # roles[role_name]
+            name = match[1]
+            raise ArgumentError, "Unable to create #{self.class} from #{item.class}:#{item.inspect}: must be recipe[#{name}] or role[#{name}]"
+
           else
             # recipe_name
             @type = :recipe

--- a/chef/spec/unit/run_list/run_list_item_spec.rb
+++ b/chef/spec/unit/run_list/run_list_item_spec.rb
@@ -69,6 +69,18 @@ describe Chef::RunList::RunListItem do
       item.to_s.should == 'recipe[lobster]'
       item.name.should == 'lobster'
     end
+
+    it "raises an exception when the string has typo on the type part" do
+      lambda {Chef::RunList::RunListItem.new("Recipe[lobster]") }.should raise_error(ArgumentError)
+    end
+
+    it "raises an exception when the string has extra space between the type and the name" do
+      lambda {Chef::RunList::RunListItem.new("recipe [lobster]") }.should raise_error(ArgumentError)
+    end
+
+    it "raises an exception when the string does not close the bracket" do
+      lambda {Chef::RunList::RunListItem.new("recipe[lobster") }.should raise_error(ArgumentError)
+    end
   end
 
   describe "comparing to other run list items" do


### PR DESCRIPTION
This commit adds extra check for RunListItems with bad type or spaces. This was taken by plain recipes.

I tried to reproduce the user cases from the ticket on the unit tests. There is one case that is related with another ticket (linked in this one) and is fixed (no closed yet) in there. That case is to add more than one item. This is really an issue from Knife so I didn't try to fix or test here.

I tried the tests and tried the user cases by hand, before and after the fix. Seems to be ok, please test it and give me some feedback.

Thanks
