### PR TITLE
knife client show does not show validator/admin correctly

### DIFF
--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -162,9 +162,7 @@ class Chef
       if response.kind_of?(Chef::ApiClient)
         response
       else
-        client = Chef::ApiClient.new
-        client.name(response['clientname'])
-        client
+        json_create(response)
       end
     end
 

--- a/spec/unit/api_client_spec.rb
+++ b/spec/unit/api_client_spec.rb
@@ -164,7 +164,7 @@ describe Chef::ApiClient do
 
   end
 
-  describe "when loading from JSON", :focus => true do
+  describe "when loading from JSON" do
     before do
     end
 


### PR DESCRIPTION
Delegate ApiClient.load to ApiClient.json_create. This means the validator/public_key/admin fields of the ApiClient object now get set properly

Added unit test for ApiClient.load
