### PR TITLE
[CHEF-3075] Allow 1 character environment names.

### DIFF
--- a/chef/lib/chef/client.rb
+++ b/chef/lib/chef/client.rb
@@ -244,7 +244,7 @@ class Chef
     def build_node
       # Allow user to override the environment of a node by specifying
       # a config parameter.
-      if Chef::Config[:environment] && !Chef::Config[:environment].chop.empty?
+      if Chef::Config[:environment] && !Chef::Config[:environment].chomp.empty?
         @node.chef_environment(Chef::Config[:environment])
       end
 

--- a/chef/spec/unit/client_spec.rb
+++ b/chef/spec/unit/client_spec.rb
@@ -233,6 +233,13 @@ shared_examples_for Chef::Client do
       @node[:recipes].length.should == 1
       @node[:recipes].should include("cookbook1")
     end
+
+    it "should set the environment from specified configuration value" do
+      Chef::Config[:environment] = "A"
+      @client.build_node
+      @node.chef_environment.should == "A"
+    end
+
   end
 
   describe "when a run list override is provided" do


### PR DESCRIPTION
String#chop will remove the last character of a string, preventing
single-character environment names.  String#chomp removes the last
character only if it is the record separator.
