### PR TITLE
Fix ResourceReporter#post_reporting_data http error handling. Fixes #1550

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -231,18 +231,17 @@ class Chef
         Chef::Log.info("Sending resource update report (run-id: #{run_id})")
         Chef::Log.debug run_data.inspect
         compressed_data = encode_gzip(run_data.to_json)
+        Chef::Log.debug("Sending compressed run data...")
+        # Since we're posting compressed data we can not directly call post_rest which expects JSON
+        reporting_url = @rest_client.create_url(resource_history_url)
         begin
-          Chef::Log.debug("Sending compressed run data...")
-          # Since we're posting compressed data we can not directly call post_rest which expects JSON
-          reporting_url = @rest_client.create_url(resource_history_url)
           @rest_client.raw_http_request(:POST, reporting_url, headers({'Content-Encoding' => 'gzip'}), compressed_data)
         rescue StandardError => e
-          raise if !e.respond_to? :response
-          if e.response.code.to_s == "400"
+          if e.respond_to? :response
             Chef::FileCache.store("failed-reporting-data.json", Chef::JSONCompat.to_json_pretty(run_data), 0640)
-            Chef::Log.error("Failed to post reporting data to server (HTTP 400), saving to #{Chef::FileCache.load("failed-reporting-data.json", false)}")
+            Chef::Log.error("Failed to post reporting data to server (HTTP #{e.response.code}), saving to #{Chef::FileCache.load("failed-reporting-data.json", false)}")
           else
-            Chef::Log.error("Failed to post reporting data to server (HTTP #{e.response.code.to_s})")
+            Chef::Log.error("Failed to post reporting data to server (#{e})")
           end
         end
       else

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -21,6 +21,7 @@
 
 require File.expand_path("../../spec_helper", __FILE__)
 require 'chef/resource_reporter'
+require 'socket'
 
 describe Chef::ResourceReporter do
   before(:all) do
@@ -738,12 +739,20 @@ describe Chef::ResourceReporter do
         @resource_reporter.post_reporting_data
       end
 
+      it "should log if a socket error happens" do
+        @rest_client.stub(:raw_http_request).and_raise(SocketError.new("test socket error"))
+        Chef::Log.should_receive(:error).with(/test socket error/)
+
+        @resource_reporter.post_reporting_data
+
+      end
+
       it "should raise if an unkwown error happens" do
-        @rest_client.stub(:raw_http_request).and_raise(RuntimeError.new)
+        @rest_client.stub(:raw_http_request).and_raise(Exception.new)
 
         lambda {
           @resource_reporter.post_reporting_data
-        }.should raise_error(RuntimeError)
+        }.should raise_error(Exception)
       end
     end
   end


### PR DESCRIPTION
All the details are at https://github.com/opscode/chef/issues/1550

If you think it's better to catch _all possible exceptions_ please, see this discussion first: https://gist.github.com/tenderlove/245188

Any comments?
