### PR TITLE
[CHEF-4399] - Line endings for templates are based on the platform the template was written on not on the node platform

### DIFF
--- a/spec/functional/resource/template_spec.rb
+++ b/spec/functional/resource/template_spec.rb
@@ -189,54 +189,21 @@ describe Chef::Resource::Template do
   end
 
   describe "when template source contains windows style line endings" do
-
     include_context "diff disabled"
 
-    let(:expected_content) {
-      "Template rendering libraries\r\nshould support\r\ndifferent line endings\r\n\r\n"
-    }
-
-    context "for all lines" do
-      let(:resource) do
-        r = create_resource
-        r.source "all_windows_line_endings.erb"
-        r
-      end
-
-      it "output should contain windows line endings" do
-        resource.run_action(:create)
-        binread(path).each_line do |line|
-          line.should end_with("\r\n")
+    ["all", "some", "no"].each do |test_case|
+      context "for #{test_case} lines" do
+        let(:resource) do
+          r = create_resource
+          r.source "#{test_case}_windows_line_endings.erb"
+          r
         end
-      end
-    end
 
-    context "for some lines" do
-      let(:resource) do
-        r = create_resource
-        r.source "some_windows_line_endings.erb"
-        r
-      end
-
-      it "output should contain windows line endings" do
-        resource.run_action(:create)
-        binread(path).each_line do |line|
-          line.should end_with("\r\n")
-        end
-      end
-    end
-
-    context "for no lines" do
-      let(:resource) do
-        r = create_resource
-        r.source "no_windows_line_endings.erb"
-        r
-      end
-
-      it "output should not contain windows line endings" do
-        resource.run_action(:create)
-        IO.read(path).each_line do |line|
-          line.should_not end_with("\r\n")
+        it "output should contain platform's line endings" do
+          resource.run_action(:create)
+          binread(path).each_line do |line|
+            line.should end_with(Chef::Platform.windows? ? "\r\n" : "\n")
+          end
         end
       end
     end

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -33,6 +33,40 @@ describe Chef::Mixin::Template, "render_template" do
     output.should == "bar"
   end
 
+  template_contents = [ "Fancy\r\nTemplate\r\n\r\n",
+                        "Fancy\nTemplate\n\n",
+                        "Fancy\r\nTemplate\n\r\n"]
+
+  describe "when running on windows" do
+    before do
+      Chef::Platform.stub!(:windows?).and_return(true)
+    end
+
+    it "should render the templates with windows line endings" do
+      template_contents.each do |template_content|
+        output = @context.render_template_from_string(template_content)
+        output.each_line do |line|
+          line.should end_with("\r\n")
+        end
+      end
+    end
+  end
+
+  describe "when running on unix" do
+    before do
+      Chef::Platform.stub!(:windows?).and_return(false)
+    end
+
+    it "should render the templates with unix line endings" do
+      template_contents.each do |template_content|
+        output = @context.render_template_from_string(template_content)
+        output.each_line do |line|
+          line.should end_with("\n")
+        end
+      end
+    end
+  end
+
   it "should provide a node method to access @node" do
     @context[:node] = "tehShizzle"
     output = @context.render_template_from_string("<%= @node %>")


### PR DESCRIPTION
This PR adds makes sure that template rendering uses the line endings of the platform chef is running on.

http://manhattan.ci.opscode.us/job/chef-cvt-test/47/

@danielsdeleo thoughts?
