### PR TITLE
WIP: attempt to save CHEF-2418

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -436,6 +436,12 @@ class Chef
                              Chef::Config[:knife][:ssh_user])
       end
 
+      # This is a bit overly complicated because of the way we want knife ssh to work with -P causing a password prompt for
+      # the user, but we have to be conscious that this code gets included in knife bootstrap and knife * server create as
+      # well.  We want to change the semantics so that the default is false and 'nil' means -P without an argument on the
+      # command line.  But the other utilities expect nil to be the default and we can't prompt in that case. So we effectively
+      # use ssh_password_ng to determine if we're coming from knife ssh or from the other utilities.  The other utilties can
+      # also be patched to use ssh_password_ng easily as long they follow the convention that the default is false.
       def configure_password
         if config.has_key?(:ssh_password_ng) && config[:ssh_password_ng].nil?
           # If the parameter is called on the command line with no value

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -280,4 +280,111 @@ describe Chef::Knife::Ssh do
       end
     end
   end
+
+  describe "#configure_password" do
+    before do
+      @knife.config.delete(:ssh_password_ng)
+      @knife.config.delete(:ssh_password)
+    end
+
+    context "when setting ssh_password_ng from knife ssh" do
+      # in this case ssh_password_ng exists, but ssh_password does not
+      it "should prompt for a password when ssh_passsword_ng is nil"  do
+        @knife.config[:ssh_password_ng] = nil
+        @knife.should_receive(:get_password).and_return("mysekretpassw0rd")
+        @knife.configure_password
+        @knife.config[:ssh_password].should == "mysekretpassw0rd"
+      end
+
+      it "should set ssh_password to false if ssh_password_ng is false"  do
+        @knife.config[:ssh_password_ng] = false
+        @knife.should_not_receive(:get_password)
+        @knife.configure_password
+        @knife.config[:ssh_password].should be_false
+      end
+
+      it "should set ssh_password to ssh_password_ng if we set a password" do
+        @knife.config[:ssh_password_ng] = "mysekretpassw0rd"
+        @knife.should_not_receive(:get_password)
+        @knife.configure_password
+        @knife.config[:ssh_password].should == "mysekretpassw0rd"
+      end
+    end
+
+    context "when setting ssh_password from knife bootstrap / knife * server create" do
+      # in this case ssh_password exists, but ssh_password_ng does not
+      it "should set ssh_password to nil when ssh_password is nil" do
+        @knife.config[:ssh_password] = nil
+        @knife.should_not_receive(:get_password)
+        @knife.configure_password
+        @knife.config[:ssh_password].should be_nil
+      end
+
+      it "should set ssh_password to false when ssh_password is false" do
+        @knife.config[:ssh_password] = false
+        @knife.should_not_receive(:get_password)
+        @knife.configure_password
+        @knife.config[:ssh_password].should be_false
+      end
+
+      it "should set ssh_password to ssh_password if we set a password" do
+        @knife.config[:ssh_password] = "mysekretpassw0rd"
+        @knife.should_not_receive(:get_password)
+        @knife.configure_password
+        @knife.config[:ssh_password].should == "mysekretpassw0rd"
+      end
+    end
+    context "when setting ssh_password in the config variable" do
+      before(:each) do
+        Chef::Config[:knife][:ssh_password] = "my_knife_passw0rd"
+      end
+      context "when setting ssh_password_ng from knife ssh" do
+        # in this case ssh_password_ng exists, but ssh_password does not
+        it "should prompt for a password when ssh_passsword_ng is nil"  do
+          @knife.config[:ssh_password_ng] = nil
+          @knife.should_receive(:get_password).and_return("mysekretpassw0rd")
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "mysekretpassw0rd"
+        end
+
+        it "should set ssh_password to the configured knife.rb value if ssh_password_ng is false"  do
+          @knife.config[:ssh_password_ng] = false
+          @knife.should_not_receive(:get_password)
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "my_knife_passw0rd"
+        end
+
+        it "should set ssh_password to ssh_password_ng if we set a password" do
+          @knife.config[:ssh_password_ng] = "mysekretpassw0rd"
+          @knife.should_not_receive(:get_password)
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "mysekretpassw0rd"
+        end
+      end
+
+      context "when setting ssh_password from knife bootstrap / knife * server create" do
+        # in this case ssh_password exists, but ssh_password_ng does not
+        it "should set ssh_password to the configured knife.rb value when ssh_password is nil" do
+          @knife.config[:ssh_password] = nil
+          @knife.should_not_receive(:get_password)
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "my_knife_passw0rd"
+        end
+
+        it "should set ssh_password to the configured knife.rb value when ssh_password is false" do
+          @knife.config[:ssh_password] = false
+          @knife.should_not_receive(:get_password)
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "my_knife_passw0rd"
+        end
+
+        it "should set ssh_password to ssh_password if we set a password" do
+          @knife.config[:ssh_password] = "mysekretpassw0rd"
+          @knife.should_not_receive(:get_password)
+          @knife.configure_password
+          @knife.config[:ssh_password].should == "mysekretpassw0rd"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
implement ssh_password_ng config option only in knife ssh
- commands like knife bootstrap and knife \* server create will not set
- can use #has_key? as a test if we're running knife ssh or not
- do not prompt for password if ssh_password_ng does not exist
- not surfaced in knife.rb still uses old ssh_password config option
