### PR TITLE
[CHEF-3068] Chef resources display incorrectly

### DIFF
--- a/chef/lib/chef/resource.rb
+++ b/chef/lib/chef/resource.rb
@@ -394,10 +394,10 @@ F
     end
 
     def defined_at
+      (file, line_no) = source_line.match(/(.*):(\d+)$/).matches
       if cookbook_name && recipe_name && source_line
-        "#{cookbook_name}::#{recipe_name} line #{source_line.split(':')[1]}"
+        "#{cookbook_name}::#{recipe_name} line #{line_no}"
       elsif source_line
-        file, line_no = source_line.split(':')
         "#{file} line #{line_no}"
       else
         "dynamically defined"


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3068

Chef resources display incorrectly in log files on windows due to splitting on :
