### PR TITLE
fixes for 'rake install' on ruby-2.0.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,10 +48,12 @@ begin
   end
 rescue LoadError
   puts "sdoc is not available. (sudo) gem install sdoc to generate rdoc documentation."
+rescue TypeError
+  puts "sdoc is not working on ruby-2.0.0 and throwing an odd TypeError, rdoc generation will be disabled on ruby 2.0 until that gets fixed."
 end
 
 task :install => :package do
-  sh %{gem install pkg/#{GEM_NAME}-#{Chef::VERSION} --no-rdoc --no-ri}
+  sh %{gem install pkg/#{GEM_NAME}-#{Chef::VERSION}.gem --no-rdoc --no-ri}
 end
 
 task :uninstall do


### PR DESCRIPTION
the patch to add the .gem extension should be pretty straight forwards and i've tested this on ruby 1.8.7/1.9.3/2.0.0 and its worked.

the TypeError exception is to deal with this:

```
rake aborted!
no implicit conversion of nil into Hash
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/sdoc-0.3.20/lib/sdoc/generator.rb:10:in `require'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/sdoc-0.3.20/lib/sdoc/generator.rb:10:in `<top (required)>'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/sdoc-0.3.20/lib/sdoc.rb:7:in `require'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/sdoc-0.3.20/lib/sdoc.rb:7:in `<top (required)>'
/Users/lamont/oc/chef/Rakefile:39:in `require'
/Users/lamont/oc/chef/Rakefile:39:in `<top (required)>'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/rake_module.rb:25:in `load'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/rake_module.rb:25:in `load_rakefile'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:589:in `raw_load_rakefile'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:89:in `block in load_rakefile'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:88:in `load_rakefile'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:72:in `block in run'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/bin/ruby_noexec_wrapper:14:in `eval'
/Users/lamont/.rvm/gems/ruby-2.0.0-p195/bin/ruby_noexec_wrapper:14:in `<main>'
(See full trace by running task with --trace)
```

which i looked into, but which makes no sense at all to me, and the google was not useful for enlightenment.  its an ugly hack, but once the root cause of the sdoc/ruby-2.0.0 issue is fixed, it'll naturally stop getting exercised... 
