### PR TITLE
Chef 4994: knife cookbook site share fails on windows

### DIFF
--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -23,6 +23,8 @@ class Chef
   class Knife
     class CookbookSiteShare < Knife
 
+      include Chef::Mixin::ShellOut
+
       deps do
         require 'chef/cookbook_loader'
         require 'chef/cookbook_uploader'
@@ -57,7 +59,7 @@ class Chef
           begin
             Chef::Log.debug("Temp cookbook directory is #{tmp_cookbook_dir.inspect}")
             ui.info("Making tarball #{cookbook_name}.tgz")
-            Chef::Mixin::ShellOut::shell_out!("tar -czf #{cookbook_name}.tgz #{cookbook_name}", :cwd => tmp_cookbook_dir)
+            shell_out!("tar -czf #{cookbook_name}.tgz #{cookbook_name}", :cwd => tmp_cookbook_dir)
           rescue => e
             ui.error("Error making tarball #{cookbook_name}.tgz: #{e.message}. Increase log verbosity (-VV) for more information.")
             Chef::Log.debug("\n#{e.backtrace.join("\n")}")

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -39,7 +39,7 @@ describe Chef::Knife::CookbookSiteShare do
     @cookbook_uploader.stub(:validate_cookbooks).and_return(true)
     Chef::CookbookSiteStreamingUploader.stub(:create_build_dir).and_return(Dir.mktmpdir)
 
-    Chef::Mixin::ShellOut.stub(:shell_out!).and_return(true)
+    @knife.stub(:shell_out!).and_return(true)
     @stdout = StringIO.new
     @knife.ui.stub(:stdout).and_return(@stdout)
   end
@@ -76,14 +76,14 @@ describe Chef::Knife::CookbookSiteShare do
     end
 
     it 'should make a tarball of the cookbook' do
-      Chef::Mixin::ShellOut.should_receive(:shell_out!) do |args|
+      @knife.should_receive(:shell_out!) do |args|
         args.to_s.should match /tar -czf/
       end
       @knife.run
     end
 
     it 'should exit and log to error when the tarball creation fails' do
-      Chef::Mixin::ShellOut.stub(:shell_out!).and_raise(Chef::Exceptions::Exec)
+      @knife.stub(:shell_out!).and_raise(Chef::Exceptions::Exec)
       @knife.ui.should_receive(:error)
       lambda { @knife.run }.should raise_error(SystemExit)
     end


### PR DESCRIPTION
Full ticket details here: https://tickets.opscode.com/browse/CHEF-4994

cookbook_site_share was using the deprecated Chef::Mixin::Command.  Moving it over to Chef::Mixin::ShellOut clears up the issue.

Tested by manually uploading a cookbook from Mac & Windows as well as running unit and functional tests on Mac OS.
