### PR TITLE
[CHEF-3404] Allow dynamic resolving of resource providers

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -27,6 +27,54 @@ class Chef
     include Chef::DSL::Recipe
     include Chef::Mixin::WhyRun
 
+
+    class << self
+      include Enumerable
+
+      @@providers = []
+
+      attr_reader :implementations
+      attr_reader :supported_platforms
+
+      def inherited(klass)
+        @@providers << klass
+      end
+
+      def providers
+        @@providers
+      end
+
+      def each
+        providers.each { |provider| yield provider }
+        providers
+      end
+
+      def implements(*resources)
+        options = resources.last.is_a?(Hash) ? resources.pop : {}
+
+        @implementations = resources.map { |resource| resource.to_sym }
+        @supported_platforms = Array(options[:on_platforms] || :all)
+      end
+
+      def implements?(resource)
+        klass_name = resource.class.to_s.split('::').last
+        resource_name = klass_name.gsub(/([a-z0-9])([A-Z])/, '\1_\2').downcase
+
+        implementations && implementations.include?(resource_name.to_sym)
+      end
+
+      def supports_platform?(platform)
+        supported_platforms && (
+          supported_platforms.include?(:all) ||
+          supported_platforms.include?(platform.to_sym))
+      end
+
+      def enabled?(node)
+        true
+      end
+    end
+
+
     attr_accessor :new_resource
     attr_accessor :current_resource
     attr_accessor :run_context

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -30,6 +30,29 @@ class Chef
 
       CRON_ATTRIBUTES = [:minute, :hour, :day, :month, :weekday, :command, :mailto, :path, :shell, :home, :environment]
 
+      implements  :cron,
+                  :on_platforms => [
+                    :amazon,
+                    :arch,
+                    :centos,
+                    :debian,
+                    :fedora,
+                    :freebsd,
+                    :gcel,
+                    :gentoo,
+                    :linaro,
+                    :linuxmint,
+                    :opensuse,
+                    :oracle,
+                    :raspbian,
+                    :redhat,
+                    :scientific,
+                    :suse,
+                    :ubuntu,
+                    :xcp,
+                    :xenserver
+                  ]
+
       def initialize(new_resource, run_context)
         super(new_resource, run_context)
         @cron_exists = false

--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -21,6 +21,9 @@ class Chef
     class Group
       class Pw < Chef::Provider::Group
 
+        implements  :group,
+                    :on_platforms => :freebsd
+
         def load_current_resource
           super
         end

--- a/lib/chef/provider/package/freebsd.rb
+++ b/lib/chef/provider/package/freebsd.rb
@@ -30,6 +30,11 @@ class Chef
 
         include Chef::Mixin::GetSourceFromPackage
 
+        implements  :package,
+                    :freebsd_package,
+                    :on_platforms => :freebsd
+
+
         def initialize(*args)
           super
           @current_resource = Chef::Resource::Package.new(@new_resource.name)

--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -27,6 +27,9 @@ class Chef
 
         include Chef::Mixin::ShellOut
 
+        implements  :service,
+                    :on_platforms => [:freebsd, :netbsd]
+
         def load_current_resource
           @current_resource = Chef::Resource::Service.new(@new_resource.name)
           @current_resource.service_name(@new_resource.service_name)

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -23,6 +23,9 @@ class Chef
     class User
       class Pw < Chef::Provider::User
 
+        implements  :user,
+                    :on_platforms => :freebsd
+
         def load_current_resource
           super
           raise Chef::Exceptions::User, "Could not find binary /usr/sbin/pw for #{@new_resource}" unless ::File.exists?("/usr/sbin/pw")

--- a/lib/chef/provider_resolver.rb
+++ b/lib/chef/provider_resolver.rb
@@ -1,0 +1,57 @@
+#
+# Author:: Richard Manyanza (<liseki@nyikacraftsmen.com>)
+# Copyright:: Copyright (c) 2014 Richard Manyanza.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class ProviderResolver
+
+    attr_reader :node
+    attr_reader :providers
+
+    def initialize(node)
+      @node = node
+      @providers = []
+      @loaded = false
+    end
+
+    def load(reload = false)
+      return if loaded? && !reload
+
+      @providers = [] if reload
+
+      Chef::Provider.each do |provider|
+        @providers << provider if provider.supports_platform?(@node[:platform])
+      end
+
+      @loaded = true
+    end
+
+    def loaded?
+      !!@loaded
+    end
+
+    def resolve(resource)
+      self.load if !loaded?
+
+      providers = @providers.find_all do |provider|
+        provider.enabled?(node) && provider.implements?(resource)
+      end
+
+      resource.evaluate_providers(providers)
+    end
+  end
+end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -649,6 +649,10 @@ F
       raise ArgumentError, "nil is not a valid action for resource #{self}" if action.nil?
     end
 
