### PR TITLE
Print deprecation notices for chef-repo rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Add method shell_out_with_systems_locale to ShellOut.
 * Fix knife cookbook site share on windows (CHEF-4994)
+* chef-repo rake tasks are deprecated; print relevant information for
+  each one.
 
 ## Last Release: 11.14.0
 


### PR DESCRIPTION
These rake tasks get loaded by the opscode/chef-repo's Rakefile. I
propose that be removed, as the functionality of these rake tasks is
superseded by other tools as noted in the output displayed now for
each task. The functionality is either built into knife, is provided
by a cookbook, or is provided by other tools in the Chef ecosystem,
all of which are included in the ChefDK.

This supersedes #1619.
