### PR TITLE
fix for chef 3386

### DIFF
--- a/distro/debian/etc/init.d/chef-client
+++ b/distro/debian/etc/init.d/chef-client
@@ -165,8 +165,10 @@ case "$1" in
   restart|force-reload)
     log_daemon_msg "Restarting $DESC" "$NAME"
     errcode=0
-    stop_server || errcode=$?
-    [ -n "$DIETIME" ] && sleep $DIETIME
+    if running ; then
+      stop_server || errcode=$?
+      [ -n "$DIETIME" ] && sleep $DIETIME
+    fi
     start_server || errcode=$?
     [ -n "$STARTTIME" ] && sleep $STARTTIME
     running || errcode=$?


### PR DESCRIPTION
Proper PID check for "restart" action

This is a fix for http://tickets.opscode.com/browse/CHEF-3386
