### PR TITLE
[CHEF-3663] Search for .chef in ENV[PWD] if set

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -226,13 +226,22 @@ class Chef
       exit 10
     end
 
-    @@chef_config_dir = nil
+    def self.working_directory
+      ENV['PWD'] || Dir.pwd
+    end
+
+    def self.reset_config_path!
+      @@chef_config_dir = nil
+    end
+
+    reset_config_path!
+
 
     # search upward from current_dir until .chef directory is found
     def self.chef_config_dir
       if @@chef_config_dir.nil? # share this with subclasses
         @@chef_config_dir = false
-        full_path = Dir.pwd.split(File::SEPARATOR)
+        full_path = working_directory.split(File::SEPARATOR)
         (full_path.length - 1).downto(0) do |i|
           candidate_directory = File.join(full_path[0..i] + [".chef" ])
           if File.exist?(candidate_directory) && File.directory?(candidate_directory)


### PR DESCRIPTION
Prefer ENV["PWD"] for current working dir, but fall back to Dir.pwd if
not set. Fixes config path searching when part of the path hierarchy is
a symlinked directory.
