### PR TITLE
Make sure the attributes with value nil are not converted to { } when they are being merged at the same precedence level.

### DIFF
--- a/chef/lib/chef/mixin/deep_merge.rb
+++ b/chef/lib/chef/mixin/deep_merge.rb
@@ -146,7 +146,12 @@ class Chef
                 # is not applicable anymore because it results in
                 # duplicates when merging two array values with
                 # :horizontal_precedence = true.
-                dest[src_key] = deep_merge!(src_value, { }, options.merge(:debug_indent => di + '  '))
+                if src_value.nil?
+                  # Nothing to compute with an extra deep_merge!
+                  dest[src_key] = src_value
+                else
+                  dest[src_key] = deep_merge!(src_value, { }, options.merge(:debug_indent => di + '  '))
+                end
               end
             else # dest isn't a hash, so we overwrite it completely (if permitted)
               if overwrite_unmergeable


### PR DESCRIPTION
Problem: 

If one has below in their roles / cookbooks: 

1-) In the role:

``` json
default_attributes:  
  something: 
    foo: 
      some_path: null
```

2-) In the cookbook attributes:

``` ruby
default['something']['foo'] =  { 'some_other_path' => "crayons" }
```

And when you iterate on node.default['something']['foo'] as below

``` ruby
node.default['something']['foo'].each do |path, value|
  puts "Path is #{path}. Value is #{value}"
end
```

With 10.30.0.rc.1 you will get: 

``` ruby
Path is some_other_path. Value is crayons
Path is some_path. Value is {}
```

Expected value you should get is: 

``` ruby
Path is some_other_path. Value is crayons
Path is some_path. Value is 
```
