### PR TITLE
Changing initial cookbook version to 0.1.0

### DIFF
--- a/chef/lib/chef/knife/cookbook_create.rb
+++ b/chef/lib/chef/knife/cookbook_create.rb
@@ -253,7 +253,7 @@ maintainer_email "#{email}"
 license          "#{license_name}"
 description      "Installs/Configures #{cookbook_name}"
 #{long_description}
-version          "0.0.1"
+version          "0.1.0"
 EOH
           end
         end


### PR DESCRIPTION
This is a simple change for CHEF-3321.  When using knife cookbook create, the initial cookbook version will now be 0.1.0.
