### PR TITLE
[CHEF-4913] Bump ffi version to 1.5.0

### DIFF
--- a/chef-x86-mingw32.gemspec
+++ b/chef-x86-mingw32.gemspec
@@ -4,7 +4,7 @@ gemspec = eval(IO.read(File.expand_path("../chef.gemspec", __FILE__)))
 gemspec.platform = "x86-mingw32"
 
 gemspec.add_dependency "mixlib-shellout", "1.2.0"
-gemspec.add_dependency "ffi", "1.3.1"
+gemspec.add_dependency "ffi", "1.5.0"
 gemspec.add_dependency "rdp-ruby-wmi", "0.3.1"
 gemspec.add_dependency "windows-api", "0.4.2"
 gemspec.add_dependency "windows-pr", "1.2.2"


### PR DESCRIPTION
Fixes missing pre-compiled library for Ruby 2.0.0 when using Windows.

JIRA ticket: https://tickets.opscode.com/browse/CHEF-4913
Original ffi issue: https://github.com/ffi/ffi/issues/252
