### PR TITLE
Fixed potential security issue in subversion resource

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -625,7 +625,7 @@ F
         provider_for_action(action).run_action
       rescue Exception => e
         if ignore_failure
-          Chef::Log.error("#{self} (#{defined_at}) had an error: #{e.message}; ignore_failure is set, continuing")
+          Chef::Log.error("#{custom_exception_message(e)}; ignore_failure is set, continuing")
           events.resource_failed(self, action, e)
         elsif retries > 0
           events.resource_failed_retriable(self, action, retries, e)
@@ -660,8 +660,12 @@ F
       end
     end
 
+    def custom_exception_message(e)
+      "#{self} (#{defined_at}) had an error: #{e.class.name}: #{e.message}"
+    end
+
     def customize_exception(e)
-      new_exception = e.exception("#{self} (#{defined_at}) had an error: #{e.class.name}: #{e.message}")
+      new_exception = e.exception(custom_exception_message(e))
       new_exception.set_backtrace(e.backtrace)
       new_exception
     end

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -32,6 +32,10 @@ class Chef
         allowed_actions << :force_export
       end
 
+      # Override exception to strip password if any, so it won't appear in logs and different Chef notifications
+      def custom_exception_message(e)
+        "#{self} (#{defined_at}) had an error: #{e.class.name}: #{svn_password ? e.message.gsub(svn_password, "[hidden_password]") : e.message}"
+      end
     end
   end
 end

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -55,4 +55,9 @@ describe Chef::Resource::Subversion do
     @svn.svn_arguments.should be_nil
   end
 
+  it "hides password from custom exception message" do
+    @svn.svn_password "l33th4x0rpa$$w0rd"
+    e = @svn.customize_exception(Chef::Exceptions::Exec.new "Exception with password #{@svn.svn_password}")
+    e.message.include?(@svn.svn_password).should be_false
+  end
 end


### PR DESCRIPTION
Hi!
I found that my notification handler posts svn password in exception string to my notification handler, and this is kinda wrong and insecure. Of course I will fix actual handler, but people tend to do such mistakes, and it's better to be safe than sorry.
In order to mitigate this risk I extracted exception message string into separate method, which is overwritten in Subversion resource + added unit test for this case.
What do you think?
