### PR TITLE
Minor update of readme 2012

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,7 +52,7 @@ Install the Chef Gems from source in this repository.
 Install the following RubyGems:
 
 * rake
-* rspec (2.5.0)
+* rspec (2.8.0)
 * dep_selector (requires Gecode to compile native extensions)
 
 Run rake or rake spec:
@@ -134,7 +134,7 @@ Documentation:
 Chef - A configuration management system
 
 Author:: Adam Jacob (<adam@opscode.com>)
-Copyright:: Copyright (c) 2008-2011 Opscode, Inc.
+Copyright:: Copyright (c) 2008-2012 Opscode, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-server-api/README.rdoc
+++ b/chef-server-api/README.rdoc
@@ -12,19 +12,19 @@ I'm in ur netwerk, cookin up yer servers. :)
 
 chef:
 
-*  ruby-openid  
-*  json  
-*  erubis  
-*  stomp  
-*  ohai  
+*  ruby-openid
+*  json
+*  erubis
+*  stomp
+*  ohai
 
 chef-server and the chef-server-api (merb slice), same requires as chef above, plus:
 
-*  merb-core 
-*  merb-haml 
+*  merb-core
+*  merb-haml
 *  thin
 *  haml
-*  ruby-openid 
+*  ruby-openid
 *  syntax
 
 Interim Note:
@@ -46,10 +46,10 @@ External Servers:
 Install all of the above.  To fire up a develpment environment, do the following:
 
   * Start CouchDB with 'couchdb'
-  * Start stompserver with 'stompserver' 
+  * Start stompserver with 'stompserver'
   * Start chef-indexer with:
 
-    chef-indexer -l debug 
+    chef-indexer -l debug
 
   * Start chef-server:
 
@@ -57,7 +57,7 @@ Install all of the above.  To fire up a develpment environment, do the following
 
   * Test run chef to begin node registration:
 
-    sudo ./bin/chef-client 
+    sudo ./bin/chef-client
 
   * Validate the node registration:
 
@@ -67,14 +67,14 @@ Install all of the above.  To fire up a develpment environment, do the following
 
   * Test run chef with:
 
-    chef-client 
+    chef-client
 
 == LICENSE:
 
 Chef - A configuration management system
 
 Author:: Adam Jacob (<adam@opscode.com>)
-Copyright:: Copyright (c) 2008 Opscode, Inc.
+Copyright:: Copyright (c) 2008-2012 Opscode, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-server/README.rdoc
+++ b/chef-server/README.rdoc
@@ -12,7 +12,7 @@ Chef Server is a meta package. It only exists to depend on the other packages ne
 Chef Server - The server component of the Chef configuration management system
 
 Author:: Adam Jacob (<adam@opscode.com>)
-Copyright:: Copyright (c) 2008, 2009, 2010 Opscode, Inc.
+Copyright:: Copyright (c) 2008-2012 Opscode, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-solr/README.rdoc
+++ b/chef-solr/README.rdoc
@@ -9,4 +9,4 @@ For more information, see the following pages on the Chef Wiki:
 
 == Copyright
 
-Copyright (c) 2009 Adam Jacob. See LICENSE for details.
+Copyright (c) 2009-2012 Adam Jacob. See LICENSE for details.

--- a/chef/README.rdoc
+++ b/chef/README.rdoc
@@ -155,7 +155,7 @@ Documentation:
 Chef - A configuration management system
 
 Author:: Adam Jacob (<adam@opscode.com>)
-Copyright:: Copyright (c) 2008, 2009 Opscode, Inc.
+Copyright:: Copyright (c) 2008-2012 Opscode, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Update &copy; up to 2012.
- Remove some trailing spaces.
- Require RSpec 2.8.0 instead of 2.5.0.
