### PR TITLE
Spec fixes for Windows

### DIFF
--- a/spec/unit/workstation_config_loader_spec.rb
+++ b/spec/unit/workstation_config_loader_spec.rb
@@ -235,7 +235,7 @@ describe Chef::WorkstationConfigLoader do
 
       let(:explicit_config_location) do
         # could use described_class, but remove all ':' from the path if so.
-        t = Tempfile.new("Chef::WorkstationConfigLoader-rspec-test")
+        t = Tempfile.new("Chef-WorkstationConfigLoader-rspec-test")
         t.print(config_content)
         t.close
         t.path


### PR DESCRIPTION
- Switch pwd environment variable depending on platform.
- Hardcode the temp file name instead of using described_class: Windows doesn't like ':' in paths.
