### PR TITLE
[chef_fs/file_system] Ignore missing entry at destination when purging

### DIFF
--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -285,8 +285,12 @@ class Chef
                 if options[:dry_run]
                   ui.output "Would delete #{dest_path}" if ui
                 else
-                  dest_entry.delete(true)
-                  ui.output "Deleted extra entry #{dest_path} (purge is on)" if ui
+                  begin
+                    dest_entry.delete(true)
+                    ui.output "Deleted extra entry #{dest_path} (purge is on)" if ui
+                  rescue Chef::ChefFS::FileSystem::NotFoundError
+                    ui.output "Entry #{dest_path} does not exist. Nothing to do. (purge is on)" if ui
+                  end
                 end
               else
                 ui.output ("Not deleting extra entry #{dest_path} (purge is off)") if ui


### PR DESCRIPTION
If a user attempts to call #copy_to with a path that does not exist at
either the source or destination and :purge set to true, we currently
fail with an error trying to delete the non-existent entry at the
destination.

This patch ignores that failure.
