### PR TITLE
Mixlib's shellout expects streams to have a shift operator

### DIFF
--- a/lib/chef/event_dispatch/events_output_stream.rb
+++ b/lib/chef/event_dispatch/events_output_stream.rb
@@ -21,6 +21,11 @@ class Chef
         events.stream_output(self, str, options)
       end
 
+      # Mixlib shellout expects streams to have a shift operator 
+      def <<(str)
+        print(str)
+      end
+
       def close
         events.stream_closed(self, options)
       end


### PR DESCRIPTION
In metal we use the EventsOutputStream and pass that to shellout. Shellout does the following:

```ruby
@live_stdout << chunk if @live_stdout
```
here: https://github.com/opscode/mixlib-shellout/blob/master/lib/mixlib/shellout/unix.rb#L256 - where @live_stdout is an EventsOutputStream object, which then bombs because the object doesn't have a shift operator.

cc @jkeiser 