### PR TITLE
Disable diffs during file functional tests

### DIFF
--- a/spec/support/shared/functional/diff_disabled.rb
+++ b/spec/support/shared/functional/diff_disabled.rb
@@ -1,0 +1,11 @@
+
+shared_context "diff disabled"  do
+  before do
+    @original_diff_disable = Chef::Config[:diff_disabled]
+    Chef::Config[:diff_disabled] = true
+  end
+
+  after do
+    Chef::Config[:diff_disabled] = @original_diff_disable
+  end
+end

--- a/spec/support/shared/functional/directory_resource.rb
+++ b/spec/support/shared/functional/directory_resource.rb
@@ -18,6 +18,8 @@
 
 shared_examples_for "a directory resource" do
 
+  include_context "diff disabled"
+
   let(:expect_updated?) {true}
 
   context "when the target directory does not exist" do

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -25,6 +25,8 @@ shared_examples_for "a file with the wrong content" do
     sha256_checksum(path).should == @expected_checksum
   end
 
+  include_context "diff disabled"
+
   context "when running action :create" do
     context "with backups enabled" do
       before do
@@ -96,6 +98,8 @@ shared_examples_for "a file with the correct content" do
     sha256_checksum(path).should == @expected_checksum
   end
 
+  include_context "diff disabled"
+
   describe "when running action :create" do
     before do
       resource.run_action(:create)
@@ -143,9 +147,13 @@ shared_examples_for "a file with the correct content" do
 end
 
 shared_examples_for "a file resource" do
+
+  include_context "diff disabled"
+
   before do
     Chef::Log.level = :info
   end
+
    # note the stripping of the drive letter from the tmpdir on windows
   let(:backup_glob) { File.join(CHEF_SPEC_BACKUP_PATH, Dir.tmpdir.sub(/^([A-Za-z]:)/, ""), "#{file_base}*") }
 
@@ -291,6 +299,7 @@ shared_examples_for "a file resource" do
 end
 
 shared_examples_for "a file that inherits permissions from a parent directory" do
+  include_context "diff disabled"
   include_context "use Windows permissions"
   context "on Windows", :windows_only do
     it "has only inherited aces if no explicit aces were specified" do

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -127,6 +127,9 @@ shared_context "use Windows permissions", :windows_only do
 end
 
 shared_examples_for "a securable resource" do
+
+  include_context "diff disabled"
+
   context "on Unix", :unix_only do
     let(:expected_user_name) { 'nobody' }
     let(:expected_uid) { Etc.getpwnam(expected_user_name).uid }

--- a/spec/support/shared/functional/securable_resource_with_reporting.rb
+++ b/spec/support/shared/functional/securable_resource_with_reporting.rb
@@ -1,6 +1,8 @@
 
 shared_examples_for "a securable resource with reporting" do
 
+  include_context "diff disabled"
+
   let(:current_resource) do
     provider = resource.provider_for_action(resource.action)
     provider.load_current_resource


### PR DESCRIPTION
No functional tests actually use the diff behavior and this speeds them
up quite a bit.
