### PR TITLE
[CHEF-3965] Additional option for knife bootstrap to accept JSON files for firstboot

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -109,8 +109,15 @@ class Chef
       option :first_boot_attributes,
         :short => "-j JSON_ATTRIBS",
         :long => "--json-attributes",
-        :description => "A JSON string to be added to the first run of chef-client",
+        :description => "A JSON string to be added to the first run of chef-client. Takes precedence over -J.",
         :proc => lambda { |o| JSON.parse(o) },
+        :default => {}
+
+      option :first_boot_file,
+        :short => "-J JSON_FILE",
+        :long => "--json-file",
+        :description => "A JSON file to be added to the first run of chef-client. Is overridden by -j.",
+        :proc => lambda { |o| JSON.parse(File.read(o)) },
         :default => {}
 
       option :host_key_verify,
@@ -170,7 +177,7 @@ class Chef
         @node_name = Array(@name_args).first
         # back compat--templates may use this setting:
         config[:server_name] = @node_name
-        
+
         $stdout.sync = true
 
         ui.info("Bootstrapping Chef on #{ui.color(@node_name, :bold)}")

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -25,7 +25,7 @@ class Chef
       # following instance variables:
       # * @config   - a hash of knife's config values
       # * @run_list - the run list for the node to boostrap
-      # 
+      #
       class BootstrapContext
 
         def initialize(config, run_list, chef_config)
@@ -94,9 +94,9 @@ CONFIG
         def chef_version
           knife_config[:bootstrap_version] || Chef::VERSION
         end
-        
+
         def first_boot
-          (@config[:first_boot_attributes] || {}).merge(:run_list => @run_list)
+          (@config[:first_boot_attributes] || @config[:first_boot_file] || {}).merge(:run_list => @run_list)
         end
 
       end


### PR DESCRIPTION
Folks,

we are making heavy use of the -j option in knife bootstrap and found it somewhat cumbersome to keep `.sh` scripts around with inline JSON.

Mainly for our own convenience, I added a new configuration option to the `bootstrap` plugin to accept a JSON file instead of inline JSON attributes. Accordingly, I modified the `BootstrapContext` class to honor the new parameter.

Precedence is _JSON attributes_ (`-j|--json-attributes`) > _JSON file_ (`-J|--json-file`); that is, if both are supplied, attributes will win and the file is not considered at all.

Hope this patch is useful for you as well.

Cheers,
Alexander
