### PR TITLE
Running knife with unicode input gives rise to error: "data not multiple of block length (OpenSSL::Cipher::CipherError)"

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -185,6 +185,7 @@ class Chef
         exit_status = 0
         subsession ||= session
         command = fixup_sudo(command)
+        command.force_encoding('binary')
         subsession.open_channel do |ch|
           ch.request_pty
           ch.exec command do |ch, success|


### PR DESCRIPTION
Attempting to run a unicode command via chef will give the following stacktrace.

This is traced to an underlying bug in Net::SSH. A workaround is given on the following pull request.
