### PR TITLE
CHEF-3307: Use metadata name when loading cookbook

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -19,12 +19,14 @@ class Chef
 
 
       attr_reader :cookbook_name
+      attr_reader :cookbook_pathname
       attr_reader :cookbook_settings
       attr_reader :metadata_filenames
 
       def initialize(path, chefignore=nil)
         @cookbook_path = File.expand_path( path )
         @cookbook_name = File.basename( path )
+        @cookbook_pathname = @cookbook_name
         @chefignore = chefignore
         @metadata = Hash.new
         @relative_path = /#{Regexp.escape(@cookbook_path)}\/(.+)$/
@@ -65,13 +67,16 @@ class Chef
         if empty?
           Chef::Log.warn "found a directory #{cookbook_name} in the cookbook path, but it contains no cookbook files. skipping."
         end
+
+        cookbook_version
+
         @cookbook_settings
       end
 
       def cookbook_version
         return nil if empty?
 
-        Chef::CookbookVersion.new(@cookbook_name.to_sym).tap do |c|
+        Chef::CookbookVersion.new(@cookbook_pathname.to_sym).tap do |c|
           c.root_dir             = @cookbook_path
           c.attribute_filenames  = cookbook_settings[:attribute_filenames].values
           c.definition_filenames = cookbook_settings[:definition_filenames].values
@@ -84,6 +89,10 @@ class Chef
           c.root_filenames       = cookbook_settings[:root_filenames].values
           c.metadata_filenames   = @metadata_filenames
           c.metadata             = metadata(c)
+          if c.metadata.name
+            @cookbook_name       = c.metadata.name
+            c.name               = @cookbook_name.to_sym
+          end
         end
       end
 

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -51,6 +51,7 @@ class Chef
     attr_accessor :provider_filenames
     attr_accessor :root_filenames
     attr_accessor :name
+    attr_accessor :pathname
     attr_accessor :metadata
     attr_accessor :metadata_filenames
     attr_accessor :status
@@ -194,6 +195,7 @@ class Chef
     # object<Chef::CookbookVersion>:: Duh. :)
     def initialize(name)
       @name = name
+      @pathname = name
       @frozen = false
       @attribute_filenames = Array.new
       @definition_filenames = Array.new
@@ -707,11 +709,11 @@ class Chef
           specificity = "default"
 
           if segment == :root_files
-            matcher = segment_file.match(".+/#{Regexp.escape(name.to_s)}/(.+)")
+            matcher = segment_file.match(".+/#{Regexp.escape(pathname.to_s)}/(.+)")
             file_name = matcher[1]
             path = file_name
           elsif segment == :templates || segment == :files
-            matcher = segment_file.match("/#{Regexp.escape(name.to_s)}/(#{Regexp.escape(segment.to_s)}/(.+?)/(.+))")
+            matcher = segment_file.match("/#{Regexp.escape(pathname.to_s)}/(#{Regexp.escape(segment.to_s)}/(.+?)/(.+))")
             unless matcher
               Chef::Log.debug("Skipping file #{segment_file}, as it isn't in any of the proper directories (platform-version, platform or default)")
               Chef::Log.debug("You probably need to move #{segment_file} into the 'default' sub-directory")
@@ -721,7 +723,7 @@ class Chef
             specificity = matcher[2]
             file_name = matcher[3]
           else
-            matcher = segment_file.match("/#{Regexp.escape(name.to_s)}/(#{Regexp.escape(segment.to_s)}/(.+))")
+            matcher = segment_file.match("/#{Regexp.escape(pathname.to_s)}/(#{Regexp.escape(segment.to_s)}/(.+))")
             path = matcher[1]
             file_name = matcher[2]
           end


### PR DESCRIPTION
If a name attribute is loaded from a cookbooks metadata, use this for dependency checks and references as specified in documentation. Ensure real pathname is retained so that manifests can still be generated correctly.

In addition we must read the metadata implicitly when cookbooks are loaded to ensure we are using the correct name.

Fixes: [CHEF-3307](http://tickets.opscode.com/browse/CHEF-3307)
