### PR TITLE
[CHEF-3489] Permit whitespace in chef-client's -o argument.

### DIFF
--- a/chef/lib/chef/client.rb
+++ b/chef/lib/chef/client.rb
@@ -453,7 +453,10 @@ class Chef
 
     # Ensures runlist override contains RunListItem instances
     def runlist_override_sanity_check!
-      @override_runlist = @override_runlist.split(',') if @override_runlist.is_a?(String)
+      # Convert to array and remove whitespace
+      if @override_runlist.is_a?(String)
+        @override_runlist = @override_runlist.split(',').map { |e| e.strip }
+      end
       @override_runlist = [@override_runlist].flatten.compact
       @override_runlist.map! do |item|
         if(item.is_a?(Chef::RunList::RunListItem))

--- a/chef/spec/unit/client_spec.rb
+++ b/chef/spec/unit/client_spec.rb
@@ -242,12 +242,16 @@ shared_examples_for Chef::Client do
       @node.chef_environment("_default")
       @node[:platform] = "example-platform"
       @node[:platform_version] = "example-platform-1.0"
+    end
 
-      @client = Chef::Client.new(nil, :override_runlist => 'role[test_role]')
-      @client.node = @node
+    it "should permit spaces in overriding run list" do
+      @client = Chef::Client.new(nil, :override_runlist => 'role[a], role[b]')
     end
 
     it "should override the run list and save original runlist" do
+      @client = Chef::Client.new(nil, :override_runlist => 'role[test_role]')
+      @client.node = @node
+
       @node.run_list << "role[role_containing_cookbook1]"
 
       override_role = Chef::Role.new


### PR DESCRIPTION
Resolves CHEF-3489 - when using the --override-runlist option, whitespace should be permitted between the items in the list.
