### PR TITLE
[CHEF-5182] Add provider mappings for cloudlinux distributive.

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -219,6 +219,15 @@ class Chef
               :ifconfig => Chef::Provider::Ifconfig::Redhat
             }
           },
+          :cloudlinux   => {
+            :default => {
+              :service => Chef::Provider::Service::Redhat,
+              :cron => Chef::Provider::Cron,
+              :package => Chef::Provider::Package::Yum,
+              :mdadm => Chef::Provider::Mdadm,
+              :ifconfig => Chef::Provider::Ifconfig::Redhat
+            }
+          },
           :gentoo   => {
             :default => {
               :package => Chef::Provider::Package::Portage,


### PR DESCRIPTION
CloudLinux is an RHEL/CentOS enhancement that is used by shared hosting providers to limit resource usage by user. More info: http://cloudlinux.com/about/tech.php.
CloudLinux provider mapping must be the same as CentOS provider mapping.
