### PR TITLE
Multitenant local mode by default

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", "~> 3.1"
+  s.add_dependency "chef-zero", "~> 3.1", ">= 3.1.3"
   s.add_dependency "pry", "~> 0.9"
 
   s.add_dependency 'plist', '~> 3.1.0'

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -21,7 +21,6 @@ require 'socket'
 require 'chef/config'
 require 'chef/config_fetcher'
 require 'chef/exceptions'
-require 'chef/local_mode'
 require 'chef/log'
 require 'chef/platform'
 require 'mixlib/cli'
@@ -40,8 +39,6 @@ class Chef::Application
     # Always switch to a readable directory. Keeps subsequent Dir.chdir() {}
     # from failing due to permissions when launched as a less privileged user.
   end
-
-  attr_reader :local_mode
 
   # Reconfigure the application. You'll want to override and super this method.
   def reconfigure
@@ -188,24 +185,20 @@ class Chef::Application
 
   # Initializes Chef::Client instance and runs it
   def run_chef_client(specific_recipes = [])
-    Chef::LocalMode.start do |local_mode|
-      @local_mode = local_mode
-      override_runlist = config[:override_runlist]
-      if specific_recipes.size > 0
-        override_runlist ||= []
-      end
-      @chef_client = Chef::Client.new(
-        @chef_client_json,
-        :override_runlist => config[:override_runlist],
-        :specific_recipes => specific_recipes,
-        :runlist => config[:runlist]
-      )
-      @chef_client_json = nil
-
-      @chef_client.run
-      @chef_client = nil
-      @local_mode = nil
+    override_runlist = config[:override_runlist]
+    if specific_recipes.size > 0
+      override_runlist ||= []
     end
+    @chef_client = Chef::Client.new(
+      @chef_client_json,
+      :override_runlist => config[:override_runlist],
+      :specific_recipes => specific_recipes,
+      :runlist => config[:runlist]
+    )
+    @chef_client_json = nil
+
+    @chef_client.run
+    @chef_client = nil
   end
 
   private

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -41,6 +41,8 @@ class Chef::Application
     # from failing due to permissions when launched as a less privileged user.
   end
 
+  attr_reader :local_mode
+
   # Reconfigure the application. You'll want to override and super this method.
   def reconfigure
     configure_chef
@@ -186,7 +188,8 @@ class Chef::Application
 
   # Initializes Chef::Client instance and runs it
   def run_chef_client(specific_recipes = [])
-    Chef::LocalMode.with_server_connectivity do
+    Chef::LocalMode.start do |local_mode|
+      @local_mode = local_mode
       override_runlist = config[:override_runlist]
       if specific_recipes.size > 0
         override_runlist ||= []
@@ -201,6 +204,7 @@ class Chef::Application
 
       @chef_client.run
       @chef_client = nil
+      @local_mode = nil
     end
   end
 

--- a/lib/chef/chef_fs/file_system/chef_server_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server_root_dir.rb
@@ -81,10 +81,13 @@ class Chef
         end
 
         def org
-          @org ||= if URI.parse(chef_server_url).path =~ /^\/+organizations\/+([^\/]+)$/
-            $1
-          else
-            nil
+          @org ||= begin
+            path = Pathname.new(URI.parse(chef_server_url).path).cleanpath
+            if File.basename(File.dirname(path)) == 'organizations'
+              File.basename(path)
+            else
+              nil
+            end
           end
         end
 

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -341,7 +341,7 @@ class Chef
     # - otherwise, it is "https://localhost:443".
     default :chef_server_url do
       if chef_server_root
-        if has_key?(:organization)
+        if organization
           File.join(chef_server_root, 'organizations', organization)
         end
       elsif chef_zero.enabled
@@ -372,7 +372,7 @@ class Chef
       if has_key?(:chef_server_url)
         # https://blah.com/organizations/foo -> https://blah.com
         path = Pathname.new(URI.parse(chef_server_url).path).cleanpath
-        if !has_key?(:organization) || path.basename.to_s == organization
+        if path.basename.to_s == organization
           path = path.dirname
           if path.basename.to_s == 'organizations'
             URI.join(chef_server_url, path.dirname.to_s).to_s.chomp('/')
@@ -400,12 +400,7 @@ class Chef
     #   when chef_server_url = https://blah.com/organizations/orgname,
     #   organization = orgname.
     default(:organization) do
-      if chef_zero.enabled
-        unless chef_zero.chef_11_osc_compat
-          'chef'
-        end
-
-      elsif has_key?(:chef_server_url)
+      if has_key?(:chef_server_url)
         # https://blah.com/organizations/foo -> foo
         path = Pathname.new(URI.parse(chef_server_url).path).cleanpath
         if path.dirname.basename.to_s == 'organizations'

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -58,6 +58,7 @@ class Chef
 
     attr_accessor :name_args
     attr_accessor :ui
+    attr_reader :local_mode
 
     # Configure mixlib-cli to always separate defaults from user-supplied CLI options
     def self.use_separate_defaults?
@@ -489,8 +490,13 @@ class Chef
         ui.error "You need to add a #run method to your knife command before you can use it"
       end
       enforce_path_sanity
-      Chef::LocalMode.with_server_connectivity do
-        run
+      Chef::LocalMode.start do |local_mode|
+        @local_mode = local_mode
+        begin
+          run
+        ensure
+          @local_mode = nil
+        end
       end
     rescue Exception => e
       raise if raise_exception || Chef::Config[:verbosity] == 2

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -611,15 +611,28 @@ class Chef
 
     def rest
       @rest ||= begin
-        require 'chef/rest'
-        Chef::REST.new(Chef::Config[:chef_server_url])
+        if Chef::Config[:chef_server_url]
+          require 'chef/rest'
+          Chef::REST.new(Chef::Config[:chef_server_url])
+        end
+      end
+    end
+
+    def rest_root
+      @rest_root ||= begin
+        if Chef::Config[:chef_server_root]
+          require 'chef/rest'
+          Chef::REST.new(Chef::Config[:chef_server_root])
+        end
       end
     end
 
     def noauth_rest
-      @rest ||= begin
-        require 'chef/rest'
-        Chef::REST.new(Chef::Config[:chef_server_url], false, false)
+      @noauth_rest ||= begin
+        if Chef::Config[:chef_server_url]
+          require 'chef/rest'
+          Chef::REST.new(Chef::Config[:chef_server_url], false, false)
+        end
       end
     end
 

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -16,9 +16,13 @@ class Chef
         :long => '--chef-zero-host IP',
         :description => 'Overrides the host upon which chef-zero listens. Default is 127.0.0.1.'
 
