### PR TITLE
[CHEF-3872] Adding support for platform XCP/xcp, which is the open source version

### DIFF
--- a/lib/chef/platform.rb
+++ b/lib/chef/platform.rb
@@ -115,6 +115,14 @@ class Chef
               :mdadm => Chef::Provider::Mdadm
             }
           },
+          :xcp   => {
+            :default => {
+              :service => Chef::Provider::Service::Redhat,
+              :cron => Chef::Provider::Cron,
+              :package => Chef::Provider::Package::Yum,
+              :mdadm => Chef::Provider::Mdadm
+            }
+          },
           :centos   => {
             :default => {
               :service => Chef::Provider::Service::Redhat,


### PR DESCRIPTION
modified lib/chef/platform.rb
