### PR TITLE
[CHEF-4341] Use symlink source when inspecting current permissions

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -74,7 +74,7 @@ class Chef
         # Let children resources override constructing the @current_resource
         @current_resource ||= Chef::Resource::File.new(@new_resource.name)
         @current_resource.path(@new_resource.path)
-        if real_file?(@current_resource.path) && ::File.exists?(@current_resource.path)
+        if ::File.exists?(@current_resource.path) && ::File.file?(::File.realpath(@current_resource.path))
           if @action != :create_if_missing && @current_resource.respond_to?(:checksum)
             @current_resource.checksum(checksum(@current_resource.path))
           end
@@ -292,6 +292,7 @@ class Chef
             converge_by(description) do
               unlink(@new_resource.path)
             end
+            @current_resource.checksum = nil
             @file_unlinked = true
           end
         end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -36,6 +36,8 @@ class Chef
         state_attrs :checksum, :owner, :group, :mode
       end
 
+      attr_writer :checksum
+
       provides :file, :on_platforms => :all
 
       def initialize(name, run_context=nil)

--- a/lib/chef/scan_access_control.rb
+++ b/lib/chef/scan_access_control.rb
@@ -127,7 +127,12 @@ class Chef
     end
 
     def stat
-      @stat ||= @new_resource.instance_of?(Chef::Resource::Link) ? ::File.lstat(@new_resource.path) : ::File.stat(@new_resource.path)
+      @stat ||= if @new_resource.instance_of?(Chef::Resource::Link)
+        ::File.lstat(@new_resource.path)
+      else
+        realpath = ::File.realpath(@new_resource.path)
+        ::File.stat(realpath)
+      end
     end
   end
 end

--- a/spec/unit/scan_access_control_spec.rb
+++ b/spec/unit/scan_access_control_spec.rb
@@ -21,7 +21,8 @@ require 'chef/scan_access_control'
 describe Chef::ScanAccessControl do
 
   before do
-    @new_resource = Chef::Resource::File.new("/tmp/foo/bar/baz/qux")
+    @new_resource = Chef::Resource::File.new("/tmp/foo/bar/baz/link")
+    @real_file = "/tmp/foo/bar/real/file"
     @current_resource = Chef::Resource::File.new(@new_resource.path)
     @scanner = Chef::ScanAccessControl.new(@new_resource, @current_resource)
   end
@@ -49,7 +50,8 @@ describe Chef::ScanAccessControl do
 
     before do
       @stat = mock("File::Stat for #{@new_resource.path}", :uid => 0, :gid => 0, :mode => 00100644)
-      File.should_receive(:stat).with(@new_resource.path).and_return(@stat)
+      File.should_receive(:realpath).with(@new_resource.path).and_return(@real_file)
+      File.should_receive(:stat).with(@real_file).and_return(@stat)
       File.should_receive(:exist?).with(@new_resource.path).and_return(true)
     end
 


### PR DESCRIPTION
Fixes CHEF-4341 http://tickets.opscode.com/browse/CHEF-4341

When manage_symlink_source is enabled, File providers update
current_resource with the security attributes of the source file.
Subsequent actions (e.g., running FileAccessControl) use the values set
on current_resource to determine if they need to modify the system, so
setting them incorrect leads to a file resource being (not) updated
incorrectly.
