### PR TITLE
[CHEF-2737] remove subtractive merge

### DIFF
--- a/chef/lib/chef/mixin/deep_merge.rb
+++ b/chef/lib/chef/mixin/deep_merge.rb
@@ -29,7 +29,13 @@ class Chef
 
       class InvalidSubtractiveMerge < ArgumentError; end
 
+
       OLD_KNOCKOUT_PREFIX = "!merge:".freeze
+
+      # Regex to match the "knockout prefix" that was used to indicate
+      # subtractive merging in Chef 10.x and previous. Subtractive merging is
+      # removed as of Chef 11, but we detect attempted use of it and raise an
+      # error (see: raise_if_knockout_used!)
       OLD_KNOCKOUT_MATCH = %r[!merge].freeze
 
       extend self
@@ -73,6 +79,7 @@ class Chef
         end
 
         raise_if_knockout_used!(source)
+        raise_if_knockout_used!(dest)
         case source
         when nil
           dest
@@ -103,12 +110,16 @@ class Chef
         dest
       end # deep_merge!
 
+      # Checks for attempted use of subtractive merge, which was removed for
+      # Chef 11.0. If subtractive merge use is detected, will raise an
+      # InvalidSubtractiveMerge exception.
       def raise_if_knockout_used!(obj)
         if uses_knockout?(obj)
           raise InvalidSubtractiveMerge, "subtractive merge with !merge is no longer supported"
         end
       end
 
+      # Checks for attempted use of subtractive merge in +obj+.
       def uses_knockout?(obj)
         case obj
         when String

--- a/chef/spec/unit/mixin/deep_merge_spec.rb
+++ b/chef/spec/unit/mixin/deep_merge_spec.rb
@@ -287,9 +287,27 @@ describe Chef::Mixin::DeepMerge do
   end
 
   describe "role_merge" do
-    it "errors out if knockout merge use is detected" do
+    it "errors out if knockout merge use is detected in an array" do
       hash_dst = {"property" => ["2","4"]}
       hash_src = {"property" => ["1","!merge:4"]}
+      lambda {@dm.role_merge(hash_dst, hash_src)}.should raise_error(Chef::Mixin::DeepMerge::InvalidSubtractiveMerge)
+    end
+
+    it "errors out if knockout merge use is detected in an array (reversed merge order)" do
+      hash_dst = {"property" => ["1","!merge:4"]}
+      hash_src = {"property" => ["2","4"]}
+      lambda {@dm.role_merge(hash_dst, hash_src)}.should raise_error(Chef::Mixin::DeepMerge::InvalidSubtractiveMerge)
+    end
+
+    it "errors out if knockout merge use is detected in a string" do
+      hash_dst = {"property" => ["2","4"]}
+      hash_src = {"property" => "!merge"}
+      lambda {@dm.role_merge(hash_dst, hash_src)}.should raise_error(Chef::Mixin::DeepMerge::InvalidSubtractiveMerge)
+    end
+
+    it "errors out if knockout merge use is detected in a string (reversed merge order)" do
+      hash_dst = {"property" => "!merge"}
+      hash_src= {"property" => ["2","4"]}
       lambda {@dm.role_merge(hash_dst, hash_src)}.should raise_error(Chef::Mixin::DeepMerge::InvalidSubtractiveMerge)
     end
   end


### PR DESCRIPTION
Removes subtractive merge from deep_merge. Attempts to detect usage of subtractive merge and will raise an error.

Also removed all the other unused features from deep_merge.
