### PR TITLE
Don't modify variable passed to env resource when updating

### DIFF
--- a/lib/chef/provider/env.rb
+++ b/lib/chef/provider/env.rb
@@ -143,7 +143,7 @@ class Chef
       def modify_env
         if @new_resource.delim
           #e.g. add to PATH
-          @new_resource.value << @new_resource.delim << @current_resource.value
+          @new_resource.value(@new_resource.value + @new_resource.delim + @current_resource.value)
         end
         create_env
       end

--- a/spec/unit/provider/env_spec.rb
+++ b/spec/unit/provider/env_spec.rb
@@ -229,4 +229,23 @@ describe Chef::Provider::Env do
       @provider.compare_value.should be_true
     end
   end
+
+  describe "modify_env" do
+    before(:each) do
+      @provider.stub(:create_env).and_return(true)
+      @new_resource.delim ";"
+
+      @current_resource = Chef::Resource::Env.new("FOO")
+      @current_resource.value "C:/foo/bin"
+      @provider.current_resource = @current_resource
+    end
+
+    it "should not modify the variable passed to the resource" do
+      new_value = "C:/bar/bin"
+      passed_value = new_value.dup
+      @new_resource.value(passed_value)
+      @provider.modify_env
+      passed_value.should == new_value
+    end
+  end
 end


### PR DESCRIPTION
When using a delimiter, the passed value is prepended to the given
environment variable. Unfortunately this has the side effect of modifying
the variable passed to the resource. Oftentimes this is an attribute,
used somewhere else after that, with the wrong, modified value.

Sample code that exhibits the issue:

``` ruby
node.default[:foobar] = 'hello'

env 'test' do
  value 'bye'
end

env 'test' do
  value node[:foobar]
  delim ::File::PATH_SEPARATOR
end

ruby_block 'puts' do
  block do
    Chef::Log.info "foobar: #{node[:foobar]}"
  end
end
```

This outputs:

> INFO: foobar: hello;bye
