### PR TITLE
[#CHEF-2760] Allow search query strings to include '/' (forward-slash) characters

### DIFF
--- a/chef/lib/chef/solr_query/lucene.treetop
+++ b/chef/lib/chef/solr_query/lucene.treetop
@@ -129,15 +129,15 @@ grammar Lucene
   end
 
   rule valid_letter
-    start_letter+ ([a-zA-Z0-9*?_.-] / '\\' special_char)*
+    start_letter+ ([a-zA-Z0-9*?_.-/] / '\\' special_char)*
   end
 
   rule start_letter
-    [a-zA-Z0-9._*] / '\\' special_char
+    [a-zA-Z0-9._*/] / '\\' special_char
   end
 
   rule end_letter
-    [a-zA-Z0-9*?_.] / '\\' special_char
+    [a-zA-Z0-9*?_./] / '\\' special_char
   end
 
   rule special_char


### PR DESCRIPTION
This was the solution that I posted in the comments. I have confirmed it to work as expected in my own chef deployment.
