### PR TITLE
Only check WOW64 process when system architecture is x64.

### DIFF
--- a/lib/chef/provider/windows_script.rb
+++ b/lib/chef/provider/windows_script.rb
@@ -36,6 +36,7 @@ class Chef
 
         @is_wow64 = wow64_architecture_override_required?(run_context.node, target_architecture)
 
+        # if the user wants to run the script 32 bit && we are on a 64bit windows system && we are running a 64bit ruby ==> fail
         if ( target_architecture == :i386 ) && node_windows_architecture(run_context.node) == :x86_64 && !is_i386_process_on_x86_64_windows?
           raise Chef::Exceptions::Win32ArchitectureIncorrect,
           "Support for the i386 architecture from a 64-bit Ruby runtime is not yet implemented"


### PR DESCRIPTION
Fixes https://github.com/opscode/chef/issues/1549.

The issue here is that according to [msdn](http://msdn.microsoft.com/en-us/library/windows/desktop/ms684139%28v=vs.85%29.aspx) IsWow64Process returns `false` on 32 bit windows systems. Since we're not differentiating 32 bit systems from 64 bit systems we're raising an unnecessary error here.

Windows specs in CI is happy with this [here](http://ci.opscode.us/job/chef-client-test/828/).

I'm open to other solutions @jmink, @btm :smile: 
