### PR TITLE
Make Chef::Config.versioned_cookbooks configurable by consumers

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -103,7 +103,7 @@ class Chef
                   value.each do |file|
                     if file.is_a?(Hash) && file.has_key?('checksum')
                       relative = ['file_store', 'repo', 'cookbooks']
-                      if Chef::Config.versioned_cookbooks
+                      if chef_fs.versioned_cookbooks
                         relative << "#{path[1]}-#{path[2]}"
                       else
                         relative << path[1]
@@ -190,7 +190,7 @@ class Chef
         elsif path[0] == 'cookbooks' && path.length == 1
           with_entry(path) do |entry|
             begin
-              if Chef::Config.versioned_cookbooks
+              if chef_fs.versioned_cookbooks
                 # /cookbooks/name-version -> /cookbooks/name
                 entry.children.map { |child| split_name_version(child.name)[0] }.uniq
               else
@@ -203,7 +203,7 @@ class Chef
           end
 
         elsif path[0] == 'cookbooks' && path.length == 2
-          if Chef::Config.versioned_cookbooks
+          if chef_fs.versioned_cookbooks
             result = with_entry([ 'cookbooks' ]) do |entry|
               # list /cookbooks/name = filter /cookbooks/name-version down to name
               entry.children.map { |child| split_name_version(child.name) }.
@@ -261,7 +261,7 @@ class Chef
       end
 
       def write_cookbook(path, data, *options)
-        if Chef::Config.versioned_cookbooks
+        if chef_fs.versioned_cookbooks
           cookbook_path = File.join('cookbooks', "#{path[1]}-#{path[2]}")
         else
           cookbook_path = File.join('cookbooks', path[1])
@@ -318,7 +318,7 @@ class Chef
         elsif path[0] == 'cookbooks'
           if path.length == 2
             raise ChefZero::DataStore::DataNotFoundError.new(path)
-          elsif Chef::Config.versioned_cookbooks
+          elsif chef_fs.versioned_cookbooks
             if path.length >= 3
               # cookbooks/name/version -> cookbooks/name-version
               path = [ path[0], "#{path[1]}-#{path[2]}" ] + path[3..-1]
@@ -351,7 +351,7 @@ class Chef
           end
 
         elsif path[0] == 'cookbooks'
-          if Chef::Config.versioned_cookbooks
+          if chef_fs.versioned_cookbooks
             # cookbooks/name-version/... -> cookbooks/name/version/...
             if path.length >= 2
               name, version = split_name_version(path[1])

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -68,7 +68,7 @@ class Chef
 
       def create_local_fs
         require 'chef/chef_fs/file_system/chef_repository_file_system_root_dir'
-        Chef::ChefFS::FileSystem::ChefRepositoryFileSystemRootDir.new(object_paths, Array(chef_config[:chef_repo_path]).flatten)
+        Chef::ChefFS::FileSystem::ChefRepositoryFileSystemRootDir.new(object_paths, Array(chef_config[:chef_repo_path]).flatten, @chef_config)
       end
 
       # Returns the given real path's location relative to the server root.

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
@@ -35,7 +35,7 @@ class Chef
             loader = Chef::Cookbook::CookbookVersionLoader.new(file_path, parent.chefignore)
             # We need the canonical cookbook name if we are using versioned cookbooks, but we don't
             # want to spend a lot of time adding code to the main Chef libraries
-            if Chef::Config[:versioned_cookbooks]
+            if root.versioned_cookbooks
               _canonical_name = canonical_cookbook_name(File.basename(file_path))
               fail "When versioned_cookbooks mode is on, cookbook #{file_path} must match format <cookbook_name>-x.y.z"  unless _canonical_name
 

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
@@ -48,17 +48,21 @@ class Chef
         #   ...
         # - root_paths - an array of paths representing the top level, where
         #   org.json, members.json, and invites.json will be stored.
-        #
-        def initialize(child_paths, root_paths=[])
+        # - chef_config - a hash of options that looks suspiciously like the ones
+        #   stored in Chef::Config, containing at least these keys:
+        #   - :versioned_cookbooks - whether to include versions in cookbook names
+        def initialize(child_paths, root_paths=[], chef_config=Chef::Config)
           super("", nil)
           @child_paths = child_paths
           @root_paths = root_paths
