### PR TITLE
remove some uses of from_json

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -187,7 +187,7 @@ class Chef
 
       def apply_json_cookbook_version_metadata(file)
         begin
-          data = Chef::JSONCompat.from_json(IO.read(file), :create_additions => false)
+          data = Chef::JSONCompat.parse(IO.read(file))
           @metadata.from_hash(data['metadata'])
         rescue Chef::Exceptions::JSON::ParseError
           Chef::Log.error("Couldn't parse cookbook metadata JSON for #@cookbook_name in " + file)
@@ -198,7 +198,7 @@ class Chef
       def set_frozen
         if uploaded_cookbook_version_file
           begin
-            data = Chef::JSONCompat.from_json(IO.read(uploaded_cookbook_version_file), :create_additions => false)
+            data = Chef::JSONCompat.parse(IO.read(uploaded_cookbook_version_file))
             @frozen = data['frozen?']
           rescue Chef::Exceptions::JSON::ParseError
             Chef::Log.error("Couldn't parse cookbook metadata JSON for #@cookbook_name in #{uploaded_cookbook_version_file}")

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -50,7 +50,7 @@ class Chef
             if @inflate_json_class
               return_value = Chef::JSONCompat.from_json(http_response.body.chomp)
             else
-              return_value = Chef::JSONCompat.from_json(http_response.body.chomp, :create_additions => false)
+              return_value = Chef::JSONCompat.parse(http_response.body.chomp)
             end
           end
           [http_response, rest_request, return_value]

--- a/lib/chef/knife/core/node_editor.rb
+++ b/lib/chef/knife/core/node_editor.rb
@@ -42,8 +42,8 @@ class Chef
       end
 
       def updated?
-        pristine_copy = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(node), :create_additions => false)
-        updated_copy  = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(@updated_node), :create_additions => false)
+        pristine_copy = Chef::JSONCompat.parse(Chef::JSONCompat.to_json(node))
+        updated_copy  = Chef::JSONCompat.parse(Chef::JSONCompat.to_json(@updated_node))
         unless pristine_copy == updated_copy
           updated_properties = %w{name normal chef_environment run_list default override automatic}.reject do |key|
              pristine_copy[key] == updated_copy[key]
@@ -107,4 +107,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -195,8 +195,8 @@ class Chef
         # We wouldn't have to do these shenanigans if all the editable objects
         # implemented to_hash, or if to_json against a hash returned a string
         # with stable key order.
-        object_parsed_again = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(object), :create_additions => false)
-        output_parsed_again = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(output), :create_additions => false)
+        object_parsed_again = Chef::JSONCompat.parse(Chef::JSONCompat.to_json(object))
+        output_parsed_again = Chef::JSONCompat.parse(Chef::JSONCompat.to_json(output))
         if object_parsed_again != output_parsed_again
           output.save
           self.msg("Saved #{output}")

--- a/lib/chef/provider/deploy/revision.rb
+++ b/lib/chef/provider/deploy/revision.rb
@@ -90,7 +90,7 @@ class Chef
 
         def load_cache
           begin
-            Chef::JSONCompat.from_json(Chef::FileCache.load("revision-deploys/#{new_resource.name}"))
+            Chef::JSONCompat.parse(Chef::FileCache.load("revision-deploys/#{new_resource.name}"))
           rescue Chef::Exceptions::FileNotFound
             sorted_releases_from_filesystem
           end

--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -139,7 +139,7 @@ class Chef
         end
 
         def load_data
-          Chef::JSONCompat.from_json(load_json_data)
+          Chef::JSONCompat.parse(load_json_data)
         rescue Chef::Exceptions::FileNotFound, Chef::Exceptions::JSON::ParseError
           false
         end


### PR DESCRIPTION
fix some things that don't need create_additions at all and just
return standard ruby objects without json_class.  convert to
JSONCompat#parse which doesn't do any json_class inflation.
