### PR TITLE
CHEF-5316: Constantly update owner/group in the resource of link

### DIFF
--- a/lib/chef/scan_access_control.rb
+++ b/lib/chef/scan_access_control.rb
@@ -46,7 +46,7 @@ class Chef
 
     # Modifies @current_resource, setting the current access control state.
     def set_all!
-      if ::File.exist?(new_resource.path)
+      if ::File.exist?(new_resource.path) || ::File.symlink?(new_resource.path)
         set_owner
         set_group
         set_mode

--- a/spec/unit/provider/link_spec.rb
+++ b/spec/unit/provider/link_spec.rb
@@ -112,11 +112,26 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
       it "should update the source of the existing link to the link's target" do
         provider.current_resource.to.should == canonicalize("#{CHEF_SPEC_DATA}/fofile")
       end
-      it "should not set the owner" do
-        provider.current_resource.owner.should be_nil
+      it "should set the owner" do
+        provider.current_resource.owner.should == 501
       end
-      it "should not set the group" do
-        provider.current_resource.group.should be_nil
+      it "should set the group" do
+        provider.current_resource.group.should == 501
+      end
+
+      context "when new resource sets owner/group associated" do
+        before do
+          new_resource.owner 502
+          new_resource.group 502
+          provider.load_current_resource
+        end
+
+        it "should set the owner difference" do
+          provider.current_resource.owner.should_not == provider.new_resource.owner
+        end
+        it "should set the group difference" do
+          provider.current_resource.group.should_not == provider.new_resource.group
+        end
       end
     end
   end

--- a/spec/unit/scan_access_control_spec.rb
+++ b/spec/unit/scan_access_control_spec.rb
@@ -52,133 +52,148 @@ describe Chef::ScanAccessControl do
       @stat = double("File::Stat for #{@new_resource.path}", :uid => 0, :gid => 0, :mode => 00100644)
       File.should_receive(:realpath).with(@new_resource.path).and_return(@real_file)
       File.should_receive(:stat).with(@real_file).and_return(@stat)
-      File.should_receive(:exist?).with(@new_resource.path).and_return(true)
     end
 
-    describe "when new_resource does not specify mode, user or group" do
-      # these tests are necessary for minitest-chef-handler to use as an API, see CHEF-3235
-      before do
-        @scanner.set_all!
-      end
+    shared_examples_for "current resource settings" do
 
-      it "sets the mode of the current resource to the current mode as a String" do
-        @current_resource.mode.should == "0644"
-      end
-
-      context "on unix", :unix_only do
-        it "sets the group of the current resource to the current group as a String" do
-          @current_resource.group.should == Etc.getgrgid(0).name
+      describe "when new_resource does not specify mode, user or group" do
+        # these tests are necessary for minitest-chef-handler to use as an API, see CHEF-3235
+        before do
+          @scanner.set_all!
         end
 
-        it "sets the owner of the current resource to the current owner as a String" do
+        it "sets the mode of the current resource to the current mode as a String" do
+          @current_resource.mode.should == "0644"
+        end
+
+        context "on unix", :unix_only do
+          it "sets the group of the current resource to the current group as a String" do
+            @current_resource.group.should == Etc.getgrgid(0).name
+          end
+
+          it "sets the owner of the current resource to the current owner as a String" do
+            @current_resource.user.should == "root"
+          end
+        end
+
+        context "on windows", :windows_only do
+          it "sets the group of the current resource to the current group as a String" do
+            @current_resource.group.should == 0
+          end
+
+          it "sets the owner of the current resource to the current owner as a String" do
+            @current_resource.user.should == 0
+          end
+        end
+      end
+
+      describe "when new_resource specifies the mode with a string" do
+        before do
+          @new_resource.mode("0755")
+          @scanner.set_all!
+        end
+
+        it "sets the mode of the current resource to the file's current mode as a string" do
+          @current_resource.mode.should == "0644"
+        end
+      end
+
+      describe "when new_resource specified the mode with an integer" do
+        before do
+          @new_resource.mode(00755)
+          @scanner.set_all!
+        end
+
+        it "sets the mode of the current resource to the current mode as a String" do
+          @current_resource.mode.should == "0644"
+        end
+      end
+
+      describe "when new_resource specifies the user with a UID" do
+        before do
+          @new_resource.user(0)
+          @scanner.set_all!
+        end
+
+        it "sets the owner of current_resource to the UID of the current owner" do
+          @current_resource.user.should == 0
+        end
+      end
+
+      describe "when new_resource specifies the user with a username" do
+        before do
+          @new_resource.user("root")
+        end
+
+        it "sets the owner of current_resource to the username of the current owner" do
+          @root_passwd = double("Struct::Passwd for uid 0", :name => "root")
+          Etc.should_receive(:getpwuid).with(0).and_return(@root_passwd)
+          @scanner.set_all!
+
           @current_resource.user.should == "root"
         end
-      end
 
-      context "on windows", :windows_only do
-        it "sets the group of the current resource to the current group as a String" do
-          @current_resource.group.should == 0
-        end
-
-        it "sets the owner of the current resource to the current owner as a String" do
-          @current_resource.user.should == 0
+        describe "and there is no passwd entry for the user" do
+          it "sets the owner of the current_resource to the UID" do
+            Etc.should_receive(:getpwuid).with(0).and_raise(ArgumentError)
+            @scanner.set_all!
+            @current_resource.user.should == 0
+          end
         end
       end
