### PR TITLE
Fix creation of non-empty FreeBSD groups

### DIFF
--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -39,7 +39,14 @@ class Chef
         def create_group
           command = "pw groupadd"
           command << set_options
-          member_options = set_members_options
+
+          # pw group[add|mod] -M is used to set the full membership list on a
+          # new or existing group. Because pw groupadd does not support the -m
+          # and -d options used by manage_group, we treat group creation as a
+          # special case and use -M.
+          Chef::Log.debug("#{@new_resource} setting group members: #{@new_resource.members.join(',')}")
+          member_options = [" -M #{@new_resource.members.join(',')}"]
+
           if member_options.empty?
             run_command(:command => command)
           else

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -49,7 +49,7 @@ describe Chef::Provider::Group::Pw do
   describe "when creating a group" do
     it "should run pw groupadd with the return of set_options and set_members_option" do
       @new_resource.gid(23)
-      @provider.should_receive(:run_command).with({ :command => "pw groupadd wheel -g '23'" }).and_return(true)
+      @provider.should_receive(:run_command).with({ :command => "pw groupadd wheel -g '23' -M root,aj" }).and_return(true)
       @provider.create_group
     end
   end
@@ -113,7 +113,7 @@ describe Chef::Provider::Group::Pw do
         @provider.set_members_options
       end
 
-      it "should set the -M option with the members joined by ','" do
+      it "should set the -m option with the members joined by ','" do
         @provider.set_members_options.should eql([ " -m all,your,base" ])
       end
     end


### PR DESCRIPTION
When Chef creates a new FreeBSD group, the `pw groupadd` system command is
invoked. If the group is to have members at the time it is created,
prior to this change Chef would try to specify the new members with the `-m`
option. Unfortunately, `pw groupadd` has no `-m` option: one is supposed
to use `-M` instead. See the following excerpt from the `pw` man page:

```
pw [-V etcdir] groupadd [group|gid] [-C config] [-q] [-n group] [-g gid]
  [-M members] [-o] [-h fd | -H fd] [-N] [-P] [-Y]
pw [-V etcdir] groupdel [group|gid] [-n name] [-g gid] [-Y]
pw [-V etcdir] groupmod [group|gid] [-C config] [-q] [-n name] [-g gid]
  [-l name] [-M members] [-m newmembers] [-d oldmembers] [-h fd | -H fd]
  [-N] [-P] [-Y]
```

http://www.freebsd.org/cgi/man.cgi?query=pw&apropos=0&sektion=0&manpath=FreeBSD+9.3-RELEASE&arch=default&format=html

This commit lets Chef use `pw groupadd -M`.
