### PR TITLE
Match group func tests to specification

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -371,12 +371,10 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" }
     describe "when there is no group" do
       it "raises an error on modify" do
         lambda { group_resource.run_action(:modify) }.should raise_error
-        #group_should_not_exist(group_name)
       end
 
       it "does not raise an error on manage" do
         lambda { group_resource.run_action(:manage) }.should_not raise_error
-        #group_should_not_exist(group_name)
       end
     end
 


### PR DESCRIPTION
When a group does not exist, the group resource should raise an exception on action modify,
but not on action_manage.

Also update the `not_to raise_error(SpecificError)` deprecated syntax.
