### PR TITLE
[CHEF-3957] directory resource whyrun error when dir does not exist

### DIFF
--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -107,10 +107,10 @@ class Chef
               ::Dir.mkdir(@new_resource.path)
             end
             Chef::Log.info("#{@new_resource} created directory #{@new_resource.path}")
+            update_new_file_state
           end 
         end
         set_all_access_controls
-        update_new_file_state
       end
 
       def action_delete


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3957.

When you create a recipe using the directory resource, chef-client/solo fail [No such file or directory] error occurs when it run the why-run with the directory does not exist.
