### PR TITLE
[CHEF-5084] Fix for git HWRP that adds option to specify revision type

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -244,7 +244,11 @@ class Chef
                       when '', 'HEAD'
                         'HEAD'
                       else
-                        @new_resource.revision + '*'
+                        prefix = {
+                          :both => '',
+                          :branch => 'heads/',
+                          :tag => 'tags/'}[@new_resource.revision_type]
+                        prefix + @new_resource.revision + '*'
                       end
         command = git("ls-remote \"#{@new_resource.repository}\" \"#{rev_pattern}\"")
         @resolved_reference = shell_out!(command, run_options).stdout

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -27,6 +27,7 @@ class Chef
         @resource_name = :git
         @provider = Chef::Provider::Git
         @additional_remotes = Hash[]
+        @revision_type = :both
       end
 
       def additional_remotes(arg=nil)
@@ -37,9 +38,16 @@ class Chef
         )
       end
 
+      def revision_type(arg=nil)
+        set_or_return(
+          :revision_type,
+          arg,
+          :kind_of => Symbol,
+          :default => :both
+      end
+
       alias :branch :revision
       alias :reference :revision
-
       alias :repo :repository
     end
   end


### PR DESCRIPTION
You can now specify the `git` resource's revision (or aliases [branch, reference]) as either a `:tag` or a `:branch`. The other option is `:both`, which is default, and does not restrict the `git ls-remote` command to heads or tags.
