### PR TITLE
not_if/only_if does not honor script resource's environment

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -125,6 +125,26 @@ class Chef
         )
       end
 
+      def only_if(command=nil, opts={}, &block)
+        opts = conditional_options.merge(opts)
+        super
+      end
+
+      def not_if(command=nil, opts={}, &block)
+        opts = conditional_options.merge(opts)
+        super
+      end
+
+      private
+
+      def conditional_options
+        { :user => user,
+          :group => group,
+          :environment => environment,
+          :cwd => cwd,
+          :timeout => timeout
+        }.delete_if { |_, v| v.nil? }
+      end
     end
   end
 end


### PR DESCRIPTION
Whenever I have a somewhat complex script, which uses specific `environment` options, I have to manually set those values in the not_if block as well, because they are not set in this specific block.

Take this example:

``` ruby
execute 'upload_validation_key' do
  action  :run
  not_if  <<-EOF.strip_heredoc
    export AWS_ACCESS_KEY_ID=#{Kabisa::Encryption.get('aws_access_key_id')}
    export AWS_SECRET_ACCESS_KEY=#{Kabisa::Encryption.get('aws_secret_access_key')}

    REMOTE=$(aws s3 ls s3://our-bucket-id | \
      grep "validation-#{service.environment.current}" | \
      cut -d' ' -f1,2 | xargs -0 date +%s -d | cut -c-7)

    LOCAL=$(python -c "import os,time; print int(os.path.getmtime(
      '/etc/chef/validation.pem'))" | cut -c-7)

    test "$REMOTE" = "$LOCAL"
  EOF
  command <<-EOF.strip_heredoc
    aws s3 cp validation.pem \
      s3://our-bucket-id/validation-#{service.environment.current} \
      --region 'eu-west-1'
  EOF
  cwd '/etc/chef'
  environment(
    'AWS_ACCESS_KEY_ID' => Kabisa::Encryption.get('aws_access_key_id'),
    'AWS_SECRET_ACCESS_KEY' => Kabisa::Encryption.get('aws_secret_access_key')
  )
end
```

In this case, I have to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` twice, both in the `environment` option, and through the shell script in the `not_if` block.

I noticed an old ticket in the old issue tracker mentioning this problem:

https://tickets.opscode.com/browse/CHEF-2306

But I couldn't find anything about it in the current issue tracker, and only saw the ticket being closed as "not a bug", which I wonder if that really is the case.
