### PR TITLE
CHEF-4913: ffi 1.3.1 is too low a version when using Ruby 2.0.0 with Windows

### DIFF
--- a/chef-x86-mingw32.gemspec
+++ b/chef-x86-mingw32.gemspec
@@ -3,7 +3,7 @@ gemspec = eval(IO.read(File.expand_path("../chef.gemspec", __FILE__)))
 
 gemspec.platform = "x86-mingw32"
 
-gemspec.add_dependency "ffi", "1.3.1"
+gemspec.add_dependency "ffi", "1.5.0"
 gemspec.add_dependency "rdp-ruby-wmi", "0.3.1"
 gemspec.add_dependency "windows-api", "0.4.2"
 gemspec.add_dependency "windows-pr", "1.2.2"


### PR DESCRIPTION
Incorporating fixes for some breaking changes into the fix for CHEF-4913.
