### PR TITLE
Fix RHEL pre 7 provider service mapping

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -223,7 +223,7 @@ class Chef
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               },
               "< 7" => {
-                :service => Chef::Provider::Service::Systemd
+                :service => Chef::Provider::Service::Redhat
               }
             },
             :ibm_powerkvm   => {


### PR DESCRIPTION
This is to fix the issue made when the Redhat-based 7 distro
support was added.

Steps to reproduce:
- add a cookbook recipe that starts a service, e.g. nginx
- run chef

Expected
- nginx to be started and reboot enabled

Actual

```
==> test6: [2014-09-27T12:41:48+00:00] ERROR: service[nginx] (nginx::package line 46) had an error: Errno::ENOENT: No such file or directory - /bin/systemctl is-active nginx --quiet
==> test6: [2014-09-27T12:41:48+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
