### PR TITLE
Fixed a tiny issue with the resource failure inspector

### DIFF
--- a/chef/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/chef/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -92,8 +92,8 @@ class Chef
 
         def format_line(line_nr, line)
           # Print line number as 1-indexed not zero
-          line_nr_string = (line_nr + 1).to_s.rjust(3) + ": "
-          line_nr_string + line
+          line_nr_string = (line_nr + 1).to_s.rjust(3).to_s + ": "
+          line_nr_string + line.to_s
         end
 
       end


### PR DESCRIPTION
Added ".to_s" to prevent errors in line formatting when the output contains blank lines.  I encountered this issue myself while debugging a file.  My coworker Andrew (potatosalad on github) pointed out the fix.