+          @versioned_cookbooks = chef_config[:versioned_cookbooks]
         end
 
         attr_accessor :write_pretty_json
 
         attr_reader :root_paths
         attr_reader :child_paths
+        attr_reader :versioned_cookbooks
 
         CHILDREN = %w(invitations.json members.json org.json)
 
@@ -104,7 +108,7 @@ class Chef
         def fs_description
           repo_paths = root_paths || [ File.dirname(child_paths['cookbooks'][0]) ]
           result = "repository at #{repo_paths.join(', ')}\n"
-          if Chef::Config[:versioned_cookbooks]
+          if versioned_cookbooks
             result << "  Multiple versions per cookbook\n"
           else
             result << "  One version per cookbook\n"

--- a/lib/chef/chef_fs/file_system/chef_server_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server_root_dir.rb
@@ -56,6 +56,7 @@ class Chef
         #   - :repo_mode - the repository mode, :hosted_everything, :everything or :static.
         #                  This determines the set of subdirectories the Chef server
         #                  will offer up.
+        #   - :versioned_cookbooks - whether or not to include versions in cookbook names
         # - options - other options:
         #   - :cookbook_version - when cookbooks are retrieved, grab this version for them.
         #
@@ -66,6 +67,7 @@ class Chef
           @chef_private_key = chef_config[:client_key]
           @environment = chef_config[:environment]
           @repo_mode = chef_config[:repo_mode]
+          @versioned_cookbooks = chef_config[:versioned_cookbooks]
           @root_name = root_name
           @cookbook_version = options[:cookbook_version] # Used in knife diff and download for server cookbook version
         end
@@ -76,6 +78,7 @@ class Chef
         attr_reader :environment
         attr_reader :repo_mode
         attr_reader :cookbook_version
+        attr_reader :versioned_cookbooks
 
         def fs_description
           "Chef server at #{chef_server_url} (user #{chef_username}), repo_mode = #{repo_mode}"

--- a/lib/chef/chef_fs/file_system/cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/cookbook_dir.rb
@@ -32,7 +32,7 @@ class Chef
           @exists = options[:exists]
           # If the name is apache2-1.0.0 and versioned_cookbooks is on, we know
           # the actual cookbook_name and version.
-          if Chef::Config[:versioned_cookbooks]
+          if root.versioned_cookbooks
             if name =~ VALID_VERSIONED_COOKBOOK_NAME
               @cookbook_name = $1
               @version = $2

--- a/lib/chef/chef_fs/file_system/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/cookbooks_dir.rb
@@ -51,7 +51,7 @@ class Chef
 
         def children
           @children ||= begin
-            if Chef::Config[:versioned_cookbooks]
+            if root.versioned_cookbooks
               result = []
               root.get_json("#{api_path}/?num_versions=all").each_pair do |cookbook_name, cookbooks|
                 cookbooks['versions'].each do |cookbook_version|
@@ -71,7 +71,7 @@ class Chef
         end
 
         def upload_cookbook_from(other, options = {})
-          Chef::Config[:versioned_cookbooks] ? upload_versioned_cookbook(other, options) : upload_unversioned_cookbook(other, options)
+          root.versioned_cookbooks ? upload_versioned_cookbook(other, options) : upload_unversioned_cookbook(other, options)
         rescue Timeout::Error => e
           raise Chef::ChefFS::FileSystem::OperationFailedError.new(:write, self, e), "Timeout writing: #{e}"
         rescue Net::HTTPServerException => e
@@ -155,7 +155,7 @@ class Chef
 
         def can_have_child?(name, is_dir)
           return false if !is_dir
-          return false if Chef::Config[:versioned_cookbooks] && name !~ Chef::ChefFS::FileSystem::CookbookDir::VALID_VERSIONED_COOKBOOK_NAME
+          return false if root.versioned_cookbooks && name !~ Chef::ChefFS::FileSystem::CookbookDir::VALID_VERSIONED_COOKBOOK_NAME
           return true
         end
       end


### PR DESCRIPTION
without having to modify Chef::Config itself

This doesn't affect any Chef tests; Cheffish needs the capability (plus it's just good cleanliness).
