### PR TITLE
Ignore corrupt cache control data; re-download file

### DIFF
--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -87,11 +87,12 @@ class Chef
         end
 
         def load
-          previous_cc_data = load_data
-          apply(previous_cc_data)
-          self
-        rescue Chef::Exceptions::FileNotFound
-          false
+          if previous_cc_data = load_data
+            apply(previous_cc_data)
+            self
+          else
+            false
+          end
         end
 
         def validate!(current_copy_checksum)
@@ -139,6 +140,8 @@ class Chef
 
         def load_data
           Chef::JSONCompat.from_json(load_json_data)
+        rescue Chef::Exceptions::FileNotFound, Yajl::ParseError
+          false
         end
 
         def load_json_data

--- a/spec/unit/provider/remote_file/cache_control_data_spec.rb
+++ b/spec/unit/provider/remote_file/cache_control_data_spec.rb
@@ -108,6 +108,15 @@ describe Chef::Provider::RemoteFile::CacheControlData do
         cache_control_data.mtime.should == mtime
       end
     end
+
+    context "and the cached checksum data is corrupted" do
+      let(:cache_json_data) { '{"foo",,"bar" []}' }
+
+      it "returns empty cache control data" do
+        cache_control_data.etag.should be_nil
+        cache_control_data.mtime.should be_nil
+      end
+    end
   end
 
   describe "when saving to disk" do


### PR DESCRIPTION
Fixes CHEF-4365: http://tickets.opscode.com/browse/CHEF-4365

A corrupt cache control file will cause a persistent failure of the
related remote_file resource. Since this data is just a cache of HTTP
headers, Chef can ignore corrupted cache control data, re-download the
source file, and then re-populate the cache with not-corrupt data.
