### PR TITLE
CHEF-4782: Don't re-enable service on Debian on every run

### DIFF
--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -113,7 +113,7 @@ class Chef
 
         # Override method from parent to ensure priority is up-to-date
         def action_enable
-          if @current_resource.enabled && @current_resource.priority == @new_resource.priority
+          if @current_resource.enabled && (@new_resource.priority.nil? || (@current_resource.priority == @new_resource.priority))
             Chef::Log.debug("#{@new_resource} already enabled - nothing to do")
           else
             converge_by("enable service #{@new_resource}") do

--- a/spec/unit/provider/service/debian_service_spec.rb
+++ b/spec/unit/provider/service/debian_service_spec.rb
@@ -244,6 +244,7 @@ insserv: remove service /etc/init.d/../rc0.d/K20chef-client
     context "when the service is enabled" do
       before do
         @current_resource.enabled(true)
+        @current_resource.priority(80)
       end
 
       context "and the service sets no priority" do
@@ -252,7 +253,6 @@ insserv: remove service /etc/init.d/../rc0.d/K20chef-client
 
       context "and the service requests the same priority as is set" do
         before do
-          @current_resource.priority(80)
           @new_resource.priority(80)
         end
         it_behaves_like "the service is up to date"
@@ -260,8 +260,7 @@ insserv: remove service /etc/init.d/../rc0.d/K20chef-client
 
       context "and the service requests a different priority than is set" do
         before do
-          @current_resource.priority(20)
-          @new_resource.priority(80)
+          @new_resource.priority(20)
         end
         it_behaves_like "the service is not up to date"
       end


### PR DESCRIPTION
If a service is already enabled and priority is default don't re-enable it on every run.

https://tickets.opscode.com/browse/CHEF-4782
