### PR TITLE
pin ffi_yajl to 1.0.0 with semver constraint

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   # it's the version I had when I tested.
   s.add_dependency "mime-types", "~> 1.16"
 
-  s.add_dependency "ffi-yajl"
+  s.add_dependency "ffi-yajl", "~> 1.0"
   s.add_dependency "net-ssh", "~> 2.6"
   s.add_dependency "net-ssh-multi", "~> 1.1"
   # CHEF-3027: The knife-cloud plugins require newer features from highline, core chef should not.


### PR DESCRIPTION
0.1.5 is broken when JSON.pretty_generate(foo, nil) is called with
an explicit nil, so we have an absolute lower floor there on working
correctly.

We should release a 1.0.0 of ffi-yajl and pin to '~> 1.0' before
relesing the 11.14.0 final release.
