### PR TITLE
Remove node_name lookup in knife ssh error handler

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -106,13 +106,6 @@ class Chef
       def session
         config[:on_error] ||= :skip
         ssh_error_handler = Proc.new do |server|
-          if config[:manual]
-            node_name = server.host
-          else
-            @action_nodes.each do |n|
-              node_name = n if format_for_display(n)[config[:attribute]] == server.host
-            end
-          end
           case config[:on_error]
           when :skip
             ui.warn "Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}"


### PR DESCRIPTION
It is no longer used, but causes problems as action_nodes can sometimes contain nil entries (see skip on the loop in search_nodes to cater for this).

Commit b57226b4a8c80b865cd3e256923ba07e5ac09749 removes the previous requirement for this.
