### PR TITLE
[CHEF-3270] Ensure path is not nil

### DIFF
--- a/chef/lib/chef/mixin/path_sanity.rb
+++ b/chef/lib/chef/mixin/path_sanity.rb
@@ -22,6 +22,9 @@ class Chef
 
       def enforce_path_sanity(env=ENV)
         if Chef::Config[:enforce_path_sanity]
+          # Ensure path is not nil
+          env["PATH"] ||= ""
+
           path_separator = Chef::Platform.windows? ? ';' : ':'
           existing_paths = env["PATH"].split(path_separator)
           # ensure the Ruby and Gem bindirs are included


### PR DESCRIPTION
Otherwise when running in empty env (env -i /usr/bin/chef-client), we're ending up with something looking like:
[Fri, 06 Jul 2012 16:51:04 +0200] INFO: **\* Chef 0.10.10 ***
[Fri, 06 Jul 2012 16:51:04 +0200] FATAL: Stacktrace dumped to /var/cache/chef/chef-stacktrace.out
[Fri, 06 Jul 2012 16:51:04 +0200] FATAL: NoMethodError: private method `split' called for nil:NilClass

stacktrace.out:

<pre>
Generated at Fri Jul 06 17:01:18 +0200 2012
NoMethodError: private method `split' called for nil:NilClass
/usr/lib/ruby/vendor_ruby/chef/mixin/path_sanity.rb:26:in `enforce_path_sanity'
/usr/lib/ruby/vendor_ruby/chef/client.rb:151:in `run'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:254:in `run_application'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:241:in `loop'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:241:in `run_application'
/usr/lib/ruby/vendor_ruby/chef/application.rb:70:in `run'
</pre>
