### PR TITLE
[CHEF-4842] Fix comparison of user resources with non-ASCII comments

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -63,10 +63,14 @@ class Chef
         if user_info
           @current_resource.uid(user_info.uid)
           @current_resource.gid(user_info.gid)
-          @current_resource.comment(user_info.gecos)
           @current_resource.home(user_info.dir)
           @current_resource.shell(user_info.shell)
           @current_resource.password(user_info.passwd)
+
+          if @new_resource.comment && user_info.gecos.respond_to?(:force_encoding)
+            user_info.gecos.force_encoding(@new_resource.comment.encoding)
+          end
+          @current_resource.comment(user_info.gecos)
 
           if @new_resource.password && @current_resource.password == 'x'
             begin

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -91,6 +91,12 @@ describe Chef::Provider::User do
       @current_resource.username.should == @new_resource.username
     end
 
+    it "should change the encoding of gecos to the encoding of the new resource", :ruby_gte_19_only do
+      @pw_user.gecos.force_encoding('ASCII-8BIT')
+      @provider.load_current_resource
+      @provider.current_resource.comment.encoding.should == @new_resource.comment.encoding
+    end
+
     it "should look up the user in /etc/passwd with getpwnam" do
       Etc.should_receive(:getpwnam).with(@new_resource.username).and_return(@pw_user)
       @provider.load_current_resource


### PR DESCRIPTION
In case a comment of a user resource includes non-ASCII characters, the
comparison whether the resource was changed will always fail. Therefore,
such user resources will get modified during every chef-client run.

Example:

```
user "marci" do
  comment "Márton Salomváry"
  # ...
end
```

So far, this resulted in a comparision of "M\xC3\xA1rton
Salomv\xC3\xA1ry" with "Márton Salomváry" which fails, unless the
encoding gets changed prior to the comparision.

https://tickets.opscode.com/browse/CHEF-4842
