### PR TITLE
[CHEF-2744] check for the length only if it has config[:attribute] defined

### DIFF
--- a/chef/lib/chef/knife/core/generic_presenter.rb
+++ b/chef/lib/chef/knife/core/generic_presenter.rb
@@ -70,7 +70,7 @@ class Chef
             require 'stringio'
             # If you were looking for some attribute and there is only one match
             # just dump the attribute value
-            if data.length == 1 and config[:attribute]
+            if config[:attribute] and data.length == 1
               data.values[0]
             else
               out = StringIO.new


### PR DESCRIPTION
The `if` stament just need to check for the `length` if we looking for an attribute. In that case, the `data` will be a `Hash` (with the results) which do has a `length` method.
