### PR TITLE
Fix Incorrect Version Number

### DIFF
--- a/chef/lib/chef/version.rb
+++ b/chef/lib/chef/version.rb
@@ -17,7 +17,7 @@
 
 class Chef
   CHEF_ROOT = File.dirname(File.expand_path(File.dirname(__FILE__)))
-  VERSION = '10.12.0'
+  VERSION = '0.10.12'
 end
 
 # NOTE: the Chef::Version class is defined in version_class.rb


### PR DESCRIPTION
- version was listed as 10.12.0 instead of 0.10.12, isn't that a mistake?
- to remove bad version: sudo gem uninstall chef -v 10.12.0
