### PR TITLE
Reading crontab of non-root unix user should read as that user

### DIFF
--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -33,6 +33,8 @@ class Chef
           crontab = shell_out('/usr/bin/crontab -l', :user => @new_resource.user)
           status = crontab.status.exitstatus
 
+          Chef::Log.debug crontab.format_for_exception if status > 0
+
           if status > 1
             raise Chef::Exceptions::Cron, "Error determining state of #{@new_resource.name}, exit: #{status}"
           end

--- a/spec/unit/provider/cron/unix_spec.rb
+++ b/spec/unit/provider/cron/unix_spec.rb
@@ -59,6 +59,8 @@ describe Chef::Provider::Cron::Unix do
     end
 
     before do
+      allow(Chef::Log).to receive(:debug)
+      allow(shell_out).to receive(:format_for_exception).and_return("formatted command output")
       allow(provider).to receive(:shell_out).with('/usr/bin/crontab -l', :user => username).and_return(shell_out)
     end
 
@@ -78,6 +80,11 @@ describe Chef::Provider::Cron::Unix do
       it "should return nil if the user has no crontab" do
         expect(provider.send(:read_crontab)).to be_nil
       end
+
+      it "logs the crontab output to debug" do
+        provider.send(:read_crontab)
+        expect(Chef::Log).to have_received(:debug).with("formatted command output")
+      end
     end
 
     context "when any other error occurs" do
@@ -87,6 +94,11 @@ describe Chef::Provider::Cron::Unix do
         expect {
           provider.send(:read_crontab)
         }.to raise_error(Chef::Exceptions::Cron, "Error determining state of #{new_resource.name}, exit: 2")
+      end
+
+      it "logs the crontab output to debug" do
+        provider.send(:read_crontab) rescue nil
+        expect(Chef::Log).to have_received(:debug).with("formatted command output")
       end
     end
   end


### PR DESCRIPTION
Crontab on Solaris and Illumos systems with auditing enabled tries to audit attempts by root to read non-root user crontabs. If chef-client runs without an auditing context (as happens by default when running in SMF), these crontab calls will fails with exit status 1.

By switching to the non-root user first (which somehow does not require auditing), we should be able to read user crontabs without an auditing context.

Note that I'm doing some jank at the end to ensure the existing crontab has a trailing newline. I'm open to suggestions if there's a less janky and preferred alternative.
