### PR TITLE
[CHEF-4100] Don't raise exception for existing but merely empty files

### DIFF
--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -33,7 +33,7 @@ class Chef
         @file_edited = false
 
         raise ArgumentError, "File doesn't exist" unless File.exist? @original_pathname
-        raise ArgumentError, "File is blank" unless (@contents = File.new(@original_pathname).readlines).length > 0
+        @contents = File.new(@original_pathname).readlines
       end
 
       #search the file line by line and match each line with the given regex


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4100

raise call where the file exists but is just empty causes trouble with its own code

It breaks its own insert_line_if_no_match() for no good reason (inserting a line in an empty file is a valid editing operation).

The only code caring about 'contents' is the private helper method search_match() and 'contents' being a zero-length array there is no issue.
