### PR TITLE
[CHEF-2682] Redirected API requests can result in confusing error messages

### DIFF
--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -222,6 +222,9 @@ class Chef
           elsif response.kind_of?(Net::HTTPNotModified) # Must be tested before Net::HTTPRedirection because it's subclass.
             false
           elsif redirect_location = redirected_to(response)
+            if method != :GET
+              Chef::Log.warn("Following a redirect with GET, original request's method was #{method.to_s}")
+            end
             follow_redirect {api_request(:GET, create_url(redirect_location))}
           else
             # have to decompress the body before making an exception for it. But the body could be nil.


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-2682

Added a warning when following a redirect with a different method than that of the original request; this solution:
1. preserves conformity with RFC 2616, which states the following:
   "If the 301 status code is received in response to a request other than GET or HEAD, the user agent MUST NOT automatically redirect the request unless it can be confirmed by the user, since this might change the conditions under which the request was issued."
2. effectively fixes the bug by providing a non-confusing (or at least, less-confusing) log message.
