### PR TITLE
[COOK-3358] Correct path to various gem executables.

### DIFF
--- a/chef/distro/debian/etc/init.d/chef-client
+++ b/chef/distro/debian/etc/init.d/chef-client
@@ -15,7 +15,7 @@
 # description: starts up chef-client in daemon mode.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/chef-client
+DAEMON=$(which chef-client)
 NAME=chef-client
 DESC=chef-client
 PIDFILE=/var/run/chef/client.pid

--- a/chef/distro/debian/etc/init.d/chef-expander
+++ b/chef/distro/debian/etc/init.d/chef-expander
@@ -15,7 +15,7 @@
 # description: starts up chef-expander in daemon mode.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/chef-expander
+DAEMON=$(which chef-expander)
 NAME=chef-expander
 DESC=chef-expander
 PIDFILE=/var/run/chef/expander.pid

--- a/chef/distro/debian/etc/init.d/chef-server
+++ b/chef/distro/debian/etc/init.d/chef-server
@@ -15,7 +15,7 @@
 # description: starts up chef-server webui.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/chef-server
+DAEMON=$(which chef-server)
 PIDFILE=/var/run/chef/server.%s.pid
 MAINPID=/var/run/chef/server.main.pid
 NAME=chef-server

--- a/chef/distro/debian/etc/init.d/chef-server-webui
+++ b/chef/distro/debian/etc/init.d/chef-server-webui
@@ -15,7 +15,7 @@
 # description: starts up chef-server webui.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/chef-server-webui
+DAEMON=$(which chef-server-webui)
 PIDFILE=/var/run/chef/server-webui.%s.pid
 MAINPID=/var/run/chef/server-webui.main.pid
 NAME=chef-server-webui

--- a/chef/distro/debian/etc/init.d/chef-solr
+++ b/chef/distro/debian/etc/init.d/chef-solr
@@ -15,7 +15,7 @@
 # description: starts up chef-solr in daemon mode.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/chef-solr
+DAEMON=$(which chef-solr)
 DAEMON_NAME=java
 NAME=chef-solr
 DESC=chef-solr


### PR DESCRIPTION
Rubygems is placing executables under /usr/local/bin
on Ubuntu 12.04.  When using the 'init' init_style,
the following services do not start.
  chef-solr, chef-expander, chef-server, and chef-server-webui
