### PR TITLE
[CHEF-3237] Fix Mac OS X service provider. Do not fail when HOME is not set

### DIFF
--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -24,11 +24,18 @@ class Chef
       class Macosx < Chef::Provider::Service::Simple
         include Chef::Mixin::ShellOut
 
-        PLIST_DIRS = %w{~/Library/LaunchAgents
-                         /Library/LaunchAgents
+        def self.gather_plist_dirs
+          locations = %w{/Library/LaunchAgents
                          /Library/LaunchDaemons
                          /System/Library/LaunchAgents
                          /System/Library/LaunchDaemons }
+
+          locations.tap do |locations|
+            locations << '~/Library/LaunchAgents' if ENV['HOME']
+          end
+        end
+
+        PLIST_DIRS = Macosx.gather_plist_dirs
 
         def load_current_resource
           @current_resource = Chef::Resource::Service.new(@new_resource.name)
@@ -42,28 +49,28 @@ class Chef
 
         def define_resource_requirements
           #super
-          requirements.assert(:enable) do |a| 
+          requirements.assert(:enable) do |a|
             a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :enable"
           end
 
-          requirements.assert(:disable) do |a| 
+          requirements.assert(:disable) do |a|
             a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :disable"
           end
 
-          requirements.assert(:reload) do |a| 
+          requirements.assert(:reload) do |a|
             a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
           end
 
-          requirements.assert(:all_actions) do |a| 
-            a.assertion { @plist_size < 2 } 
+          requirements.assert(:all_actions) do |a|
+            a.assertion { @plist_size < 2 }
             a.failure_message Chef::Exceptions::Service, "Several plist files match service name. Please use full service name."
           end
 
-          requirements.assert(:all_actions) do |a| 
-            a.assertion { @plist_size > 0 } 
+          requirements.assert(:all_actions) do |a|
+            a.assertion { @plist_size > 0 }
             # No failrue here in original code - so we also will not
             # fail. Instead warn that the service is potentially missing
-            a.whyrun "Assuming that the service would have been previously installed and is currently disabled." do 
+            a.whyrun "Assuming that the service would have been previously installed and is currently disabled." do
               @current_resource.enabled(false)
               @current_resource.running(false)
             end

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -19,107 +19,63 @@
 require 'spec_helper'
 
 describe Chef::Provider::Service::Macosx do
-  let(:node) { Chef::Node.new }
-  let(:events) {Chef::EventDispatch::Dispatcher.new}
-  let(:run_context) { Chef::RunContext.new(node, {}, events) }
-  let(:provider) { described_class.new(new_resource, run_context) }
-  let(:stdout) { StringIO.new }
+  describe ".gather_plist_dirs" do
+    context "when HOME directory is set" do
+      it "includes users's LaunchAgents folder" do
+        described_class.gather_plist_dirs.should include("~/Library/LaunchAgents")
+      end
+    end
 
-  before do
-    Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
-    provider.stub!(:shell_out!).
-             with("launchctl list", {:group => 1001, :user => 101}).
-             and_return(mock("ouput", :stdout => stdout))
+    context "when HOME directory is not set" do
+      before do
+        @home_dir = ENV.delete('HOME')
+      end
 
-    File.stub!(:stat).and_return(mock("stat", :gid => 1001, :uid => 101))
+      after do
+        ENV['HOME'] = @home_dir
+      end
+
+      it "doesn't include user's LaunchAgents folder" do
+        described_class.gather_plist_dirs.should_not include("~/Library/LaunchAgents")
+      end
+    end
   end
 
-  ["redis-server", "io.redis.redis-server"].each do |service_name|
-    context "when service name is given as #{service_name}" do
-      let(:new_resource) { Chef::Resource::Service.new(service_name) }
-      let!(:current_resource) { Chef::Resource::Service.new(service_name) }
+  context "when service name is given as" do
+    let(:node) { Chef::Node.new }
+    let(:events) {Chef::EventDispatch::Dispatcher.new}
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:provider) { described_class.new(new_resource, run_context) }
+    let(:stdout) { StringIO.new }
 
