### PR TITLE
WIP - deploy resilience w/o auto-rollback

### DIFF
--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -228,6 +228,8 @@ class Chef
       end
 
       def cleanup!
+        release_created(release_path)
+
         chop = -1 - @new_resource.keep_releases
         all_releases[0..chop].each do |old_release|
           converge_by("remove old release #{old_release}") do
@@ -263,10 +265,11 @@ class Chef
       def copy_cached_repo
         target_dir_path = @new_resource.deploy_to + "/releases"
         converge_by("deploy from repo to #{@target_dir_path} ") do
+          FileUtils.rm_rf(target_dir_path) if ::File.exist?(target_dir_path)
           FileUtils.mkdir_p(target_dir_path)
           FileUtils.cp_r(::File.join(@new_resource.destination, "."), release_path, :preserve => true)
           Chef::Log.info "#{@new_resource} copied the cached checkout to #{release_path}"
-          release_created(release_path)
+          #release_created(release_path)
         end
       end
 


### PR DESCRIPTION
This would need some work before merging, putting this up here for discussion.

This is an approach to making the deploy resource redeploy after a failed deploy. It works by not storing a release in the release order cache until the very end of the deploy. When the user runs chef again, the deploy resource loads the release order cache, see that the current (botched) release is not first in the list, and will essentially do a force deploy on top of the last attempt.
### The Good:
- Failed deployments don't auto-rollback, so the primary behavior of a failed deploy doesn't change.
- Files on disk are left in the same state as when the failure occurred, so users can poke around for debugging purposes (auto-rollback deletes the botched deploy).
- Re-running Chef after fixing the root issue (e.g., bad callback code, transient github error) will get the deployment into the desired state.
### The Bad:
- If the user nukes the release order cache, we fallback to inspecting what's on disk. This will cause the deploy resource to behave as if the application is correctly deployed (or should be rolled-back-to).
- If the user never redeploys the same application version, the deploy resource will never delete the directory with the botched code (this is a minor issue that can be solved by making the cleanup code smarter).
