### PR TITLE
Remove deprecated `::File.exists?` Using `::File.exist?` instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,11 @@ matrix:
     - rvm: 1.9.3
     - rvm: 2.0.0
     - rvm: 2.1.1
+    - rvm: 2.1.2
     - rvm: 2.1.1
+      gemfile: pedant.gemfile
+      script: bundle exec rake pedant
+    - rvm: 2.1.2
       gemfile: pedant.gemfile
       script: bundle exec rake pedant
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,4 @@ end
 
 # If you want to load debugging tools into the bundle exec sandbox,
 # add these additional dependencies into chef/Gemfile.local
-eval(IO.read(__FILE__ + '.local'), binding) if File.exists?(__FILE__ + '.local')
+eval(IO.read(__FILE__ + '.local'), binding) if File.exist?(__FILE__ + '.local')

--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -66,7 +66,7 @@ class Chef
       end
 
       def assert_destination_writable!
-        if (File.exists?(destination) && !File.writable?(destination)) or !File.writable?(File.dirname(destination))
+        if (File.exist?(destination) && !File.writable?(destination)) or !File.writable?(File.dirname(destination))
           raise Chef::Exceptions::CannotWritePrivateKey, "I cannot write your private key to #{destination} - check permissions?"
         end
       end

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
@@ -94,7 +94,7 @@ class Chef
         end
 
         def can_upload?
-          File.exists?(uploaded_cookbook_version_path) || children.size > 0
+          File.exist?(uploaded_cookbook_version_path) || children.size > 0
         end
 
         protected

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbooks_dir.rb
@@ -69,7 +69,7 @@ class Chef
 
           # Write out .uploaded-cookbook-version.json
           cookbook_file_path = File.join(file_path, cookbook_name)
-          if !File.exists?(cookbook_file_path)
+          if !File.exist?(cookbook_file_path)
             FileUtils.mkdir_p(cookbook_file_path)
           end
           uploaded_cookbook_version_path = File.join(cookbook_file_path, Chef::Cookbook::CookbookVersionLoader::UPLOADED_COOKBOOK_VERSION_FILE)

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
@@ -88,7 +88,7 @@ class Chef
 
         def make_child_entry(name)
           paths = child_paths[name].select do |path|
-            File.exists?(path)
+            File.exist?(path)
           end
           if paths.size == 0
             return nil

--- a/lib/chef/chef_fs/file_system/file_system_entry.rb
+++ b/lib/chef/chef_fs/file_system/file_system_entry.rb
@@ -80,7 +80,7 @@ class Chef
         end
 
         def exists?
-          File.exists?(file_path)
+          File.exist?(file_path)
         end
 
         def read

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -314,7 +314,7 @@ class Chef
       if !config[:client_key]
         @events.skipping_registration(client_name, config)
         Chef::Log.debug("Client key is unspecified - skipping registration")
-      elsif File.exists?(config[:client_key])
+      elsif File.exist?(config[:client_key])
         @events.skipping_registration(client_name, config)
         Chef::Log.debug("Client key #{config[:client_key]} is present - skipping registration")
       else
@@ -461,7 +461,7 @@ class Chef
     end
 
     def empty_directory?(path)
-      !File.exists?(path) || (Dir.entries(path).size <= 2)
+      !File.exist?(path) || (Dir.entries(path).size <= 2)
     end
 
     def is_last_element?(index, object)

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -259,7 +259,7 @@ class Chef
 
     # Returns true only if the path exists and is readable and writeable for the user.
     def self.path_accessible?(path)
-      File.exists?(path) && File.readable?(path) && File.writable?(path)
+      File.exist?(path) && File.readable?(path) && File.writable?(path)
     end
 
     # Where cookbook files are stored on the server (by content checksum)

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -61,13 +61,13 @@ class Chef
 
         remove_ignored_files
 
-        if File.exists?(File.join(@cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE))
+        if File.exist?(File.join(@cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE))
           @uploaded_cookbook_version_file = File.join(@cookbook_path, UPLOADED_COOKBOOK_VERSION_FILE)
         end
 
-        if File.exists?(File.join(@cookbook_path, "metadata.rb"))
+        if File.exist?(File.join(@cookbook_path, "metadata.rb"))
           @metadata_filenames << File.join(@cookbook_path, "metadata.rb")
-        elsif File.exists?(File.join(@cookbook_path, "metadata.json"))
+        elsif File.exist?(File.join(@cookbook_path, "metadata.json"))
           @metadata_filenames << File.join(@cookbook_path, "metadata.json")
         elsif @uploaded_cookbook_version_file
           @metadata_filenames << @uploaded_cookbook_version_file

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -497,7 +497,7 @@ class Chef
     end
 
     def reload_metadata!
-      if File.exists?(metadata_json_file)
+      if File.exist?(metadata_json_file)
         metadata.from_json(IO.read(metadata_json_file))
       end
     end

--- a/lib/chef/deprecation/provider/cookbook_file.rb
+++ b/lib/chef/deprecation/provider/cookbook_file.rb
@@ -44,7 +44,7 @@ class Chef
         end
 
         def backup_new_resource
-          if ::File.exists?(@new_resource.path)
+          if ::File.exist?(@new_resource.path)
             backup @new_resource.path
           end
         end

--- a/lib/chef/deprecation/provider/file.rb
+++ b/lib/chef/deprecation/provider/file.rb
@@ -51,10 +51,10 @@ class Chef
           suppress_resource_reporting = false
 
           return [ "(diff output suppressed by config)" ] if Chef::Config[:diff_disabled]
-          return [ "(no temp file with new content, diff output suppressed)" ] unless ::File.exists?(temp_path)  # should never happen?
+          return [ "(no temp file with new content, diff output suppressed)" ] unless ::File.exist?(temp_path)  # should never happen?
 
           # solaris does not support diff -N, so create tempfile to diff against if we are creating a new file
-          target_path = if ::File.exists?(@current_resource.path)
+          target_path = if ::File.exist?(@current_resource.path)
                           @current_resource.path
                         else
                           suppress_resource_reporting = true  # suppress big diffs going to resource reporting service
@@ -117,7 +117,7 @@ class Chef
             description << "update content in file #{@new_resource.path} from #{short_cksum(@current_resource.checksum)} to #{short_cksum(new_resource_content_checksum)}"
             description << diff_current_from_content(@new_resource.content)
             converge_by(description) do
-              backup @new_resource.path if ::File.exists?(@new_resource.path)
+              backup @new_resource.path if ::File.exist?(@new_resource.path)
               ::File.open(@new_resource.path, "w") {|f| f.write @new_resource.content }
               Chef::Log.info("#{@new_resource} contents updated")
             end

--- a/lib/chef/deprecation/provider/remote_file.rb
+++ b/lib/chef/deprecation/provider/remote_file.rb
@@ -33,7 +33,7 @@ class Chef
 
         def matches_current_checksum?(candidate_file)
           Chef::Log.debug "#{@new_resource} checking for file existence of #{@new_resource.path}"
-          if ::File.exists?(@new_resource.path)
+          if ::File.exist?(@new_resource.path)
             Chef::Log.debug "#{@new_resource} file exists at #{@new_resource.path}"
             @new_resource.checksum(checksum(candidate_file.path))
             Chef::Log.debug "#{@new_resource} target checksum: #{@current_resource.checksum}"
@@ -47,7 +47,7 @@ class Chef
         end
 
         def backup_new_resource
-          if ::File.exists?(@new_resource.path)
+          if ::File.exist?(@new_resource.path)
             Chef::Log.debug "#{@new_resource} checksum changed from #{@current_resource.checksum} to #{@new_resource.checksum}"
             backup @new_resource.path
           end

--- a/lib/chef/dsl/reboot_pending.rb
+++ b/lib/chef/dsl/reboot_pending.rb
@@ -51,7 +51,7 @@ class Chef
                 [1,2,3].include?(registry_get_values('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').select { |v| v[:name] == "Flags" }[0][:data]))
         elsif platform?("ubuntu")
           # This should work for Debian as well if update-notifier-common happens to be installed. We need an API for that.
-          File.exists?('/var/run/reboot-required')
+          File.exist?('/var/run/reboot-required')
         else
           raise Chef::Exceptions::UnsupportedPlatform.new(node[:platform])
         end

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -252,10 +252,10 @@ class Chef
       js_file = File.join(Chef::Config[:environment_path], "#{name}.json")
       rb_file = File.join(Chef::Config[:environment_path], "#{name}.rb")
 
-      if File.exists?(js_file)
+      if File.exist?(js_file)
         # from_json returns object.class => json_class in the JSON.
         Chef::JSONCompat.from_json(IO.read(js_file))
-      elsif File.exists?(rb_file)
+      elsif File.exist?(rb_file)
         environment = Chef::Environment.new
         environment.name(name)
         environment.from_file(rb_file)

--- a/lib/chef/file_access_control/windows.rb
+++ b/lib/chef/file_access_control/windows.rb
@@ -114,7 +114,7 @@ class Chef
       end
 
       def should_update_dacl?
-        return true unless ::File.exists?(file)
+        return true unless ::File.exist?(file)
         dacl = target_dacl
         existing_dacl = existing_descriptor.dacl
         inherits = target_inherits
@@ -147,7 +147,7 @@ class Chef
       end
 
       def should_update_group?
-        return true unless ::File.exists?(file)
+        return true unless ::File.exist?(file)
         (group = target_group) && (group != existing_descriptor.group)
       end
 
@@ -166,7 +166,7 @@ class Chef
       end
 
       def should_update_owner?
-        return true unless ::File.exists?(file)
+        return true unless ::File.exist?(file)
         (owner = target_owner) && (owner != existing_descriptor.owner)
       end
 

--- a/lib/chef/file_cache.rb
+++ b/lib/chef/file_cache.rb
@@ -78,7 +78,7 @@ class Chef
 
         file_path_array = File.split(path)
         file_name = file_path_array.pop
-        if File.exists?(file) && File.writable?(file)
+        if File.exist?(file) && File.writable?(file)
           FileUtils.mv(
             file,
             File.join(create_cache_path(File.join(file_path_array), true), file_name)
@@ -111,7 +111,7 @@ class Chef
           }
         )
         cache_path = create_cache_path(path, false)
-        raise Chef::Exceptions::FileNotFound, "Cannot find #{cache_path} for #{path}!" unless File.exists?(cache_path)
+        raise Chef::Exceptions::FileNotFound, "Cannot find #{cache_path} for #{path}!" unless File.exist?(cache_path)
         if read
           File.read(cache_path)
         else
@@ -137,7 +137,7 @@ class Chef
           }
         )
         cache_path = create_cache_path(path, false)
-        if File.exists?(cache_path)
+        if File.exist?(cache_path)
           File.unlink(cache_path)
         end
         true
@@ -184,7 +184,7 @@ class Chef
           }
         )
         full_path = create_cache_path(path, false)
-        if File.exists?(full_path)
+        if File.exist?(full_path)
           true
         else
           false

