### PR TITLE
Fix test failure happening only on Jenkins 12.04+1.9.3: don't call File....

### DIFF
--- a/spec/unit/workstation_config_loader_spec.rb
+++ b/spec/unit/workstation_config_loader_spec.rb
@@ -241,7 +241,7 @@ describe Chef::WorkstationConfigLoader do
         t.path
       end
 
-      after { File.unlink(explicit_config_location) }
+      after { File.unlink(explicit_config_location) if File.exists?(explicit_config_location) }
 
       context "and is valid" do
 


### PR DESCRIPTION
...unlink if the file isn't there.
