### PR TITLE
Correct the Arch Linux mapping to use Systemd Service Provider

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -233,7 +233,7 @@ class Chef
           :arch   => {
             :default => {
               :package => Chef::Provider::Package::Pacman,
-              :service => Chef::Provider::Service::Arch,
+              :service => Chef::Provider::Service::Systemd,
               :cron => Chef::Provider::Cron,
               :mdadm => Chef::Provider::Mdadm
             }


### PR DESCRIPTION
Mapping corrected so that arch systems use the current & correct systemd service
