### PR TITLE
Fix user group modification for smartos

### DIFF
--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -45,7 +45,7 @@ class Chef
         
         def modify_group_members
           case node[:platform]
-          when "openbsd", "netbsd", "aix", "solaris2"
+          when "openbsd", "netbsd", "aix", "solaris2", "smartos"
             append_flags = "-G"
           when "solaris"
             append_flags = "-a -G"

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -46,7 +46,8 @@ describe Chef::Provider::Group::Usermod do
       platforms = {
         "openbsd" => "-G",
         "netbsd" => "-G",
-        "solaris" => "-a -G"
+        "solaris" => "-a -G",
+        "smartos" => "-G"
       }
 
       before do


### PR DESCRIPTION
Use -G instead of -a -G for changing group membership on SmartOS.
