### PR TITLE
don't output newlines when only showing node IDs

### DIFF
--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -114,7 +114,9 @@ class Chef
           ui.msg("\n")
           result_items.each do |item|
             output(item)
-            ui.msg("\n")
+            unless config[:id_only]
+              ui.msg("\n")
+            end
           end
         end
       end


### PR DESCRIPTION
I often use the output of knife search -i and pipe it into other shell commands. However since it prints an additional newline after every host I always also have to pipe it through `sed -e "/^$/d"` first. Since the newlines don't help much when only outputting the IDs I added a conditional to not add them when using `:id_only`.
