### PR TITLE
Configurable lazy loading of template, cookbook_file

### DIFF
--- a/chef/lib/chef/cookbook_version.rb
+++ b/chef/lib/chef/cookbook_version.rb
@@ -351,8 +351,11 @@ class Chef
 
       # files and templates are lazily loaded, and will be done later.
       eager_segments = COOKBOOK_SEGMENTS.dup
-      eager_segments.delete(:files)
-      eager_segments.delete(:templates)
+
+      unless Chef::Config[:no_lazy_load] then
+        eager_segments.delete(:files)
+        eager_segments.delete(:templates)
+      end
 
       eager_segments.each do |segment|
         segment_filenames = Array.new


### PR DESCRIPTION
This change makes lazy loading behavior configurable.

To disable lazy loads, just add 'no_lazy_load true' to client.rb.

The reason for the change is that when running with Hosted Chef, lazy loads lead Hosted Chef to generate temporary S3 URLs at compile time for cookbook_file and template resources.  The URLs expire after one hour, and that was breaking a long Chef run that's necessary to get an instance of my application up and running.

I filed this bug on this issue: http://tickets.opscode.com/browse/CHEF-3045
