### PR TITLE
Relax version constraint on JSON to ~> 1.7.6

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", ">= 0.6.0"
 
   s.add_dependency "rest-client", ">= 1.0.4", "< 1.7.0"
-  s.add_dependency "json", ">= 1.4.4", "<= 1.6.1"
+  s.add_dependency "json", "~> 1.7.6"
   s.add_dependency "yajl-ruby", "~> 1.1"
   s.add_dependency "net-ssh", "~> 2.2.2"
   s.add_dependency "net-ssh-multi", "~> 1.1.0"


### PR DESCRIPTION
This fixes a number of tickets including:
- [CHEF-3824](http://tickets.opscode.com/browse/CHEF-3824)
- [CHEF-2960](http://tickets.opscode.com/browse/CHEF-2960)
- [CHEF-3712](http://tickets.opscode.com/browse/CHEF-3712)
