### PR TITLE
Lcg/http resource query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [**Xabier de Zuazo**](https://github.com/zuazo):
   Remove the unused StreamingCookbookUploader class (CHEF-4586)
 
+* http_request no longer appends "?message=" query string to GET and HEAD requests
 * added shell_out commands directly to the recipe DSL
 * cookbook synchronizer deletes old files from cookbooks
 * do not clear file cache when override run list is set (CHEF-3684)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Chef Client Release Notes:
 
+## http_request resource no longer appends query string
+
+Previously the http_request GET and HEAD requests appended a hard-coded "?message=resource_name" 
+query parameter that could not be overridden.  That feature has been dropped.  Cookbooks that
+actually relied on that should manually add the message query string to the URL they pass to
+the resource.
+
 ## Added Chef::Mixin::ShellOut methods to Recipe DSL
 
 Added the ability to use shell_out, shell_out! and shell_out_with_systems_locale in the Recipe

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -33,13 +33,13 @@ class Chef
         @http = Chef::HTTP::Simple.new(@new_resource.url)
       end
 
-      # Send a HEAD request to @new_resource.url, with ?message=@new_resource.message
+      # Send a HEAD request to @new_resource.url
       def action_head
         message = check_message(@new_resource.message)
         # CHEF-4762: we expect a nil return value from Chef::HTTP for a "200 Success" response
         # and false for a "304 Not Modified" response
         modified = @http.head(
-          "#{@new_resource.url}?message=#{message}",
+          "#{@new_resource.url}",
           @new_resource.headers
         )
         Chef::Log.info("#{@new_resource} HEAD to #{@new_resource.url} successful")
@@ -50,13 +50,13 @@ class Chef
         end
       end
 
-      # Send a GET request to @new_resource.url, with ?message=@new_resource.message
+      # Send a GET request to @new_resource.url
       def action_get
         converge_by("#{@new_resource} GET to #{@new_resource.url}") do
 
           message = check_message(@new_resource.message)
           body = @http.get(
-            "#{@new_resource.url}?message=#{message}",
+            "#{@new_resource.url}",
             @new_resource.headers
           )
           Chef::Log.info("#{@new_resource} GET to #{@new_resource.url} successful")

--- a/spec/unit/provider/http_request_spec.rb
+++ b/spec/unit/provider/http_request_spec.rb
@@ -53,13 +53,13 @@ describe Chef::Provider::HttpRequest do
 
       it "should inflate a message block at runtime" do
         @new_resource.message { "return" }
-        @http.should_receive(:get).with("http://www.opscode.com/?message=return", {})
+        @http.should_receive(:get).with("http://www.opscode.com/", {})
         @provider.run_action(:get)
         @new_resource.should be_updated
       end
 
       it "should run a GET request" do
-        @http.should_receive(:get).with("http://www.opscode.com/?message=is cool", {})
+        @http.should_receive(:get).with("http://www.opscode.com/", {})
         @provider.run_action(:get)
         @new_resource.should be_updated
       end
@@ -112,25 +112,25 @@ describe Chef::Provider::HttpRequest do
 
       it "should inflate a message block at runtime" do
         @new_resource.message { "return" }
-        @http.should_receive(:head).with("http://www.opscode.com/?message=return", {}).and_return(nil)
+        @http.should_receive(:head).with("http://www.opscode.com/", {}).and_return(nil)
         @provider.run_action(:head)
         @new_resource.should be_updated
       end
 
       it "should run a HEAD request" do
-        @http.should_receive(:head).with("http://www.opscode.com/?message=is cool", {}).and_return(nil)
+        @http.should_receive(:head).with("http://www.opscode.com/", {}).and_return(nil)
         @provider.run_action(:head)
         @new_resource.should be_updated
       end
 
       it "should update a HEAD request with empty string response body (CHEF-4762)" do
-        @http.should_receive(:head).with("http://www.opscode.com/?message=is cool", {}).and_return("")
+        @http.should_receive(:head).with("http://www.opscode.com/", {}).and_return("")
         @provider.run_action(:head)
         @new_resource.should be_updated
       end
 
       it "should update a HEAD request with nil response body (CHEF-4762)" do
-        @http.should_receive(:head).with("http://www.opscode.com/?message=is cool", {}).and_return(nil)
+        @http.should_receive(:head).with("http://www.opscode.com/", {}).and_return(nil)
         @provider.run_action(:head)
         @new_resource.should be_updated
       end
@@ -138,14 +138,14 @@ describe Chef::Provider::HttpRequest do
       it "should not update a HEAD request if a not modified response (CHEF-4762)" do
         if_modified_since = File.mtime(__FILE__).httpdate
         @new_resource.headers "If-Modified-Since" => if_modified_since
-        @http.should_receive(:head).with("http://www.opscode.com/?message=is cool", {"If-Modified-Since" => if_modified_since}).and_return(false)
+        @http.should_receive(:head).with("http://www.opscode.com/", {"If-Modified-Since" => if_modified_since}).and_return(false)
         @provider.run_action(:head)
         @new_resource.should_not be_updated
       end
 
       it "should run a HEAD request with If-Modified-Since header" do
         @new_resource.headers "If-Modified-Since" => File.mtime(__FILE__).httpdate
-        @http.should_receive(:head).with("http://www.opscode.com/?message=is cool", @new_resource.headers)
+        @http.should_receive(:head).with("http://www.opscode.com/", @new_resource.headers)
         @provider.run_action(:head)
       end
 


### PR DESCRIPTION
Chef 12 slightly breaking change to get rid of the hardcoded query parameter in the http_request resource.
