### PR TITLE
revert this line

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -273,6 +273,8 @@ class Chef
             @platform_cache ||= {}
           end
 
+          include Chef::Mixin::ShellOut
+
           attr_reader :gem_binary_location
 
           def initialize(gem_binary_location)


### PR DESCRIPTION
Chef::Provider::Package::Rubygems::AlternateGemEnvironment does
not inherit from Chef::Provider
