### PR TITLE
[CHEF-4424] default solo.rb path is invalid on Windows

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -31,7 +31,7 @@ class Chef::Application::Solo < Chef::Application
   option :config_file,
     :short => "-c CONFIG",
     :long  => "--config CONFIG",
-    :default => Chef::Config.platform_specfic_path('/etc/chef/solo.rb'),
+    :default => Chef::Config.platform_specific_path('/etc/chef/solo.rb'),
     :description => "The configuration file to use"
 
   option :formatter,


### PR DESCRIPTION
Fix typo: platform_specfic_path -> platform_specific_path
