### PR TITLE
CHEF-3577: Allow ssh config port and user to be used

### DIFF
--- a/chef/lib/chef/knife/bootstrap.rb
+++ b/chef/lib/chef/knife/bootstrap.rb
@@ -51,7 +51,6 @@ class Chef
         :short => "-p PORT",
         :long => "--ssh-port PORT",
         :description => "The ssh port",
-        :default => "22",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_port] = key }
 
       option :ssh_gateway,

--- a/chef/spec/unit/knife/ssh_spec.rb
+++ b/chef/spec/unit/knife/ssh_spec.rb
@@ -180,5 +180,22 @@ describe Chef::Knife::Ssh do
     end
   end
 
+  describe "#session_from_list" do
+    before :each do
+      @knife.instance_variable_set(:@longest, 0)
+      ssh_config = {:timeout => 50, :user => "locutus", :port => 23 }
+      Net::SSH.stub!(:configuration_for).with('the.b.org').and_return(ssh_config)
+    end
+
+    it "uses the port from an ssh config file" do
+      @knife.session_from_list(['the.b.org'])
+      @knife.session.servers[0].port.should == 23
+    end
+
+    it "uses the user from an ssh config file" do
+      @knife.session_from_list(['the.b.org'])
+      @knife.session.servers[0].user.should == "locutus"
+    end
+  end
 end
 


### PR DESCRIPTION
Net::SSH::Multi takes a user argument which we pass, so we need to read
the user from the ssh_config before passing the user and use it if
applicable.

We also were sending port 22 even if the user hadn't specified a port,
due to a mixlib-cli default. This would override any port set in an
ssh config. It isn't necessary to send a port, Net::SSH will default to
22 on its own.
