### PR TITLE
[CHEF-2906] Check for exclude in base repo and add if does not exist

### DIFF
--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -7,6 +7,10 @@ if [ ! -f /usr/bin/chef-client ]; then
   wget <%= "--proxy=on " if knife_config[:bootstrap_proxy] %>http://rpm.aegisco.com/aegisco/rhel/aegisco-rhel.rpm
   rpm -Uvh aegisco-rhel.rpm
 
+  if [[ ! $(grep -w exclude=ruby* /etc/yum.repos.d/CentOS-Base.repo) ]]; then
+    sed -i "s/\[base\]/\0\n\exclude=ruby*/g" /etc/yum.repos.d/CentOS-Base.repo
+  fi
+
   yum install -y ruby ruby-devel gcc gcc-c++ automake autoconf make
 
   cd /tmp


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2906

Modify bootstrap file to add an exclude for ruby in the CentOS-Base.repo. This is done via sed just prior to the yum install commands.
