### PR TITLE
WIP: CHEF-4811: metadata.json should take precedence over metadata.rb

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -43,7 +43,9 @@ class Chef
         @metadata_filenames = []
       end
 
-      def load_cookbooks
+      def load_cookbooks(opts = {})
+        ignore_metadata_rb = opts[:ignore_metadata_rb] || false
+
         load_as(:attribute_filenames, 'attributes', '*.rb')
         load_as(:definition_filenames, 'definitions', '*.rb')
         load_as(:recipe_filenames, 'recipes', '*.rb')
@@ -56,10 +58,16 @@ class Chef
 
         remove_ignored_files
 
-        if File.exists?(File.join(@cookbook_path, "metadata.rb"))
-          @metadata_filenames << File.join(@cookbook_path, "metadata.rb")
-        elsif File.exists?(File.join(@cookbook_path, "metadata.json"))
-          @metadata_filenames << File.join(@cookbook_path, "metadata.json")
+        if ignore_metadata_rb
+          if File.exists?(File.join(@cookbook_path, "metadata.json"))
+            @metadata_filenames << File.join(@cookbook_path, "metadata.json")
+          end
+        else
+          if File.exists?(File.join(@cookbook_path, "metadata.rb"))
+            @metadata_filenames << File.join(@cookbook_path, "metadata.rb")
+          elsif File.exists?(File.join(@cookbook_path, "metadata.json"))
+            @metadata_filenames << File.join(@cookbook_path, "metadata.json")
+          end
         end
 
         if empty?

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -79,7 +79,7 @@ class Chef
         cookbook_path = File.join(repo_path, cookbook_name.to_s)
         next unless File.directory?(cookbook_path) and Dir[File.join(repo_path, "*")].include?(cookbook_path)
         loader = Cookbook::CookbookVersionLoader.new(cookbook_path, @chefignores[repo_path])
-        loader.load_cookbooks
+        loader.load_cookbooks(:ignore_metadata_rb => true)
         next if loader.empty?
         cookbook_name = loader.cookbook_name
         @cookbooks_paths[cookbook_name] << cookbook_path # for deprecation warnings

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -68,6 +68,7 @@ class Chef
     # Cookbook loader used to raise an argument error when cookbook not found.
     # for back compat, need to raise an error that inherits from ArgumentError
     class CookbookNotFoundInRepo < ArgumentError; end
+    class CookbookNoMetadataJSON < ArgumentError; end
     class RecipeNotFound < ArgumentError; end
     class AttributeNotFound < RuntimeError; end
     class InvalidCommandOption < RuntimeError; end


### PR DESCRIPTION
change cookbook_version_loader to take an option to ignore
metadata.rb, use that in cookbook_loader to ignore metadata.rb.

idea is to leave knife semantics as-is but change chef-client to
ignore metadata.rb
