### PR TITLE
[CHEF-1855] Knife cookbook upload should throw error when no metadata fi...

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -60,6 +60,9 @@ class Chef
           @metadata_filenames << File.join(@cookbook_path, "metadata.rb")
         elsif File.exists?(File.join(@cookbook_path, "metadata.json"))
           @metadata_filenames << File.join(@cookbook_path, "metadata.json")
+        else
+          Chef::Log.error "metadata.rb/metadata.json file not found at cookbook path #{@cookbook_path}"
+          raise Chef::Exceptions::MetadataNotFound, "Metadata file not found for cookbook #{cookbook_name} at #{@cookbook_path}"
         end
 
         if empty?

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -64,6 +64,7 @@ class Chef
     class AmbiguousRunlistSpecification < ArgumentError; end
     class CookbookFrozen < ArgumentError; end
     class CookbookNotFound < RuntimeError; end
+    class MetadataNotFound < RuntimeError; end
     # Cookbook loader used to raise an argument error when cookbook not found.
     # for back compat, need to raise an error that inherits from ArgumentError
     class CookbookNotFoundInRepo < ArgumentError; end

--- a/spec/data/bad-cookbooks/no-metadata-file/README.md
+++ b/spec/data/bad-cookbooks/no-metadata-file/README.md
@@ -1,0 +1,4 @@
+Description
+===========
+Sample cookbook that does not have a metadata.rb
+

--- a/spec/data/bad-cookbooks/no-metadata-file/recipes/default.rb
+++ b/spec/data/bad-cookbooks/no-metadata-file/recipes/default.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: no-metadata-file
+# Recipe:: default
+#
+
+# Not a useful recipe - just for testing purpose.

--- a/spec/data/cookbooks/angrybash/metadata.rb
+++ b/spec/data/cookbooks/angrybash/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/cookbooks/apache2/metadata.rb
+++ b/spec/data/cookbooks/apache2/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/cookbooks/borken/metadata.rb
+++ b/spec/data/cookbooks/borken/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/cookbooks/java/metadata.rb
+++ b/spec/data/cookbooks/java/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/cookbooks/openldap/metadata.rb
+++ b/spec/data/cookbooks/openldap/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/kitchen/openldap/metadata.rb
+++ b/spec/data/kitchen/openldap/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/run_context/cookbooks/dependency1/metadata.rb
+++ b/spec/data/run_context/cookbooks/dependency1/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/run_context/cookbooks/dependency2/metadata.rb
+++ b/spec/data/run_context/cookbooks/dependency2/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/run_context/cookbooks/no-default-attr/metadata.rb
+++ b/spec/data/run_context/cookbooks/no-default-attr/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/data/run_context/cookbooks/test/metadata.rb
+++ b/spec/data/run_context/cookbooks/test/metadata.rb
@@ -1,0 +1,5 @@
+maintainer        "Opscode, Inc."
+maintainer_email  "cookbooks@opscode.com"
+license           "Apache 2.0"
+description      "Test cookbook"
+version          "0.1.0"

--- a/spec/unit/cookbook/syntax_check_spec.rb
+++ b/spec/unit/cookbook/syntax_check_spec.rb
@@ -90,7 +90,8 @@ describe Chef::Cookbook::SyntaxCheck do
     @attr_files = %w{default.rb smokey.rb}.map { |f| File.join(@cookbook_path, 'attributes', f) }
     @defn_files = %w{client.rb server.rb}.map { |f| File.join(@cookbook_path, 'definitions', f)}
     @recipes = %w{default.rb gigantor.rb one.rb}.map { |f| File.join(@cookbook_path, 'recipes', f) }
-    @ruby_files = @attr_files + @defn_files + @recipes
+    @metadata_file = %w{metadata.rb}.map { |f| File.join(@cookbook_path, f) }
+    @ruby_files = @attr_files + @defn_files + @recipes + @metadata_file
 
     @template_files = %w{openldap_stuff.conf.erb openldap_variable_stuff.conf.erb test.erb}.map { |f| File.join(@cookbook_path, 'templates', 'default', f)}
 
@@ -174,8 +175,9 @@ describe Chef::Cookbook::SyntaxCheck do
         end
 
         it "does not remove the invalid file from the list of untested files" do
-          @syntax_check.untested_ruby_files.should include(File.join(@cookbook_path, 'recipes', 'default.rb'))
-          lambda { @syntax_check.validate_ruby_files }.should_not change(@syntax_check, :untested_ruby_files)
+          @syntax_check.untested_ruby_files.should match_array([File.join(@cookbook_path, 'recipes', 'default.rb'), File.join(@cookbook_path, 'metadata.rb')])
+          @syntax_check.validate_ruby_files
+          @syntax_check.untested_ruby_files.should match_array([File.join(@cookbook_path, 'recipes', 'default.rb')])
         end
 
         it "indicates that a template file has a syntax error" do

--- a/spec/unit/cookbook_loader_spec.rb
+++ b/spec/unit/cookbook_loader_spec.rb
@@ -204,4 +204,20 @@ describe Chef::CookbookLoader do
       end   
     end
   end # loading only one cookbook
+
+  describe Chef::CookbookLoader do
+    describe "load_cookbook" do
+      describe "without a metadata file" do
+        let(:cookbook_ldr) do
+          @repo_paths = [File.expand_path(File.join(CHEF_SPEC_DATA, "bad-cookbooks")) ]
+          Chef::CookbookLoader.new(@repo_paths)
+        end
+
+        it"should throw an exception and fail" do
+          expect { cookbook_ldr.load_cookbooks }.to raise_error(Chef::Exceptions::MetadataNotFound)
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-1855

re-requesting pull request to chef 11

Knife raises an exception when metadata file is not present in the cookbook folder, this will be a breaking change for chef 11
