### PR TITLE
[CHEF-4513] HTTPS proxy not set (wget only) using HTTPS to download the Omnibus installer.

### DIFF
--- a/lib/chef/knife/bootstrap/chef-full.erb
+++ b/lib/chef/knife/bootstrap/chef-full.erb
@@ -1,5 +1,5 @@
 bash -c '
-<%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+<%= "export https_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
 
 exists() {
   if command -v $1 &>/dev/null


### PR DESCRIPTION
See http://tickets.opscode.com/browse/CHEF-4513
