### PR TITLE
CHEF-5134: Warn on no SSL verification

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -311,7 +311,7 @@ class Chef
     # === Returns
     # rest<Chef::REST>:: returns Chef::REST connection object
     def register(client_name=node_name, config=Chef::Config)
-      if Chef::Config[:ssl_verify_mode] == :verify_none && !Chef::Config[:verify_api_cert]
+      if config[:ssl_verify_mode] == :verify_none && !config[:verify_api_cert]
         Chef::Log.warn "SSL validation of Chef API Endpoint is disabled, " \
                        "set verify_api_cert to true or ssl_verify_mode to :verify_peer to enable."
       end


### PR DESCRIPTION
only checking before we register the node to avoid
spamming SSL verification errors on every single connection.

because its in register it shouldn't warn in solo/apply
use cases (you still can use remote_file in those so maybe
we should also warn there?  i decided that'd be more annoying
than typically useful, YMMV...)
