### PR TITLE
change default service mapping for SLES to systemd

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -197,10 +197,13 @@ class Chef
             },
             :suse     => {
               :default => {
-                :service => Chef::Provider::Service::Redhat,
+                :service => Chef::Provider::Service::Systemd,
                 :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Zypper,
                 :group => Chef::Provider::Group::Suse
+              },
+              "< 12.0" => {
+                :service => Chef::Provider::Service::Redhat
               }
             },
             :oracle  => {

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -278,6 +278,17 @@ describe Chef::Platform do
       pmap[:package].should eql(Chef::Provider::Package::Ips)
     end
 
+    it "should use the Redhat service provider on SLES11" do
+      1.upto(3) do |sp|
+        pmap = Chef::Platform.find("SUSE", "11.#{sp}")
+        pmap[:service].should eql(Chef::Provider::Service::Redhat)
+      end
+    end
+
+    it "should use the Systemd service provider on SLES12" do
+        pmap = Chef::Platform.find("SUSE", "12.0")
+        pmap[:service].should eql(Chef::Provider::Service::Systemd)
+    end
   end
 
 end


### PR DESCRIPTION
Systemd is the new default starting with SLES12, the old versions should
still use the "Redhat" provider.
