### PR TITLE
Add indentation to pretty-print LWRPs with inline resources

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -10,7 +10,6 @@ class Chef
 
       attr_reader :start_time, :end_time
       cli_name(:doc)
-      
 
       def initialize(out, err)
         super
@@ -112,7 +111,7 @@ class Chef
       # Called before cookbook sync starts
       def cookbook_sync_start(cookbook_count)
         puts_line "Synchronizing Cookbooks:"
-        indent_by(2)
+        indent
       end
 
       # Called when cookbook +cookbook_name+ has been sync'd
@@ -126,7 +125,7 @@ class Chef
 
       # Called after all cookbooks have been sync'd.
       def cookbook_sync_complete
-        indent_by(-2)
+        unindent
       end
 
       # Called when cookbook loading starts.
@@ -149,7 +148,7 @@ class Chef
 
       # Called when the converge phase is finished.
       def converge_complete
-        indent_by(-2) if @current_recipe
+        unindent if @current_recipe
       end
 
       # Called before action is executed on a resource.
@@ -161,14 +160,14 @@ class Chef
         end
 
         if resource_recipe != @current_recipe && !resource.enclosing_provider
-          indent_by(-2) if @current_recipe
+          unindent if @current_recipe
           puts_line "Recipe: #{resource_recipe}"
           @current_recipe = resource_recipe
-          indent_by(2)
+          indent
         end
         # TODO: info about notifies
         start_line "* #{resource} action #{action}"
-        indent_by(2)
+        indent
       end
 
       # Called when a resource fails, but will retry.
@@ -178,14 +177,14 @@ class Chef
       # Called when a resource fails and will not be retried.
       def resource_failed(resource, action, exception)
         super
-        indent_by(-2)
+        unindent
       end
 
       # Called when a resource action has been skipped b/c of a conditional
       def resource_skipped(resource, action, conditional)
         # TODO: more info about conditional
         puts " (skipped due to #{conditional.short_description})"
-        indent_by(-2)
+        unindent
       end
 
       # Called after #load_current_resource has run.
@@ -196,12 +195,12 @@ class Chef
       def resource_up_to_date(resource, action)
         @up_to_date_resources+= 1
         puts " (up to date)"
-        indent_by(-2)
+        unindent
       end
 
       def resource_bypassed(resource, action, provider)
         puts " (Skipped: whyrun not supported by provider #{provider.class.name})"
-        indent_by(-2)
+        unindent
       end
 
       def output_record(line)
@@ -231,7 +230,7 @@ class Chef
       # Called after a resource has been completely converged.
       def resource_updated(resource, action)
         @updated_resources += 1
-        indent_by(-2)
+        unindent
         puts "\n"
       end
 
@@ -245,7 +244,7 @@ class Chef
       def handlers_start(handler_count)
         puts ''
         puts "Running handlers:"
-        indent_by(2)
+        indent
       end
 
       # Called after an individual handler has run
@@ -255,7 +254,7 @@ class Chef
 
       # Called after all handlers have executed
       def handlers_completed
-        indent_by(-2)
+        unindent
         puts_line "Running handlers complete\n"
       end
 
@@ -275,6 +274,14 @@ class Chef
         [ message ].flatten.each do |line|
           start_line("* #{line}", color)
         end
+      end
+
+      def indent
+        indent_by(2)
+      end
+
+      def unindent
+        indent_by(-2)
       end
     end
   end

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -1,0 +1,73 @@
+require 'support/shared/integration/integration_helper'
+require 'chef/mixin/shell_out'
+
+describe "LWRPs with inline resources" do
+  extend IntegrationSupport
+  include Chef::Mixin::ShellOut
+
+  let(:chef_dir) { File.join(File.dirname(__FILE__), "..", "..", "..", "bin") }
+
+  # Invoke `chef-client` as `ruby PATH/TO/chef-client`. This ensures the
+  # following constraints are satisfied:
+  # * Windows: windows can only run batch scripts as bare executables. Rubygems
+  # creates batch wrappers for installed gems, but we don't have batch wrappers
+  # in the source tree.
+  # * Other `chef-client` in PATH: A common case is running the tests on a
+  # machine that has omnibus chef installed. In that case we need to ensure
+  # we're running `chef-client` from the source tree and not the external one.
+  # cf. CHEF-4914
+  let(:chef_client) { "ruby #{chef_dir}/chef-client" }
+
+  when_the_repository "has a cookbook with a nested LWRP" do
+  	directory 'cookbooks/x' do
+
+      file 'resources/do_nothing.rb', <<EOM
+actions :create, :nothing
+default_action :create
+EOM
+      file 'providers/do_nothing.rb', <<EOM
+action :create do
+end
+EOM
+
+  	  file 'resources/my_machine.rb', <<EOM
+actions :create, :nothing
+default_action :create
+EOM
+      file 'providers/my_machine.rb', <<EOM
+use_inline_resources
+action :create do
+  x_do_nothing 'a'
+  x_do_nothing 'b'
+end
+EOM
+
+  	  file 'recipes/default.rb', <<EOM
+x_my_machine "me"
+x_my_machine "you"
+EOM
+
+  	end # directory 'cookbooks/x'
+
+    it "should complete with success" do
+      file 'config/client.rb', <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+log_level :warn
+EOM
+
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" --no-color -F doc -o 'x::default'", :cwd => chef_dir)
+      result.stdout.should include(<<EOM)
+  * x_my_machine[me] action create
+    * x_do_nothing[a] action create (up to date)
+    * x_do_nothing[b] action create (up to date)
+     (up to date)
+  * x_my_machine[you] action create
+    * x_do_nothing[a] action create (up to date)
+    * x_do_nothing[b] action create (up to date)
+     (up to date)
+EOM
+      result.error!
+    end
+  end
+end


### PR DESCRIPTION
Pretty print LWRPs.  This implements the printing proposal at https://github.com/opscode/chef-rfc/blob/jk/in_parallel/rfc1-in_parallel.md#output-formatting-groups :

Nested resources currently print something like this:

```
Recipe: @recipe_files::/Users/jkeiser/oc/code/opscode/chef-rfc/blah.rb
  * compound_resource[a] action create  * file[/Users/jkeiser/x.txt] action create (up to date)
  * file[/Users/jkeiser/y.txt] action create (up to date)
 (up to date)
```

With this proposal, a resource_group or other compound resource would print like this:

```
Recipe: @recipe_files::/Users/jkeiser/oc/code/opscode/chef-rfc/blah.rb
 * compound_resource[a] action create
   * file[/Users/jkeiser/x.txt] action create (up to date)
   * file[/Users/jkeiser/y.txt] action create (up to date)
    (up to date)
```