+      def initialize(*args)
+        super(*args)
+        config[:local_mode] = true
+      end
+
       def configure_chef
         super
-        Chef::Config.local_mode = true
         Chef::Config[:repo_mode] = config[:repo_mode] if config[:repo_mode]
 
         # --chef-repo-path forcibly overrides all other paths
@@ -37,7 +41,7 @@ class Chef
           local_mode.chef_zero_server.stop
           local_mode.chef_zero_server.start(stdout) # to print header
         ensure
-          local_mode.chef_zero_server.stop
+          local_mode.chef_zero_server.stop if local_mode && local_mode.chef_zero_server
         end
       end
     end

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -31,13 +31,13 @@ class Chef
       end
 
       def run
-        server = Chef::LocalMode.chef_zero_server
+        server = local_mode.chef_zero_server
         begin
-          output "Serving files from:\n#{Chef::LocalMode.chef_fs.fs_description}"
-          server.stop
-          server.start(stdout) # to print header
+          output "Serving files from:\n#{local_mode.chef_fs.fs_description}"
+          local_mode.chef_zero_server.stop
+          local_mode.chef_zero_server.start(stdout) # to print header
         ensure
-          server.stop
+          local_mode.chef_zero_server.stop
         end
       end
     end

--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -17,76 +17,187 @@
 require 'chef/config'
 
 class Chef
-  module LocalMode
-    # Create a chef local server (if the configuration requires one) for the
+  class LocalMode
+    #
+    # Create a chef local server (if the config[:ration] requires one) for the
     # duration of the given block.
     #
+    # If given a block, local mode will be stopped before returning.
     #     # This ...
-    #     with_server_connectivity { stuff }
+    #     Chef::LocalMode.start { |local_mode| stuff }
     #
     #     # Is exactly equivalent to this ...
-    #     Chef::LocalMode.setup_server_connectivity
+    #     local_mode = Chef::LocalMode.new(Chef::Config)
+    #     local_mode.start
     #     begin
     #       stuff
     #     ensure
-    #       Chef::LocalMode.destroy_server_connectivity
+    #       local_mode.stop
     #     end
     #
-    def self.with_server_connectivity
-      setup_server_connectivity
-      begin
-        yield
-      ensure
-        destroy_server_connectivity
+    def self.start(config = Chef::Config)
+      local_mode = LocalMode.new(config)
+      local_mode.start
+      if block_given?
+        begin
+          yield local_mode
+        ensure
+          local_mode.stop
+          local_mode = nil
+        end
+      else
+        local_mode
       end
     end
 
-    # If Chef::Config.chef_zero.enabled is true, sets up a chef-zero server
-    # according to the Chef::Config.chef_zero and path options, and sets
-    # chef_server_url to point at it.
-    def self.setup_server_connectivity
-      if Chef::Config.chef_zero.enabled
-        destroy_server_connectivity
+    # Create a new LocalMode-honoring object.
+    # == Input
+    #
+    # Takes a config[:hash] with the keys:
+    #   :chef_zero  - hash with config[:for] chef_zero, with these keys:
+    #     :enabled  - whether to run chef-zero (if false, this class does nothing)
+    #     :host     - the host to run chef-zero on
+    #     :port     - the port (or array/enumerable range of ports) to start chef-zero on
+    #     :chef_11_osc_compat - true if we should run in Chef 11 OSC compatibility mode,
+    #                           with no ACLs/groups/containers/organizations.
+    #   :organization - the default organization to create in chef-zero (nil for none).
+    #   :chef_repo_path - the directory where Chef objects are stored (nodes,
+    #                     roles, etc.).  May be an array of paths.
+    #   :acl_path, :client_path, :container_path, :cookbook_path,
+    #   :environment_path, :group_path, :node_path, :role_path, :user_path -
+    #      directory where given objects are stored (if different from
+    #      chef_repo_path/roles, chef_repo_path/nodes, etc.).  May be an array
+    #      of paths.
+    #   :repo_mode - the mode of the repository: :hosted_everything, :everything
+    #                or :static.  :hosted_everything is the default.  :everything
+    #                is the default if chef_11_osc_compat is on.
+    #   :node_name - the name of the user to connect to the server with
+    #   :client_key - a path to a private key to sign requests with
+    #
+    # == Output
+    #
+    # When start is called, these "config" hash keys will be updated:
+    #   :chef_server_root - https://{chef_zero.host}:{chef_zero.port}
+    #   :chef_server_url  - {chef_server_root}/organizations/#{organization}
+    #
+    # If chef_11_osc_compat is on, chef_server_url will be set to the root,
+    # and chef_server_root will be set to nil.
+    #
+    def initialize(config)
+      @config = config
+    end
 
+    attr_reader :config
+
+    # If config[:chef_zero][:enabled] is true, sets up a chef-zero server
+    # according to the config[:chef_zero][:and] path options, and sets
+    # chef_server_url to point at it.
+    def start
+      if config[:chef_zero][:enabled]
+        stop
+
+        # Try not to incur the cost of loading things unless we need them
         require 'chef_zero/server'
         require 'chef/chef_fs/chef_fs_data_store'
         require 'chef/chef_fs/config'
 
-        @chef_fs = Chef::ChefFS::Config.new.local_fs
+        @saved_config = config.save
+
+        #
+        # Start up the chef repo filesystem
+        #
+        @chef_fs = Chef::ChefFS::Config.new(config).local_fs
         @chef_fs.write_pretty_json = true
         data_store = Chef::ChefFS::ChefFSDataStore.new(@chef_fs)
-        data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, 'chef')
+        # If the data store already has an org.json, grab an org name
+        # from that.
+        if !config.has_key?(:organization) && data_store.exists?([ 'org' ])
+          org = JSON.parse(data_store.get([ 'org' ]), :create_additions => false)
+          config[:organization] = org['name'] if org.is_a?(Hash)
+        end
+        config[:organization] ||= 'chef'
+        data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, config[:organization] || 'chef')
+
+        #
+        # Start the chef-zero server
+        #
         server_options = {}
         server_options[:data_store] = data_store
         server_options[:log_level] = Chef::Log.level
-        server_options[:host] = Chef::Config.chef_zero.host
-        server_options[:port] = parse_port(Chef::Config.chef_zero.port)
+        server_options[:host] = config[:chef_zero][:host]
+        server_options[:port] = parse_port(config[:chef_zero][:port])
+        if config[:chef_zero][:chef_11_osc_compat]
+          server_options[:osc_compat] = true
+          server_options[:single_org] = config[:organization]
+        else
+          server_options[:osc_compat] = false
+          server_options[:single_org] = false
+        end
         @chef_zero_server = ChefZero::Server.new(server_options)
         @chef_zero_server.start_background
