### PR TITLE
Increase timeout of apt-get commands for long downloads

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -123,7 +123,9 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(command)
-          shell_out!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
+          # Six hours chosen as an arbitrary value to prevent long package downloads from failing the chef-run.
+          timeout = 21600
+          shell_out!(command, :timeout => timeout, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
         end
 
       end


### PR DESCRIPTION
The timeout value of apt-get commands was increased to prevent long
downloads from failing the chef-client run. The default value of
shell_out's timeout at time of commit was 600 seconds. If any command
ran over that, the chef-run would fail - specifically apt-get install
commands in this case.
