### PR TITLE
Make access to path use the accessor method

### DIFF
--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -86,7 +86,7 @@ class Chef
 
       # make link quack like a file (XXX: not for public consumption)
       def path
-        @target_file
+        target_file
       end
 
       private


### PR DESCRIPTION
By linking the path property directly to the instance variable, we were circumventing the set_or_return call which is required to process the DelayedEvaluator.

fixes #1769 
