### PR TITLE
do not accept exitstatus == 1 as success

### DIFF
--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -35,7 +35,7 @@ class Chef
             crontab = stdout.read
             cronerr = stderr.read
           end
-          if status.exitstatus != 0
+          if not status.success?
             raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status.exitstatus}, stderr: #{cronerr.chomp}"
           end
           crontab

--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -33,7 +33,7 @@ class Chef
           status = popen4("crontab -l #{@new_resource.user}") do |pid, stdin, stdout, stderr|
             crontab = stdout.read
           end
-          if status.exitstatus > 1
+          if not status.success?
             raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status.exitstatus}"
           end
           crontab

--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -30,11 +30,13 @@ class Chef
 
         def read_crontab
           crontab = nil
+          cronerr = nil
           status = popen4("crontab -l #{@new_resource.user}") do |pid, stdin, stdout, stderr|
             crontab = stdout.read
+            cronerr = stderr.read
           end
           if status.exitstatus != 0
-            raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status.exitstatus}"
+            raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status.exitstatus}, stderr: #{cronerr.chomp}"
           end
           crontab
         end

--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -33,7 +33,7 @@ class Chef
           status = popen4("crontab -l #{@new_resource.user}") do |pid, stdin, stdout, stderr|
             crontab = stdout.read
           end
-          if not status.success?
+          if status.exitstatus != 0
             raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status.exitstatus}"
           end
           crontab


### PR DESCRIPTION
status.exitstatus of 1 is a failure. In fact, it's a very common exit code for failures on cron.  Unless there is a specific reason that exit status 1 is supposed to be considered okay — and I strongly suspect that there is none — then it should not be treated as okay.  I think this is just an off-by-one error and that >= was meant instead of >, or 0 instead of 1.

We can avoid the question by using Process::Status#success? instead.