### PR TITLE
use net/http/persistent for keepalives

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-zero", "~> 4.5"
 
   s.add_dependency "plist", "~> 3.1.0"
+  s.add_dependency "net-http-persistent", "~> 2.0"
 
   # Audit mode requires these, so they are non-developmental dependencies now
   %w{rspec-core rspec-expectations rspec-mocks}.each { |gem| s.add_dependency gem, "~> 3.4" }

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -51,6 +51,7 @@ require "chef/policy_builder"
 require "chef/request_id"
 require "chef/platform/rebooter"
 require "chef/mixin/deprecation"
+require "chef/http/client_cache"
 require "ohai"
 require "rbconfig"
 
@@ -316,6 +317,7 @@ class Chef
         @run_status = nil
         run_context = nil
         runlock.release
+        Chef::HTTP::ClientCache.instance.shutdown
       end
 
       # Raise audit, converge, and other errors here so that we exit

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -76,6 +76,8 @@ class Chef
     attr_reader :options
     attr_reader :middlewares
 
+    attr_reader :http_client_cache
+
     # Create a HTTP client object. The supplied +url+ is used as the base for
     # all subsequent requests. For example, when initialized with a base url
     # http://localhost:4000, a call to +get+ with 'nodes' will make an
@@ -83,6 +85,7 @@ class Chef
     def initialize(url, options = {})
       @url = url
       @default_headers = options[:headers] || {}
+      @http_client_cache = options[:http_client_cache]
       @sign_on_redirect = true
       @redirects_followed = 0
       @redirect_limit = 10
@@ -211,7 +214,7 @@ class Chef
         }
         SocketlessChefZeroClient.new(base_url)
       else
-        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
+        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy, :http_client_cache => http_client_cache))
       end
     end
 

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -214,7 +214,7 @@ class Chef
         }
         SocketlessChefZeroClient.new(base_url)
       else
-        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy, :http_client_cache => http_client_cache))
+        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy, :http_client_cache => http_client_cache)
       end
     end
 

--- a/lib/chef/http/client_cache.rb
+++ b/lib/chef/http/client_cache.rb
@@ -1,0 +1,121 @@
+#--
+# Author:: Lamont Granquist (<lamont@getchef.com>)
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "net/http/persistent"
+require "singleton"
+require "forwardable"
+
+class Chef
+  class HTTP
+    class ClientCache
+      include Singleton
+      extend Forwardable
+
+      attr_accessor :config
+      attr_accessor :logger
+      attr_accessor :caches
+      attr_accessor :read_timeout
+      attr_accessor :open_timeout
+      attr_accessor :max_requests
+      attr_accessor :idle_timeout
+
+      def initialize
+        reset!
+      end
+
+      # Changing the SSL policy on a Net::HTTP::Persistent object invalidates all of the
+      # connections, so we create a cache of them based on SSL policy
+      def for_ssl_policy(ssl_policy, opts = {})
+        set_opts(opts)
+        caches[ssl_policy.hash] ||=
+          begin
+            logger.debug "Creating new Net::HTTP::Persistent object for #{ssl_policy}"
+            cache = new_cache
+            ssl_policy.apply_to(cache, config: config) if ssl_policy
+            cache
+          end
+      end
+
+      def set_opts(opts)
+        opts ||= {}
+        @config = opts[:config] if opts[:config]
+        @logger = opts[:logger] if opts[:logger]
+      end
+
+      def config=(hash)
+        reset_vars!
+        @config = hash
+      end
+
+      def config
+        @config ||= Chef::Config
+      end
+
+      def logger
+        @logger ||= Chef::Log.logger
+      end
+
+      def shutdown
+        logger.debug "Shutting down Net::HTTP::Persistent caches"
+        caches.each_value do |cache|
+          cache.shutdown
+        end
+        reset!
+      end
+
+      def reset_vars!
+        @read_timeout = nil
+        @open_timeout = nil
+        @max_requests = nil
+        @idle_timeout = nil
+      end
+
+      def reset!
+        logger.debug "Releasing Net::HTTP::Persistent cache objects"
+        @caches = {}
+      end
+
+      def read_timeout
+        @read_timeout ||= config[:rest_timeout]
+      end
+
+      def open_timeout
+        @open_timeout ||= config[:rest_timeout]
+      end
+
+      def max_requests
+        @max_requests ||= config[:max_requests]
+      end
+
+      def idle_timeout
+        @idle_timeout ||= config[:idle_timeout]
+      end
+
+      private
+
+      def new_cache
+        cache = Net::HTTP::Persistent.new
+        cache.read_timeout = read_timeout
+        cache.open_timeout = open_timeout
+        cache.max_requests = max_requests
+        cache.idle_timeout = idle_timeout
+        cache
+      end
+    end
+  end
+end

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -109,10 +109,6 @@ class Chef
         end
       end
 
-      def config
-        Chef::Config
-      end
-
       # DEPRECATED. Call request on an HTTP client object instead.
       def http_client
         @http_client ||= BasicClient.new(url).http_client

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -31,14 +31,16 @@ class Chef
     # Configures SSL behavior on an HTTP object via visitor pattern.
     class DefaultSSLPolicy
 
-      def self.apply_to(http_client)
-        new(http_client).apply
+      def self.apply_to(http_client, opts = {})
+        new(http_client, opts).apply
         http_client
       end
 
       attr_reader :http_client
 
-      def initialize(http_client)
+      def initialize(http_client, opts = {})
+        opts ||= {}
+        @config = opts[:config] if opts[:config]
         @http_client = http_client
       end
 
@@ -102,7 +104,7 @@ class Chef
       end
 
       def config
-        Chef::Config
+        @config ||= Chef::Config
       end
 
       private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,6 +201,10 @@ RSpec.configure do |config|
     Chef.reset!
 
     Chef::Config.reset
+    Chef::HTTP::ClientCache.instance.shutdown
+    Chef::HTTP::ClientCache.instance.open_timeout = 0.1
+    Chef::HTTP::ClientCache.instance.read_timeout = 0.1
+    Chef::HTTP::ClientCache.instance.max_requests = 1
 
     # By default, treat deprecation warnings as errors in tests.
     Chef::Config.treat_deprecation_warnings_as_errors(true)


### PR DESCRIPTION
- converts all Chef connections to use keepalives

anything that uses Chef::REST or Chef::HTTP will benefit from this now.

:warning: :construction: Still WIP :warning: :construction: 