### PR TITLE
Fix "undefined method binread" in functional tests on Ruby 1.8.7

### DIFF
--- a/spec/functional/resource/template_spec.rb
+++ b/spec/functional/resource/template_spec.rb
@@ -192,7 +192,7 @@ describe Chef::Resource::Template do
 
     include_context "diff disabled"
 
-    let (:expected_content) {
+    let(:expected_content) {
       "Template rendering libraries\r\nshould support\r\ndifferent line endings\r\n\r\n"
     }
 


### PR DESCRIPTION
- No `IO.binread` on 1.8
- Fix space between method call and argument (triggers ruby warnings).
