### PR TITLE
to see this on command line with default :auto level we need to warn

### DIFF
--- a/lib/chef/run_lock.rb
+++ b/lib/chef/run_lock.rb
@@ -58,7 +58,7 @@ class Chef
       unless runlock.flock(File::LOCK_EX|File::LOCK_NB)
         # Another chef client running...
         runpid = runlock.read.strip.chomp
-        Chef::Log.info("Chef client #{runpid} is running, will wait for it to finish and then run.")
+        Chef::Log.warn("Chef client #{runpid} is running, will wait for it to finish and then run.")
         runlock.flock(File::LOCK_EX)
       end
       # We grabbed the run lock.  Save the pid.


### PR DESCRIPTION
without this the console just hangs while the background daemonized chef-client is running.
