### PR TITLE
Ensure node[:tags] is not equal to nil

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -313,7 +313,7 @@ class Chef
 
     # Lazy initializer for tags attribute
     def tags
-      normal[:tags] = [] unless attribute?(:tags)
+      normal[:tags] = [] if not attribute?(:tags) or node[:tags].nil?
       normal[:tags]
     end
 


### PR DESCRIPTION
Started using tagging recently and noticed that tagged? and the like fail on nodes where node[:tags] is equal to nil. This PR ensures that node[:tags] defaults to Array.