### PR TITLE
CHEF-4990 Fix provider for the state of 'maintenance' Solaris  services.

### DIFF
--- a/spec/unit/provider/service/solaris_smf_service_spec.rb
+++ b/spec/unit/provider/service/solaris_smf_service_spec.rb
@@ -54,33 +54,46 @@ describe Chef::Provider::Service::Solaris do
 
     describe "when discovering the current service state" do
       it "should create a current resource with the name of the new resource" do
-        @provider.stub(:popen4).with("/bin/svcs -l chef").and_return(@status)
+        @provider.stub!(:shell_out!).with("/bin/svcs -l chef").and_return(@status)
         Chef::Resource::Service.should_receive(:new).and_return(@current_resource)
         @provider.load_current_resource
       end
 
 
       it "should return the current resource" do
-        @provider.stub(:popen4).with("/bin/svcs -l chef").and_return(@status)
+        @provider.stub!(:shell_out!).with("/bin/svcs -l chef").and_return(@status)
         @provider.load_current_resource.should eql(@current_resource)
       end
 
-      it "should popen4 '/bin/svcs -l service_name'" do
-        @provider.should_receive(:popen4).with("/bin/svcs -l chef").and_return(@status)
+      it "should call '/bin/svcs -l service_name'" do
+        @provider.should_receive(:shell_out!).with("/bin/svcs -l chef").and_return(@status)
         @provider.load_current_resource
       end
 
       it "should mark service as not running" do
-        @provider.stub(:popen4).and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+        @provider.stub!(:shell_out!).and_return(@status)
         @current_resource.should_receive(:running).with(false)
         @provider.load_current_resource
       end
 
       it "should mark service as running" do
-        @stdout.stub(:each).and_yield("state online")
-        @provider.stub(:popen4).and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+        @status = mock("Status", :exitstatus => 0, :stdout => 'state online')
+        @provider.stub!(:shell_out!).and_return(@status)
         @current_resource.should_receive(:running).with(true)
         @provider.load_current_resource
+      end
+
+      it "should not mark service as maintenance" do
+        @provider.stub!(:shell_out!).and_return(@status)
+        @provider.load_current_resource
+        @provider.maintenance.should be_false
+      end
+
+      it "should mark service as maintenance" do
+        @status = mock("Status", :exitstatus => 0, :stdout => 'state maintenance')
+        @provider.stub!(:shell_out!).and_return(@status)
+        @provider.load_current_resource
+        @provider.maintenance.should be_true
       end
     end
 
@@ -91,19 +104,31 @@ describe Chef::Provider::Service::Solaris do
       end
 
       it "should call svcadm enable -s chef" do
-        @new_resource.stub(:enable_command).and_return("#{@new_resource.enable_command}")
+        @new_resource.stub!(:enable_command).and_return("#{@new_resource.enable_command}")
+        @provider.should_not_receive(:shell_out!).with("/usr/sbin/svcadm clear #{@current_resource.service_name}")
         @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm enable -s #{@current_resource.service_name}").and_return(@status)
-				@provider.enable_service.should be_true
+        @provider.enable_service.should be_true
         @current_resource.enabled.should be_true
       end
 
       it "should call svcadm enable -s chef for start_service" do
-        @new_resource.stub(:start_command).and_return("#{@new_resource.start_command}")
+        @new_resource.stub!(:start_command).and_return("#{@new_resource.start_command}")
+        @provider.should_not_receive(:shell_out!).with("/usr/sbin/svcadm clear #{@current_resource.service_name}")
         @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm enable -s #{@current_resource.service_name}").and_return(@status)
         @provider.start_service.should be_true
         @current_resource.enabled.should be_true
       end
 
+      it "should call svcadm clear chef for start_service when state maintenance" do
+        @status = mock("Status", :exitstatus => 0, :stdout => 'state maintenance')
+        @provider.stub!(:shell_out!).and_return(@status)
+        @provider.load_current_resource
+        @new_resource.stub!(:enable_command).and_return("#{@new_resource.enable_command}")
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm clear #{@current_resource.service_name}").and_return(@status)
+        @provider.should_receive(:shell_out!).with("/usr/sbin/svcadm enable -s #{@current_resource.service_name}").and_return(@status)
+        @provider.enable_service.should be_true
+        @current_resource.enabled.should be_true
+      end
     end
 
 


### PR DESCRIPTION
pull request of [CHEF-4990](https://tickets.opscode.com/browse/CHEF-4990)

```
Chef::Provider::Service::Solaris
  should raise an error if /bin/svcs does not exist
  on a host with /bin/svcs
    when discovering the current service state
      should create a current resource with the name of the new resource
      should return the current resource
      should call '/bin/svcs -l service_name'
      should mark service as not running
      should mark service as running
      should not mark service as maintenance  # new
      should mark service as maintenance        # new
    when enabling the service
      should call svcadm enable -s chef
      should call svcadm enable -s chef for start_service
      should call svcadm clear chef for start_service when state maintenance    # new
    when disabling the service
      should call svcadm disable -s chef
      should call svcadm disable -s chef for stop_service
    when reloading the service
      should call svcadm refresh chef

Finished in 0.08953 seconds
14 examples, 0 failures
```
