### PR TITLE
Check before creating a new system mutex on windows.

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -471,10 +471,6 @@ class Chef
     # === Returns
     # true:: Always returns true.
     def do_run
-      # Check for windows administrator rights incase they create an
-      # issue while trying to create / acquire run_lock.
-      do_windows_admin_check
-
       runlock = RunLock.new(Chef::Config.lockfile)
       runlock.acquire
       # don't add code that may fail before entering this section to be sure to release lock
@@ -496,6 +492,8 @@ class Chef
         run_status.start_clock
         Chef::Log.info("Starting Chef Run for #{node.name}")
         run_started
+
+        do_windows_admin_check
 
         run_context = setup_run_context
 


### PR DESCRIPTION
This is needed when multiple user accounts are running chef-client on systems. This scenario is imminent when they configure chef to run as service on windows which by default runs as "Local System" and when they try to run chef client manually as Administrator.

NOTE: Non-admin users do not wait on the run_lock but can create a run_lock if there is not one already.

@adamedx can you test this out on your windows system to double check?

Here are the repro steps for the issue I've seen on my system: 

1-) Install 11.8.0.rc.3 and enable chef service during installation.
2-) Use the below resource in the recipe and make a run

``` ruby
ruby_block "sleeping..." do
  block do
    sleep 100
  end
end
```

3-) Check c:\chef\client.log to make sure you have a chef run going on
4-) Run chef-client -l debug using Administrator account 
5-) Run should fail with access denied. 

To get the fix you can do:
1-) Get this fix and do a "rake gem" in your chef code directory
2-) Copy the mingw gem onto your windows box.
3-) Execute "gem uninstall chef on your windows box."
4-) Execute "gem install --local path_to_chef_gem"

After that repro steps shouldn't repro.

Also on a seperate note I've seen that non-admin users can make a chef-client run.
