### PR TITLE
Add default configuration for http proxies

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -384,6 +384,11 @@ class Chef
       default :hints, {}
     end
 
+    # HTTP Proxy settings
+    default :http_proxy, nil
+    default :https_proxy, nil
+    default :no_proxy, nil
+
     # Those lists of regular expressions define what chef considers a
     # valid user and group name
     if RUBY_PLATFORM =~ /mswin|mingw|windows/

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -196,6 +196,18 @@ describe Chef::Config do
       Chef::Config[:ssl_ca_file].should be_nil
     end
 
+    it "Chef::Config[:http_proxy] defaults to nil" do
+      Chef::Config[:http_proxy].should be_nil
+    end
+
+    it "Chef::Config[:https_proxy] defaults to nil" do
+      Chef::Config[:https_proxy].should be_nil
+    end
+
+    it "Chef::Config[:no_proxy] defaults to nil" do
+      Chef::Config[:no_proxy].should be_nil
+    end
+
     it "Chef::Config[:data_bag_path] defaults to /var/chef/data_bags" do
       data_bag_path =
         Chef::Config.platform_specific_path("/var/chef/data_bags")


### PR DESCRIPTION
This just adds default config options for http_proxy.

It might be better to honor the system environment options here, rather than default to nil, but that would be a behavior change.
