### PR TITLE
CHEF-4850 Close file in Chef::Util::FileEdit after reading contents

### DIFF
--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -33,7 +33,7 @@ class Chef
         @file_edited = false
 
         raise ArgumentError, "File doesn't exist" unless File.exist? @original_pathname
-        @contents = File.new(@original_pathname).readlines
+        @contents = File.new(@original_pathname){ |f| f.readlines }
       end
 
       #search the file line by line and match each line with the given regex


### PR DESCRIPTION
When using Chef::Util::FileEdit to modify a file, the open leaks a file handle
This is probably only noticeable on Windows clients as the open file becomes locked
