### PR TITLE
[CHEF-3393] Configure syck YAML engine for Ruby 1.9 and above

### DIFF
--- a/chef/lib/chef/encrypted_data_bag_item.rb
+++ b/chef/lib/chef/encrypted_data_bag_item.rb
@@ -22,6 +22,8 @@ require 'chef/data_bag_item'
 require 'yaml'
 require 'open-uri'
 
+YAML::ENGINE.yamler = 'syck' if RUBY_VERSION > '1.9'
+
 # An EncryptedDataBagItem represents a read-only data bag item where
 # all values, except for the value associated with the id key, have
 # been encrypted.


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3393

Chef should fixate the configuration of the YAML engine used to serialize/deserialize values in encrypted data bags.  If different YAML engines are used on one side (encryption) vs. the other (decryption) the output can be modified and escaped in funny ways.  Chef should not rely on the Ruby runtime to set this, since it effects the values end-to-end.

Here is an example of a simple encrypted data bag showing this error in output: https://gist.github.com/2564a3cc61702d3852e3

This uses knife.rb locally to swap the version of YAML::ENGINE configured between write/read.
