### PR TITLE
Run remote_file functional tests w/ HTTPS

### DIFF
--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -18,6 +18,7 @@
 
 require 'rubygems'
 require 'webrick'
+require 'webrick/https'
 require 'rack'
 #require 'thin'
 require 'singleton'


### PR DESCRIPTION
- Run standard file behavior functional tests with HTTPS on port 9000.
- Confirms CHEF-3005 fixed.
- Refactor tests to run against different server configurations.
