### PR TITLE
[CHEF-3159] Fail with exit 1 if the init script is missing

### DIFF
--- a/distro/debian/etc/init.d/chef-client
+++ b/distro/debian/etc/init.d/chef-client
@@ -20,7 +20,7 @@ NAME=chef-client
 DESC=chef-client
 PIDFILE=/var/run/chef/client.pid
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 

--- a/distro/debian/etc/init.d/chef-expander
+++ b/distro/debian/etc/init.d/chef-expander
@@ -20,7 +20,7 @@ NAME=chef-expander
 DESC=chef-expander
 PIDFILE=/var/run/chef/expander.pid
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 

--- a/distro/debian/etc/init.d/chef-server
+++ b/distro/debian/etc/init.d/chef-server
@@ -21,7 +21,7 @@ MAINPID=/var/run/chef/server.main.pid
 NAME=chef-server
 DESC=chef-server
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 

--- a/distro/debian/etc/init.d/chef-server-webui
+++ b/distro/debian/etc/init.d/chef-server-webui
@@ -21,7 +21,7 @@ MAINPID=/var/run/chef/server-webui.main.pid
 NAME=chef-server-webui
 DESC=chef-server-webui
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 

--- a/distro/debian/etc/init.d/chef-solr
+++ b/distro/debian/etc/init.d/chef-solr
@@ -21,7 +21,7 @@ NAME=chef-solr
 DESC=chef-solr
 PIDFILE=/var/run/chef/solr.pid
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 

--- a/distro/debian/etc/init/chef-client.conf
+++ b/distro/debian/etc/init/chef-client.conf
@@ -11,7 +11,7 @@ respawn
 respawn limit 5 30
 
 pre-start script
-    test -x /usr/bin/chef-client || { stop; exit 0; }
+    test -x /usr/bin/chef-client || { stop; exit 1; }
 end script
 
 exec /usr/bin/chef-client -i 1800 -L /var/log/chef/client.log

--- a/distro/debian/etc/init/chef-expander.conf
+++ b/distro/debian/etc/init/chef-expander.conf
@@ -11,7 +11,7 @@ respawn
 respawn limit 5 30
 
 pre-start script
-    test -x /usr/bin/chef-expander || { stop; exit 0; }
+    test -x /usr/bin/chef-expander || { stop; exit 1; }
 end script
 
 exec /usr/bin/chef-expander -c /etc/chef/solr.rb -L /var/log/chef/expander.log -n 1 -i 1

--- a/distro/debian/etc/init/chef-server-webui.conf
+++ b/distro/debian/etc/init/chef-server-webui.conf
@@ -11,7 +11,7 @@ respawn
 respawn limit 5 30
 
 pre-start script
-    test -x /usr/bin/chef-server-webui || { stop; exit 0; }
+    test -x /usr/bin/chef-server-webui || { stop; exit 1; }
 end script
 
 exec /usr/bin/chef-server-webui -e production -p 4040 -L /var/log/chef/server-webui.log

--- a/distro/debian/etc/init/chef-server.conf
+++ b/distro/debian/etc/init/chef-server.conf
@@ -11,7 +11,7 @@ respawn
 respawn limit 5 30
 
 pre-start script
-    test -x /usr/bin/chef-server || { stop; exit 0; }
+    test -x /usr/bin/chef-server || { stop; exit 1; }
 end script
 
 exec /usr/bin/chef-server -e production -p 4000 -L /var/log/chef/server.log

--- a/distro/debian/etc/init/chef-solr.conf
+++ b/distro/debian/etc/init/chef-solr.conf
@@ -11,7 +11,7 @@ respawn
 respawn limit 5 30
 
 pre-start script
-    test -x /usr/bin/chef-solr || { stop; exit 0; }
+    test -x /usr/bin/chef-solr || { stop; exit 1; }
 end script
 
 exec /usr/bin/chef-solr -c /etc/chef/solr.rb -L /var/log/chef/solr.log


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3159
