### PR TITLE
CHEF-4927 - coerce group GID to string

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -84,7 +84,7 @@ class Chef
       # <false>:: If a change is not required
       def compare_group
         @change_desc = [ ]
-        if @new_resource.gid != @current_resource.gid
+        if @new_resource.gid.to_s  != @current_resource.gid.to_s
           @change_desc << "change gid #{@current_resource.gid} to #{@new_resource.gid}"
         end
 

--- a/spec/unit/provider/group_spec.rb
+++ b/spec/unit/provider/group_spec.rb
@@ -96,6 +96,11 @@ describe Chef::Provider::User do
       @provider.compare_group.should be_false
     end
 
+    it "should coerce an integer to a string for comparison" do
+      @current_resource.stub!(:gid).and_return("500")
+      @provider.compare_group.should be_false
+    end
+
     it "should return false if append is true and the group member(s) already exists" do
       @current_resource.members << "extra_user"
       @new_resource.stub!(:append).and_return(true)


### PR DESCRIPTION
To remain consistent with the way the user provider works, coerce both
new_resource and current_resource GIDs to strings for comparison. This
allows users to write their resources like:

``` ruby
group "zone" do
  gid 233
end
```

or

``` ruby
group "zone" do
  gid "233"
end
```

Without this change, every time Chef runs when a string GID is
specified, it will modify the group, which is not desirable.
