### PR TITLE
[CHEF-3690] Restore run_chef_client private method relied upon by Windows...

### DIFF
--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -136,6 +136,18 @@ class Chef
 
       private
 
+      # Initializes Chef::Client instance and runs it
+      def run_chef_client
+        @chef_client = Chef::Client.new(
+          @chef_client_json,
+          :override_runlist => config[:override_runlist]
+        )
+        @chef_client_json = nil
+
+        @chef_client.run
+        @chef_client = nil
+      end
+
       def apply_config(config_file_path)
         Chef::Config.from_file(config_file_path)
         Chef::Config.merge!(config)


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3690

This fix restores a private method run_chef_client that was removed from the WindowsService class, even though the class still attempts to call this method in its service_main method. Besides meaning that the class itself is fundamentally broken, this causes the functionality of WindowsService to break.

The commit that removed this class appears to be https://github.com/opscode/chef/commit/04bdf7152d0fd88db7281d1675846b82bac66634#diff-3

The ticket that tracks the effect on customers is http://tickets.opscode.com/browse/CHEF-3690. T

Impact is that anyone attempting to use the chef gem's ability to install itself as a Windows service can no longer do so. This fix restores the functionality by simply adding back the private method.
