### PR TITLE
CHEF-4380: package resource with "source" is broken on EL6 using 11.6.0rc3

### DIFF
--- a/chef/lib/chef/provider/package/yum.rb
+++ b/chef/lib/chef/provider/package/yum.rb
@@ -947,6 +947,7 @@ class Chef
         end # YumCache
 
         include Chef::Mixin::GetSourceFromPackage
+        include Chef::Mixin::ShellOut
 
         def initialize(new_resource, run_context)
           super


### PR DESCRIPTION
Backport from 11-stable. 

Tested on centos 6 with: 

``` ruby
package "daemonize" do
  source "/tmp/daemonize-1.7.3-1.el6.x86_64.rpm"
end
```
