### PR TITLE
CHEF-4596 / CHEF-4631 : Pick the array that is higher in the precedence order instead of merging during deep merge

### DIFF
--- a/chef/lib/chef/mixin/deep_merge.rb
+++ b/chef/lib/chef/mixin/deep_merge.rb
@@ -181,7 +181,10 @@ class Chef
               puts if merge_debug
             end
             puts "#{di} merging arrays: #{source.inspect} :: #{dest.inspect}" if merge_debug
-            dest = dest | source
+            # When merging to arrays instead of merging and
+            # deduplicating the elements pick the array that is higher
+            # in the inheritance order.
+            dest = source
             dest.sort! if sort_merged_arrays
           elsif overwrite_unmergeable
             puts "#{di} overwriting dest: #{source.inspect} -over-> #{dest.inspect}" if merge_debug


### PR DESCRIPTION
CHEF-4596: .to_hash sometimes unique-ifies internal arrays
CHEF-4631: to_hash returns all precedence instead of highest precedence

These two issues have the same root cause. The underlying issue is that when we encounter a case where we need to merge two arrays during deep merge we currently deduplicate and merge the elements. This PR changes this behavior to pick the array that is higher in the precedence order rather than merging them. 

With this change above two issues are fixed as below:

``` ruby
chef > node.default['fb']['foo'] = {'foo' => ['a', 'b', 'a'], 'bar' => ['a', 'b', 'a']}
 => {"foo"=>["a", "b", "a"], "bar"=>["a", "b", "a"]} 
chef > node['fb']['foo'].to_hash
 => {"foo"=>["a", "b", "a"], "bar"=>["a", "b", "a"]} 
chef > 
chef > node.default['example']['example_ssh']['users']['root']['authorized_princs'] = ['default']
 => ["default"] 
chef > node.override['example']['example_ssh']['users']['root']['authorized_princs'] = ['override']
 => ["override"] 
chef > node['example']['example_ssh']['users']['root'].to_hash['authorized_princs']
 => ["override"] 
```

Similarly this change would mean that if an attribute is a hash that contains an array; and if this attribute is set in both override & default; the array with the highest precedence will win: 

``` ruby
chef > node.default['example'] = { 'foo' => [1, 2] }
 => {"foo"=>[1, 2]} 
chef > node.override['example'] = { 'foo' => [1, 4] }
 => {"foo"=>[1, 4]} 
chef > node['example']['foo']
 => [1, 4]
```

Note that this changes the deep merge behavior of chef and some tests are expected to be broken for now.
