### PR TITLE
Make ubuntu10.04-gems compatible with Ubuntu 12.04 (precise)

### DIFF
--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
@@ -3,7 +3,10 @@ bash -c '
 
 if [ ! -f /usr/bin/chef-client ]; then
   apt-get update
-  apt-get install -y ruby ruby1.8-dev build-essential wget libruby-extras libruby1.8-extras
+  apt-get install -y ruby ruby1.8-dev build-essential wget
+  if [[ $(apt-cache search libruby-extras) ]]; then
+    apt-get install -y libruby-extras libruby1.8-extras
+  fi
   cd /tmp
   wget <%= "--proxy=on " if knife_config[:bootstrap_proxy] %>http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz
   tar zxf rubygems-1.6.2.tgz


### PR DESCRIPTION
Packages libruby-extras, libruby1.8-extras were deleted in Ubuntu 12.04. Make them install only if found in apt-cache. Without this change, chef bootstrap and things like knife-ec2 fail on Ubuntu 12.04.
