### PR TITLE
CHEF-4888: Call WIN32OLE.ole_initialize in sub-threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Add knife 'ssl check' and 'ssl fetch' commands for debugging SSL errors (CHEF-4711)
 * Cron resource accepts a weekday attribute as a symbol. (CHEF-4848)
 * Cron resource accepts special strings, e.g. @reboot (CHEF-2816)
+* Call WIN32OLE.ole_initialize before using WMI (CHEF-4888)
 
 ## Last Release: 11.10.0 (02/06/2014)
 

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -30,11 +30,17 @@ class Chef
 
       def windows_server_2003?
         return false unless windows?
-
         require 'ruby-wmi'
+
+        # CHEF-4888: Work around ruby #2618, expected to be fixed in Ruby 2.1.0
+        # https://github.com/ruby/ruby/commit/588504b20f5cc880ad51827b93e571e32446e5db
+        # https://github.com/ruby/ruby/commit/27ed294c7134c0de582007af3c915a635a6506cd
+        WIN32OLE.ole_initialize
 
         host = WMI::Win32_OperatingSystem.find(:first)
         (host.version && host.version.start_with?("5.2"))
+
+        WIN32OLE.ole_uninitialize
       end
     end
 

--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -116,8 +116,16 @@ class Chef
         # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
         require 'ruby-wmi'
 
+        # CHEF-4888: Work around ruby #2618, expected to be fixed in Ruby 2.1.0
+        # https://github.com/ruby/ruby/commit/588504b20f5cc880ad51827b93e571e32446e5db
+        # https://github.com/ruby/ruby/commit/27ed294c7134c0de582007af3c915a635a6506cd
+
+        WIN32OLE.ole_initialize
+
         os_info = WMI::Win32_OperatingSystem.find(:first)
         os_version = os_info.send('Version')
+
+        WIN32OLE.ole_uninitialize
 
         # The operating system version is a string in the following form
         # that can be split into components based on the '.' delimiter:

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Bryan McLellan <btm@loftninjas.org>
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe "Chef::Platform#windows_server_2003?" do
+  it "returns false early when not on windows" do
+    Chef::Platform.stub(:windows?).and_return(false)
+    expect(Chef::Platform).not_to receive(:require) 
+    expect(Chef::Platform.windows_server_2003?).to be_false
+  end
+
+  # CHEF-4888: Need to call WIN32OLE.ole_initialize in new threads
+  it "does not raise an exception" do
+    expect { Thread.fork { Chef::Platform.windows_server_2003? }.join }.not_to raise_error
+  end
+end


### PR DESCRIPTION
An exception is raised when loading WIN32OLE (including via ruby-wmi) in one
thread and used in a sub-thread without calling ole_initialize in that thread.
This is common in irb/chef-shell's sub-shells that are created in recipe_mode
and attribute_mode. Since it will be a while before this is fixed in Ruby
and ruby-wmi/rdp-ruby-wmi are stale, we workaround the bug here.

Ruby issue: https://bugs.ruby-lang.org/issues/2618
