### PR TITLE
mark some obvious tests as :windows_only

### DIFF
--- a/spec/unit/provider/group/windows_spec.rb
+++ b/spec/unit/provider/group/windows_spec.rb
@@ -27,7 +27,7 @@ class Chef
   end
 end
 
-describe Chef::Provider::Group::Windows do
+describe Chef::Provider::Group::Windows, :windows_only do
   before do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new
@@ -86,7 +86,7 @@ describe Chef::Provider::Group::Windows do
   end
 end
 
-describe Chef::Provider::Group::Windows, "NetGroup" do
+describe Chef::Provider::Group::Windows, "NetGroup", :windows_only do
   before do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new

--- a/spec/unit/provider/mount/windows_spec.rb
+++ b/spec/unit/provider/mount/windows_spec.rb
@@ -32,7 +32,7 @@ end
 GUID = "\\\\?\\Volume{578e72b5-6e70-11df-b5c5-000c29d4a7d9}\\"
 REMOTE = "\\\\server-name\\path"
 
-describe Chef::Provider::Mount::Windows do
+describe Chef::Provider::Mount::Windows, :windows_only do
   before(:each) do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -19,288 +19,283 @@
 
 require 'spec_helper'
 
-describe Chef::Provider::Service::Windows, "load_current_resource" do
-  before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::Service.new("chef")
-    @provider = Chef::Provider::Service::Windows.new(@new_resource, @run_context)
-    Object.send(:remove_const, 'Win32') if defined?(Win32)
-    Win32 = Module.new
-    Win32::Service = Class.new
-    Win32::Service::AUTO_START = 0x00000002
-    Win32::Service::DISABLED = 0x00000004
-    Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-      double("StatusStruct", :current_state => "running"))
-    Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
-      double("ConfigStruct", :start_type => "auto start"))
-    Win32::Service.stub(:exists?).and_return(true)
-  end
-
-  it "should set the current resources service name to the new resources service name" do
-    @provider.load_current_resource
-    @provider.current_resource.service_name.should == 'chef'
-  end
-
-  it "should return the current resource" do
-    @provider.load_current_resource.should equal(@provider.current_resource)
-  end
-
-  it "should set the current resources status" do
-    @provider.load_current_resource
-    @provider.current_resource.running.should be_true
-  end
-
-  it "should set the current resources start type" do
-    @provider.load_current_resource
-    @provider.current_resource.enabled.should be_true
-  end
-
-  describe Chef::Provider::Service::Windows, "start_service" do
+describe Chef::Provider::Service::Windows, :windows_only do
     before(:each) do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "stopped"),
-        double("StatusStruct", :current_state => "running"))
-    end
-
-    it "should call the start command if one is specified" do
-      @new_resource.start_command "sc start chef"
-      @provider.should_receive(:shell_out!).with("#{@new_resource.start_command}").and_return("Starting custom service")
-      @provider.start_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should use the built-in command if no start command is specified" do
-      Win32::Service.should_receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should do nothing if the service does not exist" do
-      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should do nothing if the service is running" do
+      @node = Chef::Node.new
+      @events = Chef::EventDispatch::Dispatcher.new
+      @run_context = Chef::RunContext.new(@node, {}, @events)
+      @new_resource = Chef::Resource::Service.new("chef")
+      @provider = Chef::Provider::Service::Windows.new(@new_resource, @run_context)
+      Object.send(:remove_const, 'Win32') if defined?(Win32)
+      Win32 = Module.new
+      Win32::Service = Class.new
+      Win32::Service::AUTO_START = 0x00000002
+      Win32::Service::DISABLED = 0x00000004
       Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      @new_resource.updated_by_last_action?.should be_false
+      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+        double("ConfigStruct", :start_type => "auto start"))
+      Win32::Service.stub(:exists?).and_return(true)
     end
 
-    it "should raise an error if the service is paused" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "paused"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should wait and continue if the service is in start_pending" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "start pending"),
-        double("StatusStruct", :current_state => "start pending"),
-        double("StatusStruct", :current_state => "running"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should fail if the service is in stop_pending" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "stop pending"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-  end
-
-
-  describe Chef::Provider::Service::Windows, "stop_service" do
-
-    before(:each) do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "running"),
-        double("StatusStruct", :current_state => "stopped"))
-    end
-
-    it "should call the stop command if one is specified" do
-      @new_resource.stop_command "sc stop chef"
-      @provider.should_receive(:shell_out!).with("#{@new_resource.stop_command}").and_return("Stopping custom service")
-      @provider.stop_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should use the built-in command if no stop command is specified" do
-      Win32::Service.should_receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should do nothing if the service does not exist" do
-      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
-      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should do nothing if the service is stopped" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "stopped"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should raise an error if the service is paused" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "paused"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should wait and continue if the service is in stop_pending" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "stop pending"),
-        double("StatusStruct", :current_state => "stop pending"),
-        double("StatusStruct", :current_state => "stopped"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should fail if the service is in start_pending" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "start pending"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
-      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should pass custom timeout to the stop command if provided" do
-      Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
-        mock("StatusStruct", :current_state => "running"))
-      @new_resource.timeout 1
-      Win32::Service.should_receive(:stop).with(@new_resource.service_name)
-      Timeout.timeout(2) do
-        expect { @provider.stop_service }.to raise_error(Timeout::Error)
+    describe "load_current_resource" do
+      it "should set the current resources service name to the new resources service name" do
+        @provider.load_current_resource
+        @provider.current_resource.service_name.should == 'chef'
       end
