### PR TITLE
Add 'require thread' to cookbook_uploader to get Queue defined.

### DIFF
--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -1,6 +1,7 @@
 
 require 'set'
 require 'rest_client'
+require 'thread'
 require 'chef/exceptions'
 require 'chef/knife/cookbook_metadata'
 require 'chef/digester'


### PR DESCRIPTION
Without this change, when I run

```
knife cookbook upload MY_RECIPE
```

for any recipe, I get the error:

```
/usr/lib/ruby/gems/1.8/gems/chef-11.6.0/lib/chef/cookbook_uploader.rb:16:in `work_queue': uninitialized constant Chef::CookbookUploader::Queue (NameError)
```

With this change, the command works fine.
