### PR TITLE
added svn args for info when getting current revision

### DIFF
--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -139,7 +139,7 @@ class Chef
 
       def find_current_revision
         return nil unless ::File.exist?(::File.join(@new_resource.destination, ".svn"))
-        command = scm(:info)
+        command = scm(:info, @new_resource.svn_info_args)
         status, svn_info, error_message = output_of_command(command, run_options(:cwd => cwd))
 
         unless [0,1].include?(status.exitstatus)

--- a/spec/unit/provider/subversion_spec.rb
+++ b/spec/unit/provider/subversion_spec.rb
@@ -45,6 +45,7 @@ describe Chef::Provider::Subversion do
       @stdout = double("stdout")
       @stderr = double("stderr")
       @exitstatus = double("exitstatus")
+      @resource.svn_info_args("--config-dir /etc/subversion")
     end
 
     it "sets the revision to nil if there isn't any deployed code yet" do
@@ -68,7 +69,7 @@ describe Chef::Provider::Subversion do
       @stdout.stub(:string).and_return(example_svn_info)
       @stderr.stub(:string).and_return("")
       @exitstatus.stub(:exitstatus).and_return(0)
-      expected_command = ["svn info", {:cwd=>"/my/deploy/dir"}]
+      expected_command = ["svn info --config-dir /etc/subversion", {:cwd=>"/my/deploy/dir"}]
       @provider.should_receive(:popen4).with(*expected_command).
                                         and_yield("no-pid", "no-stdin", @stdout,@stderr).
                                         and_return(@exitstatus)


### PR DESCRIPTION
When svn_args_info is present in the subversion resource in a recipe, i.e.

```ruby
subversion "MyApp" do
  repository "http://some.svn.com/trunk/"
  revision "HEAD"
  destination "/opt/mysources/couch"
  svn_arguments '--config-dir /etc/subversion/'
  svn_info_args '--config-dir /etc/subversion/'
  action :sync
end
```

Running will fail because the svn info command issued by find_current_revision doesn't include the arguments.
In my case it was because I was using a system user for the checkout and the command was returning:
```
---- Begin output of  ----
STDOUT:
STDERR: svn: warning: W000013: Can't open file '/root/.subversion/servers': Permission denied
---- End output of  ----
```

The PR adds any arguments that are passed to that instance of svn info as well.