### PR TITLE
[CHEF-3858] rescue bad json errors and re-raise as decryption failures

### DIFF
--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -175,6 +175,11 @@ class Chef::EncryptedDataBagItem
 
       def for_decrypted_item
         Yajl::Parser.parse(decrypted_data)["json_wrapper"]
+      rescue Yajl::ParseError
+        # convert to a DecryptionFailure error because the most likely scenario
+        # here is that the decryption step was unsuccessful but returned bad
+        # data rather than raising an error.
+        raise DecryptionFailure, "Error decrypting data bag value. Most likely the provided key is incorrect"
       end
 
 

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -92,6 +92,17 @@ describe Chef::EncryptedDataBagItem::Decryptor do
       decryptor.for_decrypted_item.should eq plaintext_data
     end
 
+    describe "and the decryption step returns invalid data" do
+      it "raises a decryption failure error" do
+        # Over a large number of tests on a variety of systems, we occasionally
+        # see the decryption step "succeed" but return invalid data (e.g., not
+        # the original plain text) [CHEF-3858]
+        decryptor.should_receive(:decrypted_data).and_return("lksajdf")
+        lambda { decryptor.for_decrypted_item }.should raise_error(Chef::EncryptedDataBagItem::DecryptionFailure)
+      end
+
+    end
+
     context "and the provided key is incorrect" do
       let(:decryption_key) { "wrong-passwd" }
 


### PR DESCRIPTION
After some discussion with @seth about https://github.com/opscode/chef/pull/740, we decided to avoid changes (even backwards compatible ones) in the encrypted data bag item format and instead add a new format version. I'll rescind pull 740 and rework it as a new format version.

This patch instead just catches yajl parse errors and re-raises them as decryption failure errors. This will ensure that even when the decryption step returns malformed data rather than raising, the code will eventually raise the same decryption failure exception.
