### PR TITLE
CHEF-4531: Add resource to TemplateContext

### DIFF
--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -39,6 +39,7 @@ class Chef
           context = TemplateContext.new(@new_resource.variables)
           context[:node] = @run_context.node
           context[:template_finder] = template_finder
+          context[:resource] = @new_resource
           context._extend_modules(@new_resource.helper_modules)
           output = context.render_template(template_location)
 

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -62,11 +62,17 @@ describe Chef::Mixin::Template, "render_template" do
       @template_context = Chef::Mixin::Template::TemplateContext.new({})
       @template_context[:node] = @node
       @template_context[:template_finder] = Chef::Provider::TemplateFinder.new(@run_context, @resource.cookbook_name, @node)
+      @template_context[:resource] = @resource
     end
 
     it "should provide a render method" do
       output = @template_context.render_template_from_string("before {<%= render('test.erb').strip -%>} after")
       output.should == "before {We could be diving for pearls!} after"
+    end
+
+    it "should provide access to the resource" do
+      output = @template_context.render_template_from_string("resource_name: <%= @resource.name %>")
+      output.should == "resource_name: #{@rendered_file_location}"
     end
 
     it "should render local files" do


### PR DESCRIPTION
Adding the resource to the TemplateContext allows a user in the ERB
to be able to reference metadata about the requesting resource.

This can be useful if a person wants to offer a hint in their
rendered file as to which cookbook/recipe is rendering it.
