### PR TITLE
Add opt-in code coverage reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group(:docgen) do
 end
 
 group(:development, :test) do
+  gem "simplecov"
   gem 'rack', "~> 1.5.1"
 
   gem 'ruby-shadow', :platforms => :ruby unless RUBY_PLATFORM.downcase.match(/(darwin|freebsd)/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,17 @@ $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 $:.unshift(File.expand_path("../lib", __FILE__))
 $:.unshift(File.dirname(__FILE__))
 
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter "/spec/"
+    add_group "Remote File", "remote_file"
+    add_group "Resources", "/resource/"
+    add_group "Providers", "/provider/"
+    add_group "Knife", "knife"
+  end
+end
+
 require 'chef'
 require 'chef/knife'
 Chef::Knife.load_commands


### PR DESCRIPTION
Run tests with, e.g., `COVERAGE=t bundle exec rspec PATH` to generate a
report
