### PR TITLE
[CHEF-4901] Upgrade Chef Zero & move Puma back to development dependencies

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", "~> 1.7", ">= 1.7.2"
-  s.add_dependency "puma", "~> 1.6"
+  # There's a bug with Chef Zero and IPV6 prior to version 2.0.2
+  s.add_dependency "chef-zero", "~> 2.0", ">= 2.0.2"
 
   s.add_dependency "pry", "~> 0.9"
 

--- a/spec/integration/knife/redirection_spec.rb
+++ b/spec/integration/knife/redirection_spec.rb
@@ -15,38 +15,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'puma'
 require 'support/shared/integration/integration_helper'
 require 'chef/knife/list'
 
 describe 'redirection' do
   extend IntegrationSupport
   include KnifeSupport
+  include AppServerSupport
 
   when_the_chef_server 'has a role' do
     role 'x', {}
 
     context 'and another server redirects to it with 302' do
       before :each do
-        @real_chef_server_url = Chef::Config.chef_server_url
+        real_chef_server_url = Chef::Config.chef_server_url
         Chef::Config.chef_server_url = "http://127.0.0.1:9018"
         app = lambda do |env|
-          [302, {'Content-Type' => 'text','Location' => "#{@real_chef_server_url}#{env['PATH_INFO']}" }, ['302 found'] ]
+          [302, {'Content-Type' => 'text','Location' => "#{real_chef_server_url}#{env['PATH_INFO']}" }, ['302 found'] ]
         end
-        @redirector_server = Puma::Server.new(app, Puma::Events.new(STDERR, STDOUT))
-        @redirector_server.add_tcp_listener("127.0.0.1", 9018)
-        @redirector_server.run
-        Timeout::timeout(5) do
-          until @redirector_server.running
-            sleep(0.01)
-          end
-          raise @server_error if @server_error
-        end
+        @redirector_server, @redirector_server_thread = start_app_server(app, 9018)
       end
 
       after :each do
-        Chef::Config.chef_server_url = @real_chef_server_url
-        @redirector_server.stop(true)
+        @redirector_server.shutdown if @redirector_server
+        @redirector_thread.kill if @redirector_thread
       end
 
       it 'knife list /roles returns the role' do

--- a/spec/support/shared/integration/app_server_support.rb
+++ b/spec/support/shared/integration/app_server_support.rb
@@ -1,0 +1,42 @@
+#
+# Author:: John Keiser (<jkeiser@opscode.com>)
+# Author:: Ho-Sheng Hsiao (<hosh@opscode.com>)
+# Copyright:: Copyright (c) 2012, 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rack'
+require 'stringio'
+
+module AppServerSupport
+  def start_app_server(app, port)
+    server = nil
+    thread = Thread.new do
+      Rack::Handler::WEBrick.run(app,
+        :Port => 9018,
+        :AccessLog => [],
+        :Logger => WEBrick::Log::new(StringIO.new, 7)
+      ) do |found_server|
+        server = found_server
+      end
+    end
+    Timeout::timeout(5) do
+      until server && server.status == :Running
+        sleep(0.01)
+      end
+    end
+    [server, thread]
+  end
+end

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -23,6 +23,7 @@ require 'chef/config'
 require 'chef_zero/rspec'
 require 'json'
 require 'support/shared/integration/knife_support'
+require 'support/shared/integration/app_server_support'
 require 'spec_helper'
 
 module IntegrationSupport


### PR DESCRIPTION
https://tickets.opscode.com/browse/CHEF-4901

This commit upgrades Chef Zero to version 2.0.0, which removed Puma entirely. Chef no longer requires Puma at runtime, so it can be moved into the development gem group. Chef Zero 2.0 runs entirely in WEBrick and also uses less memory and a more direct threading approach.
