### PR TITLE
[CHEF-4845] Fix typo in aix packager provider regexp

### DIFF
--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -88,7 +88,7 @@ class Chef
           status = popen4("installp -L -d #{@new_resource.source}") do |pid, stdin, stdout, stderr|
             stdout.each_line do |line|
               case line
-              when /\w:{Regexp.escape(@new_resource.package_name)}:(.*)/
+              when /\w:#{Regexp.escape(@new_resource.package_name)}:(.*)/
                 fields = line.split(":")
                 @candidate_version = fields[2]
                 @new_resource.version(fields[2])


### PR DESCRIPTION
While it's not guaranteed without tests that this change will generate
the expected regular expression, it's certainly not worse than what
has been used so far. Moreover, this will silence the ruby warnings
about invalid regular expressions during chef-client runs.

Fixes the following warnings.

```
/var/lib/gems/1.8/gems/chef-11.8.0/bin/../lib/chef/provider/package/aix.rb:91: warning: regexp has invalid interval
/var/lib/gems/1.8/gems/chef-11.8.0/bin/../lib/chef/provider/package/aix.rb:91: warning: regexp has `}' without escape
```