+    def evaluate_providers(providers)
+      provider = providers.first
+    end
+
     def provider_for_action(action)
       # leverage new platform => short_name => resource
       # which requires explicitly setting provider in

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 require 'chef/resource_collection'
+require 'chef/provider_resolver'
 require 'chef/cookbook_version'
 require 'chef/node'
 require 'chef/role'
@@ -49,6 +50,8 @@ class Chef
     # recipes, which is triggered by #load. (See also: CookbookCompiler)
     attr_accessor :resource_collection
 
+    attr_reader :provider_resolver
+
     # A Hash containing the immediate notifications triggered by resources
     # during the converge phase of the chef run.
     attr_accessor :immediate_notification_collection
@@ -77,6 +80,7 @@ class Chef
       @events = events
 
       @node.run_context = self
+      @provider_resolver = Chef::ProviderResolver.new(@node)
     end
 
     # Triggers the compile phase of the chef run. Implemented by
@@ -84,6 +88,8 @@ class Chef
     def load(run_list_expansion)
       compiler = CookbookCompiler.new(self, run_list_expansion, events)
       compiler.compile
+
+      @provider_resolver.load
     end
 
     # Adds an immediate notification to the

--- a/lib/chef/runner.rb
+++ b/lib/chef/runner.rb
@@ -43,6 +43,10 @@ class Chef
       @run_context.events
     end
 
+    def provider_resolver
+      @run_context.provider_resolver
+    end
+
     # Determine the appropriate provider for the given resource, then
     # execute it.
     def run_action(resource, action, notification_type=nil, notifying_resource=nil)
@@ -78,6 +82,7 @@ class Chef
 
       # Execute each resource.
       run_context.resource_collection.execute_each_resource do |resource|
+        provider_resolver.resolve(resource)
         Array(resource.action).each {|action| run_action(resource, action)}
       end
 

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -1,0 +1,91 @@
+#
+# Author:: Richard Manyanza (<liseki@nyikacraftsmen.com>)
+# Copyright:: Copyright (c) 2014 Richard Manyanza.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::ProviderResolver do
+  before(:each) do
+    @node = Chef::Node.new
+    @provider_resolver = Chef::ProviderResolver.new(@node)
+  end
+
+  describe "Initialization" do
+    it "should not load providers" do
+      @provider_resolver.loaded?.should be_false
+    end
+  end
+
+
+  describe "Loading providers" do
+  end
+
+
+  describe "on FreeBSD" do
+    before(:each) do
+      @node.normal[:platform] = :freebsd
+    end
+
+    describe "loading" do
+      before(:each) do
+        @provider_resolver.load
+      end
+
+      it "should load FreeBSD providers" do
+        providers = [
+          Chef::Provider::User::Pw,
+          Chef::Provider::Group::Pw,
+          Chef::Provider::Service::Freebsd,
+          Chef::Provider::Package::Freebsd,
+          Chef::Provider::Cron
+        ]
+
+        @provider_resolver.providers.length.should == providers.length
+        providers.each do |provider|
+          @provider_resolver.providers.include?(provider).should be_true
+        end
+      end
+    end
+
+    describe "resolving" do
+      it "should handle user" do
+        user = Chef::Resource::User.new('toor')
+        @provider_resolver.resolve(user).should == Chef::Provider::User::Pw
+      end
+
+      it "should handle group" do
+        group = Chef::Resource::Group.new('ops')
+        @provider_resolver.resolve(group).should == Chef::Provider::Group::Pw
+      end
+
+      it "should handle service" do
+        service = Chef::Resource::Service.new('nginx')
+        @provider_resolver.resolve(service).should == Chef::Provider::Service::Freebsd
+      end
+
+      it "should handle package" do
+        package = Chef::Resource::Package.new('zsh')
+        @provider_resolver.resolve(package).should == Chef::Provider::Package::Freebsd
+      end
+
+      it "should handle cron" do
+        cron = Chef::Resource::Cron.new('security_status_report')
+        @provider_resolver.resolve(cron).should == Chef::Provider::Cron
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a rough sketch to demonstrate approach. This approach relies on each provider specifying which resource(s) it implements and on which platforms. This information is currently available in the provider mapping. Each provider also has to indicate whether or not it is enabled; this is true by default. So you could have 2 or more providers for a single resource on a given platform but not all of them may be enabled on the node.

The resolver picks up the supported providers and allows the resource to evaluate them. By default this is just picking the first one. On [CHEF-3404](https://tickets.opscode.com/browse/CHEF-3404) this might allow the opportunity to throw an exception if more than one provider is enabled.

At the moment I have implemented this provider interface for FreeBSD providers. With that we could remove the FreeBSD entry in provider mapping. For all FreeBSD providers to resolve dynamically we would have to specify `:on_platforms => :all` for all the OS-agnostic providers (file, directory, link etc).
