### PR TITLE
CHEF-4381 Chef::Provider::Service::Invokercd does not work at all 

### DIFF
--- a/lib/chef/provider/service/invokercd.rb
+++ b/lib/chef/provider/service/invokercd.rb
@@ -27,8 +27,102 @@ class Chef
 
         def initialize(new_resource, run_context)
           super
-          @init_command = "/usr/sbin/invoke-rc.d #{@new_resource.service_name}"
+          @init_command = "/usr/sbin/invoke-rc.d"
+          @invokercd_init_command = "#{@init_command} #{@new_resource.service_name}"
         end
+
+        def start_service
+          if @new_resource.start_command
+            shell_out!(@new_resource.start_command)
+          else
+            shell_out!("#{@invokercd_init_command} start")
+          end
+        end
+
+        def stop_service
+          if @new_resource.stop_command
+            shell_out!(@new_resource.stop_command)
+          else
+            shell_out!("#{@invokercd_init_command} stop")
+          end
+        end
+
+        def restart_service
+          if @new_resource.restart_command
+            shell_out!(@new_resource.restart_command)
+          elsif not @new_resource.supports[:restart] == true
+            stop_service
+            sleep 1
+            start_service
+          else
+            shell_out!("#{@invokercd_init_command} restart")
+          end
+        end
+
+        def reload_service
+          if @new_resource.reload_command
+            shell_out!(@new_resource.reload_command)
+          else
+            shell_out!("#{@invokercd_init_command} reload")
+          end
+        end
+
+        protected
+          def determine_current_status!
+            if @new_resource.status_command
+              Chef::Log.debug("#{@new_resource} you have specified a status command, running..")
+
+              begin
+                if shell_out(@new_resource.status_command).exitstatus == 0
+                  @current_resource.running true
+                  Chef::Log.debug("#{@new_resource} is running")
+                end
+              rescue Mixlib::ShellOut::ShellCommandFailed, SystemCallError
+              # ShellOut sometimes throws different types of Exceptions than ShellCommandFailed.
+              # Temporarily catching different types of exceptions here until we get Shellout fixed.
+              # TODO: Remove the line before one we get the ShellOut fix.
+                @status_load_success = false
+                @current_resource.running false
+                nil
+              end
+
+            elsif @new_resource.supports[:status]
+              Chef::Log.debug("#{@new_resource} supports status, running")
+              begin
+                if shell_out("#{@invokercd_init_command} status").exitstatus == 0
+                  @current_resource.running true
+                  Chef::Log.debug("#{@new_resource} is running")
+                end
+              # ShellOut sometimes throws different types of Exceptions than ShellCommandFailed.
+              # Temporarily catching different types of exceptions here until we get Shellout fixed.
+              # TODO: Remove the line before one we get the ShellOut fix.
+              rescue Mixlib::ShellOut::ShellCommandFailed, SystemCallError
+                @status_load_success = false
+                @current_resource.running false
+                nil
+              end
+            else
+              Chef::Log.debug "#{@new_resource} falling back to process table inspection"
+              r = Regexp.new(@new_resource.pattern)
+              Chef::Log.debug "#{@new_resource} attempting to match '#{@new_resource.pattern}' (#{r.inspect}) against process list"
+              begin
+                shell_out!(ps_cmd).stdout.each_line do |line|
+                  if r.match(line)
+                    @current_resource.running true
+                    break
+                  end
+                end
+
+                @current_resource.running false unless @current_resource.running
+                Chef::Log.debug "#{@new_resource} running: #{@current_resource.running}"
+              # ShellOut sometimes throws different types of Exceptions than ShellCommandFailed.
+              # Temporarily catching different types of exceptions here until we get Shellout fixed.
+              # TODO: Remove the line before one we get the ShellOut fix.
+              rescue Mixlib::ShellOut::ShellCommandFailed, SystemCallError
+                @ps_command_failed = true
+              end
+            end
+          end
       end
     end
   end


### PR DESCRIPTION
I've rewritten invoke provider, it passes all tests. However I'm not sure what to do with `determine_current_status!` method. I've had to change one line there, any suggestions are welcome.

<pre>$ bundle exec rspec spec/unit/provider/service/invokercd_service_spec.rb
ProductName:	Mac OS X
ProductVersion:	10.9.1
BuildVersion:	13B42
Run options:
  include {:focus=>true}
  exclude {:provider=>#<Proc:./spec/spec_helper.rb:136>, :arch=>#<Proc:./spec/spec_helper.rb:130>, :requires_root_or_running_windows=>true, :requires_root=>true, :ruby_gte_20_only=>true, :ruby_20_only=>true, :ruby_18_only=>true, :selinux_only=>true, :system_windows_service_gem_only=>true, :solaris_only=>true, :windows_domain_joined_only=>true, :windows32_only=>true, :windows64_only=>true, :win2k3_only=>true, :windows_only=>true, :volatile=>true, :external=>true}

All examples were filtered out; ignoring {:focus=>true}

Chef::Provider::Service::Invokercd load_current_resource
  should create a current resource with the name of the new resource
  should set the current resources service name to the new resources service name
  should return the current resource
  when the service supports status
    should run '/usr/sbin/invoke-rc.d service_name status'
    should set running to true if the status command returns 0
    should set running to false if the status command returns anything except 0
    should set running to false if the status command raises
  when a status command has been specified
    should run the services status command if one has been specified
  when the node has not specified a ps command
    should raise error if the node has a nil ps attribute and no other means to get status
    should raise error if the node has an empty ps attribute and no other means to get status
  when we have a 'ps' attribute
    should shell_out! the node's ps command
    should set running to true if the regex matches the output
    should set running to false if the regex doesn't match
    should raise an exception if ps fails
  when starting the service
    should call the start command if one is specified
    should call '/usr/sbin/invoke-rc.d service_name start' if no start command is specified
  Chef::Provider::Service::Invokercd stop_service
    should call the stop command if one is specified
    should call '/usr/sbin/invoke-rc.d service_name stop' if no stop command is specified
  when restarting a service
    should call 'restart' on the service_name if the resource supports it
    should call the restart_command if one has been specified
    should just call stop, then start when the resource doesn't support restart and no restart_command is specified
  when reloading a service
    should call 'reload' on the service if it supports it
    should should run the user specified reload command if one is specified and the service doesn't support reload

Finished in 0.04888 seconds
23 examples, 0 failures</pre>