### PR TITLE
Give a more informative error message for malformed keys

### DIFF
--- a/chef/lib/chef/rest/auth_credentials.rb
+++ b/chef/lib/chef/rest/auth_credentials.rb
@@ -63,7 +63,8 @@ class Chef
         raise Chef::Exceptions::PrivateKeyMissing, "I cannot read #{key_file}, which you told me to use to sign requests!"
       rescue OpenSSL::PKey::RSAError
         msg = "The file #{key_file} does not contain a correctly formatted private key.\n"
-        msg << "The key file should begin with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'"
+        msg << "The key file should begin with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'\n"
+        msg << "The key file should not contain extraneous characters"
         raise Chef::Exceptions::InvalidPrivateKey, msg
       end
 


### PR DESCRIPTION
It often happens that pasting private keys results in control codes being pasted in the private key.

In those scenarios, the error message is not very informative as the start and end line may be perfectly legit. I would prefer a more informative error message instead.
