### PR TITLE
Increase the default yum timeout to 5 minutes.

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -189,7 +189,7 @@ class Chef
     chef_server_url   "https://localhost:443"
 
     rest_timeout 300
-    yum_timeout 300
+    yum_timeout 900
     solo  false
     splay nil
     why_run false


### PR DESCRIPTION
11.6.0 introduced timeout to package resources that are using yum. 

Currently the default timeout is set to 2 minutes. We've found out during test-kitchen tests that 2 minutes is a small amount of timeout and some customers might hit this timeout by just upgrading to 11.6. 

This PR increases the timeout to 5 minutes. I strongly think we should increase the timeout and I'm open to any other number than 5 minutes :)
