### PR TITLE
Exclude knife integration tests on server platforms

### DIFF
--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -22,7 +22,7 @@ require 'chef/knife/show'
 require 'chef/knife/raw'
 require 'chef/knife/cookbook_upload'
 
-describe 'ChefFSDataStore tests' do
+describe 'ChefFSDataStore tests', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/chef_repo_path_spec.rb
+++ b/spec/integration/knife/chef_repo_path_spec.rb
@@ -20,7 +20,7 @@ require 'support/shared/context/config'
 require 'chef/knife/list'
 require 'chef/knife/show'
 
-describe 'chef_repo_path tests' do
+describe 'chef_repo_path tests', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/chef_repository_file_system_spec.rb
+++ b/spec/integration/knife/chef_repository_file_system_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'chef/knife/list'
 require 'chef/knife/show'
 
-describe 'General chef_repo file system checks' do
+describe 'General chef_repo file system checks', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/chefignore_spec.rb
+++ b/spec/integration/knife/chefignore_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'chef/knife/list'
 require 'chef/knife/show'
 
-describe 'chefignore tests' do
+describe 'chefignore tests', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/common_options_spec.rb
+++ b/spec/integration/knife/common_options_spec.rb
@@ -18,7 +18,7 @@
 require 'support/shared/integration/integration_helper'
 require 'chef/knife/raw'
 
-describe 'knife common options' do
+describe 'knife common options', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/cookbook_api_ipv6_spec.rb
+++ b/spec/integration/knife/cookbook_api_ipv6_spec.rb
@@ -18,7 +18,7 @@
 require 'support/shared/integration/integration_helper'
 require 'chef/mixin/shell_out'
 
-describe "Knife cookbook API integration with IPv6" do
+describe "Knife cookbook API integration with IPv6", :workstation do
   include IntegrationSupport
   include Chef::Mixin::ShellOut
 

--- a/spec/integration/knife/delete_spec.rb
+++ b/spec/integration/knife/delete_spec.rb
@@ -20,7 +20,7 @@ require 'chef/knife/delete'
 require 'chef/knife/list'
 require 'chef/knife/raw'
 
-describe 'knife delete' do
+describe 'knife delete', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'support/shared/context/config'
 require 'chef/knife/deps'
 
-describe 'knife deps' do
+describe 'knife deps', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/diff_spec.rb
+++ b/spec/integration/knife/diff_spec.rb
@@ -18,7 +18,7 @@
 require 'support/shared/integration/integration_helper'
 require 'chef/knife/diff'
 
-describe 'knife diff' do
+describe 'knife diff', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'chef/knife/download'
 require 'chef/knife/diff'
 
-describe 'knife download' do
+describe 'knife download', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/list_spec.rb
+++ b/spec/integration/knife/list_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'support/shared/context/config'
 require 'chef/knife/list'
 
-describe 'knife list' do
+describe 'knife list', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/raw_spec.rb
+++ b/spec/integration/knife/raw_spec.rb
@@ -20,7 +20,7 @@ require 'support/shared/context/config'
 require 'chef/knife/raw'
 require 'chef/knife/show'
 
-describe 'knife raw' do
+describe 'knife raw', :workstation do
   include IntegrationSupport
   include KnifeSupport
   include AppServerSupport

--- a/spec/integration/knife/redirection_spec.rb
+++ b/spec/integration/knife/redirection_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'support/shared/context/config'
 require 'chef/knife/list'
 
-describe 'redirection' do
+describe 'redirection', :workstation do
   include IntegrationSupport
   include KnifeSupport
   include AppServerSupport

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'chef/knife/serve'
 require 'chef/server_api'
 
-describe 'knife serve' do
+describe 'knife serve', :workstation do
   include IntegrationSupport
   include KnifeSupport
   include AppServerSupport

--- a/spec/integration/knife/show_spec.rb
+++ b/spec/integration/knife/show_spec.rb
@@ -19,7 +19,7 @@ require 'support/shared/integration/integration_helper'
 require 'support/shared/context/config'
 require 'chef/knife/show'
 
-describe 'knife show' do
+describe 'knife show', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -20,7 +20,7 @@ require 'chef/knife/upload'
 require 'chef/knife/diff'
 require 'chef/knife/raw'
 
-describe 'knife upload' do
+describe 'knife upload', :workstation do
   include IntegrationSupport
   include KnifeSupport
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,9 @@ RSpec.configure do |config|
   config.filter_run :focus => true
   config.filter_run_excluding :external => true
 
+  # Only run these tests on platforms that are also chef workstations
+  config.filter_run_excluding :workstation if solaris?
+
   # Tests that randomly fail, but may have value.
   config.filter_run_excluding :volatile => true
   config.filter_run_excluding :volatile_on_solaris => true if solaris?


### PR DESCRIPTION
Not all platforms (looking at you solaris) need bother running the knife tests
because we don't consider them to be workstation platforms. Excluding them
will reduce transient failures and speed up the tests.
