### PR TITLE
Pick mixlib-shellout 1.3.0.rc.0 to prepare for 10.30.0.rc.0

### DIFF
--- a/chef/chef.gemspec
+++ b/chef/chef.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", "~> 1.1"
   s.add_dependency "mixlib-log", "~> 1.3"
   s.add_dependency "mixlib-authentication", "~> 1.3"
-  s.add_dependency "mixlib-shellout", "~> 1.1"
+  s.add_dependency "mixlib-shellout", "= 1.3.0.rc.0"
   s.add_dependency "ohai", ">= 0.6.0", "< 7.0.0"
 
   s.add_dependency "rest-client", ">= 1.0.4", "< 1.7.0"


### PR DESCRIPTION
Normally we do tricks in omnibus-chef to get the RC versions of the gems we would like to include in the chef release candidates. However since we don't have a different project for mixlib-shellout in the omnibus-chef or omnibus-software here we are temporarily changing the gem dependency of the chef gem. 

Even though this is not the ideal solution, workarounds via omnibus-chef would cause multiple versions of mixlib-shellout or multiple versions of dependencies to be installed. 
