### PR TITLE
remove setting proxy environment variables

### DIFF
--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -211,7 +211,6 @@ class Chef
       def reconfigure(startup_parameters=[])
         configure_chef startup_parameters
         configure_logging
-        configure_proxy_environment_variables
 
         Chef::Config[:chef_server_url] = config[:chef_server_url] if config.has_key? :chef_server_url
         unless Chef::Config[:exception_handlers].any? {|h| Chef::Handler::ErrorReport === h}


### PR DESCRIPTION
The windows service application does not inherit from application, as I thought it did, so `configure_proxy_environment_variables` was causing failures. We don't need to configure proxy environment variables in this application, so I've removed the line. Spec for windows service passes.
