### PR TITLE
CHEF-3305: chef-server Gemfile improvements

### DIFF
--- a/chef-server-api/Gemfile
+++ b/chef-server-api/Gemfile
@@ -1,9 +1,11 @@
+$:.push File.expand_path("../lib", __FILE__)
+require "chef-server-api/version"
+
 source :rubygems
 
 gem 'bunny'
 gem 'uuidtools'
 gem 'ohai'
-gem 'thin'
 gem 'dep_selector'
 
 merb_gems_version = "1.1.3"
@@ -13,8 +15,13 @@ gem "merb-haml", merb_gems_version
 gem "merb-helpers", merb_gems_version
 gem "merb-param-protection", merb_gems_version
 
-gem 'chef', :path => '../chef'
-gem 'chef-solr', :path => '../chef-solr'
+gem "chef", ChefServerApi::VERSION, :require => false # load individual parts as needed
+gem "chef-solr", ChefServerApi::VERSION, :require => "chef/solr"
+
+group(:dev) do
+  gem "thin"
+  gem "pry"
+end
 
 group :test do
   gem "rake"
@@ -22,4 +29,8 @@ group :test do
   gem "rspec", "~> 2.5"
   gem "webrat"
   gem "webrat-rspec-rails"
+end
+
+group(:prod) do
+  gem "unicorn", "~> 2.0.0"
 end

--- a/chef-server-webui/Gemfile
+++ b/chef-server-webui/Gemfile
@@ -1,4 +1,27 @@
-# A sample Gemfile
-source :gemcutter
-#
-# gem "rails"
+$:.push File.expand_path("../lib", __FILE__)
+require "chef-server-webui/version"
+
+source :rubygems
+
+gem "haml"
+gem "ruby-openid"
+gem "coderay"
+
+merb_gems_version = "1.1.3"
+gem "merb-core", merb_gems_version
+gem "merb-assets", merb_gems_version
+gem "merb-haml", merb_gems_version
+gem "merb-helpers", merb_gems_version
+gem "merb-param-protection", merb_gems_version
+
+gem "chef", ChefServerWebui::VERSION, :require => false # load individual parts as needed
+gem "chef-solr", ChefServerWebui::VERSION, :require => false
+
+group(:dev) do
+  gem "thin"
+  gem "pry"
+end
+
+group(:prod) do
+  gem "unicorn", "~> 2.0.0"
+end


### PR DESCRIPTION
This patch is in support of improvements in `omnibus-chef` represented by the following PR:
https://github.com/opscode/omnibus-chef/pull/4

The main goal is to give `chef-server-api` and `chef-server-webui` grown-up Gemfile's that can be leveraged when the components are deployed in `chef-server` managed by Omnibus packages.

Associated CHEF ticket: http://tickets.opscode.com/browse/CHEF-3305
