### PR TITLE
CHEF-4472 remote_file resource fails on windows host for any defined source

### DIFF
--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -36,8 +36,8 @@ class Chef
         # Fetches the file at uri, returning a Tempfile-like File handle
         def fetch
           tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
-          Chef::Log.debug("#{new_resource} staging #{uri.path} to #{tempfile.path}")
-          FileUtils.cp(uri.path, tempfile.path)
+          Chef::Log.debug("#{new_resource} staging #{uri.path.gsub(/^\/([a-zA-Z]:)/,'\1')} to #{tempfile.path}")
+          FileUtils.cp(uri.path.gsub(/^\/([a-zA-Z]:)/,'\1'), tempfile.path)
           tempfile.close if tempfile
           tempfile
         end


### PR DESCRIPTION
CHEF-4472 remote_file resource fails on windows host for any defined source

URI.parse("file:///c:/file.txt").path return /c:/files.txt which is not correct for File class methods, the leading slash has to be removed.

To restrict potential leading slash removal under *nix I extented the regex to letter and : so the only caveat under *nix is path starting by /<letter>:/ which sounds unlikely to appear and anyway could be worked around with a temp link if needed.

As I'm not sure I had explained it clearly I commented my tests under irb:

``` ruby
#Let's try to access a file
irb(main):005:0> URI.parse("file://z:/all.js").path
=> "/all.js"
#Ok, it needs an extra / at start

irb(main):006:0> URI.parse("file:///z:/all.js").path
=> "/z:/all.js"
#Great I've my file (seems) does File understand this path ?

irb(main):008:0> File.file?(URI.parse("file:///z:/all.js").path)
=> false
#Hum ok, maybe it would be able to figure it out anyway...

irb(main):007:0> File.file?(URI.parse("file://z:/all.js").path)
=> false
#Still not, I need the drive letter without the extra slash at start, let try gsub

irb(main):009:0> URI.parse("file:///z:/all.js").path.gsub(/^\/([a-zA-Z]:)/,'\1')
=> "z:/all.js"
irb(main):010:0> File.file?(URI.parse("file:///z:/all.js").path.gsub(/^\/([a-zA-Z]:)/,'\1'))
=> true

#It works ;)
```
