### PR TITLE
[CHEF-3597] Handle frozen strings in knife.rb chef_server_url var.

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -67,7 +67,7 @@ class Chef
     # url<String>:: String to be set for all of the chef-server-api URL's
     #
     config_attr_writer :chef_server_url do |url|
-      url.strip!
+      url = url.strip
       configure do |c|
         [ :registration_url,
           :template_url,

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -62,6 +62,14 @@ describe Chef::Config do
     it_behaves_like "server URL"
   end
 
+  context "when the url is a frozen string" do
+    before do
+      Chef::Config.chef_server_url = " https://junglist.gen.nz".freeze
+    end
+
+    it_behaves_like "server URL"
+  end
+
   describe "class method: manage_secret_key" do
     before do
       Chef::FileCache.stub!(:load).and_return(true)


### PR DESCRIPTION
**Currently being tracked as [COOK-3597](http://tickets.opscode.com/browse/COOK-3597)**

> This issue was introduced with the implementation of [CHEF-3443](http://tickets.opscode.com/browse/COOK-3443). If the value for `chef_server_url` is a frozen String (like when coming from `ENV`), a runtime error is thrown (`RuntimeError: can't modify frozen String`). Currently the URL is being striped of leading/trailing whitespace but is being mutated directly with `#strip!`.
