### PR TITLE
Fix Windows 2003 CI issues

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -38,9 +38,11 @@ class Chef
         WIN32OLE.ole_initialize
 
         host = WMI::Win32_OperatingSystem.find(:first)
-        (host.version && host.version.start_with?("5.2"))
+        is_server_2003 = (host.version && host.version.start_with?("5.2"))
 
         WIN32OLE.ole_uninitialize
+
+        is_server_2003
       end
     end
 

--- a/spec/functional/win32/versions_spec.rb
+++ b/spec/functional/win32/versions_spec.rb
@@ -22,7 +22,7 @@ if Chef::Platform.windows?
   require 'ruby-wmi'
 end
 
-describe "Chef::ReservedNames::Win32::Version", :windows_only do
+describe "Chef::ReservedNames::Win32::Version", :windows_only, :not_supported_on_win2k3 do
   before do
 
     host = WMI::Win32_OperatingSystem.find(:first)
@@ -57,7 +57,7 @@ describe "Chef::ReservedNames::Win32::Version", :windows_only do
       end
     end
   end
-  
+
   context "Win32 version object" do
     it "should have have one method for each marketing version" do
       versions = 0
@@ -88,7 +88,7 @@ describe "Chef::ReservedNames::Win32::Version", :windows_only do
       for_each_windows_version { |method_name| @version.send(method_name.to_sym) }
     end
   end
-  
+
   context "Windows Operating System version" do
     it "should match the version from WMI" do
       @current_os_version.should include(@version.marketing_name)


### PR DESCRIPTION
- Make sure that return value is preserved windows_server_2003?
- Disable version_specs on 2003 since the API is not supported.
