### PR TITLE
Use HTTPS to RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
use https when connecting to rubygems to prevent MITM hacks
