### PR TITLE
don't mask missing file errors when trying to read the config

### DIFF
--- a/chef/lib/chef/application.rb
+++ b/chef/lib/chef/application.rb
@@ -82,6 +82,8 @@ class Chef::Application
         ::File::open(config[:config_file]) { |f| apply_config(f.path) }
       end
     rescue Errno::ENOENT => error
+      raise error unless error.message =~ /#{config[:config_file]}$/
+
       Chef::Log.warn("*****************************************")
       Chef::Log.warn("Did not find config file: #{config[:config_file]}, using command line options.")
       Chef::Log.warn("*****************************************")


### PR DESCRIPTION
I ran into a problem getting "Did not find config file: config/solo.rb" when it was definitely there, and after poking around in the code realized what was happening - within a library called from config/solo.rb, I was trying to read another file, which was missing. However the rescue block for reading the config assumes Errno::ENOENT means the config file itself was missing

This fix is a bit hack-ish - there's probably a bunch of better solutions, but I wanted to point out the problem and provide at least a minimal fix
