### PR TITLE
Fix bug where environments could not be used with chef-solo

### DIFF
--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -253,8 +253,10 @@ class Chef
       rb_file = File.join(Chef::Config[:environment_path], "#{name}.rb")
 
       if File.exists?(js_file)
-        # from_json returns object.class => json_class in the JSON.
-        Chef::JSONCompat.from_json(IO.read(js_file))
+        environment = Chef::Environment.new
+        environment.name(name)
+        environment.update_from_params(Chef::JSONCompat.from_json(IO.read(js_file)))
+        environment
       elsif File.exists?(rb_file)
         environment = Chef::Environment.new
         environment.name(name)


### PR DESCRIPTION
When running chef-solo and trying to load an environment, it was loading a Hash, instead of an Environment class (probably due to legacy code that wasn't updated). Here's a fix I provided for that.

@beso323
