### PR TITLE
[OC-11667] Don't overwrite the :default provider map if :default is passed as the platform

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -507,6 +507,8 @@ class Chef
             if platforms.has_key?(args[:platform])
               if platforms[args[:platform]].has_key?(:default)
                 platforms[args[:platform]][:default][args[:resource].to_sym] = args[:provider]
+              elsif args[:platform] == :default
+                platforms[:default][args[:resource].to_sym] = args[:provider]
               else
                 platforms[args[:platform]] = { :default => { args[:resource].to_sym => args[:provider] } }
               end

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -254,6 +254,16 @@ describe Chef::Platform do
 
     end
 
+    it "does not overwrite the platform map when using :default platform" do
+      Chef::Platform.set(
+        :resource => :file,
+        :platform => :default,
+        :provider => "new school"
+      )
+      Chef::Platform.platforms[:default][:file].should eql("new school")
+      Chef::Platform.platforms[:default][:cat].should eql("nice")
+    end
+
   end
 
   context "while testing the configured platform data" do


### PR DESCRIPTION
If you attempt to configure a `:default` platform provider mapping with:

``` ruby
Chef::Platform.set(
  :provider => Chef::Provider::User::MyOrgsUser
  :resource => :user
  :platform => :default
)
```

The `:default` provider mapping will be erroneously overwritten, meaning [these defaults](https://github.com/opscode/chef/blob/master/lib/chef/platform/provider_mapping.rb#L363-387) will be overwritten to 

``` ruby
{:default=>{:user=>Chef::Provider::User::MyOrgUser}}"
```

This will break common resources like `log` that depend on the default provider mapping being correct.  The error messaging is very misleading.

Not specifying `:default` as the platform is a nice way to work around this, however, it's hardly intuitive and the error messaging is very misleading.
