### PR TITLE
CHEF-5211: fix configure hostname guessing

### DIFF
--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -156,7 +156,7 @@ EOH
         o.load_plugins
         o.require_plugin 'os'
         o.require_plugin 'hostname'
-        o[:fqdn] || 'localhost'
+        o[:fqdn] || o[:machinename] || o[:hostname] || 'localhost'
       end
 
       def config_file

--- a/spec/functional/knife/configure_spec.rb
+++ b/spec/functional/knife/configure_spec.rb
@@ -32,6 +32,7 @@ describe "knife configure" do
 
   it "loads the fqdn from Ohai" do
     knife_configure = Chef::Knife::Configure.new
-    expect(knife_configure.guess_servername).to eql(ohai[:fqdn])
+    hostname_guess = ohai[:fqdn] || ohai[:machinename] || ohai[:hostname] || 'localhost'
+    expect(knife_configure.guess_servername).to eql(hostname_guess)
   end
 end


### PR DESCRIPTION
ohai[:fqdn] depends on DNS and may be nil.  change the algorithm to use
the hostnaome of the machine as a fallback using the same algorithm
that Chef::Client uses for guessing the node_name of a host.
