### PR TITLE
[CHEF-4093] added the initial command for checking environment cookbook constraints.

### DIFF
--- a/lib/chef/knife/environment_compare.rb
+++ b/lib/chef/knife/environment_compare.rb
@@ -38,10 +38,10 @@ class Chef
         # Get the commandline environments or all if none are provided.
         environments = environment_list     
 
-        # Get a list of all cookbooks that have constraninst and their environment.
+        # Get a list of all cookbooks that have constraints and their environment.
         constraints = constraint_list(environments) 
 
-        # Get the total list of cookbooks that have contraints
+        # Get the total list of cookbooks that have constraints
         cookbooks = cookbook_list(constraints)
 
         # If we cannot find any cookbooks, we can stop here.
@@ -77,10 +77,10 @@ class Chef
         constraints = {}
         environments.each do |env,url|
           # Because you cannot modify the default environment I filter it out here.
-          unless "#{env}" == "_default"
+          unless env == "_default"
             envdata = Chef::Environment.load(env)
             ver = envdata.cookbook_versions
-            constraints["#{env}"] = ver
+            constraints[env] = ver
           end
         end
         constraints

--- a/spec/unit/knife/environment_compare_spec.rb
+++ b/spec/unit/knife/environment_compare_spec.rb
@@ -49,8 +49,6 @@ describe Chef::Knife::EnvironmentCompare do
 
     @knife.stub(:cookbook_list).and_return(@cookbooks)
 
-    #  cookbooks = rest.get_rest("/cookbooks?num_versions=1")
-
     @rest_double = double('rest')
     @knife.stub(:rest).and_return(@rest_double)
     @cookbook_names = ['apache2', 'mysql', 'foo', 'bar', 'dummy', 'chef_handler']
@@ -61,9 +59,6 @@ describe Chef::Knife::EnvironmentCompare do
                               'versions' => [{'version' => '1.0.1',
                                               'url' => "#{@base_url}/#{item}/1.0.1"}]}
     end 
-
-    # @rest_mock.should_receive(:get_rest).with('/cookbooks?num_versions=1').
-    #                                       and_return(@cookbook_data)
 
     @rest_double.stub(:get_rest).with("/cookbooks?num_versions=1").and_return(@cookbook_data)
 
@@ -89,7 +84,7 @@ describe Chef::Knife::EnvironmentCompare do
   end
 
   describe 'with -m or --mismatch' do
-    it 'should display mismatch environments / cookbooks and the version constrants of the cookbooks' do
+    it 'should display mismatch environments / cookbooks and the version constraints of the cookbooks' do
       @knife.config[:format] = 'summary'
       @knife.config[:mismatch] = true
       @knife.run


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4093

new command for the knife tool to compare cookbook constraints between your chef environments. very handy if you work with DTAP model and want to compare all your cookbook version throughout your environment.
