### PR TITLE
Localize rescues in Recipe method_missing DSL

### DIFF
--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -55,12 +55,14 @@ class Chef
           # Otherwise, we're rocking the regular resource call route.
           declare_resource(method_symbol, args[0], caller[0], &block)
         else
-          super
+          begin
+            super
+          rescue NoMethodError
+            raise NoMethodError, "No resource or method named `#{method_symbol}' for #{describe_self_for_error}"
+          rescue NameError
+            raise NameError, "No resource, method, or local variable named `#{method_symbol}' for #{describe_self_for_error}"
+          end
         end
-      rescue NoMethodError
-        raise NoMethodError, "No resource or method named `#{method_symbol}' for #{describe_self_for_error}"
-      rescue NameError
-        raise NameError, "No resource, method, or local variable named `#{method_symbol}' for #{describe_self_for_error}"
       end
 
       def has_resource_definition?(name)

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -202,6 +202,19 @@ describe Chef::Recipe do
 
     end
 
+    describe "when creating a resource that contains an error in the attributes block" do
+
+      it "does not obfuscate the error source" do
+        lambda do
+          @recipe.zen_master("klopp") do
+            this_method_doesnt_exist
+          end
+        end.should raise_error(NoMethodError, "undefined method `this_method_doesnt_exist' for Chef::Resource::ZenMaster")
+
+      end
+
+    end
+
     describe "resource definitions" do
       it "should execute defined resources" do
         crow_define = Chef::ResourceDefinition.new


### PR DESCRIPTION
A change in the Recipe DSL included overzealous gobbling of NoMethodError, such that an invalid method name _inside_ a resource would result in a customized NoMethodError saying that the resource name itself was invalid. For example:

```
================================================================================
Recipe Compile Error in /private/tmp/error_message_repro/repro/recipes/default.rb
================================================================================


NoMethodError
-------------
No resource or method named `file' for `Chef::Recipe "default"'


Cookbook Trace:
---------------
  /private/tmp/error_message_repro/repro/recipes/default.rb:1:in `from_file'


Relevant File Content:
----------------------
/private/tmp/error_message_repro/repro/recipes/default.rb:

  1>> file "/tmp/whatever" do
  2:    no_method_here
  3:  end
  4:  
```
