### PR TITLE
Allows subclasses to customize the #converge_by message of Chef::Provider::Execute

### DIFF
--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -56,10 +56,16 @@ class Chef
         if STDOUT.tty? && !Chef::Config[:daemon] && Chef::Log.info?
           opts[:live_stream] = STDOUT
         end
-        converge_by("execute #{@new_resource.command}") do 
+        converge_by(converge_identity) do
           result = shell_out!(@new_resource.command, opts)
           Chef::Log.info("#{@new_resource} ran successfully")
         end
+      end
+
+      protected
+
+      def converge_identity
+        "execute #{@new_resource.command}"
       end
 
       private


### PR DESCRIPTION
`Chef::Provider::Execute` has sophisticated execution logic which makes it a great base class for specialized providers tied to execution-oriented resources such as rake & Thor tasks, etc. The resources associated with these providers can subclass `Chef::Resource::Execute` and treat `command` as a calculated (read-only) attribute.

To make this extra-nice, it would be great to customize the default `converge_by` message. This pull request replaces the hard-wired `"execute #{@new_resource.command}"` message with a protected `converge_identity` method, which would allow the following:

``` ruby
class Chef::Provider::Rake < Chef::Provider::Execute
  protected
  def converge_identity
    "rake #{@new_resource.task}#{@new_resource.arguments}"
  end
end
```

Simple but powerful because it keeps with Chef's tradition of generating clear and accurate messages.
