### PR TITLE
[CHEF-3930] Retry failed 'apt-get install' after running 'apt-get update'

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -88,10 +88,39 @@ class Chef
         end
 
         def install_package(name, version)
-          package_name = "#{name}=#{version}"
-          package_name = name if @is_virtual_package
+          rescued = false
+          begin
+            # Keep all the things in the block for retry
+            Chef::Log.debug("#{@new_resource} Candidate Version: #{version}")
+            package_name = "#{name}=#{version}"
+            package_name = name if @is_virtual_package
+
+            run_command_with_systems_locale(
+              :command => "apt-get -q -y#{expand_options(default_release_options)}#{expand_options(@new_resource.options)} install #{package_name}",
+              :environment => {
+                "DEBIAN_FRONTEND" => "noninteractive"
+              }
+            )
+          rescue Exception => e
+            if rescued == false && @new_resource.auto_update == true
+              rescued = true
+              update_aptitude_cache
+              # Reload our resource to get new version information
+              load_current_resource
+              Chef::Log.debug("#{@new_resource} Old Candidate Version: #{version}")
+              version = @candidate_version
+              Chef::Log.debug("#{@new_resource} New Candidate Version: #{version}")
+              retry
+            else
+              raise Chef::Exceptions::Exec, e.message
+            end
+          end
+        end
+
+        def update_aptitude_cache
+          Chef::Log.info("#{@new_resource} Updating Aptitude Cache")
           run_command_with_systems_locale(
-            :command => "apt-get -q -y#{expand_options(default_release_options)}#{expand_options(@new_resource.options)} install #{package_name}",
+            :command => "apt-get update",
             :environment => {
               "DEBIAN_FRONTEND" => "noninteractive"
             }

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,12 +22,13 @@ require 'chef/provider/package/apt'
 class Chef
   class Resource
     class AptPackage < Chef::Resource::Package
-      
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :apt_package
         @provider = Chef::Provider::Package::Apt
         @default_release = nil
+        @auto_update = true
       end
 
       def default_release(arg=nil)
@@ -35,6 +36,16 @@ class Chef
           :default_release,
           arg,
           :kind_of => [ String ]
+        )
+      end
+
+      def auto_update(arg=nil)
+        # Use the term auto_update to align with apt-get terms where update is
+        # different from upgrade
+        set_or_return(
+          :auto_update,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3930

Add logic to catch exceptions from apt-get install and run `apt-get update`.  After the update reload the appropriate resource information and retry once after the apt-get update.  This behavior is the new default but can be disabled by setting ':auto_update false'.
