### PR TITLE
Add display_name handling to Chef::ChefFS::DataHandler::UserDataHandler

### DIFF
--- a/lib/chef/chef_fs/data_handler/user_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/user_data_handler.rb
@@ -8,6 +8,7 @@ class Chef
           normalize_hash(user, {
             'name' => remove_dot_json(entry.name),
             'username' => remove_dot_json(entry.name),
+            'display_name' => remove_dot_json(entry.name),
             'admin' => false,
             'json_class' => 'Chef::WebUIUser',
             'chef_type' => 'webui_user',


### PR DESCRIPTION
@jkeiser & I are working on compatibility for Cheffish with Enterprise chef.

Add support for user full name string as display_name to Chef::ChefFS::DataHandler::UserDataHandler.
