### PR TITLE
[CHEF-3952] ensure tf exists before :close!

### DIFF
--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -250,7 +250,7 @@ class Chef
                 tempfile = stream_to_tempfile(url, r, &block)
                 yield tempfile
               ensure
-                tempfile.close!
+                tempfile.close! if tempfile
               end
             else
               tempfile = stream_to_tempfile(url, r)
@@ -400,7 +400,7 @@ class Chef
       tf.close
       tf
     rescue Exception
-      tf.close!
+      tf.close! if tf
       raise
     end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3952

Quick fix for people experiencing 3952 and probably other things. Initially appeared to be a problem with how we resolve binary content, but even an improved method resulted in tempfile being `nil`.

It may also be worth addressing the `binary_contents?` method.