--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -64,7 +64,7 @@ class Chef
           return nil if dynamic_resource?
           @snippet ||= begin
             if file = resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1] and line = resource.source_line[/^#{file}:([\d]+)/,1].to_i
-              return nil unless ::File.exists?(file)
+              return nil unless ::File.exist?(file)
               lines = IO.readlines(file)
 
               relevant_lines = ["# In #{file}\n\n"]

--- a/lib/chef/handler/json_file.rb
+++ b/lib/chef/handler/json_file.rb
@@ -52,7 +52,7 @@ class Chef
       end
 
       def build_report_dir
-        unless File.exists?(config[:path])
+        unless File.exist?(config[:path])
           FileUtils.mkdir_p(config[:path])
           File.chmod(00700, config[:path])
         end

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -89,10 +89,10 @@ class Chef
           unless (config[:ssl_client_cert] && config[:ssl_client_key])
             raise Chef::Exceptions::ConfigurationError, "You must configure ssl_client_cert and ssl_client_key together"
           end
-          unless ::File.exists?(config[:ssl_client_cert])
+          unless ::File.exist?(config[:ssl_client_cert])
             raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_cert #{config[:ssl_client_cert]} does not exist"
           end
-          unless ::File.exists?(config[:ssl_client_key])
+          unless ::File.exist?(config[:ssl_client_key])
             raise Chef::Exceptions::ConfigurationError, "The configured ssl_client_key #{config[:ssl_client_key]} does not exist"
           end
           http_client.cert = OpenSSL::X509::Certificate.new(::File.read(config[:ssl_client_cert]))

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -189,7 +189,7 @@ class Chef
 
         template = Array(bootstrap_files).find do |bootstrap_template|
           Chef::Log.debug("Looking for bootstrap template in #{File.dirname(bootstrap_template)}")
-          File.exists?(bootstrap_template)
+          File.exist?(bootstrap_template)
         end
 
         unless template

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -126,7 +126,7 @@ EOH
         config[:config_file] ||= ask_question("Where should I put the config file? ", :default => "#{Chef::Config[:user_home]}/.chef/knife.rb")
         # have to use expand path to expand the tilde character to the user's home
         config[:config_file] = File.expand_path(config[:config_file])
-        if File.exists?(config[:config_file])
+        if File.exist?(config[:config_file])
           confirm("Overwrite #{config[:config_file]}")
         end
       end

--- a/lib/chef/knife/cookbook_create.rb
+++ b/lib/chef/knife/cookbook_create.rb
@@ -89,7 +89,7 @@ class Chef
         FileUtils.mkdir_p "#{File.join(dir, cookbook_name, "providers")}"
         FileUtils.mkdir_p "#{File.join(dir, cookbook_name, "files", "default")}"
         FileUtils.mkdir_p "#{File.join(dir, cookbook_name, "templates", "default")}"
-        unless File.exists?(File.join(dir, cookbook_name, "recipes", "default.rb"))
+        unless File.exist?(File.join(dir, cookbook_name, "recipes", "default.rb"))
           open(File.join(dir, cookbook_name, "recipes", "default.rb"), "w") do |file|
             file.puts <<-EOH
 #
@@ -182,7 +182,7 @@ EOH
 
       def create_changelog(dir, cookbook_name)
         msg("** Creating CHANGELOG for cookbook: #{cookbook_name}")
-        unless File.exists?(File.join(dir,cookbook_name,'CHANGELOG.md'))
+        unless File.exist?(File.join(dir,cookbook_name,'CHANGELOG.md'))
           open(File.join(dir, cookbook_name, 'CHANGELOG.md'),'w') do |file|
             file.puts <<-EOH
 #{cookbook_name} CHANGELOG
@@ -205,7 +205,7 @@ EOH
 
       def create_readme(dir, cookbook_name, readme_format)
         msg("** Creating README for cookbook: #{cookbook_name}")
-        unless File.exists?(File.join(dir, cookbook_name, "README.#{readme_format}"))
+        unless File.exist?(File.join(dir, cookbook_name, "README.#{readme_format}"))
           open(File.join(dir, cookbook_name, "README.#{readme_format}"), "w") do |file|
             case readme_format
             when "rdoc"
@@ -415,9 +415,9 @@ EOH
                          "All rights reserved"
                        end
 
-        unless File.exists?(File.join(dir, cookbook_name, "metadata.rb"))
+        unless File.exist?(File.join(dir, cookbook_name, "metadata.rb"))
           open(File.join(dir, cookbook_name, "metadata.rb"), "w") do |file|
-            if File.exists?(File.join(dir, cookbook_name, "README.#{readme_format}"))
+            if File.exist?(File.join(dir, cookbook_name, "README.#{readme_format}"))
               long_description = "long_description IO.read(File.join(File.dirname(__FILE__), 'README.#{readme_format}'))"
             end
             file.puts <<-EOH

--- a/lib/chef/knife/cookbook_download.rb
+++ b/lib/chef/knife/cookbook_download.rb
@@ -73,7 +73,7 @@ class Chef
         manifest = cookbook.manifest
 
         basedir = File.join(config[:download_directory], "#{@cookbook_name}-#{cookbook.version}")
-        if File.exists?(basedir)
+        if File.exist?(basedir)
           if config[:force]
             Chef::Log.debug("Deleting #{basedir}")
             FileUtils.rm_rf(basedir)

--- a/lib/chef/knife/cookbook_metadata.rb
+++ b/lib/chef/knife/cookbook_metadata.rb
@@ -63,7 +63,7 @@ class Chef
       def generate_metadata(cookbook)
         Array(config[:cookbook_path]).reverse.each do |path|
           file = File.expand_path(File.join(path, cookbook, 'metadata.rb'))
-          if File.exists?(file)
+          if File.exist?(file)
             generate_metadata_from_file(cookbook, file)
           else
             validate_metadata_json(path, cookbook)

--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -102,7 +102,7 @@ class Chef
         end
 
         def file_exists_and_is_readable?(file)
-          File.exists?(file) && File.readable?(file)
+          File.exist?(file) && File.readable?(file)
         end
 
       end

--- a/lib/chef/knife/exec.rb
+++ b/lib/chef/knife/exec.rb
@@ -63,7 +63,7 @@ class Chef::Knife::Exec < Chef::Knife
   def find_script(x)
     # Try to find a script. First try expanding the path given.
     script = File.expand_path(x)
-    return script if File.exists?(script)
+    return script if File.exist?(script)
 
     # Failing that, try searching the script path. If we can't find
     # anything, fail gracefully.
@@ -73,7 +73,7 @@ class Chef::Knife::Exec < Chef::Knife
       path = File.expand_path(path)
       test = File.join(path, x)
       Chef::Log.debug("Testing: #{test}")
-      if File.exists?(test)
+      if File.exist?(test)
         script = test
         Chef::Log.debug("Found: #{test}")
         return script

--- a/lib/chef/knife/help.rb
+++ b/lib/chef/knife/help.rb
@@ -90,7 +90,7 @@ MOAR_HELP
       end
 
       def find_manpage_path(topic)
-        if ::File.exists?(::File.expand_path("../distro/common/man/man1/#{topic}.1", CHEF_ROOT))
+        if ::File.exist?(::File.expand_path("../distro/common/man/man1/#{topic}.1", CHEF_ROOT))
           # If we've provided the man page in the gem, give that
           return ::File.expand_path("../distro/common/man/man1/#{topic}.1", CHEF_ROOT)
         else

--- a/lib/chef/mixin/command.rb
+++ b/lib/chef/mixin/command.rb
@@ -92,7 +92,7 @@ class Chef
 
         # TODO: This is the wrong place for this responsibility.
         if args.has_key?(:creates)
-          if File.exists?(args[:creates])
+          if File.exist?(args[:creates])
             Chef::Log.debug("Skipping #{args[:command]} - creates #{args[:creates]} exists.")
             return false
           end

--- a/lib/chef/mixin/from_file.rb
+++ b/lib/chef/mixin/from_file.rb
@@ -26,7 +26,7 @@ class Chef
       #
       # Raises an IOError if the file cannot be found, or is not readable.
       def from_file(filename)
-        if File.exists?(filename) && File.readable?(filename)
+        if File.exist?(filename) && File.readable?(filename)
           self.instance_eval(IO.read(filename), filename, 1)
         else
           raise IOError, "Cannot open or read #{filename}!"
@@ -38,7 +38,7 @@ class Chef
       #
       # Raises an IOError if the file cannot be found, or is not readable.
       def class_from_file(filename)
-        if File.exists?(filename) && File.readable?(filename)
+        if File.exist?(filename) && File.readable?(filename)
           self.class_eval(IO.read(filename), filename, 1)
         else
           raise IOError, "Cannot open or read #{filename}!"

--- a/lib/chef/mixin/get_source_from_package.rb
+++ b/lib/chef/mixin/get_source_from_package.rb
@@ -31,7 +31,7 @@ class Chef
         super
         # if we're passed something that looks like a filesystem path, with no source, use it
         #  - require at least one '/' in the path to avoid gem_package "foo" breaking if a file named 'foo' exists in the cwd
-        if new_resource.source.nil? && new_resource.package_name.match(/#{::File::SEPARATOR}/) && ::File.exists?(new_resource.package_name)
+        if new_resource.source.nil? && new_resource.package_name.match(/#{::File::SEPARATOR}/) && ::File.exist?(new_resource.package_name)
           Chef::Log.debug("No package source specified, but #{new_resource.package_name} exists on the filesystem, copying to package source")
           new_resource.source(@new_resource.package_name)
         end

--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -205,7 +205,7 @@ class Chef
           # step, we still want to keep going in whyrun mode.
           #
           # assert(:create, :create_if_missing) do |a|
-          #   a.assertion { File::exists?(@new_resource.source) }
+          #   a.assertion { File.exist?(@new_resource.source) }
           #   a.whyrun "Template source file does not exist, assuming it would have been created."
           #   a.block_action!
           # end

--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -461,9 +461,9 @@ class Chef
       end
 
       def save_release_state
-        if ::File.exists?(@new_resource.current_path)
+        if ::File.exist?(@new_resource.current_path)
           release = ::File.readlink(@new_resource.current_path)
-          @previous_release_path = release if ::File.exists?(release)
+          @previous_release_path = release if ::File.exist?(release)
         end
       end
 

--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -34,7 +34,7 @@ class Chef
       def load_current_resource
         @current_resource = Chef::Resource::Directory.new(@new_resource.name)
         @current_resource.path(@new_resource.path)
-        if ::File.exists?(@current_resource.path) && @action != :create_if_missing
+        if ::File.exist?(@current_resource.path) && @action != :create_if_missing
           load_resource_attributes_from_file(@current_resource)
         end
         @current_resource
@@ -58,7 +58,7 @@ class Chef
               # make sure we have write permissions to that directory
               is_parent_writable = lambda do |base_dir|
                 base_dir = ::File.dirname(base_dir)
-                if ::File.exists?(base_dir)
+                if ::File.exist?(base_dir)
                   ::File.writable?(base_dir)
                 else
                   is_parent_writable.call(base_dir)
@@ -68,7 +68,7 @@ class Chef
             else
               # in why run mode & parent directory does not exist no permissions check is required
               # If not in why run, permissions must be valid and we rely on prior assertion that dir exists
-              if !whyrun_mode? || ::File.exists?(parent_directory)
+              if !whyrun_mode? || ::File.exist?(parent_directory)
                 ::File.writable?(parent_directory)
               else
                 true
@@ -81,7 +81,7 @@ class Chef
 
         requirements.assert(:delete) do |a|
           a.assertion do
-            if ::File.exists?(@new_resource.path)
+            if ::File.exist?(@new_resource.path)
               ::File.directory?(@new_resource.path) && ::File.writable?(@new_resource.path)
             else
               true
@@ -95,7 +95,7 @@ class Chef
       end
 
       def action_create
-        unless ::File.exists?(@new_resource.path)
+        unless ::File.exist?(@new_resource.path)
           converge_by("create new directory #{@new_resource.path}") do
             if @new_resource.recursive == true
               ::FileUtils.mkdir_p(@new_resource.path)
@@ -111,7 +111,7 @@ class Chef
       end
 
       def action_delete
-        if ::File.exists?(@new_resource.path)
+        if ::File.exist?(@new_resource.path)
           converge_by("delete existing directory #{@new_resource.path}") do
             if @new_resource.recursive == true
               FileUtils.rm_rf(@new_resource.path)

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -72,11 +72,11 @@ class Chef
             Chef::Log.warn "You have provided relative path for execute#creates (#{sentinel_file}) without execute#cwd (see CHEF-3819)"
           end
 
-          if ::File.exists?(sentinel_file)
+          if ::File.exist?(sentinel_file)
             sentinel_file
           elsif cwd && relative
             sentinel_file = ::File.join(cwd, sentinel_file)
-            sentinel_file if ::File.exists?(sentinel_file)
+            sentinel_file if ::File.exist?(sentinel_file)
           end
         end
       end

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -74,7 +74,7 @@ class Chef
         # Let children resources override constructing the @current_resource
         @current_resource ||= Chef::Resource::File.new(@new_resource.name)
         @current_resource.path(@new_resource.path)
-        if ::File.exists?(@current_resource.path) && ::File.file?(::File.realpath(@current_resource.path))
+        if ::File.exist?(@current_resource.path) && ::File.file?(::File.realpath(@current_resource.path))
           if managing_content?
             Chef::Log.debug("#{@new_resource} checksumming file at #{@new_resource.path}.")
             @current_resource.checksum(checksum(@current_resource.path))
@@ -96,7 +96,7 @@ class Chef
         end
 
         # Make sure the file is deletable if it exists, otherwise fail.
-        if ::File.exists?(@new_resource.path)
+        if ::File.exist?(@new_resource.path)
           requirements.assert(:delete) do |a|
             a.assertion { ::File.writable?(@new_resource.path) }
             a.failure_message(Chef::Exceptions::InsufficientPermissions,"File #{@new_resource.path} exists but is not writable so it cannot be deleted")
@@ -125,7 +125,7 @@ class Chef
       end
 
       def action_create_if_missing
-        if ::File.exists?(@new_resource.path)
+        if ::File.exist?(@new_resource.path)
           Chef::Log.debug("#{@new_resource} exists at #{@new_resource.path} taking no action.")
         else
           action_create
@@ -133,7 +133,7 @@ class Chef
       end
 
       def action_delete
-        if ::File.exists?(@new_resource.path)
+        if ::File.exist?(@new_resource.path)
           converge_by("delete file #{@new_resource.path}") do
             do_backup unless file_class.symlink?(@new_resource.path)
             ::File.delete(@new_resource.path)
@@ -314,7 +314,7 @@ class Chef
 
       def do_create_file
         @file_created = false
-        if !::File.exists?(@new_resource.path) || file_unlinked?
+        if !::File.exist?(@new_resource.path) || file_unlinked?
           converge_by("create new file #{@new_resource.path}") do
             deployment_strategy.create(@new_resource.path)
             Chef::Log.info("#{@new_resource} created file #{@new_resource.path}")
@@ -349,7 +349,7 @@ class Chef
         # a nil tempfile is okay, means the resource has no content or no new content
         return if tempfile.nil?
         # but a tempfile that has no path or doesn't exist should not happen
-        if tempfile.path.nil? || !::File.exists?(tempfile.path)
+        if tempfile.path.nil? || !::File.exist?(tempfile.path)
           raise "chef-client is confused, trying to deploy a file that has no path or does not exist..."
         end
 

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -109,7 +109,7 @@ class Chef
         def define_resource_requirements
           super
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exists?("/usr/bin/dscl") }
+            a.assertion { ::File.exist?("/usr/bin/dscl") }
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/bin/dscl for #{@new_resource.name}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end

--- a/lib/chef/provider/group/gpasswd.rb
+++ b/lib/chef/provider/group/gpasswd.rb
@@ -33,7 +33,7 @@ class Chef
         def define_resource_requirements
           super
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exists?("/usr/bin/gpasswd") }
+            a.assertion { ::File.exist?("/usr/bin/gpasswd") }
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/bin/gpasswd for #{@new_resource}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -35,7 +35,7 @@ class Chef
           super
           required_binaries.each do |required_binary|
             requirements.assert(:all_actions) do |a|
-              a.assertion { ::File.exists?(required_binary) }
+              a.assertion { ::File.exist?(required_binary) }
               a.failure_message Chef::Exceptions::Group, "Could not find binary #{required_binary} for #{@new_resource}"
               # No whyrun alternative: this component should be available in the base install of any given system that uses it
             end

--- a/lib/chef/provider/group/groupmod.rb
+++ b/lib/chef/provider/group/groupmod.rb
@@ -28,7 +28,7 @@ class Chef
         def load_current_resource
           super
           [ "group", "user" ].each do |binary|
-            raise Chef::Exceptions::Group, "Could not find binary /usr/sbin/#{binary} for #{@new_resource}" unless ::File.exists?("/usr/sbin/#{binary}")
+            raise Chef::Exceptions::Group, "Could not find binary /usr/sbin/#{binary} for #{@new_resource}" unless ::File.exist?("/usr/sbin/#{binary}")
           end
         end
 

--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -29,7 +29,7 @@ class Chef
           super
 
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exists?("/usr/sbin/pw") }
+            a.assertion { ::File.exist?("/usr/sbin/pw") }
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/sbin/pw for #{@new_resource}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end

--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -33,7 +33,7 @@ class Chef
         def define_resource_requirements
           super
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exists?("/usr/sbin/groupmod") }
+            a.assertion { ::File.exist?("/usr/sbin/groupmod") }
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/sbin/groupmod for #{@new_resource.name}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -34,7 +34,7 @@ class Chef
           super
 
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exists?("/usr/sbin/usermod") }
+            a.assertion { ::File.exist?("/usr/sbin/usermod") }
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/sbin/usermod for #{@new_resource}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end

--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -67,7 +67,7 @@ iface <%= @new_resource.device %> inet static
           # roll our own file_edit resource, this will not get reported until we have a file_edit resource
           interfaces_dot_d_for_regexp = INTERFACES_DOT_D_DIR.gsub(/\./, '\.')  # escape dots for the regexp
           regexp = %r{^\s*source\s+#{interfaces_dot_d_for_regexp}/\*\s*$}
-          unless ::File.exists?(INTERFACES_FILE) && regexp.match(IO.read(INTERFACES_FILE))
+          unless ::File.exist?(INTERFACES_FILE) && regexp.match(IO.read(INTERFACES_FILE))
             converge_by("modifying #{INTERFACES_FILE} to source #{INTERFACES_DOT_D_DIR}") do
               conf = Chef::Util::FileEdit.new(INTERFACES_FILE)
               conf.insert_line_if_no_match(regexp, "source #{INTERFACES_DOT_D_DIR}/*")

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -55,8 +55,8 @@ class Chef
           )
         else
           @current_resource.link_type(:hard)
-          if ::File.exists?(@current_resource.target_file)
-            if ::File.exists?(@new_resource.to) &&
+          if ::File.exist?(@current_resource.target_file)
+            if ::File.exist?(@new_resource.to) &&
                file_class.stat(@current_resource.target_file).ino ==
                file_class.stat(@new_resource.to).ino
               @current_resource.to(canonicalize(@new_resource.to))

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -42,9 +42,9 @@ class Chef
 
         def mountable?
           # only check for existence of non-remote devices
-          if (device_should_exist? && !::File.exists?(device_real) )
+          if (device_should_exist? && !::File.exist?(device_real) )
             raise Chef::Exceptions::Mount, "Device #{@new_resource.device} does not exist"
-          elsif( @new_resource.mount_point != "none" && !::File.exists?(@new_resource.mount_point) )
+          elsif( @new_resource.mount_point != "none" && !::File.exist?(@new_resource.mount_point) )
             raise Chef::Exceptions::Mount, "Mount point #{@new_resource.mount_point} does not exist"
           end
           return true
@@ -79,7 +79,7 @@ class Chef
           # "mount" outputs the mount points as real paths. Convert
           # the mount_point of the resource to a real path in case it
           # contains symlinks in its parents dirs.
-          real_mount_point = if ::File.exists? @new_resource.mount_point
+          real_mount_point = if ::File.exist? @new_resource.mount_point
                                ::File.realpath(@new_resource.mount_point)
                              else
                                @new_resource.mount_point

--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -47,7 +47,7 @@ class Chef
           @new_resource.version(nil)
 
           if @new_resource.source
-            @package_source_found = ::File.exists?(@new_resource.source)
+            @package_source_found = ::File.exist?(@new_resource.source)
             if @package_source_found
               Chef::Log.debug("#{@new_resource} checking pkg status")
               status = popen4("installp -L -d #{@new_resource.source}") do |pid, stdin, stdout, stderr|

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -54,7 +54,7 @@ class Chef
           @new_resource.version(nil)
 
           if @new_resource.source
-            @source_exists = ::File.exists?(@new_resource.source)
+            @source_exists = ::File.exist?(@new_resource.source)
             if @source_exists
               # Get information from the package if supplied
               Chef::Log.debug("#{@new_resource} checking dpkg status")

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -55,7 +55,7 @@ class Chef
 
           repos = ["extra","core","community"]
 
