### PR TITLE
Adds warning when default --attribute is in effect

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -396,6 +396,11 @@ class Chef
       end
 
       def configure_attribute
+
+        if !config[:attribute]
+          ui.warn "No node attribute (-a or --attribute) was specified for use when connecting to the node(s). The default of \"fqdn\" will be used."
+        end
+
         # Setting 'knife[:ssh_attribute] = "foo"' in knife.rb => Chef::Config[:knife][:ssh_attribute] == 'foo'
         # Running 'knife ssh -a foo' => both Chef::Config[:knife][:ssh_attribute] && config[:attribute] == foo
         # Thus we can differentiate between a config file value and a command line override at this point by checking config[:attribute]


### PR DESCRIPTION
A common pitfall for new or intermediate users of Chef is invoking "knife ssh ..." without specifying the crucial "-a or --attribute" flag/option. When -a is not explicitly specified, node["fqdn"] is used to establish ssh connections. The node's "fqdn" attribute may or may not be a navigable hostname(s). Some fall into the pit and some never know they need -a.

ala https://github.com/opscode/knife-ec2/commit/8a6fd7a3e3c96588070465f75b3254a7951b567d
