### PR TITLE
use systemd for recent fedora and rhel 7

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -154,10 +154,13 @@ class Chef
             },
             :scientific => {
               :default => {
-                :service => Chef::Provider::Service::Redhat,
+                :service => Chef::Provider::Service::Systemd,
                 :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
                 :mdadm => Chef::Provider::Mdadm
+              },
+              "< 7" => {
+                :service => Chef::Provider::Service::Redhat
               }
             },
             :fedora   => {
@@ -194,10 +197,13 @@ class Chef
             },
             :oracle  => {
               :default => {
-                :service => Chef::Provider::Service::Redhat,
+                :service => Chef::Provider::Service::Systemd,
                 :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
                 :mdadm => Chef::Provider::Mdadm
+              },
+              "< 7" => {
+                :service => Chef::Provider::Service::Redhat
               }
             },
             :redhat   => {


### PR DESCRIPTION
Although Redhat has largely made <code>chkconfig</code> compatible with <code>systemd</code>, the status function of <code>Chef::Provider::Service::Redhat</code> does not work with newer services, because the only output produced by <code>chkconfig --list</code> is:

```
$ chkconfig --list

Note: This output shows SysV services only and does not include native
      systemd services. SysV configuration data might be overridden by native
      systemd configuration.

      If you want to list systemd services use 'systemctl list-unit-files'.
      To see services enabled on particular target use
      'systemctl list-dependencies [target]'.

netconsole      0:off   1:off   2:off   3:off   4:off   5:off   6:off
network         0:off   1:off   2:off   3:off   4:off   5:off   6:off
```

This means that either:
- Redhat needs to make <code>chkconfig --list</code> fully compatible (not likely)
- <code>Chef::Provider::Service::Redhat</code> needs to switch to just use <code>chkconfig $service</code>
- RHEL based platforms that use systemd should switch to using <code>Chef::Provider::Service::Systemd</code>

I'm in favor of the latter, because it will simplify usage of systemd on these platforms, and is not dependent on a backwards-compatibility feature that could some day be dropped. According to [Fedora](https://fedoraproject.org/wiki/Systemd#Does_chkconfig_command_work_with_systemd.3F), their version of <code>systemctl</code> also provides backwards compatibility with <code>chkconfig</code>
