### PR TITLE
don't depend on line separator in partial tests

### DIFF
--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -31,7 +31,7 @@ class Chef
         if IO.respond_to?(:binread)
           IO.binread(file)
         else
-          IO.read(file)
+          File.open(file, "rb") {|f| f.read }
         end
       end
 

--- a/spec/data/partial_one.erb
+++ b/spec/data/partial_one.erb
@@ -1,1 +1,1 @@
-partial one <%= render 'test.erb', :cookbook => 'openldap' %> calling home
+partial one <%= render('test.erb', :cookbook => 'openldap').strip %> calling home

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -65,8 +65,8 @@ describe Chef::Mixin::Template, "render_template" do
     end
 
     it "should provide a render method" do
-      output = @template_context.render_template_from_string("before {<%= render 'test.erb' %>} after")
-      output.should == "before {We could be diving for pearls!#{sep}} after"
+      output = @template_context.render_template_from_string("before {<%= render('test.erb').strip -%>} after")
+      output.should == "before {We could be diving for pearls!} after"
     end
 
     it "should render local files" do
@@ -85,8 +85,8 @@ describe Chef::Mixin::Template, "render_template" do
     it "should render partials from a different cookbook" do
       @template_context[:template_finder] = Chef::Provider::TemplateFinder.new(@run_context, 'apache2', @node)
 
-      output = @template_context.render_template_from_string("before {<%= render 'test.erb', :cookbook => 'openldap' %>} after")
-      output.should == "before {We could be diving for pearls!#{sep}} after"
+      output = @template_context.render_template_from_string("before {<%= render('test.erb', :cookbook => 'openldap').strip %>} after")
+      output.should == "before {We could be diving for pearls!} after"
     end
 
     it "should render using the source argument if provided" do
@@ -139,8 +139,8 @@ describe Chef::Mixin::Template, "render_template" do
     it "should render nested partials" do
       path = File.expand_path(File.join(CHEF_SPEC_DATA, "partial_one.erb"))
 
-      output = @template_context.render_template_from_string("before {<%= render '#{path}', :local => true %>} after")
-      output.should == "before {partial one We could be diving for pearls!#{sep} calling home#{sep}} after"
+      output = @template_context.render_template_from_string("before {<%= render('#{path}', :local => true).strip %>} after")
+      output.should == "before {partial one We could be diving for pearls! calling home} after"
     end
 
     describe "when customizing the template context" do


### PR DESCRIPTION
In some windows testing environments no line separator conversion is
happening. This may be a function of git settings, or something else in
our test cluster environment. In any case, line separators are
irrelevant to these tests, as they are testing the partial template
feature. We could remove the line endings from the test fixture files,
but editors like vim add hidden newlines at the end of files, so this is
difficult to maintain. Stripping the line endings within the test code
is more sustainable option.
