### PR TITLE
[CHEF-3383] - regression in cookbook site share

### DIFF
--- a/chef/lib/chef/knife/cookbook_site_share.rb
+++ b/chef/lib/chef/knife/cookbook_site_share.rb
@@ -50,7 +50,7 @@ class Chef
         cl = Chef::CookbookLoader.new(config[:cookbook_path])
         if cl.cookbook_exists?(cookbook_name)
           cookbook = cl[cookbook_name]
-          Chef::CookbookUploader.new(cookbook,config[:cookbook_path]).validate_cookbook
+          Chef::CookbookUploader.new(cookbook,config[:cookbook_path]).validate_cookbooks
           tmp_cookbook_dir = Chef::CookbookSiteStreamingUploader.create_build_dir(cookbook)
           begin
             Chef::Log.debug("Temp cookbook directory is #{tmp_cookbook_dir.inspect}")

--- a/chef/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/chef/spec/unit/knife/cookbook_site_share_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Knife::CookbookSiteShare do
 
     @cookbook_uploader = Chef::CookbookUploader.new('herpderp', File.join(CHEF_SPEC_DATA, 'cookbooks'), :rest => "norest")
     Chef::CookbookUploader.stub!(:new).and_return(@cookbook_uploader)
-    @cookbook_uploader.stub!(:validate_cookbook).and_return(true)
+    @cookbook_uploader.stub!(:validate_cookbooks).and_return(true)
     Chef::CookbookSiteStreamingUploader.stub!(:create_build_dir).and_return(Dir.mktmpdir)
 
     Chef::Mixin::Command.stub(:run_command).and_return(true)


### PR DESCRIPTION
- Chef::CookbookUpload#validate_cookbook was changed to
  #validate_cookbooks
- The cookbook site share command was not updated for the method
- The spec stubbed the return of #validate_cookbook as true meaning it
  wouldn't have tested this change.
