### PR TITLE
Add missing requires to HTTP and HTTP::Simple

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -21,12 +21,14 @@
 # limitations under the License.
 #
 
+require 'tempfile'
 require 'net/https'
 require 'uri'
 require 'chef/http/basic_client'
 require 'chef/monkey_patches/string'
 require 'chef/monkey_patches/net_http'
 require 'chef/config'
+require 'chef/platform/query_helpers'
 require 'chef/exceptions'
 
 class Chef

--- a/lib/chef/http/simple.rb
+++ b/lib/chef/http/simple.rb
@@ -1,7 +1,8 @@
 require 'chef/http'
 require 'chef/http/authenticator'
 require 'chef/http/decompressor'
-
+require 'chef/http/cookie_manager'
+require 'chef/http/validate_content_length'
 
 class Chef
   class HTTP


### PR DESCRIPTION
This allows you to `require 'chef/http/simple'` in other code without manually requiring `HTTP::Simple`'s dependencies.
