### PR TITLE
FileEdit#prepend_line_if_missing

### DIFF
--- a/lib/chef/util/editor.rb
+++ b/lib/chef/util/editor.rb
@@ -37,14 +37,15 @@ class Chef
       end
 
       def append_line_if_missing(search, line_to_append)
-        count = 0
-
-        unless @lines.find { |line| line.match(search) }
-          count = 1
+        when_missing_line(search) do
           @lines << line_to_append
         end
+      end
 
-        count
+      def prepend_line_if_missing(search, line_to_prepend)
+        when_missing_line(search) do
+          @lines.unshift line_to_prepend
+        end
       end
 
       def remove_lines(search)
@@ -86,6 +87,22 @@ class Chef
 
         count
       end
+
+      private
+
+      def when_missing_line(line, &block)
+        count = 0 
+        if missing_line?(line)
+          count = 1
+          block.call
+        end
+        count
+      end
+
+      def missing_line?(searched_line)
+        ! @lines.find { |line| line.match(searched_line) }
+      end
+      
     end
   end
 end

--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -76,6 +76,12 @@ class Chef
         @changes = (editor.append_line_if_missing(regex, newline) > 0) || @changes
       end
 
+      #search the file line by line and match each line with the given regex
+      #if not matched, insert newline at the beginning of the file
+      def prepend_line_if_no_match(regex, newline)
+        @changes = (editor.prepend_line_if_missing(regex, newline) > 0) || @changes
+      end
+
       def unwritten_changes?
         !!@changes
       end

--- a/spec/unit/util/editor_spec.rb
+++ b/spec/unit/util/editor_spec.rb
@@ -48,7 +48,7 @@ describe Chef::Util::Editor do
     context 'when there is no match' do
       subject(:execute) { editor.append_line_if_missing('missing', 'new') }
 
-      it('returns the number of added lines') { should be == 1 }
+      it('returns that it added one line') { should be == 1 }
       it 'adds a line to the end' do
         execute
         expect(editor.lines).to be == ['one', 'two', 'two', 'three', 'new']
@@ -67,6 +67,32 @@ describe Chef::Util::Editor do
     it 'matches a Regexp' do
       expect(editor.append_line_if_missing(/ee$/, 'new')).to be == 0
       expect(editor.append_line_if_missing(/^ee/, 'new')).to be == 1
+    end
+  end
+
+  describe '#prepend_line_if_missing' do
+    context 'when there is no match' do
+      subject(:execute) { editor.prepend_line_if_missing('missing', 'new') }
+
+      it('returns that it added one line') { should be == 1 }
+      it 'adds a line at the beginning' do
+        execute 
+        expect(editor.lines).to be == ['new', 'one', 'two', 'two', 'three']
+      end
+    end
+
+    context 'when there is a match' do
+      subject(:execute) { editor.prepend_line_if_missing('two', 'new') }
+
+      it('returns the number of lines') { should be == 0 }
+      it 'does not add any lines' do
+        expect { execute }.to_not change { editor.lines }
+      end
+    end
+
+    it 'matches a Regexp' do
+      expect(editor.prepend_line_if_missing(/ee$/, 'new')).to be == 0
+      expect(editor.prepend_line_if_missing(/^ee/, 'new')).to be == 1
     end
   end
 

--- a/spec/unit/util/file_edit_spec.rb
+++ b/spec/unit/util/file_edit_spec.rb
@@ -81,6 +81,16 @@ new line inserted
     EOF
   end
 
+  let(:prepend_before_content) do
+    <<-EOF
+new line inserted
+127.0.0.1       localhost
+255.255.255.255 broadcasthost
+::1             localhost
+fe80::1%lo0     localhost
+    EOF
+  end
+
   let(:append_twice) do
     <<-EOF
 127.0.0.1       localhost
@@ -89,6 +99,17 @@ new line inserted
 fe80::1%lo0     localhost
 once
 twice
+    EOF
+  end
+
+  let(:prepend_twice) do
+    <<-EOF
+twice
+once
+127.0.0.1       localhost
+255.255.255.255 broadcasthost
+::1             localhost
+fe80::1%lo0     localhost
     EOF
   end
 
@@ -211,6 +232,29 @@ twice
       fedit.insert_line_if_no_match(/missing/, "twice")
       fedit.write_file
       expect(edited_file_contents).to eq(append_twice)
+    end
+  end
+
+  describe "prepend_line_if_no_match" do
+    it "should search for match and prepend the given line if no line match" do
+      fedit.prepend_line_if_no_match(/pattern/, "new line inserted")
+      fedit.unwritten_changes?.should be_true
+      fedit.write_file
+      expect(edited_file_contents).to eq(prepend_before_content)
+    end
+
+    it "should do nothing if there is a match" do
+      fedit.prepend_line_if_no_match(/localhost/, "replacement")
+      fedit.unwritten_changes?.should be_false
+      fedit.write_file
+      expect(edited_file_contents).to eq(starting_content)
+    end
+
+    it "should work more than once" do
+      fedit.prepend_line_if_no_match(/missing/, "once")
+      fedit.prepend_line_if_no_match(/missing/, "twice")
+      fedit.write_file
+      expect(edited_file_contents).to eq(prepend_twice)
     end
   end
 


### PR DESCRIPTION
This method can be used to prepend environment variable before a script evaluation for example. 