### PR TITLE
OC-8641 - new_resource.cookbook_version is nil for some resources

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -67,9 +67,6 @@ class Chef
         if new_resource.cookbook_name
           as_hash["cookbook_name"] = new_resource.cookbook_name
           as_hash["cookbook_version"] = new_resource.cookbook_version.version
-        else
-          as_hash["cookbook_name"] = ""
-          as_hash["cookbook_version"] = "0.0.0"
         end
 
         as_hash

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -455,12 +455,12 @@ describe Chef::ResourceReporter do
         @first_update_report["result"].should == "create"
       end
 
-      it "includes a default (blank) cookbook name" do
-        @first_update_report["cookbook_name"].should == ""
+      it "does not include a cookbook name for the resource" do
+        @first_update_report.should_not have_key("cookbook_name")
       end
 
-      it "includes a default (0.0.0) cookbook version" do
-        @first_update_report["cookbook_version"].should == "0.0.0"
+      it "does not include a cookbook version for the resource" do
+        @first_update_report.should_not have_key("cookbook_version")
       end
     end
 


### PR DESCRIPTION
Since the existing tests mocked out Resource#cookbook_version it missed
the case where if Resource#cookbook_name is nil then cookbook_version would
also be nil.

Added guard logic around setting the cookbook_name, cookbook_version
in resource_reporter.rb to protect against the case where cookbook_name
is nil.
