### PR TITLE
Chef 3680 - fix StaleAttribute errors when converting node to JSON

### DIFF
--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -76,6 +76,10 @@ class Chef
         super(data)
       end
 
+      def dup
+        Array.new(map {|e| e.dup})
+      end
+
     end
 
     # == VividMash
@@ -183,6 +187,10 @@ class Chef
         else
           value
         end
+      end
+
+      def dup
+        Mash.new(self)
       end
 
     end

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -195,8 +195,9 @@ class Chef
       end
 
       def dup
-        Array.new(self)
+        Array.new(map {|e| e.dup })
       end
+
     end
 
     # == ImmutableMash
@@ -381,6 +382,7 @@ class Chef
       def dup
         Mash.new(self)
       end
+
     end
 
   end

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1038,6 +1038,17 @@ describe Chef::Node::Attribute do
     end
   end
 
+  describe "when not mutated" do
+
+    it "does not reset the cache when dup'd [CHEF-3680]" do
+      @attributes.default[:foo][:bar] = "set on original"
+      subtree = @attributes[:foo]
+      @attributes.default[:foo].dup[:bar] = "set on dup"
+      subtree[:bar].should == "set on original"
+    end
+
+  end
+
   describe "when setting a component attribute to a new value" do
     it "converts the input in to a VividMash tree (default)" do
       @attributes.default = {}


### PR DESCRIPTION
Error was caused because dups of Attribute collections (AttrArray and VividMash) were bumping the serial number of the root Chef::Node::Attribute, causing subsequent reads to fail. Since usually duping an object indicates that you don't intend for changes to affect the dup'ed object, I fixe the issue by making #dup convert collections to more primitive versions (with no connection to the root Chef::Node::Attribute).
