### PR TITLE
[OC-8391] Windows Password Policies

### DIFF
--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -37,6 +37,11 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
   #[:symbol_name, default_val]
   #default_val duals as field type
   #array index duals as structure offset
+
+  #OC-8391
+  #Changing [:password, nil], to [:password, ""],
+  #if :password is set to nil, windows user creation api ignores the password policy applied
+  #thus initializing it with empty string value.
   USER_INFO_3 = [
     [:name, nil],
     [:password, ""],
@@ -183,6 +188,8 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
   def disable_account
     user_modify do |user|
       user[:flags] |= UF_ACCOUNTDISABLE
+      #This does not set the password to nil. It (for some reason) means to ignore updating the field.
+      #please refer to https://github.com/jmccann/chef/commit/ff732aab4f7e79f215567bcc3dc4e4f7295207ee#commitcomment-3413715
       user[:password] = nil
     end
   end
@@ -190,6 +197,8 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
   def enable_account
     user_modify do |user|
       user[:flags] &= ~UF_ACCOUNTDISABLE
+      #This does not set the password to nil. It (for some reason) means to ignore updating the field.
+      #please refer to https://github.com/jmccann/chef/commit/ff732aab4f7e79f215567bcc3dc4e4f7295207ee#commitcomment-3413715
       user[:password] = nil
     end
   end


### PR DESCRIPTION
Cases validated are, on 2k8 and 2k12 machines
When password policy enforced and relaxed

``` ruby
user "user_of_fortune" do
  action :create
end
```

``` ruby
user "user_of_fortune" do
  password ""
  action :create
end
```

``` ruby
user "user_of_fortune" do
  password "Chef2UncleNed!"
  action :create
end
```

``` ruby
user "user_of_fortune" do
  action :lock
end
```

``` ruby
user "user_of_fortune" do
  action :unlock
end
```

``` ruby
user "user_of_fortune" do
  action :manage
end
```

``` ruby
user "user_of_fortune" do
  action :modify
end
```

``` ruby
user "user_of_fortune" do
  action :remove
end
```