-        Chef::Log.info("Started chef-zero at #{@chef_zero_server.url} with #{@chef_fs.fs_description}")
-        Chef::Config.chef_server_url = @chef_zero_server.url
+        Chef::Log.info("Started#{config[:chef_zero][:chef_11_osc_compat] ? " OSC-compatible" : ""} chef-zero at #{@chef_zero_server.url} with #{@chef_fs.fs_description}")
+        Chef::Log.debug("Server options #{server_options}")
+
+        # Set server url in config
+        if config[:chef_zero][:chef_11_osc_compat]
+          config[:chef_server_url] = @chef_zero_server.url
+          config.delete(:chef_server_root)
+          config.delete(:organization)
+        else
+          config[:chef_server_root] = @chef_zero_server.url
+          config.delete(:chef_server_url) # Default will do us just fine, thanks.
+          begin
+            root.post('/organizations', { 'name' => config[:organization] })
+          rescue Net::HTTPServerException => e
+            if e.response.code != '409'
+              raise
+            end
+          end
+        end
       end
     end
 
-    # Return the current chef-zero server set up by setup_server_connectivity.
-    def self.chef_zero_server
+    def root
+      Chef::ServerAPI.new(config[:chef_server_root], :client_name => config[:node_name], :signing_key_filename => config[:client_key])
+    end
+
+    # Return the current chef-zero server set up by start.
+    def chef_zero_server
       @chef_zero_server
     end
 
     # Return the chef_fs object for the current chef-zero server.
-    def self.chef_fs
+    def chef_fs
       @chef_fs
     end
 
     # If chef_zero_server is non-nil, stop it and remove references to it.
-    def self.destroy_server_connectivity
+    def stop
       if @chef_zero_server
         @chef_zero_server.stop
         @chef_zero_server = nil
       end
+      # Restore config
+      if @saved_config
+        # We are trying to be surgical with our restore, and only restore
+        # values that we put there.
+        [:chef_server_url, :chef_server_root, :organization].each do |key|
+          # TODO give mixlib-config a better restore method that is willing
+          # to delete keys that are not saved
+          if @saved_config.has_key?(key)
+            config[:chef_server_url] = @saved_config[key]
+          else
+            config.delete(key)
+          end
+        end
+
+        @saved_config = nil
+      end
     end
 
-    def self.parse_port(port)
+    private
+
+    def parse_port(port)
       if port.is_a?(String)
         parts = port.split(',')
         if parts.size == 1

--- a/lib/chef/server_api.rb
+++ b/lib/chef/server_api.rb
@@ -28,8 +28,14 @@ class Chef
   class ServerAPI < Chef::HTTP
 
     def initialize(url = Chef::Config[:chef_server_url], options = {})
-      options[:client_name] ||= Chef::Config[:node_name]
-      options[:signing_key_filename] ||= Chef::Config[:client_key]
+      # merge will allow even nil keys to overwrite the defaults.
+      # If you *don't* specify :signing_key_filename, we want to grab it from
+      # Chef::Config.  If you specify :signing_key_filename => nil, we want to
+      # leave it nil.
+      options = {
+        :client_name => Chef::Config[:node_name],
+        :signing_key_filename => Chef::Config[:client_key]
+      }.merge(options)
       super(url, options)
     end
 

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -27,7 +27,7 @@ local_mode true
 cookbook_path "#{path_to('cookbooks')}"
 EOM
 
-      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default'", :cwd => chef_dir)
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default' -l debug", :cwd => chef_dir)
       result.error!
     end
 

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -29,20 +29,25 @@ describe 'ChefFSDataStore tests' do
   let(:cookbook_x_100_metadata_rb) { cb_metadata("x", "1.0.0") }
   let(:cookbook_z_100_metadata_rb) { cb_metadata("z", "1.0.0") }
 
-  when_the_repository "has one of each thing" do
+  context 'In OSC 11 compatibility mode' do
     before do
-      file 'clients/x.json', {}
-      file 'cookbooks/x/metadata.rb', cookbook_x_100_metadata_rb
-      file 'data_bags/x/y.json', {}
-      file 'environments/x.json', {}
-      file 'nodes/x.json', {}
-      file 'roles/x.json', {}
-      file 'users/x.json', {}
+      Chef::Config.chef_zero.chef_11_osc_compat = true
     end
 
-    context 'GET /TYPE' do
-      it 'knife list -z -R returns everything' do
-        knife('list -z -Rfp /').should_succeed <<EOM
+    when_the_repository "has one of each thing" do
+      before do
+        file 'clients/x.json', {}
+        file 'cookbooks/x/metadata.rb', cookbook_x_100_metadata_rb
+        file 'data_bags/x/y.json', {}
+        file 'environments/x.json', {}
+        file 'nodes/x.json', {}
+        file 'roles/x.json', {}
+        file 'users/x.json', {}
+      end
+
+      context 'GET /TYPE' do
+        it 'knife list -z -R returns everything' do
+          knife('list -z -Rfp /').should_succeed <<EOM
 /clients/
 /clients/x.json
 /cookbooks/
@@ -60,205 +65,205 @@ describe 'ChefFSDataStore tests' do
 /users/
 /users/x.json
 EOM
-      end
-    end
-
-    context 'DELETE /TYPE/NAME' do
-      it 'knife delete -z /clients/x.json works' do
-        knife('delete -z /clients/x.json').should_succeed "Deleted /clients/x.json\n"
-        knife('list -z -Rfp /clients').should_succeed ''
+        end
       end
 
