### PR TITLE
When reporting a resource, before and after should always be a hash

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -52,8 +52,8 @@ class Chef
         as_hash["type"]   = new_resource.class.dsl_name
         as_hash["name"]   = new_resource.name
         as_hash["id"]     = new_resource.identity
-        as_hash["after"]  = new_resource.state
-        as_hash["before"] = current_resource ? current_resource.state : {}
+        as_hash["after"]  = state(new_resource)
+        as_hash["before"] = current_resource ? state(current_resource) : {}
         as_hash["duration"] = (elapsed_time * 1000).to_i.to_s
         as_hash["delta"]  = new_resource.diff if new_resource.respond_to?("diff")
         as_hash["delta"]  = "" if as_hash["delta"].nil?
@@ -80,6 +80,12 @@ class Chef
         !self.exception
       end
 
+      def state(r)
+        r.class.state_attrs.inject({}) do |state_attrs, attr_name|
+          state_attrs[attr_name] = r.send(attr_name)
+          state_attrs
+        end
+      end
     end # End class ResouceReport
 
     attr_reader :updated_resources

--- a/spec/support/lib/chef/resource/with_state.rb
+++ b/spec/support/lib/chef/resource/with_state.rb
@@ -1,0 +1,37 @@
+#
+# Author:: Adam Jacob (<adam@opscode.com>)
+# Copyright:: Copyright (c) 2008, 2010 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife'
+require 'chef/json_compat'
+
+class Chef
+  class Resource
+    class WithState < Chef::Resource
+      attr_accessor :state
+
+      def initialize(name, run_context=nil)
+        @resource_name = :with_state
+        super
+      end
+
+      def state
+        @state
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a Resource (or LWRP) overrides Resource#state (meaning to set an
attribute named state) this collides with the state function used to
gather up the state_attrs

Fix this by ignoring the return from Resource#state if it's not a
Hash
