### PR TITLE
[CHEF-3514] Do not use hardcoded tmp file paths in bootstrap scripts

### DIFF
--- a/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/archlinux-gems.erb
@@ -10,19 +10,16 @@ if [ ! -f /usr/bin/chef-client ]; then
 fi
 
 mkdir -p /etc/chef
-(
-cat <<'EOP'
+
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -31,16 +28,13 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 log_level        :info
 log_location     STDOUT
 chef_server_url  "<%= @chef_config[:chef_server_url] %>"
@@ -60,12 +54,9 @@ http_proxy         "<%= knife_config[:bootstrap_proxy] %>"
 https_proxy        "<%= knife_config[:bootstrap_proxy] %>"
 <% end -%>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/centos5-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/centos5-gems.erb
@@ -26,19 +26,15 @@ gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
 
 mkdir -p /etc/chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -47,24 +43,18 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/chef-full.erb
+++ b/chef/lib/chef/knife/bootstrap/chef-full.erb
@@ -25,19 +25,15 @@ fi
 
 mkdir -p /etc/chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -46,24 +42,18 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/fedora13-gems.erb
@@ -10,19 +10,15 @@ gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
 
 mkdir -p /etc/chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -31,24 +27,18 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-apt.erb
@@ -10,19 +10,15 @@ fi
 apt-get update
 apt-get install -y chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -31,11 +27,9 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
@@ -52,10 +46,8 @@ echo 'http_proxy  "knife_config[:bootstrap_proxy]"' >> /etc/chef/client.rb
 echo 'https_proxy "knife_config[:bootstrap_proxy]"' >> /etc/chef/client.rb
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb
@@ -14,19 +14,15 @@ gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
 
 mkdir -p /etc/chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -35,24 +31,18 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'

--- a/chef/lib/chef/knife/bootstrap/ubuntu12.04-gems.erb
+++ b/chef/lib/chef/knife/bootstrap/ubuntu12.04-gems.erb
@@ -12,19 +12,15 @@ gem install chef --no-rdoc --no-ri --verbose <%= bootstrap_version_string %>
 
 mkdir -p /etc/chef
 
-(
-cat <<'EOP'
+awk NF > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-) | awk NF > /etc/chef/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
 <% if @chef_config[:encrypted_data_bag_secret] -%>
-(
-cat <<'EOP'
+awk NF > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-) | awk NF > /etc/chef/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>
 
@@ -33,24 +29,18 @@ chmod 0600 /etc/chef/encrypted_data_bag_secret
 mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-(
-cat <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= hash.to_json %>
 EOP
-) > /etc/chef/ohai/hints/<%= name %>.json
 <% end -%>
 <% end -%>
 
-(
-cat <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
-) > /etc/chef/client.rb
 
-(
-cat <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
-) > /etc/chef/first-boot.json
 
 <%= start_chef %>'


### PR DESCRIPTION
Prefer pipelines and process substitution when possible, and use `mktemp` elsewhere.

This commit is based on "10-stable" branch. Tell me if you want it to be rebased on master.
