### PR TITLE
[CHEF-5075] Fix json_attribs and recipe_url load order.

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -195,6 +195,8 @@ class Chef::Application::Solo < Chef::Application
       Chef::Mixin::Command.run_command(:command => "tar zxvf #{path} -C #{recipes_path}")
     end
 
+    # json_attribs shuld be fetched after recipe_url tarball is unpacked.
+    # Otherwise it may fail if points to local file from tarball.
     if Chef::Config[:json_attribs]
       config_fetcher = Chef::ConfigFetcher.new(Chef::Config[:json_attribs])
       @chef_client_json = config_fetcher.fetch_json


### PR DESCRIPTION
When json_attribs parameter points to local file that should be unpacked from tarball in recipe_url, the run fails. Chef-solo first tries to load attribs file, but it is not loaded yet.

Proposed solution: change load order.
