### PR TITLE
CHEF-4791 Add more windows service states to the start/stop control flow

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -39,7 +39,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
   PAUSE_PENDING = 'pause pending'
   PAUSED = 'paused'
   START_PENDING = 'start pending'
-  STOP_PENDING = 'stop pending'
+  STOP_PENDING  = 'stop pending'
 
   def whyrun_supported?
     false
@@ -57,11 +57,11 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
   def start_service
     if Win32::Service.exists?(@new_resource.service_name)
-	  state = current_state
+      state = current_state
       if state == RUNNING
         Chef::Log.debug "#{@new_resource} already started - nothing to do"
-	  elsif state == START_PENDING
-		Chef::Log.debug "#{@new_resource} already sent start signal - waiting for start"
+      elsif state == START_PENDING
+        Chef::Log.debug "#{@new_resource} already sent start signal - waiting for start"
         spawn_command_thread do
           wait_for_state(RUNNING)
         end
@@ -76,8 +76,8 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
           end
         end
         @new_resource.updated_by_last_action(true)
-	  else 
-        raise Chef::Exceptions::Service, "Service #{@new_resource} can't be started from state [#{current_state}]"
+      else 
+        raise Chef::Exceptions::Service, "Service #{@new_resource} can't be started from state [#{state}]"
       end
     else
         Chef::Log.debug "#{@new_resource} does not exist - nothing to do"
@@ -86,7 +86,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
 
   def stop_service
     if Win32::Service.exists?(@new_resource.service_name)
-	  state = current_state
+      state = current_state
       if state == RUNNING
         if @new_resource.stop_command
           Chef::Log.debug "#{@new_resource} stopping service using the given stop_command"
@@ -98,15 +98,15 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
           end
         end
         @new_resource.updated_by_last_action(true)
-	  elsif state == STOPPED
-		Chef::Log.debug "#{@new_resource} already stopped - nothing to do"
-	  elsif state == STOP_PENDING
-	    Chef::Log.debug "#{@new_resource} already sent stop signal - waiting for stop"
-	    spawn_command_thread do
-		  wait_for_state(STOPPED)
-	    end
+      elsif state == STOPPED
+        Chef::Log.debug "#{@new_resource} already stopped - nothing to do"
+      elsif state == STOP_PENDING
+        Chef::Log.debug "#{@new_resource} already sent stop signal - waiting for stop"
+        spawn_command_thread do
+          wait_for_state(STOPPED)
+        end
       else
-        raise Chef::Exceptions::Service, "Service #{@new_resource} can't be stopped from state [#{current_state}]"
+        raise Chef::Exceptions::Service, "Service #{@new_resource} can't be stopped from state [#{state}]"
       end
     else
       Chef::Log.debug "#{@new_resource} does not exist - nothing to do"

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -31,11 +31,11 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     Win32::Service = Class.new
     Win32::Service::AUTO_START = 0x00000002
     Win32::Service::DISABLED = 0x00000004
-    Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-      mock("StatusStruct", :current_state => "running"))
-    Win32::Service.stub!(:config_info).with(@new_resource.service_name).and_return(
-      mock("ConfigStruct", :start_type => "auto start"))
-    Win32::Service.stub!(:exists?).and_return(true)
+    Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+      double("StatusStruct", :current_state => "running"))
+    Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+      double("ConfigStruct", :start_type => "auto start"))
+    Win32::Service.stub(:exists?).and_return(true)
   end
 
   it "should set the current resources service name to the new resources service name" do
@@ -59,9 +59,9 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
 
   describe Chef::Provider::Service::Windows, "start_service" do
     before(:each) do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "stopped"),
-        mock("StatusStruct", :current_state => "running"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "stopped"),
+        double("StatusStruct", :current_state => "running"))
     end
 
     it "should call the start command if one is specified" do
@@ -78,15 +78,15 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should do nothing if the service does not exist" do
-      Win32::Service.stub!(:exists?).with(@new_resource.service_name).and_return(false)
+      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
       Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
       @provider.start_service
       @new_resource.updated_by_last_action?.should be_false
     end
 
     it "should do nothing if the service is running" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "running"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "running"))
       @provider.load_current_resource
       Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
       @provider.start_service
@@ -94,22 +94,43 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 	
     it "should raise an error if the service is paused" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "paused"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "paused"))
       @provider.load_current_resource
       Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
       expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
       @new_resource.updated_by_last_action?.should be_false
     end
+
+    it "should wait and continue if the service is in start_pending" do
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "start pending"),
+        double("StatusStruct", :current_state => "start pending"),
+        double("StatusStruct", :current_state => "running"))
+      @provider.load_current_resource
+      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+      @provider.start_service
+      @new_resource.updated_by_last_action?.should be_false
+    end
 	
+    it "should fail if the service is in stop_pending" do
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "stop pending"))
+      @provider.load_current_resource
+      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
+      @new_resource.updated_by_last_action?.should be_false
+    end
+
   end
+
 
   describe Chef::Provider::Service::Windows, "stop_service" do
 
     before(:each) do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "running"),
-        mock("StatusStruct", :current_state => "stopped"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "running"),
+        double("StatusStruct", :current_state => "stopped"))
     end
 
     it "should call the stop command if one is specified" do
