### PR TITLE
DSC spec platform detection via WMI

### DIFF
--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -19,7 +19,7 @@
 require 'spec_helper'
 require 'chef/mixin/windows_architecture_helper'
 
-describe Chef::Resource::DscScript, :windows_2008r2_or_later do
+describe Chef::Resource::DscScript, :windows_powershell_dsc_only do
   include Chef::Mixin::WindowsArchitectureHelper
   before(:all) do
     @temp_dir = ::Dir.mktmpdir("dsc-functional-test")

--- a/spec/functional/util/powershell/cmdlet_spec.rb
+++ b/spec/functional/util/powershell/cmdlet_spec.rb
@@ -88,7 +88,7 @@ describe Chef::Util::Powershell::Cmdlet, :windows_only do
 
   context "when returning json" do
     let(:cmd_output_format) { :json }
-    it "returns json format data" do
+    it "returns json format data", :windows_powershell_dsc_only do
       result = cmdlet_alias_requires_switch_or_argument.run({},{},'ls')
       expect(result.succeeded?).to eq(true)
       expect(lambda{JSON.parse(result.return_value)}).not_to raise_error
@@ -97,7 +97,7 @@ describe Chef::Util::Powershell::Cmdlet, :windows_only do
 
   context "when returning Ruby objects" do
     let(:cmd_output_format) { :object }    
-    it "returns object format data" do
+    it "returns object format data", :windows_powershell_dsc_only do
       result = simple_cmdlet.run({},{:cwd => etc_directory}, 'hosts')
       expect(result.succeeded?).to eq(true)
       data = result.return_value

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,8 @@ RSpec.configure do |config|
   config.filter_run_excluding :windows_2008r2_or_later => true unless windows_2008r2_or_later?
   config.filter_run_excluding :windows64_only => true unless windows64?
   config.filter_run_excluding :windows32_only => true unless windows32?
+  config.filter_run_excluding :windows_powershell_dsc_only => true unless windows_powershell_dsc?
+  config.filter_run_excluding :windows_powershell_no_dsc_only => true unless ! windows_powershell_dsc?
   config.filter_run_excluding :windows_domain_joined_only => true unless windows_domain_joined?
   config.filter_run_excluding :solaris_only => true unless solaris?
   config.filter_run_excluding :system_windows_service_gem_only => true unless system_windows_service_gem?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -60,6 +60,18 @@ def windows_2008r2_or_later?
   components.length >=2 && components[0] >= 6 && components[1] >= 1
 end
 
+def windows_powershell_dsc?
+  return false unless windows?
+  supports_dsc = false
+  begin
+    wmi = WmiLite::Wmi.new('root/microsoft/windows/desiredstateconfiguration')
+    lcm = wmi.query("SELECT * FROM meta_class WHERE __this ISA 'MSFT_DSCLocalConfigurationManager'")
+    supports_dsc = !! lcm
+  rescue WmiLite::WmiException
+  end
+  supports_dsc
+end
+
 def mac_osx_106?
   if File.exists? "/usr/bin/sw_vers"
     result = shell_out("/usr/bin/sw_vers")


### PR DESCRIPTION
Specs for DSC should only run if you have DSC support. Use WMI to check for the presence of MSFT_DSCLocalConfigurationManager in root/microsoft/windows/desiredstateconfiguration.
