### PR TITLE
[CHEF-3958] Allow templates/ directory to be used with remote_directory

### DIFF
--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -48,6 +48,7 @@ class Chef
         @overwrite = true
         @allowed_actions.push(:create, :create_if_missing, :delete)
         @cookbook = nil
+        @type = "files"
         @provider = Chef::Provider::RemoteDirectory
       end
 
@@ -116,6 +117,14 @@ class Chef
       def cookbook(args=nil)
         set_or_return(
           :cookbook,
+          args,
+          :kind_of => String
+        )
+      end 
+
+      def type(args=nil)
+        set_or_return(
+          :type,
           args,
           :kind_of => String
         )


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3958

This PR allows the templates/ directory to be used with the remote_directory resource. The motivation for this was to streamline cookbooks we use by enabling a workflow where files and templates exist in the same parent directory. I find myself often thinking of files just as templates with no variables.

I've added a `type` parameter to remote_directory whose default of "files" mimics the current behavior. By setting this parameter to "templates", Chef will look in the templates/ directory of the cookbook specified instead. A brief example from the ticket:

``` ruby
# will look in templates/
remote_directory "/opt/dir1" do
  source "subdir"
  type "templates"
end

# will look in files/
remote_directory "/opt/dir2" do
  source "subdir"
end
```

I've tested this on Ubuntu 10.04 and 12.04 with the Opscode vagrant boxes. The primary changes are on L96 and L129-133 of the provider file, and the changes in the resource file. I believe this should be backwards-compatible.

Thank you!
