### PR TITLE
Adding request_id to the set of headers for every request that will be sent to erchef

### DIFF
--- a/lib/chef/http/remote_request_id.rb
+++ b/lib/chef/http/remote_request_id.rb
@@ -1,0 +1,46 @@
+# Author:: Prajakta Purohit (<prajakta@opscode.com>)
+# Copyright:: Copyright (c) 2009, 2010, 2013, 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/request_id'
+
+class Chef
+  class HTTP
+    class RemoteRequestID
+
+      def initialize(opts={})
+      end
+
+      def handle_request(method, url, headers={}, data=false)
+        headers.merge!({'X-REMOTE-REQUEST-ID' => Chef::RequestID.instance.request_id})
+        [method, url, headers, data]
+      end
+
+      def handle_response(http_response, rest_request, return_value)
+        [http_response, rest_request, return_value]
+      end
+
+      def stream_response_handler(response)
+        nil
+      end
+
+      def handle_stream_complete(http_response, rest_request, return_value)
+        [http_response, rest_request, return_value]
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/raw.rb
+++ b/lib/chef/knife/raw.rb
@@ -42,6 +42,7 @@ class Chef
         use Chef::HTTP::CookieManager
         use Chef::HTTP::Decompressor
         use Chef::HTTP::Authenticator
+        use Chef::HTTP::RemoteRequestID
       end
 
       def run

--- a/lib/chef/request_id.rb
+++ b/lib/chef/request_id.rb
@@ -1,0 +1,37 @@
+# Author:: Prajakta Purohit (<prajakta@opscode.com>)
+# Copyright:: Copyright (c) 2009, 2010, 2013, 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/monkey_patches/securerandom'
+require 'singleton'
+
+class Chef
+  class RequestID
+    include Singleton
+
+    def reset_request_id
+      @request_id = nil
+    end
+
+    def request_id
+      @request_id ||= generate_request_id
+    end
+
+    def generate_request_id
+      SecureRandom.uuid
+    end
+  end
+end

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -107,7 +107,6 @@ class Chef
       @pending_update  = nil
       @status = "success"
       @exception = nil
-      @run_id = SecureRandom.uuid
       @rest_client = rest_client
       @error_descriptions = {}
     end
@@ -118,7 +117,7 @@ class Chef
       if reporting_enabled?
         begin
           resource_history_url = "reports/nodes/#{node_name}/runs"
-          server_response = @rest_client.post_rest(resource_history_url, {:action => :start, :run_id => @run_id,
+          server_response = @rest_client.post_rest(resource_history_url, {:action => :start, :run_id => run_id,
                                                                           :start_time => start_time.to_s}, headers)
         rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
           handle_error_starting_run(e, resource_history_url)
@@ -156,6 +155,10 @@ class Chef
       end
 
       @reporting_enabled = false
+    end
+
+    def run_id
+      @run_status.run_id
     end
 
     def resource_current_state_loaded(new_resource, action, current_resource)
@@ -214,8 +217,8 @@ class Chef
     def post_reporting_data
       if reporting_enabled?
         run_data = prepare_run_data
-        resource_history_url = "reports/nodes/#{node_name}/runs/#{@run_id}"
-        Chef::Log.info("Sending resource update report (run-id: #{@run_id})")
+        resource_history_url = "reports/nodes/#{node_name}/runs/#{run_id}"
+        Chef::Log.info("Sending resource update report (run-id: #{run_id})")
         Chef::Log.debug run_data.inspect
         compressed_data = encode_gzip(run_data.to_json)
         begin

--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -36,6 +36,7 @@ require 'chef/http/validate_content_length'
 require 'chef/config'
 require 'chef/exceptions'
 require 'chef/platform/query_helpers'
+require 'chef/http/remote_request_id'
 
 class Chef
   # == Chef::REST
@@ -62,6 +63,7 @@ class Chef
 
       @decompressor = Decompressor.new(options)
       @authenticator = Authenticator.new(options)
+      @request_id = RemoteRequestID.new(options)
 
       @middlewares << ValidateContentLength.new(options)
       @middlewares << JSONInput.new(options)
@@ -69,6 +71,8 @@ class Chef
       @middlewares << CookieManager.new(options)
       @middlewares << @decompressor
       @middlewares << @authenticator
+      @middlewares << @request_id
+
     end
 
     def signing_key_filename
@@ -132,7 +136,7 @@ class Chef
     def raw_http_request(method, path, headers, data)
       url = create_url(path)
       method, url, headers, data = @authenticator.handle_request(method, url, headers, data)
-
+      method, url, headers, data = @request_id.handle_request(method, url, headers, data)
       response, rest_request, return_value = send_http_request(method, url, headers, data)
       response.error! unless success_response?(response)
       return_value

--- a/lib/chef/run_status.rb
+++ b/lib/chef/run_status.rb
@@ -37,6 +37,8 @@ class Chef::RunStatus
 
   attr_writer :exception
 
+  attr_accessor :run_id
+
   def initialize(node, events)
     @node = node
     @events = events
@@ -112,7 +114,8 @@ class Chef::RunStatus
       :all_resources => all_resources,
       :updated_resources => updated_resources,
       :exception => formatted_exception,
-      :backtrace => backtrace}
+      :backtrace => backtrace,
+      :run_id => run_id}
   end
 
   # Returns a string of the format "ExceptionClass: message" or +nil+ if no

