### PR TITLE
[CHEF-4289] IPS provider performs unnecessary upgrades

### DIFF
--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -57,7 +57,7 @@ class Chef
             case line
             when /^\s+State: Installed/
               installed = true
-            when /^\s+Version: (.*)/
+            when /^\s+Version: ([0-9,\.]+)\s/
               @candidate_version = $1.split[0]
               if installed
                 @current_resource.version($1)


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4289

This change restricts the version match regex to the actual IPS version of the package, avoiding any optional, extraneous text, which appears for packages that have the pkg.human-version attribute.
