### PR TITLE
Modified configure_session method to skip the lopp if nil item is returned.

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -129,7 +129,7 @@ class Chef
                    # if a command line attribute was not passed, and we have a cloud public_hostname, use that.
                    # see #configure_attribute for the source of config[:attribute] and config[:override_attribute]
                    if !config[:override_attribute] && item[:cloud] and item[:cloud][:public_hostname]
-                     i = item[:cloud][:public_ipv4]
+                     i = item[:cloud][:public_hostname]
                    elsif config[:override_attribute]
                      i = format_for_display(item)[config[:override_attribute]]
                    else


### PR DESCRIPTION
If we don't skip nil items then the if condition fails
with No Method error. ie.
if !config[:override_attribute] && nil[:cloud] && nil[:cloud][:public_hostname]
is obviously nonsense
