### PR TITLE
Enable Travis CI notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,21 @@ branches:
     - 11-stable
 
 script: bundle exec rspec --color --format progress
+
+notifications:
+  on_success: change
+  on_failure: always
+  on_start: false
+  irc:
+    channels:
+      - "chat.freenode.net#chef-hacking"
+  webhooks:
+    urls:
+      # Gitter IM
+      - secure: "HmMKr/ysKVyKUJ24PRCHcA8QCmlFoukrYumY0GRLzvaFWO8PknHO1t/0RbrKRb2ed/hgkFd+RKNCYvSvcE8Ahr2vlMrBeGHGfVeOGkWtbhLgNqo1b50Ll9CqvTM8X2ZIq6hIWraanwoYRQu/8uGL29yH4lBi7DhpTkFwBMLulhQ="
+  hipchat:
+    rooms:
+      # Build Statuses
+      - secure: "G8MNo94L8bmWWwkH2/ViB2QaZnZHZscYM/mEjDbOGd15sqrruwckeARyBoUcRI7P1C6AFmS4IKCNVXa6KzX4Pbh51gQWM92zRpRTZpplwtXz53/1l8ajLFLLMLvEMTlBFAANUKEUFAQPY4dMa14V3Qc5oijfIncN61k4nZNTKpY="
+      # Open Source
+      - secure: "hmcex4PpG5dn8WvjndONO4xCUKOC5kPU/bUEGRrfVbe2YKJE7t0XXbNDC96W/xBgzgnJzvf1Er0zJKDrNf4qEDEWFoozdN00WLcqREgaLLS3Seto2FjR/BpBk5q+sCV0rwwEMms2P4Qk+VSnDCnm9EaeM55hOabqNuOrRzoZLBQ="


### PR DESCRIPTION
This commit enables notifications to the following communication 
channels:
- HipChat - "Build Statuses" and "Open Source" rooms
- IRC - #chef-hacking channel
- Gitter IM - opscode/chef chat room

Notifications will only be sent if a build fails OR a failed build 
transitions to successful.

/cc @opscode/release-engineers @btm @sersut 
