### PR TITLE
Allow setting resource_name programatically

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -59,15 +59,17 @@ class Chef
         resource_class
       end
 
-      # Set the resource snake_case name. Should only be called via
-      # build_from_file.
-      def self.resource_name=(resource_name)
-        @resource_name = resource_name
+      # Set the resource name for this LWRP
+      def self.resource_name(arg = NULL_ARG)
+        if arg.equal?(NULL_ARG)
+          @resource_name
+        else
+          @resource_name = arg
+        end
       end
 
-      # Returns the resource snake_case name
-      def self.resource_name
-        @resource_name
+      class << self
+        alias_method :resource_name=, :resource_name
       end
 
       # Define an attribute on this resource, including optional validation
@@ -122,6 +124,13 @@ class Chef
       # Default initializer. Sets the default action and allowed actions.
       def initialize(name, run_context=nil)
         super(name, run_context)
+
+        # Raise an exception if the resource_name was not defined
+        if self.class.resource_name.nil?
+          raise Chef::Exceptions::InvalidResourceSpecification,
+            "You must specify `resource_name'!"
+        end
+
         @resource_name = self.class.resource_name.to_sym
         @action = self.class.default_action
         allowed_actions.push(self.class.valid_actions).flatten!

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -133,6 +133,33 @@ describe "LWRP" do
       cls.node[:penguin_name].should eql("jackass")
     end
 
+    context "resource_name" do
+      let(:klass) { Class.new(Chef::Resource::LWRPBase) }
+
+      it "returns nil when the resource_name is not set" do
+        expect(klass.resource_name).to be_nil
+      end
+
+      it "allows to user to user the resource_name" do
+        expect {
+          klass.resource_name(:foo)
+        }.to_not raise_error
+      end
+
+      it "returns the set value for the resource" do
+        klass.resource_name(:foo)
+        expect(klass.resource_name).to eq(:foo)
+      end
+
+      context "when creating a new instance" do
+        it "raises an exception if resource_name is nil" do
+          expect {
+            klass.new('blah')
+          }.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
+        end
+      end
+    end
+
   end
 
   describe "Lightweight Chef::Provider" do


### PR DESCRIPTION
Previously this was marked as an internal API, but I am making it public. We are reliably using this API in our LHWRPs in Release Engineering and it is truly a delightful experience.

This deprecates using `resource_name = :foo` in favor of the more "Chef-like" `resource_name(:foo)`.

/cc @opscode/client-eng @opscode/release-engineers 
