### PR TITLE
[CHEF-4206] Update the service's current status when calling start or stop.

### DIFF
--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -72,6 +72,7 @@ class Chef
         end
 
         def start_service
+          set_service_status
           if @current_resource.running
             Chef::Log.debug("#{@new_resource} already running, not starting")
           else
@@ -84,6 +85,7 @@ class Chef
         end
 
         def stop_service
+          set_service_status
           unless @current_resource.running
             Chef::Log.debug("#{@new_resource} not running, not stopping")
           else


### PR DESCRIPTION
https://tickets.opscode.com/browse/CHEF-4206

Because the OSX service resource only checks the state of the service on load, a restart of an already running service will fail. This adds updates to check the state of the service on the stop and start actions, to ensure that it's acting upon current information.
