### PR TITLE
Warning if target hostname resembles "knife bootstrap windows winrm" command.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -217,7 +217,7 @@ class Chef
         if Array(@name_args).first.nil?
           ui.error("Must pass an FQDN or ip to bootstrap")
           exit 1
-        elsif Array(@name_args).include?("windows")
+        elsif Array(@name_args).first == "windows"
           ui.warn("Hostname containing 'windows' specified. Please install 'knife-windows' if you are attempting to bootstrap a Windows node via WinRM.")
         end
       end


### PR DESCRIPTION
Only appears if "knife-windows" is not present on the system.
