### PR TITLE
[CHEF-5211] Adding load_plugins call to ensure ohai plugins are loaded

### DIFF
--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -153,6 +153,7 @@ EOH
 
       def guess_servername
         o = Ohai::System.new
+        o.load_plugins
         o.require_plugin 'os'
         o.require_plugin 'hostname'
         o[:fqdn] || 'localhost'


### PR DESCRIPTION
Attempting to require ohai plugins before they are loaded into a new Ohai::System object returns AttributeNotFound errors. This adds a load_plugins call to the guess_servername method in Chef::Knife::Configure before requiring the 'os' and 'hostname' plugins.
