### PR TITLE
CHEF-3128 Don't unset the modification flag.

### DIFF
--- a/chef/lib/chef/mixin/enforce_ownership_and_permissions.rb
+++ b/chef/lib/chef/mixin/enforce_ownership_and_permissions.rb
@@ -31,7 +31,9 @@ class Chef
         end
         access_controls = Chef::FileAccessControl.new(new_resource, path)
         access_controls.set_all
-        new_resource.updated_by_last_action(access_controls.modified?)
+        if access_controls.modified?
+          new_resource.updated_by_last_action(true)
+        end
       end
 
     end


### PR DESCRIPTION
Previously if no permission changes were required, a newly created file could
have its modification flag unset by this mixin, which can prevent event
notifications.
