### PR TITLE
[CHEF-4334] Can't parse release candidate version number

### DIFF
--- a/lib/chef/version_class.rb
+++ b/lib/chef/version_class.rb
@@ -56,7 +56,7 @@ class Chef
     def parse(str="")
       @major, @minor, @patch =
         case str.to_s
-        when /^(\d+)\.(\d+)\.(\d+)(\.rc)(\.\d+)?$/
+        when /^(\d+)\.(\d+)\.(\d+)((\.rc){1}(\.\d+)?)?$/
           [ $1.to_i, $2.to_i, $3.to_i ]
         when /^(\d+)\.(\d+)$/
           [ $1.to_i, $2.to_i, 0 ]

--- a/spec/unit/version_class_spec.rb
+++ b/spec/unit/version_class_spec.rb
@@ -28,12 +28,12 @@ describe Chef::Version do
     @v0.to_s.should == "0.0.0"
     @v123.to_s.should == "1.2.3"
   end
-  
+
   it "should make a round trip with its string representation" do
     a = Chef::Version.new(@v123.to_s)
     a.should == @v123
   end
-  
+
   it "should transform 1.2 to 1.2.0" do
     Chef::Version.new("1.2").to_s.should == "1.2.0"
   end
@@ -44,7 +44,7 @@ describe Chef::Version do
   end
 
   describe "when creating valid Versions" do
-    good_versions = %w(1.2 1.2.3 1000.80.50000 0.300.25 001.02.00003)
+    good_versions = %w(1.2 1.2.3 1000.80.50000 0.300.25 001.02.00003 12.2.3.rc 33.3.1.rc.5)
     good_versions.each do |v|
       it "should accept '#{v}'" do
         Chef::Version.new v
@@ -54,7 +54,8 @@ describe Chef::Version do
 
   describe "when given bogus input" do
     bad_versions = ["1.2.3.4", "1.2.a4", "1", "a", "1.2 3", "1.2 a",
-                    "1 2 3", "1-2-3", "1_2_3", "1.2_3", "1.2-3"]
+                    "1 2 3", "1-2-3", "1_2_3", "1.2_3", "1.2-3",
+                    "12.33.1.rc.b", "12.33.4444.12.rc", "55.32.11.cr.2"]
     the_error = Chef::Exceptions::InvalidCookbookVersion
     bad_versions.each do |v|
       it "should raise #{the_error} when given '#{v}'" do


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4334

Error when using a release candidate

``` text
/usr/local/rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/chef-11.6.0.rc.0/lib/chef/version_class.rb:65:in `parse'
:
deploy_revision[railsapp] (/tmp/vagrant-chef-1/chef-solo-1/cookbooks/application/providers/default.rb line 122) had an error:
Chef::Exceptions::InvalidCookbookVersion: application_ruby_rails[railsapp] (enquirli::test line 115) had an error:
Chef::Exceptions::InvalidCookbookVersion: '11.6.0.rc.0' does not match 'x.y.z' or 'x.y' (Chef::Exceptions::InvalidCookbookVersion)
```
