### PR TITLE
[CHEF-4677] bootstrap configure diff_disabled on cient

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -94,6 +94,12 @@ class Chef
         :description => "Do not proxy locations for the node being bootstrapped",
         :proc => Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
+      option :diff_disabled,
+        :long => "--diff-disabled",
+        :description => "suppress file diffs for the node being bootstrapped",
+        :proc => Proc.new { |dd| Chef::Config[:knife][:diff_disabled] = dd },
+        :boolean => true
+
       option :distro,
         :short => "-d DISTRO",
         :long => "--distro DISTRO",

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -82,6 +82,10 @@ CONFIG
             client_rb << %Q{no_proxy       "#{knife_config[:bootstrap_no_proxy]}"\n}
           end
 
+          if knife_config[:diff_disabled]
+            client_rb << %Q{diff_disabled       "#{knife_config[:diff_disabled]}"\n}
+          end
+
           if encrypted_data_bag_secret
             client_rb << %Q{encrypted_data_bag_secret "/etc/chef/encrypted_data_bag_secret"\n}
           end

--- a/spec/data/bootstrap/diff_disabled.erb
+++ b/spec/data/bootstrap/diff_disabled.erb
@@ -1,0 +1,2 @@
+bash -c '
+<%= config_content %>'

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -151,6 +151,25 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
+  describe "should configure the client to suppress diff when specified" do
+    subject(:knife) { described_class.new }
+    let(:template_file) { File.expand_path(File.join(CHEF_SPEC_DATA, "bootstrap", "diff_disabled.erb")) }
+    let(:rendered_template) do
+      knife.instance_variable_set("@template_file", template_file)
+      knife.parse_options(options)
+      template_string = knife.read_template
+      knife.render_template(template_string)
+    end
+
+    context "via --diff-disabled" do
+      let(:options){ ["--diff-disabled"] }
+
+      it "renders the client.rb with a diff_disabled" do
+        rendered_template.should match(%r{.*diff_disabled\s*"true".*})
+      end
+    end
+  end
+
   describe "specifying the encrypted data bag secret key" do
     subject(:knife) { described_class.new }
     let(:secret) { "supersekret" }


### PR DESCRIPTION
setting --diff-disabled will suppress file diffs on the client

setting "knife[:diff_disabled] = true" in knife.rb
has the same effect
