### PR TITLE
Retry on ssh failure in knife/ssh.rb

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -125,6 +125,7 @@ class Chef
               throw :go, :retry
             else
               throw :go, :raise
+            end
           end
         end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -119,7 +119,12 @@ class Chef
             $!.backtrace.each { |l| Chef::Log.debug(l) }
           when :raise
             #Net::SSH::Multi magic to force exception to be re-raised.
-            throw :go, :raise
+            @connection_attempts ||= 0
+            if @connection_attempts < 3
+              @connection_attempts += 1
+              throw :go, :retry
+            else
+              throw :go, :raise
           end
         end
 


### PR DESCRIPTION
We were seeing problems where the ssh_command call from the "knife ec2 create server ..." command was timing out regularly between the chef server in Northern California and a new AWS instance in Northern Virginia. To alleviate this I added code that retries the ssh command up to three times before failing. 