### PR TITLE
Add a --force option to protect against accidental deletion of validators

### DIFF
--- a/lib/chef/knife/client_delete.rb
+++ b/lib/chef/knife/client_delete.rb
@@ -27,6 +27,11 @@ class Chef
         require 'chef/json_compat'
       end
 
+      option :force,
+       :short => "-f",
+       :long => "--force",
+       :description => "Force deletion of client if it's a validator"
+
       banner "knife client delete CLIENT (options)"
 
       def run
@@ -38,7 +43,16 @@ class Chef
           exit 1
         end
 
-        delete_object(Chef::ApiClient, @client_name)
+        delete_object(Chef::ApiClient, @client_name, 'client') {
+          object = Chef::ApiClient.load(@client_name)
+          if object.validator
+            unless config[:force]
+              ui.fatal("You must specify --force to delete the validator client #{@client_name}")
+              exit 2
+            end
+          end
+          object.destroy
+        }
       end
 
     end

--- a/spec/unit/knife/client_delete_spec.rb
+++ b/spec/unit/knife/client_delete_spec.rb
@@ -21,12 +21,16 @@ require 'spec_helper'
 describe Chef::Knife::ClientDelete do
   before(:each) do
     @knife = Chef::Knife::ClientDelete.new
+    # defaults
+    @knife.config = {
+      :force => false
+    }
     @knife.name_args = [ 'adam' ]
   end
 
   describe 'run' do
     it 'should delete the client' do
-      @knife.should_receive(:delete_object).with(Chef::ApiClient, 'adam')
+      @knife.should_receive(:delete_object).with(Chef::ApiClient, 'adam', 'client')
       @knife.run
     end
 
@@ -35,6 +39,45 @@ describe Chef::Knife::ClientDelete do
       @knife.should_receive(:show_usage)
       @knife.ui.should_receive(:fatal)
       lambda { @knife.run }.should raise_error(SystemExit)
+    end
+  end
+
+  describe 'with a validator' do
+    before(:each) do
+      Chef::Knife::UI.stub(:confirm).and_return(true)
+      @knife.stub(:confirm).and_return(true)
+      @client = Chef::ApiClient.new
+      Chef::ApiClient.should_receive(:load).and_return(@client)
+    end
+
+    it 'should delete non-validator client if --force is not set' do
+      @knife.config[:force] = false
+      @client.should_receive(:destroy).and_return(@client)
+      @knife.should_receive(:msg)
+
+      @knife.run
+    end
+
+    it 'should delete non-validator client if --force is set' do
+      @knife.config[:force] = true
+      @client.should_receive(:destroy).and_return(@client)
+      @knife.should_receive(:msg)
+
+      @knife.run
+    end
+
+    it 'should not delete validator client if --force is not set' do
+      @client.validator(true)
+      @knife.ui.should_receive(:fatal)
+      lambda { @knife.run}.should raise_error(SystemExit)
+    end
+
+    it 'should delete validator client if --force is set' do
+      @knife.config[:force] = true
+      @client.should_receive(:destroy).and_return(@client)
+      @knife.should_receive(:msg)
+
+      @knife.run
     end
   end
 end


### PR DESCRIPTION
It's hard to recover an org from having a deleted validator client -
this patch protects against deleting validator accidentally e.g. in a
for loop around knife client delete by requiring you to specify --force

Includes specs around this new functionality
