### PR TITLE
[CHEF-4197] ensure capture groups are populated

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -229,7 +229,7 @@ class Chef
             # So given a symlink like this:
             # /dev/mapper/vgroot-tmp.vol -> /dev/dm-9
             # First it will try to match "/dev/mapper/vgroot-tmp.vol". If there is no match it will try matching for "/dev/dm-9".
-            "(?:#{Regexp.escape(device_real)}|#{Regexp.escape(::File.readlink(device_real))})"
+            "(?:(?:#{Regexp.escape(device_real)}|#{Regexp.escape(::File.readlink(device_real))}))"
           else
             Regexp.escape(device_real)
           end


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4197

Wrap the alternation groups in an outer group to ensure that the named captures are populated regardless of whether the first or second clause matches. If the device file is a symlink (Ubuntu 12), then the mount options will be incorrectly populated. This may well manifest when moving from Ubuntu 10.x to Ubuntu 12.x.
