### PR TITLE
CHEF-4963 - Mixlib-shellout library is incorrect for Chef 11.8.2

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", "~> 1.4"
   s.add_dependency "mixlib-log", "~> 1.3"
   s.add_dependency "mixlib-authentication", "~> 1.3"
-  s.add_dependency "mixlib-shellout", "~> 1.2"
+  s.add_dependency "mixlib-shellout", "~> 1.3"
   s.add_dependency "ohai", "~> 6.0"
 
   s.add_dependency "rest-client", ">= 1.0.4", "< 1.7.0"


### PR DESCRIPTION
Pending a full build run. 

/cc: @danielsdeleo 
