### PR TITLE
Fix windows gem dependencies on 10-stable

### DIFF
--- a/chef/chef-x86-mingw32.gemspec
+++ b/chef/chef-x86-mingw32.gemspec
@@ -3,7 +3,6 @@ gemspec = eval(IO.read(File.expand_path("../chef.gemspec", __FILE__)))
 
 gemspec.platform = "x86-mingw32"
 
-gemspec.add_dependency "systemu", "2.2.0"  # CHEF-3718
 gemspec.add_dependency "ffi", "1.0.9"
 gemspec.add_dependency "rdp-ruby-wmi", "0.3.1"
 gemspec.add_dependency "windows-api", "0.4.0"


### PR DESCRIPTION
Minimally bump the version numbers of windows gems so that we don't have a conflict with mixlib-shellout gems.

Here is  passing windows build with the change.

http://ci.opscode.us/job/chef-client-build/1123/build_os=windows-2008r2,machine_architecture=x64,role=oss-builder/
