### PR TITLE
CHEF-3511: call chkconfig --add instead of on

### DIFF
--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -65,7 +65,7 @@ class Chef
         end
 
         def enable_service()
-          shell_out! "/sbin/chkconfig #{@new_resource.service_name} on"
+          shell_out! "/sbin/chkconfig --add #{@new_resource.service_name}"
         end
 
         def disable_service()


### PR DESCRIPTION
The correct way to enable a service on RHEL for chkconfig management
is to pass chkconfig the --add option; passing it on instead will
result in it ignoring the service's init script's chkconfig lines or
LSB stanza, enabling it for default runlevels and skipping kill
entry creation.
