### PR TITLE
[CHEF-4507] Smartos package provider to match resource package_name

### DIFF
--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -64,14 +64,14 @@ class Chef
           pkg = shell_out!("/opt/local/bin/pkgin se #{new_resource.package_name}", :env => nil, :returns => [0,1])
           pkg.stdout.each_line do |line|
             case line
-            when /^#{name}/
+            when /^#{new_resource.package_name}/
               name, version = line.split[0].split(/-([^-]+)$/)
             end
           end
           @candidate_version = version
           version
         end
-     
+
         def install_package(name, version)
           Chef::Log.debug("#{@new_resource} installing package #{name} version #{version}")
           package = "#{name}-#{version}"

--- a/spec/unit/provider/package/smartos_spec.rb
+++ b/spec/unit/provider/package/smartos_spec.rb
@@ -69,6 +69,24 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
 
 	end
 
+  describe "candidate_version" do
+    it "should return the candidate_version variable if already setup" do
+      @provider.candidate_version = "2.1.1"
+      @provider.should_not_receive(:shell_out!)
+      @provider.candidate_version
+    end
+
+    it "should lookup the candidate_version if the variable is not already set" do
+      search = mock()
+      search.should_receive(:each_line).
+        and_yield("something-varnish-1.1.1  something varnish like\n").
+        and_yield("varnish-2.3.4 actual varnish\n")
+      @shell_out = mock('shell_out!', :stdout => search)
+      @provider.should_receive(:shell_out!).with('/opt/local/bin/pkgin se varnish', :env => nil, :returns => [0,1]).and_return(@shell_out)
+      @provider.candidate_version.should == "2.3.4"
+    end
+  end
+
 	describe "when manipulating a resource" do
 	
 		it "run pkgin and install the package" do


### PR DESCRIPTION
Previously, the check for package name/version matched on the local variable "name," which on the first loop is nil. This matches any line. On subsequent loops, the test is against whatever was found in line 1. Since pkgsrc will return any package that match search terms (even in descriptions or other metadata), it is very likely that the incorrect candidate version will be returned, and chef runs will fail (it will then try to install a non-existent package version).