-      describe "#load_current_resource" do
-        context "when launchctl returns pid in service list" do
-          let(:stdout) { StringIO.new <<-SVC_LIST }
-12761 - 0x100114220.old.machinit.thing
-7777  - io.redis.redis-server
-- - com.lol.stopped-thing
-SVC_LIST
+    ["redis-server", "io.redis.redis-server"].each do |service_name|
+      before do
+        Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
+        provider.stub!(:shell_out!).
+                 with("launchctl list", {:group => 1001, :user => 101}).
+                 and_return(mock("ouput", :stdout => stdout))
 
-          before do
-            provider.load_current_resource
-          end
+        File.stub!(:stat).and_return(mock("stat", :gid => 1001, :uid => 101))
+      end
 
-          it "sets resource running state to true" do
-            provider.current_resource.running.should be_true
-          end
+      context "#{service_name}" do
+        let(:new_resource) { Chef::Resource::Service.new(service_name) }
+        let!(:current_resource) { Chef::Resource::Service.new(service_name) }
 
-          it "sets resouce enabled state to true" do
-            provider.current_resource.enabled.should be_true
-          end
-        end
+        describe "#load_current_resource" do
+          context "when launchctl returns pid in service list" do
+            let(:stdout) { StringIO.new <<-SVC_LIST }
+  12761 - 0x100114220.old.machinit.thing
+  7777  - io.redis.redis-server
+  - - com.lol.stopped-thing
+  SVC_LIST
 
-        describe "running unsupported actions" do
-          before do
-            Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
-          end
-          it "should throw an exception when enable action is attempted" do
-            lambda {provider.run_action(:enable)}.should raise_error(Chef::Exceptions::UnsupportedAction)
-          end
-          it "should throw an exception when reload action is attempted" do
-            lambda {provider.run_action(:reload)}.should raise_error(Chef::Exceptions::UnsupportedAction)
-          end
-          it "should throw an exception when disable action is attempted" do
-            lambda {provider.run_action(:disable)}.should raise_error(Chef::Exceptions::UnsupportedAction)
-          end
-        end
-        context "when launchctl returns empty service pid" do
-          let(:stdout) { StringIO.new <<-SVC_LIST }
-12761 - 0x100114220.old.machinit.thing
-- - io.redis.redis-server
-- - com.lol.stopped-thing
-SVC_LIST
-
-          before do
-            provider.load_current_resource
-          end
-
-          it "sets resource running state to false" do
-            provider.current_resource.running.should be_false
-          end
-
-          it "sets resouce enabled state to true" do
-            provider.current_resource.enabled.should be_true
-          end
-        end
-
-        context "when launchctl doesn't return service entry at all" do
-          let(:stdout) { StringIO.new <<-SVC_LIST }
-12761 - 0x100114220.old.machinit.thing
-- - com.lol.stopped-thing
-SVC_LIST
-
-          it "sets service running state to false" do
-            provider.load_current_resource
-            provider.current_resource.running.should be_false
-          end
-
-          context "and plist for service is not available" do
             before do
-              Dir.stub!(:glob).and_return([])
               provider.load_current_resource
             end
 
-            it "sets resouce enabled state to false" do
-              provider.current_resource.enabled.should be_false
-            end
-          end
-
-          context "and plist for service is available" do
-            before do
-              Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
-              provider.load_current_resource
+            it "sets resource running state to true" do
+              provider.current_resource.running.should be_true
             end
 
             it "sets resouce enabled state to true" do
@@ -127,101 +83,169 @@ SVC_LIST
             end
           end
 
