### PR TITLE
New option for 'knife ssh' : --sudo-password

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -98,6 +98,10 @@ class Chef
         :boolean => true,
         :default => true
 
+      option :sudo_password,
+        :long => "--sudo-password PASSWORD"
+        :description => "The password to use for 'sudo' commands. WARNING: using this option has limited security issues"
+
       def session
         config[:on_error] ||= :skip
         ssh_error_handler = Proc.new do |server|
@@ -259,7 +263,7 @@ class Chef
       end
 
       def get_password
-        @password ||= prompt_for_password
+        @password ||= config[:sudo_password] || prompt_for_password
       end
 
       def prompt_for_password(prompt = "Enter your password: ")

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -99,7 +99,7 @@ class Chef
         :default => true
 
       option :sudo_password,
-        :long => "--sudo-password PASSWORD"
+        :long => "--sudo-password PASSWORD",
         :description => "The password to use for 'sudo' commands. WARNING: using this option has limited security issues"
 
       def session

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -171,6 +171,19 @@ describe Chef::Knife::Ssh do
     end
   end
 
+  describe "#get_password" do
+    before do
+      @knife.stub!(:prompt_for_password).and_return { "prompted_password" }
+    end
+    it "should prompt for the sudo password if none was provided" do
+      @knife.get_password.should == "prompted_password"
+    end
+    it "should use the sudo password provided by --sudo-password without prompting the user" do
+      @knife.config[:sudo_password] = "option_provided_password"
+      @knife.get_password.should == "option_provided_password"
+    end
+  end
+
   describe "#session_from_list" do
     before :each do
       @knife.instance_variable_set(:@longest, 0)


### PR DESCRIPTION
I'd like to add a new '--sudo-password' option to the 'knife ssh' command, to allow using 'knife ssh' with sudo in automated scripts.

I am aware that this has security limitations (hence the warning in the option description) but I do believe that this option could be really convenient.