### PR TITLE
[CHEF-2089] Add variants support to MacPorts resource and provider

### DIFF
--- a/chef/lib/chef/provider/package/macports.rb
+++ b/chef/lib/chef/provider/package/macports.rb
@@ -21,7 +21,7 @@ class Chef
         end
 
         def current_installed_version
-          command = "port installed #{@new_resource.package_name}"
+          command = "port installed #{@new_resource.package_name}#{expand_options(@new_resource.variants)}"
           output = get_response_from_command(command)
 
           response = nil
@@ -33,7 +33,7 @@ class Chef
         end
 
         def macports_candidate_version
-          command = "port info --version #{@new_resource.package_name}"
+          command = "port info --version #{@new_resource.package_name}#{expand_options(@new_resource.variants)}"
           output = get_response_from_command(command)
 
           match = output.match(/^version: (.+)$/)
@@ -43,7 +43,7 @@ class Chef
 
         def install_package(name, version)
           unless @current_resource.version == version
-            command = "port#{expand_options(@new_resource.options)} install #{name}"
+            command = "port#{expand_options(@new_resource.options)} install #{name}#{expand_options(@new_resource.variants)}"
             command << " @#{version}" if version and !version.empty? 
             run_command_with_systems_locale(
               :command => command
@@ -52,7 +52,7 @@ class Chef
         end
 
         def purge_package(name, version)
-          command = "port#{expand_options(@new_resource.options)} uninstall #{name}"
+          command = "port#{expand_options(@new_resource.options)} uninstall #{name}#{expand_options(@new_resource.variants)}"
           command << " @#{version}" if version and !version.empty?
           run_command_with_systems_locale(
             :command => command
@@ -60,7 +60,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          command = "port#{expand_options(@new_resource.options)} deactivate #{name}"
+          command = "port#{expand_options(@new_resource.options)} deactivate #{name}#{expand_options(@new_resource.variants)}"
           command << " @#{version}" if version and !version.empty?
 
           run_command_with_systems_locale(
@@ -79,7 +79,7 @@ class Chef
             install_package(name, version)
           elsif current_version != version
             run_command_with_systems_locale(
-              :command => "port#{expand_options(@new_resource.options)} upgrade #{name} @#{version}"
+              :command => "port#{expand_options(@new_resource.options)} upgrade #{name}#{expand_options(@new_resource.variants)} @#{version}"
             )
           end
         end

--- a/chef/lib/chef/resource/macports_package.rb
+++ b/chef/lib/chef/resource/macports_package.rb
@@ -23,6 +23,15 @@ class Chef
         super
         @resource_name = :macports_package
         @provider = Chef::Provider::Package::Macports
+        @variants = nil
+      end
+
+      def variants(arg=nil)
+        set_or_return(
+          :variants,
+          arg,
+          :kind_of => [ String ]
+        )
       end
     end
   end

--- a/chef/spec/unit/resource/macports_package_spec.rb
+++ b/chef/spec/unit/resource/macports_package_spec.rb
@@ -34,4 +34,13 @@ describe Chef::Resource::MacportsPackage, "initialize" do
   it "should set the provider to Chef::Provider::Package::Macports" do
     @resource.provider.should eql(Chef::Provider::Package::Macports)
   end
+
+  it "should default to a nil variants attribute" do
+    @resource.variants.should eql(nil)
+  end
+
+  it "should allow you to set the variants attribute" do
+    @resource.variants "+variant"
+    @resource.variants.should eql("+variant")
+  end
 end

--- a/features/data/cookbooks/packages/recipes/macports_install_zsh_mpcompletion.rb
+++ b/features/data/cookbooks/packages/recipes/macports_install_zsh_mpcompletion.rb
@@ -1,0 +1,4 @@
+package "zsh" do
+  action :install
+  variants "+mpcompletion"
+end

--- a/features/data/cookbooks/packages/recipes/macports_purge_zsh_mpcompletion.rb
+++ b/features/data/cookbooks/packages/recipes/macports_purge_zsh_mpcompletion.rb
@@ -1,0 +1,4 @@
+package "zsh" do
+  action :purge
+  variants "+mpcompletion"
+end

--- a/features/data/cookbooks/packages/recipes/macports_remove_zsh_mpcompletion.rb
+++ b/features/data/cookbooks/packages/recipes/macports_remove_zsh_mpcompletion.rb
@@ -1,0 +1,4 @@
+package "zsh" do
+  action :remove
+  variants "+mp_completion"
+end

--- a/features/data/cookbooks/packages/recipes/macports_upgrade_zsh_mpcompletion.rb
+++ b/features/data/cookbooks/packages/recipes/macports_upgrade_zsh_mpcompletion.rb
@@ -1,0 +1,9 @@
+package "zsh" do
+  action :remove
+  variants "+mp_completion"
+end
+
+package "zsh" do
+  action :upgrade
+  variants "+mp_completion"
+end

--- a/features/provider/package/macports.feature
+++ b/features/provider/package/macports.feature
@@ -11,9 +11,13 @@ Feature: Macports integration
     And there <should> be a binary on the path called '<binary>'
 
   Examples:
-    | recipe                                 | binary   | should     | exitcode |
-    | packages::macports_install_yydecode    | yydecode | should     | 0        |
-    | packages::macports_remove_yydecode     | yydecode | should not | 0        |
-    | packages::macports_upgrade_yydecode    | yydecode | should     | 0        |
-    | packages::macports_purge_yydecode      | yydecode | should not | 0        |
-    | packages::macports_install_bad_package | fdsafdsa | should not | 1        |
+    | recipe                                      | binary   | should     | exitcode |
+    | packages::macports_install_yydecode         | yydecode | should     | 0        |
+    | packages::macports_remove_yydecode          | yydecode | should not | 0        |
+    | packages::macports_upgrade_yydecode         | yydecode | should     | 0        |
+    | packages::macports_purge_yydecode           | yydecode | should not | 0        |
+    | packages::macports_install_bad_package      | fdsafdsa | should not | 1        |
+    | packages::macports_install_zsh_mpcompletion | zsh      | should     | 0        |
+    | packages::macports_remove_zsh_mpcompletion  | zsh      | should not | 0        |
+    | packages::macports_upgrade_zsh_mpcompletion | zsh      | should     | 0        |
+    | packages::macports_purge_zsh_mpcompletion   | zsh      | should not | 0        |


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2089

Add support for variants to Chef::Provider::Package::Macports and
Chef::Resource::MacportsPackage.
Add unit tests for both of those classes to cover new variants support.
Add cucumber feature to cover variants support in MacPorts.
