### PR TITLE
[CHEF-4101] DeepMerge - support overwriting hash values with nil

### DIFF
--- a/lib/chef/mixin/deep_merge.rb
+++ b/lib/chef/mixin/deep_merge.rb
@@ -86,8 +86,12 @@ class Chef
         when Hash
           source.each do |src_key, src_value|
             if dest.kind_of?(Hash)
-              if dest[src_key]
-                dest[src_key] = deep_merge!(src_value, dest[src_key])
+              if dest.has_key? src_key
+                if dest[src_key].nil?
+                  dest[src_key] = nil
+                else
+                  dest[src_key] = deep_merge!(src_value, dest[src_key])
+                end
               else # dest[src_key] doesn't exist so we take whatever source has
                 raise_if_knockout_used!(src_value)
                 dest[src_key] = src_value

--- a/spec/unit/mixin/deep_merge_spec.rb
+++ b/spec/unit/mixin/deep_merge_spec.rb
@@ -236,6 +236,20 @@ describe Chef::Mixin::DeepMerge, "deep_merge!" do
     @dm.deep_merge!(hash_src, hash_dst)
     hash_dst.should == {"item" => "orange"}
   end
+
+  it 'should overwrite hashes with nil' do
+    hash_src = {"item" => { "1" => "2"}, "other" => true }
+    hash_dst = {"item" => nil }
+    @dm.deep_merge!(hash_src, hash_dst)
+    hash_dst.should == {"item" => nil, "other" => true }
+  end
+
+  it 'should overwrite strings with nil' do
+    hash_src = {"item" => "to_overwrite", "other" => false }
+    hash_dst = {"item" => nil }
+    @dm.deep_merge!(hash_src, hash_dst)
+    hash_dst.should == {"item" => nil, "other" => false }
+  end
 end # deep_merge!
 
 # Chef specific


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4101

The current deep merge algorithm does not provide a nice way to clear a value from a hash. I suggest to support overwrite hash values with nil - currently the old value is not changed. If the value of a key should not changed, this key should be removed, which results in the old behavior.

Old implementation:

``` ruby
{ :x => { y: => "1"} }
+
{ :x => nil }
=
{ :x => { y: => "1"} }
```

Suggested implementation:

``` ruby
{ :x => { y: => "1"} }
+
{ :x => nil }
=
{ :x => nil }
```
