### PR TITLE
CHEF-5198: a better fix

### DIFF
--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -61,7 +61,16 @@ class Chef
         base_headers.each do |name, value|
           Chef::Log.debug("#{name}: #{value}")
         end
+        Chef::Log.debug("---- End HTTP Request Header Data ----")
         http_client.request(http_request) do |response|
+          Chef::Log.debug("---- HTTP Status and Header Data: ----")
+          Chef::Log.debug("HTTP #{response.http_version} #{response.code} #{response.msg}")
+
+          response.each do |header, value|
+            Chef::Log.debug("#{header}: #{value}")
+          end
+          Chef::Log.debug("---- End HTTP Status/Header Data ----")
+
           yield response if block_given?
           # http_client.request may not have the return signature we want, so
           # force the issue:

--- a/lib/chef/http/simple.rb
+++ b/lib/chef/http/simple.rb
@@ -7,12 +7,15 @@ class Chef
   class HTTP
 
     class Simple < HTTP
-      # When we 'use' middleware the first middleware is applied last on requests and
-      # first on responses (confusingly).  So validatecontentlength must come before
-      # decompressor in order to be applied before decmopressing the response.
-      use ValidateContentLength
+
       use Decompressor
       use CookieManager
+
+      # ValidateContentLength should come after Decompressor
+      # because the order of middlewares is reversed when handling
+      # responses.
+      use ValidateContentLength
+
     end
   end
 end

--- a/spec/unit/http/simple_spec.rb
+++ b/spec/unit/http/simple_spec.rb
@@ -27,6 +27,6 @@ describe Chef::HTTP::Simple do
 
     content_length.should_not be_nil
     decompressor.should_not be_nil
-    (decompressor > content_length).should be_true
+    (decompressor < content_length).should be_true
   end
 end


### PR DESCRIPTION
- reverts previous fix to CHEF-5198
- applies stream handler middleware in (proper) reverse order
- adds debugging around middleware application
- moves dumping of response header debugging to before applying
  response/streaming middleware
