### PR TITLE
Make sure --concurrency 1 works while uploading multiple cookbooks.

### DIFF
--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -20,7 +20,7 @@ class Chef
     def self.setup_worker_threads(concurrency=10)
       @worker_threads ||= begin
         work_queue
-        (1...concurrency).map do
+        (1..concurrency).map do
           Thread.new do
             loop do
               work_queue.pop.call


### PR DESCRIPTION
`1...concurreny` doesn't setup any workers when concurrency is set to 1. 

`1..concurrency` does.
