### PR TITLE
Fix 'knife cookbook upload --all'

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -95,7 +95,7 @@ class Chef
         @server_side_cookbooks = Chef::CookbookVersion.list_all_versions
         justify_width = @server_side_cookbooks.map {|name| name.size}.max.to_i + 2
         if config[:all]
-
+          cookbook_repo.load_cookbooks
           cbs = []
           cookbook_repo.each do |cookbook_name, cookbook|
             cbs << cookbook


### PR DESCRIPTION
Cookbooks could be uploaded individually, but attempting to load all at once was resulting in the following error against Chef 11 servers:

ERROR: The data in your request was invalid
Response: Field 'checksums' invalid

The immediate cause of this message is that knife was trying to create a sandbox with no files, which we explicitly forbid on Chef 11.

The ultimate cause of this was introduced on August 14, 2012 with commit 70c019f3.  It appears this was an incomplete refactoring of the CookbookLoader class.  Before the refactoring, a cookbook loader would load its cookbooks lazily in each method that needed them.  The refactoring made this explicit, but an explicit call was not added to the knife cookbook upload command.

This addresses CHEF-3638.
