### PR TITLE
[CHEF-4184] Support ISC license for knife cookbook create.

### DIFF
--- a/lib/chef/knife/cookbook_create.rb
+++ b/lib/chef/knife/cookbook_create.rb
@@ -43,7 +43,7 @@ class Chef
       option :cookbook_license,
         :short => "-I LICENSE",
         :long => "--license LICENSE",
-        :description => "License for cookbook, apachev2, gplv2, gplv3, mit or none"
+        :description => "License for cookbook, apachev2, gplv2, gplv3, isc, mit or none"
 
       option :cookbook_copyright,
         :short => "-C COPYRIGHT",
@@ -146,6 +146,21 @@ EOH
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+EOH
+            when "isc"
+              file.puts <<-EOH
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 EOH
             when "mit"
@@ -409,6 +424,8 @@ EOH
                          "GNU Public License 2.0"
                        when "gplv3"
                          "GNU Public License 3.0"
+                       when "isc"
+                         "ISC"
                        when "mit"
                          "MIT"
                        when "none"

--- a/spec/unit/knife/cookbook_create_spec.rb
+++ b/spec/unit/knife/cookbook_create_spec.rb
@@ -177,6 +177,22 @@ describe Chef::Knife::CookbookCreate do
       @knife.run
     end
 
+    it "should allow specifying the isc license" do
+      @dir = Dir.tmpdir
+      @knife.config = {
+        :cookbook_path => @dir,
+        :cookbook_copyright => "Opscode, Inc",
+        :cookbook_email => "nuo@opscode.com",
+        :cookbook_license => "isc"
+      }
+      @knife.name_args=["foobar"]
+      @knife.should_receive(:create_cookbook).with(@dir, @knife.name_args.first, "Opscode, Inc", "isc")
+      @knife.should_receive(:create_readme).with(@dir, @knife.name_args.first, "md")
+      @knife.should_receive(:create_changelog).with(@dir, @knife.name_args.first)
+      @knife.should_receive(:create_metadata).with(@dir, @knife.name_args.first, "Opscode, Inc", "nuo@opscode.com", "isc", "md")
+      @knife.run
+    end
+
     it "should allow specifying the rdoc readme format" do
       @dir = Dir.tmpdir
       @knife.config = {


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4184

Trivial addition of the ISC license template for use with the `--license` option of knife cookbook create.  Includes test.