--- a/lib/chef/server_api.rb
+++ b/lib/chef/server_api.rb
@@ -22,6 +22,7 @@ require 'chef/http/cookie_manager'
 require 'chef/http/decompressor'
 require 'chef/http/json_input'
 require 'chef/http/json_output'
+require 'chef/http/remote_request_id'
 
 class Chef
   class ServerAPI < Chef::HTTP
@@ -37,5 +38,6 @@ class Chef
     use Chef::HTTP::CookieManager
     use Chef::HTTP::Decompressor
     use Chef::HTTP::Authenticator
+    use Chef::HTTP::RemoteRequestID
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -183,7 +183,8 @@ shared_examples_for Chef::Client do
       #   Client.register will then turn around create another
       #   Chef::REST object, this time with the client key it got from the
       #   previous step.
-      Chef::REST.should_receive(:new).with(Chef::Config[:chef_server_url], @fqdn, Chef::Config[:client_key]).exactly(1).and_return(mock_chef_rest_for_node)
+      Chef::REST.should_receive(:new).with(Chef::Config[:chef_server_url], @fqdn, Chef::Config[:client_key]
+                                          ).exactly(1).and_return(mock_chef_rest_for_node)
 
       # --Client#build_node
       #   looks up the node, which we will return, then later saves it.

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -38,7 +38,6 @@ describe Chef::ResourceReporter do
     @rest_client = double("Chef::REST (mock)")
     @rest_client.stub(:post_rest).and_return(true)
     @resource_reporter = Chef::ResourceReporter.new(@rest_client)
-    @run_id = @resource_reporter.run_id
     @new_resource      = Chef::Resource::File.new("/tmp/a-file.txt")
     @new_resource.cookbook_name = "monkey"
     @cookbook_version = double("Cookbook::Version", :version => "1.2.3")
@@ -49,6 +48,7 @@ describe Chef::ResourceReporter do
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
     @run_status = Chef::RunStatus.new(@node, @events)
+    @run_id = @run_status.run_id
     Time.stub(:now).and_return(@start_time, @end_time)
   end
 

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -59,12 +59,18 @@ describe Chef::REST do
 
   let(:log_stringio) { StringIO.new }
 
+  let(:request_id) {"1234"}
+
   let(:rest) do
     Chef::REST::CookieJar.stub(:instance).and_return({})
+    Chef::RequestID.instance.stub(:request_id).and_return(request_id)
     rest = Chef::REST.new(base_url, nil, nil)
     Chef::REST::CookieJar.instance.clear
     rest
   end
