### PR TITLE
Fix OSX Group provider to be properly idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Set Net::HTTP open_timeout. (backport Chef-1585)
 * Fix RPM package version detection (backport Issue 1554)
 * Support for single letter environments.
-*
+* [**Phil Dibowitz**](https://github.com/jaymzh):
+  'group' provider on OSX properly uses 'dscl' to determine existing groups
 
 ## 10.32.2
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,5 +9,6 @@ Details about the thing that changed that needs to get included in the Release N
 # Chef Client 10.x Release Notes:
 
 * Backport CHEF-5223 Fix to 10-stable
+* 'group' provider on OSX properly uses 'dscl' to determine existing groups
 
 # Chef Client 10.x Breaking Changes:

--- a/chef/spec/unit/provider/group/dscl_spec.rb
+++ b/chef/spec/unit/provider/group/dscl_spec.rb
@@ -293,3 +293,38 @@ describe Chef::Provider::Group::Dscl do
     end
   end
 end
+
+describe 'Test DSCL loading' do
+  before do
+    @node = Chef::Node.new
+    @events = Chef::EventDispatch::Dispatcher.new
+    @run_context = Chef::RunContext.new(@node, {}, @events)
+    @new_resource = Chef::Resource::Group.new("aj")
+    @provider = Chef::Provider::Group::Dscl.new(@new_resource, @run_context)
+    @output = <<-EOF
+AppleMetaNodeLocation: /Local/Default
+Comment:
+ Test Group
+GeneratedUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA
+NestedGroups: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAB
+Password: *
+PrimaryGroupID: 999
+RealName:
+ TestGroup
+RecordName: com.apple.aj
+RecordType: dsRecTypeStandard:Groups
+GroupMembership: waka bar
+EOF
+    @provider.stub(:safe_dscl).with("read /Groups/aj").and_return(@output)
+    @current_resource = @provider.load_current_resource
+  end
+
+  it 'should parse gid properly' do
+    File.stub(:exists?).and_return(true)
+    @current_resource.gid.should eq("999")
+  end
+  it 'should parse members properly' do
+    File.stub(:exists?).and_return(true)
+    @current_resource.members.should eq(['waka', 'bar'])
+  end
+end


### PR DESCRIPTION
Currently the OSX Group provider use the 'Etc' module to determine
what exists, and the 'dscl' command to change things. Etc will look
to /etc/group by default and fallback to 'dscl', which causes idempotency
incorrectness. This change the Group provider to simply look at 'dscl' always.
