### PR TITLE
CHEF-3780: Add a pre-boot bootstrap option

### DIFF
--- a/lib/chef/knife/bootstrap/chef-full.erb
+++ b/lib/chef/knife/bootstrap/chef-full.erb
@@ -66,4 +66,10 @@ cat > /etc/chef/first-boot.json <<'EOP'
 <%= first_boot.to_json %>
 EOP
 
+<% if @chef_config[:pre_boot] && @chef_config[:pre_boot][:run_list] -%>
+cat > /etc/chef/pre-boot.json <<'EOP'
+<%= pre_boot.to_json %>
+EOP
+<% end -%>
+
 <%= start_chef %>'

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -92,9 +92,19 @@ CONFIG
         def start_chef
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
           client_path = @chef_config[:chef_client_path] || 'chef-client'
-          s = "#{client_path} -j /etc/chef/first-boot.json"
-          s << " -E #{bootstrap_environment}" if chef_version.to_f != 0.9 # only use the -E option on Chef 0.10+
-          s
+          environment = if chef_version.to_f != 0.9 # only use the -E option on Chef 0.10+
+                          " -E #{bootstrap_environment}"
+                        else
+                          ""
+                        end
+
+          # CHEF-3780: initial run for setting up authentication, networking, or anything that HAS
+          # to already be configured before we can do much else.
+          if @chef_config[:pre_boot] && @chef_config[:pre_boot][:run_list]
+            "#{client_path} -j /etc/chef/pre-boot.json #{environment} && #{client_path} -j /etc/chef/first-boot.json #{environment}"
+          else
+            "#{client_path} -j /etc/chef/first-boot.json" << environment
+          end
         end
 
         def knife_config
@@ -103,6 +113,10 @@ CONFIG
 
         def chef_version
           knife_config[:bootstrap_version] || Chef::VERSION
+        end
+
+        def pre_boot 
+          (@config[:first_boot_attributes] || {}).merge(:run_list => @chef_config[:pre_boot][:run_list]) if @chef_config[:pre_boot][:run_list]
         end
 
         def first_boot


### PR DESCRIPTION
We may need to set up parts of the system that have to be configured first,
such as authentication that modifies nsswitch.conf. This adds
Chef::Config[:pre_boot][:run_list] which should contain any run_list items that
must be complete before the rest of the run begins.

https://tickets.opscode.com/browse/CHEF-3780
