### PR TITLE
Fix provider user/useradd: universal_options is array, not string

### DIFF
--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -38,7 +38,7 @@ class Chef
         end
 
         def manage_user
-          if universal_options != ""
+          if universal_options.size > 0
             command = compile_command("usermod") do |u|
               u.concat(universal_options)
             end


### PR DESCRIPTION
When I provision receipt with creating user many times it error:

```
Expected process to exit with [0], but received '2'
---- Begin output of ["usermod", "USERNAME"] ----
STDOUT:
STDERR: usermod: no options
Usage: usermod [options] LOGIN
```

It's because check universal_options in user provider. This options return array, but compare with string.
