### PR TITLE
[ COOK-4028 ] zypper remove not working wiht OpenSuse 13.1

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -106,7 +106,7 @@ class Chef
 
         private
         def zypper_package(command, pkgname, version)
-          version = "=#{version}" unless version.empty?
+          version = "=#{version}" unless version.nil? || version.empty?
           if zypper_version < 1.0
             shell_out!("zypper#{gpg_checks} #{command} -y #{pkgname}")
           else


### PR DESCRIPTION
checking version for nil solves the problem
