### PR TITLE
add keepalives to cookbook synchronizer

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -62,7 +62,6 @@ class Chef
 
     end
 
-
     def self.middlewares
       @middlewares ||= []
     end
@@ -87,6 +86,8 @@ class Chef
       @sign_on_redirect = true
       @redirects_followed = 0
       @redirect_limit = 10
+
+      @client_cache = options[:client_cache]
 
       @middlewares = []
       self.class.middlewares.each do |middleware_class|
@@ -197,7 +198,11 @@ class Chef
 
     def http_client(base_url=nil)
       base_url ||= url
-      BasicClient.new(base_url)
+      if @client_cache
+        @client_cache.client_for(base_url)
+      else
+        BasicClient.new(base_url)
+      end
     end
 
     protected
@@ -281,7 +286,6 @@ class Chef
         end
       end
     end
-
 
     # Wraps an HTTP request with retry logic.
     # === Arguments
@@ -379,7 +383,6 @@ class Chef
       tf.close!
       raise
     end
-
 
     public
 

--- a/lib/chef/http/basic_client_cache.rb
+++ b/lib/chef/http/basic_client_cache.rb
@@ -1,0 +1,40 @@
+#--
+# Author:: Lamont Granquist (<lamont@opscode.com>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'uri'
+require 'chef/http/basic_client'
+
+class Chef
+  class HTTP
+    class BasicClientCache
+
+      attr_accessor :client_cache
+
+      def initialize
+        @client_cache = {}
+      end
+
+      def client_for(uri, opts = {})
+        opts ||= {}
+        uri = URI.parse(uri) if uri.is_a? String
+        cache_key = uri.hostname + ';' + uri.port.to_s + ';' + opts[:ssl_policy].to_s
+        client_cache[cache_key] ||= BasicClient.new(uri, opts)
+      end
+    end
+  end
+end

--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -190,7 +190,11 @@ class Chef
 
     def http_client(base_url=nil)
       base_url ||= url
-      BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
+      if @client_cache
+        @client_cache.client_for(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
+      else
+        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
+      end
     end
 
     ############################################################################


### PR DESCRIPTION
adds a basic_client_cache that 'users' can create and pass into
Chef::HTTP/REST in order to cache their clients based on hostname +
port + options
