### PR TITLE
Make solo tarballs work on windows; fixes #1515

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,10 @@ end
 group(:development, :test) do
   gem "simplecov"
   gem 'rack', "~> 1.5.1"
-
   gem 'ruby-shadow', :platforms => :ruby unless RUBY_PLATFORM.downcase.match(/(aix|cygwin)/)
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'ruby_gntp'
 end
 
 # If you want to load debugging tools into the bundle exec sandbox,

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard :rspec, :cmd => "bundle exec rspec" do
+  watch(%r{^spec/unit/.+_spec\.rb$})
+  watch(%r{^lib/chef/(.+)\.rb$})     { |m| "spec/unit/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -191,7 +191,7 @@ class Chef::Application::Solo < Chef::Application
     end
 
     if Chef::Config[:recipe_url]
-      cookbooks_path = Array(Chef::Config[:cookbook_path]).detect{|e| e =~ /#{Chef::Config.platform_path_separator}cookbooks#{Chef::Config.platform_path_separator}*$/ }
+      cookbooks_path = Array(Chef::Config[:cookbook_path]).detect{|e| e =~ /#{Chef::Config.platform_path_separator_escaped}cookbooks#{Chef::Config.platform_path_separator_escaped}*$/ }
       recipes_path = File.expand_path(File.join(cookbooks_path, '..'))
 
       Chef::Log.debug "Creating path #{recipes_path} to extract recipes into"
@@ -202,7 +202,7 @@ class Chef::Application::Solo < Chef::Application
           f.write(r.read)
         end
       end
-      Chef::Mixin::Command.run_command(:command => "tar zxvf #{path} -C #{recipes_path}")
+      Chef::Mixin::ShellOut.shell_out!("tar zxvf #{path} -C #{recipes_path}")
     end
   end
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -191,7 +191,7 @@ class Chef::Application::Solo < Chef::Application
     end
 
     if Chef::Config[:recipe_url]
-      cookbooks_path = Array(Chef::Config[:cookbook_path]).detect{|e| e =~ /\/cookbooks\/*$/ }
+      cookbooks_path = Array(Chef::Config[:cookbook_path]).detect{|e| e =~ /#{Chef::Config.platform_path_separator}cookbooks#{Chef::Config.platform_path_separator}*$/ }
       recipes_path = File.expand_path(File.join(cookbooks_path, '..'))
 
       Chef::Log.debug "Creating path #{recipes_path} to extract recipes into"

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -72,6 +72,14 @@ class Chef
       end
     end
 
+    def self.platform_path_separator_escaped
+      if on_windows?
+        "#{platform_path_separator}#{platform_path_separator}"
+      else
+        platform_path_separator
+      end
+    end
+
     def self.path_join(*args)
       args = args.flatten
       args.inject do |joined_path, component|

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -25,6 +25,17 @@ require 'chef/config'
 class Chef
   module Mixin
     module ShellOut
+      class Wrapper
+        extend Chef::Mixin::ShellOut
+      end
+
+      def self.shell_out(*command_args)
+        Chef::Mixin::ShellOut::Wrapper.new.shell_out(*command_args)
+      end
+
+      def self.shell_out!(*command_args)
+        Chef::Mixin::ShellOut::Wrapper.new.shell_out!(*command_args)
+      end
 
       # shell_out! runs a command on the system and will raise an error if the command fails, which is what you want
       # for debugging, shell_out and shell_out! both will display command output to the tty when the log level is debug

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -67,7 +67,6 @@ describe Chef::Application::Solo do
     end
 
 
-
     describe "when the recipe_url configuration option is specified" do
       before do
         Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
@@ -79,7 +78,7 @@ describe Chef::Application::Solo do
         @target_file = StringIO.new
         File.stub(:open).with("#{Dir.tmpdir}/chef-solo/recipes.tgz", "wb").and_yield(@target_file)
 
-        Chef::Mixin::Command.stub(:run_command).and_return(true)
+        Chef::Mixin::ShellOut.stub(:shell_out!).and_return(true)
       end
 
       it "should create the recipes path based on the parent of the cookbook path" do
@@ -98,12 +97,11 @@ describe Chef::Application::Solo do
       end
 
       it "should untar the target file to the parent of the cookbook path" do
-        Chef::Mixin::Command.should_receive(:run_command).with({:command => "tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo"}).and_return(true)
+        Chef::Mixin::ShellOut.should_receive(:shell_out!).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo").and_return(true)
         @app.reconfigure
       end
     end
   end
-
 
   describe "after the application has been configured" do
     before do


### PR DESCRIPTION
Adds Guard support to Chef.

Makes solo tarballs work on windows, by converting to ShellOut and adding smarter path separator support to the regex that detects the cookbook directory to untar into.