### PR TITLE
CHEF-4600 Add timeout for Chef::Provider::Service::Windows

### DIFF
--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -42,6 +42,7 @@ class Chef
         @reload_command = nil
         @init_command = nil
         @priority = nil
+		@timeout = nil
         @action = "nothing"
         @startup_type = :automatic
         @supports = { :restart => false, :reload => false, :status => false }
@@ -156,6 +157,13 @@ class Chef
                       :kind_of => [ Integer, String, Hash ])
       end
 
+	  # timeout only applies to the windows service manager
+	  def timeout(arg=nil)
+        set_or_return(:timeout,
+                      arg,
+                      :kind_of => Integer )
+      end
+	  
       def parameters(arg=nil)
         set_or_return(
           :parameters,

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -130,6 +130,18 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       @provider.stop_service
       @new_resource.updated_by_last_action?.should be_false
     end
+	
+    it "should pass custom timeout to the stop command if provided" do
+      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
+        mock("StatusStruct", :current_state => "running"))
+	  @new_resource.timeout 1
+      Win32::Service.should_receive(:stop).with(@new_resource.service_name)
+	  Timeout.timeout(2) do
+		expect { @provider.stop_service }.to raise_error(Timeout::Error)
+	  end
+      @new_resource.updated_by_last_action?.should be_false
+    end
+	
   end
 
   describe Chef::Provider::Service::Windows, "restart_service" do


### PR DESCRIPTION
Added timeout to resource.
Added default and lookup for timeout to provider.
Added spec test that timeout occurs.
