### PR TITLE
switch rhel5/rhel6 back to redhat provider

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -26,7 +26,6 @@ require 'chef/version_constraint/platform'
 # Therefore, we do the includes inline rather than up top.
 require 'chef/provider'
 
-
 class Chef
   class Platform
 
@@ -223,7 +222,7 @@ class Chef
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               },
               "< 7" => {
-                :service => Chef::Provider::Service::Systemd
+                :service => Chef::Provider::Service::Redhat
               }
             },
             :ibm_powerkvm   => {


### PR DESCRIPTION
looks like a fairly bad typo bug snuck in when we switched
rhel7 to systemd.
