### PR TITLE
exclusively use markdown for README formatting

### DIFF
--- a/chef/lib/chef/knife/cookbook_create.rb
+++ b/chef/lib/chef/knife/cookbook_create.rb
@@ -35,11 +35,6 @@ class Chef
         :long => "--cookbook-path PATH",
         :description => "The directory where the cookbook will be created"
 
-      option :readme_format,
-        :short => "-r FORMAT",
-        :long => "--readme-format FORMAT",
-        :description => "Format of the README file, supported formats are 'md' (markdown) and 'rdoc' (rdoc)"
-
       option :cookbook_license,
         :short => "-I LICENSE",
         :long => "--license LICENSE",
@@ -72,11 +67,10 @@ class Chef
         copyright = config[:cookbook_copyright] || "YOUR_COMPANY_NAME"
         email = config[:cookbook_email] || "YOUR_EMAIL"
         license = ((config[:cookbook_license] != "false") && config[:cookbook_license]) || "none"
-        readme_format = ((config[:readme_format] != "false") && config[:readme_format]) || "md"
-        create_cookbook(cookbook_path,cookbook_name, copyright, license)
-        create_readme(cookbook_path,cookbook_name,readme_format)
-        create_changelog(cookbook_path,cookbook_name)
-        create_metadata(cookbook_path,cookbook_name, copyright, email, license,readme_format)
+        create_cookbook(cookbook_path, cookbook_name, copyright, license)
+        create_readme(cookbook_path, cookbook_name)
+        create_changelog(cookbook_path, cookbook_name)
+        create_metadata(cookbook_path, cookbook_name, copyright, email, license)
       end
 
       def create_cookbook(dir, cookbook_name, copyright, license)
@@ -193,7 +187,7 @@ This file is used to list changes made in each version of #{cookbook_name}.
 
 * Initial release of #{cookbook_name}
 
-- - - 
+- - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
 
 The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.
@@ -202,24 +196,11 @@ EOH
         end
       end
 
-      def create_readme(dir, cookbook_name,readme_format)
+      def create_readme(dir, cookbook_name)
         msg("** Creating README for cookbook: #{cookbook_name}")
-        unless File.exists?(File.join(dir, cookbook_name, "README.#{readme_format}"))
-          open(File.join(dir, cookbook_name, "README.#{readme_format}"), "w") do |file|
-            case readme_format
-            when "rdoc"
-              file.puts <<-EOH
-= DESCRIPTION:
-
-= REQUIREMENTS:
-
-= ATTRIBUTES:
-
-= USAGE:
-
-EOH
-            when "md","mkd","txt"
-              file.puts <<-EOH
+        unless File.exists?(File.join(dir, cookbook_name, "README.md"))
+          open(File.join(dir, cookbook_name, "README.md"), "w") do |file|
+            file.puts <<-EOH
 Description
 ===========
 
@@ -233,23 +214,11 @@ Usage
 =====
 
 EOH
-            else
-              file.puts <<-EOH
-Description
-
-Requirements
-
-Attributes
-
-Usage
-
-EOH
-            end
           end
         end
       end
 
-      def create_metadata(dir, cookbook_name, copyright, email, license,readme_format)
+      def create_metadata(dir, cookbook_name, copyright, email, license)
         msg("** Creating metadata for cookbook: #{cookbook_name}")
 
         license_name = case license
@@ -267,8 +236,8 @@ EOH
 
         unless File.exists?(File.join(dir, cookbook_name, "metadata.rb"))
           open(File.join(dir, cookbook_name, "metadata.rb"), "w") do |file|
-            if File.exists?(File.join(dir, cookbook_name, "README.#{readme_format}"))
-              long_description = "long_description IO.read(File.join(File.dirname(__FILE__), 'README.#{readme_format}'))"
+            if File.exists?(File.join(dir, cookbook_name, "README.md"))
+              long_description = "long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))"
             end
             file.puts <<-EOH
 maintainer       "#{copyright}"


### PR DESCRIPTION
Ticket: http://tickets.opscode.com/browse/CHEF-3347

This PR removes md support as well as the `readme_format` option for `knife cookbook create COOKBOOK` command. More details are in the ticket.
