### PR TITLE
remove default ErrorReport exception handler

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -217,9 +217,6 @@ class Chef::Application::Client < Chef::Application
     super
 
     Chef::Config[:chef_server_url] = config[:chef_server_url] if config.has_key? :chef_server_url
-    unless Chef::Config[:exception_handlers].any? {|h| Chef::Handler::ErrorReport === h}
-      Chef::Config[:exception_handlers] << Chef::Handler::ErrorReport.new
-    end
 
     if Chef::Config[:daemonize]
       Chef::Config[:interval] ||= 1800


### PR DESCRIPTION
ErrorHandler is responsible for [CHEF-2694 ErrorHandler json format can cause complete meltdown of chef client](http://tickets.opscode.com/browse/CHEF-2694)