-      it 'knife delete -z -r /cookbooks/x works' do
-        knife('delete -z -r /cookbooks/x').should_succeed "Deleted /cookbooks/x\n"
-        knife('list -z -Rfp /cookbooks').should_succeed ''
+      context 'DELETE /TYPE/NAME' do
+        it 'knife delete -z /clients/x.json works' do
+          knife('delete -z /clients/x.json').should_succeed "Deleted /clients/x.json\n"
+          knife('list -z -Rfp /clients').should_succeed ''
+        end
+
+        it 'knife delete -z -r /cookbooks/x works' do
+          knife('delete -z -r /cookbooks/x').should_succeed "Deleted /cookbooks/x\n"
+          knife('list -z -Rfp /cookbooks').should_succeed ''
+        end
+
+        it 'knife delete -z -r /data_bags/x works' do
+          knife('delete -z -r /data_bags/x').should_succeed "Deleted /data_bags/x\n"
+          knife('list -z -Rfp /data_bags').should_succeed ''
+        end
+
+        it 'knife delete -z /data_bags/x/y.json works' do
+          knife('delete -z /data_bags/x/y.json').should_succeed "Deleted /data_bags/x/y.json\n"
+          knife('list -z -Rfp /data_bags').should_succeed "/data_bags/x/\n"
+        end
+
+        it 'knife delete -z /environments/x.json works' do
+          knife('delete -z /environments/x.json').should_succeed "Deleted /environments/x.json\n"
+          knife('list -z -Rfp /environments').should_succeed ''
+        end
+
+        it 'knife delete -z /nodes/x.json works' do
+          knife('delete -z /nodes/x.json').should_succeed "Deleted /nodes/x.json\n"
+          knife('list -z -Rfp /nodes').should_succeed ''
+        end
+
+        it 'knife delete -z /roles/x.json works' do
+          knife('delete -z /roles/x.json').should_succeed "Deleted /roles/x.json\n"
+          knife('list -z -Rfp /roles').should_succeed ''
+        end
+
+        it 'knife delete -z /users/x.json works' do
+          knife('delete -z /users/x.json').should_succeed "Deleted /users/x.json\n"
+          knife('list -z -Rfp /users').should_succeed ''
+        end
       end
 
-      it 'knife delete -z -r /data_bags/x works' do
-        knife('delete -z -r /data_bags/x').should_succeed "Deleted /data_bags/x\n"
-        knife('list -z -Rfp /data_bags').should_succeed ''
+      context 'GET /TYPE/NAME' do
+        it 'knife show -z /clients/x.json works' do
+          knife('show -z /clients/x.json').should_succeed( /"x"/ )
+        end
+
+        it 'knife show -z /cookbooks/x/metadata.rb works' do
+          knife('show -z /cookbooks/x/metadata.rb').should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
+        end
+
+        it 'knife show -z /data_bags/x/y.json works' do
+          knife('show -z /data_bags/x/y.json').should_succeed( /"y"/ )
+        end
+
+        it 'knife show -z /environments/x.json works' do
+          knife('show -z /environments/x.json').should_succeed( /"x"/ )
+        end
+
+        it 'knife show -z /nodes/x.json works' do
+          knife('show -z /nodes/x.json').should_succeed( /"x"/ )
+        end
+
+        it 'knife show -z /roles/x.json works' do
+          knife('show -z /roles/x.json').should_succeed( /"x"/ )
+        end
+
+        it 'knife show -z /users/x.json works' do
+          knife('show -z /users/x.json').should_succeed( /"x"/ )
+        end
       end
 
-      it 'knife delete -z /data_bags/x/y.json works' do
-        knife('delete -z /data_bags/x/y.json').should_succeed "Deleted /data_bags/x/y.json\n"
-        knife('list -z -Rfp /data_bags').should_succeed "/data_bags/x/\n"
-      end
+      context 'PUT /TYPE/NAME' do
+        before do
+          file 'empty.json', {}
+          file 'rolestuff.json', '{"description":"hi there","name":"x"}'
+          file 'cookbooks_to_upload/x/metadata.rb', cookbook_x_100_metadata_rb
+        end
 
-      it 'knife delete -z /environments/x.json works' do
-        knife('delete -z /environments/x.json').should_succeed "Deleted /environments/x.json\n"
-        knife('list -z -Rfp /environments').should_succeed ''
-      end
+        it 'knife raw -z -i empty.json -m PUT /clients/x' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_succeed( /"x"/ )
+          knife('list --local /clients').should_succeed "/clients/x.json\n"
+        end
 
-      it 'knife delete -z /nodes/x.json works' do
-        knife('delete -z /nodes/x.json').should_succeed "Deleted /nodes/x.json\n"
-        knife('list -z -Rfp /nodes').should_succeed ''
-      end
-
-      it 'knife delete -z /roles/x.json works' do
-        knife('delete -z /roles/x.json').should_succeed "Deleted /roles/x.json\n"
-        knife('list -z -Rfp /roles').should_succeed ''
-      end
-
-      it 'knife delete -z /users/x.json works' do
-        knife('delete -z /users/x.json').should_succeed "Deleted /users/x.json\n"
-        knife('list -z -Rfp /users').should_succeed ''
-      end
-    end
-
-    context 'GET /TYPE/NAME' do
-      it 'knife show -z /clients/x.json works' do
-        knife('show -z /clients/x.json').should_succeed( /"x"/ )
-      end
-
-      it 'knife show -z /cookbooks/x/metadata.rb works' do
-        knife('show -z /cookbooks/x/metadata.rb').should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
-      end
-
-      it 'knife show -z /data_bags/x/y.json works' do
-        knife('show -z /data_bags/x/y.json').should_succeed( /"y"/ )
-      end
-
-      it 'knife show -z /environments/x.json works' do
-        knife('show -z /environments/x.json').should_succeed( /"x"/ )
-      end
-
-      it 'knife show -z /nodes/x.json works' do
-        knife('show -z /nodes/x.json').should_succeed( /"x"/ )
-      end
-
-      it 'knife show -z /roles/x.json works' do
-        knife('show -z /roles/x.json').should_succeed( /"x"/ )
-      end
-
-      it 'knife show -z /users/x.json works' do
-        knife('show -z /users/x.json').should_succeed( /"x"/ )
-      end
-    end
-
-    context 'PUT /TYPE/NAME' do
-      before do
-        file 'empty.json', {}
-        file 'rolestuff.json', '{"description":"hi there","name":"x"}'
-        file 'cookbooks_to_upload/x/metadata.rb', cookbook_x_100_metadata_rb
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /clients/x' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_succeed( /"x"/ )
-        knife('list --local /clients').should_succeed "/clients/x.json\n"
-      end
-
-      it 'knife cookbook upload works' do
-        knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} x").should_succeed :stderr => <<EOM
+        it 'knife cookbook upload works' do
+          knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} x").should_succeed :stderr => <<EOM
 Uploading x              [1.0.0]
 Uploaded 1 cookbook.
 EOM
-        knife('list --local -Rfp /cookbooks').should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
-      end
+          knife('list --local -Rfp /cookbooks').should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
+        end
 
