### PR TITLE
CHEF-4482 : change user attribute comparison to string compares

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -113,7 +113,7 @@ class Chef
       # <false>:: If the users are identical
       def compare_user
         [ :uid, :gid, :comment, :home, :shell, :password ].any? do |user_attrib|
-          !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib) != @current_resource.send(user_attrib)
+          !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib).to_s != @current_resource.send(user_attrib).to_s
         end
       end
 

--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -124,7 +124,7 @@ class Chef
         end
 
         def update_options(field, option, opts)
-          if @current_resource.send(field) != new_resource.send(field)
+          if @current_resource.send(field).to_s != new_resource.send(field).to_s
             if new_resource.send(field)
               Chef::Log.debug("#{new_resource} setting #{field} to #{new_resource.send(field)}")
               opts << option << new_resource.send(field).to_s


### PR DESCRIPTION
Here's one possible solution for CHEF-4482. Since at their core these values in /etc/passwd and which are passed to the useradd or usermod binaries are strings we can just compare them all as strings and this case is solved.
