### PR TITLE
Modify travis notifications so that we are notified only when a stable branch is broken.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,10 @@ matrix:
     - secure: SOMYGVfHLkHsH6koxpw68YQ4ydEo6YXPhHbrYGQbehUbFa6+OZzBcAJRJbKjyhD2AZRvNr2jB8XnjYKvVyDGQRpkWhGYZ7CpHqINpDsqKBsbiMe3/+KmKQqS+UKxNGefquoOvyQ1N8Xy77dkWYokRtGMEuR12RkZLonxiDW8Qyg=
     ### END TEST KITCHEN ONLY ###
 notifications:
+  on_change: true
+  on_failure: true
   on_success: change
-  on_failure: always
-  on_start: false
+  on_pull_requests: false
   irc:
     channels:
     - chat.freenode.net#chef-hacking


### PR DESCRIPTION
We are mimicking RelEng here: 

https://github.com/opscode/omnibus/blob/master/.travis.yml#L16-L21

You can checkout the "Release Engineering" channel for an example of what kind of notifications this will lead to :smile: 

/cc: @opscode/client-engineers 
