### PR TITLE
Map 'ibm_powerkvm' to Red Hat-like package manager

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -222,6 +222,15 @@ class Chef
               :ifconfig => Chef::Provider::Ifconfig::Redhat
             }
           },
+          :ibm_powerkvm   => {
+            :default => {
+              :service => Chef::Provider::Service::Redhat,
+              :cron => Chef::Provider::Cron,
+              :package => Chef::Provider::Package::Yum,
+              :mdadm => Chef::Provider::Mdadm,
+              :ifconfig => Chef::Provider::Ifconfig::Redhat
+            }
+          },
           :gentoo   => {
             :default => {
               :package => Chef::Provider::Package::Portage,


### PR DESCRIPTION
Include 'ibm_powerkvm' in provider mappings.

Fixes CHEF-5135
