### PR TITLE
CHEF-2627: run() and ssh_command() of Chef::Knife::Ssh should return the exit status of the SSH command executed

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -178,6 +178,7 @@ class Chef
       end
 
       def ssh_command(command, subsession=nil)
+        exit_status = 0
         subsession ||= session
         command = fixup_sudo(command)
         subsession.open_channel do |ch|
@@ -190,9 +191,13 @@ class Chef
                 ichannel.send_data("#{get_password}\n")
               end
             end
+            ch.on_request "exit-status" do |ichannel, data|
+              exit_status = data.read_long
+            end
           end
         end
         session.loop
+        exit_status
       end
 
       def get_password
@@ -363,6 +368,7 @@ class Chef
         configure_identity_file
         configure_session
 
+        exit_status =
         case @name_args[1]
         when "interactive"
           interactive
@@ -379,6 +385,7 @@ class Chef
         end
 
         session.close
+        exit_status
       end
 
     end


### PR DESCRIPTION
Hello Chef,

This patch to resolve CHEF-2627 (http://tickets.opscode.com/browse/CHEF-2627). It's inspired by the code snippet in Ironfan project : https://github.com/infochimps-labs/ironfan/blob/master/lib/chef/knife/cluster_ssh.rb#L100

I have tested it manually. Please take a look :)

Thanks!
Jesse Hu
