### PR TITLE
guard_interpreter requires a command

### DIFF
--- a/lib/chef/resource/conditional.rb
+++ b/lib/chef/resource/conditional.rb
@@ -52,6 +52,11 @@ class Chef
           @block = nil
         when nil
           raise ArgumentError, "only_if/not_if requires either a command or a block" unless block_given?
+          if parent_resource.guard_interpreter != :default
+            msg = "#{parent_resource.name} was given a guard_interpreter of #{parent_resource.guard_interpreter}, "
+            msg << "but not given a command as a string. guard_interpreter does not support blocks."
+            raise ArgumentError, msg
+          end
           @guard_interpreter = nil
           @command, @command_opts = nil, nil
           @block = block

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -27,6 +27,15 @@ describe Chef::Resource::Conditional do
     @parent_resource = Chef::Resource.new(nil, Chef::Node.new)
   end
 
+  it "raises an exception when a guard_interpreter is specified and a block is given" do
+    @parent_resource.guard_interpreter :canadian_mounties
+    expect { Chef::Resource::Conditional.send(:new, :always, @parent_resource, nil, {}) { True } }.to raise_error(ArgumentError, /does not support blocks/)
+  end
+
+  it "raises an exception when neither a block or command is given" do
+    expect { Chef::Resource::Conditional.send(:new, :always, @parent_resource, nil, {})}.to raise_error(ArgumentError, /requires either a command or a block/)
+  end
+
   describe "when created as an `only_if`" do
     describe "after running a successful command" do
       before do


### PR DESCRIPTION
Raises an exception if guard_interpreter is set (not :default) and we are not
given a command (i.e. we are given a block). This is not supported, as we pass
a command to an external interpreter.

Related to #1943