-          if(::File.exists?("/etc/pacman.conf"))
+          if(::File.exist?("/etc/pacman.conf"))
             pacman = ::File.read("/etc/pacman.conf")
             repos = pacman.scan(/\[(.+)\]/).flatten
           end

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -51,7 +51,7 @@ class Chef
           @new_resource.version(nil)
 
           if @new_resource.source
-            unless ::File.exists?(@new_resource.source)
+            unless ::File.exist?(@new_resource.source)
               @package_source_exists = false
               return
             end

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -410,7 +410,7 @@ class Chef
         def find_gem_by_path
           Chef::Log.debug("#{@new_resource} searching for 'gem' binary in path: #{ENV['PATH']}")
           separator = ::File::ALT_SEPARATOR ? ::File::ALT_SEPARATOR : ::File::SEPARATOR
-          path_to_first_gem = ENV['PATH'].split(::File::PATH_SEPARATOR).select { |path| ::File.exists?(path + separator + "gem") }.first
+          path_to_first_gem = ENV['PATH'].split(::File::PATH_SEPARATOR).select { |path| ::File.exist?(path + separator + "gem") }.first
           raise Chef::Exceptions::FileNotFound, "Unable to find 'gem' binary in path: #{ENV['PATH']}" if path_to_first_gem.nil?
           path_to_first_gem + separator + "gem"
         end

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -50,7 +50,7 @@ class Chef
           @new_resource.version(nil)
 
           if @new_resource.source
-            @package_source_found = ::File.exists?(@new_resource.source)
+            @package_source_found = ::File.exist?(@new_resource.source)
             if @package_source_found
               Chef::Log.debug("#{@new_resource} checking pkg status")
               status = popen4("pkginfo -l -d #{@new_resource.source} #{@new_resource.package_name}") do |pid, stdin, stdout, stderr|

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1068,7 +1068,7 @@ class Chef
           @current_resource.package_name(@new_resource.package_name)
 
           if @new_resource.source
-            unless ::File.exists?(@new_resource.source)
+            unless ::File.exist?(@new_resource.source)
               raise Chef::Exceptions::Package, "Package #{@new_resource.name} not found: #{@new_resource.source}"
             end
 

--- a/lib/chef/provider/service/arch.rb
+++ b/lib/chef/provider/service/arch.rb
@@ -26,7 +26,7 @@ class Chef::Provider::Service::Arch < Chef::Provider::Service::Init
   end
 
   def load_current_resource
-    raise Chef::Exceptions::Service, "Could not find /etc/rc.conf"  unless ::File.exists?("/etc/rc.conf")
+    raise Chef::Exceptions::Service, "Could not find /etc/rc.conf"  unless ::File.exist?("/etc/rc.conf")
     raise Chef::Exceptions::Service, "No DAEMONS found in /etc/rc.conf"  unless ::File.read("/etc/rc.conf").match(/DAEMONS=\((.*)\)/m)
     super
 

--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -39,7 +39,7 @@ class Chef
           shared_resource_requirements
           requirements.assert(:all_actions) do |a|
             update_rcd = "/usr/sbin/update-rc.d"
-            a.assertion { ::File.exists? update_rcd }
+            a.assertion { ::File.exist? update_rcd }
             a.failure_message Chef::Exceptions::Service, "#{update_rcd} does not exist!"
             # no whyrun recovery - this is a base system component of debian
             # distros and must be present

--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -34,9 +34,9 @@ class Chef
           @rcd_script_found = true
           @enabled_state_found = false
           # Determine if we're talking about /etc/rc.d or /usr/local/etc/rc.d
-          if ::File.exists?("/etc/rc.d/#{current_resource.service_name}")
+          if ::File.exist?("/etc/rc.d/#{current_resource.service_name}")
             @init_command = "/etc/rc.d/#{current_resource.service_name}"
-          elsif ::File.exists?("/usr/local/etc/rc.d/#{current_resource.service_name}")
+          elsif ::File.exist?("/usr/local/etc/rc.d/#{current_resource.service_name}")
             @init_command = "/usr/local/etc/rc.d/#{current_resource.service_name}"
           else
             @rcd_script_found = false
@@ -47,7 +47,7 @@ class Chef
           # Default to disabled if the service doesn't currently exist
           # at all
           var_name = service_enable_variable_name
-          if ::File.exists?("/etc/rc.conf") && var_name
+          if ::File.exist?("/etc/rc.conf") && var_name
             read_rc_conf.each do |line|
               case line
               when /#{Regexp.escape(var_name)}="(\w+)"/

--- a/lib/chef/provider/service/gentoo.rb
+++ b/lib/chef/provider/service/gentoo.rb
@@ -31,7 +31,7 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
     @current_resource.enabled(
       Dir.glob("/etc/runlevels/**/#{@current_resource.service_name}").any? do |file|
         @found_script = true
-        exists = ::File.exists? file
+        exists = ::File.exist? file
         readable = ::File.readable? file
         Chef::Log.debug "#{@new_resource} exists: #{exists}, readable: #{readable}"
         exists and readable
@@ -44,7 +44,7 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
 
   def define_resource_requirements
     requirements.assert(:all_actions) do |a|
-      a.assertion { ::File.exists?("/sbin/rc-update") }
+      a.assertion { ::File.exist?("/sbin/rc-update") }
       a.failure_message Chef::Exceptions::Service, "/sbin/rc-update does not exist"
       # no whyrun recovery -t his is a core component whose presence is
       # unlikely to be affected by what we do in the course of a chef run

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -40,7 +40,7 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             chkconfig_file = "/sbin/chkconfig"
-            a.assertion { ::File.exists? chkconfig_file  }
+            a.assertion { ::File.exist? chkconfig_file  }
             a.failure_message Chef::Exceptions::Service, "#{chkconfig_file} does not exist!"
           end
 
@@ -54,7 +54,7 @@ class Chef
         def load_current_resource
           super
 
-          if ::File.exists?("/sbin/chkconfig")
+          if ::File.exist?("/sbin/chkconfig")
             chkconfig = shell_out!("/sbin/chkconfig --list #{@current_resource.service_name}", :returns => [0,1])
             @current_resource.enabled(!!(chkconfig.stdout =~ CHKCONFIG_ON))
             @service_missing = !!(chkconfig.stderr =~ CHKCONFIG_MISSING)

--- a/lib/chef/provider/service/solaris.rb
+++ b/lib/chef/provider/service/solaris.rb
@@ -39,7 +39,7 @@ class Chef
         def load_current_resource
           @current_resource = Chef::Resource::Service.new(@new_resource.name)
           @current_resource.service_name(@new_resource.service_name)
-          unless ::File.exists? "/bin/svcs"
+          unless ::File.exist? "/bin/svcs"
             raise Chef::Exceptions::Service, "/bin/svcs does not exist!"
           end
           @status = service_status.enabled

--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -119,7 +119,7 @@ class Chef
             end
           end
           # Get enabled/disabled state by reading job configuration file
-          if ::File.exists?("#{@upstart_job_dir}/#{@new_resource.service_name}#{@upstart_conf_suffix}")
+          if ::File.exist?("#{@upstart_job_dir}/#{@new_resource.service_name}#{@upstart_conf_suffix}")
             Chef::Log.debug("#{@new_resource} found #{@upstart_job_dir}/#{@new_resource.service_name}#{@upstart_conf_suffix}")
             ::File.open("#{@upstart_job_dir}/#{@new_resource.service_name}#{@upstart_conf_suffix}",'r') do |file|
               while line = file.gets

--- a/lib/chef/provider/template.rb
+++ b/lib/chef/provider/template.rb
@@ -45,7 +45,7 @@ class Chef
         super
 
         requirements.assert(:create, :create_if_missing) do |a|
-          a.assertion { ::File::exists?(content.template_location) }
+          a.assertion { ::File.exist?(content.template_location) }
           a.failure_message "Template source #{content.template_location} could not be found."
           a.whyrun "Template source #{content.template_location} does not exist. Assuming it would have been created."
           a.block_action!

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -147,7 +147,7 @@ class Chef
 
         def load_current_resource
           super
-          raise Chef::Exceptions::User, "Could not find binary /usr/bin/dscl for #{@new_resource}" unless ::File.exists?("/usr/bin/dscl")
+          raise Chef::Exceptions::User, "Could not find binary /usr/bin/dscl for #{@new_resource}" unless ::File.exist?("/usr/bin/dscl")
         end
 
         def create_user
@@ -191,7 +191,7 @@ class Chef
         end
 
         def dscl_set_shell
-          if @new_resource.password || ::File.exists?("#{@new_resource.shell}")
+          if @new_resource.password || ::File.exist?("#{@new_resource.shell}")
             safe_dscl("create /Users/#{@new_resource.username} UserShell '#{@new_resource.shell}'")
           else
             safe_dscl("create /Users/#{@new_resource.username} UserShell '/usr/bin/false'")
@@ -259,7 +259,7 @@ class Chef
 
         def ditto_home
           skel = "/System/Library/User Template/English.lproj"
-          raise(Chef::Exceptions::User,"can't find skel at: #{skel}") unless ::File.exists?(skel)
+          raise(Chef::Exceptions::User,"can't find skel at: #{skel}") unless ::File.exist?(skel)
           shell_out! "ditto '#{skel}' '#{@new_resource.home}'"
           ::FileUtils.chown_R(@new_resource.username,@new_resource.gid.to_s,@new_resource.home)
         end

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -25,7 +25,7 @@ class Chef
 
         def load_current_resource
           super
-          raise Chef::Exceptions::User, "Could not find binary /usr/sbin/pw for #{@new_resource}" unless ::File.exists?("/usr/sbin/pw")
+          raise Chef::Exceptions::User, "Could not find binary /usr/sbin/pw for #{@new_resource}" unless ::File.exist?("/usr/sbin/pw")
         end
 
         def create_user

--- a/lib/chef/role.rb
+++ b/lib/chef/role.rb
@@ -243,10 +243,10 @@ class Chef
         end
         js_path, rb_path = js_files.first, rb_files.first
 
-        if js_path && File.exists?(js_path)
+        if js_path && File.exist?(js_path)
           # from_json returns object.class => json_class in the JSON.
           return Chef::JSONCompat.from_json(IO.read(js_path))
-        elsif rb_path && File.exists?(rb_path)
+        elsif rb_path && File.exist?(rb_path)
           role = Chef::Role.new
           role.name(name)
           role.from_file(rb_path)

--- a/lib/chef/scan_access_control.rb
+++ b/lib/chef/scan_access_control.rb
@@ -47,13 +47,9 @@ class Chef
     # Modifies @current_resource, setting the current access control state.
     def set_all!
       if ::File.exist?(new_resource.path)
-        if new_resource.is_a?(::Chef::Resource::Link)
-          if current_resource.link_type == :symbolic
-            set_all
-          else
-            set_all unless ::File.exist?(current_resource.path)
-          end
-        else
+        if !new_resource.is_a?(::Chef::Resource::Link)
+          set_all
+        elsif current_resource.link_type == :symbolic
           set_all
         end
       else

--- a/lib/chef/scan_access_control.rb
+++ b/lib/chef/scan_access_control.rb
@@ -47,11 +47,7 @@ class Chef
     # Modifies @current_resource, setting the current access control state.
     def set_all!
       if ::File.exist?(new_resource.path)
-        if !new_resource.is_a?(::Chef::Resource::Link)
-          set_all
-        elsif current_resource.link_type == :symbolic
-          set_all
-        end
+        set_all
       else
         # leave the values as nil.
       end

--- a/lib/chef/scan_access_control.rb
+++ b/lib/chef/scan_access_control.rb
@@ -47,12 +47,24 @@ class Chef
     # Modifies @current_resource, setting the current access control state.
     def set_all!
       if ::File.exist?(new_resource.path)
-        set_owner
-        set_group
-        set_mode
+        if new_resource.is_a?(::Chef::Resource::Link)
+          if current_resource.link_type == :symbolic
+            set_all
+          else
+            set_all unless ::File.exist?(current_resource.path)
+          end
+        else
+          set_all
+        end
       else
         # leave the values as nil.
       end
+    end
+
+    def set_all
+      set_owner
+      set_group
+      set_mode
     end
 
     # Set the owner attribute of +current_resource+ to whatever the current
@@ -128,11 +140,11 @@ class Chef
 
     def stat
       @stat ||= if @new_resource.instance_of?(Chef::Resource::Link)
-        ::File.lstat(@new_resource.path)
-      else
-        realpath = ::File.realpath(@new_resource.path)
-        ::File.stat(realpath)
-      end
+                  ::File.lstat(@new_resource.path)
+                else
+                  realpath = ::File.realpath(@new_resource.path)
+                  ::File.stat(realpath)
+                end
     end
   end
 end

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -288,7 +288,7 @@ FOOTER
       config[:config_file] = config_file_for_shell_mode(environment)
       config_msg = config[:config_file] || "none (standalone session)"
       puts "loading configuration: #{config_msg}"
-      Chef::Config.from_file(config[:config_file]) if !config[:config_file].nil? && File.exists?(config[:config_file]) && File.readable?(config[:config_file])
+      Chef::Config.from_file(config[:config_file]) if !config[:config_file].nil? && File.exist?(config[:config_file]) && File.readable?(config[:config_file])
       Chef::Config.merge!(config)
     end
 

--- a/lib/chef/tasks/chef_repo.rake
+++ b/lib/chef/tasks/chef_repo.rake
@@ -62,11 +62,11 @@ end
 
 desc "Install the latest copy of the repository on this Chef Server"
 task :install => [ :update, :roles, :upload_cookbooks ] do
-  if File.exists?(File.join(TOPDIR, "config", "server.rb"))
+  if File.exist?(File.join(TOPDIR, "config", "server.rb"))
     puts "* Installing new Chef Server Config"
     sh "#{LOCAL_EXEC_PREFIX} rsync -rlt --delete --exclude '.svn' --exclude '.git*' config/server.rb #{REMOTE_PATH_PREFIX}#{CHEF_SERVER_CONFIG}"
   end
-  if File.exists?(File.join(TOPDIR, "config", "client.rb"))
+  if File.exist?(File.join(TOPDIR, "config", "client.rb"))
     puts "* Installing new Chef Client Config"
     sh "#{LOCAL_EXEC_PREFIX} rsync -rlt --delete --exclude '.svn' --exclude '.git*' config/client.rb #{REMOTE_PATH_PREFIX}#{CHEF_CLIENT_CONFIG}"
   end
@@ -94,7 +94,7 @@ def create_cookbook(dir)
   sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "providers")}"
   sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "files", "default")}"
   sh "mkdir -p #{File.join(dir, ENV["COOKBOOK"], "templates", "default")}"
-  unless File.exists?(File.join(dir, ENV["COOKBOOK"], "recipes", "default.rb"))
+  unless File.exist?(File.join(dir, ENV["COOKBOOK"], "recipes", "default.rb"))
     open(File.join(dir, ENV["COOKBOOK"], "recipes", "default.rb"), "w") do |file|
       file.puts <<-EOH
 #
@@ -133,7 +133,7 @@ end
 def create_readme(dir)
   raise "Must provide a COOKBOOK=" unless ENV["COOKBOOK"]
   puts "** Creating README for cookbook: #{ENV["COOKBOOK"]}"
-  unless File.exists?(File.join(dir, ENV["COOKBOOK"], "README.rdoc"))
+  unless File.exist?(File.join(dir, ENV["COOKBOOK"], "README.rdoc"))
     open(File.join(dir, ENV["COOKBOOK"], "README.md"), "w") do |file|
       file.puts <<-EOH
 Description
@@ -164,9 +164,9 @@ def create_metadata(dir)
     license = "All rights reserved"
   end
 
-  unless File.exists?(File.join(dir, ENV["COOKBOOK"], "metadata.rb"))
+  unless File.exist?(File.join(dir, ENV["COOKBOOK"], "metadata.rb"))
     open(File.join(dir, ENV["COOKBOOK"], "metadata.rb"), "w") do |file|
