### PR TITLE
Finalizing data types that are uploaded to reporting.

### DIFF
--- a/lib/chef/formatters/error_descriptor.rb
+++ b/lib/chef/formatters/error_descriptor.rb
@@ -31,7 +31,7 @@ class Chef
       end
 
       def section(heading, text)
-        @sections << [heading, text]
+        @sections << {heading => text}
       end
 
       def display(out)
@@ -40,7 +40,9 @@ class Chef
         out.puts "=" * 80
         out.puts "\n"
         sections.each do |section|
-          display_section(section, out)
+          section.each do |heading, text|
+            display_section(heading, text, out)
+          end
         end
       end
 
@@ -53,8 +55,7 @@ class Chef
 
       private
 
-      def display_section(section, out)
-        heading, text = section
+      def display_section(heading, text, out)
         out.puts heading
         out.puts "-" * heading.size
         out.puts text

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -408,7 +408,7 @@ describe Chef::ResourceReporter do
 
       it "includes the error inspector output in the event data" do
         @report["data"]["exception"].should have_key("description")
-        @report["data"]["exception"]["description"].should include({"title"=>"Error expanding the run_list:", "sections"=>[["Unexpected Error:", "RSpec::Mocks::Mock: Object not found"]]})
+        @report["data"]["exception"]["description"].should include({"title"=>"Error expanding the run_list:", "sections"=>[{"Unexpected Error:" => "RSpec::Mocks::Mock: Object not found"}]})
       end
 
     end


### PR DESCRIPTION
Change error description sections elements to be hashes.

It is much easier for erlang to validate the json that chef-client sends up if exception_data.description.sections is of structure:

[{"str1" => "value1"}, ... ]

As opposed to current structure of:

[["str1", "value1"], ... ]

This change was achieved by updating error_description.rb. I also updated relevant test.
