### PR TITLE
[CHEF-3611] Add ability to download from private AWS S3 buckets

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -249,6 +249,10 @@ class Chef
     # Where should chef-solo download recipes from?
     recipe_url nil
 
+    # Support AWS credentials for private S3 storage for recipes
+    aws_access_key_id nil
+    aws_secret_access_key nil
+
     # Sets the version of the signed header authentication protocol to use (see
     # the 'mixlib-authorization' project for more detail). Currently, versions
     # 1.0 and 1.1 are available; however, the chef-server must first be


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3611

Introduce new URL scheme s3://<bucket>/<key> for :recipe_url
that will trigger signing mechanism and convert link to https://
scheme. One could use s3:// or any other valid S3 endpoint,
like s3-eu-east-1://

Required configuration variables are:
'aws_access_key_id' and 'aws_secret_access_key' - your credentials
for secured S3 bucket.