-          describe "and several plists match service name" do
-            it "throws exception" do
-              Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist",
-                                           "/Users/wtf/something.plist"])
+          describe "running unsupported actions" do
+            before do
+              Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
+            end
+            it "should throw an exception when enable action is attempted" do
+              lambda {provider.run_action(:enable)}.should raise_error(Chef::Exceptions::UnsupportedAction)
+            end
+            it "should throw an exception when reload action is attempted" do
+              lambda {provider.run_action(:reload)}.should raise_error(Chef::Exceptions::UnsupportedAction)
+            end
+            it "should throw an exception when disable action is attempted" do
+              lambda {provider.run_action(:disable)}.should raise_error(Chef::Exceptions::UnsupportedAction)
+            end
+          end
+          context "when launchctl returns empty service pid" do
+            let(:stdout) { StringIO.new <<-SVC_LIST }
+  12761 - 0x100114220.old.machinit.thing
+  - - io.redis.redis-server
+  - - com.lol.stopped-thing
+  SVC_LIST
+
+            before do
               provider.load_current_resource
-              provider.define_resource_requirements
-              lambda { provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Service)
+            end
+
+            it "sets resource running state to false" do
+              provider.current_resource.running.should be_false
+            end
+
+            it "sets resouce enabled state to true" do
+              provider.current_resource.enabled.should be_true
+            end
+          end
+
+          context "when launchctl doesn't return service entry at all" do
+            let(:stdout) { StringIO.new <<-SVC_LIST }
+  12761 - 0x100114220.old.machinit.thing
+  - - com.lol.stopped-thing
+  SVC_LIST
+
+            it "sets service running state to false" do
+              provider.load_current_resource
+              provider.current_resource.running.should be_false
+            end
+
+            context "and plist for service is not available" do
+              before do
+                Dir.stub!(:glob).and_return([])
+                provider.load_current_resource
+              end
+
+              it "sets resouce enabled state to false" do
+                provider.current_resource.enabled.should be_false
+              end
+            end
+
+            context "and plist for service is available" do
+              before do
+                Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist"], [])
+                provider.load_current_resource
+              end
+
+              it "sets resouce enabled state to true" do
+                provider.current_resource.enabled.should be_true
+              end
+            end
+
+            describe "and several plists match service name" do
+              it "throws exception" do
+                Dir.stub!(:glob).and_return(["/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist",
+                                             "/Users/wtf/something.plist"])
+                provider.load_current_resource
+                provider.define_resource_requirements
+                lambda { provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Service)
+              end
             end
           end
         end
-      end
-      describe "#start_service" do
-        before do
-          Chef::Resource::Service.stub!(:new).and_return(current_resource)
-          provider.load_current_resource
-          current_resource.stub!(:running).and_return(false)
+        describe "#start_service" do
+          before do
+            Chef::Resource::Service.stub!(:new).and_return(current_resource)
+            provider.load_current_resource
+            current_resource.stub!(:running).and_return(false)
+          end
+
+          it "calls the start command if one is specified and service is not running" do
+            new_resource.stub!(:start_command).and_return("cowsay dirty")
+
+            provider.should_receive(:shell_out!).with("cowsay dirty")
+            provider.start_service
+          end
+
+          it "shows warning message if service is already running" do
+            current_resource.stub!(:running).and_return(true)
+            Chef::Log.should_receive(:debug).with("service[#{service_name}] already running, not starting")
+
+            provider.start_service
+          end
+
+          it "starts service via launchctl if service found" do
+            provider.should_receive(:shell_out!).
+                     with("launchctl load -w '/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist'",
+                           :group => 1001, :user => 101).
+                     and_return(0)
+
+            provider.start_service
+          end
         end
 
-        it "calls the start command if one is specified and service is not running" do
-          new_resource.stub!(:start_command).and_return("cowsay dirty")
+        describe "#stop_service" do
+          before do
+            Chef::Resource::Service.stub!(:new).and_return(current_resource)
 
