### PR TITLE
Enable client-side key generation by default (fixes #1711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix SuSE package removal failure (Issue 1732).
 * Enable Travis to run Test Kitchen with Kitchen EC2.
 * End-to-end tests for Ubuntu 12.04
+* Enable client-side key generation by default. (Issue 1711)
 
 
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -456,15 +456,15 @@ class Chef
     default :validation_client_name, "chef-validator"
 
     # When creating a new client via the validation_client account, Chef 11
-    # servers allow the client to generate a key pair locally and sent the
+    # servers allow the client to generate a key pair locally and send the
     # public key to the server. This is more secure and helps offload work from
     # the server, enhancing scalability. If enabled and the remote server
     # implements only the Chef 10 API, client registration will not work
     # properly.
     #
-    # The default value is `false` (Server generates client keys). Set to
-    # `true` to enable client-side key generation.
-    default(:local_key_generation) { false }
+    # The default value is `true`. Set to `false` to disable client-side key
+    # generation (server generates client keys).
+    default(:local_key_generation) { true }
 
     # Zypper package provider gpg checks. Set to true to enable package
     # gpg signature checking. This will be default in the


### PR DESCRIPTION
\cc @opscode/client-engineers 
