### PR TITLE
Chef 3560: knife ssh -G user@gateway does not prompt for gateway password

### DIFF
--- a/chef/lib/chef/knife/ssh.rb
+++ b/chef/lib/chef/knife/ssh.rb
@@ -125,8 +125,10 @@ class Chef
           session.via(gw_host, gw_user || config[:ssh_user], gw_opts)
         end
       rescue Net::SSH::AuthenticationFailed
-        gw_opts.merge!(:password => prompt_for_password)
-        session.via(gw_host, gw_user || config[:ssh_user], gw_opts)
+        user = gw_user || config[:ssh_user]
+        prompt = "Enter the password for #{user}@#{gw_host}: "
+        gw_opts.merge!(:password => prompt_for_password(prompt))
+        session.via(gw_host, user, gw_opts)
       end
 
       def configure_session
@@ -235,8 +237,8 @@ class Chef
         @password ||= prompt_for_password
       end
 
-      def prompt_for_password
-        ui.ask("Enter your password: ") { |q| q.echo = false }
+      def prompt_for_password(prompt = "Enter your password: ")
+        ui.ask(prompt) { |q| q.echo = false }
       end
 
       # Present the prompt and read a single line from the console. It also

--- a/chef/spec/functional/knife/ssh_spec.rb
+++ b/chef/spec/functional/knife/ssh_spec.rb
@@ -243,7 +243,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "should prompt the user for a password" do
-        @knife.ui.should_receive(:ask).with("Enter your password: ").and_return("password")
+        @knife.ui.should_receive(:ask).with("Enter the password for user@ec2.public_hostname: ").and_return("password")
         @knife.run
       end
     end


### PR DESCRIPTION
knife ssh QUERY COMMAND -G user@gateway does not prompt for the user's gateway password.

This pull request will cause knife to prompt for the user's password if required by the gateway.
