### PR TITLE
Allow ChefFS to copy cookbooks from one server to another

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -208,11 +208,10 @@ class Chef
     end
 
     def url_for_checksum(checksum)
-      Chef::CookbookVersion::COOKBOOK_SEGMENTS.each do |segment|
+      COOKBOOK_SEGMENTS.each do |segment|
         f = manifest[segment].find {|c| c["checksum"] == checksum }
-        break if f
+        return f["url"] if f
       end
-      f["url"]
     end
 
     def recipe_filenames=(*filenames)

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -207,6 +207,14 @@ class Chef
       results
     end
 
+    def url_for_checksum(checksum)
+      Chef::CookbookVersion::COOKBOOK_SEGMENTS.each do |segment|
+        f = manifest[segment].find {|c| c["checksum"] == checksum }
+        break if f
+      end
+      f["url"]
+    end
+
     def recipe_filenames=(*filenames)
       @recipe_filenames = filenames.flatten
       @recipe_filenames_by_name = filenames_by_name(recipe_filenames)


### PR DESCRIPTION
This allows ChefFS to copy cookbooks from one server to another.  Currently ChefFS only supports cookbook operations when either the source or destination is a filesystem.

The upload_checksum() function is taken from cookbook_uploader.rb

This is still a WIP but wanted to get some feed back on it sooner rather than later.