### PR TITLE
[CHEF-3772] Use the sync(-s) option to get exit status.

### DIFF
--- a/lib/chef/provider/service/solaris.rb
+++ b/lib/chef/provider/service/solaris.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef/mixin/shell_out'
 require 'chef/provider/service'
 require 'chef/mixin/command'
 
@@ -23,6 +24,7 @@ class Chef
   class Provider
     class Service
       class Solaris < Chef::Provider::Service
+        include Chef::Mixin::ShellOut
 
         def initialize(new_resource, run_context=nil)
           super
@@ -42,23 +44,22 @@ class Chef
         end
 
         def enable_service
-          run_command(:command => "#{default_init_command} enable #{@new_resource.service_name}")
-          return service_status.enabled
+          shell_out!("#{default_init_command} enable -s #{@new_resource.service_name}")
         end
 
         def disable_service
-          run_command(:command => "#{default_init_command} disable #{@new_resource.service_name}")
-          return service_status.enabled
+          shell_out!("#{default_init_command} disable -s #{@new_resource.service_name}")
         end
 
         alias_method :stop_service, :disable_service
         alias_method :start_service, :enable_service
 
         def reload_service
-          run_command(:command => "#{default_init_command} refresh #{@new_resource.service_name}")
+          shell_out!("#{default_init_command} refresh #{@new_resource.service_name}")
         end
 
         def restart_service
+          ## svcadm restart doesn't supports sync(-s) option
           disable_service
           return enable_service
         end

--- a/spec/unit/provider/service/solaris_smf_service_spec.rb
+++ b/spec/unit/provider/service/solaris_smf_service_spec.rb
@@ -37,6 +37,8 @@ describe Chef::Provider::Service::Solaris do
     @pid = 2342
     @stdout_string = "state disabled"
     @stdout.stub!(:gets).and_return(@stdout_string)
+    @status = mock("Status", :exitstatus => 0, :stdout => @stdout)
+    @provider.stub!(:shell_out!).and_return(@status)
   end
 
   it "should raise an error if /bin/svcs does not exist" do
@@ -84,21 +86,22 @@ describe Chef::Provider::Service::Solaris do
 
     describe "when enabling the service" do
       before(:each) do
-        #@provider = Chef::Provider::Service::Solaris.new(@node, @new_resource)
         @provider.current_resource = @current_resource
         @current_resource.enabled(true)
       end
 
       it "should call svcadm enable -s chef" do
-        @provider.should_receive(:run_command).with({:command => "/usr/sbin/svcadm enable -s chef"})
-        @provider.should_receive(:service_status).and_return(@current_resource)
-        @provider.enable_service.should be_true
+        @new_resource.stub!(:enable_command).and_return("#{@new_resource.enable_command}")
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm enable -s #{@current_resource.service_name}").and_return(@status)
+				@provider.enable_service.should be_true
+        @current_resource.enabled.should be_true
       end
 
       it "should call svcadm enable -s chef for start_service" do
-        @provider.should_receive(:run_command).with({:command => "/usr/sbin/svcadm enable -s chef"})
-        @provider.should_receive(:service_status).and_return(@current_resource)
+        @new_resource.stub!(:start_command).and_return("#{@new_resource.start_command}")
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm enable -s #{@current_resource.service_name}").and_return(@status)
         @provider.start_service.should be_true
+        @current_resource.enabled.should be_true
       end
 
     end
@@ -111,15 +114,15 @@ describe Chef::Provider::Service::Solaris do
       end
 
       it "should call svcadm disable -s chef" do
-        @provider.should_receive(:run_command).with({:command => "/usr/sbin/svcadm disable -s chef"})
-        @provider.should_receive(:service_status).and_return(@current_resource)
-        @provider.disable_service.should be_false
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm disable -s chef").and_return(@status)
+        @provider.disable_service.should be_true
+        @current_resource.enabled.should be_false
       end
 
       it "should call svcadm disable -s chef for stop_service" do
-        @provider.should_receive(:run_command).with({:command => "/usr/sbin/svcadm disable -s chef"})
-        @provider.should_receive(:service_status).and_return(@current_resource)
-        @provider.stop_service.should be_false
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm disable -s chef")
+        @provider.stop_service.should be_true
+        @current_resource.enabled.should be_false
       end
 
     end
@@ -131,8 +134,8 @@ describe Chef::Provider::Service::Solaris do
       end
 
       it "should call svcadm refresh chef" do
-        @provider.should_receive(:run_command).with({:command => "/usr/sbin/svcadm refresh chef"}).and_return(@status)
-        @provider.reload_service.should be_true
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm refresh chef").and_return(@status)
+        @provider.reload_service
       end
 
     end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3772
-  svcadm to wait and return errors back to the provider
-  switch method from run_command to shellout!

unit test is passed.
