### PR TITLE
[COOK-3739] Stopping a non-existent Windows Service Causes Exception

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -138,11 +138,11 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
   private
   def current_state
-    Win32::Service.status(@new_resource.service_name).current_state
+    Win32::Service.exists?(@new_resource.service_name) && Win32::Service.status(@new_resource.service_name).current_state
   end
 
   def start_type
-    Win32::Service.config_info(@new_resource.service_name).start_type
+    Win32::Service.exists?(@new_resource.service_name) && Win32::Service.config_info(@new_resource.service_name).start_type
   end
 
   # Helper method that waits for a status to change its state since state


### PR DESCRIPTION
This checks the existence of the service bringing the private methods in line with the actions allowing the load_current_resource to complete without throwing an exception if the service has yet to be installed.
