### PR TITLE
knife bootstrap template for Ubuntu 12.04 which uses the omnibus package...

### DIFF
--- a/chef/lib/chef/knife/bootstrap/ubuntu12.04-apt.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu12.04-apt.erb
@@ -1,0 +1,57 @@
+bash -c '
+<%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+
+if [ ! -f /usr/bin/chef-client ]; then
+  aptitude update
+  aptitude install -y ruby ruby1.8-dev build-essential wget libruby1.8 rubygems
+fi
+
+gem update --no-rdoc --no-ri
+curl -L http://www.opscode.com/chef/install.sh | sudo bash
+
+mkdir -p /etc/chef
+
+(
+cat <<'EOP'
+<%= validation_key %>
+EOP
+) > /tmp/validation.pem
+awk NF /tmp/validation.pem > /etc/chef/validation.pem
+rm /tmp/validation.pem
+
+<% if @chef_config[:encrypted_data_bag_secret] -%>
+(
+cat <<'EOP'
+<%= encrypted_data_bag_secret %>
+EOP
+) > /tmp/encrypted_data_bag_secret
+awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+rm /tmp/encrypted_data_bag_secret
+<% end -%>
+
+<%# Generate Ohai Hints -%>
+<% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
+mkdir -p /etc/chef/ohai/hints
+<% end -%>
+
+<% @chef_config[:knife][:hints].each do |name, hash| -%>
+(
+cat <<'EOP'
+<%= hash.to_json %>
+EOP
+) > /etc/chef/ohai/hints/<%= name %>.json
+<% end -%>
+
+(
+cat <<'EOP'
+<%= config_content %>
+EOP
+) > /etc/chef/client.rb
+
+(
+cat <<'EOP'
+<%= { "run_list" => @run_list }.to_json %>
+EOP
+) > /etc/chef/first-boot.json
+
+<%= start_chef %>'


### PR DESCRIPTION
Jtimberman mentioned that starting with 10.12 the recommended method for installing chef is with the omnibus packages, so this additional bootstrap template reflects that standard.
