### PR TITLE
CHEF-3193: LOCK_TIMEOUT in yum-dump.py should be configurable

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -313,6 +313,7 @@ class Chef
 
     default :rest_timeout, 300
     default :yum_timeout, 900
+    default :yum_lock_timeout, 30
     default :solo,  false
     default :splay, nil
     default :why_run, false

--- a/lib/chef/provider/package/yum-dump.py
+++ b/lib/chef/provider/package/yum-dump.py
@@ -43,9 +43,6 @@ from distutils import version
 
 YUM_PID_FILE='/var/run/yum.pid'
 
-# Seconds to wait for exclusive access to yum
-LOCK_TIMEOUT = 10
-
 YUM_VER = version.StrictVersion(yum.__version__)
 YUM_MAJOR = YUM_VER.version[0]
 
@@ -219,8 +216,8 @@ def yum_dump(options):
   # Wrap the collection and output of packages in yum's global lock to prevent
   # any inconsistencies.
   try:
-    # Spin up to LOCK_TIMEOUT
-    countdown = LOCK_TIMEOUT
+    # Spin up to --yum-lock-timeout option
+    countdown = options.yum_lock_timeout
     while True:
       try:
         yb.doLock(YUM_PID_FILE)
@@ -230,7 +227,7 @@ def yum_dump(options):
         countdown -= 1
         if countdown == 0:
            print >> sys.stderr, "yum-dump Locking Error! Couldn't obtain an " \
-             "exclusive yum lock in %d seconds. Giving up." % LOCK_TIMEOUT
+             "exclusive yum lock in %d seconds. Giving up." % options.yum_lock_timeout
            return 200
       else:
         break
@@ -281,6 +278,9 @@ def main():
   parser.add_option("--disablerepo",
                     action="callback",  callback=gather_repo_opts, type="string", dest="repo_control", default=[],
                     help="disable repositories by id or glob")
+  parser.add_option("--yum-lock-timeout",
+                    action="callback",  type="int", dest="yum_lock_timeout", default=30,
+                    help="Time in seconds to wait for yum process lock")
 
   (options, args) = parser.parse_args()
 

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -704,6 +704,8 @@ class Chef
               opts << " #{@extra_repo_control}"
             end
 
+            opts << " --yum-lock-timeout #{Chef::Config[:yum_lock_timeout]}"
+
             one_line = false
             error = nil
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -1619,25 +1619,32 @@ EOF
 
     it "should run yum-dump.py using the system python when next_refresh is for :all" do
       @yc.reload
-      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --installed-provides$}, :timeout=>Chef::Config[:yum_timeout])
+      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --installed-provides --yum-lock-timeout 30$}, :timeout=>Chef::Config[:yum_timeout])
       @yc.refresh
     end
 
     it "should run yum-dump.py with the installed flag when next_refresh is for :installed" do
       @yc.reload_installed
-      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --installed$}, :timeout=>Chef::Config[:yum_timeout])
+      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --installed --yum-lock-timeout 30$}, :timeout=>Chef::Config[:yum_timeout])
       @yc.refresh
     end
 
     it "should run yum-dump.py with the all-provides flag when next_refresh is for :provides" do
       @yc.reload_provides
-      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --all-provides$}, :timeout=>Chef::Config[:yum_timeout])
+      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --all-provides --yum-lock-timeout 30$}, :timeout=>Chef::Config[:yum_timeout])
       @yc.refresh
     end
 
     it "should pass extra_repo_control args to yum-dump.py" do
       @yc.enable_extra_repo_control("--enablerepo=foo --disablerepo=bar")
-      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --installed-provides --enablerepo=foo --disablerepo=bar$}, :timeout=>Chef::Config[:yum_timeout])
+      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --installed-provides --enablerepo=foo --disablerepo=bar --yum-lock-timeout 30$}, :timeout=>Chef::Config[:yum_timeout])
+      @yc.refresh
+    end
+
+    it "should pass extra_repo_control args and configured yum lock timeout to yum-dump.py" do
+      Chef::Config[:yum_lock_timeout] = 999
+      @yc.enable_extra_repo_control("--enablerepo=foo --disablerepo=bar")
+      @yc.should_receive(:shell_out!).with(%r{^/usr/bin/python .*/yum-dump.py --options --installed-provides --enablerepo=foo --disablerepo=bar --yum-lock-timeout 999$}, :timeout=>Chef::Config[:yum_timeout])
       @yc.refresh
     end
 


### PR DESCRIPTION
Allow yum lock timeout from env var as a short term solution.

Issue: CHEF-3193
