### PR TITLE
[CHEF-3356] Adds support for environments when running under chef-solo

### DIFF
--- a/chef/lib/chef/config.rb
+++ b/chef/lib/chef/config.rb
@@ -2,7 +2,8 @@
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Christopher Brown (<cb@opscode.com>)
 # Author:: AJ Christensen (<aj@opscode.com>)
-# Author:: Mark Mzyk (mmzyk@opscode.com)
+# Author:: Mark Mzyk (<mmzyk@opscode.com>)
+# Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
 # Copyright:: Copyright (c) 2008 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -211,6 +212,8 @@ class Chef
     role_path platform_specific_path("/var/chef/roles")
 
     data_bag_path platform_specific_path("/var/chef/data_bags")
+
+    environment_path platform_specific_path("/var/chef/environments")
 
     # Where should chef-solo download recipes from?
     recipe_url nil

--- a/chef/lib/chef/exceptions.rb
+++ b/chef/lib/chef/exceptions.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Seth Falcon (<seth@opscode.com>)
+# Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
 # Copyright:: Copyright 2008-2010 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -97,9 +98,12 @@ class Chef
 
     # File operation attempted but no permissions to perform it
     class InsufficientPermissions < RuntimeError; end
-   
+
     # Ifconfig failed
     class Ifconfig < RuntimeError; end
+
+    class InvalidEnvironmentPath < ArgumentError; end
+    class EnvironmentNotFound < RuntimeError; end
 
     # Backcompat with Chef::ShellOut code:
     require 'mixlib/shellout/exceptions'

--- a/chef/spec/unit/config_spec.rb
+++ b/chef/spec/unit/config_spec.rb
@@ -1,5 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
+# Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
 # Copyright:: Copyright (c) 2008 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -173,6 +174,16 @@ describe Chef::Config do
       end
 
       Chef::Config[:data_bag_path].should == data_bag_path
+    end
+
+    it "Chef::Config[:environment_path] defaults to /var/chef/environments" do
+      environment_path = if windows?
+        "C:\\chef\\environments"
+      else
+        "/var/chef/environments"
+      end
+
+      Chef::Config[:environment_path].should == environment_path
     end
   end
 

--- a/chef/spec/unit/exceptions_spec.rb
+++ b/chef/spec/unit/exceptions_spec.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Thomas Bishop (<bishop.thomas@gmail.com>)
 # Author:: Christopher Walters (<cw@opscode.com>)
+# Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
 # Copyright:: Copyright (c) 2010 Thomas Bishop
 # Copyright:: Copyright (c) 2010 Opscode, Inc.
 # License:: Apache License, Version 2.0
@@ -8,9 +9,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +64,9 @@ describe Chef::Exceptions do
     Chef::Exceptions::ResourceNotFound => RuntimeError,
     Chef::Exceptions::InvalidResourceSpecification => ArgumentError,
     Chef::Exceptions::SolrConnectionError => RuntimeError,
-    Chef::Exceptions::InvalidDataBagPath => ArgumentError
+    Chef::Exceptions::InvalidDataBagPath => ArgumentError,
+    Chef::Exceptions::InvalidEnvironmentPath => ArgumentError,
+    Chef::Exceptions::EnvironmentNotFound => RuntimeError
   }
 
   exception_to_super_class.each do |exception, expected_super_class|


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3356

This code will add environment support when running under chef-solo without the previous requirement to load environments from a chef server via the api.  Environments may now be configured locally using files in either json or ruby dsl in the configurable evironment_path directory.
