### PR TITLE
[CHEF-3619] fix obsolete require of 'rake/rdoctask'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ require File.dirname(__FILE__) + '/lib/chef/version'
 
 require 'rubygems'
 require 'rubygems/package_task'
-require 'rake/rdoctask'
+require 'rdoc/task'
 require './tasks/rspec.rb'
 
 GEM_NAME = "chef"


### PR DESCRIPTION
'rake/doctask' has been deprecated for quite a while but since version
10.0.0, rake no longer simply warns, and now fails with a cryptic
error:

$ rake -T
rake aborted!
GONE
/home/adam/chef/Rakefile:24:in `require'
/home/adam/chef/Rakefile:24:in`<top (required)>'
/home/adam/.rvm/gems/ruby-1.9.3-p194@chef/bin/ruby_noexec_wrapper:14:in `eval'
/home/adam/.rvm/gems/ruby-1.9.3-p194@chef/bin/ruby_noexec_wrapper:14:in`<main>'
(See full trace by running task with --trace)
