### PR TITLE
Change --yum-lock-timeout option action to store.

### DIFF
--- a/lib/chef/provider/package/yum-dump.py
+++ b/lib/chef/provider/package/yum-dump.py
@@ -279,7 +279,7 @@ def main():
                     action="callback",  callback=gather_repo_opts, type="string", dest="repo_control", default=[],
                     help="disable repositories by id or glob")
   parser.add_option("--yum-lock-timeout",
-                    action="callback",  type="int", dest="yum_lock_timeout", default=30,
+                    action="store",  type="int", dest="yum_lock_timeout", default=30,
                     help="Time in seconds to wait for yum process lock")
 
   (options, args) = parser.parse_args()


### PR DESCRIPTION
Yum was failing because the `--yum-lock-timeout` option's action was `"callback"`, and no callback function was provided, or needed. Manually verified on CentOS 6.4 that `sudo chef-apply -e "package 'httpd'"` successfully installs the httpd package.

I'm looking into the tests right now to see why they weren't failing.

\cc @opscode/client-eng 
