### PR TITLE
Parallels cloud server platform support.

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -229,6 +229,15 @@ class Chef
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               }
             },
+            :parallels   => {
+                :default => {
+                    :service => Chef::Provider::Service::Redhat,
+                    :cron => Chef::Provider::Cron,
+                    :package => Chef::Provider::Package::Yum,
+                    :mdadm => Chef::Provider::Mdadm,
+                    :ifconfig => Chef::Provider::Ifconfig::Redhat
+                }
+            },
             :gentoo   => {
               :default => {
                 :package => Chef::Provider::Package::Portage,


### PR DESCRIPTION
Parallels cloud server(PCS) is RHEL/CentOS commercial fork, what used to create private clouds. More info: http://www.parallels.com/products/pcs/ . Support of detecting for this platform in ohai is in pull request: https://github.com/opscode/ohai/pull/369 .
