### PR TITLE
Return rack-compliant 404 messages

### DIFF
--- a/spec/functional/tiny_server_spec.rb
+++ b/spec/functional/tiny_server_spec.rb
@@ -54,8 +54,8 @@ describe TinyServer::API do
     response = @api.call("REQUEST_METHOD" => "GET", "REQUEST_URI" => '/no_such_thing')
     response[0].should == 404
     response[1].should == {'Content-Type' => 'application/json'}
-    response[2].should be_a_kind_of(String)
-    response_obj = Chef::JSONCompat.from_json(response[2])
+    response[2].should be_a_kind_of(Array)
+    response_obj = Chef::JSONCompat.from_json(response[2].first)
     response_obj["message"].should == "no data matches the request for /no_such_thing"
     response_obj["available_routes"].should == {"GET"=>[], "PUT"=>[], "POST"=>[], "DELETE"=>[]}
     response_obj["request"].should == {"REQUEST_METHOD"=>"GET", "REQUEST_URI"=>"/no_such_thing"}

--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -152,7 +152,7 @@ module TinyServer
                       :available_routes => @routes, :request => env}
         # Uncomment me for glorious debugging
         # pp :not_found => debug_info
-        [404, {'Content-Type' => 'application/json'}, debug_info.to_json]
+        [404, {'Content-Type' => 'application/json'}, [ debug_info.to_json ]]
       end
     end
 


### PR DESCRIPTION
This fixes the NoMethodError undefined method each for String that spams the output in the tests.
