### PR TITLE
proposed chef-3471 fix - more verbose awk expression

### DIFF
--- a/lib/chef/knife/bootstrap/chef-full.erb
+++ b/lib/chef/knife/bootstrap/chef-full.erb
@@ -30,7 +30,7 @@ cat <<'EOP'
 <%= validation_key %>
 EOP
 ) > /tmp/validation.pem
-awk NF /tmp/validation.pem > /etc/chef/validation.pem
+awk "NF > 0" /tmp/validation.pem > /etc/chef/validation.pem
 rm /tmp/validation.pem
 chmod 0600 /etc/chef/validation.pem
 
@@ -40,7 +40,7 @@ cat <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
 ) > /tmp/encrypted_data_bag_secret
-awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+awk "NF > 0" /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
 rm /tmp/encrypted_data_bag_secret
 chmod 0600 /etc/chef/encrypted_data_bag_secret
 <% end -%>


### PR DESCRIPTION
I just spent the day working this through completely from the Solaris 11 perspective.; mostly same situation -- /usr/bin/awk is the old original awk that's in the default root user path, so that's kinda what we're stuck with unless some unfortunate sysadmin feels like mucking with the OS before installing chef.  We're pretty allergic to that sort of manual work here and think it best to simply remove the "gawkisms" and speak plain old generic awk so everyone can use the same script.  We need to graft in an awk instruction that'll omit blank lines across all awk versions.

The solution proposed above won't work because of the first line of the bootstrap delineates a huge single quoted string that's terminated clear at the end of the script.  Any attempt to use another single quote inline terminates that string prematurely, causing the remaining characters to play havoc on the system.

My solution, which I tested with plain old awk, nawk and GNU awk, is to simply replace the 

NR

awk expression with a more verbose expression that means the same thing and wrap it in double quotes (not single quotes that'll conflict with the body of the script as mentioned above), like so:

"NR > 0"

I forked the opscode/chef repo to jritorto/chef, made the adjustment and have submitted a pull request to opscode.  Diff here: https://github.com/jritorto/chef/commit/0020eb99ef69b1d24f6cdc41b838fec1d5af33e4 . 

hope to hear back from opscode & see this live soon; thanks.

jake, modcloth ops
