### PR TITLE
[CHEF-5057] Add default choice option to confirm prompt

### DIFF
--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -205,13 +205,23 @@ class Chef
         output(format_for_display(object)) if config[:print_after]
       end
 
-      def confirm(question, append_instructions=true)
+      def confirm(question, append_instructions=true, default_choice=nil)
         return true if config[:yes]
 
+        case default_choice
+        when 'Y', 'y'
+          instructions = '? (Y/n)'
+        when 'N', 'n'
+          instructions = '? (y/N)'
+        else
+          instructions = '? (Y/N)'
+        end
+
         stdout.print question
-        stdout.print "? (Y/N) " if append_instructions
+        stdout.print instructions if append_instructions
         answer = stdin.readline
         answer.chomp!
+        answer == '' ? answer = default_choice : answer
         case answer
         when "Y", "y"
           true

--- a/spec/unit/knife/core/ui_spec.rb
+++ b/spec/unit/knife/core/ui_spec.rb
@@ -437,6 +437,40 @@ EOM
       }.should raise_error(SystemExit) { |e| e.status.should == 3 }
     end
 
+    describe "with 'Y' as a default choice" do
+      it 'should return true if you answer default' do
+        @ui.stdin.stub(:readline).and_return("\n")
+        @ui.confirm(@question, false, 'Y').should == true
+      end
+
+      it "should show 'Y' as the default in the instructions" do
+        out = StringIO.new
+        @ui.stdin.stub(:readline).and_return("\n")
+        @ui.stub(:stdout).and_return(out)
+        @ui.confirm(@question, true, 'Y').should == true
+        out.string.should == "#{@question}? (Y/n)"
+      end
+    end
+
+    describe "with 'N' as a default choice" do
+      it 'should exit 3 if you answer default' do
+        @ui.stdin.stub(:readline).and_return("\n")
+        lambda {
+          @ui.confirm(@question, false, 'N')
+        }.should raise_error(SystemExit) { |e| e.status.should == 3 }
+      end
+
+      it "should show 'N' as the default in the instructions" do
+        out = StringIO.new
+        @ui.stdin.stub(:readline).and_return("\n")
+        @ui.stub(:stdout).and_return(out)
+        lambda {
+          @ui.confirm(@question, true, 'N')
+        }.should raise_error(SystemExit) { |e| e.status.should == 3 }
+        out.string.should == "#{@question}? (y/N)You said no, so I'm done here.\n"
+      end
+    end
+
     describe "with --y or --yes passed" do
       it "should return true" do
         @ui.config[:yes] = true


### PR DESCRIPTION
This commit allows a default choice to be provided for a ui.confirm prompt.  "-y" flag still takes precedence, and the previous behavior is preserved for existing code ("Y/N", no default choice).

Testing done:

bundle exec rake spec - passes
bundle exec rspec spec/unit/knife/core - passes