-      it 'knife raw -z -i empty.json -m PUT /data/x/y' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_succeed( /"y"/ )
-        knife('list --local -Rfp /data_bags').should_succeed "/data_bags/x/\n/data_bags/x/y.json\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /data/x/y' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_succeed( /"y"/ )
+          knife('list --local -Rfp /data_bags').should_succeed "/data_bags/x/\n/data_bags/x/y.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m PUT /environments/x' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_succeed( /"x"/ )
-        knife('list --local /environments').should_succeed "/environments/x.json\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /environments/x' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_succeed( /"x"/ )
+          knife('list --local /environments').should_succeed "/environments/x.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m PUT /nodes/x' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_succeed( /"x"/ )
-        knife('list --local /nodes').should_succeed "/nodes/x.json\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /nodes/x' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_succeed( /"x"/ )
+          knife('list --local /nodes').should_succeed "/nodes/x.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m PUT /roles/x' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_succeed( /"x"/ )
-        knife('list --local /roles').should_succeed "/roles/x.json\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /roles/x' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_succeed( /"x"/ )
+          knife('list --local /roles').should_succeed "/roles/x.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m PUT /users/x' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_succeed( /"x"/ )
-        knife('list --local /users').should_succeed "/users/x.json\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /users/x' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_succeed( /"x"/ )
+          knife('list --local /users').should_succeed "/users/x.json\n"
+        end
 
-      it 'After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty', :pending => (RUBY_VERSION < "1.9") do
-        knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
-        IO.read(path_to('roles/x.json')).should == <<EOM.strip
+        it 'After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty', :pending => (RUBY_VERSION < "1.9") do
+          knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
+          IO.read(path_to('roles/x.json')).should == <<EOM.strip
 {
   "name": "x",
   "description": "hi there"
 }
 EOM
+        end
       end
     end
-  end
 
-  when_the_repository 'is empty' do
-    context 'POST /TYPE/NAME' do
-      before do
-        file 'empty.json', { 'name' => 'z' }
-        file 'empty_x.json', { 'name' => 'x' }
-        file 'empty_id.json', { 'id' => 'z' }
-        file 'rolestuff.json', '{"description":"hi there","name":"x"}'
-        file 'cookbooks_to_upload/z/metadata.rb', cookbook_z_100_metadata_rb
-      end
+    when_the_repository 'is empty' do
+      context 'POST /TYPE/NAME' do
+        before do
+          file 'empty.json', { 'name' => 'z' }
+          file 'empty_x.json', { 'name' => 'x' }
+          file 'empty_id.json', { 'id' => 'z' }
+          file 'rolestuff.json', '{"description":"hi there","name":"x"}'
+          file 'cookbooks_to_upload/z/metadata.rb', cookbook_z_100_metadata_rb
+        end
 
-      it 'knife raw -z -i empty.json -m POST /clients' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /clients").should_succeed( /uri/ )
-        knife('list --local /clients').should_succeed "/clients/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /clients' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /clients").should_succeed( /uri/ )
+          knife('list --local /clients').should_succeed "/clients/z.json\n"
+        end
 
-      it 'knife cookbook upload works' do
-        knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} z").should_succeed :stderr => <<EOM
+        it 'knife cookbook upload works' do
+          knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} z").should_succeed :stderr => <<EOM
 Uploading z            [1.0.0]
 Uploaded 1 cookbook.
 EOM
-        knife('list --local -Rfp /cookbooks').should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
-      end
+          knife('list --local -Rfp /cookbooks').should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /data' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /data").should_succeed( /uri/ )
-        knife('list --local -Rfp /data_bags').should_succeed "/data_bags/z/\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /data' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /data").should_succeed( /uri/ )
+          knife('list --local -Rfp /data_bags').should_succeed "/data_bags/z/\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /data/x' do
-        knife("raw -z -i #{path_to('empty_x.json')} -m POST /data").should_succeed( /uri/ )
-        knife("raw -z -i #{path_to('empty_id.json')} -m POST /data/x").should_succeed( /"z"/ )
-        knife('list --local -Rfp /data_bags').should_succeed "/data_bags/x/\n/data_bags/x/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /data/x' do
+          knife("raw -z -i #{path_to('empty_x.json')} -m POST /data").should_succeed( /uri/ )
+          knife("raw -z -i #{path_to('empty_id.json')} -m POST /data/x").should_succeed( /"z"/ )
+          knife('list --local -Rfp /data_bags').should_succeed "/data_bags/x/\n/data_bags/x/z.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /environments' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /environments").should_succeed( /uri/ )
-        knife('list --local /environments').should_succeed "/environments/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /environments' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /environments").should_succeed( /uri/ )
+          knife('list --local /environments').should_succeed "/environments/z.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /nodes' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /nodes").should_succeed( /uri/ )
-        knife('list --local /nodes').should_succeed "/nodes/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /nodes' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /nodes").should_succeed( /uri/ )
+          knife('list --local /nodes').should_succeed "/nodes/z.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /roles' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /roles").should_succeed( /uri/ )
-        knife('list --local /roles').should_succeed "/roles/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /roles' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /roles").should_succeed( /uri/ )
+          knife('list --local /roles').should_succeed "/roles/z.json\n"
+        end
 
-      it 'knife raw -z -i empty.json -m POST /users' do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /users").should_succeed( /uri/ )
-        knife('list --local /users').should_succeed "/users/z.json\n"
-      end
+        it 'knife raw -z -i empty.json -m POST /users' do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /users").should_succeed( /uri/ )
+          knife('list --local /users').should_succeed "/users/z.json\n"
+        end
 
-      it 'After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty', :pending => (RUBY_VERSION < "1.9") do
-        knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
-        IO.read(path_to('roles/x.json')).should == <<EOM.strip
+        it 'After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty', :pending => (RUBY_VERSION < "1.9") do
+          knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
+          IO.read(path_to('roles/x.json')).should == <<EOM.strip
 {
   "name": "x",
   "description": "hi there"
 }
 EOM
+        end
       end
-    end
 
-    it 'knife list -z -R returns nothing' do
-      knife('list -z -Rfp /').should_succeed <<EOM
+      it 'knife list -z -R returns nothing' do
+        knife('list -z -Rfp /').should_succeed <<EOM
 /clients/
 /cookbooks/
 /data_bags/
@@ -267,99 +272,100 @@ EOM
 /roles/
 /users/
 EOM
-    end
-
-    context 'DELETE /TYPE/NAME' do
-      it 'knife delete -z /clients/x.json fails with an error' do
-        knife('delete -z /clients/x.json').should_fail "ERROR: /clients/x.json: No such file or directory\n"
       end
 
