### PR TITLE
[CHEF-4439] Allow single letter usernames.

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -436,7 +436,7 @@ class Chef
 
       default :fatal_windows_admin_check, false
     else
-      default :user_valid_regex, [ /^([-a-zA-Z0-9_.]+[\\@]?[-a-zA-Z0-9_.]+)$/, /^\d+$/ ]
+      default :user_valid_regex, [ /^([-a-zA-Z0-9_.]+[\\@]?[-a-zA-Z0-9_.]*)$/, /^\d+$/ ]
       default :group_valid_regex, [ /^([-a-zA-Z0-9_.\\@^ ]+)$/, /^\d+$/ ]
     end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -269,4 +269,13 @@ describe Chef::Config do
       expect{Chef::Config.log_location = missing_path}.to raise_error Chef::Exceptions::ConfigurationError
     end
   end
+
+  describe "Chef::Config[:user_valid_regex]" do
+    context "on a platform that is not Windows" do
+      it "allows one letter usernames" do
+        any_match = Chef::Config[:user_valid_regex].any? { |regex| regex.match('a') }
+        expect(any_match).to be_true
+      end
+    end
+  end
 end


### PR DESCRIPTION
On non-Windows platforms single letter usernames are valid,
so make the valid user regex allow them.
