### PR TITLE
Added check for empty cookbook list in knife.

### DIFF
--- a/lib/chef/knife/cookbook_list.rb
+++ b/lib/chef/knife/cookbook_list.rb
@@ -40,7 +40,9 @@ class Chef
         num_versions = config[:all_versions] ? "num_versions=all" : "num_versions=1"
         api_endpoint = env ? "/environments/#{env}/cookbooks?#{num_versions}" : "/cookbooks?#{num_versions}"
         cookbook_versions = rest.get_rest(api_endpoint)
-        ui.output(format_cookbook_list_for_display(cookbook_versions))
+        if cookbook_versions
+          ui.output(format_cookbook_list_for_display(cookbook_versions))
+        end
       end
     end
   end


### PR DESCRIPTION
Issue CHEF-3219 - 'knife cookbook list' returned a blank line when the cookbook list was empty. Added a check for an empty cookbook list.
