### PR TITLE
Fix OSX Group provider to be properly idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
   knife diagnostic messages sent to stdout instead of stderr
 * [**Xabier de Zuazo**](https://github.com/zuazo):
   Remove the unused StreamingCookbookUploader class (CHEF-4586)
-
 * http_request no longer appends "?message=" query string to GET and HEAD requests
 * added shell_out commands directly to the recipe DSL
 * cookbook synchronizer deletes old files from cookbooks
@@ -26,6 +25,8 @@
 * Fix knife cookbook site share on windows (CHEF-4994)
 * chef-repo rake tasks are deprecated; print relevant information for
   each one.
+* [**Phil Dibowitz**](https://github.com/jaymzh):
+  'group' provider on OSX properly uses 'dscl' to determine existing groups
 
 ## Last Release: 11.14.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -82,3 +82,10 @@ it has been removed. See: https://github.com/opscode/chef/commit/12c9bed3a5a7ab8
 `Chef::Cookbook::FileVendor` was previously configured by passing a
 block to the `on_create` method; it is now configured by calling either
 `fetch_from_remote` or `fetch_from_disk`. See: https://github.com/opscode/chef/commit/3b2b4de8e7f0d55524f2a0ccaf3e1aa9f2d371eb
+
+## 'group' provider on OSX properly uses 'dscl' to determine existing groups
+
+On OSX, the 'group' provider would use 'etc' to determine existing groups,
+but 'dscl' to add groups, causing broken idempotency if something existed
+in /etc/group. The provider now uses 'dscl' for both idempotenty checks and
+modifications.

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -39,11 +39,33 @@ class Chef
           return result[2]
         end
 
-        # This is handled in providers/group.rb by Etc.getgrnam()
-        # def group_exists?(group)
-        #   groups = safe_dscl("list /Groups")
-        #   !! ( groups =~ Regexp.new("\n#{group}\n") )
-        # end
+        def load_current_resource
+          @current_resource = Chef::Resource::Group.new(@new_resource.name)
+          @current_resource.group_name(@new_resource.name)
+          group_info = nil
+          begin
+            group_info = safe_dscl("read /Groups/#{@new_resource.name}")
+          rescue Chef::Exceptions::Group
+            @group_exists = false
+            Chef::Log.debug("#{@new_resource} group does not exist")
+          end
+
+          if group_info
+            group_info.each_line do |line|
+              key, val = line.split(': ')
+              val.strip! if val
+              case key.downcase
+              when 'primarygroupid'
+                @new_resource.gid(val) unless @new_resource.gid
+                @current_resource.gid(val)
+              when 'groupmembership'
+                @current_resource.members(val.split(' '))
+              end
+            end
+          end
+
+          @current_resource
+        end
 
         # get a free GID greater than 200
         def get_free_gid(search_limit=1000)
@@ -113,10 +135,6 @@ class Chef
             a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/bin/dscl for #{@new_resource.name}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
           end
-        end
-
-        def load_current_resource
-          super
         end
 
         def create_group


### PR DESCRIPTION
Currently the OSX Group provider use the 'Etc' module to determine
what exists, and the 'dscl' command to change things. Etc will look
to /etc/group by default and fallback to 'dscl', which causes idempotency
incorrectness. This change the Group provider to simply look at 'dscl' always.
