### PR TITLE
[CHEF-4011] use `platform_specific_path` helper in specs

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -230,12 +230,8 @@ describe Chef::Config do
     end
 
     it "Chef::Config[:data_bag_path] defaults to /var/chef/data_bags" do
-      data_bag_path = if windows?
-        "C:\\chef\\data_bags"
-      else
-        "/var/chef/data_bags"
-      end
-
+      data_bag_path =
+        Chef::Config.platform_specific_path("/var/chef/data_bags")
       Chef::Config[:data_bag_path].should == data_bag_path
     end
   end
@@ -262,7 +258,9 @@ describe Chef::Config do
   end
 
   describe "Chef::Config[:encrypted_data_bag_secret]" do
-    db_secret_default_path = "/etc/chef/encrypted_data_bag_secret"
+    db_secret_default_path =
+      Chef::Config.platform_specific_path("/etc/chef/encrypted_data_bag_secret")
+
     let(:db_secret_default_path){ db_secret_default_path }
 
     before do


### PR DESCRIPTION
This will fix the following test failures when specs are run on Windows:

1) Chef::Config Chef::Config[:encrypted_data_bag_secret] /etc/chef/encrypted_data_bag_secret exists sets the value to /etc/chef/encrypted_data_bag_secret
     Failure/Error: require 'chef/config'
       <File (class)> received :exist? with unexpected arguments
         expected: ("/etc/chef/encrypted_data_bag_secret")
              got: ("C:\chef\encrypted_data_bag_secret")
        Please stub a default value first if message might be received with other args as well. 
     # C:/jenkins/workspace/chef-ruby1.9.2-windows/lib/chef/config.rb:280:in `<class:Config>'
     # C:/jenkins/workspace/chef-ruby1.9.2-windows/lib/chef/config.rb:25:in`class:Chef'
     # C:/jenkins/workspace/chef-ruby1.9.2-windows/lib/chef/config.rb:24:in `<top (required)>'
     # C:/jenkins/workspace/chef-ruby1.9.2-windows/spec/unit/config_spec.rb:273:in`require'
     # C:/jenkins/workspace/chef-ruby1.9.2-windows/spec/unit/config_spec.rb:273:in `block (3 levels) in <top (required)>'
