### PR TITLE
Skip all unsupported platforms in remount test

### DIFF
--- a/spec/functional/resource/mount_spec.rb
+++ b/spec/functional/resource/mount_spec.rb
@@ -164,7 +164,9 @@ describe Chef::Resource::Mount, :requires_root, :external => include_flag do
   end
 
   # don't run the remount tests on solaris2 (tmpfs does not support remount)
-  describe "when the filesystem should be remounted and the resource supports remounting", :external => ohai[:platform] == "solaris2" do
+  # Need to make sure the platforms we've already excluded are considered:
+  skip_remount = include_flag || (ohai[:platform] == "solaris2")
+  describe "when the filesystem should be remounted and the resource supports remounting", :external => skip_remount do
     it "should remount the filesystem if it is mounted" do
       new_resource.run_action(:mount)
       mount_should_exist(new_resource.mount_point, new_resource.device)


### PR DESCRIPTION
In the ChefDK tests, we're getting a failure:

```
1) Chef::Resource::Mount when the filesystem should be remounted and the resource supports remounting should remount the filesystem if it is mounted
     Failure/Error: new_resource.run_action(:mount)
     TypeError:
       mount[/tmp/testmount20140612-80998-1m7klx2] (dynamically defined) had an error: TypeError: no implicit conversion of nil into String
     # ./lib/chef/provider/mount/mount.rb:242:in `symlink?'
     # ./lib/chef/provider/mount/mount.rb:242:in `device_mount_regex'
     # ./lib/chef/provider/mount/mount.rb:90:in `block in mounted?'
     # ./lib/chef/provider/mount/mount.rb:88:in `each_line'
     # ./lib/chef/provider/mount/mount.rb:88:in `mounted?'
     # ./lib/chef/provider/mount/mount.rb:39:in `load_current_resource'
     # ./lib/chef/provider.rb:104:in `run_action'
     # ./lib/chef/resource.rb:648:in `run_action'
     # ./spec/functional/resource/mount_spec.rb:169:in `block (3 levels) in <top (required)>'
```

Looking at the tests, you'd expect this to be skipped on Mac:

https://github.com/opscode/chef/blob/master/spec/functional/resource/mount_spec.rb#L24-26
https://github.com/opscode/chef/blob/master/spec/functional/resource/mount_spec.rb#L32-61

I was not able to reproduce this issue in a local git checkout. I suspected it could be related to ruby or rspec versions, but I have tried blowing away Gemfile.lock and re-bundling and also Ruby 2.0, 2.1.0 and 2.1.2, none of which reproduced the issue (installing 2.1.1 now just to check). In any case, this consistently reproduces with just `bundle exec rspec spec/functional/resource/mount_spec.rb` on the build machine. I found that the exclude tag on the build machine is completely overriding the exclude tag from its parent context.

This patch provides a minimal fix for the issue, but I think we could make all this a bit more obvious and resilient by making the platforms explicit (assuming rspec supports this kind of data structure in the tags), like

``` ruby
describe "a thing", :platforms => [:ubuntu, :centos, :solaris] do
# stuff
end
```
