### PR TITLE
CHEF-3664 The 'map' variable is defined and never used in the set_or_return method of lib/chef/mixim/params_validate.rb

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -78,9 +78,6 @@ class Chef
           
       def set_or_return(symbol, arg, validation)
         iv_symbol = "@#{symbol.to_s}".to_sym
-        map = {
-          symbol => validation
-        }
 
         if arg == nil && self.instance_variable_defined?(iv_symbol) == true
           self.instance_variable_get(iv_symbol)


### PR DESCRIPTION
The internal 'map' variable is never used; for the sake of symmetry with the other argument passed to validate, I think 'map' should be removed altogether.

This pull request replaces https://github.com/opscode/chef/pull/518 : I thought pull requests were based on 'static' commits, hadn't realized they were based on branches instead.
