### PR TITLE
CHEF-4773: ruby-shadow supports darwin+freebsd now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group(:development, :test) do
   gem "simplecov"
   gem 'rack', "~> 1.5.1"
 
-  gem 'ruby-shadow', :platforms => :ruby unless RUBY_PLATFORM.downcase.match(/(darwin|freebsd|aix)/)
+  gem 'ruby-shadow', :platforms => :ruby unless RUBY_PLATFORM.downcase.match(/aix/)
 end
 
 # If you want to load debugging tools into the bundle exec sandbox,


### PR DESCRIPTION
- comment in https://tickets.opscode.com/browse/CHEF-4402