-      @new_resource.updated_by_last_action?.should be_false
+
+      it "should return the current resource" do
+        @provider.load_current_resource.should equal(@provider.current_resource)
+      end
+
+      it "should set the current resources status" do
+        @provider.load_current_resource
+        @provider.current_resource.running.should be_true
+      end
+
+      it "should set the current resources start type" do
+        @provider.load_current_resource
+        @provider.current_resource.enabled.should be_true
+      end
     end
 
-  end
+    describe "start_service" do
+      before(:each) do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "stopped"),
+          double("StatusStruct", :current_state => "running"))
+      end
 
-  describe Chef::Provider::Service::Windows, "restart_service" do
+      it "should call the start command if one is specified" do
+        @new_resource.start_command "sc start chef"
+        @provider.should_receive(:shell_out!).with("#{@new_resource.start_command}").and_return("Starting custom service")
+        @provider.start_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
 
-    it "should call the restart command if one is specified" do
-      @new_resource.restart_command "sc restart"
-      @provider.should_receive(:shell_out!).with("#{@new_resource.restart_command}")
-      @provider.restart_service
-      @new_resource.updated_by_last_action?.should be_true
+      it "should use the built-in command if no start command is specified" do
+        Win32::Service.should_receive(:start).with(@new_resource.service_name)
+        @provider.start_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should do nothing if the service does not exist" do
+        Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        @provider.start_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should do nothing if the service is running" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "running"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        @provider.start_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should raise an error if the service is paused" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "paused"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should wait and continue if the service is in start_pending" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "start pending"),
+          double("StatusStruct", :current_state => "start pending"),
+          double("StatusStruct", :current_state => "running"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        @provider.start_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should fail if the service is in stop_pending" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "stop pending"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
+        @new_resource.updated_by_last_action?.should be_false
+      end
     end
 
-    it "should stop then start the service if it is running" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "running"),
-        double("StatusStruct", :current_state => "stopped"),
-        double("StatusStruct", :current_state => "stopped"),
-        double("StatusStruct", :current_state => "running"))
-      Win32::Service.should_receive(:stop).with(@new_resource.service_name)
-      Win32::Service.should_receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      @new_resource.updated_by_last_action?.should be_true
+    describe "stop_service" do
+      before(:each) do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "running"),
+          double("StatusStruct", :current_state => "stopped"))
+      end
+
+      it "should call the stop command if one is specified" do
+        @new_resource.stop_command "sc stop chef"
+        @provider.should_receive(:shell_out!).with("#{@new_resource.stop_command}").and_return("Stopping custom service")
+        @provider.stop_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should use the built-in command if no stop command is specified" do
+        Win32::Service.should_receive(:stop).with(@new_resource.service_name)
+        @provider.stop_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should do nothing if the service does not exist" do
+        Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
+        Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+        @provider.stop_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should do nothing if the service is stopped" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "stopped"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+        @provider.stop_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should raise an error if the service is paused" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "paused"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should wait and continue if the service is in stop_pending" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "stop pending"),
+          double("StatusStruct", :current_state => "stop pending"),
+          double("StatusStruct", :current_state => "stopped"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+        @provider.stop_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should fail if the service is in start_pending" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "start pending"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+        expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should pass custom timeout to the stop command if provided" do
+        Win32::Service.stub!(:status).with(@new_resource.service_name).and_return(
+          mock("StatusStruct", :current_state => "running"))
+        @new_resource.timeout 1
+        Win32::Service.should_receive(:stop).with(@new_resource.service_name)
+        Timeout.timeout(2) do
+          expect { @provider.stop_service }.to raise_error(Timeout::Error)
+        end
+        @new_resource.updated_by_last_action?.should be_false
+      end
     end
 
-    it "should just start the service if it is stopped" do
-      Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
-        double("StatusStruct", :current_state => "stopped"),
-        double("StatusStruct", :current_state => "stopped"),
-        double("StatusStruct", :current_state => "running"))
-      Win32::Service.should_receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      @new_resource.updated_by_last_action?.should be_true
+    describe "restart_service" do
+      it "should call the restart command if one is specified" do
+        @new_resource.restart_command "sc restart"
+        @provider.should_receive(:shell_out!).with("#{@new_resource.restart_command}")
+        @provider.restart_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should stop then start the service if it is running" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "running"),
+          double("StatusStruct", :current_state => "stopped"),
+          double("StatusStruct", :current_state => "stopped"),
+          double("StatusStruct", :current_state => "running"))
+        Win32::Service.should_receive(:stop).with(@new_resource.service_name)
+        Win32::Service.should_receive(:start).with(@new_resource.service_name)
+        @provider.restart_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should just start the service if it is stopped" do
+        Win32::Service.stub(:status).with(@new_resource.service_name).and_return(
+          double("StatusStruct", :current_state => "stopped"),
+          double("StatusStruct", :current_state => "stopped"),
+          double("StatusStruct", :current_state => "running"))
+        Win32::Service.should_receive(:start).with(@new_resource.service_name)
+        @provider.restart_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should do nothing if the service does not exist" do
+        Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
+        Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
+        Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
+        @provider.restart_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
     end
 
