### PR TITLE
Don't swallow end to end failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ matrix:
     before_script:
     - cd kitchen-tests
     script:
-    - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && bundle exec kitchen test || true'
+    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen test; fi
     after_script:
-    - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && bundle exec kitchen destroy || true'
+    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen destroy; fi
     env:
     - KITCHEN_YAML=.kitchen.travis.yml
     - EC2_SSH_KEY_PATH=~/.ssh/id_aws.pem


### PR DESCRIPTION
Using `|| true` at the end of the after script was swallowing failed end to end tests, and Travis would falsely report success. This will return the exit status of the command, or 0 if secure environment variables aren't available.
