### PR TITLE
Support platform "suse" and "opensuse" on OpenSuSE

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -173,6 +173,17 @@ class Chef
               :ifconfig => Chef::Provider::Ifconfig::Redhat
             }
           },
+          :opensuse     => {
+            :default => {
+              :service => Chef::Provider::Service::Redhat,
+              :cron => Chef::Provider::Cron,
+              :package => Chef::Provider::Package::Zypper,
+              :group => Chef::Provider::Group::Suse
+            },
+            ">= 12.3" => {
+              :group => Chef::Provider::Group::Usermod
+            }
+          },
           :suse     => {
             :default => {
               :service => Chef::Provider::Service::Redhat,
@@ -180,6 +191,16 @@ class Chef
               :package => Chef::Provider::Package::Zypper,
               :group => Chef::Provider::Group::Suse
             },
+            ###############################################
+            # TODO: Remove this after ohai update is released.
+            # Only OpenSuSE 12.3+ should use the Usermod group provider:
+            # Ohai before OHAI-339 is applied reports both OpenSuSE and SuSE
+            # Enterprise as "suse", Ohai after OHAI-339 will report OpenSuSE as
+            # "opensuse".
+            #
+            # In order to support OpenSuSE both before and after the Ohai
+            # change, I'm leaving this here. It needs to get removed before
+            # SuSE enterprise 12.3 ships.
             ">= 12.3" => {
               :group => Chef::Provider::Group::Usermod
             }

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -47,7 +47,7 @@ class Chef
           case node[:platform]
           when "openbsd", "netbsd", "aix", "solaris2", "smartos"
             append_flags = "-G"
-          when "solaris", "suse"
+          when "solaris", "suse", "opensuse"
             append_flags = "-a -G"
           end
 

--- a/spec/functional/resource/user_spec.rb
+++ b/spec/functional/resource/user_spec.rb
@@ -505,7 +505,7 @@ describe Chef::Resource::User, :unix_only, :requires_root do
       context "and has no password" do
 
         # TODO: platform_family should be setup in spec_helper w/ tags
-        if OHAI_SYSTEM["platform_family"] == "suse"
+        if %w[suse opensuse].include?(OHAI_SYSTEM["platform_family"])
           # suse gets this right:
           it "errors out trying to unlock the user" do
             @error.should be_a(Mixlib::ShellOut::ShellCommandFailed)

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -28,6 +28,7 @@ describe "Chef::Platform supports" do
     :centos,
     :fedora,
     :suse,
+    :opensuse,
     :redhat,
     :oracle,
     :gentoo,

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -48,6 +48,7 @@ describe Chef::Provider::Group::Usermod do
         "netbsd" => "-G",
         "solaris" => "-a -G",
         "suse" => "-a -G",
+        "opensuse" => "-a -G",
         "smartos" => "-G"
       }
 


### PR DESCRIPTION
Fixes CHEF-4356: http://tickets.opscode.com/browse/CHEF-4356

A future update to Ohai (OHAI-339) will change the detected platform on
OpenSuSE from "suse" to "opensuse" to allow users to distinguish between
open and enterprise versions. Add provider mapping for "opensuse" such
that Chef will work correctly for both cases.
