### PR TITLE
CHEF-3698: Do not set log_level by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * ruby-shadow is not installed on cygwin platform anymore. (CHEF-4946)
 * Upgrade chef-zero to 2.0, remove native-compiled puma as chef dependency. (CHEF-4901/CHEF-5005)
 * Don't honor splay when sent USR1 signal.
+* Don't set log_level in client.rb by default (CHEF-3698)
 
 ## Last Release: 11.10.0 (02/06/2014)
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -62,7 +62,6 @@ class Chef
 
         def config_content
           client_rb = <<-CONFIG
-log_level        :auto
 log_location     STDOUT
 chef_server_url  "#{@chef_config[:chef_server_url]}"
 validation_client_name "#{@chef_config[:validation_client_name]}"

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -47,13 +47,16 @@ describe Chef::Knife::Core::BootstrapContext do
 
   it "generates the config file data" do
     expected=<<-EXPECTED
-log_level        :auto
 log_location     STDOUT
 chef_server_url  "http://chef.example.com:4444"
 validation_client_name "chef-validator-testing"
 # Using default node name (fqdn)
 EXPECTED
     bootstrap_context.config_content.should eq expected
+  end
+
+  it "does not set a default log_level" do
+    expect(bootstrap_context.config_content).not_to match(/log_level/)
   end
 
   describe "alternate chef-client path" do


### PR DESCRIPTION
The default log level for Chef 10 was "info" but on Chef 11 it is "auto"
which does not work on Chef 10. This prevents you from bootstrapping a
Chef 10 node from a Chef 11 workstation. We can leave out log_level and
Chef will use the built in defaults.

https://tickets.opscode.com/browse/CHEF-3698
