### PR TITLE
print the path to the configuration file used

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -164,7 +164,6 @@ class Chef
 
     def self.load_config(explicit_config_file)
       config_loader = WorkstationConfigLoader.new(explicit_config_file, Chef::Log)
-      Chef::Log.debug("Using configuration from #{config_loader.config_location}")
       config_loader.load
 
       ui.warn("No knife configuration file found") if config_loader.no_config_found?
@@ -393,6 +392,8 @@ class Chef
 
       merge_configs
       apply_computed_config
+      # This has to be after apply_computed_config so that Mixlib::Log is configured
+      Chef::Log.info("Using configuration from #{config[:config_file]}") if config[:config_file]
     end
 
     def show_usage

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -260,8 +260,25 @@ describe Chef::Knife do
         knife_command.configure_chef
         knife_command.config[:opt_with_default].should == "from-cli"
       end
-    end
 
+      context "verbosity is greater than zero" do
+        let(:fake_config) { "/does/not/exist/knife.rb" }
+
+        before do
+          @knife.config[:verbosity] = 1
+          @knife.config[:config_file] = fake_config
+          config_loader = double("Chef::WorkstationConfigLoader", :load => true, :no_config_found? => false, :chef_config_dir => "/etc/chef", :config_location => fake_config)
+          allow(Chef::WorkstationConfigLoader).to receive(:new).and_return(config_loader)
+        end
+
+        it "prints the path to the configuration file used" do
+          @stdout, @stderr, @stdin = StringIO.new, StringIO.new, StringIO.new
+          @knife.ui = Chef::Knife::UI.new(@stdout, @stderr, @stdin, {})
+          expect(Chef::Log).to receive(:info).with("Using configuration from #{fake_config}")
+          @knife.configure_chef
+        end
+      end
+    end
   end
 
   describe "when first created" do


### PR DESCRIPTION
when verbosity > 0, it prints the path to the configuration file used
