### PR TITLE
CHEF-4849: Implement `#response_file_variables` in Package resource

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -202,6 +202,7 @@ class Chef
         if template_available?(@new_resource.response_file)
           Chef::Log.debug("#{@new_resource} fetching preseed file via Template")
           remote_file = Chef::Resource::Template.new(cache_seed_to, run_context)
+          remote_file.variables(@new_resource.response_file_variables)
         elsif cookbook_file_available?(@new_resource.response_file)
           Chef::Log.debug("#{@new_resource} fetching preseed file via cookbook_file")
           remote_file = Chef::Resource::CookbookFile.new(cache_seed_to, run_context)

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -36,6 +36,7 @@ class Chef
         @package_name = name
         @resource_name = :package
         @response_file = nil
+        @response_file_variables = Hash.new
         @source = nil
         @version = nil
       end
@@ -61,6 +62,14 @@ class Chef
           :response_file,
           arg,
           :kind_of => [ String ]
+        )
+      end
+
+      def response_file_variables(arg=nil)
+        set_or_return(
+          :response_file_variables,
+          arg,
+          :kind_of => [ Hash ]
         )
       end
 

--- a/spec/data/cookbooks/preseed/templates/default/preseed-template-variables.seed
+++ b/spec/data/cookbooks/preseed/templates/default/preseed-template-variables.seed
@@ -1,0 +1,1 @@
+chef-integration-test chef-integration-test/sample-var string "<%= @template_variable -%>"

--- a/spec/functional/resource/package_spec.rb
+++ b/spec/functional/resource/package_spec.rb
@@ -273,6 +273,23 @@ describe Chef::Resource::Package, metadata do
             package_resource.should be_updated_by_last_action
           end
 
+          context "with variables" do
+            let(:package_resource) do
+              r = base_resource
+              r.cookbook_name = "preseed"
+              r.response_file("preseed-template.seed")
+              r.response_file_variables({ :template_variable => 'SUPPORTS VARIABLES' })
+              r
+            end
+
+            it "preseeds the package, then installs it" do
+              package_resource.run_action(:install)
+              cmd = shell_out!("debconf-show chef-integration-test")
+              cmd.stdout.should include('chef-integration-test/sample-var: "SUPPORTS VARIABLES"')
+              package_resource.should be_updated_by_last_action
+            end
+          end
+
         end
       end # installing w/ preseed
     end # when package not installed

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -49,6 +49,11 @@ describe Chef::Resource::Package do
     @resource.response_file.should eql("something")
   end
 
+  it "should accept a hash for response file template variables" do
+    @resource.response_file_variables({:variables => true})
+    @resource.response_file_variables.should eql({:variables => true})
+  end
+
   it "should accept a string for the source" do
     @resource.source "something"
     @resource.source.should eql("something")


### PR DESCRIPTION
Now that Chef properly supports a package `response_file` using
`Chef::Resource::Template`, the Package resource should implement the
`response_file_variables` method so that variables do not have to exist as node attributes
(eg - for seeding DB passwords for configuration files generated by packages).
