### PR TITLE
fix for rspec 2.99

### DIFF
--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -436,7 +436,7 @@ describe Chef::ResourceReporter do
         @backtrace = ["foo.rb:1 in `foo!'","bar.rb:2 in `bar!","'baz.rb:3 in `baz!'"]
         @node = Chef::Node.new
         @node.name("spitfire")
-        @exception = double("ArgumentError")
+        @exception = ArgumentError.new
         @exception.stub(:inspect).and_return("Net::HTTPServerException")
         @exception.stub(:message).and_return("Object not found")
         @exception.stub(:backtrace).and_return(@backtrace)
@@ -463,7 +463,7 @@ describe Chef::ResourceReporter do
 
       it "includes the error inspector output in the event data" do
         @report["data"]["exception"].should have_key("description")
-        @report["data"]["exception"]["description"].should include({"title"=>"Error expanding the run_list:", "sections"=>[{"Unexpected Error:" => "RSpec::Mocks::Mock: Object not found"}]})
+        @report["data"]["exception"]["description"].should include({"title"=>"Error expanding the run_list:", "sections"=>[{"Unexpected Error:" => "ArgumentError: Object not found"}]})
       end
 
     end


### PR DESCRIPTION
2.99 renames RSpec::Mocks::Mock to RSpec::Mocks::Double.  This change
uses a real exception class and avoids mocking it so that we aren't
brittle against rspec's own class namespace.
