### PR TITLE
explicitly include EnforceOwnershipAndPermissions where it's used

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -26,7 +26,6 @@ class Chef
   class Provider
     include Chef::DSL::Recipe
     include Chef::Mixin::WhyRun
-    include Chef::Mixin::EnforceOwnershipAndPermissions
 
     attr_accessor :new_resource
     attr_accessor :current_resource

--- a/lib/chef/provider/cookbook_file.rb
+++ b/lib/chef/provider/cookbook_file.rb
@@ -23,6 +23,9 @@ require 'tempfile'
 class Chef
   class Provider
     class CookbookFile < Chef::Provider::File
+
+      include Chef::Mixin::EnforceOwnershipAndPermissions
+
       def whyrun_supported?
         true
       end

--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -26,6 +26,9 @@ require 'fileutils'
 class Chef
   class Provider
     class Directory < Chef::Provider::File
+
+      include Chef::Mixin::EnforceOwnershipAndPermissions
+
       def whyrun_supported?
         true
       end

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -30,6 +30,7 @@ class Chef
 
   class Provider
     class File < Chef::Provider
+      include Chef::Mixin::EnforceOwnershipAndPermissions
       include Chef::Mixin::Checksum
       include Chef::Mixin::ShellOut
 

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -27,6 +27,8 @@ require 'chef/scan_access_control'
 class Chef
   class Provider
     class Link < Chef::Provider
+
+      include Chef::Mixin::EnforceOwnershipAndPermissions
       include Chef::Mixin::ShellOut
       include Chef::Mixin::FileClass
 

--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -30,6 +30,8 @@ require 'set'
 class Chef
   class Provider
     class RemoteDirectory < Chef::Provider::Directory
+
+      include Chef::Mixin::EnforceOwnershipAndPermissions
       include Chef::Mixin::FileClass
 
       def action_create

--- a/lib/chef/provider/remote_file.rb
+++ b/lib/chef/provider/remote_file.rb
@@ -26,6 +26,8 @@ class Chef
   class Provider
     class RemoteFile < Chef::Provider::File
 
+      include Chef::Mixin::EnforceOwnershipAndPermissions
+
       def load_current_resource
         @current_resource = Chef::Resource::RemoteFile.new(@new_resource.name)
         super

--- a/lib/chef/provider/template.rb
+++ b/lib/chef/provider/template.rb
@@ -28,6 +28,7 @@ class Chef
 
     class Template < Chef::Provider::File
 
+      include Chef::Mixin::EnforceOwnershipAndPermissions
       include Chef::Mixin::Checksum
       include Chef::Mixin::Template
 
@@ -35,7 +36,7 @@ class Chef
         @current_resource = Chef::Resource::Template.new(@new_resource.name)
         super
       end
-      
+
       def define_resource_requirements
         super
 


### PR DESCRIPTION
`EnforceOwnershipAndPermissions` is only used for file-like providers, so it should not be included in the base provider class. Furthermore, explicitly including it into each class that uses it makes it easier to understand where the methods it defines come from.
