### PR TITLE
[CHEF-3413] Protect secret files created by bootstrap templates

### DIFF
--- a/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
@@ -17,6 +17,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -26,6 +27,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -30,6 +30,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -39,6 +40,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/chef-full.erb
+++ b/chef/lib/chef/knife/bootstrap/chef-full.erb
@@ -32,7 +32,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
-
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -42,6 +42,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
@@ -17,6 +17,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -26,6 +27,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
@@ -17,6 +17,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -26,6 +27,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
@@ -24,6 +24,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -33,6 +34,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>

--- a/chef/lib/chef/knife/bootstrap/ubuntu12.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu12.04-gems.erb
@@ -19,6 +19,7 @@ EOP
 ) > /tmp/validation.pem
 awk NF /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
+chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
 (
@@ -28,6 +29,7 @@ EOP
 ) > /tmp/encrypted_data_bag_secret
 awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
+chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
 <%# Generate Ohai Hints -%>


### PR DESCRIPTION
Set /etc/chef/validation.pem and /etc/chef/encrypted_data_bag_secret only readable by root.

This is a competing fix for #384.
