### PR TITLE
Remove most references to wiki from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Chef - A configuration management system
 |                      |                                          |
 |:---------------------|:-----------------------------------------|
 | **Author:**          | Adam Jacob (<adam@opscode.com>)
-| **Copyright:**       | Copyright (c) 2008-2012 Opscode, Inc.
+| **Copyright:**       | Copyright (c) 2008-2014 Chef Software, Inc.
 | **License:**         | Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Replace most references to the wiki with appropriate docs.opscode.com
  content.
- Put a link to learnchef at the very top for new users
- Half of the development guide was "how to install from source"; make
  that its own section instead of linking to wiki.
