### PR TITLE
Always set a correct Host header to avoid net/http bug

### DIFF
--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -58,6 +58,8 @@ class Chef
 
       SLASH = "/".freeze
 
+      HOST_LOWER = "host".freeze
+
       def self.user_agent=(ua)
         @user_agent = ua
       end
@@ -77,6 +79,10 @@ class Chef
 
       def host
         @url.hostname
+      end
+
+      def uri_safe_host
+        @url.host
       end
 
       def port
@@ -132,6 +138,7 @@ class Chef
         # No response compression unless we asked for it explicitly:
         @headers[HTTPRequest::ACCEPT_ENCODING] ||= "identity"
         @headers['X-Chef-Version'] = ::Chef::VERSION
+        @headers['Host'] = "#{uri_safe_host}:#{port}" unless @headers.keys.any? {|k| k.downcase.to_s == HOST_LOWER }
         @headers
       end
 

--- a/spec/unit/rest/auth_credentials_spec.rb
+++ b/spec/unit/rest/auth_credentials_spec.rb
@@ -135,7 +135,10 @@ describe Chef::REST::RESTRequest do
     @auth_credentials = Chef::REST::AuthCredentials.new("client-name", CHEF_SPEC_DATA + '/ssl/private_key.pem')
     @url = URI.parse("http://chef.example.com:4000/?q=chef_is_awesome")
     @req_body = '{"json_data":"as_a_string"}'
-    @headers = {"Content-type" =>"application/json", "Accept"=>"application/json", "Accept-Encoding" => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE}
+    @headers = { "Content-type" =>"application/json",
+                 "Accept"=>"application/json",
+                 "Accept-Encoding" => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+                 "Host" => "chef.example.com:4000" }
     @request = Chef::REST::RESTRequest.new(:POST, @url, @req_body, @headers)
   end
 

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -212,6 +212,8 @@ describe Chef::REST do
       Chef::Config[:ssl_client_key]  = nil
       @url = URI.parse("https://one:80/?foo=bar")
 
+      @host_header = "one:80"
+
       @http_response = Net::HTTPSuccess.new("1.1", "200", "successful rest req")
       @http_response.stub(:read_body)
       @http_response.stub(:body).and_return("ninja")
@@ -240,7 +242,10 @@ describe Chef::REST do
       end
 
       it "should build a new HTTP GET request without the application/json accept header" do
-        expected_headers = {'Accept' => "*/*", 'X-Chef-Version' => Chef::VERSION, 'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE}
+        expected_headers = {'Accept' => "*/*",
+                            'X-Chef-Version' => Chef::VERSION,
+                            'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+                            'Host' => @host_header}
         Net::HTTP::Get.should_receive(:new).with("/?foo=bar", expected_headers).and_return(@request_mock)
         @rest.streaming_request(@url, {})
       end
@@ -286,7 +291,8 @@ describe Chef::REST do
 
         @base_headers = {"Accept" => "application/json",
           "X-Chef-Version" => Chef::VERSION,
-          "Accept-Encoding" => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE
+          "Accept-Encoding" => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+          "Host" => @host_header
         }
       end
 
@@ -485,7 +491,10 @@ describe Chef::REST do
       end
 
       it " build a new HTTP GET request without the application/json accept header" do
-        expected_headers = {'Accept' => "*/*", 'X-Chef-Version' => Chef::VERSION, 'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE}
+        expected_headers = {'Accept' => "*/*",
+                            'X-Chef-Version' => Chef::VERSION,
+                            'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+                            'Host' => @host_header}
         Net::HTTP::Get.should_receive(:new).with("/?foo=bar", expected_headers).and_return(@request_mock)
         @rest.streaming_request(@url, {})
       end


### PR DESCRIPTION
Net::HTTP fails to surround IPv6 addresses in brackets when constructing
a Host header. Net::HTTP respects any user-supplied Host header, so we
ensure that the Host header is correctly formatted by setting it
manually for all requests.
