### PR TITLE
CHEF-4422 Truncate cache paths for remote file

### DIFF
--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -149,7 +149,10 @@ class Chef
         end
 
         def sanitized_cache_file_basename
-          scrubbed_uri = uri.gsub(/\W/, '_')
+          # Scrub and truncate in accordance with the goals of keeping the name
+          # human-readable but within the bounds of local file system
+          # path length limits
+          scrubbed_uri = uri.gsub(/\W/, '_')[0..63]
           uri_md5 = Chef::Digester.instance.generate_md5_checksum(StringIO.new(uri))
           "#{scrubbed_uri}-#{uri_md5}.json"
         end

--- a/spec/functional/provider/remote_file/cache_control_data_spec.rb
+++ b/spec/functional/provider/remote_file/cache_control_data_spec.rb
@@ -1,0 +1,91 @@
+#
+# Author:: Adam Edwards (<adamed@opscode.com>)
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'uri'
+
+describe Chef::Provider::RemoteFile::CacheControlData do
+
+  before(:each) do
+    Chef::Config[:file_cache_path] = Dir.mktmpdir
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(Chef::Config[:file_cache_path])
+  end
+
+  let(:uri) { URI.parse("http://www.bing.com/robots.txt") }
+  
+  describe "when the cache control data save method is invoked" do
+
+    subject(:cache_control_data) do
+      Chef::Provider::RemoteFile::CacheControlData.load_and_validate(uri, file_checksum)
+    end
+
+    # the checksum of the file last we fetched it.
+    let(:file_checksum) { "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
+
+    let(:etag) { "\"a-strong-identifier\"" }
+    let(:mtime) { "Thu, 01 Aug 2013 08:16:32 GMT" }
+
+    before do
+      cache_control_data.etag = etag
+      cache_control_data.mtime = mtime
+      cache_control_data.checksum = file_checksum
+    end
+
+    it "writes data to the cache" do
+      cache_control_data.save
+    end
+
+    it "writes the data to the cache and the same data can be read back" do
+      cache_control_data.save
+      saved_cache_control_data = Chef::Provider::RemoteFile::CacheControlData.load_and_validate(uri, file_checksum)
+      saved_cache_control_data.etag.should == cache_control_data.etag
+      saved_cache_control_data.mtime.should == cache_control_data.mtime
+      saved_cache_control_data.checksum.should == cache_control_data.checksum  
+    end
+
+    # Cover the very long remote file path case -- see CHEF-4422 where
+    # local cache file names generated from the long uri exceeded
+    # local file system path limits resulting in exceptions from
+    # file system API's on both Windows and Unix systems.
+    context "when the length of the uri exceeds the path length limits for the local file system" do
+      let(:uri_exceeds_file_system_limit) do
+        URI.parse("http://www.bing.com/" + ('0' * 1024))
+      end
+
+      let(:uri) { uri_exceeds_file_system_limit }
+
+      it "writes data to the cache" do
+        cache_control_data.save
+      end
+
+      it "writes the data to the cache and the same data can be read back" do
+        cache_control_data.save
+        saved_cache_control_data = Chef::Provider::RemoteFile::CacheControlData.load_and_validate(uri, file_checksum)
+        saved_cache_control_data.etag.should == cache_control_data.etag
+        saved_cache_control_data.mtime.should == cache_control_data.mtime
+        saved_cache_control_data.checksum.should == cache_control_data.checksum  
+      end
+
+    end
+  end
+
+end
+


### PR DESCRIPTION
Both Windows and Unix systems place limits on the path lengths of files in the local file system that are much lower than the limits for a uri used for the http protocol. Because of this, the CacheControlData class's usage of the Chef FileCache on the local file system when storing data about files referenced by the remote_file resource, would throw exceptions for sufficiently long URI's. This occurred because the local file name that CacheControlData specified to FileCache contained an interpolated version of the remote_file's uri that was at least as long as the uri., When FileCache tried to access such files, the relevant system calls would throw an exception. In the case of Windows, this occurred when the path specified to FileCache was greater than MAX_PATH = 260 characters, and the limit was somewhat more generous on systems such as FreeBSD but still there.

The fix was simple to truncate the variable part of the file name that is based on the URI -- the other parts of the file name include an MD5 hash represented in hexadecimal, so overall the path as a fixed maximum of 102 after truncating the uri to 64 characters. The uri representation in the name exists to make the local files human-readable for debugging or other forensic purposes -- it is not strictly necessary and the hash was always required to increase uniqueness. The content of the file contains a file checksum and relatively high resolution time stamps anyway, so ultimately a cache collision is no more likely with this change than earlier.
