### PR TITLE
[CHEF-4337] Allow IPv6 addresses in chef_server_url

### DIFF
--- a/lib/chef/monkey_patches/uri.rb
+++ b/lib/chef/monkey_patches/uri.rb
@@ -1,0 +1,39 @@
+# See http://bugs.ruby-lang.org/issues/3788
+module URI
+  class Generic
+    unless method_defined?(:hostname)
+      # extract the host part of the URI and unwrap brackets for IPv6 addresses.
+      #
+      # This method is same as URI::Generic#host except
+      # brackets for IPv6 (andn future IP) addresses are removed.
+      #
+      # u = URI("http://[::1]/bar")
+      # p u.hostname      #=> "::1"
+      # p u.host          #=> "[::1]"
+      #
+      def hostname
+        v = self.host
+        /\A\[(.*)\]\z/ =~ v ? $1 : v
+      end
+
+      # set the host part of the URI as the argument with brackets for IPv6 addresses.
+      #
+      # This method is same as URI::Generic#host= except
+      # the argument can be bare IPv6 address.
+      #
+      # u = URI("http://foo/bar")
+      # p u.to_s                  #=> "http://foo/bar"
+      # u.hostname = "::1"
+      # p u.to_s                  #=> "http://[::1]/bar"
+      #
+      # If the arugument seems IPv6 address,
+      # it is wrapped by brackets.
+      #
+      def hostname=(v)
+        v = "[#{v}]" if /\A\[.*\]\z/ !~ v && /:/ =~ v
+        self.host = v
+      end
+    end
+  end
+end
+

--- a/lib/chef/rest/rest_request.rb
+++ b/lib/chef/rest/rest_request.rb
@@ -23,6 +23,7 @@
 require 'uri'
 require 'net/http'
 require 'chef/rest/cookie_jar'
+require 'chef/monkey_patches/uri'
 
 # To load faster, we only want ohai's version string.
 # However, in ohai before 0.6.0, the version is defined


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-4337

Due to improper usage of URI#host (in lieu of URI#hostname), chef-client was unable to connect to the server using direct IPv6 URI like "http://[::1]/".

See http://bugs.ruby-lang.org/issues/3788 for more details.
