### PR TITLE
[CHEF-3835] Fix net-ssh* gem dependencies.

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency "json", ">= 1.4.4", "<= 1.6.1"
   s.add_dependency "yajl-ruby", "~> 1.1"
   s.add_dependency "net-ssh", "~> 2.2.2"
-  s.add_dependency "net-ssh-multi", "~> 1.1.0"
+  s.add_dependency "net-ssh-multi", "= 1.1.0"
+  s.add_dependency "net-ssh-gateway", "= 1.1.0"
   # CHEF-3027: The knife-cloud plugins require newer features from highline, core chef should not.
   s.add_dependency "highline", ">= 1.6.9"
   s.add_dependency "erubis"


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3835

New versions of net-ssh-multi and net-ssh-gateway depend on `net-ssh >= 2.6.4` which breaks chef's dependency on `net-ssh ~> 2.2.2`.

This locks `net-ssh-multi` and `net-ssh-gateway` at `1.1.0`
