### PR TITLE
Making sure file exist before attemping unlinking it. Otherwise cause er...

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -296,7 +296,7 @@ class Chef
       def do_unlink
         @file_unlinked = false
         if @new_resource.force_unlink
-          if !real_file?(@new_resource.path)
+          if !real_file?(@new_resource.path) && ::File.file?(@new_resource.path)
             # unlink things that aren't normal files
             description = "unlink #{file_type_string(@new_resource.path)} at #{@new_resource.path}"
             converge_by(description) do


### PR DESCRIPTION
When "force_unlink true" is use, if the file doesn't already exist, file creation will fail because the old code will attempt to unlink it without checking to see if it exist.
- file[/etc/resolvconf/resolv.conf.d/tail] action create       [2014-04-27T18:53:31+00:00] INFO: Processing file[/etc/resolvconf/resolv.conf.d/tail] action create (resolvconf::install line 23)
  
     ================================================================================
  
     Error executing action `create` on resource 'file[/etc/resolvconf/resolv.conf.d/tail]'
     ================================================================================
  
     Errno::ENOENT
  ---
  
     No such file or directory - /etc/resolvconf/resolv.conf.d/tail
  
     Resource Declaration:
  ---
  
     # In /tmp/kitchen/cache/cookbooks/resolvconf/recipes/install.rb
  
  ```
  23: file "/etc/resolvconf/resolv.conf.d/tail" do
  24:   mode    00644
  25:   content "abc"
  26:   action :create
  27:   # Remove file if it is not a regular file (e.g. a symlink)
  
  28:   # This is useful, as sometimes the backup stored in the file "original"
  29:   # is symlinked to "tail"
  30:   force_unlink true
  31: end
  ```
  
     Compiled Resource:
  ---
  
     # Declared in /tmp/kitchen/cache/cookbooks/resolvconf/recipes/install.rb:23:in `from_file'
  
     file("/etc/resolvconf/resolv.conf.d/tail") do
       provider Chef::Provider::File
  
  ```
   action [:create]
   retries 0
   retry_delay 2
   guard_interpreter :default
   path "/etc/resolvconf/resolv.conf.d/tail"
   backup 5
   atomic_update true
   force_unlink true
   cookbook_name "resolvconf"
   recipe_name "install"
   mode 420
   content "abc"
  ```
  
     end
