### PR TITLE
CHEF-3938: don't disable gpg checks in zypper commands

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -297,6 +297,12 @@ class Chef
     signing_ca_domain "opensource.opscode.com"
     signing_ca_email "opensource-cert@opscode.com"
 
+    # Zypper package provider gpg checks. Set to true to enable package
+    # gpg signature checking. This will be default in the
+    # future. Setting to false disables the warnings.
+    # Leaving this set to nil or false is a security hazard!
+    zypper_check_gpg nil
+
     # Report Handlers
     report_handlers []
 

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -91,11 +91,11 @@ class Chef
             )
           elsif version
             run_command(
-              :command => "zypper -n --no-gpg-checks install -l  #{name}=#{version}"
+              :command => "zypper -n#{gpg_checks} install -l #{name}=#{version}"
             )
           else
             run_command(
-              :command => "zypper -n --no-gpg-checks install -l  #{name}"
+              :command => "zypper -n#{gpg_checks} install -l #{name}"
             )
           end
         end
@@ -107,11 +107,11 @@ class Chef
             )
           elsif version
             run_command(
-              :command => "zypper -n --no-gpg-checks install -l #{name}=#{version}"
+              :command => "zypper -n#{gpg_checks} install -l #{name}=#{version}"
             )
           else
             run_command(
-              :command => "zypper -n --no-gpg-checks install -l #{name}"
+              :command => "zypper -n#{gpg_checks} install -l #{name}"
             )
           end
         end
@@ -123,21 +123,33 @@ class Chef
             )
           elsif version
             run_command(
-              :command => "zypper -n --no-gpg-checks remove  #{name}=#{version}"
+              :command => "zypper -n#{gpg_checks} remove #{name}=#{version}"
             )
           else
             run_command(
-              :command => "zypper -n --no-gpg-checks remove  #{name}"
+              :command => "zypper -n#{gpg_checks} remove #{name}"
             )
           end
-            
-         
         end
       
         def purge_package(name, version)
           remove_package(name, version)
         end
-      
+
+        private
+        def gpg_checks()
+          case Chef::Config[:zypper_check_gpg]
+          when true
+            ""
+          when false
+            " --no-gpg-checks"
+          when nil
+            Chef::Log.warn("Chef::Config[:zypper_check_gpg] was not set. " + 
+              "All packages will be installed without gpg signature checks. " + 
+              "This is a security hazard.")
+            " --no-gpg-checks"
+          end
+        end
       end
     end
   end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -92,8 +92,24 @@ describe Chef::Provider::Package::Zypper do
 
   describe "install_package" do
     it "should run zypper install with the package name and version" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(true)
       @provider.should_receive(:run_command).with({
-          :command => "zypper -n --no-gpg-checks install -l  emacs=1.0",
+          :command => "zypper -n install -l emacs=1.0",
+        })
+      @provider.install_package("emacs", "1.0")
+    end
+    it "should run zypper install without gpg checks" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(false)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks install -l emacs=1.0",
+        })
+      @provider.install_package("emacs", "1.0")
+    end
+    it "should warn about gpg checks on zypper install" do
+      Chef::Log.should_receive(:warn).with(
+        /All packages will be installed without gpg signature checks/)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks install -l emacs=1.0",
         })
       @provider.install_package("emacs", "1.0")
     end
@@ -101,6 +117,22 @@ describe Chef::Provider::Package::Zypper do
 
   describe "upgrade_package" do
     it "should run zypper update with the package name and version" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(true)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n install -l emacs=1.0",
+        })
+      @provider.upgrade_package("emacs", "1.0")
+    end
+    it "should run zypper update without gpg checks" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(false)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks install -l emacs=1.0",
+        })
+      @provider.upgrade_package("emacs", "1.0")
+    end
+    it "should warn about gpg checks on zypper upgrade" do
+      Chef::Log.should_receive(:warn).with(
+        /All packages will be installed without gpg signature checks/)
       @provider.should_receive(:run_command).with({
           :command => "zypper -n --no-gpg-checks install -l emacs=1.0",
         })
@@ -110,8 +142,24 @@ describe Chef::Provider::Package::Zypper do
 
   describe "remove_package" do
     it "should run zypper remove with the package name" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(true)
       @provider.should_receive(:run_command).with({
-          :command => "zypper -n --no-gpg-checks remove  emacs=1.0",
+          :command => "zypper -n remove emacs=1.0",
+        })
+      @provider.remove_package("emacs", "1.0")
+    end
+    it "should run zypper remove without gpg checks" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(false)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks remove emacs=1.0",
+        })
+      @provider.remove_package("emacs", "1.0")
+    end
+    it "should warn about gpg checks on zypper remove" do
+      Chef::Log.should_receive(:warn).with(
+        /All packages will be installed without gpg signature checks/)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks remove emacs=1.0",
         })
       @provider.remove_package("emacs", "1.0")
     end
@@ -120,6 +168,21 @@ describe Chef::Provider::Package::Zypper do
   describe "purge_package" do
     it "should run remove_package with the name and version" do
       @provider.should_receive(:remove_package).with("emacs", "1.0")
+      @provider.purge_package("emacs", "1.0")
+    end
+    it "should run zypper purge without gpg checks" do
+      Chef::Config.stub(:[]).with(:zypper_check_gpg).and_return(false)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks remove emacs=1.0",
+        })
+      @provider.purge_package("emacs", "1.0")
+    end
+    it "should warn about gpg checks on zypper purge" do
+      Chef::Log.should_receive(:warn).with(
+        /All packages will be installed without gpg signature checks/)
+      @provider.should_receive(:run_command).with({
+          :command => "zypper -n --no-gpg-checks remove emacs=1.0",
+        })
       @provider.purge_package("emacs", "1.0")
     end
   end


### PR DESCRIPTION
The zypper package provider should check the gpg signature of packages by default. Doing otherwise is a security hazard. This should be configurable.
