### PR TITLE
[CHEF-3075] Allow 1 character environment names.

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -293,7 +293,7 @@ class Chef
     def build_node
       # Allow user to override the environment of a node by specifying
       # a config parameter.
-      if Chef::Config[:environment] && !Chef::Config[:environment].chop.empty?
+      if Chef::Config[:environment] && !Chef::Config[:environment].chomp.empty?
         @node.chef_environment(Chef::Config[:environment])
       end
 
@@ -582,4 +582,3 @@ end
 require 'chef/cookbook_loader'
 require 'chef/cookbook_version'
 require 'chef/cookbook/synchronizer'
-

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -339,6 +339,15 @@ shared_examples_for Chef::Client do
       @node[:recipes].length.should == 1
       @node[:recipes].should include("cookbook1")
     end
+
+    it "should set the environment from the specified configuration value" do
+      Chef::Config[:environment] = "A"
+      @client.build_node
+      @node.chef_environment.should == "A"
+    end
+  end
+
+
   end
 
   describe "windows_admin_check" do


### PR DESCRIPTION
String#chop will remove the last character of a string, preventing
single-character environment names. String#chomp removes the last
character only if it is the record separator.