-      it 'knife delete -z -r /cookbooks/x fails with an error' do
-        knife('delete -z -r /cookbooks/x').should_fail "ERROR: /cookbooks/x: No such file or directory\n"
+      context 'DELETE /TYPE/NAME' do
+        it 'knife delete -z /clients/x.json fails with an error' do
+          knife('delete -z /clients/x.json').should_fail "ERROR: /clients/x.json: No such file or directory\n"
+        end
+
+        it 'knife delete -z -r /cookbooks/x fails with an error' do
+          knife('delete -z -r /cookbooks/x').should_fail "ERROR: /cookbooks/x: No such file or directory\n"
+        end
+
+        it 'knife delete -z -r /data_bags/x fails with an error' do
+          knife('delete -z -r /data_bags/x').should_fail "ERROR: /data_bags/x: No such file or directory\n"
+        end
+
+        it 'knife delete -z /data_bags/x/y.json fails with an error' do
+          knife('delete -z /data_bags/x/y.json').should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
+        end
+
+        it 'knife delete -z /environments/x.json fails with an error' do
+          knife('delete -z /environments/x.json').should_fail "ERROR: /environments/x.json: No such file or directory\n"
+        end
+
+        it 'knife delete -z /nodes/x.json fails with an error' do
+          knife('delete -z /nodes/x.json').should_fail "ERROR: /nodes/x.json: No such file or directory\n"
+        end
+
+        it 'knife delete -z /roles/x.json fails with an error' do
+          knife('delete -z /roles/x.json').should_fail "ERROR: /roles/x.json: No such file or directory\n"
+        end
+
+        it 'knife delete -z /users/x.json fails with an error' do
+          knife('delete -z /users/x.json').should_fail "ERROR: /users/x.json: No such file or directory\n"
+        end
       end
 
-      it 'knife delete -z -r /data_bags/x fails with an error' do
-        knife('delete -z -r /data_bags/x').should_fail "ERROR: /data_bags/x: No such file or directory\n"
+      context 'GET /TYPE/NAME' do
+        it 'knife show -z /clients/x.json fails with an error' do
+          knife('show -z /clients/x.json').should_fail "ERROR: /clients/x.json: No such file or directory\n"
+        end
+
+        it 'knife show -z /cookbooks/x/metadata.rb fails with an error' do
+          knife('show -z /cookbooks/x/metadata.rb').should_fail "ERROR: /cookbooks/x/metadata.rb: No such file or directory\n"
+        end
+
+        it 'knife show -z /data_bags/x/y.json fails with an error' do
+          knife('show -z /data_bags/x/y.json').should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
+        end
+
+        it 'knife show -z /environments/x.json fails with an error' do
+          knife('show -z /environments/x.json').should_fail "ERROR: /environments/x.json: No such file or directory\n"
+        end
+
+        it 'knife show -z /nodes/x.json fails with an error' do
+          knife('show -z /nodes/x.json').should_fail "ERROR: /nodes/x.json: No such file or directory\n"
+        end
+
+        it 'knife show -z /roles/x.json fails with an error' do
+          knife('show -z /roles/x.json').should_fail "ERROR: /roles/x.json: No such file or directory\n"
+        end
+
+        it 'knife show -z /users/x.json fails with an error' do
+          knife('show -z /users/x.json').should_fail "ERROR: /users/x.json: No such file or directory\n"
+        end
       end
 
-      it 'knife delete -z /data_bags/x/y.json fails with an error' do
-        knife('delete -z /data_bags/x/y.json').should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
-      end
+      context 'PUT /TYPE/NAME' do
+        before do
+          file 'empty.json', {}
+        end
 
-      it 'knife delete -z /environments/x.json fails with an error' do
-        knife('delete -z /environments/x.json').should_fail "ERROR: /environments/x.json: No such file or directory\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /clients/x fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_fail( /404/ )
+        end
 
-      it 'knife delete -z /nodes/x.json fails with an error' do
-        knife('delete -z /nodes/x.json').should_fail "ERROR: /nodes/x.json: No such file or directory\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /data/x/y fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_fail( /404/ )
+        end
 
-      it 'knife delete -z /roles/x.json fails with an error' do
-        knife('delete -z /roles/x.json').should_fail "ERROR: /roles/x.json: No such file or directory\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /environments/x fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_fail( /404/ )
+        end
 
-      it 'knife delete -z /users/x.json fails with an error' do
-        knife('delete -z /users/x.json').should_fail "ERROR: /users/x.json: No such file or directory\n"
-      end
-    end
+        it 'knife raw -z -i empty.json -m PUT /nodes/x fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_fail( /404/ )
+        end
 
-    context 'GET /TYPE/NAME' do
-      it 'knife show -z /clients/x.json fails with an error' do
-        knife('show -z /clients/x.json').should_fail "ERROR: /clients/x.json: No such file or directory\n"
-      end
+        it 'knife raw -z -i empty.json -m PUT /roles/x fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_fail( /404/ )
+        end
 
-      it 'knife show -z /cookbooks/x/metadata.rb fails with an error' do
-        knife('show -z /cookbooks/x/metadata.rb').should_fail "ERROR: /cookbooks/x/metadata.rb: No such file or directory\n"
-      end
-
-      it 'knife show -z /data_bags/x/y.json fails with an error' do
-        knife('show -z /data_bags/x/y.json').should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
-      end
-
-      it 'knife show -z /environments/x.json fails with an error' do
-        knife('show -z /environments/x.json').should_fail "ERROR: /environments/x.json: No such file or directory\n"
-      end
-
-      it 'knife show -z /nodes/x.json fails with an error' do
-        knife('show -z /nodes/x.json').should_fail "ERROR: /nodes/x.json: No such file or directory\n"
-      end
-
-      it 'knife show -z /roles/x.json fails with an error' do
-        knife('show -z /roles/x.json').should_fail "ERROR: /roles/x.json: No such file or directory\n"
-      end
-
-      it 'knife show -z /users/x.json fails with an error' do
-        knife('show -z /users/x.json').should_fail "ERROR: /users/x.json: No such file or directory\n"
-      end
-    end
-
-    context 'PUT /TYPE/NAME' do
-      before do
-        file 'empty.json', {}
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /clients/x fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_fail( /404/ )
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /data/x/y fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_fail( /404/ )
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /environments/x fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_fail( /404/ )
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /nodes/x fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_fail( /404/ )
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /roles/x fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_fail( /404/ )
-      end
-
-      it 'knife raw -z -i empty.json -m PUT /users/x fails with 404' do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_fail( /404/ )
+        it 'knife raw -z -i empty.json -m PUT /users/x fails with 404' do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_fail( /404/ )
+        end
       end
     end
   end

