### PR TITLE
[CHEF-3793] fix missing requires, add smoke test for knife

### DIFF
--- a/lib/chef/mixin/language.rb
+++ b/lib/chef/mixin/language.rb
@@ -18,6 +18,7 @@
 
 require 'chef/dsl/platform_introspection'
 require 'chef/dsl/data_query'
+require 'chef/mixin/deprecation'
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/language_include_attribute.rb
+++ b/lib/chef/mixin/language_include_attribute.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/dsl/include_attribute'
+require 'chef/mixin/deprecation'
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/language_include_recipe.rb
+++ b/lib/chef/mixin/language_include_recipe.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/dsl/include_recipe'
+require 'chef/mixin/deprecation'
 
 class Chef
   module Mixin

--- a/spec/functional/knife/smoke_test.rb
+++ b/spec/functional/knife/smoke_test.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Daniel DeLeo (<dan@opscode.com>)
+# Copyright:: Copyright (c) 2010 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe "knife smoke tests" do
+
+  # Since our specs load all code, there could be a case where knife does not
+  # run correctly b/c of a missing require, but is not caught by other tests.
+  #
+  # We run `knife -v` to verify that knife at least loads all its code.
+  it "can run and print its version" do
+    knife_path = File.expand_path("../../bin/knife", CHEF_SPEC_DATA)
+    knife_cmd = Mixlib::ShellOut.new("#{knife_path} -v")
+    knife_cmd.run_command
+    knife_cmd.error!
+    knife_cmd.stdout.should include(Chef::VERSION)
+  end
+end


### PR DESCRIPTION
Verified that the smoke test fails without patches.
