### PR TITLE
CHEF-3375(2): remote_file support for URL lists to use as mirrors

### DIFF
--- a/chef/lib/chef/resource/remote_file.rb
+++ b/chef/lib/chef/resource/remote_file.rb
@@ -36,14 +36,14 @@ class Chef
         @provider = Chef::Provider::RemoteFile
       end
 
-      def source(args=nil)
-        validate_source(args) unless args.nil?
+      def source(*args)
+        if not args.empty?
+          args = args.flatten
+          validate_source(args)
+          @source = args
+        end
 
-        set_or_return(
-          :source,
-          args,
-          :kind_of => String
-        )
+        @source
       end
 
       def checksum(args=nil)
@@ -61,14 +61,17 @@ class Chef
       private
 
       def validate_source(source)
-        unless absolute_uri?(source)
-          raise Exceptions::InvalidRemoteFileURI,
-            "'#{source}' is not a valid `source` parameter for #{resource_name}. `source` must be an absolute URI"
+        raise ArgumentError, "#{resource_name} has an empty source" if source.empty?
+        source.each do |src|
+          unless absolute_uri?(src)
+            raise Exceptions::InvalidRemoteFileURI,
+              "#{src.inspect} is not a valid `source` parameter for #{resource_name}. `source` must be an absolute URI or an array of URIs."
+          end
         end
       end
 
       def absolute_uri?(source)
-        URI.parse(source).absolute?
+        source.kind_of?(String) and URI.parse(source).absolute?
       rescue URI::InvalidURIError
         false
       end

--- a/chef/spec/unit/resource/remote_file_spec.rb
+++ b/chef/spec/unit/resource/remote_file_spec.rb
@@ -46,11 +46,25 @@ describe Chef::Resource::RemoteFile do
 
     it "should accept a URI for the remote file source" do
       @resource.source "http://opscode.com/"
-      @resource.source.should eql("http://opscode.com/")
+      @resource.source.should eql([ "http://opscode.com/" ])
+    end
+
+    it "should accept an array of URIs for the remote file source" do
+      @resource.source([ "http://opscode.com/", "http://puppetlabs.com/" ])
+      @resource.source.should eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
+    end
+
+    it "should accept an multiple URIs as arguments for the remote file source" do
+      @resource.source("http://opscode.com/", "http://puppetlabs.com/")
+      @resource.source.should eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
     end
 
     it "does not accept a non-URI as the source" do
       lambda { @resource.source("not-a-uri") }.should raise_error(Chef::Exceptions::InvalidRemoteFileURI)
+    end
+
+    it "should raise and exception when source is an empty array" do
+      lambda { @resource.source([]) }.should raise_error(ArgumentError)
     end
 
   end


### PR DESCRIPTION
CHEF-3375: remote_file support for URL lists to use as mirrors
