### PR TITLE
[CHEF-3067] Add bitmap attribute to the mdadm resource.

### DIFF
--- a/chef/lib/chef/provider/mdadm.rb
+++ b/chef/lib/chef/provider/mdadm.rb
@@ -51,7 +51,7 @@ class Chef
 
       def action_create
         unless @current_resource.exists
-          command = "yes | mdadm --create #{@new_resource.raid_device} --chunk=#{@new_resource.chunk} --level #{@new_resource.level} --metadata=#{@new_resource.metadata} --raid-devices #{@new_resource.devices.length} #{@new_resource.devices.join(" ")}"
+          command = "yes | mdadm --create #{@new_resource.raid_device} --chunk=#{@new_resource.chunk} --level #{@new_resource.level} --metadata=#{@new_resource.metadata} --bitmap=#{@new_resource.bitmap} --raid-devices #{@new_resource.devices.length} #{@new_resource.devices.join(" ")}"
           Chef::Log.debug("#{@new_resource} mdadm command: #{command}")
           #pid, stdin, stdout, stderr = popen4(command)
           shell_out!(command)

--- a/chef/lib/chef/resource/mdadm.rb
+++ b/chef/lib/chef/resource/mdadm.rb
@@ -31,6 +31,7 @@ class Chef
         @exists = false
         @level = 1
         @metadata = "0.90"
+        @bitmap = "none"
         @raid_device = name
 
         @action = :create
@@ -72,6 +73,14 @@ class Chef
       def metadata(arg=nil)
         set_or_return(
           :metadata,
+          arg,
+          :kind_of => [ String ]
+        )
+      end
+
+      def bitmap(arg=nil)
+        set_or_return(
+          :bitmap,
           arg,
           :kind_of => [ String ]
         )

--- a/chef/spec/unit/provider/mdadm_spec.rb
+++ b/chef/spec/unit/provider/mdadm_spec.rb
@@ -71,7 +71,7 @@ describe "initialize" do
     describe "when creating the metadevice" do
       it "should create the raid device if it doesnt exist" do
         @current_resource.exists(false)
-        expected_command = "yes | mdadm --create /dev/md1 --chunk=256 --level 1 --metadata=0.90 --raid-devices 2 /dev/sdz1 /dev/sdz2"
+        expected_command = "yes | mdadm --create /dev/md1 --chunk=256 --level 1 --metadata=0.90 --bitmap=none --raid-devices 2 /dev/sdz1 /dev/sdz2"
         @provider.should_receive(:shell_out!).with(expected_command)
         @provider.action_create
       end

--- a/chef/spec/unit/resource/mdadm_spec.rb
+++ b/chef/spec/unit/resource/mdadm_spec.rb
@@ -63,6 +63,11 @@ describe Chef::Resource::Mdadm do
     @resource.metadata.should eql("1.2")
   end
 
+  it "should allow you to set the bitmap attribute" do
+    @resource.metadata "internal"
+    @resource.metadata.should eql("internal")
+  end
+
   it "should allow you to set the devices attribute" do
     @resource.devices ["/dev/sda", "/dev/sdb"]
     @resource.devices.should eql(["/dev/sda", "/dev/sdb"])


### PR DESCRIPTION
The `mdadm` resource does not currently allow you to create an array with a write-intent bitmap. Exposing this attribute would allow people to create arrays that rebuild/recovery quicker: https://raid.wiki.kernel.org/articles/w/r/i/Write-intent_bitmap.html
