### PR TITLE
Chef 2996 - Add ability to use a regexp for value_for_platform platform version specifier

### DIFF
--- a/chef/lib/chef/mixin/language.rb
+++ b/chef/lib/chef/mixin/language.rb
@@ -33,9 +33,10 @@ class Chef
         # platform_hash (Hash) a hash of the same structure as Chef::Platform,
         # like this:
         #   {
-        #     :debian => {:default => 'the value for all debian'}
-        #     [:centos, :redhat, :fedora] => {:default => "value for all EL variants"}
+        #     :debian => {:default => 'the value for all debian'},
+        #     [:centos, :redhat, :fedora] => {:default => "value for all EL variants"},
         #     :ubuntu => { :default => "default for ubuntu", '10.04' => "value for 10.04 only"},
+        #     :scientific => { /6\.\d+/ => "value for all 6.x variants" },
         #     :default => "the default when nothing else matches"
         #   }
         # * platforms can be specified as Symbols or Strings
@@ -53,6 +54,8 @@ class Chef
           platform, version = node[:platform].to_s, node[:platform_version].to_s
           if @values.key?(platform) && @values[platform].key?(version)
             @values[platform][version]
+          elsif @values.key?(platform) && @values[platform].find { |k,v| version =~ Regexp.new(k) }
+            @values[platform].find { |k,v| version =~ Regexp.new(k) }[1]
           elsif @values.key?(platform) && @values[platform].key?("default")
             @values[platform]["default"]
           elsif @values.key?("default")

--- a/chef/spec/unit/mixin/language_spec.rb
+++ b/chef/spec/unit/mixin/language_spec.rb
@@ -101,6 +101,27 @@ describe Chef::Mixin::Language do
     end
   end
 
+  describe "when platform versions includes a regex" do
+    before(:each) do
+      @platform_hash["scientific"] = { 
+        /6\.\d+/ => "scientific-6.x", 
+        "default" => "no-match" 
+      }
+    end
+
+    it "returns a platform specific value if the current platform version matches the regex" do
+      @node[:platform] = "scientific"
+      @node[:platform_version] = "6.2"
+      @language.value_for_platform(@platform_hash).should == "scientific-6.x"
+    end
+
+    it "returns a default value for the current platform if the regex is not matched" do
+      @node[:platform] = "scientific"
+      @node[:platform_version] = "5.7"
+      @language.value_for_platform(@platform_hash).should == "no-match"
+    end
+  end
+
   describe "when checking platform?" do 
     before(:each) do
       @language = LanguageTester.new


### PR DESCRIPTION
This allows you to specify a regexp to represent a platform version specifier for value_for_platform. This lets you to match on all versions or a subset of versions of a major release of a distro.

http://tickets.opscode.com/browse/CHEF-2996
