### PR TITLE
CHEF-4972 Upstart provider should obey the `supports[:reload]` option

### DIFF
--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -150,7 +150,7 @@ class Chef
       end
 
       def reload_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :restart"
+        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
       end
 
       protected

--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -188,9 +188,11 @@ class Chef
         def reload_service
           if @new_resource.reload_command
             super
-          else
+          elsif @new_resource.supports[:reload]
             # upstart >= 0.6.3-4 supports reload (HUP)
             run_command_with_systems_locale(:command => "/sbin/reload #{@job}")
+          else
+            raise Chef::Exceptions::UnsupportedAction, "#{@new_resource} does not support :reload"
           end
         end
 

--- a/spec/unit/provider/service/init_service_spec.rb
+++ b/spec/unit/provider/service/init_service_spec.rb
@@ -216,7 +216,7 @@ RUNNING_PS
       @provider.reload_service()
     end
 
-    it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
+    it "should run the user specified reload command if one is specified and the service doesn't support reload" do
       @new_resource.reload_command("/etc/init.d/chef lollerpants")
       @provider.should_receive(:shell_out!).with("/etc/init.d/chef lollerpants")
       @provider.reload_service()

--- a/spec/unit/provider/service_spec.rb
+++ b/spec/unit/provider/service_spec.rb
@@ -103,6 +103,12 @@ describe Chef::Provider::Service do
       @current_resource.supports(:restart => true)
     end
 
+    it "should raise an exception if restart isn't supported" do
+      @current_resource.supports(:restart => false)
+      @current_resource.stub!(:restart_command).and_return(false)
+      lambda { @provider.run_action(:restart) }.should raise_error(Chef::Exceptions::UnsupportedAction, /does not support :restart/)
+    end
+
     it "should restart the service if it's supported and set the resource as updated" do
       @provider.should_receive(:restart_service).and_return(true)
       @provider.run_action(:restart)
@@ -125,7 +131,7 @@ describe Chef::Provider::Service do
     it "should raise an exception if reload isn't supported" do
       @new_resource.supports(:reload => false)
       @new_resource.stub!(:reload_command).and_return(false)
-      lambda { @provider.run_action(:reload) }.should raise_error(Chef::Exceptions::UnsupportedAction)
+      lambda { @provider.run_action(:reload) }.should raise_error(Chef::Exceptions::UnsupportedAction, /does not support :reload/)
     end
 
     it "should reload the service if it is running and set the resource as updated" do


### PR DESCRIPTION
For example, Upstart jobs that run once on a certain event, like `/etc/init/hostname` and `/etc/init/passwd` don't support reload - an error code of 1 will be returned by `/sbin/reload`.

This patch makes `supports reload: false` work for a `service`, instead of ignoring it (and attempting to reload via `/sbin/reload`).

Other trivial changes (small stuff I noticed while reading the code):
* Fix "restart" copy that should say "reload".
* Add missing test case for an exception being raised by `Chef::Provider::Service` if restart isn't supported.

Ticket: https://tickets.opscode.com/browse/CHEF-4972