### PR TITLE
CHEF-3136: Dont always add -L chef-client CLI option

### DIFF
--- a/chef/distro/debian/etc/init.d/chef-client
+++ b/chef/distro/debian/etc/init.d/chef-client
@@ -30,7 +30,11 @@ if [ ! -d /var/run/chef ]; then
   mkdir /var/run/chef
 fi
 
-DAEMON_OPTS="-d -P $PIDFILE -L $LOGFILE -c $CONFIG -i $INTERVAL -s $SPLAY"
+DAEMON_OPTS="-d -P $PIDFILE -c $CONFIG -i $INTERVAL -s $SPLAY"
+
+if [ ! -z $LOGFILE ]; then
+  DAEMON_OPTS="${DAEMON_OPTS} -L $LOGFILE"
+fi
 
 running_pid() {
   pid=$1


### PR DESCRIPTION
The option is no longer added if LOGFILE is commented in default/chef-client, so custom loggers defined in client.rb are no longer overrider by the -L CLI option.
