### PR TITLE
avoid appearing very, very wrong

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -206,7 +206,7 @@ class Chef
         Chef::Log.debug "Fork successful. Waiting for new chef pid: #{pid}"
         result = Process.waitpid2(pid)
         handle_child_exit(result)
-        Chef::Log.debug "Forked child successfully reaped (pid: #{pid})"
+        Chef::Log.debug "Forked instance successfully reaped (pid: #{pid})"
         true
       else
         do_run


### PR DESCRIPTION
A colleague brought this to my attention.
The initial viewing of this line could be controversial to some.

In other places of the same code, the term "instance" is used in logging, not child.
