### PR TITLE
Remove unneeded requires when using CookbookVersionLoader

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -1,5 +1,4 @@
 
-require 'chef/config'
 require 'chef/cookbook_version'
 require 'chef/cookbook/chefignore'
 require 'chef/cookbook/metadata'

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -20,9 +20,6 @@
 # limitations under the License.
 
 require 'chef/log'
-require 'chef/node'
-require 'chef/resource_definition_list'
-require 'chef/recipe'
 require 'chef/cookbook/file_vendor'
 require 'chef/cookbook/metadata'
 require 'chef/version_class'


### PR DESCRIPTION
CookbookVersion and CookbookVersionLoader may interact with classes
defined in these files, but never reference their constants directly, so
they do not need to be loaded.

/cc @opscode/client-eng 
