### PR TITLE
CHEF-4015 fix group provider for openSUSE 12.3

### DIFF
--- a/lib/chef/platform.rb
+++ b/lib/chef/platform.rb
@@ -170,6 +170,9 @@ class Chef
               :cron => Chef::Provider::Cron,
               :package => Chef::Provider::Package::Zypper,
               :group => Chef::Provider::Group::Suse
+            },
+            ">= 12.3" => {
+              :group => Chef::Provider::Group::Usermod
             }
           },
           :oracle  => {

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -47,7 +47,7 @@ class Chef
           case node[:platform]
           when "openbsd", "netbsd", "aix", "solaris2"
             append_flags = "-G"
-          when "solaris"
+          when "solaris", "suse"
             append_flags = "-a -G"
           end
 

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -46,7 +46,8 @@ describe Chef::Provider::Group::Usermod do
       platforms = {
         "openbsd" => "-G",
         "netbsd" => "-G",
-        "solaris" => "-a -G"
+        "solaris" => "-a -G",
+        "suse" => "-a -G"
       }
 
       before do


### PR DESCRIPTION
openSUSE 12.3 switched to shadow-utils where groupadd doesn't have the
-A option, instead the usermod command now works similar to other
distributions