### PR TITLE
[CHEF-4587] Windows service provider should treat all START_TYPEs != DISABLED as enabled

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -42,7 +42,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
     @current_resource.service_name(@new_resource.service_name)
     @current_resource.running(current_state == RUNNING)
     Chef::Log.debug "#{@new_resource} running: #{@current_resource.running}"
-    @current_resource.enabled(start_type == AUTO_START)
+    @current_resource.enabled(start_type != DISABLED)
     Chef::Log.debug "#{@new_resource} enabled: #{@current_resource.enabled}"
     @current_resource
   end
@@ -122,7 +122,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
   def disable_service
     if Win32::Service.exists?(@new_resource.service_name)
-      if start_type == AUTO_START
+      if start_type != DISABLED
         Win32::Service.configure(
           :service_name => @new_resource.service_name,
           :start_type => Win32::Service::DISABLED


### PR DESCRIPTION
Currently, the Windows service provider only treats "Automatic (Delayed Start)"
and "Automatic" START_TYPEs as an enabled service. It should also treat
"Manual" as an enabled service.

A "Manual" service is not a disabled service.  A "Manual" service can be started
by another service that depends on it or by an application or by human
intervention.

If we want Chef to ensure a service is truly disabled then the service's
START_TYPE should be set to "Disabled".
