### PR TITLE
CHEF-3411: Do not try to inspect recipes that do not exist

### DIFF
--- a/chef/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/chef/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -56,6 +56,7 @@ class Chef
           return nil if dynamic_resource?
           @snippet ||= begin
             if file = resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1] and line = resource.source_line[/^#{file}:([\d]+)/,1].to_i
+              return nil unless ::File.exists?(file)
               lines = IO.readlines(file)
 
               relevant_lines = ["# In #{file}\n\n"]


### PR DESCRIPTION
We can't easily look at a recipe that was written in chef-shell, so
we should try to open that 'file' because we will mask the real
exception.
