### PR TITLE
[CHEF-3910] Allow config[:user_password] to be set via CLI

### DIFF
--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -59,6 +59,10 @@ class Chef
         :long => "--validation-key PATH",
         :description => "The location of the location of the validation key (usually a file named validation.pem)"
 
+      option :user_password,
+        :long => "--user-password PASSWORD",
+        :description => "The password for creating a client user"
+
       def configure_chef
         # We are just faking out the system so that you can do this without a key specified
         Chef::Config[:node_name] = 'woot'


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3910

When using "knife client --initial" everything can be passed from the command line, with the exception of the user password. This makes it broken automation wise.
