### PR TITLE
CHEF-4130 - name tempfile correctly

### DIFF
--- a/lib/chef/knife/core/node_editor.rb
+++ b/lib/chef/knife/core/node_editor.rb
@@ -111,7 +111,7 @@ class Chef
       def tempfile_for(data)
         # TODO: include useful info like the node name in the temp file
         # name
-        basename = "knife-edit-" << rand(1_000_000_000_000_000).to_s.rjust(15, '0') << '.js'
+        basename = "knife-edit-" << rand(1_000_000_000_000_000).to_s.rjust(15, '0') << '.json'
         filename = File.join(Dir.tmpdir, basename)
         File.open(filename, "w+") do |f|
           f.sync = true


### PR DESCRIPTION
When one edits an object via knife, the tempfile winds up with a file extension of .js . If one's using a syntax checker like syntastic, you get jslint validation errors because json is not strictly validatable as js.
