### PR TITLE
[CHEF-3273] Fix unparsable files returning empty errors

### DIFF
--- a/chef-server-webui/app/controllers/cookbooks.rb
+++ b/chef-server-webui/app/controllers/cookbooks.rb
@@ -155,6 +155,7 @@ class Cookbooks < Application
         syntax_highlight(url)
       rescue
         Chef::Log.error("Error while parsing file #{url}")
+        show_plain_file(url)
       end
     end
   end


### PR DESCRIPTION
Like forgotten vim undofiles uploaded in chef.
