### PR TITLE
Switch to ruby 2.1.1 to workaround travis rvm issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
     - rvm: 1.8.7-p374
     - rvm: 1.9.3
     - rvm: 2.0.0
-    - rvm: 2.1.0
-    - rvm: 2.1.0
+    - rvm: 2.1.1
+    - rvm: 2.1.1
       gemfile: pedant.gemfile
       script: bundle exec rake pedant
 


### PR DESCRIPTION
See what travis has to say in a minute....
