### PR TITLE
[CHEF-3143] - Omnibus path and gem binary fix

### DIFF
--- a/chef/lib/chef/provider/package/rubygems.rb
+++ b/chef/lib/chef/provider/package/rubygems.rb
@@ -344,6 +344,7 @@ class Chef
             # Opscode Omnibus - The ruby that ships inside omnibus is only used for Chef
             # Default to installing somewhere more functional
             gem_location = find_gem_by_path
+            @new_resource.gem_binary gem_location
             @gem_env = AlternateGemEnvironment.new(gem_location)
             Chef::Log.debug("#{@new_resource} using gem '#{gem_location}'")
           else
@@ -353,7 +354,7 @@ class Chef
         end
 
         def is_omnibus?
-          if RbConfig::CONFIG['bindir'] == "/opt/chef/embedded/bin"
+          if RbConfig::CONFIG['bindir'] =~ %r!/opt/(opscode|chef)/embedded/bin!
             Chef::Log.debug("#{@new_resource} detected omnibus installation in #{RbConfig::CONFIG['bindir']}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3143

The check for the omnibus path should be a regular expression so it
can detect either /opt/opscode or /opt/chef locations in the event
that a user upgraded an existing chef-full installation by installing
the gem.

The @new_resource.gem_binary path should be set to the detected gem
binary location (via find_gem_by_path), else it will be nil and cause
the gem to be installed through the API, instead of using the binary.
