### PR TITLE
CHEF-4469 Allow installing packages from Jumpstart share

### DIFF
--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -107,13 +107,23 @@ class Chef
         def install_package(name, version)
           Chef::Log.debug("#{@new_resource} package install options: #{@new_resource.options}")
           if @new_resource.options.nil?
+            if ::File.directory?(@new_resource.source) # CHEF-4469
+              command = "pkgadd -n -d #{@new_resource.source} #{@new_resource.package_name}"
+            else
+              command = "pkgadd -n -d #{@new_resource.source} all"
+            end
             run_command_with_systems_locale(
-                    :command => "pkgadd -n -d #{@new_resource.source} all"
+                    :command => command
                   )
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           else
+            if ::File.directory?(@new_resource.source) # CHEF-4469
+              command = "pkgadd -n#{expand_options(@new_resource.options)} -d #{@new_resource.source} #{@new_resource.package_name}"
+            else
+              command = "pkgadd -n#{expand_options(@new_resource.options)} -d #{@new_resource.source} all"
+            end
             run_command_with_systems_locale(
-              :command => "pkgadd -n#{expand_options(@new_resource.options)} -d #{@new_resource.source} all"
+              :command => command
             )
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           end


### PR DESCRIPTION
A common case in the world of Solaris is one where there is a Jumpstart boot+install server on the network. This, by definition, offers up the Solaris media in the form of an NFS share where each installable SysV package is exploded already into its own directory.

For example, SUNWntpr (the NTP "Root" package)

```
client% ls /net/pompeii/Solaris_10/Product/SUNWntpr
archive/  install/  pkginfo  pkgmap  reloc/
client%
```

This patch to the Solaris package provider detects if the 'source' (required attribute when using Solaris package provider) is a directory and acts differently if so. It allows the following to work in this scenario (where it does not currently):

```
package 'SUNWntpr' do
  source '/net/pompeii/Solaris_10/Product'
end
```

Prior to this, package installation from an 'exploded' package directory would not work no matter what crazy package name + source location I constructed. pkgadd would barf.
