### PR TITLE
Yum package calls readlines on a string.

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -759,7 +759,7 @@ class Chef
                 @rpmdb << pkg
               end
 
-              error = status.stderr.readlines
+              error = status.stderr
             rescue Mixlib::ShellOut::CommandTimeout => e
               Chef::Log.error("#{helper} exceeded timeout #{Chef::Config[:yum_timeout]}")
               raise(e)


### PR DESCRIPTION
2a3d8a762f5d0b3fce36dd44106c0ac04caa5eba introduced a regression and broke install on yum provider. 

CI run: http://ci.opscode.us/view/Chef%20Client%20Build%20Pipeline/job/chef-client-test/411/
