### PR TITLE
default case should be same as log_level :auto

### DIFF
--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -186,18 +186,8 @@ describe Chef::Application do
       @app.configure_logging
     end
 
-    it "should initialise the chef logger level" do
-      # By default, Chef translates :auto to :warn
-      Chef::Log.should_receive(:level=).with(:warn).and_return(true)
-      @app.configure_logging
-    end
-
-    context "and log_level is :auto" do
-      before do
-        Chef::Config[:log_level] = :auto
-      end
-
-      context "and STDOUT is to a tty" do
+    shared_examples_for "log_level_is_auto" do
+      context "when STDOUT is to a tty" do
         before do
           STDOUT.stub!(:tty?).and_return(true)
         end
@@ -207,7 +197,7 @@ describe Chef::Application do
           Chef::Log.level.should == :warn
         end
 
-        context "and force_logger is configured" do
+        context "when force_logger is configured" do
           before do
             Chef::Config[:force_logger] = true
           end
@@ -219,7 +209,7 @@ describe Chef::Application do
         end
       end
 
-      context "and STDOUT is not to a tty" do
+      context "when STDOUT is not to a tty" do
         before do
           STDOUT.stub!(:tty?).and_return(false)
         end
@@ -229,7 +219,7 @@ describe Chef::Application do
           Chef::Log.level.should == :info
         end
 
-        context "and force_formatter is configured" do
+        context "when force_formatter is configured" do
           before do
             Chef::Config[:force_formatter] = true
           end
@@ -239,7 +229,18 @@ describe Chef::Application do
           end
         end
       end
+    end
 
+    context "when log_level is not set" do
+      it_behaves_like "log_level_is_auto"
+    end
+
+    context "when log_level is :auto" do
+      before do
+        Chef::Config[:log_level] = :auto
+      end
+
+      it_behaves_like "log_level_is_auto"
     end
   end
 


### PR DESCRIPTION
- this was failing when not run on a tty
- expands test to ensure default case looks just like :auto case