@@ -126,15 +147,15 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should do nothing if the service does not exist" do
-      Win32::Service.stub!(:exists?).with(@new_resource.service_name).and_return(false)
+      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
       Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
       @provider.stop_service
       @new_resource.updated_by_last_action?.should be_false
     end
 
     it "should do nothing if the service is stopped" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "stopped"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "stopped"))
       @provider.load_current_resource
       Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
       @provider.stop_service
@@ -142,14 +163,34 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 	
     it "should raise an error if the service is paused" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "paused"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "paused"))
       @provider.load_current_resource
       Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
+      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
       @new_resource.updated_by_last_action?.should be_false
     end
 	
+    it "should wait and continue if the service is in stop_pending" do
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "stop pending"),
+        double("StatusStruct", :current_state => "stop pending"),
+        double("StatusStruct", :current_state => "stopped"))
+      @provider.load_current_resource
+      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+      @provider.stop_service
+      @new_resource.updated_by_last_action?.should be_false
+    end
+
+    it "should fail if the service is in start_pending" do
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "start pending"))
+      @provider.load_current_resource
+      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
+      @new_resource.updated_by_last_action?.should be_false
+    end
+
   end
 
   describe Chef::Provider::Service::Windows, "restart_service" do
@@ -162,11 +203,11 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should stop then start the service if it is running" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "running"),
-        mock("StatusStruct", :current_state => "stopped"),
-        mock("StatusStruct", :current_state => "stopped"),
-        mock("StatusStruct", :current_state => "running"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "running"),
+        double("StatusStruct", :current_state => "stopped"),
+        double("StatusStruct", :current_state => "stopped"),
+        double("StatusStruct", :current_state => "running"))
       Win32::Service.should_receive(:stop).with(@new_resource.service_name)
       Win32::Service.should_receive(:start).with(@new_resource.service_name)
       @provider.restart_service
@@ -174,17 +215,17 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should just start the service if it is stopped" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "stopped"),
-        mock("StatusStruct", :current_state => "stopped"),
-        mock("StatusStruct", :current_state => "running"))
+      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+        double("StatusStruct", :current_state => "stopped"),
+        double("StatusStruct", :current_state => "stopped"),
+        double("StatusStruct", :current_state => "running"))
       Win32::Service.should_receive(:start).with(@new_resource.service_name)
       @provider.restart_service
       @new_resource.updated_by_last_action?.should be_true
     end
 
     it "should do nothing if the service does not exist" do
-      Win32::Service.stub!(:exists?).with(@new_resource.service_name).and_return(false)
+      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
       Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
       Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
       @provider.restart_service
@@ -196,8 +237,8 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
   describe Chef::Provider::Service::Windows, "enable_service" do
 
     before(:each) do
-      Win32::Service.stub!(:config_info).with(@new_resource.service_name).and_return(
-        mock("ConfigStruct", :start_type => "disabled"))
+      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+        double("ConfigStruct", :start_type => "disabled"))
     end
 
     it "should enable service" do
@@ -207,15 +248,15 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should do nothing if the service does not exist" do
-      Win32::Service.stub!(:exists?).with(@new_resource.service_name).and_return(false)
+      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
       Win32::Service.should_not_receive(:configure)
       @provider.enable_service
       @new_resource.updated_by_last_action?.should be_false
     end
 
     it "should do nothing if the service is enabled" do
-      Win32::Service.stub!(:config_info).with(@new_resource.service_name).and_return(
-        mock("ConfigStruct", :start_type => "auto start"))
+      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+        double("ConfigStruct", :start_type => "auto start"))
       Win32::Service.should_not_receive(:configure)
       @provider.enable_service
       @new_resource.updated_by_last_action?.should be_false
@@ -225,8 +266,8 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
   describe Chef::Provider::Service::Windows, "disable_service" do
 
     before(:each) do
-      Win32::Service.stub!(:config_info).with(@new_resource.service_name).and_return(
-        mock("ConfigStruct", :start_type => "auto start"))
+      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+        double("ConfigStruct", :start_type => "auto start"))
     end
 
     it "should disable service" do
@@ -236,15 +277,15 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
 
     it "should do nothing if the service does not exist" do
-      Win32::Service.stub!(:exists?).with(@new_resource.service_name).and_return(false)
+      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
       Win32::Service.should_not_receive(:configure)
       @provider.disable_service
       @new_resource.updated_by_last_action?.should be_false
     end
 
     it "should do nothing if the service is disabled" do
-      Win32::Service.stub!(:config_info).with(@new_resource.service_name).and_return(
-        mock("ConfigStruct", :start_type => "disabled"))
+      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+        double("ConfigStruct", :start_type => "disabled"))
       @provider.load_current_resource
       Win32::Service.should_not_receive(:configure)
       @provider.disable_service


### PR DESCRIPTION
Add start_pending and stop_pending to the controllalbe list (stopped,started)
Raise exceptions on hitting any other states
Add test's for exceptions on uncontrollable states.
http://msdn.microsoft.com/en-us/library/windows/desktop/ee126211(v=vs.85).aspx
