### PR TITLE
chef_gem: should use omnibus installed `gem`.

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -525,7 +525,11 @@ class Chef
         end
 
         def gem_binary_path
-          @new_resource.gem_binary || 'gem'
+          if is_omnibus? && @new_resource.instance_of?(Chef::Resource::ChefGem)
+            RbConfig::CONFIG['bindir'] + "/gem"
+          else
+            @new_resource.gem_binary || 'gem'
+          end
         end
 
         def install_via_gem_command(name, version)


### PR DESCRIPTION
In the event that string options are passed to chef_gem then the logic
states that we will shell out and invoke the gem binary.  The problem
with this is it picks up whatever gem is installed in the PATH which is
probably not the omnibus version...

This fix simply uses the bundled `gem` binary when using chef_gem which
is the desired behavior.
