### PR TITLE
File refactor local cleanup

### DIFF
--- a/spec/unit/provider/remote_file/local_file_spec.rb
+++ b/spec/unit/provider/remote_file/local_file_spec.rb
@@ -28,95 +28,33 @@ describe Chef::Provider::RemoteFile::LocalFile do
 
   context "when first created" do
 
-    context "and the current resource has no source" do
-
-      it "stores the uri it is passed" do
-        fetcher.uri.should == uri
-      end
-
-      it "stores the new_resource" do
-        fetcher.new_resource.should == new_resource
-      end
-
-      it "stores nil for the last_modified date" do
-        fetcher.last_modified.should == nil
-      end
+    it "stores the uri it is passed" do
+      fetcher.uri.should == uri
     end
 
-    context "and the current resource has a source" do
-
-      before do
-        current_resource.source("file:///nyan_cat.png")
-      end
-
-      context "and use_last_modified is enabled" do
-        before do
-          new_resource.use_last_modified(true)
-        end
-
-        it "stores the last_modified string when the voodoo matches" do
-          Chef::Provider::RemoteFile::Util.should_receive(:uri_matches_string?).with(uri, current_resource.source[0]).and_return(true)
-          current_resource.stub!(:last_modified).and_return(Time.new)
-          fetcher.last_modified.should == current_resource.last_modified
-        end
-      end
-
-      describe "and use_last_modified is disabled in the new_resource" do
-        before do
-          new_resource.use_last_modified(false)
-        end
-
-        it "stores nil for the last_modified date" do
-          current_resource.stub!(:last_modified).and_return(Time.new)
-          fetcher.last_modified.should == nil
-        end
-      end
-
+    it "stores the new_resource" do
+      fetcher.new_resource.should == new_resource
     end
 
   end
 
   describe "when fetching the object" do
 
-    let(:now) { Time.now }
+    let(:tempfile) { mock("Tempfile", :path => "/tmp/foo/bar/nyan.png") }
+    let(:chef_tempfile) { mock("Chef::FileContentManagement::Tempfile", :tempfile => tempfile) }
 
     before do
       current_resource.source("file:///nyan_cat.png")
-      new_resource.use_last_modified(true)
-      current_resource.stub!(:last_modified).and_return(now)
-      Chef::Provider::RemoteFile::Util.should_receive(:uri_matches_string?).with(uri, current_resource.source[0]).and_return(true)
     end
 
-    context "and the source has not been modified" do
-      before do
-        ::File.stub!(:mtime).and_return(now)
-      end
+    it "stages the local file to a temporary file" do
+      Chef::FileContentManagement::Tempfile.should_receive(:new).with(new_resource).and_return(chef_tempfile)
+      ::FileUtils.should_receive(:cp).with(uri.path, tempfile.path)
 
-      it "returns nil tempfile when the source file has not been modified" do
-        result = fetcher.fetch
-        result.raw_file.should be_nil
-        result.etag.should be_nil
-        result.mtime.should == now
-      end
-    end
-
-    context "and the source has been modified" do
-      let(:tempfile) { mock("Tempfile", :path => "/tmp/nyan.png") }
-      let(:chef_tempfile) { mock("Chef::FileContentManagement::Tempfile", :tempfile => tempfile) }
-
-      before do
-        ::File.stub!(:mtime).and_return(now + 10)
-      end
-
-      it "calls Chef::FileContentManagement::Tempfile to get a tempfile" do
-        Chef::FileContentManagement::Tempfile.should_receive(:new).with(new_resource).and_return(chef_tempfile)
-        ::FileUtils.should_receive(:cp).with(uri.path, tempfile.path)
-
-        result = fetcher.fetch
-        result.raw_file.should == tempfile
-        result.etag.should be_nil
-        result.mtime.should == (now + 10)
-      end
+      result = fetcher.fetch
+      result.raw_file.should == tempfile
+      result.etag.should be_nil
+      result.mtime.should be_nil
     end
 
   end


### PR DESCRIPTION
removes dependence on remote file provider setting mtime and such on the resources (which was removed in previous patch). Also de-mocks and simplifies the tests.

Made a note to add "conditional get" behavior back in later, but skipping that for now in the interest of getting this overall patch merged.
