### PR TITLE
[CHEF-5018] Use File.open instead of File.new with block.

### DIFF
--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -33,7 +33,7 @@ class Chef
         @file_edited = false
 
         raise ArgumentError, "File doesn't exist" unless File.exist? @original_pathname
-        @contents = File.new(@original_pathname){ |f| f.readlines }
+        @contents = File.open(@original_pathname) {|f| f.readlines }
       end
 
       #search the file line by line and match each line with the given regex

--- a/spec/unit/provider/ifconfig/debian_spec.rb
+++ b/spec/unit/provider/ifconfig/debian_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Provider::Ifconfig::Debian do
     @config_file_ifaces = StringIO.new
     @config_file_ifcfg = StringIO.new
     FileUtils.should_receive(:cp)
-    File.should_receive(:new).with(@config_filename_ifaces).and_return(StringIO.new)
+    File.should_receive(:open).with(@config_filename_ifaces).and_return(StringIO.new)
     File.should_receive(:open).with(@config_filename_ifaces, "w").and_yield(@config_file_ifaces)
     File.should_receive(:new).with(@config_filename_ifcfg, "w").and_return(@config_file_ifcfg)
     File.should_receive(:exist?).with(@config_filename_ifaces).and_return(true)


### PR DESCRIPTION
Since File::new() does not take block, we should use File.open instead of File.new with block.

Warning example:

```
Chef::Util::FileEdit
  initialiize
/Users/ryota/code/github/opscode/chef/lib/chef/util/file_edit.rb:36: warning: File::new() does not take block; use File::open() instead
/Users/ryota/code/github/opscode/chef/lib/chef/util/file_edit.rb:36: warning: File::new() does not take block; use File::open() instead
    should create a new Chef::Util::FileEdit object
/Users/ryota/code/github/opscode/chef/lib/chef/util/file_edit.rb:36: warning: File::new() does not take block; use File::open() instead
    should throw an exception if the input file does not exist
/Users/ryota/code/github/opscode/chef/lib/chef/util/file_edit.rb:36: warning: File::new() does not take block; use File::open() instead
    should throw an exception if the input file is blank
```

https://tickets.opscode.com/browse/CHEF-5018
