### PR TITLE
fixes reopened CHEF-707 issue on OSX

### DIFF
--- a/chef/lib/chef/provider/user/dscl.rb
+++ b/chef/lib/chef/provider/user/dscl.rb
@@ -180,7 +180,11 @@ class Chef
         
         def dscl_set_gid
           unless @new_resource.gid && @new_resource.gid.to_s.match(/^\d+$/)
-            possible_gid = safe_dscl("read /Groups/#{@new_resource.gid} PrimaryGroupID").split(" ").last
+            begin
+              possible_gid = safe_dscl("read /Groups/#{@new_resource.gid} PrimaryGroupID").split(" ").last
+            rescue Chef::Exceptions::DsclCommandFailed => e
+              raise Chef::Exceptions::GroupIDNotFound.new("Group not found for #{@new_resource.gid} when creating user #{@new_resource.username}")
+            end
             @new_resource.gid(possible_gid) if possible_gid && possible_gid.match(/^\d+$/)
           end
           safe_dscl("create /Users/#{@new_resource.username} PrimaryGroupID '#{@new_resource.gid}'")

--- a/chef/spec/unit/provider/user/dscl_spec.rb
+++ b/chef/spec/unit/provider/user/dscl_spec.rb
@@ -383,7 +383,7 @@ describe Chef::Provider::User::Dscl do
       it "should raise an exception when the group does not exist" do
         shell_return = ShellCmdResult.new("<dscl_cmd> DS Error: -14136 (eDSRecordNotFound)", 'err', -14136)
         @provider.should_receive(:shell_out).with('dscl . -read /Groups/newgroup PrimaryGroupID').and_return(shell_return)
-        lambda { @provider.dscl_set_gid }.should raise_error(Chef::Exceptions::DsclCommandFailed)
+        lambda { @provider.dscl_set_gid }.should raise_error(Chef::Exceptions::GroupIDNotFound)
       end
     end
   end


### PR DESCRIPTION
Fixes CHEF-707 on OSX: User dscl Provider will map a string gid/group name to numeric group ID if possible
