### PR TITLE
Keep a daemonized chef-client's forked process from reaping the parent pid file

### DIFF
--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -154,8 +154,34 @@ describe Chef::Daemon do
         FileUtils.should_receive(:rm).with("/var/run/chef/chef-client.pid")
         Chef::Daemon.remove_pid_file
       end
+    
 
+    end
 
+    describe "when the pid file exists and the process is forked" do
+      
+      before do
+        File.stub!(:exists?).with("/var/run/chef/chef-client.pid").and_return(true)
+        Chef::Daemon.stub!(:forked?) { true }
+      end
+      
+      it "should not remove the file" do
+        FileUtils.should_not_receive(:rm)
+        Chef::Daemon.remove_pid_file
+      end
+      
+    end
+    
+    describe "when the pid file exists and the process is not forked" do
+      before do
+        File.stub!(:exists?).with("/var/run/chef/chef-client.pid").and_return(true)
+        Chef::Daemon.stub!(:forked?) { false }
+      end
+      
+      it "should remove the file" do
+        FileUtils.should_receive(:rm)
+        Chef::Daemon.remove_pid_file
+      end
     end
 
     describe "when the pid file does not exist" do


### PR DESCRIPTION
This is a proposed fix for CHEF-3367.  It also includes an rspec test for the fix.

Without this fix a forked process will reap its parent's pid file,
breaking init script functionality.  A start call to the init script
will then launch a new process, since the init script is ignorant of the
already running process.
