### PR TITLE
CHEF-4911: Use the :bootstrap_version if set by the user.

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -114,7 +114,20 @@ CONFIG
         # If user is on X.Y.Z bootstrap will use the latest X release
         # X here can be 10 or 11
         def latest_current_chef_version_string
-          "-v #{chef_version.split(".").first}"
+          chef_version_string = if knife_config[:bootstrap_version]
+            knife_config[:bootstrap_version]
+          else
+            Chef::VERSION.split(".").first
+          end
+
+          installer_version_string = ["-v", chef_version_string]
+
+          # If bootstrapping a pre-release version add -p to the installer string
+          if chef_version_string.split(".").length > 3
+            installer_version_string << "-p"
+          end
+
+          installer_version_string.join(" ")
         end
 
         def first_boot

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -166,5 +166,35 @@ EXPECTED
       end
     end
   end
-end
 
+  describe "when a bootstrap_version is specified" do
+    let(:chef_config) do
+      {
+        :knife => {:bootstrap_version => "11.12.4" }
+      }
+    end
+
+    it "should send the full version to the installer" do
+      bootstrap_context.latest_current_chef_version_string.should eq("-v 11.12.4")
+    end
+  end
+
+  describe "when a pre-release bootstrap_version is specified" do
+    let(:chef_config) do
+      {
+        :knife => {:bootstrap_version => "11.12.4.rc.0" }
+      }
+    end
+
+    it "should send the full version to the installer and set the pre-release flag" do
+      bootstrap_context.latest_current_chef_version_string.should eq("-v 11.12.4.rc.0 -p")
+    end
+  end
+
+  describe "when a bootstrap_version is not specified" do
+    it "should send the latest current to the installer" do
+      # Intentionally hard coded in order not to replicate the logic.
+      bootstrap_context.latest_current_chef_version_string.should eq("-v 11")
+    end
+  end
+end


### PR DESCRIPTION
Thanks @lamont-granquist for catching this. 

We should use the specified :bootstrap_version fully if user has set it in config. 

Also added some spec tests which I should have done before. 

/cc: @danielsdeleo 
