### PR TITLE
CHEF-4778: Doc fix to highlight that -E is not respected by knife ssh [search] 

### DIFF
--- a/distro/common/markdown/man1/knife.mkd
+++ b/distro/common/markdown/man1/knife.mkd
@@ -41,7 +41,7 @@ documentation using `knife help TOPIC`.
   * `-c`, `--config` CONFIG:
     The configuration file to use
   * `-E`, `--environment ENVIRONMENT`:
-    Set the Chef environment
+    Set the Chef environment (except for in searches, where this will be flagrantly ignored)
   * `-e`, `--editor` EDITOR:
     Set the editor to use for interactive commands
   * `-F`, `--format` FORMAT:

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -51,7 +51,7 @@ class Chef::Application::Knife < Chef::Application
   option :environment,
     :short        => "-E ENVIRONMENT",
     :long         => "--environment ENVIRONMENT",
-    :description  => "Set the Chef environment"
+    :description  => "Set the Chef environment (except for in searches, where this will be flagrantly ignored)"
 
   option :editor,
     :short        => "-e EDITOR",


### PR DESCRIPTION
I noticed this when my production server host names were being listed in Chef activity after switching to a new deployment tactic. For example, it's fairly safe to assume that the command below will only run on staging:

```
$ knife ssh -E stag "role:api" "foo"
```

Actually it runs on ANY node with role:api, which is not only unexpected but ludicrously dangerous in the case of deployments.

You can do this:

```
$ knife ssh "chef_environment:stag AND role:api" "foo"
```

I did that after doing an emergency rollback. I'd like this documentation change to be done to avoid that happening to others. Happy to change wording of course.
