### PR TITLE
[CHEF-3025] Add --json-attributes option to knife bootstrap

### DIFF
--- a/chef/lib/chef/knife/bootstrap.rb
+++ b/chef/lib/chef/knife/bootstrap.rb
@@ -105,6 +105,13 @@ class Chef
         :description => "Comma separated list of roles/recipes to apply",
         :proc => lambda { |o| o.split(/[\s,]+/) },
         :default => []
+      
+      option :first_boot_attributes,
+        :short => "-j JSON_ATTRIBS",
+        :long => "--json-attributes",
+        :description => "A JSON string to be added to the first run of chef-client",
+        :proc => lambda { |o| JSON.parse(o) },
+        :default => {}
 
       option :host_key_verify,
         :long => "--[no-]host-key-verify",

--- a/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
@@ -53,7 +53,7 @@ EOP
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -49,7 +49,7 @@ EOP
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/bootstrap/chef-full.erb
+++ b/chef/lib/chef/knife/bootstrap/chef-full.erb
@@ -52,7 +52,7 @@ EOP
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
@@ -36,7 +36,7 @@ EOP
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
@@ -43,7 +43,7 @@ echo 'https_proxy "knife_config[:bootstrap_proxy]"' >> /etc/chef/client.rb
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
@@ -43,7 +43,7 @@ EOP
 
 (
 cat <<'EOP'
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>
 EOP
 ) > /etc/chef/first-boot.json
 

--- a/chef/lib/chef/knife/core/bootstrap_context.rb
+++ b/chef/lib/chef/knife/core/bootstrap_context.rb
@@ -94,6 +94,10 @@ CONFIG
         def chef_version
           knife_config[:bootstrap_version] || Chef::VERSION
         end
+        
+        def first_boot
+          (@config[:first_boot_attributes] || {}).merge(:run_list => @run_list)
+        end
 
       end
     end

--- a/chef/spec/data/bootstrap/test.erb
+++ b/chef/spec/data/bootstrap/test.erb
@@ -1,1 +1,1 @@
-<%= { "run_list" => @run_list }.to_json %>
+<%= first_boot.to_json %>

--- a/chef/spec/unit/knife/bootstrap_spec.rb
+++ b/chef/spec/unit/knife/bootstrap_spec.rb
@@ -72,6 +72,13 @@ describe Chef::Knife::Bootstrap do
     @knife.parse_options(["-r", "role[base],recipe[cupcakes]"])
     @knife.render_template(template_string).should == '{"run_list":["role[base]","recipe[cupcakes]"]}'
   end
+  
+  it "should have foo => {bar => baz} in the first_boot" do
+    template_string = @knife.load_template(@knife.config[:template_file])
+    @knife.parse_options(["-j", '{"foo":{"bar":"baz"}}'])
+    @knife.render_template(template_string).should == '{"foo":{"bar":"baz"},"run_list":[]}'
+  end
+  
 
   it "should take the node name from ARGV" do
     @knife.name_args = ['barf']

--- a/chef/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/chef/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -104,6 +104,25 @@ EXPECTED
       @context.bootstrap_version_string.should == '--version 123.45.678'
     end
   end
+  
+  describe "when JSON attributes are given" do
+    before do
+      conf = @config.dup
+      conf[:first_boot_attributes] = {:baz => :quux}
+      @context = Chef::Knife::Core::BootstrapContext.new(conf, @run_list, @chef_config)
+    end
 
+    it "adds the attributes to first_boot" do
+      @context.first_boot.to_json.should == {:baz => :quux, :run_list => @run_list}.to_json
+    end
+  end
+  
+  describe "when JSON attributes are NOT given" do
+    it "sets first_boot equal to run_list" do
+      @context.first_boot.to_json.should == {:run_list => @run_list}.to_json
+    end
+  end
+  
+  
 end
 


### PR DESCRIPTION
[CHEF-3025] Add --json-attributes option to knife bootstrap, which will be merged into the first_boot variable in the bootstrap context along with the run list.

http://tickets.opscode.com/browse/CHEF-3025
