### PR TITLE
Don't work knife ssh command on Amazon EC2 Chef Client

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -124,7 +124,11 @@ class Chef
                  q = Chef::Search::Query.new
                  @action_nodes = q.search(:node, @name_args[0])[0]
                  @action_nodes.each do |item|
-                   i = format_for_display(item)[config[:attribute]]
+                   if(item["cloud"])
+                     i = item["cloud"]["public_hostname"]
+                   else
+                     i = format_for_display(item)[config[:attribute]]
+                   end
                    r.push(i) unless i.nil?
                  end
                  r


### PR DESCRIPTION
Don't work knife ssh command on Amazon EC2 Chef Client
Because Amazon EC2 Chef Client's attribute fqdn is local host name.
I've made a patch to resolve this problem. It changes from local_host to public_hostname .
