### PR TITLE
CHEF-3577: Allow ssh config port and user to be used

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -51,7 +51,6 @@ class Chef
         :short => "-p PORT",
         :long => "--ssh-port PORT",
         :description => "The ssh port",
-        :default => "22",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_port] = key }
 
       option :ssh_gateway,

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -72,7 +72,6 @@ class Chef
         :short => "-p PORT",
         :long => "--ssh-port PORT",
         :description => "The ssh port",
-        :default => "22",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_port] = key }
 
       option :ssh_gateway,
@@ -169,10 +168,16 @@ class Chef
 
           hostspec = config[:ssh_user] ? "#{config[:ssh_user]}@#{item}" : item
           session_opts = {}
+
+          ssh_config = Net::SSH.configuration_for(item)
+
+          # Chef::Config[:knife][:ssh_user] is parsed in #configure_user and written to config[:ssh_user]
+          user = first_non_nil(config[:ssh_user], ssh_config[:user])
+          hostspec = user ? "#{user}@#{item}" : item
           session_opts[:keys] = File.expand_path(config[:identity_file]) if config[:identity_file]
           session_opts[:keys_only] = true if config[:identity_file]
           session_opts[:password] = config[:ssh_password] if config[:ssh_password]
-          session_opts[:port] = Chef::Config[:knife][:ssh_port] || config[:ssh_port]
+          session_opts[:port] = first_non_nil(config[:ssh_port], Chef::Config[:knife][:ssh_port], ssh_config[:port])
           session_opts[:logger] = Chef::Log.logger if Chef::Log.level == :debug
 
           if !config[:host_key_verify]
@@ -186,6 +191,11 @@ class Chef
         end
 
         session
+      end
+
+      def first_non_nil(*args)
+        args.each { |x| return x if !x.nil? }
+        nil
       end
 
       def fixup_sudo(command)

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -178,5 +178,22 @@ describe Chef::Knife::Ssh do
     end
   end
 
+  describe "#session_from_list" do
+    before :each do
+      @knife.instance_variable_set(:@longest, 0)
+      ssh_config = {:timeout => 50, :user => "locutus", :port => 23 }
+      Net::SSH.stub!(:configuration_for).with('the.b.org').and_return(ssh_config)
+    end
+
+    it "uses the port from an ssh config file" do
+      @knife.session_from_list(['the.b.org'])
+      @knife.session.servers[0].port.should == 23
+    end
+
+    it "uses the user from an ssh config file" do
+      @knife.session_from_list(['the.b.org'])
+      @knife.session.servers[0].user.should == "locutus"
+    end
+  end
 end
 


### PR DESCRIPTION
Net::SSH::Multi takes a user argument which we pass, so we need to read
the user from the ssh_config before passing the user and use it if
applicable.

We also were sending port 22 even if the user hadn't specified a port,
due to a mixlib-cli default. This would override any port set in an
ssh config. It isn't necessary to send a port, Net::SSH will default to
22 on its own.

Credits: @btm
