### PR TITLE
Make log provider idempotent

### DIFF
--- a/lib/chef/provider/log.rb
+++ b/lib/chef/provider/log.rb
@@ -39,7 +39,9 @@ class Chef
         # true:: Always return true
         def action_write
           Chef::Log.send(@new_resource.level, @new_resource.message)
-          @new_resource.updated_by_last_action(true)
+          if Chef::Config[:log_level] == @new_resource.level
+            @new_resource.updated_by_last_action(true)
+          end
         end
 
       end
@@ -49,6 +51,4 @@ class Chef
   end
 
 end
-
-
 

--- a/spec/unit/provider/log_spec.rb
+++ b/spec/unit/provider/log_spec.rb
@@ -77,5 +77,13 @@ describe Chef::Provider::Log::ChefLog do
       Chef::Log.should_receive(:fatal).with(@log_str).and_return(true)
       @provider.action_write
   end
+  
+  it "should not update the resource if the message wouldn't have been written to the log" do
+      @new_resource = Chef::Resource::Log.new(@log_str)
+      @new_resource.level :fatal
+      @provider = Chef::Provider::Log::ChefLog.new(@new_resource, @run_context)
+      @provider.action_write
+      @new_resource.updated.should be_false
+  end
 
 end


### PR DESCRIPTION
Added condition to log provider to prevent the resource from being
updated if the message wouldn't have been written to the log.

Added test to log_spec.rb to ensure this is the case.
