### PR TITLE
Fix DPKG_INFO regexp to work with packages like oracle-j2re1.7_1.7.0+update45_amd64.deb

### DIFF
--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -25,7 +25,7 @@ class Chef
   class Provider
     class Package
       class Dpkg < Chef::Provider::Package::Apt
-        DPKG_INFO = /([a-z\d\-\+\.]+)\t([\w\d.~-]+)/
+        DPKG_INFO = /([^\t]+)\t([^\t]+)\b/
         DPKG_INSTALLED = /^Status: install ok installed/
         DPKG_VERSION = /^Version: (.+)$/
 


### PR DESCRIPTION
simplify regexp and fix it for package like this : 

$ dpkg-deb -W /tmp/oracle-j2re1.7_1.7.0+update45_amd64.deb 
oracle-j2re1.7	1.7.0+update45