### PR TITLE
Fix a bug when receiving a relative redirect location

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -208,9 +208,6 @@ class Chef
         URI.parse(path)
       elsif path.nil? or path.empty?
         URI.parse(@url)
-      elsif @url.is_a?(URI)
-        @url.path = path
-        return @url
       else
         # The regular expressions used here are to make sure '@url' does not have
         # any trailing slashes and 'path' does not have any leading slashes. This
@@ -274,7 +271,7 @@ class Chef
         elsif redirect_location = redirected_to(response)
           if [:GET, :HEAD].include?(method)
             follow_redirect do
-              send_http_request(method, create_url(redirect_location), headers, body, &response_handler)
+              send_http_request(method, url+redirect_location, headers, body, &response_handler)
             end
           else
             raise Exceptions::InvalidRedirect, "#{method} request was redirected from #{url} to #{redirect_location}. Only GET and HEAD support redirects."

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -44,11 +44,6 @@ describe Chef::HTTP do
       http.create_url('///api/endpoint?url=http://foo.bar').should eql(URI.parse('http://www.getchef.com/organization/org/api/endpoint?url=http://foo.bar'))
     end
 
-    it 'should return a correctly formatted url when @url is a URI' do
-      http = Chef::HTTP.new(URI.parse('http://www.getchef.com/index.html'))
-      http.create_url('/some/redirected/location/index.html').should eql(URI.parse('http://www.getchef.com/some/redirected/location/index.html'))
-    end
-
   end # create_url
 
   describe "head" do


### PR DESCRIPTION
Currently when you use a provider that somewhere along the line uses
Chef::HTTP.request or Chef::HTTP.streaming_request, you will receive an
error when the response is a redirect with a relative location.