-      if File.exists?(File.join(dir, ENV["COOKBOOK"], 'README.rdoc'))
+      if File.exist?(File.join(dir, ENV["COOKBOOK"], 'README.rdoc'))
         long_description = "long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))"
       end
       file.puts <<-EOH
@@ -266,7 +266,7 @@ namespace :databag do
     input_databag = args[:databag] || 'none_specified'
     databag = File.join(path, input_databag)
 
-    if File.exists?(databag) && File.directory?(databag)
+    if File.exist?(databag) && File.directory?(databag)
       system "knife data bag create #{input_databag}"
       Dir.foreach(databag) do |item|
         name, type = item.split('.')
@@ -281,7 +281,7 @@ namespace :databag do
 
   desc "Upload all databags"
   task :upload_all do
-    if File.exists?(path) && File.directory?(path)
+    if File.exist?(path) && File.directory?(path)
       Dir.foreach(path) do |databag|
         if databag == databag[/^[\-[:alnum:]_]+$/]
           Rake::Task['databag:upload'].execute( { :databag => databag } )
@@ -296,9 +296,9 @@ namespace :databag do
   task :create, :databag do |t, args|
     input_databag = args[:databag] || 'none_specified'
 
-    FileUtils.mkdir(path) unless File.exists?(path)
+    FileUtils.mkdir(path) unless File.exist?(path)
     databag = File.join(path, input_databag)
-    FileUtils.mkdir(databag) unless File.exists?(databag)
+    FileUtils.mkdir(databag) unless File.exist?(databag)
   end
 
   desc "Create a databag item stub"
@@ -307,10 +307,10 @@ namespace :databag do
     input_item = args[:item] || false
 
     databag = File.join(path, input_databag)
-    if File.exists?(databag) && File.directory?(databag)
+    if File.exist?(databag) && File.directory?(databag)
       if input_item
         json_filename = File.join(databag, "#{input_item}.json")
