### PR TITLE
change mysql-client package

### DIFF
--- a/kitchen-tests/test/integration/webapp/serverspec/localhost/default_spec.rb
+++ b/kitchen-tests/test/integration/webapp/serverspec/localhost/default_spec.rb
@@ -25,9 +25,9 @@ describe "webapp::default", :end_to_end => true do
       end
     end
 
-    describe "mysql-client package" do
+    describe "mysql-client-5.5 package" do
       include_examples "a package" do
-        let(:package_name) { "mysql-client" }
+        let(:package_name) { "mysql-client-5.5" }
       end
     end
 


### PR DESCRIPTION
mysql cookbook now installs mysql-client-5.5 by default
