### PR TITLE
CHEF-3568: expand path in validation_key for bootstrap

### DIFF
--- a/chef/lib/chef/knife/core/bootstrap_context.rb
+++ b/chef/lib/chef/knife/core/bootstrap_context.rb
@@ -47,11 +47,11 @@ class Chef
         end
 
         def validation_key
-          IO.read(@chef_config[:validation_key])
+          IO.read(File.expand_path(@chef_config[:validation_key]))
         end
 
         def encrypted_data_bag_secret
-          IO.read(@chef_config[:encrypted_data_bag_secret])
+          IO.read(File.expand_path(@chef_config[:encrypted_data_bag_secret]))
         end
 
         def config_content

--- a/chef/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/chef/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -56,6 +56,13 @@ describe Chef::Knife::Core::BootstrapContext do
     @context.validation_key.should == IO.read(File.join(CHEF_SPEC_DATA, 'ssl', 'private_key.pem'))
   end
 
+  it "reads the validation key when it contains a ~" do
+    IO.should_receive(:read).with("#{ENV['HOME']}/my.key")
+    @chef_config = {:validation_key => '~/my.key'}
+    @context = Chef::Knife::Core::BootstrapContext.new(@config, @run_list, @chef_config)
+    @context.validation_key
+  end
+
   it "generates the config file data" do
     expected=<<-EXPECTED
 log_level        :info


### PR DESCRIPTION
Allows ~ in path.

Some day we should probably expand paths in Chef::Config.
Also expand encrypted data bag secret while we're in there.
