### PR TITLE
[CHEF-3940] ensure $HOME matches user executing `git`

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -269,12 +269,26 @@ class Chef
       private
 
       def run_options(run_opts={})
-        run_opts[:user] = @new_resource.user if @new_resource.user
+        env = {}
+        if @new_resource.user
+          run_opts[:user] = @new_resource.user
+          # Certain versions of `git` misbehave if git configuration is
+          # inaccessible in $HOME. We need to ensure $HOME matches the
+          # user who is executing `git` not the user running Chef.
+          env['HOME'] = begin
+            require 'etc'
+            Etc.getpwnam(@new_resource.user).dir
+          rescue ArgumentError # user not found
+            "/home/#{@new_resource.user}"
+          end
+        end
         run_opts[:group] = @new_resource.group if @new_resource.group
-        run_opts[:environment] = {"GIT_SSH" => @new_resource.ssh_wrapper} if @new_resource.ssh_wrapper
+        env['GIT_SSH'] = @new_resource.ssh_wrapper if @new_resource.ssh_wrapper
         run_opts[:log_tag] = @new_resource.to_s
         run_opts[:timeout] = @new_resource.timeout if @new_resource.timeout
+        run_opts[:environment] = env unless env.empty?
         run_opts
+
       end
 
       def cwd

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -172,7 +172,7 @@ SHAS
     let(:default_options) do
       {
         :user => deploy_user,
-        :environment => { "GIT_SSH" => wrapper },
+        :environment => { "GIT_SSH" => wrapper, "HOME" => "/home/deployNinja" },
         :log_tag => "git[web2.0 app]"
       }
     end
@@ -202,7 +202,8 @@ SHAS
     @resource.ssh_wrapper "do_it_this_way.sh"
     expected_cmd = "git clone  \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     @provider.should_receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
-                                                :environment =>{"GIT_SSH"=>"do_it_this_way.sh"},
+                                                :environment =>{"GIT_SSH"=>"do_it_this_way.sh",
+                                                                "HOME" => "/home/deployNinja"},
                                                 :log_tag => "git[web2.0 app]")
     @provider.clone
   end
@@ -256,7 +257,9 @@ SHAS
     @provider.should_receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
     expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     @provider.should_receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir",
-                                                :user => "whois", :group => "thisis", :log_tag => "git[web2.0 app]")
+                                                :user => "whois", :group => "thisis",
+                                                :log_tag => "git[web2.0 app]",
+                                                :environment=>{"HOME"=>"/home/whois"})
     @provider.fetch_updates
   end
 
@@ -304,13 +307,15 @@ SHAS
                                                  :log_tag => "git[web2.0 app]",
                                                  :user => "whois",
                                                  :group => "thisis",
+                                                 :environment=>{"HOME"=>"/home/whois"},
                                                  :returns => [0,1,2]).and_return(command_response)
       add_remote_command = "git remote add #{@resource.remote} #{@resource.repository}"
       @provider.should_receive(:shell_out!).with(add_remote_command,
                                                  :cwd => "/my/deploy/dir",
                                                  :log_tag => "git[web2.0 app]",
                                                  :user => "whois",
-                                                 :group => "thisis")
+                                                 :group => "thisis",
+                                                 :environment=>{"HOME"=>"/home/whois"})
       @provider.setup_remote_tracking_branches(@resource.remote, @resource.repository)
     end
 


### PR DESCRIPTION
Certain versions of `git` misbehave if git configuration is inaccessible in $HOME. We need to ensure $HOME matches the user who is executing `git` not the user running Chef.
