### PR TITLE
Don't eat the authentication failed exception on bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -206,7 +206,9 @@ class Chef
         begin
           knife_ssh.run
         rescue Net::SSH::AuthenticationFailed
-          unless config[:ssh_password]
+          if config[:ssh_password]
+            raise
+          else
             ui.info("Failed to authenticate #{config[:ssh_user]} - trying password auth")
             knife_ssh_with_password_auth.run
           end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -367,6 +367,12 @@ describe Chef::Knife::Bootstrap do
       @knife.run
     end
 
+    it "raises the exception if config[:ssh_password] is set and an authentication exception is raised" do
+      @knife.config[:ssh_password] = "password"
+      @knife_ssh.should_receive(:run).and_raise(Net::SSH::AuthenticationFailed)
+      lambda { @knife.run }.should raise_error(Net::SSH::AuthenticationFailed)
+    end
+
     context "Chef::Config[:encrypted_data_bag_secret] is set" do
       let(:secret_file) { File.join(CHEF_SPEC_DATA, 'bootstrap', 'encrypted_data_bag_secret') }
       before { Chef::Config[:encrypted_data_bag_secret] = secret_file }


### PR DESCRIPTION
On bootstrap, if authentication failed, the failure was hidden from users (without turning on verbose). I believe it is necessary to raise the exception so that the clients on the higher stacks can deal with it.
