### PR TITLE
Add -E flag to chef-solo in order to enable people use the new environment support in chef-solo.

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -160,6 +160,11 @@ class Chef::Application::Solo < Chef::Application
     :description  => 'Enable whyrun mode',
     :boolean      => true
 
+  option :environment,
+    :short        => '-E ENVIRONMENT',
+    :long         => '--environment ENVIRONMENT',
+    :description  => 'Set the Chef Environment on the node'
+
   attr_reader :chef_solo_json
 
   def initialize


### PR DESCRIPTION
http://tickets.opscode.com/browse/CHEF-3356 has added environment support to chef-solo. However using chef-solor from command line users can not make use of this because they can't set the environment for the node in chef-solo. 

This PR add -E flag support to chef-solo therefore people can set the environment if they want to make use of it. 

I've tested env_run_lists via roles and environment attributes manually and looking good with -E flag.