-    end
 
-    describe "when new_resource specifies the mode with a string" do
-      before do
-        @new_resource.mode("0755")
-        @scanner.set_all!
-      end
-
-      it "sets the mode of the current resource to the file's current mode as a string" do
-        @current_resource.mode.should == "0644"
-      end
-    end
-
-    describe "when new_resource specified the mode with an integer" do
-      before do
-        @new_resource.mode(00755)
-        @scanner.set_all!
-      end
-
-      it "sets the mode of the current resource to the current mode as a String" do
-        @current_resource.mode.should == "0644"
-      end
-
-    end
-
-    describe "when new_resource specifies the user with a UID" do
-
-      before do
-        @new_resource.user(0)
-        @scanner.set_all!
-      end
-
-      it "sets the owner of current_resource to the UID of the current owner" do
-        @current_resource.user.should == 0
-      end
-    end
-
-    describe "when new_resource specifies the user with a username" do
-
-      before do
-        @new_resource.user("root")
-      end
-
-      it "sets the owner of current_resource to the username of the current owner" do
-        @root_passwd = double("Struct::Passwd for uid 0", :name => "root")
-        Etc.should_receive(:getpwuid).with(0).and_return(@root_passwd)
-        @scanner.set_all!
-
-        @current_resource.user.should == "root"
-      end
-
-      describe "and there is no passwd entry for the user" do
-        it "sets the owner of the current_resource to the UID" do
-          Etc.should_receive(:getpwuid).with(0).and_raise(ArgumentError)
+      describe "when new_resource specifies the group with a GID" do
+        before do
+          @new_resource.group(0)
           @scanner.set_all!
-          @current_resource.user.should == 0
         end
-      end
-    end
 
-    describe "when new_resource specifies the group with a GID" do
-
-      before do
-        @new_resource.group(0)
-        @scanner.set_all!
-      end
-
-      it "sets the group of the current_resource to the gid of the current owner" do
-        @current_resource.group.should == 0
-      end
-
-    end
-
-    describe "when new_resource specifies the group with a group name" do
-      before do
-        @new_resource.group("wheel")
-      end
-
-      it "sets the group of the current resource to the group name" do
-        @group_entry = double("Struct::Group for wheel", :name => "wheel")
-        Etc.should_receive(:getgrgid).with(0).and_return(@group_entry)
-        @scanner.set_all!
-
-        @current_resource.group.should == "wheel"
-      end
-
-      describe "and there is no group entry for the group" do
-        it "sets the current_resource's group to the GID" do
-          Etc.should_receive(:getgrgid).with(0).and_raise(ArgumentError)
-          @scanner.set_all!
+        it "sets the group of the current_resource to the gid of the current owner" do
           @current_resource.group.should == 0
         end
       end
 
+      describe "when new_resource specifies the group with a group name" do
+        before do
+          @new_resource.group("wheel")
+        end
+
+        it "sets the group of the current resource to the group name" do
+          @group_entry = double("Struct::Group for wheel", :name => "wheel")
+          Etc.should_receive(:getgrgid).with(0).and_return(@group_entry)
+          @scanner.set_all!
+
+          @current_resource.group.should == "wheel"
+        end
+
+        describe "and there is no group entry for the group" do
+          it "sets the current_resource's group to the GID" do
+            Etc.should_receive(:getgrgid).with(0).and_raise(ArgumentError)
+            @scanner.set_all!
+            @current_resource.group.should == 0
+          end
+        end
+      end
+
     end
+
+    context "when new resource is the file" do
+      before do
+        File.should_receive(:exist?).with(@new_resource.path).and_return(true)
+        File.stub(:symlink?).with(@new_resource.path).and_return(false)
+      end
+
+      it_behaves_like "current resource settings"
+    end
+
+    context "when new resource is the link" do
+      before do
+        File.stub(:exist?).with(@new_resource.path).and_return(false)
+        File.should_receive(:symlink?).with(@new_resource.path).and_return(true)
+      end
+
+      it_behaves_like "current resource settings"
+    end
+
   end
 end
-


### PR DESCRIPTION
In the link resource, group / owner associated will be **constantly updated** in the following cases.
- target_file is already exists.
- target_file owner or group associated is the same before executing chef resources
- a to file doesn't exist

Hope to cover to checking the permissions symbolic link in this case :grin:

**Execute examples**

resource code:

``` ruby
# recipes/xxx.rb

link "/tmp/fofile-link" do
  link_type :symbolic
  to "/tmp/fofile"
  owner 501
  group 501
  action :create
end
```

symlink is exists but to file doesn't exist.

``` sh
$ ls -n1 /tmp/
lrwxrwxrwx 1 501 501 11 May 20 22:12 fofile-link -> /tmp/fofile
```

Chef exec result:

```
Starting Chef Client, version 11.12.4
Compiling Cookbooks...
...

* link[uploads] action create
  - Would change owner from '' to '501'  # => from is empty !
  - Would change group from '' to '501'  # => from is empty !
```

---

[commit diff --ignore-space-change](https://github.com/opscode/chef/pull/1447/files?w=1) (with param `?w=1`)
