### PR TITLE
Cherry-pick #2208 from opscode/jdmundrawala/env-path-spec-fix

### DIFF
--- a/spec/functional/resource/env_spec.rb
+++ b/spec/functional/resource/env_spec.rb
@@ -126,7 +126,8 @@ describe Chef::Resource::Env, :windows_only do
       context 'when using PATH' do
         let(:random_name) { Time.now.to_i }
         let(:env_val) { "#{env_value_expandable}_#{random_name}"}
-        let(:path_before) { test_resource.provider_for_action(test_resource.action).env_value('PATH') }
+        let!(:path_before) { test_resource.provider_for_action(test_resource.action).env_value('PATH') || '' }
+        let!(:env_path_before) { ENV['PATH'] }
 
         it 'should expand PATH' do
           path_before.should_not include(env_val)
@@ -142,9 +143,7 @@ describe Chef::Resource::Env, :windows_only do
           test_resource.key_name('PATH')
           test_resource.value(path_before)
           test_resource.run_action(:create)
-          if test_resource.provider_for_action(test_resource.action).env_value('PATH') != path_before
-            raise 'Failed to cleanup after ourselves'
-          end
+          ENV['PATH'] = env_path_before
         end
       end
 


### PR DESCRIPTION
restore ENV['PATH'] in env_spec after test is complete
