### PR TITLE
Lock `sdoc` down to `~> 0.3.0`

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -41,7 +41,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "pry", "~> 0.9"
 
-  %w(rdoc sdoc rake rack rspec_junit_formatter).each { |gem| s.add_development_dependency gem }
+  s.add_development_dependency "sdoc", "~> 0.3.0"
+  %w(rake rack rspec_junit_formatter).each { |gem| s.add_development_dependency gem }
   %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_development_dependency gem, "~> 2.13.0" }
 
   s.bindir       = "bin"


### PR DESCRIPTION
TL;DR - `sdoc ~> 0.4.0` depends on `rdoc ~> 4.0` and this version of 
`rdoc` breaks our Omnibus builds on Solaris!

The full explanation is going to sound long-winded...just bear with me. 
`rdoc` 0.4.0+ ships with fixture data from MarkdownTest, a Markdown 
validation test suite. Unfortunately this fixture data also has spaces 
in all of the file names. `pkgmk`, the utility we use to generate Chef 
Omnibus packages for Solaris, has a known issues processing file names 
with spaces:

http://compgroups.net/comp.unix.solaris/pkgmk-fails-when-filenames-have-space-chara/295864

Yes, this fix is a metaphor for the age old battle of hipster vs 
greybeard.

Successful CI run: http://ci.opscode.us/job/chef-client-build/1217/

/cc @lamont-granquist @yzl @danielsdeleo 
