### PR TITLE
load latest specs including prerelease to be able to use prerelease vers...

### DIFF
--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -121,7 +121,7 @@ class Chef
 
       def latest_gem_specs
         @latest_gem_specs ||= if Gem::Specification.respond_to? :latest_specs
-          Gem::Specification.latest_specs
+          Gem::Specification.latest_specs(prerelease=true)
         else
           Gem.source_index.latest_specs
         end


### PR DESCRIPTION
chef 11.6.0 and knife-solo knife-solo-0.3.0.pre5 did not work as subcommand loader of chef 11.6.0 ignores prerelease version of gems.
