### PR TITLE
Reload original knife config after knife functional tests.

### DIFF
--- a/chef/spec/functional/knife/ssh_spec.rb
+++ b/chef/spec/functional/knife/ssh_spec.rb
@@ -23,6 +23,7 @@ describe Chef::Knife::Ssh do
 
   before(:all) do
     @original_config = Chef::Config.hash_dup
+    @original_knife_config = Chef::Config[:knife].dup
     Chef::Knife::Ssh.load_deps
     @server = TinyServer::Manager.new
     @server.start
@@ -30,6 +31,7 @@ describe Chef::Knife::Ssh do
 
   after(:all) do
     Chef::Config.configuration = @original_config
+    Chef::Config[:knife] = @original_knife_config
     @server.stop
   end
 


### PR DESCRIPTION
Tested by running knife unit test after knife functional test. 

Remedy for spec/unit/knife/ssh_spec.rb:192:

  1) Chef::Knife::Ssh#session_from_list uses the port from an ssh config file
     Failure/Error: @knife.session.servers[0].port.should == 23
       expected: 23
            got: 31337 (using ==)
