### PR TITLE
Client name should not be coupled to node name.

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -127,6 +127,10 @@ class Chef
     # properly.
     configurable(:daemonize).writes_value { |v| v }
 
+    # There is no reason to couple node_name to client name during chef-client runs.
+    # This allows to configure the client name for authentication purposes.
+    configurable(:client_name).writes_value { |v| v }
+    
     # The root where all local chef object data is stored.  cookbooks, data bags,
     # environments are all assumed to be in separate directories under this.
     # chef-solo uses these directories for input data.  knife commands

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -129,7 +129,7 @@ class Chef
 
     # There is no reason to couple node_name to client name during chef-client runs.
     # This allows to configure the client name for authentication purposes.
-    configurable(:client_name).writes_value { |v| v }
+    default(:client_name) { node_name }
     
     # The root where all local chef object data is stored.  cookbooks, data bags,
     # environments are all assumed to be in separate directories under this.

--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -56,9 +56,9 @@ class Chef
     # all subsequent requests. For example, when initialized with a base url
     # http://localhost:4000, a call to +get_rest+ with 'nodes' will make an
     # HTTP GET request to http://localhost:4000/nodes
-    def initialize(url, client_name=Chef::Config[:node_name], signing_key_filename=Chef::Config[:client_key], options={})
+    def initialize(url, client_name=nil, signing_key_filename=Chef::Config[:client_key], options={})
       options = options.dup
-      options[:client_name] = (c = Chef::Config[:client_name]) ? c : client_name
+      options[:client_name] = client_name.nil || Chef::Config[:client_name]
       options[:signing_key_filename] = signing_key_filename
       super(url, options)
 

--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -58,7 +58,7 @@ class Chef
     # HTTP GET request to http://localhost:4000/nodes
     def initialize(url, client_name=Chef::Config[:node_name], signing_key_filename=Chef::Config[:client_key], options={})
       options = options.dup
-      options[:client_name] = client_name
+      options[:client_name] = (c = Chef::Config[:client_name]) ? c : client_name
       options[:signing_key_filename] = signing_key_filename
       super(url, options)
 

--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -58,7 +58,7 @@ class Chef
     # HTTP GET request to http://localhost:4000/nodes
     def initialize(url, client_name=nil, signing_key_filename=Chef::Config[:client_key], options={})
       options = options.dup
-      options[:client_name] = client_name.nil || Chef::Config[:client_name]
+      options[:client_name] = client_name || Chef::Config[:client_name]
       options[:signing_key_filename] = signing_key_filename
       super(url, options)
 


### PR DESCRIPTION
I was recently trying to use a specific client name and key and was failing miserably. It turns out that client key and client name are not set properly during chef-client runs and instead are coupled to the node name. This decouples the two if the user defines `client_name` in their `client.rb` file.