### PR TITLE
Skip IPv6 tests on Solaris

### DIFF
--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -82,7 +82,9 @@ END_CLIENT_RB
     FileUtils.rm_rf(cache_path)
   end
 
-  when_the_chef_server "is running on IPv6" do
+  # Some Solaris test platforms are too old for IPv6. These tests should not
+  # otherwise be platform dependent, so exclude solaris
+  when_the_chef_server "is running on IPv6", :not_supported_on_solaris do
 
     when_the_repository "has a cookbook with a no-op recipe" do
       cookbook 'noop', '1.0.0', { 'metadata.rb' => 'version "1.0.0"' }, "recipes" => {"default.rb" => "#raise 'foo'"}

--- a/spec/integration/knife/cookbook_api_ipv6_spec.rb
+++ b/spec/integration/knife/cookbook_api_ipv6_spec.rb
@@ -65,7 +65,9 @@ END_VALIDATION_PEM
 
     let(:knife_config_flag) { "-c '#{path_to("config/knife.rb")}'" }
 
-    context "and the chef_server_url contains an IPv6 literal" do
+    # Some Solaris test platforms are too old for IPv6. These tests should not
+    # otherwise be platform dependent, so exclude solaris
+    context "and the chef_server_url contains an IPv6 literal", :not_supported_on_solaris do
 
       # This provides helper functions we need such as #path_to()
       when_the_repository "has the cookbook to be uploaded" do


### PR DESCRIPTION
Some supported Solaris platforms are too old for IPv6. Most of the risk
in the code paths being tested exists in the userland code, so we expect
to have adequate coverage as long as the tests run on some platform.
