### PR TITLE
Create a more detailed README file

### DIFF
--- a/chef/lib/chef/knife/cookbook_create.rb
+++ b/chef/lib/chef/knife/cookbook_create.rb
@@ -212,19 +212,60 @@ EOH
 = #{cookbook_name} Cookbook
 TODO: Enter the cookbook description here.
 
+e.g.
+This cookbook makes your favorite breakfast sandwhich.
+
 == Requirements
-TODO: List your cookbook requirements.
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+==== packages
+- +toaster+ - #{cookbook_name} needs toaster to brown your bagel.
 
 == Attributes
+TODO: List you cookbook attributes here.
+
+e.g.
 ==== #{cookbook_name}::default
-- +default['#{cookbook_name}']['my_attribute']+ - this attribute does x, y, and z.
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['#{cookbook_name}']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
 
 == Usage
 ==== #{cookbook_name}::default
 TODO: Write usage instructions for each cookbook.
 
+e.g.
+Just include +#{cookbook_name}+ in your node's +run_list+:
+
+    {
+      "name":"my_node",
+      "run_list": [
+        "recipe[#{cookbook_name}]"
+      ]
+    }
+
 == Contributing
 TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write you change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
 
 == License and Authors
 Authors: TODO: List authors
@@ -235,23 +276,66 @@ EOH
 #{'='*"#{cookbook_name} Cookbook".length}
 TODO: Enter the cookbook description here.
 
+e.g.
+This cookbook makes your favorite breakfast sandwhich.
+
 Requirements
 ------------
-TODO: List your cookbook requirements.
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - #{cookbook_name} needs toaster to brown your bagel.
 
 Attributes
 ----------
+TODO: List you cookbook attributes here.
+
+e.g.
 #### #{cookbook_name}::default
-- `default['#{cookbook_name}']['my_attribute']` - this attribute does x, y, and z.
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['#{cookbook_name}']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
 
 Usage
 -----
 #### #{cookbook_name}::default
 TODO: Write usage instructions for each cookbook.
 
+e.g.
+Just include `#{cookbook_name}` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[#{cookbook_name}]"
+  ]
+}
+```
+
 Contributing
 ------------
 TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write you change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
 
 License and Authors
 -------------------
@@ -263,19 +347,48 @@ EOH
 #{'='*"#{cookbook_name} Cookbook".length}
   TODO: Enter the cookbook description here.
 
+  e.g.
+  This cookbook makes your favorite breakfast sandwhich.
+
 Requirements
-  TODO: List your cookbook requirements.
+  TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+  e.g.
+  toaster         #{cookbook_name} needs toaster to brown your bagel.
 
 Attributes
+  TODO: List you cookbook attributes here.
+
   #{cookbook_name}
-  - `default['#{cookbook_name}']['my_attribute']` - this attribute does x, y, and z.
+  Key                                   Type        Description                           Default
+  ['#{cookbook_name}']['bacon']         Boolean     whether to include bacon              true
 
 Usage
   #{cookbook_name}
   TODO: Write usage instructions for each cookbook.
 
+  e.g.
+  Just include `#{cookbook_name}` in your node's `run_list`:
+
+  [code]
+  {
+    "name":"my_node",
+    "run_list": [
+      "recipe[#{cookbook_name}]"
+    ]
+  }
+  [/code]
+
 Contributing
   TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+  e.g.
+  1. Fork the repository on Github
+  2. Create a named feature branch (like `add_component_x`)
+  3. Write you change
+  4. Write tests for your change (if applicable)
+  5. Run the tests, ensuring they all pass
+  6. Submit a Pull Request using Github
 
 License and Authors
   Authors: TODO: List authors


### PR DESCRIPTION
Ticket: http://tickets.opscode.com/browse/CHEF-3346

This PR adds a better format for the README generated with `knife cookbook create COOKBOOK`. The current one is a bit lacking. 

The hope is that, with this PR, there will be consistent formatting when viewing cookbook README files on github or other OSS systems.
