### PR TITLE
[CHEF-4421] Improve an error message "No cookbook found".

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -559,7 +559,7 @@ class Chef
         cookbook_paths = Array(Chef::Config[:cookbook_path])
         Chef::Log.debug "Loading from cookbook_path: #{cookbook_paths.map { |path| File.expand_path(path) }.join(', ')}"
         if cookbook_paths.all? {|path| empty_directory?(path) }
-          msg = "None of the cookbook paths, #{cookbook_paths.inspect}, contain any cookbooks"
+          msg = "None of the cookbook paths set in Chef::Config[:cookbook_path], #{cookbook_paths.inspect}, contain any cookbooks"
           Chef::Log.fatal(msg)
           raise Chef::Exceptions::CookbookNotFound, msg
         end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -456,7 +456,7 @@ shared_examples_for Chef::Client do
       it "raises CookbookNotFound error" do
         expect do
           @client.send(:assert_cookbook_path_not_empty, nil)
-        end.to raise_error(Chef::Exceptions::CookbookNotFound, 'None of the cookbook paths, ["/path/to/invalid/cookbook_path"], contain any cookbooks')
+        end.to raise_error(Chef::Exceptions::CookbookNotFound, 'None of the cookbook paths set in Chef::Config[:cookbook_path], ["/path/to/invalid/cookbook_path"], contain any cookbooks')
       end
     end
   end


### PR DESCRIPTION
JIRA: http://tickets.opscode.com/browse/CHEF-4421

When no cookbook is found in `cookbook_path` directory, `chef-client` or `chef-solo` prints an error message.

When `cookbook_path` is `["/path/dir/a", "/path/dir/b"]`, `/path/dir/a` has a cookbook, `/path/dir/b` has no cookbook and I run `chef-client`, I get the following message:

```
No cookbook found in ["/path/dir/a", "/path/dir/b"], make sure cookbook_path is set correctly.
```

This is confusing and **user may think both `/path/dir/a` and `/path/dir/b` have no cookbook**.

With this pull request, you will get a straightforward message like the following:

```
No cookbook found in /path/dir/b, make sure cookbook_path is set correctly.
```
