### PR TITLE
[CHEF-4632] backport #1179 - bump up upper limit on json gem to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Service Provider for MacOSX now supports `enable` and `disable`
 * Chef now gracefully handles corrupted cache files.
 * SIGTERM will once-more kill a non-daemonized chef-client (CHEF-5172)
+* bump up upper limit on json gem to 1.8.1 (CHEF-4632)
 
 ## Last Release: 10.30.4 (02/18/2014)
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -9,3 +9,4 @@ Example Contribution:
 * **jaymzh**: Service Provider for MacOSX now supports `enable` and `disable`
 * **jaymzh**: Chef now gracefully handles corrupted cache files.
 * **jaymzh**: SIGTERM will once-more kill a non-daemonized chef-client (CHEF-5172)
+* **jaymzh**: bump up upper limit on json gem to 1.8.1 (CHEF-4632)

--- a/chef/chef.gemspec
+++ b/chef/chef.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "bunny", ">= 0.6.0", "< 0.8.0"
   # The JSON gem reliably releases breaking changes as a patch release
-  s.add_dependency "json", ">= 1.4.4", "<=  1.7.7"
+  s.add_dependency "json", ">= 1.4.4", "<=  1.8.1"
   s.add_dependency "yajl-ruby", "~> 1.1"
   s.add_dependency "treetop", "~> 1.4.9"
   s.add_dependency "net-ssh", "~> 2.6"


### PR DESCRIPTION
This was a good change. Just want it in 10-stable too.
