### PR TITLE
[CHEF-3970] Allow json_class key for passed in json_attributes

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -195,7 +195,7 @@ class Chef::Application::Solo < Chef::Application
       end
 
       begin
-        @chef_client_json = Chef::JSONCompat.from_json(json_io.read)
+        @chef_client_json = Chef::JSONCompat.from_json(json_io.read).to_hash
         json_io.close unless json_io.closed?
       rescue JSON::ParserError => error
         Chef::Application.fatal!("Could not parse the provided JSON file (#{Chef::Config[:json_attribs]})!: " + error.message, 2)

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -88,6 +88,28 @@ describe Chef::Application::Solo do
         end
       end
 
+      describe "and the json_attribs include json_class: Chef::Node" do
+        before do
+          Chef::Config[:json_attribs] = "/etc/chef/dna.json"
+          @json = StringIO.new(
+            {
+              "json_class" => "Chef::Node",
+              "normal" => {
+                "a" => "b"
+              },
+              "run_list" => ["recipe[foo]"]
+            }.to_json
+          )
+          @app.stub!(:open).with("/etc/chef/dna.json").and_return(@json)
+        end
+
+        it "should parse the json out of the file" do
+          @app.reconfigure
+          @app.instance_variable_get(:@chef_client_json).should include("a" => "b")
+          @app.instance_variable_get(:@chef_client_json).should include("run_list")
+        end
+      end
+
       describe "when parsing fails" do
         before do
           Chef::Config[:json_attribs] = "/etc/chef/dna.json"


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3970

This allows for the json passed in via the `-j, --json-attributes` argument to include the json_class key. Before it would convert it to a chef object, and the run_list wouldn't be properly extracted.
