### PR TITLE
Chef 3301

### DIFF
--- a/chef/lib/chef/application/windows_service.rb
+++ b/chef/lib/chef/application/windows_service.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef'
 require 'chef/application'
 require 'chef/client'
 require 'chef/config'


### PR DESCRIPTION
Exception handler does not provide accurate information, which should also be improved (not part of this fix). If the exception is handled immediately, the message is:

uninitialized constant Chef::Resource::Template

windows_service.rb doesn't require all of the appropriate libraries to run chef-client, and the fix resolves this issue.

http://tickets.opscode.com/browse/CHEF-3301
