### PR TITLE
[CHEF-3106] - fix default path for checksum cache

### DIFF
--- a/chef/lib/chef/config.rb
+++ b/chef/lib/chef/config.rb
@@ -253,7 +253,7 @@ class Chef
     # Checksum Cache
     # Uses Moneta on the back-end
     cache_type "BasicFile"
-    cache_options({ :path => platform_specific_path("/etc/chef/cache/checksums"), :skip_expires => true })
+    cache_options({ :path => platform_specific_path("/var/chef/cache/checksums"), :skip_expires => true })
 
     # Arbitrary knife configuration data
     knife Hash.new


### PR DESCRIPTION
Change the default path for checksums in cache_options to
/var/chef/cache to be consistent with other defaults (like
file_cache_path)
