### PR TITLE
[CHEF-3237] Only appending "~/Library/LaunchAgents" when *not* running a...

### DIFF
--- a/chef/lib/chef/provider/service/macosx.rb
+++ b/chef/lib/chef/provider/service/macosx.rb
@@ -29,11 +29,8 @@ class Chef
                          /System/Library/LaunchAgents
                          /System/Library/LaunchDaemons }
 
-        def initialize(new_resource, run_context)
-          super
-          if Process.uid != 0
-            PLIST_DIRS << "~/Library/LaunchAgents"
-          end
+        if Process.uid != 0
+          PLIST_DIRS << "~/Library/LaunchAgents"
         end
 
         def load_current_resource


### PR DESCRIPTION
Only append "~/Library/LaunchAgents" when chef-client is not run as root. As root, HOME can't be resolved and the chef-client run will always return with error.