--- a/spec/integration/knife/common_options_spec.rb
+++ b/spec/integration/knife/common_options_spec.rb
@@ -39,7 +39,6 @@ describe 'knife common options' do
 
         it 'knife raw /nodes/x should retrieve the node' do
           knife('raw /nodes/x').should_succeed( /"name": "x"/ )
-          Chef::Config.chef_server_url.should == 'http://localhost:9999'
         end
       end
 
@@ -101,7 +100,6 @@ EOM
 
     it 'knife raw -z --chef-zero-port=9999 /nodes/x retrieves the node' do
       knife('raw -z --chef-zero-port=9999 /nodes/x').should_succeed( /"name": "x"/ )
-      Chef::Config.chef_server_url.should == 'http://localhost:9999'
     end
 
     context 'when the default port (8889) is already bound' do
@@ -119,7 +117,6 @@ EOM
 
       it 'knife raw -z /nodes/x retrieves the node' do
         knife('raw -z /nodes/x').should_succeed( /"name": "x"/ )
-        expect(URI(Chef::Config.chef_server_url).port).to be > 8889
       end
     end
 
@@ -138,18 +135,15 @@ EOM
 
       it 'knife raw -z --chef-zero-port=9999-20000 /nodes/x' do
         knife('raw -z --chef-zero-port=9999-20000 /nodes/x').should_succeed( /"name": "x"/ )
-        expect(URI(Chef::Config.chef_server_url).port).to be > 9999
       end
 
       it 'knife raw -z --chef-zero-port=9999-9999,19423' do
         knife('raw -z --chef-zero-port=9999-9999,19423 /nodes/x').should_succeed( /"name": "x"/ )
-        expect(URI(Chef::Config.chef_server_url).port).to be == 19423
       end
     end
 
     it 'knife raw -z --chef-zero-port=9999 /nodes/x retrieves the node' do
       knife('raw -z --chef-zero-port=9999 /nodes/x').should_succeed( /"name": "x"/ )
-      Chef::Config.chef_server_url.should == 'http://localhost:9999'
     end
   end
 end

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -250,10 +250,8 @@ EOM
 EOM
         end
         it 'knife deps --tree prints each once' do
-          knife('deps --tree /roles/foo.json /roles/self.json') do
-            stdout.should == "/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n"
-            stderr.should == "WARNING: No knife configuration file found\n"
-          end
+          result = knife('deps --tree /roles/foo.json /roles/self.json')
+          result.stdout.should == "/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n"
         end
       end
     end
@@ -588,10 +586,8 @@ EOM
 EOM
         end
         it 'knife deps --tree prints each once' do
-          knife('deps --remote --tree /roles/foo.json /roles/self.json') do
-            stdout.should == "/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n"
-            stderr.should == "WARNING: No knife configuration file found\n"
-          end
+          result = knife('deps --remote --tree /roles/foo.json /roles/self.json')
+          result.stdout.should == "/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n"
         end
       end
     end

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -29,19 +29,20 @@ describe 'knife serve' do
 
     it 'knife serve serves up /organizations/chef/nodes/x' do
       exception = nil
+      instance = nil
       t = Thread.new do
         begin
-          knife('serve --chef-zero-port=8889')
+          knife('serve --chef-zero-port=8889') { |i| instance = i }
         rescue
+          puts $!
+          puts $!.backtrace.join("\n")
           exception = $!
         end
       end
+      sleep(0.05) until instance && instance.local_mode
       begin
-        Chef::Config.log_level = :debug
-        Chef::Config.chef_server_url = 'http://localhost:8889/organizations/chef'
-        Chef::Config.node_name = nil
-        Chef::Config.client_key = nil
-        api = Chef::ServerAPI.new
+        api = Chef::ServerAPI.new('http://localhost:8889/organizations/chef',
+                                  :client_name => nil, :signing_key_filename => nil)
         api.get('nodes/x')['name'].should == 'x'
       rescue
         if exception
@@ -50,6 +51,7 @@ describe 'knife serve' do
           raise
         end
       ensure
+        instance.local_mode.stop if instance && instance.local_mode
         t.kill
       end
     end
@@ -61,19 +63,18 @@ describe 'knife serve' do
 
       it 'knife serve serves up /organizations/foo/nodes/x' do
         exception = nil
+        instance = nil
         t = Thread.new do
           begin
-            knife('serve --chef-zero-port=8889')
+            knife('serve --chef-zero-port=8889') { |i| instance = i }
           rescue
             exception = $!
           end
         end
+        sleep(0.05) until instance && instance.local_mode
         begin
-          Chef::Config.log_level = :debug
-          Chef::Config.chef_server_url = 'http://localhost:8889/organizations/foo'
-          Chef::Config.node_name = nil
-          Chef::Config.client_key = nil
-          api = Chef::ServerAPI.new
+          api = Chef::ServerAPI.new('http://localhost:8889/organizations/foo',
+                                    :client_name => nil, :signing_key_filename => nil)
           api.get('nodes/x')['name'].should == 'x'
         rescue
           if exception
@@ -82,6 +83,7 @@ describe 'knife serve' do
             raise
           end
         ensure
+          instance.local_mode.stop if instance && instance.local_mode
           t.kill
         end
       end
@@ -94,19 +96,18 @@ describe 'knife serve' do
 
       it 'knife serve serves up /nodes/x' do
         exception = nil
+        instance = nil
         t = Thread.new do
           begin
-            knife('serve --chef-zero-port=8889')
+            knife('serve --chef-zero-port=8889') { |i| instance = i }
           rescue
             exception = $!
           end
         end
+        sleep(0.05) until instance && instance.local_mode
         begin
-          Chef::Config.log_level = :debug
-          Chef::Config.chef_server_url = 'http://localhost:8889'
-          Chef::Config.node_name = nil
-          Chef::Config.client_key = nil
-          api = Chef::ServerAPI.new
+          api = Chef::ServerAPI.new('http://localhost:8889',
+                                    :client_name => nil, :signing_key_filename => nil)
           api.get('nodes/x')['name'].should == 'x'
         rescue
           if exception
@@ -115,6 +116,7 @@ describe 'knife serve' do
             raise
           end
         ensure
+          instance.local_mode.stop if instance && instance.local_mode
           t.kill
         end
       end

--- a/spec/support/shared/integration/knife_support.rb
+++ b/spec/support/shared/integration/knife_support.rb
@@ -23,7 +23,8 @@ require 'chef/log'
 
 module KnifeSupport
   DEBUG = ENV['DEBUG']
-  def knife(*args, &block)
+
+  def knife(*args)
     # Allow knife('role from file roles/blah.json') rather than requiring the
     # arguments to be split like knife('role', 'from', 'file', 'roles/blah.json')
     # If any argument will have actual spaces in it, the long form is required.
