### PR TITLE
CHEF-3402 fixed: knife ssh says "No nodes returned from search!" when FQ...

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -135,7 +135,16 @@ class Chef
                  end
                  r
                end
-        (ui.fatal("No nodes returned from search!"); exit 10) if list.length == 0
+        if list.length == 0
+          if @action_nodes.length == 0
+            ui.fatal("No nodes returned from search!")
+          else
+            ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes":"node"} found, " +
+                     "but do not have the required attribute to stablish the connection. " +
+                     "Try setting another attribute to open the connection using --attribute.")
+          end
+          exit 10
+        end
         session_from_list(list)
       end
 

--- a/chef/spec/unit/knife/ssh_spec.rb
+++ b/chef/spec/unit/knife/ssh_spec.rb
@@ -94,6 +94,21 @@ describe Chef::Knife::Ssh do
           @knife.should_receive(:exit).with(10)
           @knife.configure_session
       end
+
+      context "when there are some hosts found but they do not have an attribute to connect with" do
+        before do
+          @query.stub!(:search).and_return([[@node_foo, @node_bar]])
+          @node_foo[:fqdn] = nil
+          @node_bar[:fqdn] = nil
+          Chef::Search::Query.stub!(:new).and_return(@query)
+        end
+
+        it "should raise a specific error (CHEF-3402)" do
+          @knife.ui.should_receive(:fatal).with(/^2 nodes found/)
+          @knife.should_receive(:exit).with(10)
+          @knife.configure_session
+        end
+      end
     end
 
     context "manual is set to true" do


### PR DESCRIPTION
CHEF-3402 fixed: knife ssh says "No nodes returned from search!" when FQDN attribute is missing
