### PR TITLE
[CHEF-3610] Set log_level for chef-client when '-VV' is specified in the knife command

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -93,6 +93,7 @@ CONFIG
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
           client_path = @chef_config[:chef_client_path] || 'chef-client'
           s = "#{client_path} -j /etc/chef/first-boot.json"
+          s << ' -l debug' if @config[:verbosity] and @config[:verbosity] >= 2
           s << " -E #{bootstrap_environment}" if chef_version.to_f != 0.9 # only use the -E option on Chef 0.10+
           s
         end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -41,6 +41,13 @@ describe Chef::Knife::Core::BootstrapContext do
     bootstrap_context.start_chef.should eq "chef-client -j /etc/chef/first-boot.json -E _default"
   end
 
+  describe "when in verbosity mode" do
+    let(:config) { {:verbosity => 2} }
+    it "adds '-l debug' when verbosity is >= 2" do
+      bootstrap_context.start_chef.should eq "chef-client -j /etc/chef/first-boot.json -l debug -E _default"
+    end
+  end
+
   it "reads the validation key" do
     bootstrap_context.validation_key.should eq IO.read(File.join(CHEF_SPEC_DATA, 'ssl', 'private_key.pem'))
   end


### PR DESCRIPTION
solution discussed on https://tickets.opscode.com/browse/CHEF-3610

manually tested with '-VV' option in knife command, and the chef-client show DEBUG level output as expected.

UT also passed:
rspec spec/unit/knife/core/bootstrap_context_spec.rb 
