### PR TITLE
fix functional test context for permissions.

### DIFF
--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -25,6 +25,8 @@ end
 describe Chef::Resource::Link, :not_supported_on_win2k3 do
   let(:file_base) { "file_spec" }
 
+  let(:expect_updated?) {true}
+
   let(:base_dir) do
     if windows?
       Chef::ReservedNames::Win32::File.get_long_path_name(Dir.tmpdir.gsub('/', '\\'))

--- a/spec/support/shared/functional/directory_resource.rb
+++ b/spec/support/shared/functional/directory_resource.rb
@@ -17,6 +17,9 @@
 #
 
 shared_examples_for "a directory resource" do
+
+  let(:expect_updated?) {true}
+
   context "when the target directory does not exist" do
     before do
       # assert pre-condition

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -149,6 +149,13 @@ shared_examples_for "a file resource" do
    # note the stripping of the drive letter from the tmpdir on windows
   let(:backup_glob) { File.join(CHEF_SPEC_BACKUP_PATH, Dir.tmpdir.sub(/^([A-Za-z]:)/, ""), "#{file_base}*") }
 
+  # Most tests update the resource, but a few do not. We need to test that the
+  # resource is marked updated or not correctly, but the test contexts are
+  # composed between correct/incorrect content and correct/incorrect
+  # permissions. We override this "let" definition in the context where content
+  # and permissions are correct.
+  let(:expect_updated?) { true }
+
   def binread(file)
     content = File.open(file, "rb") do |f|
       f.read
@@ -242,7 +249,7 @@ shared_examples_for "a file resource" do
       include_context "setup broken permissions"
 
       it_behaves_like "a file with the wrong content"
-  
+
       it_behaves_like "a securable resource"
     end
   end
@@ -258,6 +265,11 @@ shared_examples_for "a file resource" do
     end
 
     describe "and the target file has the correct permissions" do
+
+      # When permissions and content are correct, chef should do nothing and
+      # the resource should not be marked updated.
+      let(:expect_updated?) { false }
+
       include_context "setup correct permissions"
 
       it_behaves_like "a file with the correct content"


### PR DESCRIPTION
- Effectively reverts 65d5c841061401a1a71d9abd1a5da5695cc34f30. "printf
  debugging" showed that the nested context blocks were not executed at
  all, so setup for correct/incorrect permissions was not happening
  correctly
- Fixes incorrect assertion that file resources should report being
  updated when no changes were made.
