### PR TITLE
[CHEF-3774] - fixes for chef-client debian init.d script

### DIFF
--- a/chef/distro/debian/etc/default/chef-client
+++ b/chef/distro/debian/etc/default/chef-client
@@ -2,3 +2,4 @@ LOGFILE=/var/log/chef/client.log
 CONFIG=/etc/chef/client.rb
 INTERVAL=1800
 SPLAY=20
+STARTTIME=1

--- a/chef/distro/debian/etc/init.d/chef-client
+++ b/chef/distro/debian/etc/init.d/chef-client
@@ -41,7 +41,7 @@ running_pid() {
   name=$2
   [ -z "$pid" ] && return 1
   [ ! -d /proc/$pid ] &&  return 1
-  cmd=`awk '/Name:/ {print $2}' /proc/$pid/status`
+  cmd=`cat /proc/$pid/cmdline | tr '\000' '\n' | awk 'NR==2'`
   [ "$cmd" != "$name" ] &&  return 1
   return 0
 }
@@ -49,7 +49,7 @@ running_pid() {
 running() {
   [ ! -f "$PIDFILE" ] && return 1
   pid=`cat $PIDFILE`
-  running_pid $pid $NAME || return 1
+  running_pid $pid $DAEMON || return 1
   return 0
 }
 


### PR DESCRIPTION
- Add 1 second sleep on chef-client start to allow pid file to get
  created
- Inspect `/proc/PID/cmdline` instead of `status` to get full daemon name
  instead of ruby process as the name
- Use daemon name (`/usr/bin/chef-client`) instead of
  name (`chef-client`) to match the return from above inspection

The above works on an Ubuntu 12.04 system.
