### PR TITLE
[CHEF-5029]: Fixed node_name to be server.host

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -114,7 +114,7 @@ class Chef
           end
           case config[:on_error]
           when :skip
-            ui.warn "Failed to connect to #{node_name} -- #{$!.class.name}: #{$!.message}"
+            ui.warn "Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}"
             $!.backtrace.each { |l| Chef::Log.debug(l) }
           when :raise
             #Net::SSH::Multi magic to force exception to be re-raised.


### PR DESCRIPTION
I know it calls it above, but it seems that it hasn't worked for a while
This does work, and allows us to see machines knife ssh fails to connect
to.
