### PR TITLE
Add -n option to zypper info to prevent it from blocking.

### DIFF
--- a/chef/lib/chef/provider/package/zypper.rb
+++ b/chef/lib/chef/provider/package/zypper.rb
@@ -36,7 +36,7 @@ class Chef
           version=''
           oud_version=''
           Chef::Log.debug("#{@new_resource} checking zypper")
-          status = popen4("zypper info #{@new_resource.package_name}") do |pid, stdin, stdout, stderr|
+          status = popen4("zypper -n info #{@new_resource.package_name}") do |pid, stdin, stdout, stderr|
             stdout.each do |line|
               case line
               when /^Version: (.+)$/


### PR DESCRIPTION
I just saw chef-client block on `zypper info sudo` here, and `strace` / `lsof` indicated that it was trying to read from `/dev/tty`.  No doubt this was caused by a local network issue which meant that `zypper` couldn't contact the remote repositories and was stuck in the interactive `Abort, retry, ignore?` loop.
