### PR TITLE
CHEF-4612: Update documentation for --secret option of knife bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -143,11 +143,6 @@ class Chef
           name, path = h.split("=")
           Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new  }
 
-      option :secret,
-        :short => "-s SECRET",
-        :long  => "--secret ",
-        :description => "The secret key to use to encrypt data bag item values"
-
       option :secret_file,
         :long => "--secret-file SECRET_FILE",
         :description => "A file containing the secret key to use to encrypt data bag item values"
@@ -267,7 +262,7 @@ machines by adding the following to your 'knife.rb' file:
   knife[:secret_file] = "/path/to/your/secret"
 
 If you would like to selectively distribute a secret key during bootstrap
-please use the '--secret' or '--secret-file' options of this command instead.
+please use the '--secret-file' options of this command instead.
 
 #{ui.color('IMPORTANT:', :red, :bold)} In a future version of Chef, this
 behavior will be removed and any 'encrypted_data_bag_secret' entries in

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -153,7 +153,6 @@ describe Chef::Knife::Bootstrap do
 
   describe "specifying the encrypted data bag secret key" do
     subject(:knife) { described_class.new }
-    let(:secret) { "supersekret" }
     let(:secret_file) { File.join(CHEF_SPEC_DATA, 'bootstrap', 'encrypted_data_bag_secret') }
     let(:options) { [] }
     let(:template_file) { File.expand_path(File.join(CHEF_SPEC_DATA, "bootstrap", "secret.erb")) }
@@ -162,18 +161,6 @@ describe Chef::Knife::Bootstrap do
       knife.parse_options(options)
       template_string = knife.read_template
       knife.render_template(template_string)
-    end
-
-    context "via --secret" do
-      let(:options){ ["--secret", secret] }
-
-      it "creates a secret file" do
-        rendered_template.should match(%r{#{secret}})
-      end
-
-      it "renders the client.rb with an encrypted_data_bag_secret entry" do
-        rendered_template.should match(%r{encrypted_data_bag_secret\s*"/etc/chef/encrypted_data_bag_secret"})
-      end
     end
 
     context "via --secret-file" do


### PR DESCRIPTION
- Attempting to use knife bootstrap --secret.. the documentation was a bit ambiguous in that I (and many others on my team) thought it would load argument passed as a file. Not that the string itself was the secret. Given that one shouldn't be passing a secret via STDIN, I've removed --secret from bootstrap and also from the tests. --secret-file is much less ambiguous. There was also another issue with -s being an alias to --secret because -s is already an alias for --server-url.
