### PR TITLE
multiple dep lines no longer supported by bundler

### DIFF
--- a/chef-x86-mingw32.gemspec
+++ b/chef-x86-mingw32.gemspec
@@ -3,7 +3,6 @@ gemspec = eval(IO.read(File.expand_path("../chef.gemspec", __FILE__)))
 
 gemspec.platform = "x86-mingw32"
 
-gemspec.add_dependency "mixlib-shellout", "1.2.0"
 gemspec.add_dependency "ffi", "1.3.1"
 gemspec.add_dependency "rdp-ruby-wmi", "0.3.1"
 gemspec.add_dependency "windows-api", "0.4.2"


### PR DESCRIPTION
our attempt to let the unix gemspec float with semver ~> 1.2 and to pin
the version exactly for windows (= 1.2.0) is no longer supported and
rake install blows up:

  if rspec-mocks is semantically versioned, use:
    add_development_dependency 'rspec-mocks', '~> 2.13', '>= 2.13.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
rake aborted!
duplicate dependency on mixlib-shellout (= 1.2.0, ~> 1.2), (~> 1.2) use:
    add_runtime_dependency 'mixlib-shellout', '= 1.2.0, ~> 1.2', '~> 1.2'

Tasks: TOP => install => package => gem => pkg/chef-11.10.0.alpha.1-x86-mingw32.gem
(See full trace by running task with --trace)

just remove the line from the windows spec and inherit from the unix spec.
