### PR TITLE
[CHEF-4173] Fix insert_line_if_no_match for multiple runs

### DIFF
--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -102,8 +102,11 @@ class Chef
         #loop through contents and do the appropriate operation depending on 'command' and 'method'
         new_contents = []
 
+        match_found = false
+
         contents.each do |line|
           if line.match(exp)
+            match_found = true
             self.file_edited = true
             case
             when command == 'r'
@@ -120,7 +123,7 @@ class Chef
             new_contents << line
           end
         end
-        if command == 'i' && method == 2 && ! file_edited
+        if command == 'i' && method == 2 && ! match_found
           new_contents << replace
           self.file_edited = true
         end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4173

This fixes an issue where the _insert_line_if_no_match_ method only works if it's the first method called on a `FileEdit` object.
