### PR TITLE
skip dependency check for knife cookbook upload

### DIFF
--- a/chef/lib/chef/knife/cookbook_upload.rb
+++ b/chef/lib/chef/knife/cookbook_upload.rb
@@ -67,6 +67,10 @@ class Chef
         :long => "--include-dependencies",
         :description => "Also upload cookbook dependencies"
 
+      option :skip_dependency_check,
+        :long => "--skip-dependency-check",
+        :description => "Skips checking if the dependencies are on the server or being uploaded."
+
       def run
         # Sanity check before we load anything from the server
         unless config[:all]
@@ -200,7 +204,7 @@ WARNING
       def upload(cookbook, justify_width)
         ui.info("Uploading #{cookbook.name.to_s.ljust(justify_width + 10)} [#{cookbook.version}]")
         check_for_broken_links!(cookbook)
-        check_for_dependencies!(cookbook)
+        check_for_dependencies!(cookbook) unless config[:skip_dependency_check]
         Chef::CookbookUploader.new(cookbook, config[:cookbook_path], :force => config[:force]).upload_cookbook
       rescue Net::HTTPServerException => e
         case e.response.code

--- a/chef/spec/unit/knife/cookbook_upload_spec.rb
+++ b/chef/spec/unit/knife/cookbook_upload_spec.rb
@@ -122,6 +122,25 @@ describe Chef::Knife::CookbookUpload do
       end
     end
 
+    describe "check for dependencies" do
+      before (:each) do
+        @knife.unstub!(:upload)
+        Chef::CookbookUploader.stub_chain(:new, :upload_cookbook)
+        @knife.stub!(:check_for_broken_dependencies!)
+      end
+
+      it "should not run when --skip-dependency-check" do
+        @knife.config[:skip_dependency_check] = true
+        @knife.should_not_receive(:check_for_dependencies!)
+        @knife.run
+      end
+
+      it "should run when --skip-dependency-check is not used" do
+        @knife.should_receive(:check_for_dependencies!).once
+        @knife.run
+      end
+    end
+
     describe 'when a frozen cookbook exists on the server' do
       it 'should fail to replace it' do
         @knife.stub!(:upload).and_raise(Chef::Exceptions::CookbookFrozen)


### PR DESCRIPTION
Add skip dependency check option to knife cookbook upload to allow a user to push several cookbooks at once possible in parallel without worrying it will fail if the chef server doesn't have the cookbooks.  The reason for this is we spin up local chef server instances for development and getting that local chef server uploaded with everything quickly was a requirement.

http://tickets.opscode.com/browse/CHEF-3317
