### PR TITLE
[CHEF-3324] chef-solr gets "in `reopen': closed stream (IOError)" on start

### DIFF
--- a/chef/lib/chef/application.rb
+++ b/chef/lib/chef/application.rb
@@ -112,6 +112,10 @@ class Chef::Application
       stdout_logger = Logger.new(STDOUT)
       STDOUT.sync = true
       stdout_logger.formatter = Chef::Log.logger.formatter
+      class << stdout_logger
+        def close
+        end
+      end
       Chef::Log.loggers <<  stdout_logger
     end
     Chef::Log.level = Chef::Config[:log_level]


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3324

chef-solr fails to start because of `STDOUT` is unintentionally closed and later code attempts to reopen it, thus resulting in the error. This patch is just a recommended fix.
