### PR TITLE
[CHEF-1804] Add deprecation notice to 10.x tree for implicit set

### DIFF
--- a/chef/lib/chef/config.rb
+++ b/chef/lib/chef/config.rb
@@ -303,6 +303,9 @@ class Chef
     cache_type "BasicFile"
     cache_options({ :path => platform_specific_path("/var/chef/cache/checksums"), :skip_expires => true })
 
+    # Set to false to silence Chef 11 deprecation warnings:
+    chef11_deprecation_warnings true
+
     # Arbitrary knife configuration data
     knife Hash.new
 

--- a/chef/lib/chef/node.rb
+++ b/chef/lib/chef/node.rb
@@ -397,7 +397,7 @@ class Chef
 
     # Lazy initializer for tags attribute
     def tags
-      self[:tags] = [] unless attribute?(:tags)
+      self.set[:tags] = [] unless attribute?(:tags)
       self[:tags]
     end
 

--- a/chef/lib/chef/node/attribute.rb
+++ b/chef/lib/chef/node/attribute.rb
@@ -318,7 +318,24 @@ class Chef
 
       def []=(key, value)
         # If we don't have one, then we'll pretend we're normal
-        @set_type ||= :normal
+        if @set_type.nil?
+          @set_type = :normal
+          warning=<<-W
+Setting attributes without specifying a precedence is deprecated and will be
+removed in Chef 11.0. To set attributes at normal precedence, change code like:
+`node["key"] = "value"` # Not this
+to:
+`node.set["key"] = "value"` # This
+
+Called from:
+W
+
+          warning_with_line_nrs = caller[0...3].inject(warning) do |msg, source_line|
+            msg << "  #{source_line}\n"
+          end
+
+          Chef::Log.warn(warning_with_line_nrs) if Chef::Config[:chef11_deprecation_warnings]
+        end
 
         if set_unless_value_present
           if get_value(set_type_hash, key) != nil


### PR DESCRIPTION
This will trigger a warning when using code like node["foo"] = "value"

Warnings can be deactivated by setting
Chef::Config[:chef11_deprecation_warnings] to false
