### PR TITLE
[10-stable] Fix crashes on invalid cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Service Provider for MacOSX now supports `enable` and `disable`
+* Chef now gracefully handles corrupted cache files.
 
 ## Last Release: 10.30.4 (02/18/2014)
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -7,3 +7,4 @@ Example Contribution:
 # Chef Client 10.x Contributions:
 
 * **jaymzh**: Service Provider for MacOSX now supports `enable` and `disable`
+* **jaymzh**: Chef now gracefully handles corrupted cache files.

--- a/chef/lib/chef/checksum_cache.rb
+++ b/chef/lib/chef/checksum_cache.rb
@@ -149,7 +149,7 @@ class Chef
 
     def fetch(key)
       @moneta.fetch(key)
-    rescue ArgumentError => e
+    rescue ArgumentError, TypeError => e
       Log.warn "Error loading cached checksum for key #{key.inspect}"
       Log.warn(e)
       repair_checksum_cache


### PR DESCRIPTION
We occasionally run into corrupt cache files, and chef can't
recover from this becuase Moneta throw TypeError instead of ArgumentError.
