### PR TITLE
Updated after_created to pass source accessor value, fixes #2047

### DIFF
--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -125,7 +125,7 @@ class Chef
       end
 
       def after_created
-        validate_source(@source)
+        validate_source(source)
       end
 
       private


### PR DESCRIPTION
Implemented fix suggested by @stevendanna and chef-shell is no longer throwing InvalidRemoteFileURI.

```
chef:recipe > remote_file "/tmp/g2" do
chef:recipe >     source lazy {"http://google.com"}
chef:recipe ?>  end
 => <remote_file[/tmp/g2] @name: "/tmp/g2" @noop: nil @before: nil @params: {} @provider: Chef::Provider::RemoteFile @allowed_actions: [:nothing, :create, :delete, :touch, :create_if_missing] @action: "create" @updated: false @updated_by_last_action: false @supports: {} @ignore_failure: false @retries: 0 @retry_delay: 2 @source_line: "(irb#1):1:in `irb_binding'" @guard_interpreter: :default @elapsed_time: 0 @sensitive: false @resource_name: :remote_file @path: "/tmp/g2" @backup: 5 @atomic_update: true @force_unlink: false @manage_symlink_source: nil @diff: nil @source: #<Chef::DelayedEvaluator:0x007fc9bf655e88@(irb#1):2> @use_etag: true @use_last_modified: true @ftp_active_mode: false @headers: {} @cookbook_name: nil @recipe_name: nil>
```
