### PR TITLE
Use thread-safe OpenSSL::Digest instead of Digest

### DIFF
--- a/lib/chef/chef_fs/file_system/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/cookbook_file.rb
@@ -18,7 +18,7 @@
 
 require 'chef/chef_fs/file_system/base_fs_object'
 require 'chef/http/simple'
-require 'digest/md5'
+require 'openssl'
 
 class Chef
   module ChefFS
@@ -74,7 +74,7 @@ class Chef
         private
 
         def calc_checksum(value)
-          Digest::MD5.hexdigest(value)
+          OpenSSL::Digest::MD5.hexdigest(value)
         end
       end
     end

--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'digest'
+require 'openssl'
 
 class Chef
   class Digester
@@ -40,7 +40,7 @@ class Chef
     end
 
     def generate_checksum(file)
-      checksum_file(file, Digest::SHA256.new)
+      checksum_file(file, OpenSSL::Digest::SHA256.new)
     end
 
     def self.generate_md5_checksum_for_file(*args)
@@ -48,11 +48,11 @@ class Chef
     end
 
     def generate_md5_checksum_for_file(file)
-      checksum_file(file, Digest::MD5.new)
+      checksum_file(file, OpenSSL::Digest::MD5.new)
     end
 
     def generate_md5_checksum(io)
-      checksum_io(io, Digest::MD5.new)
+      checksum_io(io, OpenSSL::Digest::MD5.new)
     end
 
     private
@@ -70,4 +70,3 @@ class Chef
 
   end
 end
-

--- a/lib/chef/encrypted_data_bag_item/decryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/decryptor.rb
@@ -152,7 +152,7 @@ class Chef::EncryptedDataBagItem
           d = OpenSSL::Cipher.new(algorithm)
           d.decrypt
           # We must set key before iv: https://bugs.ruby-lang.org/issues/8221
-          d.key = Digest::SHA256.digest(key)
+          d.key = OpenSSL::Digest::SHA256.digest(key)
           d.iv = iv
           d
         end

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -102,7 +102,7 @@ class Chef::EncryptedDataBagItem
           encryptor = OpenSSL::Cipher.new(algorithm)
           encryptor.encrypt
           # We must set key before iv: https://bugs.ruby-lang.org/issues/8221
-          encryptor.key = Digest::SHA256.digest(key)
+          encryptor.key = OpenSSL::Digest::SHA256.digest(key)
           @iv ||= encryptor.random_iv
           encryptor.iv = @iv
           encryptor


### PR DESCRIPTION
Fixes #1793

Related issue https://github.com/aws/aws-sdk-ruby/issues/525
