### PR TITLE
[CHEF-5150] chef-service-manager: don't create interactive service

### DIFF
--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -112,6 +112,9 @@ class Chef
                                  :service_name     => @service_name,
                                  :display_name     => @service_display_name,
                                  :description      => @service_description,
+                                 # Prior to 0.8.5, win32-service creates interactive services by default,
+                                 # and we don't want that, so we need to override the service type.
+                                 :service_type     => ::Win32::Service::SERVICE_WIN32_OWN_PROCESS,
                                  :start_type       => ::Win32::Service::SERVICE_AUTO_START,
                                  :binary_path_name => cmd
                                  )

--- a/spec/functional/win32/service_manager_spec.rb
+++ b/spec/functional/win32/service_manager_spec.rb
@@ -148,6 +148,12 @@ describe "Chef::Application::WindowsServiceManager", :windows_only, :system_wind
         service_manager.run(["-a", "install"])
       end
 
+      it "should have an own-process, non-interactive type" do
+        status = ::Win32::Service.status("spec-service")
+        status[:service_type].should == "own process"
+        status[:interactive].should be_false
+      end
+
       it "install => should say service already exists" do
           service_manager.run(["-a", "install"])
           @service_manager_output.grep(/already exists/).length.should > 0


### PR DESCRIPTION
See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683502%28v=vs.85%29.aspx
Default value in win32-service is interactive and there is no reason why
chef-client should run as that.
