### PR TITLE
[CHEF-3572] Fix chefignore whitespace matching

### DIFF
--- a/chef/lib/chef/cookbook/chefignore.rb
+++ b/chef/lib/chef/cookbook/chefignore.rb
@@ -20,7 +20,7 @@ class Chef
   class Cookbook
     class Chefignore
 
-      COMMENTS_AND_WHITESPACE = /^\w*(?:#.*)?$/
+      COMMENTS_AND_WHITESPACE = /^\s*(?:#.*)?$/
 
       attr_reader :ignores
 

--- a/chef/spec/data/cookbooks/chefignore
+++ b/chef/spec/data/cookbooks/chefignore
@@ -4,3 +4,5 @@
 #
 
 recipes/ignoreme.rb
+  # comments can be indented
+ignored

--- a/chef/spec/unit/cookbook/chefignore_spec.rb
+++ b/chef/spec/unit/cookbook/chefignore_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Cookbook::Chefignore do
   end
 
   it "loads the globs in the chefignore file" do
-    @chefignore.ignores.should =~ %w[recipes/ignoreme.rb]
+    @chefignore.ignores.should =~ %w[recipes/ignoreme.rb ignored]
   end
 
   it "removes items from an array that match the ignores" do
@@ -32,6 +32,7 @@ describe Chef::Cookbook::Chefignore do
   end
 
   it "determines if a file is ignored" do
+    @chefignore.ignored?('ignored').should be_true
     @chefignore.ignored?('recipes/ignoreme.rb').should be_true
     @chefignore.ignored?('recipes/dontignoreme.rb').should be_false
   end


### PR DESCRIPTION
`COMMENTS_AND_WHITESPACE` matched lines starting with word characters (`\w`) when it should have matched whitespaces (`\s`). Thus comment lines starting with spaces were not skipped but filenames with only word characters were.

Ticket: http://tickets.opscode.com/browse/CHEF-3572
