### PR TITLE
CHEF-3685: Fix rspec tests to work from the gem.

### DIFF
--- a/chef/chef.gemspec
+++ b/chef/chef.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.bindir       = "bin"
   s.executables  = %w( chef-client chef-solo knife shef )
   s.require_path = 'lib'
-  s.files = %w(Rakefile LICENSE README.rdoc) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH)
+  s.files = %w(Rakefile LICENSE README.rdoc) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 end


### PR DESCRIPTION
Some spec examples operate on .dotfiles. These files were missing
from the rubygems.org gem file.

Note that the fix (with FNM_DOTMATCH) correctly avoids the top-level
dotfiles because the glob operates only on subdirectories.
