### PR TITLE
fix for travis ci fails under 1.8.7

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.email = "adam@opscode.com"
   s.homepage = "http://wiki.opscode.com/display/chef"
 
+  s.add_dependency "mime-types", "~> 1.25"
   s.add_dependency "mixlib-config", "~> 2.0"
   s.add_dependency "mixlib-cli", "~> 1.3"
   s.add_dependency "mixlib-log", "~> 1.3"


### PR DESCRIPTION
newly released mime-types (2.0) requires ruby 1.9.2, so travis tests weren't passing 1.8.7
