### PR TITLE
CouchDB Creation Speedup

### DIFF
--- a/chef/lib/chef/couchdb.rb
+++ b/chef/lib/chef/couchdb.rb
@@ -69,10 +69,19 @@ class Chef
     end
 
     def create_db(check_for_existing=true)
-      @database_list = @rest.get_rest("_all_dbs")
-      if !check_for_existing || !@database_list.any? { |db| db == couchdb_database }
-        response = @rest.put_rest(couchdb_database, Hash.new)
+      database_exists = false
+
+      if check_for_existing
+        database_list = @rest.get_rest("_all_dbs")
+        if database_list.any? { |db| db == couchdb_database }
+          database_exists = true
+        end
       end
+
+      if !database_exists
+        @rest.put_rest(couchdb_database, Hash.new)
+      end
+
       couchdb_database
     end
 


### PR DESCRIPTION
Ping @jamesc @danielsdeleo @stevendanna @sersut 

When pre-creating organizations in Hosted Chef, the account service
provisions a database for the few remaining data types that are
stored in CouchDB. As the number of organizations (and databases) grows,
the length of time it takes to list all couch databases is extended and
can cause timeouts at the nginx level. This patch prevents this extra
call when the caller sets `chef_for_existing` to false, as the account
service already does.

Unit tests have been added to test this functionality, but the only way
I was able to run them was to run the specific tests I edited:

```
cd chef
bundle install
bundle exec rspec spec/unit/couchdb_spec.rb
```
