### PR TITLE
Fix trusted_certs default path under windows

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -384,7 +384,7 @@ class Chef
     # certificates in this directory will be added to whatever CA bundle ruby
     # is using. Use this to add self-signed certs for your Chef Server or local
     # HTTP file servers.
-    default(:trusted_certs_dir) { config_dir && path_join(config_dir, "trusted_certs") }
+    default(:trusted_certs_dir) { config_dir && File.join(config_dir, "trusted_certs") }
 
     # Where should chef-solo download recipes from?
     default :recipe_url, nil


### PR DESCRIPTION
The default value of the "trusted_certs" config item uses path_join which adds a native path separator, but ssl_policies.rb uses Dir.glob which treats backslashes as escape characters.  So I suggest switching to File.join to fix (config_dir is already forward slash separated).
