### PR TITLE
[CHEF-4051] Add a "clean" option to Git SCM provider

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -100,6 +100,7 @@ class Chef
             enable_submodules
             Chef::Log.info "#{@new_resource} updated to revision #{target_revision}"
           end
+          clean
           add_remotes
         else
           action_checkout
@@ -224,6 +225,14 @@ class Chef
           $1
         else
           nil
+        end
+      end
+
+      def clean
+        if @new_resource.clean
+          Chef::Log.info("#{@new_resource} cleaning working copy")
+          command = "git clean -f"
+          shell_out!(command, run_options(:cwd => @new_resource.destination, :log_level => :debug))
         end
       end
 

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -36,6 +36,7 @@ class Chef
         @remote = "origin"
         @ssh_wrapper = nil
         @depth = nil
+        @clean = false
         @allowed_actions.push(:checkout, :export, :sync, :diff, :log)
         @action = [:sync]
       end
@@ -119,6 +120,14 @@ class Chef
           :depth,
           arg,
           :kind_of => Integer
+        )
+      end
+
+      def clean(arg=nil)
+        set_or_return(
+            :clean,
+            arg,
+            :kind_of => [TrueClass, FalseClass]
         )
       end
 

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -207,6 +207,18 @@ SHAS
     @provider.enable_submodules
   end
 
+  it "runs a clean command" do
+    @resource.clean true
+    expected_cmd = "git clean -f"
+    @provider.should_receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir", :log_level => :debug, :log_tag => "git[web2.0 app]")
+    @provider.clean
+  end
+
+  it "does nothing for clean if resource.clean #=> false" do
+    @provider.should_not_receive(:shell_out!)
+    @provider.clean
+  end
+
   it "runs a sync command with default options" do
     expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     @provider.should_receive(:shell_out!).with(expected_cmd, :cwd=> "/my/deploy/dir", :log_level => :debug, :log_tag => "git[web2.0 app]")


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4051

There is no way to clean a Git checkout currently. However, it might be desired to enforce such a state. E.g. when removing submodules from version control, `git checkout` will not remove the old files.

Adding a `clean` attribute, which runs `git clean -f` after checkout makes this possible.