-          provider.should_receive(:shell_out!).with("cowsay dirty")
-          provider.start_service
+            provider.load_current_resource
+            current_resource.stub!(:running).and_return(true)
+          end
+
+          it "calls the stop command if one is specified and service is running" do
+            new_resource.stub!(:stop_command).and_return("kill -9 123")
+
+            provider.should_receive(:shell_out!).with("kill -9 123")
+            provider.stop_service
+          end
+
+          it "shows warning message if service is not running" do
+            current_resource.stub!(:running).and_return(false)
+            Chef::Log.should_receive(:debug).with("service[#{service_name}] not running, not stopping")
+
+            provider.stop_service
+          end
+
+          it "stops the service via launchctl if service found" do
+            provider.should_receive(:shell_out!).
+                     with("launchctl unload '/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist'",
+                          :group => 1001, :user => 101).
+                     and_return(0)
+
+            provider.stop_service
+          end
         end
 
-        it "shows warning message if service is already running" do
-          current_resource.stub!(:running).and_return(true)
-          Chef::Log.should_receive(:debug).with("service[#{service_name}] already running, not starting")
+        describe "#restart_service" do
+          before do
+            Chef::Resource::Service.stub!(:new).and_return(current_resource)
 
-          provider.start_service
-        end
+            provider.load_current_resource
+            current_resource.stub!(:running).and_return(true)
+            provider.stub!(:sleep)
+          end
 
-        it "starts service via launchctl if service found" do
-          provider.should_receive(:shell_out!).
-                   with("launchctl load -w '/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist'",
-                         :group => 1001, :user => 101).
-                   and_return(0)
+          it "issues a command if given" do
+            new_resource.stub!(:restart_command).and_return("reload that thing")
 
-          provider.start_service
-        end
-      end
+            provider.should_receive(:shell_out!).with("reload that thing")
+            provider.restart_service
+          end
 
-      describe "#stop_service" do
-        before do
-          Chef::Resource::Service.stub!(:new).and_return(current_resource)
+          it "stops and then starts service" do
+            provider.should_receive(:stop_service)
+            provider.should_receive(:start_service);
 
-          provider.load_current_resource
-          current_resource.stub!(:running).and_return(true)
-        end
-
-        it "calls the stop command if one is specified and service is running" do
-          new_resource.stub!(:stop_command).and_return("kill -9 123")
-
-          provider.should_receive(:shell_out!).with("kill -9 123")
-          provider.stop_service
-        end
-
-        it "shows warning message if service is not running" do
-          current_resource.stub!(:running).and_return(false)
-          Chef::Log.should_receive(:debug).with("service[#{service_name}] not running, not stopping")
-
-          provider.stop_service
-        end
-
-        it "stops the service via launchctl if service found" do
-          provider.should_receive(:shell_out!).
-                   with("launchctl unload '/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist'",
-                        :group => 1001, :user => 101).
-                   and_return(0)
-
-          provider.stop_service
-        end
-      end
-
-      describe "#restart_service" do
-        before do
-          Chef::Resource::Service.stub!(:new).and_return(current_resource)
-
-          provider.load_current_resource
-          current_resource.stub!(:running).and_return(true)
-          provider.stub!(:sleep)
-        end
-
-        it "issues a command if given" do
-          new_resource.stub!(:restart_command).and_return("reload that thing")
-
-          provider.should_receive(:shell_out!).with("reload that thing")
-          provider.restart_service
-        end
-
-        it "stops and then starts service" do
-          provider.should_receive(:stop_service)
-          provider.should_receive(:start_service);
-
-          provider.restart_service
+            provider.restart_service
+          end
         end
       end
     end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3237

Fix Mac OS X service provider. Do not fail when HOME is not set
- Do not add `~/Library/LaunchAgents` if HOME is not set
- It is safe to assume that if HOME is not set ~ will not expand - see rb_home_dir function in MRI ruby

NB: It is unclear from the diff but there is not so much changes to file, I've extracted a separate isolated context from existing tests and added a separate context for method that gathers plist dirs. You can see it here - https://github.com/iafonov/chef/blob/20ff8e5a508fad1823809c4e3988c579e05e7d4c/spec/unit/provider/service/macosx_spec.rb#L22
