### PR TITLE
Make Chef::Util::Powershell::Cmdlet Ruby 1.8.7 friendly

### DIFF
--- a/lib/chef/util/powershell/cmdlet.rb
+++ b/lib/chef/util/powershell/cmdlet.rb
@@ -88,7 +88,7 @@ class Chef::Util::Powershell
     include Chef::Mixin::WindowsArchitectureHelper
 
     def validate_switch_name!(switch_parameter_name)
-      if !!(switch_parameter_name =~ /\A[A-Za-z]+[_a-zA-Z0-9]*\Z/) == false
+      if !!(switch_parameter_name.to_s =~ /\A[A-Za-z]+[_a-zA-Z0-9]*\Z/) == false
         raise ArgumentError, "`#{switch_parameter_name}` is not a valid PowerShell cmdlet switch parameter name"
       end
     end

--- a/spec/unit/util/powershell/cmdlet_spec.rb
+++ b/spec/unit/util/powershell/cmdlet_spec.rb
@@ -80,27 +80,27 @@ describe Chef::Util::Powershell::Cmdlet do
     end
 
     it 'ignores switches with a false value' do
-      @cmdlet.send(:command_switches_string, {foo: false}).should eql('')
+      @cmdlet.send(:command_switches_string, {:foo => false}).should eql('')
     end
 
     it 'should correctly handle a value type of string' do
-      @cmdlet.send(:command_switches_string, {foo: 'bar'}).should eql("-foo 'bar'")
+      @cmdlet.send(:command_switches_string, {:foo => 'bar'}).should eql("-foo 'bar'")
     end
 
     it 'should correctly handle a value type of string even when it is 0 length' do
-      @cmdlet.send(:command_switches_string, {foo: ''}).should eql("-foo ''")
+      @cmdlet.send(:command_switches_string, {:foo => ''}).should eql("-foo ''")
     end
 
     it 'should not quote integers' do
-      @cmdlet.send(:command_switches_string, {foo: 1}).should eql("-foo 1")
+      @cmdlet.send(:command_switches_string, {:foo => 1}).should eql("-foo 1")
     end
 
     it 'should not quote floats' do
-      @cmdlet.send(:command_switches_string, {foo: 1.0}).should eql("-foo 1.0")
+      @cmdlet.send(:command_switches_string, {:foo => 1.0}).should eql("-foo 1.0")
     end
 
     it 'has just the switch when the value is true' do
-      @cmdlet.send(:command_switches_string, {foo: true}).should eql("-foo")
+      @cmdlet.send(:command_switches_string, {:foo => true}).should eql("-foo")
     end
   end
 end


### PR DESCRIPTION
Use 1.8 hash syntax
Explicitly convert the symbol to a string for comparison
