### PR TITLE
Fix compiling the same cookbook multiple times

### DIFF
--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -84,7 +84,7 @@ class Chef
           seen_cookbooks = {}
           run_list_expansion.recipes.each do |recipe|
             cookbook = Chef::Recipe.parse_recipe_name(recipe).first
-            add_cookbook_with_deps(ordered_cookbooks, seen_cookbooks, cookbook)
+            add_cookbook_with_deps(ordered_cookbooks, seen_cookbooks, cookbook.to_sym)
           end
           Chef::Log.debug("Cookbooks to compile: #{ordered_cookbooks.inspect}")
           ordered_cookbooks


### PR DESCRIPTION
cookbook_order generates the order based on the cookbook as a symbol. This assumption comes from Chef::Recipe.parse_recipe_name which to_sym's the cookbook name.

This is in contrast to #each_cookbook_dep which yields the cookbook dependencies as Strings. The symptom of this mismatch is the ordered_cookbook Array containing the same cookbook twice, once as a String and once as a Symbol.

This corrects the issue by forcing everything going into ordered_cookbooks to be a Symbol.

Here is output that shows the issue:

```
[2013-06-20T18:59:11+00:00] DEBUG: Cookbooks to compile: [:yum, "chef_gem", :rvm, "yum", :imagemagick, :edc]
```

The issue manifests itself later on when chef compiles the LWRP's twice:

```
[2013-06-20T18:59:11+00:00] DEBUG: Loading cookbook yum's providers from /tmp/vagrant-chef-1/chef-solo-1/cookbooks/yum/providers/key.rb
[2013-06-20T18:59:11+00:00] INFO: YumKey light-weight provider already initialized -- overriding!
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/provider/lwrp_base.rb:97: warning: already initialized constant YumKey
```

The redundant yum comes from the imagemagick cookbook, which contains:

```
depends :yum
```

You'll see that even when the dependency is declared as a Symbol, it pops up later as a String. So dependency list clearly #to_s's the argument before storing it. If it were `depends "yum"` the issue still exists, obviously.
