### PR TITLE
Fix dscl_user resource [Chef 11-stable]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Chef Client Changelog
 
-## Last Release: 11.14.6:
+## Unrelease Changes:
 
+* [**Phil Dibowitz**](https://github.com/jaymzh):
+  Fix 'dscl' provider for "user" resource to handle dscl caching properly
+
+## Last Release: 11.14.6:
 * Modify action for env raises Chef::Exceptions::Env exception on Windows (Chef Issues 1754)
 * Fix RPM package version detection (Issue 1554)
 * Fix a bug in reporting not to post negative duration values.

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -343,17 +343,6 @@ user password using shadow hash.")
           user_info = read_user_info
           dscl_set(user_info, :shadow_hash, shadow_info_binary)
 
-          #
-          # Before saving the user's plist file we need to wait for dscl to
-          # update its caches and flush them to disk. In order to achieve this
-          # we need to wait first for our changes to get into the dscl cache
-          # and then flush the cache to disk before saving password into the
-          # plist file. 3 seconds is the minimum experimental value for dscl
-          # cache to be updated. We can get rid of this sleep when we find a
-          # trigger to update dscl cache.
-          #
-          sleep 3
-          shell_out("dscacheutil '-flushcache'")
           save_user_info(user_info)
         end
 
@@ -555,6 +544,11 @@ user password using shadow hash.")
         def read_user_info
           user_info = nil
 
+          # We are about to read the plist directly - we have to make sure
+          # any changes in the dscl cache have been flushed to the backing
+          # plist files otherwise we will read stale data and then update it
+          # and write partially stale data back.
+          shell_out("dscacheutil '-flushcache'")
           begin
             user_plist_file = "#{USER_PLIST_DIRECTORY}/#{@new_resource.username}.plist"
             user_plist_info = run_plutil("convert xml1 -o - #{user_plist_file}")

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -376,6 +376,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
     let(:user_plist_file) { nil }
 
     before do
+      provider.should_receive(:shell_out).with("dscacheutil '-flushcache'")
       provider.should_receive(:shell_out).with("plutil -convert xml1 -o - /var/db/dslocal/nodes/Default/users/toor.plist") do
         if user_plist_file.nil?
           ShellCmdResult.new('Can not find the file', 'Sorry!!', 1)
@@ -707,15 +708,13 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
       new_resource.password("something")
     end
 
-    it "should sleep and flush the dscl cache before saving the password" do
+    it "should flush the dscl cache before reading the password" do
       provider.should_receive(:prepare_password_shadow_info).and_return({ })
       mock_shellout = double("Mock::Shellout")
       mock_shellout.stub(:run_command)
       Mixlib::ShellOut.should_receive(:new).and_return(mock_shellout)
       provider.should_receive(:read_user_info)
       provider.should_receive(:dscl_set)
-      provider.should_receive(:sleep).with(3)
-      provider.should_receive(:shell_out).with("dscacheutil '-flushcache'")
       provider.should_receive(:save_user_info)
       provider.set_password
     end
@@ -822,6 +821,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
 
   describe "when the user exists" do
     before do
+      provider.should_receive(:shell_out).with("dscacheutil '-flushcache'")
       provider.should_receive(:shell_out).with("plutil -convert xml1 -o - /var/db/dslocal/nodes/Default/users/toor.plist") do
         ShellCmdResult.new(File.read(File.join(CHEF_SPEC_DATA, "mac_users/10.9.plist.xml")), "", 0)
       end


### PR DESCRIPTION
tl;dr We are mis-handling the way dscl cache works.

We were getting the case where we would create a user, they'd end
up with the wrong shell, and then the next run would update it.

It turns out because the recent Provider::User::Dscl refactor has a bug in
that we use 'dscl' to set most things (which is good), but then before flushing
the cache, we read the object directly out of the (now-stale) plist file.

We then flush the changes to disk, but immediately overwrite them. Whoops!

This flushes the cache before we read restoring proper behavior and dropping
an unnecessary sleep
