### PR TITLE
Make sure config file selection specs can run when HOME is not set.

### DIFF
--- a/spec/unit/knife/config_file_selection_spec.rb
+++ b/spec/unit/knife/config_file_selection_spec.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,16 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'tmpdir'
 
 describe Chef::Knife do
+  before do
+    # Make sure tests can run when HOME is not set...
+    @original_home = ENV["HOME"]
+    ENV["HOME"] = Dir.tmpdir
+  end
+
+  after do
+    ENV["HOME"] = @original_home
+  end
+
   before :each do
     Chef::Config.stub!(:from_file).and_return(true)
   end
@@ -45,7 +55,7 @@ describe Chef::Knife do
     @knife.configure_chef
     @knife.config[:config_file].should == pwd_config
   end
-  
+
   it "configure knife from UPWARD" do
     upward_dir = File.expand_path "#{Dir.pwd}/.chef"
     upward_config = File.expand_path "#{upward_dir}/knife.rb"
@@ -53,23 +63,23 @@ describe Chef::Knife do
       [ upward_config ].include? arg
     end
     Chef::Knife.stub!(:chef_config_dir).and_return(upward_dir)
-    
+
     @knife = Chef::Knife.new
     @knife.configure_chef
     @knife.config[:config_file].should == upward_config
   end
-  
+
   it "configure knife from HOME" do
     home_config = File.expand_path(File.join("#{ENV['HOME']}", "/.chef/knife.rb"))
     File.stub!(:exist?).and_return do | arg |
       [ home_config ].include? arg
     end
-    
+
     @knife = Chef::Knife.new
     @knife.configure_chef
     @knife.config[:config_file].should == home_config
   end
-  
+
   it "configure knife from nothing" do
     ::File.stub!(:exist?).and_return(false)
     @knife = Chef::Knife.new
@@ -77,7 +87,7 @@ describe Chef::Knife do
     @knife.configure_chef
     @knife.config[:config_file].should be_nil
   end
-  
+
   it "configure knife precedence" do
     env_config = File.join(Dir.tmpdir, 'knife.rb')
     pwd_config = "#{Dir.pwd}/knife.rb"
@@ -90,11 +100,11 @@ describe Chef::Knife do
     end
     Chef::Knife.stub!(:chef_config_dir).and_return(upward_dir)
     ENV['KNIFE_HOME'] = Dir.tmpdir
-   
+
     @knife = Chef::Knife.new
     @knife.configure_chef
     @knife.config[:config_file].should == env_config
-    
+
     configs.delete env_config
     @knife.config.delete :config_file
     @knife.configure_chef


### PR DESCRIPTION
This is required for Manhattan CI since the slaves don't have their HOME set.
