### PR TITLE
gem resources fail when the version is set to empty string

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -534,7 +534,7 @@ class Chef
           else
             src = @new_resource.source && "  --source=#{@new_resource.source} --source=http://rubygems.org"
           end
-          if version
+          if version && !version.empty?
             shell_out!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)
           else
             shell_out!("#{gem_binary_path} install \"#{name}\" -q --no-rdoc --no-ri #{src}#{opts}", :env=>nil)


### PR DESCRIPTION
added a check for empty string as version.  This causes issues with rubygems.

When the version is an empty string, we should call gem install with no version flag and let it grab the latest.
