### PR TITLE
[CHEF-3359] - add provider defaults for omnios

### DIFF
--- a/chef/lib/chef/platform.rb
+++ b/chef/lib/chef/platform.rb
@@ -232,6 +232,14 @@ class Chef
               :group => Chef::Provider::Group::Usermod
             }
           },
+          :omnios => {
+            :default => {
+              :service => Chef::Provider::Service::Solaris,
+              :package => Chef::Provider::Package::Ips,
+              :cron => Chef::Provider::Cron::Solaris,
+              :group => Chef::Provider::Group::Usermod
+            }
+          },
           :solaris2 => {
             :default => {
               :service => Chef::Provider::Service::Solaris,


### PR DESCRIPTION
OmniOS is a distribution of Illumos and has essentially the same
providers as OpenIndiana (SMF, IPS, etc).