-        if !File.exists?(json_filename)
+        if !File.exist?(json_filename)
           stub = <<EOH
 {
   "id" : "#{input_item}"

--- a/lib/chef/util/diff.rb
+++ b/lib/chef/util/diff.rb
@@ -63,7 +63,7 @@ class Chef
 
       def use_tempfile_if_missing(file)
         tempfile = nil
-        unless File.exists?(file)
+        unless File.exist?(file)
           Chef::Log.debug("file #{file} does not exist to diff against, using empty tempfile")
           tempfile = Tempfile.new("chef-diff")
           file = tempfile.path
@@ -82,7 +82,7 @@ class Chef
           end
         end
       end
-      
+
       # produces a unified-output-format diff with 3 lines of context
       # ChefFS uses udiff() directly
       def udiff(old_file, new_file)

--- a/lib/chef/win32/file.rb
+++ b/lib/chef/win32/file.rb
@@ -70,7 +70,7 @@ class Chef
       def self.symlink?(file_name)
         is_symlink = false
         path = encode_path(file_name)
-        if ::File.exists?(file_name)
+        if ::File.exist?(file_name)
           if ((GetFileAttributesW(path) & FILE_ATTRIBUTE_REPARSE_POINT) > 0)
             file_search_handle(file_name) do |handle, find_data|
               if find_data[:dw_reserved_0] == IO_REPARSE_TAG_SYMLINK
@@ -88,7 +88,7 @@ class Chef
       # will raise a NotImplementedError, as per MRI.
       #
       def self.readlink(link_name)
-        raise Errno::ENOENT, link_name unless ::File.exists?(link_name)
+        raise Errno::ENOENT, link_name unless ::File.exist?(link_name)
         symlink_file_handle(link_name) do |handle|
           # Go to DeviceIoControl to get the symlink information
           # http://msdn.microsoft.com/en-us/library/windows/desktop/aa364571(v=vs.85).aspx

--- a/pedant.gemfile
+++ b/pedant.gemfile
@@ -20,4 +20,4 @@ end
 
 # If you want to load debugging tools into the bundle exec sandbox,
 # add these additional dependencies into chef/Gemfile.local
-eval(IO.read(__FILE__ + '.local'), binding) if File.exists?(__FILE__ + '.local')
+eval(IO.read(__FILE__ + '.local'), binding) if File.exist?(__FILE__ + '.local')

--- a/spec/functional/resource/bff_spec.rb
+++ b/spec/functional/resource/bff_spec.rb
@@ -31,12 +31,12 @@ describe Chef::Resource::BffPackage, :external => ohai[:platform] != 'aix' do
 
   def bff_pkg_should_be_installed(resource)
     expect(shell_out("lslpp -L #{resource.name}").exitstatus).to eq(0)
-    ::File.exists?("/usr/PkgA/bin/acommand")
+    ::File.exist?("/usr/PkgA/bin/acommand")
   end
 
   def bff_pkg_should_be_removed(resource)
     expect(shell_out("lslpp -L #{resource.name}").exitstatus).to eq(1)
-    !::File.exists?("/usr/PkgA/bin/acommand")
+    !::File.exist?("/usr/PkgA/bin/acommand")
   end
 
 

--- a/spec/functional/resource/cookbook_file_spec.rb
+++ b/spec/functional/resource/cookbook_file_spec.rb
@@ -74,7 +74,7 @@ describe Chef::Resource::CookbookFile do
     end
 
     after do
-      FileUtils.rm_r(windows_non_temp_dir) if Chef::Platform.windows? && File.exists?(windows_non_temp_dir)
+      FileUtils.rm_r(windows_non_temp_dir) if Chef::Platform.windows? && File.exist?(windows_non_temp_dir)
     end
 
   end

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -54,9 +54,9 @@ describe Chef::Resource::Link do
 
   after(:each) do
     begin
-      cleanup_link(to) if File.exists?(to)
-      cleanup_link(target_file) if File.exists?(target_file)
-      cleanup_link(CHEF_SPEC_BACKUP_PATH) if File.exists?(CHEF_SPEC_BACKUP_PATH)
+      cleanup_link(to) if File.exist?(to)
+      cleanup_link(target_file) if File.exist?(target_file)
+      cleanup_link(CHEF_SPEC_BACKUP_PATH) if File.exist?(CHEF_SPEC_BACKUP_PATH)
     rescue
       puts "Could not remove a file: #{$!}"
     end
@@ -220,7 +220,7 @@ describe Chef::Resource::Link do
           resource.run_action(:create)
         end
         it 'preserves the hard link' do
-          File.exists?(target_file).should be_true
+          File.exist?(target_file).should be_true
           symlink?(target_file).should be_false
           # Writing to one hardlinked file should cause both
           # to have the new value.
@@ -245,7 +245,7 @@ describe Chef::Resource::Link do
           resource.run_action(:create)
         end
         it 'links to the target file' do
-          File.exists?(target_file).should be_true
+          File.exist?(target_file).should be_true
           symlink?(target_file).should be_false
           # Writing to one hardlinked file should cause both
           # to have the new value.
@@ -285,7 +285,7 @@ describe Chef::Resource::Link do
             include_context 'delete succeeds'
             it 'the :delete action does not delete the target file' do
               resource.run_action(:delete)
-              File.exists?(to).should be_true
+              File.exist?(to).should be_true
             end
           end
           context 'pointing somewhere else' do
@@ -303,7 +303,7 @@ describe Chef::Resource::Link do
             include_context 'delete succeeds'
             it 'the :delete action does not delete the target file' do
               resource.run_action(:delete)
-              File.exists?(to).should be_true
+              File.exist?(to).should be_true
             end
           end
           context 'pointing nowhere' do
@@ -320,7 +320,7 @@ describe Chef::Resource::Link do
         context 'and the link already exists and is a hard link to the file' do
           before(:each) do
             link(to, target_file)
-            File.exists?(target_file).should be_true
+            File.exist?(target_file).should be_true
             symlink?(target_file).should be_false
           end
           include_context 'create symbolic link succeeds'
@@ -478,14 +478,14 @@ describe Chef::Resource::Link do
         context 'and the link already exists and is a hard link to the file' do
           before(:each) do
             link(to, target_file)
-            File.exists?(target_file).should be_true
+            File.exist?(target_file).should be_true
             symlink?(target_file).should be_false
           end
           include_context 'create hard link is noop'
           include_context 'delete succeeds'
           it 'the :delete action does not delete the target file' do
             resource.run_action(:delete)
-            File.exists?(to).should be_true
+            File.exist?(to).should be_true
           end
         end
         context "and the link already exists and is a file" do
@@ -552,7 +552,7 @@ describe Chef::Resource::Link do
           context 'and the link does not yet exist' do
             it 'links to the target file' do
               resource.run_action(:create)
-              File.exists?(target_file).should be_true
+              File.exist?(target_file).should be_true
               # OS X gets angry about this sort of link.  Bug in OS X, IMO.
               pending('OS X/FreeBSD/AIX symlink? and readlink working on hard links to symlinks', :if => (os_x? or freebsd? or aix?)) do
                 symlink?(target_file).should be_true
@@ -575,9 +575,9 @@ describe Chef::Resource::Link do
                 resource.run_action(:create)
                 # Windows and Unix have different definitions of exists? here, and that's OK.
                 if windows?
-                  File.exists?(target_file).should be_true
+                  File.exist?(target_file).should be_true
                 else
-                  File.exists?(target_file).should be_false
+                  File.exist?(target_file).should be_false
                 end
                 symlink?(target_file).should be_true
                 readlink(target_file).should == canonicalize(@other_target)

--- a/spec/functional/resource/rpm_spec.rb
+++ b/spec/functional/resource/rpm_spec.rb
@@ -39,7 +39,7 @@ describe Chef::Resource::RpmPackage, :requires_root, :external => exclude_test d
     # mytest rpm package works in centos, redhat and in suse without any dependency issues.
     when "centos", "redhat", "suse"
       expect(shell_out("rpm -qa | grep mytest").exitstatus).to eq(0)
-      ::File.exists?("/opt/mytest/mytest.sh") # The mytest rpm package contains the mytest.sh file
+      ::File.exist?("/opt/mytest/mytest.sh") # The mytest rpm package contains the mytest.sh file
     end
   end
 
@@ -49,7 +49,7 @@ describe Chef::Resource::RpmPackage, :requires_root, :external => exclude_test d
       expect(shell_out("rpm -qa | grep dummy").exitstatus).to eq(1)
     when "centos", "redhat", "suse"
       expect(shell_out("rpm -qa | grep mytest").exitstatus).to eq(1)
-      !::File.exists?("/opt/mytest/mytest.sh")
+      !::File.exist?("/opt/mytest/mytest.sh")
     end
   end
 

--- a/spec/functional/win32/service_manager_spec.rb
+++ b/spec/functional/win32/service_manager_spec.rb
@@ -65,7 +65,7 @@ describe "Chef::Application::WindowsServiceManager", :windows_only, :system_wind
     end
 
     # Delete the test_service_file if it exists
-    if File.exists?(test_service_file)
+    if File.exist?(test_service_file)
       File.delete(test_service_file)
     end
 
@@ -179,7 +179,7 @@ describe "Chef::Application::WindowsServiceManager", :windows_only, :system_wind
         it "start should start the service", :volatile do
           service_manager.run(["-a", "start"])
           test_service_state.should == "running"
-          File.exists?(test_service_file).should be_true
+          File.exist?(test_service_file).should be_true
         end
 
         it "stop should not affect the service" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ require 'chef/config'
 
 # If you want to load anything into the testing environment
 # without versioning it, add it to spec/support/local_gems.rb
-require 'spec/support/local_gems.rb' if File.exists?(File.join(File.dirname(__FILE__), 'support', 'local_gems.rb'))
+require 'spec/support/local_gems.rb' if File.exist?(File.join(File.dirname(__FILE__), 'support', 'local_gems.rb'))
 
 # Explicitly require spec helpers that need to load first
 require 'spec/support/platform_helpers'

--- a/spec/support/pedant/run_pedant.rb
+++ b/spec/support/pedant/run_pedant.rb
@@ -10,12 +10,12 @@ require 'fileutils'
 require 'chef/version'
 
 def start_server(chef_repo_path)
-  Dir.mkdir(chef_repo_path) if !File.exists?(chef_repo_path)
+  Dir.mkdir(chef_repo_path) if !File.exist?(chef_repo_path)
 
   # 11.6 and below had a bug where it couldn't create the repo children automatically
   if Chef::VERSION.to_f < 11.8
     %w(clients cookbooks data_bags environments nodes roles users).each do |child|
-      Dir.mkdir("#{chef_repo_path}/#{child}") if !File.exists?("#{chef_repo_path}/#{child}")
+      Dir.mkdir("#{chef_repo_path}/#{child}") if !File.exist?("#{chef_repo_path}/#{child}")
     end
   end
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -44,7 +44,7 @@ def windows_win2k3?
 end
 
 def mac_osx_106?
-  if File.exists? "/usr/bin/sw_vers"
+  if File.exist? "/usr/bin/sw_vers"
     result = shell_out("/usr/bin/sw_vers")
     result.stdout.each_line do |line|
       if line =~ /^ProductVersion:\s10.6.*$/
@@ -117,7 +117,7 @@ def selinux_enabled?
 end
 
 def suse?
-  File.exists?("/etc/SuSE-release")
+  File.exist?("/etc/SuSE-release")
 end
 
 def root?

--- a/spec/support/platforms/win32/spec_service.rb
+++ b/spec/support/platforms/win32/spec_service.rb
@@ -25,7 +25,7 @@ class SpecService < ::Win32::Daemon
 
   def service_main(*startup_parameters)
     while running? do
-      if !File.exists?(@test_service_file)
+      if !File.exist?(@test_service_file)
         File.open(@test_service_file, 'wb') do |f|
           f.write("This file is created by SpecService")
         end

--- a/spec/support/shared/functional/directory_resource.rb
+++ b/spec/support/shared/functional/directory_resource.rb
@@ -171,6 +171,6 @@ shared_context Chef::Resource::Directory do
   end
 
   after(:each) do
-    FileUtils.rm_r(path) if File.exists?(path)
+    FileUtils.rm_r(path) if File.exist?(path)
   end
 end

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -1030,8 +1030,8 @@ shared_context Chef::Resource::File  do
   end
 
   after(:each) do
-    FileUtils.rm_r(path) if File.exists?(path)
-    FileUtils.rm_r(CHEF_SPEC_BACKUP_PATH) if File.exists?(CHEF_SPEC_BACKUP_PATH)
+    FileUtils.rm_r(path) if File.exist?(path)
+    FileUtils.rm_r(CHEF_SPEC_BACKUP_PATH) if File.exist?(CHEF_SPEC_BACKUP_PATH)
   end
 
   after do

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -38,10 +38,10 @@ shared_context Chef::Resource::WindowsScript do
   end
 
   before(:each) do
-    File.delete(script_output_path) if File.exists?(script_output_path)
+    File.delete(script_output_path) if File.exist?(script_output_path)
   end
 
   after(:each) do
-    File.delete(script_output_path) if File.exists?(script_output_path)
+    File.delete(script_output_path) if File.exist?(script_output_path)
   end
 end

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -44,7 +44,7 @@ end
 def setup_normal_file
   [ resource_path, normalized_path, windows_path].each do |path|
     File.stub(:file?).with(path).and_return(true)
-    File.stub(:exists?).with(path).and_return(true)
+    File.stub(:exist?).with(path).and_return(true)
     File.stub(:exist?).with(path).and_return(true)
     File.stub(:directory?).with(path).and_return(false)
     File.stub(:writable?).with(path).and_return(true)
@@ -58,7 +58,7 @@ def setup_missing_file
   [ resource_path, normalized_path, windows_path].each do |path|
     File.stub(:file?).with(path).and_return(false)
     File.stub(:realpath?).with(path).and_return(resource_path)
-    File.stub(:exists?).with(path).and_return(false)
+    File.stub(:exist?).with(path).and_return(false)
     File.stub(:exist?).with(path).and_return(false)
     File.stub(:directory?).with(path).and_return(false)
     File.stub(:writable?).with(path).and_return(false)
@@ -71,7 +71,7 @@ def setup_symlink
   [ resource_path, normalized_path, windows_path].each do |path|
     File.stub(:file?).with(path).and_return(true)
     File.stub(:realpath?).with(path).and_return(normalized_path)
-    File.stub(:exists?).with(path).and_return(true)
+    File.stub(:exist?).with(path).and_return(true)
     File.stub(:exist?).with(path).and_return(true)
     File.stub(:directory?).with(path).and_return(false)
     File.stub(:writable?).with(path).and_return(true)
@@ -84,7 +84,7 @@ def setup_unwritable_file
   [ resource_path, normalized_path, windows_path].each do |path|
     File.stub(:file?).with(path).and_return(false)
     File.stub(:realpath?).with(path).and_raise(Errno::ENOENT)
-    File.stub(:exists?).with(path).and_return(true)
+    File.stub(:exist?).with(path).and_return(true)
     File.stub(:exist?).with(path).and_return(true)
     File.stub(:directory?).with(path).and_return(false)
     File.stub(:writable?).with(path).and_return(false)
@@ -97,7 +97,7 @@ def setup_missing_enclosing_directory
   [ resource_path, normalized_path, windows_path].each do |path|
     File.stub(:file?).with(path).and_return(false)
     File.stub(:realpath?).with(path).and_raise(Errno::ENOENT)
-    File.stub(:exists?).with(path).and_return(false)
+    File.stub(:exist?).with(path).and_return(false)
     File.stub(:exist?).with(path).and_return(false)
     File.stub(:directory?).with(path).and_return(false)
     File.stub(:writable?).with(path).and_return(false)
@@ -138,7 +138,7 @@ shared_examples_for Chef::Provider::File do
   before(:each) do
     content.stub(:tempfile).and_return(tempfile)
     File.stub(:exist?).with(tempfile.path).and_call_original
-    File.stub(:exists?).with(tempfile.path).and_call_original
+    File.stub(:exist?).with(tempfile.path).and_call_original
   end
 
   after do
@@ -482,7 +482,7 @@ shared_examples_for Chef::Provider::File do
           provider.load_current_resource
           tempfile = double('Tempfile', :path => "/tmp/foo-bar-baz")
           content.stub(:tempfile).and_return(tempfile)
-          File.should_receive(:exists?).with("/tmp/foo-bar-baz").and_return(true)
+          File.should_receive(:exist?).with("/tmp/foo-bar-baz").and_return(true)
           tempfile.should_receive(:close).once
           tempfile.should_receive(:unlink).once
         end
@@ -542,7 +542,7 @@ shared_examples_for Chef::Provider::File do
       it "raises an exception when the content object returns a tempfile that does not exist" do
         tempfile = double('Tempfile', :path => "/tmp/foo-bar-baz")
         provider.send(:content).should_receive(:tempfile).at_least(:once).and_return(tempfile)
-        File.should_receive(:exists?).with("/tmp/foo-bar-baz").and_return(false)
+        File.should_receive(:exist?).with("/tmp/foo-bar-baz").and_return(false)
         lambda{ provider.send(:do_contents_changes) }.should raise_error
       end
     end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -203,7 +203,7 @@ describe Chef::Client do
         # --Client.register
         #   Make sure Client#register thinks the client key doesn't
         #   exist, so it tries to register and create one.
-        File.should_receive(:exists?).with(Chef::Config[:client_key]).exactly(1).times.and_return(api_client_exists?)
+        File.should_receive(:exist?).with(Chef::Config[:client_key]).exactly(1).times.and_return(api_client_exists?)
 
         unless api_client_exists?
           #   Client.register will register with the validation client name.

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -175,7 +175,7 @@ describe Chef::Config do
 
       context "when /var/chef does not exist and /var is accessible" do
         it "defaults to /var/chef" do
-          File.stub(:exists?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(false)
+          File.stub(:exist?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(false)
           Chef::Config.stub(:path_accessible?).with(Chef::Config.platform_specific_path("/var")).and_return(true)
           Chef::Config[:cache_path].should == primary_cache_path
         end
@@ -183,7 +183,7 @@ describe Chef::Config do
 
       context "when /var/chef does not exist and /var is not accessible" do
         it "defaults to $HOME/.chef" do
-          File.stub(:exists?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(false)
+          File.stub(:exist?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(false)
           Chef::Config.stub(:path_accessible?).with(Chef::Config.platform_specific_path("/var")).and_return(false)
           Chef::Config[:cache_path].should == secondary_cache_path
         end
@@ -191,7 +191,7 @@ describe Chef::Config do
 
       context "when /var/chef exists and is not accessible" do
         it "defaults to $HOME/.chef" do
-          File.stub(:exists?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(true)
+          File.stub(:exist?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(true)
           File.stub(:readable?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(true)
           File.stub(:writable?).with(Chef::Config.platform_specific_path("/var/chef")).and_return(false)
 

--- a/spec/unit/dsl/reboot_pending_spec.rb
+++ b/spec/unit/dsl/reboot_pending_spec.rb
@@ -34,22 +34,22 @@ describe Chef::DSL::RebootPending do
           recipe.stub(:registry_key_exists?).and_return(false)
           recipe.stub(:registry_value_exists?).and_return(false)
         end
-  
+
         it 'should return true if "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations" exists' do
           recipe.stub(:registry_value_exists?).with('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', { :name => 'PendingFileRenameOperations' }).and_return(true)
           expect(recipe.reboot_pending?).to be_true
         end
-  
+
         it 'should return true if "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired" exists' do
           recipe.stub(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').and_return(true)
           expect(recipe.reboot_pending?).to be_true
         end
-  
+
         it 'should return true if key "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired" exists' do
           recipe.stub(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired').and_return(true)
           expect(recipe.reboot_pending?).to be_true
         end
-  
+
         it 'should return true if value "HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile" contains specific data' do
           recipe.stub(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(true)
           recipe.stub(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(
@@ -57,19 +57,19 @@ describe Chef::DSL::RebootPending do
           expect(recipe.reboot_pending?).to be_true
         end
       end
-  
+
       context "platform is ubuntu" do
         before do
           recipe.stub(:platform?).with('ubuntu').and_return(true)
         end
-  
+
         it 'should return true if /var/run/reboot-required exists' do
-          File.stub(:exists?).with('/var/run/reboot-required').and_return(true)
+          File.stub(:exist?).with('/var/run/reboot-required').and_return(true)
           expect(recipe.reboot_pending?).to be_true
         end
-  
+
         it 'should return false if /var/run/reboot-required does not exist' do
-          File.stub(:exists?).with('/var/run/reboot-required').and_return(false)
+          File.stub(:exist?).with('/var/run/reboot-required').and_return(false)
           expect(recipe.reboot_pending?).to be_false
         end
       end

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -398,8 +398,8 @@ describe Chef::Environment do
 
       it "should get the environment from the environment_path" do
         File.should_receive(:directory?).with(Chef::Config[:environment_path]).and_return(true)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).exactly(2).times.and_return(true)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).exactly(2).times.and_return(true)
         File.should_receive(:readable?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(true)
         role_dsl="name \"foo\"\ndescription \"desc\"\n"
         IO.should_receive(:read).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(role_dsl)
@@ -408,7 +408,7 @@ describe Chef::Environment do
 
       it "should return a Chef::Environment object from JSON" do
         File.should_receive(:directory?).with(Chef::Config[:environment_path]).and_return(true)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(true)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(true)
         environment_hash = {
           "name" => "foo",
           "default_attributes" => {
@@ -431,8 +431,8 @@ describe Chef::Environment do
 
       it "should return a Chef::Environment object from Ruby DSL" do
         File.should_receive(:directory?).with(Chef::Config[:environment_path]).and_return(true)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).exactly(2).times.and_return(true)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).exactly(2).times.and_return(true)
         File.should_receive(:readable?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(true)
         role_dsl="name \"foo\"\ndescription \"desc\"\n"
         IO.should_receive(:read).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(role_dsl)
@@ -453,8 +453,8 @@ describe Chef::Environment do
 
       it 'should raise an error if the file does not exist' do
         File.should_receive(:directory?).with(Chef::Config[:environment_path]).and_return(true)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
-        File.should_receive(:exists?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(false)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.json')).and_return(false)
+        File.should_receive(:exist?).with(File.join(Chef::Config[:environment_path], 'foo.rb')).and_return(false)
 
         lambda {
           Chef::Environment.load('foo')

--- a/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
@@ -136,7 +136,6 @@ describe Chef::Formatters::ErrorInspectors::ResourceFailureInspector do
 
       context "when the recipe file does not exist" do
         before do
-          #File.stub(:exist?).and_return(false)
           IO.stub(:readlines).and_raise(Errno::ENOENT)
         end
 

--- a/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
@@ -116,10 +116,10 @@ describe Chef::Formatters::ErrorInspectors::ResourceFailureInspector do
         # fake code to run through #recipe_snippet
         source_file = [ "if true", "var = non_existant", "end" ]
         IO.stub(:readlines).and_return(source_file)
-        File.stub(:exists?).and_return(true)
       end
 
       it "parses a Windows path" do
+        File.stub(:exist?).and_return(true)
         source_line = "C:/Users/btm/chef/chef/spec/unit/fake_file.rb:2: undefined local variable or method `non_existant' for main:Object (NameError)"
         @resource.source_line = source_line
         @inspector = Chef::Formatters::ErrorInspectors::ResourceFailureInspector.new(@resource, :create, @exception)
@@ -127,6 +127,7 @@ describe Chef::Formatters::ErrorInspectors::ResourceFailureInspector do
       end
 
       it "parses a unix path" do
+        File.stub(:exist?).and_return(true)
         source_line = "/home/btm/src/chef/chef/spec/unit/fake_file.rb:2: undefined local variable or method `non_existant' for main:Object (NameError)"
         @resource.source_line = source_line
         @inspector = Chef::Formatters::ErrorInspectors::ResourceFailureInspector.new(@resource, :create, @exception)
@@ -135,7 +136,7 @@ describe Chef::Formatters::ErrorInspectors::ResourceFailureInspector do
 
       context "when the recipe file does not exist" do
         before do
-          File.stub(:exists?).and_return(false)
+          #File.stub(:exist?).and_return(false)
           IO.stub(:readlines).and_raise(Errno::ENOENT)
         end
 

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -45,7 +45,6 @@ describe Chef::Knife::Bootstrap do
   end
 
   it "should look for templates early in the run" do
-    #File.stub(:exist?).and_return(true)
     @knife.name_args = ['shatner']
     @knife.stub(:read_template).and_return("")
     @knife.stub(:knife_ssh).and_return(true)

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -45,7 +45,7 @@ describe Chef::Knife::Bootstrap do
   end
 
   it "should look for templates early in the run" do
-    File.stub(:exists?).and_return(true)
+    #File.stub(:exist?).and_return(true)
     @knife.name_args = ['shatner']
     @knife.stub(:read_template).and_return("")
     @knife.stub(:knife_ssh).and_return(true)
@@ -64,7 +64,7 @@ describe Chef::Knife::Bootstrap do
   it "should load the specified template from a Ruby gem" do
     @knife.config[:template_file] = false
     Gem.stub(:find_files).and_return(["/Users/schisamo/.rvm/gems/ruby-1.9.2-p180@chef-0.10/gems/knife-windows-0.5.4/lib/chef/knife/bootstrap/fake-bootstrap-template.erb"])
-    File.stub(:exists?).and_return(true)
+    File.stub(:exist?).and_return(true)
     IO.stub(:read).and_return('random content')
     @knife.config[:distro] = 'fake-bootstrap-template'
     lambda { @knife.find_template }.should_not raise_error

--- a/spec/unit/knife/config_file_selection_spec.rb
+++ b/spec/unit/knife/config_file_selection_spec.rb
@@ -89,7 +89,6 @@ describe Chef::Knife do
   end
 
   it "configure knife from nothing" do
-    #::File.stub(:exist?).and_return(false)
     @knife = Chef::Knife.new
     @knife.ui.should_receive(:warn).with("No knife configuration file found")
     @knife.configure_chef

--- a/spec/unit/knife/config_file_selection_spec.rb
+++ b/spec/unit/knife/config_file_selection_spec.rb
@@ -89,7 +89,7 @@ describe Chef::Knife do
   end
 
   it "configure knife from nothing" do
-    ::File.stub(:exist?).and_return(false)
+    #::File.stub(:exist?).and_return(false)
     @knife = Chef::Knife.new
     @knife.ui.should_receive(:warn).with("No knife configuration file found")
     @knife.configure_chef

--- a/spec/unit/knife/cookbook_download_spec.rb
+++ b/spec/unit/knife/cookbook_download_spec.rb
@@ -76,7 +76,7 @@ describe Chef::Knife::CookbookDownload do
       it 'should determine which version if one was not explicitly specified'do
         @cookbook_mock.stub(:manifest).and_return({})
         @knife.should_receive(:determine_version).and_return('1.0.0')
-        File.should_receive(:exists?).with('/var/tmp/chef/foobar-1.0.0').and_return(false)
+        File.should_receive(:exist?).with('/var/tmp/chef/foobar-1.0.0').and_return(false)
         Chef::CookbookVersion.stub(:COOKBOOK_SEGEMENTS).and_return([])
         @knife.run
       end
@@ -93,7 +93,7 @@ describe Chef::Knife::CookbookDownload do
         end
 
         it 'should print an error and exit if the cookbook download directory already exists' do
-          File.should_receive(:exists?).with('/var/tmp/chef/foobar-1.0.0').and_return(true)
+          File.should_receive(:exist?).with('/var/tmp/chef/foobar-1.0.0').and_return(true)
           @knife.ui.should_receive(:fatal).with(/\/var\/tmp\/chef\/foobar-1\.0\.0 exists/i)
           lambda { @knife.run }.should raise_error(SystemExit)
         end
@@ -118,7 +118,7 @@ describe Chef::Knife::CookbookDownload do
           end
 
           it "should download the cookbook when the cookbook download directory doesn't exist" do
-            File.should_receive(:exists?).with('/var/tmp/chef/foobar-1.0.0').and_return(false)
+            File.should_receive(:exist?).with('/var/tmp/chef/foobar-1.0.0').and_return(false)
             @knife.run
             ['attributes', 'recipes', 'templates'].each do |segment|
               @stdout.string.should match /downloading #{segment}/im
@@ -130,7 +130,7 @@ describe Chef::Knife::CookbookDownload do
           describe 'with -f or --force' do
             it 'should remove the existing the cookbook download directory if it exists' do
               @knife.config[:force] = true
-              File.should_receive(:exists?).with('/var/tmp/chef/foobar-1.0.0').and_return(true)
+              File.should_receive(:exist?).with('/var/tmp/chef/foobar-1.0.0').and_return(true)
               FileUtils.should_receive(:rm_rf).with('/var/tmp/chef/foobar-1.0.0')
               @knife.run
             end

--- a/spec/unit/knife/cookbook_metadata_from_file_spec.rb
+++ b/spec/unit/knife/cookbook_metadata_from_file_spec.rb
@@ -34,7 +34,7 @@ describe Chef::Knife::CookbookMetadataFromFile do
   end
 
   after do
-    if File.exists?(@tgt)
+    if File.exist?(@tgt)
       File.unlink(@tgt)
     end
   end

--- a/spec/unit/knife/cookbook_metadata_spec.rb
+++ b/spec/unit/knife/cookbook_metadata_spec.rb
@@ -89,14 +89,14 @@ describe Chef::Knife::CookbookMetadata do
     end
 
     it 'should generate the metadata from metadata.rb if it exists' do
-      File.should_receive(:exists?).with("#{@cookbook_dir}/foobar/metadata.rb").
+      File.should_receive(:exist?).with("#{@cookbook_dir}/foobar/metadata.rb").
                                     and_return(true)
       @knife.should_receive(:generate_metadata_from_file).with('foobar', "#{@cookbook_dir}/foobar/metadata.rb")
       @knife.run
     end
 
     it 'should validate the metadata json if metadata.rb does not exist' do
-      File.should_receive(:exists?).with("#{@cookbook_dir}/foobar/metadata.rb").
+      File.should_receive(:exist?).with("#{@cookbook_dir}/foobar/metadata.rb").
                                     and_return(false)
       @knife.should_receive(:validate_metadata_json).with(@cookbook_dir, 'foobar')
       @knife.run

--- a/spec/unit/provider/execute_spec.rb
+++ b/spec/unit/provider/execute_spec.rb
@@ -54,7 +54,7 @@ describe Chef::Provider::Execute do
 
   it "should do nothing if the sentinel file exists" do
     @provider.stub(:load_current_resource)
-    File.should_receive(:exists?).with(@new_resource.creates).and_return(true)
+    File.should_receive(:exist?).with(@new_resource.creates).and_return(true)
     @provider.should_not_receive(:shell_out!)
     Chef::Log.should_not_receive(:warn)
 
@@ -66,8 +66,8 @@ describe Chef::Provider::Execute do
     @new_resource.cwd "/tmp"
     @new_resource.creates "foo_resource"
     @provider.stub(:load_current_resource)
-    File.should_receive(:exists?).with(@new_resource.creates).and_return(false)
-    File.should_receive(:exists?).with(File.join("/tmp", @new_resource.creates)).and_return(true)
+    File.should_receive(:exist?).with(@new_resource.creates).and_return(false)
+    File.should_receive(:exist?).with(File.join("/tmp", @new_resource.creates)).and_return(true)
     Chef::Log.should_not_receive(:warn)
     @provider.should_not_receive(:shell_out!)
 
@@ -79,7 +79,7 @@ describe Chef::Provider::Execute do
     @new_resource.creates "foo_resource"
     @provider.stub(:load_current_resource)
     Chef::Log.should_receive(:warn).with(/relative path/)
-    File.should_receive(:exists?).with(@new_resource.creates).and_return(true)
+    File.should_receive(:exist?).with(@new_resource.creates).and_return(true)
     @provider.should_not_receive(:shell_out!)
 
     @provider.run_action(:run)

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -241,13 +241,13 @@ describe Chef::Provider::Group::Dscl do
       @provider.define_resource_requirements
     end
     it "raises an error if the required binary /usr/bin/dscl doesn't exist" do
-      File.should_receive(:exists?).with("/usr/bin/dscl").and_return(false)
+      File.should_receive(:exist?).with("/usr/bin/dscl").and_return(false)
 
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
 
     it "doesn't raise an error if /usr/bin/dscl exists" do
-      File.stub(:exists?).and_return(true)
+      #File.stub(:exist?).and_return(true)
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -247,7 +247,7 @@ describe Chef::Provider::Group::Dscl do
     end
 
     it "doesn't raise an error if /usr/bin/dscl exists" do
-      #File.stub(:exist?).and_return(true)
+      File.should_receive(:exist?).with("/usr/bin/dscl").and_return(true)
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end

--- a/spec/unit/provider/group/gpasswd_spec.rb
+++ b/spec/unit/provider/group/gpasswd_spec.rb
@@ -41,13 +41,13 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
     # for Chef::Provider::Group - no need to repeat it here.  We'll
     # include only what's specific to this provider.
     it "should raise an error if the required binary /usr/bin/gpasswd doesn't exist" do
-      File.stub(:exists?).and_return(true)
-      File.should_receive(:exists?).with("/usr/bin/gpasswd").and_return(false)
+      File.stub(:exist?).and_return(true)
+      File.should_receive(:exist?).with("/usr/bin/gpasswd").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
 
     it "shouldn't raise an error if the required binaries exist" do
-      File.stub(:exists?).and_return(true)
+      File.stub(:exist?).and_return(true)
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -151,22 +151,22 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "load_current_resource" do
     before do
-      File.stub(:exists?).and_return(false)
+      #File.stub(:exist?).and_return(false)
       @provider.define_resource_requirements
     end
     it "should raise an error if the required binary /usr/sbin/groupadd doesn't exist" do
-      File.should_receive(:exists?).with("/usr/sbin/groupadd").and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/groupadd").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
     it "should raise an error if the required binary /usr/sbin/groupmod doesn't exist" do
-      File.should_receive(:exists?).with("/usr/sbin/groupadd").and_return(true)
-      File.should_receive(:exists?).with("/usr/sbin/groupmod").and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/groupadd").and_return(true)
+      File.should_receive(:exist?).with("/usr/sbin/groupmod").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
     it "should raise an error if the required binary /usr/sbin/groupdel doesn't exist" do
-      File.should_receive(:exists?).with("/usr/sbin/groupadd").and_return(true)
-      File.should_receive(:exists?).with("/usr/sbin/groupmod").and_return(true)
-      File.should_receive(:exists?).with("/usr/sbin/groupdel").and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/groupadd").and_return(true)
+      File.should_receive(:exist?).with("/usr/sbin/groupmod").and_return(true)
+      File.should_receive(:exist?).with("/usr/sbin/groupdel").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
 

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -151,7 +151,6 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "load_current_resource" do
     before do
-      #File.stub(:exist?).and_return(false)
       @provider.define_resource_requirements
     end
     it "should raise an error if the required binary /usr/sbin/groupadd doesn't exist" do

--- a/spec/unit/provider/group/groupmod_spec.rb
+++ b/spec/unit/provider/group/groupmod_spec.rb
@@ -33,17 +33,17 @@ describe Chef::Provider::Group::Groupmod do
   describe "manage_group" do
     describe "when determining the current group state" do
       it "should raise an error if the required binary /usr/sbin/group doesn't exist" do
-        File.should_receive(:exists?).with("/usr/sbin/group").and_return(false)
+        File.should_receive(:exist?).with("/usr/sbin/group").and_return(false)
         lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::Group)
       end
       it "should raise an error if the required binary /usr/sbin/user doesn't exist" do
-        File.should_receive(:exists?).with("/usr/sbin/group").and_return(true)
-        File.should_receive(:exists?).with("/usr/sbin/user").and_return(false)
+        File.should_receive(:exist?).with("/usr/sbin/group").and_return(true)
+        File.should_receive(:exist?).with("/usr/sbin/user").and_return(false)
         lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::Group)
       end
 
       it "shouldn't raise an error if the required binaries exist" do
-        File.stub(:exists?).and_return(true)
+        File.stub(:exist?).and_return(true)
         lambda { @provider.load_current_resource }.should_not raise_error
       end
     end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -126,12 +126,12 @@ describe Chef::Provider::Group::Pw do
       @provider.define_resource_requirements
     end
     it "should raise an error if the required binary /usr/sbin/pw doesn't exist" do
-      File.should_receive(:exists?).with("/usr/sbin/pw").and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/pw").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
 
     it "shouldn't raise an error if /usr/sbin/pw exists" do
-      File.stub(:exists?).and_return(true)
+      File.stub(:exist?).and_return(true)
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -57,10 +57,10 @@ describe Chef::Provider::Group::Usermod do
 
       before do
         @new_resource.stub(:members).and_return(["all", "your", "base"])
-        File.stub(:exists?).and_return(true)
       end
 
       it "should raise an error when setting the entire group directly" do
+        File.stub(:exist?).and_return(true)
         @provider.define_resource_requirements
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
@@ -69,6 +69,7 @@ describe Chef::Provider::Group::Usermod do
       end
 
       it "should raise an error when excluded_members are set" do
+        File.stub(:exist?).and_return(true)
         @provider.define_resource_requirements
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
@@ -96,19 +97,18 @@ describe Chef::Provider::Group::Usermod do
 
   describe "when loading the current resource" do
     before(:each) do
-      File.stub(:exists?).and_return(false)
       @provider.action = :create
       @provider.define_resource_requirements
     end
 
     it "should raise an error if the required binary /usr/sbin/usermod doesn't exist" do
-      File.stub(:exists?).and_return(true)
-      File.should_receive(:exists?).with("/usr/sbin/usermod").and_return(false)
+      File.stub(:exist?).and_return(true)
+      File.should_receive(:exist?).with("/usr/sbin/usermod").and_return(false)
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Group)
     end
 
     it "shouldn't raise an error if the required binaries exist" do
-      File.stub(:exists?).and_return(true)
+      File.stub(:exist?).and_return(true)
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end

--- a/spec/unit/provider/ifconfig/debian_spec.rb
+++ b/spec/unit/provider/ifconfig/debian_spec.rb
@@ -80,12 +80,12 @@ describe Chef::Provider::Ifconfig::Debian do
       context "when the interface_dot_d directory does not exist" do
         before do
           FileUtils.rmdir tempdir_path
-          expect(File.exists?(tempdir_path)).to be_false
+          expect(File.exist?(tempdir_path)).to be_false
         end
 
         it "should create the /etc/network/interfaces.d directory" do
           provider.run_action(:add)
-          expect(File.exists?(tempdir_path)).to be_true
+          expect(File.exist?(tempdir_path)).to be_true
           expect(File.directory?(tempdir_path)).to be_true
         end
 
@@ -97,7 +97,7 @@ describe Chef::Provider::Ifconfig::Debian do
 
       context "when the interface_dot_d directory exists" do
         before do
-          expect(File.exists?(tempdir_path)).to be_true
+          expect(File.exist?(tempdir_path)).to be_true
         end
 
         it "should still mark the resource as updated (we still write a file to it)" do
@@ -124,7 +124,7 @@ iface eth0 inet static
 EOF
         )
         expect(File).to receive(:new).with(config_filename_ifcfg, "w").and_return(config_file_ifcfg)
-        expect(File.exists?(tempdir_path)).to be_true  # since the file exists, the enclosing dir must also exist
+        expect(File.exist?(tempdir_path)).to be_true  # since the file exists, the enclosing dir must also exist
       end
 
       context "when the /etc/network/interfaces file has the source line" do
@@ -214,12 +214,12 @@ EOF
         context "when the interface_dot_d directory does not exist" do
           before do
             FileUtils.rmdir tempdir_path
-            expect(File.exists?(tempdir_path)).to be_false
+            expect(File.exist?(tempdir_path)).to be_false
           end
 
           it "should not create the /etc/network/interfaces.d directory" do
             provider.run_action(:add)
-            expect(File.exists?(tempdir_path)).not_to be_true
+            expect(File.exist?(tempdir_path)).not_to be_true
           end
 
           it "should mark the resource as updated" do
@@ -230,7 +230,7 @@ EOF
 
         context "when the interface_dot_d directory exists" do
           before do
-            expect(File.exists?(tempdir_path)).to be_true
+            expect(File.exist?(tempdir_path)).to be_true
           end
 
           it "should still mark the resource as updated (we still write a file to it)" do
@@ -257,7 +257,7 @@ iface eth0 inet static
                                            EOF
                                           )
           expect(File).not_to receive(:new).with(config_filename_ifcfg, "w")
-          expect(File.exists?(tempdir_path)).to be_true  # since the file exists, the enclosing dir must also exist
+          expect(File.exist?(tempdir_path)).to be_true  # since the file exists, the enclosing dir must also exist
         end
 
         context "when the /etc/network/interfaces file has the source line" do

--- a/spec/unit/provider/link_spec.rb
+++ b/spec/unit/provider/link_spec.rb
@@ -41,6 +41,9 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
   def canonicalize(path)
     Chef::Platform.windows? ? path.gsub('/', '\\') : path
   end
+  before do
+    ::File.stub(:exist?).and_call_original
+  end
 
   describe "when the target is a symlink" do
     before(:each) do
@@ -123,7 +126,7 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
 
   describe "when the target doesn't exist" do
     before do
-      File.stub(:exists?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
+      File.stub(:exist?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
       provider.file_class.stub(:symlink?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
       provider.load_current_resource
     end
@@ -148,15 +151,16 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
       stat.stub(:uid).and_return(501)
       stat.stub(:gid).and_return(501)
       stat.stub(:mode).and_return(0755)
+      provider.file_class.stub(:lstat).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(stat)
       provider.file_class.stub(:stat).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(stat)
 
-      File.stub(:exists?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(true)
+      File.stub(:exist?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(true)
       provider.file_class.stub(:symlink?).with("#{CHEF_SPEC_DATA}/fofile-link").and_return(false)
     end
 
     describe "and the source does not exist" do
       before do
-        File.stub(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(false)
+        File.stub(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(false)
         provider.load_current_resource
       end
 
@@ -183,7 +187,7 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
 
         provider.file_class.stub(:stat).with("#{CHEF_SPEC_DATA}/fofile").and_return(stat)
 
-        File.stub(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
+        File.stub(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
         provider.load_current_resource
       end
 
@@ -210,7 +214,7 @@ describe Chef::Resource::Link, :not_supported_on_win2k3 do
 
         provider.file_class.stub(:stat).with("#{CHEF_SPEC_DATA}/fofile").and_return(stat)
 
-        File.stub(:exists?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
+        File.stub(:exist?).with("#{CHEF_SPEC_DATA}/fofile").and_return(true)
         provider.load_current_resource
       end
 

--- a/spec/unit/provider/mount/aix_spec.rb
+++ b/spec/unit/provider/mount/aix_spec.rb
@@ -60,8 +60,8 @@ ENABLED
 
     @provider = Chef::Provider::Mount::Aix.new(@new_resource, @run_context)
 
-    ::File.stub(:exists?).with("/dev/sdz1").and_return true
-    ::File.stub(:exists?).with("/tmp/foo").and_return true
+    ::File.stub(:exist?).with("/dev/sdz1").and_return true
+    ::File.stub(:exist?).with("/tmp/foo").and_return true
   end
 
   def stub_mounted(provider, mounted_output)

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -34,8 +34,8 @@ describe Chef::Provider::Mount::Mount do
 
     @provider = Chef::Provider::Mount::Mount.new(@new_resource, @run_context)
 
-    ::File.stub(:exists?).with("/dev/sdz1").and_return true
-    ::File.stub(:exists?).with("/tmp/foo").and_return true
+    ::File.stub(:exist?).with("/dev/sdz1").and_return true
+    ::File.stub(:exist?).with("/tmp/foo").and_return true
     ::File.stub(:realpath).with("/dev/sdz1").and_return "/dev/sdz1"
     ::File.stub(:realpath).with("/tmp/foo").and_return "/tmp/foo"
   end
@@ -80,12 +80,12 @@ describe Chef::Provider::Mount::Mount do
     end
 
     it "should raise an error if the mount device does not exist" do
-      ::File.stub(:exists?).with("/dev/sdz1").and_return false
+      ::File.stub(:exist?).with("/dev/sdz1").and_return false
       lambda { @provider.load_current_resource();@provider.mountable? }.should raise_error(Chef::Exceptions::Mount)
     end
 
     it "should not call mountable? with load_current_resource - CHEF-1565" do
-      ::File.stub(:exists?).with("/dev/sdz1").and_return false
+      ::File.stub(:exist?).with("/dev/sdz1").and_return false
       @provider.should_receive(:mounted?).and_return(true)
       @provider.should_receive(:enabled?).and_return(true)
       @provider.should_not_receive(:mountable?)
@@ -98,12 +98,12 @@ describe Chef::Provider::Mount::Mount do
       status_findfs = double("Status", :exitstatus => 1)
       stdout_findfs = double("STDOUT", :first => nil)
       @provider.should_receive(:popen4).with("/sbin/findfs UUID=d21afe51-a0fe-4dc6-9152-ac733763ae0a").and_yield(@pid,@stdin,stdout_findfs,@stderr).and_return(status_findfs)
-      ::File.should_receive(:exists?).with("").and_return(false)
+      ::File.should_receive(:exist?).with("").and_return(false)
       lambda { @provider.load_current_resource();@provider.mountable? }.should raise_error(Chef::Exceptions::Mount)
     end
 
     it "should raise an error if the mount point does not exist" do
-      ::File.stub(:exists?).with("/tmp/foo").and_return false
+      ::File.stub(:exist?).with("/tmp/foo").and_return false
       lambda { @provider.load_current_resource();@provider.mountable? }.should raise_error(Chef::Exceptions::Mount)
     end
 

--- a/spec/unit/provider/mount/solaris_spec.rb
+++ b/spec/unit/provider/mount/solaris_spec.rb
@@ -89,10 +89,8 @@ describe Chef::Provider::Mount::Solaris do
     stub_const("Chef::Provider::Mount::Solaris::VFSTAB", vfstab_file.path )
     provider.stub(:shell_out!).with("mount -v").and_return(OpenStruct.new(:stdout => mount_output))
     File.stub(:symlink?).with(device).and_return(false)
-    File.stub(:exist?).and_call_original # Tempfile.open on ruby 1.8.7 calls File.exist?
     File.stub(:exist?).with(device).and_return(true)
     File.stub(:exist?).with(mountpoint).and_return(true)
-    expect(File).to_not receive(:exists?)
   end
 
   describe "#define_resource_requirements" do
@@ -102,7 +100,7 @@ describe Chef::Provider::Mount::Solaris do
     end
 
     it "run_action(:mount) should raise an error if the device does not exist" do
-      File.stub(:exist?).with(device).and_return(false)
+      ::File.should_receive(:exist?).with(device).and_return(false)
       expect { provider.run_action(:mount) }.to raise_error(Chef::Exceptions::Mount)
     end
 

--- a/spec/unit/provider/mount/solaris_spec.rb
+++ b/spec/unit/provider/mount/solaris_spec.rb
@@ -88,6 +88,7 @@ describe Chef::Provider::Mount::Solaris do
   before do
     stub_const("Chef::Provider::Mount::Solaris::VFSTAB", vfstab_file.path )
     provider.stub(:shell_out!).with("mount -v").and_return(OpenStruct.new(:stdout => mount_output))
+    ::File.stub(:exist?).and_call_original
     File.stub(:symlink?).with(device).and_return(false)
     File.stub(:exist?).with(device).and_return(true)
     File.stub(:exist?).with(mountpoint).and_return(true)

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Provider::Package::Aix do
     @new_resource.source("/tmp/samba.base")
 
     @provider = Chef::Provider::Package::Aix.new(@new_resource, @run_context)
-    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exist?).and_return(true)
   end
 
   describe "assessing the current package status" do
@@ -53,7 +53,7 @@ describe Chef::Provider::Package::Aix do
 
     it "should raise an exception if a source is supplied but not found" do
       @provider.stub(:popen4).and_return(@status)
-      ::File.stub(:exists?).and_return(false)
+      ::File.stub(:exist?).and_return(false)
       @provider.define_resource_requirements
       @provider.load_current_resource
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Package)

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -35,7 +35,7 @@ describe Chef::Provider::Package::Dpkg do
     @pid = double("PID")
     @provider.stub(:popen4).and_return(@status)
 
-    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exist?).and_return(true)
   end
 
   describe "when loading the current resource state" do
@@ -48,7 +48,7 @@ describe Chef::Provider::Package::Dpkg do
     it "should raise an exception if a source is supplied but not found" do
       @provider.load_current_resource
       @provider.define_resource_requirements
-      ::File.stub(:exists?).and_return(false)
+      ::File.stub(:exist?).and_return(false)
       lambda { @provider.run_action(:install) }.should raise_error(Chef::Exceptions::Package)
     end
 

--- a/spec/unit/provider/package/freebsd/pkg_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkg_spec.rb
@@ -147,6 +147,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should use the package_name as the port path when it starts with /" do
+      ::File.stub(:exist?).with('/usr/ports/www/wordpress').and_return(true)
       new_resource = Chef::Resource::Package.new("/usr/ports/www/wordpress")
       provider = Chef::Provider::Package::Freebsd::Pkg.new(new_resource, @run_context)
       provider.should_not_receive(:popen4)
@@ -157,6 +158,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       # @new_resource = double( "Chef::Resource::Package",
       #                       :package_name => "www/wordpress",
       #                       :cookbook_name => "xenoparadox")
+      ::File.stub(:exist?).with('www/wordpress').and_return(true)
       new_resource = Chef::Resource::Package.new("www/wordpress")
       provider = Chef::Provider::Package::Freebsd::Pkg.new(new_resource, @run_context)
       provider.should_not_receive(:popen4)

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -122,7 +122,7 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 PACMAN_CONF
 
-      ::File.stub(:exists?).with("/etc/pacman.conf").and_return(true)
+      ::File.stub(:exist?).with("/etc/pacman.conf").and_return(true)
       ::File.stub(:read).with("/etc/pacman.conf").and_return(@pacman_conf)
       @stdout.stub(:each).and_yield("customrepo/nano 1.2.3-4").
                             and_yield("    My custom package")

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Provider::Package::Rpm do
     @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
 
     @status = double("Status", :exitstatus => 0)
-    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exist?).and_return(true)
   end
 
   describe "when determining the current state of the package" do
@@ -48,7 +48,7 @@ describe Chef::Provider::Package::Rpm do
     end
 
     it "should raise an exception if a source is supplied but not found" do
-      ::File.stub(:exists?).and_return(false)
+      ::File.stub(:exist?).and_return(false)
       lambda { @provider.run_action(:any) }.should raise_error(Chef::Exceptions::Package)
     end
 

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -508,7 +508,6 @@ describe Chef::Provider::Package::Rubygems do
 
       # this catches 'gem_package "foo"' when "./foo" is a file in the cwd, and instead of installing './foo' it fetches the remote gem
       it "installs the gem via the gems api, when the package has no file separator characters in it, but a matching file exists in cwd" do
-        #::File.stub(:exist?).and_return(true)
         @new_resource.package_name('rspec-core')
         @provider.gem_env.should_receive(:install).with(@gem_dep, :sources => nil)
         @provider.action_install.should be_true

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -390,9 +390,9 @@ describe Chef::Provider::Package::Rubygems do
     platform_mock :unix do
       RbConfig::CONFIG.stub(:[]).with('bindir').and_return("/opt/chef/embedded/bin")
       ENV.stub(:[]).with('PATH').and_return("/usr/bin:/usr/sbin:/opt/chef/embedded/bin")
-      File.stub(:exists?).with('/usr/bin/gem').and_return(false)
-      File.stub(:exists?).with('/usr/sbin/gem').and_return(true)
-      File.stub(:exists?).with('/opt/chef/embedded/bin/gem').and_return(true) # should not get here
+      File.stub(:exist?).with('/usr/bin/gem').and_return(false)
+      File.stub(:exist?).with('/usr/sbin/gem').and_return(true)
+      File.stub(:exist?).with('/opt/chef/embedded/bin/gem').and_return(true) # should not get here
       provider = Chef::Provider::Package::Rubygems.new(@new_resource, @run_context)
       provider.gem_env.gem_binary_location.should == '/usr/sbin/gem'
     end
@@ -402,11 +402,11 @@ describe Chef::Provider::Package::Rubygems do
     platform_mock :windows do
       RbConfig::CONFIG.stub(:[]).with('bindir').and_return("d:/opscode/chef/embedded/bin")
       ENV.stub(:[]).with('PATH').and_return('C:\windows\system32;C:\windows;C:\Ruby186\bin;d:\opscode\chef\embedded\bin')
-      File.stub(:exists?).with('C:\\windows\\system32\\gem').and_return(false)
-      File.stub(:exists?).with('C:\\windows\\gem').and_return(false)
-      File.stub(:exists?).with('C:\\Ruby186\\bin\\gem').and_return(true)
-      File.stub(:exists?).with('d:\\opscode\\chef\\bin\\gem').and_return(false) # should not get here
-      File.stub(:exists?).with('d:\\opscode\\chef\\embedded\\bin\\gem').and_return(false) # should not get here
+      File.stub(:exist?).with('C:\\windows\\system32\\gem').and_return(false)
+      File.stub(:exist?).with('C:\\windows\\gem').and_return(false)
+      File.stub(:exist?).with('C:\\Ruby186\\bin\\gem').and_return(true)
+      File.stub(:exist?).with('d:\\opscode\\chef\\bin\\gem').and_return(false) # should not get here
+      File.stub(:exist?).with('d:\\opscode\\chef\\embedded\\bin\\gem').and_return(false) # should not get here
       provider = Chef::Provider::Package::Rubygems.new(@new_resource, @run_context)
       provider.gem_env.gem_binary_location.should == 'C:\Ruby186\bin\gem'
     end
@@ -508,7 +508,7 @@ describe Chef::Provider::Package::Rubygems do
 
       # this catches 'gem_package "foo"' when "./foo" is a file in the cwd, and instead of installing './foo' it fetches the remote gem
       it "installs the gem via the gems api, when the package has no file separator characters in it, but a matching file exists in cwd" do
-        ::File.stub(:exists?).and_return(true)
+        #::File.stub(:exist?).and_return(true)
         @new_resource.package_name('rspec-core')
         @provider.gem_env.should_receive(:install).with(@gem_dep, :sources => nil)
         @provider.action_install.should be_true

--- a/spec/unit/provider/package/solaris_spec.rb
+++ b/spec/unit/provider/package/solaris_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Provider::Package::Solaris do
     @new_resource.source("/tmp/bash.pkg")
 
     @provider = Chef::Provider::Package::Solaris.new(@new_resource, @run_context)
-    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exist?).and_return(true)
   end
 
   describe "assessing the current package status" do
@@ -63,7 +63,7 @@ PKGINFO
 
     it "should raise an exception if a source is supplied but not found" do
       @provider.stub(:popen4).and_return(@status)
-      ::File.stub(:exists?).and_return(false)
+      ::File.stub(:exist?).and_return(false)
       @provider.define_resource_requirements
       @provider.load_current_resource
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Package)

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -352,7 +352,7 @@ describe Chef::Provider::Package::Yum do
 
     it "should run yum localinstall if given a path to an rpm as the package" do
       @new_resource = Chef::Resource::Package.new("/tmp/emacs-21.4-20.el5.i386.rpm")
-      ::File.stub(:exists?).and_return(true)
+      ::File.stub(:exist?).and_return(true)
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @new_resource.source.should == "/tmp/emacs-21.4-20.el5.i386.rpm"
       @provider.should_receive(:yum_command).with(

--- a/spec/unit/provider/service/arch_service_spec.rb
+++ b/spec/unit/provider/service/arch_service_spec.rb
@@ -39,7 +39,8 @@ describe Chef::Provider::Service::Arch, "load_current_resource" do
 
     @provider = Chef::Provider::Service::Arch.new(@new_resource, @run_context)
 
-    ::File.stub(:exists?).with("/etc/rc.conf").and_return(true)
+    ::File.stub(:exist?).with("/etc/rc.d/chef").and_return(false)
+    ::File.stub(:exist?).with("/etc/rc.conf").and_return(true)
     ::File.stub(:read).with("/etc/rc.conf").and_return("DAEMONS=(network apache sshd)")
   end
 
@@ -111,7 +112,7 @@ describe Chef::Provider::Service::Arch, "load_current_resource" do
 
 
   it "should fail if file /etc/rc.conf does not exist" do
-    ::File.stub(:exists?).with("/etc/rc.conf").and_return(false)
+    ::File.stub(:exist?).with("/etc/rc.conf").and_return(false)
     lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::Service)
   end
 

--- a/spec/unit/provider/service/debian_service_spec.rb
+++ b/spec/unit/provider/service/debian_service_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::Service::Debian do
 
   describe "load_current_resource" do
     it "ensures /usr/sbin/update-rc.d is available" do
-      File.should_receive(:exists?).with("/usr/sbin/update-rc.d") .and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/update-rc.d") .and_return(false)
 
       @provider.define_resource_requirements
       lambda {

--- a/spec/unit/provider/service/freebsd_service_spec.rb
+++ b/spec/unit/provider/service/freebsd_service_spec.rb
@@ -47,8 +47,9 @@ PS_SAMPLE
       @status = double(:stdout => @stdout, :exitstatus => 0)
       @provider.stub(:shell_out!).with(@node[:command][:ps]).and_return(@status)
 
-      ::File.stub(:exists?).and_return(false)
-      ::File.stub(:exists?).with("/usr/local/etc/rc.d/#{@new_resource.service_name}").and_return(true)
+      ::File.stub(:exist?).with('/etc/rc.d/apache22').and_return(false)
+      ::File.stub(:exist?).with('/etc/rc.conf').and_return(false)
+      ::File.stub(:exist?).with("/usr/local/etc/rc.d/#{@new_resource.service_name}").and_return(true)
       @lines = double("lines")
       @lines.stub(:each).and_yield("sshd_enable=\"YES\"").
                           and_yield("#{@new_resource.name}_enable=\"YES\"")
@@ -128,7 +129,7 @@ RC_SAMPLE
 
     describe "when executing assertions" do
       it "should verify that /etc/rc.conf exists" do
-        ::File.should_receive(:exists?).with("/etc/rc.conf")
+        ::File.should_receive(:exist?).with("/etc/rc.conf")
         @provider.stub(:service_enable_variable_name).and_return("#{@current_resource.service_name}_enable")
         @provider.load_current_resource
       end
@@ -136,7 +137,7 @@ RC_SAMPLE
       context "and the init script is not found" do
         [ "start", "reload", "restart", "enable" ].each do |action|
           it "should raise an exception when the action is #{action}" do
-            ::File.stub(:exists?).and_return(false)
+            ::File.stub(:exist?).with("/usr/local/etc/rc.d/#{@new_resource.service_name}").and_return(false)
             @provider.load_current_resource
             @provider.define_resource_requirements
             @provider.instance_variable_get("@rcd_script_found").should be_false
@@ -154,14 +155,14 @@ RC_SAMPLE
       end
 
       it "update state when current resource enabled state could not be determined" do
-        ::File.should_receive(:exists?).with("/etc/rc.conf").and_return false
+        ::File.should_receive(:exist?).with("/etc/rc.conf").and_return false
         @provider.load_current_resource
         @provider.instance_variable_get("@enabled_state_found").should be_false
       end
 
       it "update state when current resource enabled state could be determined" do
         ::File.stub(:exist?).with("/usr/local/etc/rc.d/#{@new_resource.service_name}").and_return(true)
-        ::File.should_receive(:exists?).with("/etc/rc.conf").and_return  true
+        ::File.should_receive(:exist?).with("/etc/rc.conf").and_return  true
         @provider.load_current_resource
         @provider.instance_variable_get("@enabled_state_found").should be_false
         @provider.instance_variable_get("@rcd_script_found").should be_true

--- a/spec/unit/provider/service/gentoo_service_spec.rb
+++ b/spec/unit/provider/service/gentoo_service_spec.rb
@@ -32,16 +32,16 @@ describe Chef::Provider::Service::Gentoo do
     Chef::Resource::Service.stub(:new).and_return(@current_resource)
     @status = double("Status", :exitstatus => 0, :stdout => @stdout)
     @provider.stub(:shell_out).and_return(@status)
-    File.stub(:exists?).with("/etc/init.d/chef").and_return(true)
-    File.stub(:exists?).with("/sbin/rc-update").and_return(true)
-    File.stub(:exists?).with("/etc/runlevels/default/chef").and_return(false)
+    File.stub(:exist?).with("/etc/init.d/chef").and_return(true)
+    File.stub(:exist?).with("/sbin/rc-update").and_return(true)
+    File.stub(:exist?).with("/etc/runlevels/default/chef").and_return(false)
     File.stub(:readable?).with("/etc/runlevels/default/chef").and_return(false)
   end
  # new test: found_enabled state
   #
   describe "load_current_resource" do
     it "should raise Chef::Exceptions::Service if /sbin/rc-update does not exist" do
-      File.should_receive(:exists?).with("/sbin/rc-update").and_return(false)
+      File.should_receive(:exist?).with("/sbin/rc-update").and_return(false)
       @provider.define_resource_requirements
       lambda { @provider.process_resource_requirements }.should raise_error(Chef::Exceptions::Service)
     end
@@ -65,7 +65,7 @@ describe Chef::Provider::Service::Gentoo do
 
         describe "and the file exists and is readable" do
           before do
-            File.stub(:exists?).with("/etc/runlevels/default/chef").and_return(true)
+            File.stub(:exist?).with("/etc/runlevels/default/chef").and_return(true)
             File.stub(:readable?).with("/etc/runlevels/default/chef").and_return(true)
           end
           it "should set enabled to true" do
@@ -76,7 +76,7 @@ describe Chef::Provider::Service::Gentoo do
 
         describe "and the file exists but is not readable" do
           before do
-            File.stub(:exists?).with("/etc/runlevels/default/chef").and_return(true)
+            File.stub(:exist?).with("/etc/runlevels/default/chef").and_return(true)
             File.stub(:readable?).with("/etc/runlevels/default/chef").and_return(false)
           end
 
@@ -88,7 +88,7 @@ describe Chef::Provider::Service::Gentoo do
 
         describe "and the file does not exist" do
           before do
-            File.stub(:exists?).with("/etc/runlevels/default/chef").and_return(false)
+            File.stub(:exist?).with("/etc/runlevels/default/chef").and_return(false)
             File.stub(:readable?).with("/etc/runlevels/default/chef").and_return("foobarbaz")
           end
 

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -21,7 +21,7 @@ require 'ostruct'
 
 shared_examples_for "define_resource_requirements_common" do
   it "should raise an error if /sbin/chkconfig does not exist" do
-    File.stub(:exists?).with("/sbin/chkconfig").and_return(false)
+    File.stub(:exist?).with("/sbin/chkconfig").and_return(false)
     @provider.stub(:shell_out).with("/sbin/service chef status").and_raise(Errno::ENOENT)
     @provider.stub(:shell_out!).with("/sbin/chkconfig --list chef", :returns => [0,1]).and_raise(Errno::ENOENT)
     @provider.load_current_resource
@@ -55,7 +55,7 @@ describe "Chef::Provider::Service::Redhat" do
     @provider = Chef::Provider::Service::Redhat.new(@new_resource, @run_context)
     @provider.action = :start
     Chef::Resource::Service.stub(:new).and_return(@current_resource)
-    File.stub(:exists?).with("/sbin/chkconfig").and_return(true)
+    File.stub(:exist?).with("/sbin/chkconfig").and_return(true)
   end
 
   describe "while not in why run mode" do

--- a/spec/unit/provider/service/solaris_smf_service_spec.rb
+++ b/spec/unit/provider/service/solaris_smf_service_spec.rb
@@ -42,14 +42,14 @@ describe Chef::Provider::Service::Solaris do
   end
 
   it "should raise an error if /bin/svcs does not exist" do
-    File.should_receive(:exists?).with("/bin/svcs").and_return(false)
+    File.should_receive(:exist?).with("/bin/svcs").and_return(false)
     lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::Service)
   end
 
   describe "on a host with /bin/svcs" do
 
     before do
-      File.stub(:exists?).with('/bin/svcs').and_return(true)
+      File.stub(:exist?).with('/bin/svcs').and_return(true)
     end
 
     describe "when discovering the current service state" do

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -73,9 +73,6 @@ describe Chef::Provider::Service::Upstart do
       @stdout = StringIO.new
       @stderr = StringIO.new
       @pid = double("PID")
-
-      #::File.stub(:exist?).and_return(true)
-      #::File.stub(:open).and_return(true)
     end
 
     it "should create a current resource with the name of the new resource" do
@@ -156,7 +153,6 @@ describe Chef::Provider::Service::Upstart do
     end
 
     it "should assume disable when no job configuration file is found" do
-      #::File.stub(:exist?).and_return(false)
       @current_resource.should_receive(:running).with(false)
       @provider.load_current_resource
     end

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -74,8 +74,8 @@ describe Chef::Provider::Service::Upstart do
       @stderr = StringIO.new
       @pid = double("PID")
 
-      ::File.stub(:exists?).and_return(true)
-      ::File.stub(:open).and_return(true)
+      #::File.stub(:exist?).and_return(true)
+      #::File.stub(:open).and_return(true)
     end
 
     it "should create a current resource with the name of the new resource" do
@@ -156,14 +156,14 @@ describe Chef::Provider::Service::Upstart do
     end
 
     it "should assume disable when no job configuration file is found" do
-      ::File.stub(:exists?).and_return(false)
+      #::File.stub(:exist?).and_return(false)
       @current_resource.should_receive(:running).with(false)
       @provider.load_current_resource
     end
 
 
     it "should track state when the upstart configuration file fails to load" do
-      File.should_receive(:exists?).and_return false
+      File.should_receive(:exist?).and_return false
       @provider.load_current_resource
       @provider.instance_variable_get("@config_file_found").should == false
     end

--- a/spec/unit/provider/template_spec.rb
+++ b/spec/unit/provider/template_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Provider::Template do
 
   let(:content) do
     content = double('Chef::Provider::File::Content::Template', :template_location => "/foo/bar/baz")
-    File.stub(:exists?).with("/foo/bar/baz").and_return(true)
+    File.stub(:exist?).with("/foo/bar/baz").and_return(true)
     content
   end
 
@@ -80,7 +80,7 @@ describe Chef::Provider::Template do
     it "stops executing when the local template source can't be found" do
       setup_normal_file
       content.stub(:template_location).and_return("/baz/bar/foo")
-      File.stub(:exists?).with("/baz/bar/foo").and_return(false)
+      File.stub(:exist?).with("/baz/bar/foo").and_return(false)
       lambda { provider.run_action(:create) }.should raise_error Chef::Mixin::WhyRun::ResourceRequirements::Assertion::AssertionFailure
     end
 

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -156,8 +156,9 @@ describe Chef::Provider::User::Dscl do
       current_home_files = [current_home + '/my-dot-emacs', current_home + '/my-dot-vim']
       @current_resource.home(current_home)
       @new_resource.gid(23)
-      ::File.stub(:exists?).with('/old/home/toor').and_return(true)
-      ::File.stub(:exists?).with('/Users/toor').and_return(true)
+      ::File.stub(:exist?).with('/old/home/toor').and_return(true)
+      ::File.stub(:exist?).with('/Users/toor').and_return(true)
+      ::File.stub(:exist?).with(current_home).and_return(true)
 
       FileUtils.should_receive(:mkdir_p).with('/Users/toor').and_return(true)
       FileUtils.should_receive(:rmdir).with(current_home)
@@ -170,12 +171,12 @@ describe Chef::Provider::User::Dscl do
     end
 
     it "should raise an exception when the systems user template dir (skel) cannot be found" do
-      ::File.stub(:exists?).and_return(false,false,false)
+      #::File.stub(:exist?).and_return(false,false,false)
       lambda { @provider.modify_home }.should raise_error(Chef::Exceptions::User)
     end
 
     it "should run ditto to copy any missing files from skel to the new home dir" do
-      ::File.should_receive(:exists?).with("/System/Library/User\ Template/English.lproj").and_return(true)
+      ::File.should_receive(:exist?).with("/System/Library/User\ Template/English.lproj").and_return(true)
       FileUtils.should_receive(:chown_R).with('toor', '', '/Users/toor')
       @provider.should_receive(:shell_out!).with("ditto '/System/Library/User Template/English.lproj' '/Users/toor'")
       @provider.ditto_home
@@ -319,12 +320,12 @@ describe Chef::Provider::User::Dscl do
 
   describe "load_current_resource" do
     it "should raise an error if the required binary /usr/bin/dscl doesn't exist" do
-      ::File.should_receive(:exists?).with("/usr/bin/dscl").and_return(false)
+      ::File.should_receive(:exist?).with("/usr/bin/dscl").and_return(false)
       lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::User)
     end
 
     it "shouldn't raise an error if /usr/bin/dscl exists" do
-      ::File.stub(:exists?).and_return(true)
+      ::File.stub(:exist?).with('/usr/bin/dscl').and_return(true)
       lambda { @provider.load_current_resource }.should_not raise_error
     end
   end

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -171,7 +171,6 @@ describe Chef::Provider::User::Dscl do
     end
 
     it "should raise an exception when the systems user template dir (skel) cannot be found" do
-      #::File.stub(:exist?).and_return(false,false,false)
       lambda { @provider.modify_home }.should raise_error(Chef::Exceptions::User)
     end
 

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -240,12 +240,12 @@ describe Chef::Provider::User::Pw do
     end
 
     it "should raise an error if the required binary /usr/sbin/pw doesn't exist" do
-      File.should_receive(:exists?).with("/usr/sbin/pw").and_return(false)
+      File.should_receive(:exist?).with("/usr/sbin/pw").and_return(false)
       lambda { @provider.load_current_resource }.should raise_error(Chef::Exceptions::User)
     end
 
     it "shouldn't raise an error if /usr/sbin/pw exists" do
-      File.stub(:exists?).and_return(true)
+      File.should_receive(:exist?).with("/usr/sbin/pw").and_return(true)
       lambda { @provider.load_current_resource }.should_not raise_error
     end
   end

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -649,7 +649,7 @@ describe Chef::REST do
         expect(path).not_to be_nil
         tempfile.stub(:write).and_raise(IOError)
         rest.fetch("cookbooks/a_cookbook") {|tmpfile| "shouldn't get here"}
-        expect(File.exists?(path)).to be_false
+        expect(File.exist?(path)).to be_false
       end
 
       it "closes and unlinks the tempfile when the response is a redirect" do

--- a/spec/unit/role_spec.rb
+++ b/spec/unit/role_spec.rb
@@ -258,7 +258,7 @@ EOR
     it "should return a Chef::Role object from JSON" do
       Dir.should_receive(:glob).and_return(["#{Chef::Config[:role_path]}/memes", "#{Chef::Config[:role_path]}/memes/lolcat.json"])
       file_path = File.join(Chef::Config[:role_path], 'memes/lolcat.json')
-      File.should_receive(:exists?).with(file_path).exactly(1).times.and_return(true)
+      File.should_receive(:exist?).with(file_path).exactly(1).times.and_return(true)
       IO.should_receive(:read).with(file_path).and_return('{"name": "ceiling_cat", "json_class": "Chef::Role" }')
       @role.should be_a_kind_of(Chef::Role)
       @role.class.from_disk("lolcat")
@@ -267,7 +267,7 @@ EOR
     it "should return a Chef::Role object from a Ruby DSL" do
       Dir.should_receive(:glob).and_return(["#{Chef::Config[:role_path]}/memes", "#{Chef::Config[:role_path]}/memes/lolcat.rb"])
       rb_path = File.join(Chef::Config[:role_path], 'memes/lolcat.rb')
-      File.should_receive(:exists?).with(rb_path).exactly(2).times.and_return(true)
+      File.should_receive(:exist?).with(rb_path).exactly(2).times.and_return(true)
       File.should_receive(:readable?).with(rb_path).exactly(1).times.and_return(true)
       IO.should_receive(:read).with(rb_path).and_return(ROLE_DSL)
       @role.should be_a_kind_of(Chef::Role)
@@ -278,8 +278,8 @@ EOR
       Dir.should_receive(:glob).and_return(["#{Chef::Config[:role_path]}/memes", "#{Chef::Config[:role_path]}/memes/lolcat.json", "#{Chef::Config[:role_path]}/memes/lolcat.rb"])
       js_path = File.join(Chef::Config[:role_path], 'memes/lolcat.json')
       rb_path = File.join(Chef::Config[:role_path], 'memes/lolcat.rb')
-      File.should_receive(:exists?).with(js_path).exactly(1).times.and_return(true)
-      File.should_not_receive(:exists?).with(rb_path)
+      File.should_receive(:exist?).with(js_path).exactly(1).times.and_return(true)
+      File.should_not_receive(:exist?).with(rb_path)
       IO.should_receive(:read).with(js_path).and_return('{"name": "ceiling_cat", "json_class": "Chef::Role" }')
       @role.should be_a_kind_of(Chef::Role)
       @role.class.from_disk("lolcat")
@@ -287,13 +287,13 @@ EOR
 
     it "should raise an exception if the file does not exist" do
       Dir.should_receive(:glob).and_return(["#{Chef::Config[:role_path]}/meme.rb"])
-      File.should_not_receive(:exists?)
+      File.should_not_receive(:exist?)
       lambda {@role.class.from_disk("lolcat")}.should raise_error(Chef::Exceptions::RoleNotFound)
     end
 
     it "should raise an exception if two files exist with the same name" do
       Dir.should_receive(:glob).and_return(["#{Chef::Config[:role_path]}/memes/lolcat.rb", "#{Chef::Config[:role_path]}/lolcat.rb"])
-      File.should_not_receive(:exists?)
+      File.should_not_receive(:exist?)
       lambda {@role.class.from_disk("lolcat")}.should raise_error(Chef::Exceptions::DuplicateRole)
     end
   end
@@ -306,7 +306,7 @@ EOR
 
     it "should return a Chef::Role object from JSON" do
       Dir.should_receive(:glob).with(File.join('/path1', '**', '**')).exactly(1).times.and_return(['/path1/lolcat.json'])
-      File.should_receive(:exists?).with('/path1/lolcat.json').exactly(1).times.and_return(true)
+      File.should_receive(:exist?).with('/path1/lolcat.json').exactly(1).times.and_return(true)
       IO.should_receive(:read).with('/path1/lolcat.json').and_return('{"name": "ceiling_cat", "json_class": "Chef::Role" }')
       @role.should be_a_kind_of(Chef::Role)
       @role.class.from_disk("lolcat")
@@ -315,7 +315,7 @@ EOR
     it "should return a Chef::Role object from JSON when role is in the second path" do
       Dir.should_receive(:glob).with(File.join('/path1', '**', '**')).exactly(1).times.and_return([])
       Dir.should_receive(:glob).with(File.join('/path/path2', '**', '**')).exactly(1).times.and_return(['/path/path2/lolcat.json'])
-      File.should_receive(:exists?).with('/path/path2/lolcat.json').exactly(1).times.and_return(true)
+      File.should_receive(:exist?).with('/path/path2/lolcat.json').exactly(1).times.and_return(true)
       IO.should_receive(:read).with('/path/path2/lolcat.json').and_return('{"name": "ceiling_cat", "json_class": "Chef::Role" }')
       @role.should be_a_kind_of(Chef::Role)
       @role.class.from_disk("lolcat")
@@ -323,7 +323,7 @@ EOR
 
     it "should return a Chef::Role object from a Ruby DSL" do
       Dir.should_receive(:glob).with(File.join('/path1', '**', '**')).exactly(1).times.and_return(['/path1/lolcat.rb'])
-      File.should_receive(:exists?).with('/path1/lolcat.rb').exactly(2).times.and_return(true)
+      File.should_receive(:exist?).with('/path1/lolcat.rb').exactly(2).times.and_return(true)
       File.should_receive(:readable?).with('/path1/lolcat.rb').and_return(true)
       IO.should_receive(:read).with('/path1/lolcat.rb').exactly(1).times.and_return(ROLE_DSL)
       @role.should be_a_kind_of(Chef::Role)
@@ -333,7 +333,7 @@ EOR
     it "should return a Chef::Role object from a Ruby DSL when role is in the second path" do
       Dir.should_receive(:glob).with(File.join('/path1', '**', '**')).exactly(1).times.and_return([])
       Dir.should_receive(:glob).with(File.join('/path/path2', '**', '**')).exactly(1).times.and_return(['/path/path2/lolcat.rb'])
-      File.should_receive(:exists?).with('/path/path2/lolcat.rb').exactly(2).times.and_return(true)
+      File.should_receive(:exist?).with('/path/path2/lolcat.rb').exactly(2).times.and_return(true)
       File.should_receive(:readable?).with('/path/path2/lolcat.rb').and_return(true)
       IO.should_receive(:read).with('/path/path2/lolcat.rb').exactly(1).times.and_return(ROLE_DSL)
       @role.should be_a_kind_of(Chef::Role)


### PR DESCRIPTION
Also fixed bug with symlinks what was checked the using `exists?` and `exist?` at same time, but in specs was mocked only `exists?`