### PR TITLE
reload service only if it running, if not - start

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -93,7 +93,11 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     if @new_resource.reload_command
       super
     else
-      run_command_with_systems_locale(:command => "/bin/systemctl reload-or-restart #{@new_resource.service_name}")
+      if @current_resource.running
+        run_command_with_systems_locale(:command => "/bin/systemctl reload #{@new_resource.service_name}")
+      else
+        run_command_with_systems_locale(:command => "/bin/systemctl start #{@new_resource.service_name}")
+      end
     end
   end
 


### PR DESCRIPTION
Systemd supports confitional reload if service running, if not - it starts it.
This is very useful for some services that provide init scripts that tries to reload already running services and not start service in reload action then it not running.
Simple bird.service that illustrate this

```
[Unit]
Description=BIRD routing daemon ipv6 version
After=network.target

[Service]
ExecStart=/usr/bin/bird6 -f -u bird -g bird
ExecReload=/usr/bin/birdc6 configure
ExecStop=/usr/bin/birdc6 down

[Install]
WantedBy=multi-user.target
```

Without this patch bird service coud not be run in reload action.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
