### PR TITLE
Stress tests randomly fail in Ci. Exclude them

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,9 @@ RSpec.configure do |config|
   config.filter_run :focus => true
   config.filter_run_excluding :external => true
 
+  # Tests that randomly fail, but may have value.
+  config.filter_run_excluding :volatile => true
+
   # Add jruby filters here
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :not_supported_on_win2k3 => true if windows_win2k3?

--- a/spec/stress/win32/security_spec.rb
+++ b/spec/stress/win32/security_spec.rb
@@ -48,14 +48,14 @@ describe 'Chef::ReservedNames::Win32::Security', :windows_only do
     FileUtils.rm_rf(@test_tempdir)
   end
 
-  it "should not leak when retrieving and reading the ACE from a file" do
+  it "should not leak when retrieving and reading the ACE from a file", :volatile do
     lambda {
       sids = Chef::ReservedNames::Win32::Security::SecurableObject.new(@monkeyfoo).security_descriptor.dacl.select { |ace| ace.sid }
       GC.start
     }.should_not leak_memory(:warmup => 50, :iterations => 100)
   end
 
-  it "should not leak when creating a new ACL and setting it on a file" do
+  it "should not leak when creating a new ACL and setting it on a file", :volatile do
     securable_object = Security::SecurableObject.new(@monkeyfoo)
     lambda {
       securable_object.dacl = Security::ACL.create([


### PR DESCRIPTION
...until someone has a chance to look at them in-depth and make them
more stable.