-    it "should do nothing if the service does not exist" do
-      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
-      Win32::Service.should_not_receive(:stop).with(@new_resource.service_name)
-      Win32::Service.should_not_receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      @new_resource.updated_by_last_action?.should be_false
+    describe "enable_service" do
+      before(:each) do
+        Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+          double("ConfigStruct", :start_type => "disabled"))
+      end
+
+      it "should enable service" do
+        Win32::Service.should_receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::AUTO_START)
+        @provider.enable_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
+
+      it "should do nothing if the service does not exist" do
+        Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
+        Win32::Service.should_not_receive(:configure)
+        @provider.enable_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
+
+      it "should do nothing if the service is enabled" do
+        Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+          double("ConfigStruct", :start_type => "auto start"))
+        Win32::Service.should_not_receive(:configure)
+        @provider.enable_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
     end
 
-  end
+    describe "disable_service" do
+      before(:each) do
+        Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+          double("ConfigStruct", :start_type => "auto start"))
+      end
 
-  describe Chef::Provider::Service::Windows, "enable_service" do
+      it "should disable service" do
+        Win32::Service.should_receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::DISABLED)
+        @provider.disable_service
+        @new_resource.updated_by_last_action?.should be_true
+      end
 
-    before(:each) do
-      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
-        double("ConfigStruct", :start_type => "disabled"))
-    end
+      it "should do nothing if the service does not exist" do
+        Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
+        Win32::Service.should_not_receive(:configure)
+        @provider.disable_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
 
-    it "should enable service" do
-      Win32::Service.should_receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::AUTO_START)
-      @provider.enable_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should do nothing if the service does not exist" do
-      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
-      Win32::Service.should_not_receive(:configure)
-      @provider.enable_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should do nothing if the service is enabled" do
-      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
-        double("ConfigStruct", :start_type => "auto start"))
-      Win32::Service.should_not_receive(:configure)
-      @provider.enable_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-  end
-
-  describe Chef::Provider::Service::Windows, "disable_service" do
-
-    before(:each) do
-      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
-        double("ConfigStruct", :start_type => "auto start"))
-    end
-
-    it "should disable service" do
-      Win32::Service.should_receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::DISABLED)
-      @provider.disable_service
-      @new_resource.updated_by_last_action?.should be_true
-    end
-
-    it "should do nothing if the service does not exist" do
-      Win32::Service.stub(:exists?).with(@new_resource.service_name).and_return(false)
-      Win32::Service.should_not_receive(:configure)
-      @provider.disable_service
-      @new_resource.updated_by_last_action?.should be_false
-    end
-
-    it "should do nothing if the service is disabled" do
-      Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
-        double("ConfigStruct", :start_type => "disabled"))
-      @provider.load_current_resource
-      Win32::Service.should_not_receive(:configure)
-      @provider.disable_service
-      @new_resource.updated_by_last_action?.should be_false
+      it "should do nothing if the service is disabled" do
+        Win32::Service.stub(:config_info).with(@new_resource.service_name).and_return(
+          double("ConfigStruct", :start_type => "disabled"))
+        @provider.load_current_resource
+        Win32::Service.should_not_receive(:configure)
+        @provider.disable_service
+        @new_resource.updated_by_last_action?.should be_false
+      end
     end
 
   end

--- a/spec/unit/provider/user/windows_spec.rb
+++ b/spec/unit/provider/user/windows_spec.rb
@@ -27,7 +27,7 @@ class Chef
   end
 end
 
-describe Chef::Provider::User::Windows do
+describe Chef::Provider::User::Windows, :windows_only do
   before(:each) do
     @node = Chef::Node.new
     @new_resource = Chef::Resource::User.new("monkey")


### PR DESCRIPTION
Recent changes made `spec/unit/provider/service/windows.rb` fail on some non-windows platforms, due to stubbing. Rather than try to make the stubs work for non-windows, just mark the test as `:windows_only`. Also marked some obvious windows-only specs.
