### PR TITLE
change default group mapping for SLES to gpasswd

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -200,6 +200,9 @@ class Chef
                 :service => Chef::Provider::Service::Redhat,
                 :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Zypper,
+                :group => Chef::Provider::Group::Gpasswd
+              },
+              "< 12.0" => {
                 :group => Chef::Provider::Group::Suse
               }
             },

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -278,6 +278,17 @@ describe Chef::Platform do
       pmap[:package].should eql(Chef::Provider::Package::Ips)
     end
 
+    it "should use the SUSE group provider on SLES11" do
+      1.upto(3) do |sp|
+        pmap = Chef::Platform.find("SUSE", "11.#{sp}")
+        pmap[:group].should eql(Chef::Provider::Group::Suse)
+      end
+    end
+
+    it "should use the Gpasswd group provider on SLES12" do
+      pmap = Chef::Platform.find("SUSE", "12.0")
+      pmap[:group].should eql(Chef::Provider::Group::Gpasswd)
+    end
   end
 
 end


### PR DESCRIPTION
gpasswd is the new default starting with SLES12, the groupmod command does not
support the -A/-R commands for adding and removing users respectively