@@ -81,6 +82,8 @@ module KnifeSupport
         Chef::Log.use_log_devices([logger])
         Chef::Log.level = ( DEBUG ? :debug : :warn )
         Chef::Log::Formatter.show_time = false
+
+        yield instance if block_given?
 
         instance.run_with_pretty_exceptions(true)
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -27,8 +27,10 @@ describe Chef::Config do
       Chef::Config.chef_server_url = "https://junglist.gen.nz"
     end
 
-    it "sets the server url" do
+    it "sets chef_server_url, and leaves chef_server_root and organization blank" do
       Chef::Config.chef_server_url.should == "https://junglist.gen.nz"
+      Chef::Config.organization.should == nil
+      Chef::Config.chef_server_root.should == nil
     end
 
     context "when the url has a leading space" do
@@ -52,6 +54,106 @@ describe Chef::Config do
       end
     end
 
+    context "when the url is https://api.blah.com:9000/organizations/foo" do
+      before do
+        Chef::Config.chef_server_url = "https://api.blah.com:9000/organizations/foo"
+      end
+
+      it "sets organization to foo and chef_server_root to https://api.blah.com:9000" do
+        Chef::Config.chef_server_root.should == "https://api.blah.com:9000"
+        Chef::Config.organization.should == "foo"
+      end
+    end
+
+    context "when the url is https://api.blah.com:9000/organizations/foo/" do
+      before do
+        Chef::Config.chef_server_url = "https://api.blah.com:9000/organizations/foo/"
+      end
+
+      it "sets organization to foo and chef_server_root to https://api.blah.com:9000" do
+        Chef::Config.chef_server_root.should == "https://api.blah.com:9000"
+        Chef::Config.organization.should == "foo"
+      end
+    end
+
+    context "when the url is https://api.blah.com:9000/supercool/organizations/foo" do
+      before do
+        Chef::Config.chef_server_url = "https://api.blah.com:9000/supercool/organizations/foo"
+      end
+
+      it "sets organization to foo and chef_server_root to https://api.blah.com:9000/supercool" do
+        Chef::Config.chef_server_root.should == "https://api.blah.com:9000/supercool"
+        Chef::Config.organization.should == "foo"
+      end
+    end
+
+    context "when the url is https://api.blah.com:9000/organization/foo" do
+      before do
+        Chef::Config.chef_server_url = "https://api.blah.com:9000/organization/foo"
+      end
+
+      it "leaves chef_server_root and organization nil" do
+        Chef::Config.chef_server_root.should == nil
+        Chef::Config.organization.should == nil
+      end
+    end
+  end
+
+  describe "chef_server_root and organization" do
+    context "when organization is foo" do
+      before do
+        Chef::Config.organization = 'foo'
+      end
+
+      it "sets chef_server_root to api.opscode.com and chef_server_url to root/organizations/foo" do
+        Chef::Config.chef_server_root.should == 'https://api.opscode.com'
+        Chef::Config.chef_server_url.should == 'https://api.opscode.com/organizations/foo'
+      end
+    end
+
+    context "when chef_server_root is http://a.b.com:9000 and organization is foo" do
+      before do
+        Chef::Config.chef_server_root = 'http://a.b.com:9000'
+        Chef::Config.organization = 'foo'
+      end
+
+      it "sets chef_server_url to http://a.b.com:9000/organizations/foo" do
+        Chef::Config.chef_server_url.should == 'http://a.b.com:9000/organizations/foo'
+      end
+    end
+
+    context "when chef_server_root is http://a.b.com:9000/supercool and organization is foo" do
+      before do
+        Chef::Config.chef_server_root = 'http://a.b.com:9000/supercool'
+        Chef::Config.organization = 'foo'
+      end
+
+      it "sets chef_server_url to http://a.b.com:9000/supercool/organizations/foo" do
+        Chef::Config.chef_server_url.should == 'http://a.b.com:9000/supercool/organizations/foo'
+      end
+    end
+
+    context "when chef_server_root is http://a.b.com:9000/supercool/ and organization is foo" do
+      before do
+        Chef::Config.chef_server_root = 'http://a.b.com:9000/supercool/'
+        Chef::Config.organization = 'foo'
+      end
+
+      it "sets chef_server_url to http://a.b.com:9000/supercool/organizations/foo" do
+        Chef::Config.chef_server_url.should == 'http://a.b.com:9000/supercool/organizations/foo'
+      end
+    end
+
+    context "when chef_server_root is http://a.b.com:9000 and organization is not set" do
+      before do
+        Chef::Config.chef_server_root = 'http://a.b.com:9000'
+      end
+
+      it "sets chef_server_url and organization to nil" do
+        Chef::Config.chef_server_url.should == nil
+        Chef::Config.organization.should == nil
+      end
+    end
   end
 
   describe "when configuring formatters" do

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -427,4 +427,33 @@ describe Chef::Knife do
     end
   end
 
+  describe "rest" do
+    context "When chef_server_url, node_name and client_key are set" do
+      before do
+        Chef::Config.chef_server_url = "https://a.b.com:50/organizations/blah"
+        Chef::Config.node_name = 'foo'
+        Chef::Config.client_key = '/foo.pem'
+        Chef::HTTP::Authenticator.any_instance.stub(:load_signing_key)
+      end
+
+      it "knife.rest has those properties" do
+        @knife.rest.url.should == "https://a.b.com:50/organizations/blah"
+        @knife.rest.client_name.should == 'foo'
+        @knife.rest.signing_key_filename.should == '/foo.pem'
+      end
+
+      it "knife.noauth_rest has the url but not the username/key" do
+        @knife.noauth_rest.url.should == "https://a.b.com:50/organizations/blah"
+        @knife.noauth_rest.client_name.should == false
+        @knife.noauth_rest.signing_key_filename.should == false
+      end
+
+      it "knife.rest_root has the root url and the same username/key" do
+        @knife.rest_root.url.should == "https://a.b.com:50"
+        @knife.rest_root.client_name.should == 'foo'
+        @knife.rest_root.signing_key_filename.should == '/foo.pem'
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR:

makes local mode multi-tenant by default (chef-zero runs in multi-org mode, providing orgs, acls, groups, etc.), setting chef_server_url = http://localhost:port/organizations/chef
adds the "organization" config parameter
adds the "chef_server_root" config option to specify the top level root
points at Hosted Chef by default when organization is set
infers organization and chef_server_root from chef_server_url when specified, and vice versa
All per opscode/chef-rfc#49