### PR TITLE
find revisions by full component rather than suffix

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -254,7 +254,7 @@ class Chef
         if tagged_commit && rev_pattern != 'HEAD'
           tagged_commit[0]
         else
-          found = refs.find { |m| m[1].end_with?(@new_resource.revision) }
+          found = refs.find { |m| m[1].end_with?("/#{@new_resource.revision}") }
           if found
             found[0]
           else


### PR DESCRIPTION
Consider a repository having branches named `production` and `foo_production`.  

The `git ls-remotes` command will have output something like this:
`abcd1234abcd1234        refs/heads/foo_production`
`fedc9876fedc9876        refs/heads/production`

If you've specified `revision` as `production`, you might get `foo_production` instead, because `remote_resolve_reference` just looks for end_with?('production') instead of end_with?('/production').