### PR TITLE
Have freebsd port use pkg info if the freebsd version is >= 10000017

### DIFF
--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -34,7 +34,7 @@ class Chef
           end
 
           def current_installed_version
-            pkg_info = if supports_pkgng?
+            pkg_info = if @new_resource.supports_pkgng?
                          shell_out!("pkg info \"#{@new_resource.package_name}\"", :env => nil, :returns => [0,70])
                        else
                          shell_out!("pkg_info -E \"#{@new_resource.package_name}*\"", :env => nil, :returns => [0,1])
@@ -53,19 +53,6 @@ class Chef
           def port_dir
             super(@new_resource.package_name)
           end
-
-          private
-
-          def ships_with_pkgng?
-            # It was not until __FreeBSD_version 1000017 that pkgng became
-            # the default binary package manager. See '/usr/ports/Mk/bsd.port.mk'.
-            node[:os_version].to_i >= 1000017
-          end
-
-          def supports_pkgng?
-            ships_with_pkgng? || !!shell_out!("make -V WITH_PKGNG", :env => nil).stdout.match(/yes/i)
-          end
-
         end
       end
     end

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -52,7 +52,17 @@ class Chef
         "#{created_as_type}[#{name}]"
       end
 
+      def supports_pkgng?
+        ships_with_pkgng? || !!shell_out!("make -V WITH_PKGNG", :env => nil).stdout.match(/yes/i)
+      end
+
       private
+
+      def ships_with_pkgng?
+        # It was not until __FreeBSD_version 1000017 that pkgng became
+        # the default binary package manager. See '/usr/ports/Mk/bsd.port.mk'.
+        node.automatic[:os_version].to_i >= 1000017
+      end
 
       def assign_provider
         @provider = if @source.to_s =~ /^ports$/i
@@ -63,17 +73,6 @@ class Chef
                       Chef::Provider::Package::Freebsd::Pkg
                     end
       end
-
-      def ships_with_pkgng?
-        # It was not until __FreeBSD_version 1000017 that pkgng became
-        # the default binary package manager. See '/usr/ports/Mk/bsd.port.mk'.
-        node[:os_version].to_i >= 1000017
-      end
-
-      def supports_pkgng?
-        ships_with_pkgng? || !!shell_out!("make -V WITH_PKGNG", :env => nil).stdout.match(/yes/i)
-      end
-
     end
   end
 end

--- a/spec/unit/provider/package/freebsd/port_spec.rb
+++ b/spec/unit/provider/package/freebsd/port_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
 
-    @new_resource = Chef::Resource::Package.new("zsh")
+    @new_resource = Chef::Resource::FreebsdPackage.new("zsh", @run_context)
     @provider = Chef::Provider::Package::Freebsd::Port.new(@new_resource, @run_context)
   end
 
@@ -70,22 +70,25 @@ describe Chef::Provider::Package::Freebsd::Port do
     end
 
     it "should check 'pkg_info' if system uses pkg_* tools" do
-      @provider.stub(:supports_pkgng?)
-      @provider.should_receive(:supports_pkgng?).and_return(false)
+      @new_resource.stub(:supports_pkgng?)
+      @new_resource.should_receive(:supports_pkgng?).and_return(false)
       @provider.should_receive(:shell_out!).with('pkg_info -E "zsh*"', :env => nil, :returns => [0,1]).and_return(@pkg_info)
       @provider.current_installed_version.should == "3.1.7"
     end
 
-    it "should check 'pkg info' if make supports WITH_PKGNG" do
+    it "should check 'pkg info' if make supports WITH_PKGNG if freebsd version is < 1000017" do
       pkg_enabled = OpenStruct.new(:stdout => "yes\n")
-      @provider.should_receive(:shell_out!).with('make -V WITH_PKGNG', :env => nil).and_return(pkg_enabled)
-      @provider.should_receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
-      @provider.current_installed_version.should == "3.1.7"
+      [1000016, 1000000, 901503, 902506, 802511].each do |__freebsd_version|
+        @node.automatic_attrs[:os_version] = __freebsd_version
+        @new_resource.should_receive(:shell_out!).with('make -V WITH_PKGNG', :env => nil).and_return(pkg_enabled)
+        @provider.should_receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
+        @provider.current_installed_version.should == "3.1.7"
+      end
     end
 
     it "should check 'pkg info' if the freebsd version is greater than or equal to 1000017" do
       __freebsd_version = 1000017
-      @node.normal[:os_version] = __freebsd_version
+      @node.automatic_attrs[:os_version] = __freebsd_version
       @provider.should_receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
       @provider.current_installed_version.should == "3.1.7"
     end

--- a/spec/unit/resource/freebsd_package_spec.rb
+++ b/spec/unit/resource/freebsd_package_spec.rb
@@ -57,7 +57,7 @@ describe Chef::Resource::FreebsdPackage do
     describe "if __Freebsd_version is greater than or equal to 1000017" do
       it "should be Freebsd::Pkgng" do
         [1000017, 1000018, 1000500, 1001001, 1100000].each do |__freebsd_version|
-          @node.normal[:os_version] = __freebsd_version
+          @node.automatic_attrs[:os_version] = __freebsd_version
           @resource.after_created
           @resource.provider.should == Chef::Provider::Package::Freebsd::Pkgng
         end
@@ -79,7 +79,7 @@ describe Chef::Resource::FreebsdPackage do
         @resource.stub(:shell_out!).with("make -V WITH_PKGNG", :env => nil).and_return(pkg_enabled)
 
         [1000016, 1000000, 901503, 902506, 802511].each do |__freebsd_version|
-          @node.normal[:os_version] = __freebsd_version
+          @node.automatic_attrs[:os_version] = __freebsd_version
           @resource.after_created
           @resource.provider.should == Chef::Provider::Package::Freebsd::Pkg
         end


### PR DESCRIPTION
The port package provider for FreeBSD was not checking if the freebsd version is version 10. This causes the provider to attempt to use 'pkg_info' instead of 'pkg info'. This PR should fix this bug.
