### PR TITLE
[CHEF-4318] Display node name upon failure

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -105,7 +105,7 @@ class Chef
             node_name = server.host
           else
             @action_nodes.each do |n|
-              node_name = n if format_for_display(n)[config[:attribute]] == server.host
+              node_name = n.name if format_for_display(n)[n.name][config[:attribute]] == server.host
             end
           end
           case config[:on_error]


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4318

If a node isn't reachable, 'knife ssh' would display an error message where the node name would be empty. Node seems to now be an object instead of string - look up the name property instead of returning the node.
