### PR TITLE
Add -u to initial pacman command

### DIFF
--- a/lib/chef/knife/bootstrap/archlinux-gems.erb
+++ b/lib/chef/knife/bootstrap/archlinux-gems.erb
@@ -2,7 +2,7 @@ bash -c '
 <%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
 
 if [ ! -f /usr/bin/chef-client ]; then
-  pacman -Syy
+  pacman -Syyu --noconfirm
   pacman -S --noconfirm ruby ntp base-devel
   ntpdate -u pool.ntp.org
   gem install ohai --no-rdoc --no-ri --verbose


### PR DESCRIPTION
When you do pacman -Syy, you need to also do pacman -Su.  This will make
sure that if there are any soname bumps in the installed packages, that
they will absolutely also be pulled in as well. After the -Su, it is
safe to pacman -S again.

http://gist.io/5660494
