### PR TITLE
before migration symlinks should not run if migration is false, default ...

### DIFF
--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -189,9 +189,9 @@ class Chef
       end
 
       def migrate
-        run_symlinks_before_migrate
 
         if @new_resource.migrate
+          run_symlinks_before_migrate  
           enforce_ownership
 
           environment = @new_resource.environment

--- a/spec/unit/provider/deploy_spec.rb
+++ b/spec/unit/provider/deploy_spec.rb
@@ -338,10 +338,10 @@ describe Chef::Provider::Deploy do
     @provider.enforce_ownership
   end
 
-  it "skips the migration when resource.migrate => false but runs symlinks before migration" do
+  it "skips the migration when resource.migrate => false" do
     @resource.migrate false
     @provider.should_not_receive :run_command
-    @provider.should_receive :run_symlinks_before_migrate
+    @provider.should_not_receive :run_symlinks_before_migrate
     @provider.migrate
   end
 


### PR DESCRIPTION
...config/database.yml may not be present in all projects
