### PR TITLE
CHEF-5147: Don't check dependencies when not specified

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -171,7 +171,16 @@ class Chef
                 if ! upload_set.has_key?(cookbook_name)
                   upload_set[cookbook_name] = cookbook_repo[cookbook_name]
                   if config[:depends]
-                    upload_set[cookbook_name].metadata.dependencies.each { |dep, ver| @name_args << dep }
+                    # If including dependencies, add each dependency to the upload_set
+                    upload_set[cookbook_name].metadata.dependencies.each do |dep, ver|
+                      # TODO: Should check cookbook version here?
+                      if cookbook_repo[dep]
+                        Chef::Log.debug("config[:depends] is true, found dependency #{dep} in local repository, adding upload list")
+                        @name_args << dep
+                      else
+                        Chef::Log.debug("config[:depends] is true, dependency #{dep} not found in local repository, will check the server later")
+                      end
+                    end
                   end
                 end
               rescue Exceptions::CookbookNotFoundInRepo => e


### PR DESCRIPTION
https://tickets.opscode.com/browse/CHEF-5147

This fixes the tests for the behavior specified in CHEF-5147 that makes it so
that --include-dependencies will upload dependencies if they're on disk, but
and fail if they're not available on disk or the server.

However, overall this change means that 'knife cookbook upload' no longer
makes a dependency check, which was something we intentionally added so you
would know about dependency problems at cookbook upload time rather than
later when you run chef-client.

See the ticket for further discussion.
