### PR TITLE
[CHEF-4320] Fix logrotate settings

### DIFF
--- a/distro/redhat/etc/logrotate.d/chef-client
+++ b/distro/redhat/etc/logrotate.d/chef-client
@@ -2,7 +2,8 @@
   rotate 12
   weekly
   compress
+  missingok
   postrotate
-    /etc/init.d/chef-client condrestart >/dev/null || :
+    /etc/init.d/chef-client restart >/dev/null || :
   endscript
 }

--- a/distro/redhat/etc/logrotate.d/chef-expander
+++ b/distro/redhat/etc/logrotate.d/chef-expander
@@ -2,7 +2,8 @@
   rotate 12
   weekly
   compress
+  missingok
   postrotate
-    /etc/init.d/chef-expander condrestart >/dev/null || :
+    /etc/init.d/chef-expander restart >/dev/null || :
   endscript
 }

--- a/distro/redhat/etc/logrotate.d/chef-server
+++ b/distro/redhat/etc/logrotate.d/chef-server
@@ -2,7 +2,8 @@
   rotate 12
   weekly
   compress
+  missingok
   postrotate
-    /etc/init.d/chef-server condrestart >/dev/null || :
+    /etc/init.d/chef-server restart >/dev/null || :
   endscript
 }

--- a/distro/redhat/etc/logrotate.d/chef-server-webui
+++ b/distro/redhat/etc/logrotate.d/chef-server-webui
@@ -2,7 +2,8 @@
   rotate 12
   weekly
   compress
+  missingok
   postrotate
-    /etc/init.d/chef-server-webui condrestart >/dev/null || :
+    /etc/init.d/chef-server-webui restart >/dev/null || :
   endscript
 }

--- a/distro/redhat/etc/logrotate.d/chef-solr
+++ b/distro/redhat/etc/logrotate.d/chef-solr
@@ -2,7 +2,8 @@
   rotate 12
   weekly
   compress
+  missingok
   postrotate
-    /etc/init.d/chef-solr condrestart >/dev/null || :
+    /etc/init.d/chef-solr restart >/dev/null || :
   endscript
 }


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4320

The missing 'missingok' creates error messages by logrotate in `/var/log/messages`.
Log files are not rotated, as the services aren't properly restarted in the postrotate section of the logrotate section. The 'condrestart' parameter is not supported by the init scripts. I replaced them with 'restart'.
