### PR TITLE
Check the group membership using dscl on Mac in specs.

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -40,6 +40,11 @@ describe Chef::Resource::Group, :requires_root_or_running_windows, :not_supporte
     when "windows"
       user_sid = sid_string_from_user(user)
       user_sid.nil? ? false : Chef::Util::Windows::NetGroup.new(group_name).local_get_members.include?(user_sid)
+    when "mac_os_x"
+      membership_info = shell_out("dscl . -read /Groups/#{group_name}").stdout
+      members = membership_info.split(" ")
+      members.shift # Get rid of GroupMembership: string
+      members.include?(user)
     else
       Etc::getgrnam(group_name).mem.include?(user)
     end
@@ -420,6 +425,3 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" }
     end
   end
 end
-
-
-


### PR DESCRIPTION
Fixes the intermittent spec issue in our CI: 

```
  1) Chef::Resource::Group group manage action when there is a group behaves like correct group management when append is not set should remove the existing users and add the new users to the group
     Failure/Error: user_exist_in_group?(member).should == true
       expected: true
            got: false (using ==)
     Shared Example Group: "correct group management" called from ./spec/functional/resource/group_spec.rb:374
     # ./spec/functional/resource/group_spec.rb:106:in `block in add_members_to_group'
     # ./spec/functional/resource/group_spec.rb:105:in `each'
     # ./spec/functional/resource/group_spec.rb:105:in `add_members_to_group'
     # ./spec/functional/resource/group_spec.rb:136:in `block (4 levels) in <top (required)>'
```

@opscode/client-engineers  I would like to backport this to 11-stable and get it into the 11.18 release so that we can fix this spec issue which prevents daily Chef DK releases. @adamedx any concerns?
