### PR TITLE
Populate the actors when creating groups

### DIFF
--- a/lib/chef/chef_fs/data_handler/group_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/group_data_handler.rb
@@ -40,7 +40,7 @@ class Chef
           normalize_for_put(group, entry)
         end
 
-        def preserve_key(key)
+        def preserve_key?(key)
           return key == 'name'
         end
 

--- a/spec/unit/chef_fs/data_handler/group_handler_spec.rb
+++ b/spec/unit/chef_fs/data_handler/group_handler_spec.rb
@@ -1,0 +1,63 @@
+#
+# Author:: Ryan Cragun (<ryan@getchef.com>)
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'lib/chef/chef_fs/data_handler/group_data_handler'
+
+class TestEntry < Mash
+  attr_accessor :name, :org
+
+  def initialize(name, org)
+    @name = name
+    @org = org
+  end
+end
+
+describe Chef::ChefFS::DataHandler::GroupDataHandler do
+  describe '#normalize_for_post' do
+    let(:entry) do
+      TestEntry.new('workers.json', 'hive')
+    end
+
+    let(:group) do
+      { 'name' => 'worker_bees',
+        'clients' => %w(honey sting),
+        'users' => %w(fizz buzz),
+        'actors' => %w(honey)
+      }
+    end
+
+    let(:normalized) do
+      { 'actors' =>
+          { 'users' => %w(fizz buzz),
+            'clients'=> %w(honey sting),
+            'groups'=> []
+          },
+        'groupname' => 'workers',
+        'name' => 'worker_bees',
+        'orgname' => 'hive'
+      }
+    end
+
+    let(:handler) { described_class.new }
+
+    it 'normalizes the users, clients and groups into actors' do
+      expect(handler.normalize_for_post(group, entry)).to eq(normalized)
+    end
+  end
+end


### PR DESCRIPTION
The original issue was discovered using knife-ec-restore which requires knife-essentials for chef-client v10.x compatibility.  As knife-essentials and chef_fs have been moved into core Chef, this is a port to 11-stable of the fixes described here: https://github.com/jkeiser/knife-essentials/pull/111
