### PR TITLE
[CHEF-4301] knife site cookbook install with :use_current_branch option doesn't work with slashes in branchname

### DIFF
--- a/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -123,8 +123,7 @@ class Chef
       end
 
       def get_current_branch()
-        ref = git("symbolic-ref HEAD").stdout
-        ref.chomp.split('/')[2]
+        git("rev-parse --abbrev-ref HEAD").stdout
       end
 
       private


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4301
