### PR TITLE
CHEF-4259: Fix unpacking recipes with non-gnu tar

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -215,7 +215,7 @@ class Chef::Application::Solo < Chef::Application
           f.write(r.read)
         end
       end
-      Chef::Mixin::Command.run_command(:command => "tar zxvfC #{path} #{recipes_path}")
+      Chef::Mixin::Command.run_command(:command => "tar zxvf #{path} -C #{recipes_path}")
     end
   end
 

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -136,7 +136,7 @@ describe Chef::Application::Solo do
       end
 
       it "should untar the target file to the parent of the cookbook path" do
-        Chef::Mixin::Command.should_receive(:run_command).with({:command => "tar zxvfC #{Dir.tmpdir}/chef-solo/recipes.tgz #{Dir.tmpdir}/chef-solo"}).and_return(true)
+        Chef::Mixin::Command.should_receive(:run_command).with({:command => "tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo"}).and_return(true)
         @app.reconfigure
       end
     end


### PR DESCRIPTION
This probably isn't enough to handle every ancient version of tar, but
at least it fixes unpacking on SmartOS which is based on fairly recent
illumos.

There has been some discussion on CHEF-1201 to introduce a setting to configure a gnu compatible tar. I think the better solution is not to rely on GNU tar specific behaviour.

This could still be broken on older versions of tar that don't support decompression though, but it should work with most recent flavours.
