### PR TITLE
Allow `knife cookbook site share` to omit category

### DIFF
--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -31,7 +31,7 @@ class Chef
         require 'chef/cookbook_site_streaming_uploader'
       end
 
-      banner "knife cookbook site share COOKBOOK CATEGORY (options)"
+      banner "knife cookbook site share COOKBOOK [CATEGORY] (options)"
       category "cookbook site"
 
       option :cookbook_path,
@@ -45,16 +45,11 @@ class Chef
 
         if @name_args.length < 1
           show_usage
-          ui.fatal("You must specify the cookbook name and the category you want to share this cookbook to.")
+          ui.fatal("You must specify the cookbook name.")
           exit(1)
         elsif @name_args.length < 2
           cookbook_name = @name_args[0]
           category = get_category(cookbook_name)
-          if category.nil? || category.empty?
-            show_usage
-            ui.fatal("You must specify the cookbook name and the category you want to share this cookbook to.")
-            exit(1)
-          end
         else
           cookbook_name = @name_args[0]
           category = @name_args[1]
@@ -96,9 +91,14 @@ class Chef
       def get_category(cookbook_name)
         begin
           data = noauth_rest.get_rest("http://cookbooks.opscode.com/api/v1/cookbooks/#{@name_args[0]}")
-          data["category"]
+          if !data["category"] && data["error_code"]
+            ui.fatal("Received an error from the Opscode Cookbook site: #{data["error_code"]}. On the first time you upload it, you are required to specify the category you want to share this cookbook to.")
+            exit(1)
+          else
+            data['category']
+          end
         rescue => e
-          ui.fatal("Error fetching cookbook to determine category")
+          ui.fatal("Unable to reach Opscode Cookbook Site: #{e.message}. Increase log verbosity (-VV) for more information.")
           Chef::Log.debug("\n#{e.backtrace.join("\n")}")
           exit(1)
         end

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -77,9 +77,16 @@ describe Chef::Knife::CookbookSiteShare do
       @knife.run
     end
 
-    it 'should print usage and exit when given only 1 argument and cannot determine category' do
+    it 'should print error and exit when given only 1 argument and cannot determine category' do
       @knife.name_args = ['cookbook_name']
       @noauth_rest.should_receive(:get_rest).with("http://cookbooks.opscode.com/api/v1/cookbooks/cookbook_name").and_return(@bad_category_response)
+      @knife.ui.should_receive(:fatal)
+      lambda { @knife.run }.should raise_error(SystemExit)
+    end
+
+    it 'should print error and exit when given only 1 argument and Chef::REST throws an exception' do
+      @knife.name_args = ['cookbook_name']
+      @noauth_rest.should_receive(:get_rest).with("http://cookbooks.opscode.com/api/v1/cookbooks/cookbook_name") { raise Errno::ECONNREFUSED, "Connection refused" }
       @knife.ui.should_receive(:fatal)
       lambda { @knife.run }.should raise_error(SystemExit)
     end


### PR DESCRIPTION
Re-created against master from https://github.com/opscode/chef/pull/2198.

This adds a feature for knife to lookup the category on an existing cookbook. This enables uploading new versions of existing cookbooks with much less pain.

Fixes https://github.com/opscode/supermarket/issues/826 as well.