+
+  let(:standard_read_headers) {{"Accept"=>"application/json", "Accept"=>"application/json", "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "X-REMOTE-REQUEST-ID"=>request_id}}
+  let(:standard_write_headers) {{"Accept"=>"application/json", "Content-Type"=>"application/json", "Accept"=>"application/json", "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3", "X-REMOTE-REQUEST-ID"=>request_id}}
 
   before(:each) do
     Chef::Log.init(log_stringio)
@@ -82,7 +88,7 @@ describe Chef::REST do
 
     it "makes a :GET request with the composed url object" do
       rest.should_receive(:send_http_request).
-        with(:GET, monkey_uri, STANDARD_READ_HEADERS, false).
+        with(:GET, monkey_uri, standard_read_headers, false).
         and_return([1,2,3])
       rest.should_receive(:apply_response_middleware).with(1,2,3).and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
@@ -94,12 +100,9 @@ describe Chef::REST do
       rest.get_rest("monkey", true)
     end
 
-    STANDARD_READ_HEADERS = {"Accept"=>"application/json", "Accept"=>"application/json", "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"}
-    STANDARD_WRITE_HEADERS = {"Accept"=>"application/json", "Content-Type"=>"application/json", "Accept"=>"application/json", "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"}
-
     it "makes a :DELETE request with the composed url object" do
       rest.should_receive(:send_http_request).
-        with(:DELETE, monkey_uri, STANDARD_READ_HEADERS, false).
+        with(:DELETE, monkey_uri, standard_read_headers, false).
         and_return([1,2,3])
       rest.should_receive(:apply_response_middleware).with(1,2,3).and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
@@ -108,7 +111,7 @@ describe Chef::REST do
 
     it "makes a :POST request with the composed url object and data" do
       rest.should_receive(:send_http_request).
-        with(:POST, monkey_uri, STANDARD_WRITE_HEADERS, "\"data\"").
+        with(:POST, monkey_uri, standard_write_headers, "\"data\"").
         and_return([1,2,3])
       rest.should_receive(:apply_response_middleware).with(1,2,3).and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
@@ -117,7 +120,7 @@ describe Chef::REST do
 
     it "makes a :PUT request with the composed url object and data" do
       rest.should_receive(:send_http_request).
-        with(:PUT, monkey_uri, STANDARD_WRITE_HEADERS, "\"data\"").
+        with(:PUT, monkey_uri, standard_write_headers, "\"data\"").
         and_return([1,2,3])
       rest.should_receive(:apply_response_middleware).with(1,2,3).and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
@@ -142,27 +145,27 @@ describe Chef::REST do
     it 'calls the authn middleware' do
       data = "\"secure data\""
 
-      auth_headers = STANDARD_WRITE_HEADERS.merge({"auth_done"=>"yep"})
+      auth_headers = standard_write_headers.merge({"auth_done"=>"yep"})
 
       rest.authenticator.should_receive(:handle_request).
-        with(:POST, monkey_uri, STANDARD_WRITE_HEADERS, data).
+        with(:POST, monkey_uri, standard_write_headers, data).
         and_return([:POST, monkey_uri, auth_headers, data])
       rest.should_receive(:send_http_request).
         with(:POST, monkey_uri, auth_headers, data).
         and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
-      rest.raw_http_request(:POST, monkey_uri, STANDARD_WRITE_HEADERS, data)
+      rest.raw_http_request(:POST, monkey_uri, standard_write_headers, data)
     end
 
     it 'sets correct authn headers' do
       data = "\"secure data\""
-      method, uri, auth_headers, d = rest.authenticator.handle_request(:POST, monkey_uri, STANDARD_WRITE_HEADERS, data)
+      method, uri, auth_headers, d = rest.authenticator.handle_request(:POST, monkey_uri, standard_write_headers, data)
 
       rest.should_receive(:send_http_request).
         with(:POST, monkey_uri, auth_headers, data).
         and_return([1,2,3])
       rest.should_receive('success_response?'.to_sym).with(1).and_return(true)
-      rest.raw_http_request(:POST, monkey_uri, STANDARD_WRITE_HEADERS, data)
+      rest.raw_http_request(:POST, monkey_uri, standard_write_headers, data)
     end
   end
 
@@ -244,6 +247,7 @@ describe Chef::REST do
     let(:rest) do
       Net::HTTP.stub(:new).and_return(http_client)
       Chef::REST::CookieJar.stub(:instance).and_return({})
+      Chef::RequestID.instance.stub(:request_id).and_return(request_id)
       rest = Chef::REST.new(base_url, nil, nil)
       Chef::REST::CookieJar.instance.clear
       rest
@@ -254,6 +258,7 @@ describe Chef::REST do
         'Accept' => 'application/json',
         'X-Chef-Version' => Chef::VERSION,
         'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+        'X-REMOTE-REQUEST-ID' => request_id
       }
     end
 
@@ -275,6 +280,7 @@ describe Chef::REST do
           'X-Chef-Version' => Chef::VERSION,
           'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
           'Host' => host_header,
+          'X-REMOTE-REQUEST-ID' => request_id
         }
       end
 
@@ -283,6 +289,11 @@ describe Chef::REST do
       end
 
       it "should always include the X-Chef-Version header" do
+        Net::HTTP::Get.should_receive(:new).with("/?foo=bar", base_headers).and_return(request_mock)
+        rest.request(:GET, url, {})
+      end
+
+      it "should always include the X-Remote-Request-Id header" do
         Net::HTTP::Get.should_receive(:new).with("/?foo=bar", base_headers).and_return(request_mock)
         rest.request(:GET, url, {})
       end
@@ -342,6 +353,7 @@ describe Chef::REST do
         let(:rest) do
           Net::HTTP.stub(:new).and_return(http_client)
           Chef::REST::CookieJar.instance["#{url.host}:#{url.port}"] = "cookie monster"
+          Chef::RequestID.instance.stub(:request_id).and_return(request_id)
           rest = Chef::REST.new(base_url, nil, nil)
           rest
         end
@@ -542,7 +554,20 @@ describe Chef::REST do
         expected_headers = {'Accept' => "*/*",
                             'X-Chef-Version' => Chef::VERSION,
                             'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
-                            'Host' => host_header}
+                            'Host' => host_header,
+                            'X-REMOTE-REQUEST-ID'=> request_id
+                            }
+        Net::HTTP::Get.should_receive(:new).with("/?foo=bar", expected_headers).and_return(request_mock)
+        rest.streaming_request(url, {})
+      end
+
+      it "build a new HTTP GET request with the X-Remote-Request-Id header" do
+        expected_headers = {'Accept' => "*/*",
+                            'X-Chef-Version' => Chef::VERSION,
+                            'Accept-Encoding' => Chef::REST::RESTRequest::ENCODING_GZIP_DEFLATE,
+                            'Host' => host_header,
+                            'X-REMOTE-REQUEST-ID'=> request_id
+                            }
         Net::HTTP::Get.should_receive(:new).with("/?foo=bar", expected_headers).and_return(request_mock)
         rest.streaming_request(url, {})
       end


### PR DESCRIPTION
CCR's and knife commands have the remote-request-id in the headers.
