### PR TITLE
CHEF-5012: add methods for template breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [**Renan Vicente**](https://github.com/renanvicente):
   [pr#3771](https://github.com/chef/chef/pull/3771) add depth property for deploy resource
 
+* [pr#1259](https://github.com/chef/chef/pull/1259) CHEF-5012: add methods for template breadcrumbs
 * [pr#3656](https://github.com/chef/chef/pull/3656) remove use of self.provides?
 * [pr#3455](https://github.com/chef/chef/pull/3455) powershell\_script: do not allow suppression of syntax errors
 * [pr#3519](https://github.com/chef/chef/pull/3519) The wording seemed odd.

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -58,8 +58,55 @@ class Chef
         # by the bare `node` everywhere.
         def node
           return @node if @node
+          # XXX: we include @node even if you explicitly pass vars, so is this warning never reached?
           raise "Could not find a value for node. If you are explicitly setting variables in a template, " +
                 "include a node variable if you plan to use it."
+        end
+
+        #
+        # Helpers for adding context of which resource is rendering the template (CHEF-5012)
+        #
+
+        # name of the cookbook containing the template resource, e.g.:
+        #   test
+        def cookbook_name
+          return @cookbook_name if @cookbook_name
+        end
+
+        # name of the recipe containing the template resource, e.g.:
+        #   default
+        def recipe_name
+          return @recipe_name if @recipe_name
+        end
+
+        # string representation of the line in the recipe containing the template resource, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb:2:in `from_file'
+        def recipe_line_string
+          return @recipe_line_string if @recipe_line_string
+        end
+
+        # path to the recipe containing the template resource, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb
+        def recipe_path
+          return @recipe_path if @recipe_path
+        end
+
+        # line in the recipe containing the template reosurce, e.g.:
+        #   2
+        def recipe_line
+          return @recipe_line if @recipe_line
+        end
+
+        # name of the template source itself, e.g.:
+        #   foo.erb
+        def template_name
+          return @template_name if @template_name
+        end
+
+        # path to the template source itself, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/templates/default/foo.erb
+        def template_path
+          return @template_path if @template_path
         end
 
         #

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -44,6 +44,52 @@ class Chef
 
         attr_reader :_extension_modules
 
+        #
+        # Helpers for adding context of which resource is rendering the template (CHEF-5012)
+        #
+
+        # name of the cookbook containing the template resource, e.g.:
+        #   test
+        #
+        # @return [String] cookbook name
+        attr_reader :cookbook_name
+
+        # name of the recipe containing the template resource, e.g.:
+        #   default
+        #
+        # @return [String] recipe name
+        attr_reader :recipe_name
+
+        # string representation of the line in the recipe containing the template resource, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb:2:in `from_file'
+        #
+        # @return [String] recipe line
+        attr_reader :recipe_line_string
+
+        # path to the recipe containing the template resource, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb
+        #
+        # @return [String] recipe path
+        attr_reader :recipe_path
+
+        # line in the recipe containing the template reosurce, e.g.:
+        #   2
+        #
+        # @return [String] recipe line
+        attr_reader :recipe_line
+
+        # name of the template source itself, e.g.:
+        #   foo.erb
+        #
+        # @return [String] template name
+        attr_reader :template_name
+
+        # path to the template source itself, e.g.:
+        #   /Users/lamont/solo/cookbooks/test/templates/default/foo.erb
+        #
+        # @return [String] template path
+        attr_reader :template_path
+
         def initialize(variables)
           super
           @_extension_modules = []
@@ -58,56 +104,10 @@ class Chef
         # by the bare `node` everywhere.
         def node
           return @node if @node
-          # XXX: we include @node even if you explicitly pass vars, so is this warning never reached?
           raise "Could not find a value for node. If you are explicitly setting variables in a template, " +
                 "include a node variable if you plan to use it."
         end
 
-        #
-        # Helpers for adding context of which resource is rendering the template (CHEF-5012)
-        #
-
-        # name of the cookbook containing the template resource, e.g.:
-        #   test
-        def cookbook_name
-          return @cookbook_name if @cookbook_name
-        end
-
-        # name of the recipe containing the template resource, e.g.:
-        #   default
-        def recipe_name
-          return @recipe_name if @recipe_name
-        end
-
-        # string representation of the line in the recipe containing the template resource, e.g.:
-        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb:2:in `from_file'
-        def recipe_line_string
-          return @recipe_line_string if @recipe_line_string
-        end
-
-        # path to the recipe containing the template resource, e.g.:
-        #   /Users/lamont/solo/cookbooks/test/recipes/default.rb
-        def recipe_path
-          return @recipe_path if @recipe_path
-        end
-
-        # line in the recipe containing the template reosurce, e.g.:
-        #   2
-        def recipe_line
-          return @recipe_line if @recipe_line
-        end
-
-        # name of the template source itself, e.g.:
-        #   foo.erb
-        def template_name
-          return @template_name if @template_name
-        end
-
-        # path to the template source itself, e.g.:
-        #   /Users/lamont/solo/cookbooks/test/templates/default/foo.erb
-        def template_path
-          return @template_path if @template_path
-        end
 
         #
         # Takes the name of the partial, plus a hash of options. Returns a

--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -39,6 +39,16 @@ class Chef
           context = TemplateContext.new(@new_resource.variables)
           context[:node] = @run_context.node
           context[:template_finder] = template_finder
+
+          # helper variables
+          context[:cookbook_name] = @new_resource.cookbook_name unless context.keys.include?(:coookbook_name)
+          context[:recipe_name] = @new_resource.recipe_name unless context.keys.include?(:recipe_name)
+          context[:recipe_line_string] = @new_resource.source_line unless context.keys.include?(:recipe_line_string)
+          context[:recipe_path] = @new_resource.source_line_file unless context.keys.include?(:recipe_path)
+          context[:recipe_line] = @new_resource.source_line_number unless context.keys.include?(:recipe_line)
+          context[:template_name] = @new_resource.source unless context.keys.include?(:template_name)
+          context[:template_path] = template_location unless context.keys.include?(:template_path)
+
           context._extend_modules(@new_resource.helper_modules)
           output = context.render_template(template_location)
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1627,16 +1627,31 @@ class Chef
       run_context.delayed_notifications(self)
     end
 
+    def source_line_file
+      if source_line
+        source_line.match(/(.*):(\d+):?.*$/).to_a[1]
+      else
+        nil
+      end
+    end
+
+    def source_line_number
+      if source_line
+        source_line.match(/(.*):(\d+):?.*$/).to_a[2]
+      else
+        nil
+      end
+    end
+
     def defined_at
       # The following regexp should match these two sourceline formats:
       #   /some/path/to/file.rb:80:in `wombat_tears'
       #   C:/some/path/to/file.rb:80 in 1`wombat_tears'
       # extracting the path to the source file and the line number.
-      (file, line_no) = source_line.match(/(.*):(\d+):?.*$/).to_a[1,2] if source_line
       if cookbook_name && recipe_name && source_line
-        "#{cookbook_name}::#{recipe_name} line #{line_no}"
+        "#{cookbook_name}::#{recipe_name} line #{source_line_number}"
       elsif source_line
-        "#{file} line #{line_no}"
+        "#{source_line_file} line #{source_line_number}"
       else
         "dynamically defined"
       end

--- a/spec/data/cookbooks/openldap/templates/default/helpers.erb
+++ b/spec/data/cookbooks/openldap/templates/default/helpers.erb
@@ -1,0 +1,14 @@
+<%= @cookbook_name %>
+<%= @recipe_name %>
+<%= @recipe_line_string %>
+<%= @recipe_path %>
+<%= @recipe_line %>
+<%= @template_name %>
+<%= @template_path %>
+<%= cookbook_name %>
+<%= recipe_name %>
+<%= recipe_line_string %>
+<%= recipe_path %>
+<%= recipe_line %>
+<%= template_name %>
+<%= template_path %>

--- a/spec/unit/cookbook/syntax_check_spec.rb
+++ b/spec/unit/cookbook/syntax_check_spec.rb
@@ -53,6 +53,7 @@ describe Chef::Cookbook::SyntaxCheck do
     @ruby_files = @attr_files + @libr_files + @defn_files + @recipes + [File.join(cookbook_path, "metadata.rb")]
     basenames = %w{ helpers_via_partial_test.erb
                     helper_test.erb
+                    helpers.erb
                     openldap_stuff.conf.erb
                     openldap_variable_stuff.conf.erb
                     test.erb

--- a/spec/unit/provider/template/content_spec.rb
+++ b/spec/unit/provider/template/content_spec.rb
@@ -97,7 +97,7 @@ describe Chef::Provider::Template::Content do
     end
 
     it "creates the template with the rendered content" do
-      IO.read(content.tempfile.path).should == <<EOF
+      expect(IO.read(content.tempfile.path)).to eql <<EOF
 openldap
 default
 #{CHEF_SPEC_DATA}/cookbooks/openldap/recipes/default.rb:2:in `from_file'

--- a/spec/unit/provider/template/content_spec.rb
+++ b/spec/unit/provider/template/content_spec.rb
@@ -23,6 +23,10 @@ describe Chef::Provider::Template::Content do
   let(:new_resource) do
     double("Chef::Resource::Template (new)",
          :cookbook_name => 'openldap',
+         :recipe_name => 'default',
+         :source_line => "/Users/lamont/solo/cookbooks/openldap/recipes/default.rb:2:in `from_file'",
+         :source_line_file => "/Users/lamont/solo/cookbooks/openldap/recipes/default.rb",
+         :source_line_number => "2",
          :source => 'openldap_stuff.conf.erb',
          :local => false,
          :cookbook => nil,
@@ -75,4 +79,41 @@ describe Chef::Provider::Template::Content do
     expect(IO.read(content.tempfile.path)).to eq("slappiness is a warm gun")
   end
 
+  describe "when using location helpers" do
+    let(:new_resource) do
+      double("Chef::Resource::Template (new)",
+             :cookbook_name => 'openldap',
+             :recipe_name => 'default',
+             :source_line => CHEF_SPEC_DATA + "/cookbooks/openldap/recipes/default.rb:2:in `from_file'",
+             :source_line_file => CHEF_SPEC_DATA + "/cookbooks/openldap/recipes/default.rb",
+             :source_line_number => "2",
+             :source => 'helpers.erb',
+             :local => false,
+             :cookbook => nil,
+             :variables => {},
+             :inline_helper_blocks => {},
+             :inline_helper_modules => [],
+             :helper_modules => [])
+    end
+
+    it "creates the template with the rendered content" do
+      IO.read(content.tempfile.path).should == <<EOF
+openldap
+default
+#{CHEF_SPEC_DATA}/cookbooks/openldap/recipes/default.rb:2:in `from_file'
+#{CHEF_SPEC_DATA}/cookbooks/openldap/recipes/default.rb
+2
+helpers.erb
+#{CHEF_SPEC_DATA}/cookbooks/openldap/templates/default/helpers.erb
+openldap
+default
+#{CHEF_SPEC_DATA}/cookbooks/openldap/recipes/default.rb:2:in `from_file'
+#{CHEF_SPEC_DATA}/cookbooks/openldap/recipes/default.rb
+2
+helpers.erb
+#{CHEF_SPEC_DATA}/cookbooks/openldap/templates/default/helpers.erb
+EOF
+    end
+
+  end
 end


### PR DESCRIPTION
adds:
- cookbook_name
- recipe_name
- recipe_line_string
- recipe_path
- recipe_line
- template_name
- template_path

accessible both as instance var (@-) and method (bare), like @node/node.

closes #2984 