### PR TITLE
Auto configure the ssl_ca_file on windows under omnibus

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -356,7 +356,14 @@ class Chef
 
     # Path to the default CA bundle files.
     default :ssl_ca_path, nil
-    default :ssl_ca_file, nil
+    default(:ssl_ca_file) do
+      if on_windows? and embedded_path = embedded_dir
+        cacert_path = File.join(embedded_path, "ssl/certs/cacert.pem")
+        cacert_path if File.exist?(cacert_path)
+      else
+        nil
+      end
+    end
 
     # A directory that contains additional SSL certificates to trust. Any
     # certificates in this directory will be added to whatever CA bundle ruby

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -272,6 +272,8 @@ describe Chef::Config do
       let(:alternate_install_location) { "c:/my/alternate/install/place/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.6.0/lib/chef/config.rb" }
       let(:non_omnibus_location) { "c:/my/dev/stuff/lib/ruby/gems/1.9.1/gems/chef-11.6.0/lib/chef/config.rb" }
 
+      let(:default_ca_file) { "c:/opscode/chef/embedded/ssl/certs/cacert.pem" }
+
       it "finds the embedded dir in the default location" do
         Chef::Config.stub(:_this_file).and_return(default_config_location)
         Chef::Config.embedded_dir.should == "c:/opscode/chef/embedded"
@@ -285,6 +287,13 @@ describe Chef::Config do
       it "doesn't error when not in an omnibus install" do
         Chef::Config.stub(:_this_file).and_return(non_omnibus_location)
         Chef::Config.embedded_dir.should be_nil
+      end
+
+      it "sets the ssl_ca_cert path if the cert file is available" do
+        Chef::Config.stub(:_this_file).and_return(default_config_location)
+        Chef::Config.stub(:on_windows?).and_return(true)
+        File.stub(:exist?).with(default_ca_file).and_return(true)
+        Chef::Config.ssl_ca_file.should == default_ca_file
       end
     end
   end


### PR DESCRIPTION
- find the embedded dir under which the certs should be located
- set the default ca_file on windows to the cacert.pem included in omnibus
