### PR TITLE
Add .project to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ binstubs/
 .ruby-version
 .ruby-gemset
 
+# IDE files
+.project
+
 # Documentation
 _site/*
 .yardoc/


### PR DESCRIPTION
Adding `.project` to the `.gitignore` file. 

Obvious fix. 
