### PR TITLE
CHEF-3488: Add chef-shell to gemspec file

### DIFF
--- a/chef/chef.gemspec
+++ b/chef/chef.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_development_dependency gem, "~> 2.8.0" }
 
   s.bindir       = "bin"
-  s.executables  = %w( chef-client chef-solo knife shef )
+  s.executables  = %w( chef-client chef-solo knife chef-shell )
   s.require_path = 'lib'
   s.files = %w(Rakefile LICENSE README.rdoc) + Dir.glob("{distro,lib,tasks,spec}/**/*")
 end


### PR DESCRIPTION
Renamed shef to chef-shell in the gemspec file.

http://tickets.opscode.com/browse/CHEF-3488
