### PR TITLE
[CHEF-3330] Added functionality to create standard chef repo out of knife

### DIFF
--- a/chef/spec/unit/knife/repo_create_spec.rb
+++ b/chef/spec/unit/knife/repo_create_spec.rb
@@ -1,6 +1,0 @@
-require 'spec_helper'
-require 'tmpdir'
-
-describe Chef::Knife::RepoCreate do
-
-end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3330

The current way to get a canonical chef repository is to create it yourself (which is error prone) or clone it from opscode/chef-repo. There are two problems with cloning the chef-repo:
1. Cloning brings the git history along with it, bulking up the history of your repository in general.
2. You'll have to tweak your remotes to switch origin to upstream and create a new origin.

I built out the functionality as a knife task (`knife repo create NAME`) to automate the creation of the directory structure and standard files (readmes and Rakefile). You can pass `-p /path/to/repo` to create the repo in a different directory than the current one.

I didn't include any tests, since it is just building a directory and file structure without any dynamic elements. I mirrored how this was done from the `knife cookbook create` task.

The only thing I don't really like is keeping the text of the files in the methods themselves and I am more than open to suggestions for improving that.
