### PR TITLE
Bad handling of ShellOut:live_stream

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -33,7 +33,7 @@ class Chef
 
       def shell_out(*command_args)
         cmd = Mixlib::ShellOut.new(*run_command_compatible_options(command_args))
-        cmd.live_stream = io_for_live_stream
+        cmd.live_stream ||= io_for_live_stream
         cmd.run_command
         cmd
       end


### PR DESCRIPTION
Chef:Provider:Execute's logic on whether or not to use live_stream gets blindly stomped on here. Honoring live_stream if a caller has set it.

Obvious fix.
