### PR TITLE
[CHEF-3130] Add knife status options

### DIFF
--- a/chef/lib/chef/knife/status.rb
+++ b/chef/lib/chef/knife/status.rb
@@ -57,7 +57,7 @@ class Chef
         end
 
         all_nodes.sort { |n1, n2|
-          if (config[:sort_reverse] || Chef::Config[:knife][:sort_status_reverse]
+          if (config[:sort_reverse] || Chef::Config[:knife][:sort_status_reverse])
             (n2["ohai_time"] or 0) <=> (n1["ohai_time"] or 0)
           else
             (n1["ohai_time"] or 0) <=> (n2["ohai_time"] or 0)


### PR DESCRIPTION
Adds the ability to filter nodes that have had a successful knife run in the past hour and a flag to filter healthy nodes from `knife status`.
