### PR TITLE
The execute resource should accept both arrays and strings.

### DIFF
--- a/chef/lib/chef/resource/execute.rb
+++ b/chef/lib/chef/resource/execute.rb
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, Array ]
         )
       end
 

--- a/chef/spec/unit/resource/execute_spec.rb
+++ b/chef/spec/unit/resource/execute_spec.rb
@@ -33,9 +33,21 @@ describe Chef::Resource::Execute do
     @resource.command.should eql("some command")
   end
 
+  it "should accept an array on instantiation, too" do
+    resource = Chef::Resource::Execute.new(%w{something else})
+    resource.should be_a_kind_of(Chef::Resource)
+    resource.should be_a_kind_of(Chef::Resource::Execute)
+    resource.command.should eql(%w{something else})
+  end
+
   it "should accept a string for the command to run" do
     @resource.command "something"
     @resource.command.should eql("something")
+  end
+
+  it "should accept an array for the command to run" do
+    @resource.command %w{something else}
+    @resource.command.should eql(%w{something else})
   end
 
   it "should accept a string for the cwd" do


### PR DESCRIPTION
Arrays are already handled correctly by the execute provider (via Shellout) when
passed as the name of the execute resource, so this isn't really new behavior.
