### PR TITLE
Knife::Core::ObjectLoader.object_from_file support of Chef::EncryptedDataBagItem

### DIFF
--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -88,7 +88,7 @@ class Chef
             r = FFI_Yajl::Parser.parse(IO.read(filename))
 
             # Chef::DataBagItem doesn't work well with the json_create method
-            if @klass == Chef::DataBagItem
+            if @klass == Chef::DataBagItem || @klass == Chef::EncryptedDataBagItem
               r
             else
               @klass.json_create(r)


### PR DESCRIPTION
`object_from_file` needs to special-case `Chef::EncryptedDataBagItem` in the 
same manner as `Chef::DataBagItem`.
