### PR TITLE
added pssh (https://code.google.com/p/parallel-ssh/) support to knife ssh

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -455,7 +455,6 @@ class Chef
         command.force_encoding('binary') if command.respond_to?(:force_encoding)
 
         pssh_cmd << " " << command
-        puts pssh_cmd
         Chef::Log.debug("executing pssh with command: #{pssh_cmd}")
         exec(pssh_cmd)
       end


### PR DESCRIPTION
If the server provides Kerberos (gssapi-with-mac) only for authentication method, we need another method for executing ssh command in knife, because of ruby's Kerberos implementation(https://github.com/joekhoobyar/net-ssh-kerberos) is outdated. 

So I added pssh support to knife ssh command. 

Here's a sample command usage and output.

```
jaewoo@foo:chef-repo (master*)$ knife ssh 'role:lasvegas_redis' pssh cat /etc/issue
[1] 16:27:24 [SUCCESS] deploy@~~~
CentOS release 6.5 (Final)
Kernel \r on an \m

[2] 16:27:24 [SUCCESS] deploy@~~~
CentOS release 6.5 (Final)
Kernel \r on an \m
```
