### PR TITLE
Queue is defined by the thread library but never required

### DIFF
--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -1,4 +1,3 @@
-
 require 'set'
 require 'rest_client'
 require 'chef/exceptions'
@@ -8,6 +7,7 @@ require 'chef/cookbook_version'
 require 'chef/cookbook/syntax_check'
 require 'chef/cookbook/file_system_file_vendor'
 require 'chef/sandbox'
+require 'thread'
 
 class Chef
   class CookbookUploader


### PR DESCRIPTION
This fixes the following bug for me.

knife cookbook upload hedgeye -VV
DEBUG: Signing the request as hedgeyedev
DEBUG: Sending HTTP Request via GET to api.opscode.com:443/organizations/hedgeye/cookbooks
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: transfer-encoding: chunked
DEBUG: content-type: application/json
DEBUG: content-encoding: gzip
DEBUG: connection: close
DEBUG: server: ngx_openresty
DEBUG: x-ops-api-info: flavor=ohc;version=10.0.0;oc_erchef=0.21.8
DEBUG: date: Mon, 29 Jul 2013 20:24:19 GMT
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: decompressing gzip response
DEBUG: No chefignore file found at /Users/dscataglini/work/chef-hedgeye/cookbooks/chefignore no files will be ignored
Uploading hedgeye        [1.0.1]
DEBUG: Skipping file /Users/dscataglini/work/chef-hedgeye/cookbooks/hedgeye/templates/.DS_Store, as it isn't in any of the proper directories (platform-version, platform or default)
DEBUG: You probably need to move /Users/dscataglini/work/chef-hedgeye/cookbooks/hedgeye/templates/.DS_Store into the 'default' sub-directory
DEBUG: Versions of cookbook 'apache2' returned by the server: 0.99.3
DEBUG: Matched cookbook 'apache2' with constraint '>= 0.0.0' to cookbook version '0.99.3' on the server
DEBUG: Versions of cookbook 'sqlite' returned by the server: 0.7.0
DEBUG: Matched cookbook 'sqlite' with constraint '>= 0.0.0' to cookbook version '0.7.0' on the server
DEBUG: Versions of cookbook 'sphinx' returned by the server: 0.4.0
DEBUG: Matched cookbook 'sphinx' with constraint '>= 0.0.0' to cookbook version '0.4.0' on the server
DEBUG: Versions of cookbook 'imagemagick' returned by the server: 0.2.2, 0.2.0
DEBUG: Matched cookbook 'imagemagick' with constraint '>= 0.0.0' to cookbook version '0.2.2' on the server
DEBUG: Versions of cookbook 'git' returned by the server: 0.9.0
DEBUG: Matched cookbook 'git' with constraint '>= 0.0.0' to cookbook version '0.9.0' on the server
DEBUG: Versions of cookbook 'mysql' returned by the server: 1.0.8
DEBUG: Matched cookbook 'mysql' with constraint '>= 0.0.0' to cookbook version '1.0.8' on the server
DEBUG: Versions of cookbook 'passenger_apache2' returned by the server: 0.99.0
DEBUG: Matched cookbook 'passenger_apache2' with constraint '>= 0.0.0' to cookbook version '0.99.0' on the server
INFO: Validating ruby files
DEBUG: No chefignore file found at /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/chefignore no files will be ignored
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/libraries/radiant.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/metadata.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/cold_deploy.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/db_bootstrap.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/default.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/deploy.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/remotehd.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/reqs.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/recipes/status.rb is unchanged, skipping syntax check
DEBUG: Ruby file /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/schema.rb is unchanged, skipping syntax check
DEBUG: Testing /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/attributes/default.rb for syntax errors...
Syntax OK
INFO: Validating templates
DEBUG: Template /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/database.yml.erb is unchanged, skipping syntax check
DEBUG: Template /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/hedgeye-ssl.conf.erb is unchanged, skipping syntax check
DEBUG: Template /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/hedgeye.conf.erb is unchanged, skipping syntax check
DEBUG: Template /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/sphinx.yml.erb is unchanged, skipping syntax check
DEBUG: Template /Users/dscataglini/work/chef-hedgeye/.chef/../cookbooks/hedgeye/templates/default/status.html.erb is unchanged, skipping syntax check
INFO: Syntax OK
INFO: Saving hedgeye
DEBUG: Skipping file /Users/dscataglini/work/chef-hedgeye/cookbooks/hedgeye/templates/.DS_Store, as it isn't in any of the proper directories (platform-version, platform or default)
DEBUG: You probably need to move /Users/dscataglini/work/chef-hedgeye/cookbooks/hedgeye/templates/.DS_Store into the 'default' sub-directory
DEBUG: Signing the request as hedgeyedev
DEBUG: Sending HTTP Request via POST to api.opscode.com:443/organizations/hedgeye/sandboxes
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 201 Created
DEBUG: content-type: application/json
DEBUG: connection: close
DEBUG: server: ngx_openresty
DEBUG: content-length: 2388
DEBUG: x-ops-api-info: flavor=ohc;version=10.0.0;oc_erchef=0.21.8
DEBUG: location: http://api.opscode.com/organizations/hedgeye/sandboxes/bec4d2199a4497fc201739cebf4a6ba8
DEBUG: date: Mon, 29 Jul 2013 20:24:20 GMT
DEBUG: ---- End HTTP Status/Header Data ----
INFO: Uploading files
/Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/cookbook_uploader.rb:16:in `work_queue': uninitialized constant Chef::CookbookUploader::Queue (NameError)
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/cookbook_uploader.rb:21:in`setup_worker_threads'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/cookbook_uploader.rb:75:in `upload_cookbooks'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife/cookbook_upload.rb:231:in`upload'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife/cookbook_upload.rb:122:in `run'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife/cookbook_upload.rb:119:in`each'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife/cookbook_upload.rb:119:in `run'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife.rb:466:in`run_with_pretty_exceptions'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/knife.rb:173:in `run'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/lib/chef/application/knife.rb:123:in`run'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/gems/chef-11.6.0/bin/knife:25
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/bin/knife:19:in `load'
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/bin/knife:19
    from /Users/dscataglini/.rvm/gems/ruby-1.8.7-p358@chef/bin/ruby_noexec_wrapper:14
