### PR TITLE
CHEF-4890: Allow gem upgrades

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -495,6 +495,7 @@ class Chef
         def target_version_already_installed?
           return false unless @current_resource && @current_resource.version
           return false if @current_resource.version.nil?
+          return false if @new_resource.version.nil?
 
           Gem::Requirement.new(@new_resource.version).satisfied_by?(Gem::Version.new(@current_resource.version))
         end


### PR DESCRIPTION
This was preventing chef from finding the candidate version when
upgrading a gem and assuming there was nothing to do

Fixes CHEF-4890 https://tickets.opscode.com/browse/CHEF-4890
