### PR TITLE
Quote cookbook name/version in error message

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -260,7 +260,7 @@ WARNING
         # the version is in the cookbooks being uploaded. If not, exit and warn the user.
         cookbook.metadata.dependencies.each do |cookbook_name, version|
           unless check_server_side_cookbooks(cookbook_name, version) || check_uploading_cookbooks(cookbook_name, version)
-            ui.error "Cookbook #{cookbook.name} depends on cookbook #{cookbook_name} version #{version},"
+            ui.error "Cookbook #{cookbook.name} depends on cookbook '#{cookbook_name}' version '#{version}',"
             ui.error "which is not currently being uploaded and cannot be found on the server."
             exit 1
           end


### PR DESCRIPTION
User was getting an error message:

> ERROR: Cookbook git depends on cookbook runit, version >= 0.0.0,

Issue was the metadata for git had a dependency on 'runit,'. Should
probably also add validation to metadata depends for cookbook names, but
generally quoting user-supplied values in error messages makes this kind
of issue more obvious, so this should be a worthwhile quick fix.
