### PR TITLE
Improve detection missing WhatIf support

### DIFF
--- a/lib/chef/util/dsc/local_configuration_manager.rb
+++ b/lib/chef/util/dsc/local_configuration_manager.rb
@@ -79,7 +79,7 @@ EOH
     end
 
     def log_what_if_exception(what_if_exception_output)
-        if what_if_exception_output.gsub(/\s+/, ' ') =~ /A parameter cannot be found that matches parameter name 'Whatif'/i
+        if what_if_exception_output.gsub(/[\r\n]+/, '').gsub(/\s+/, ' ') =~ /A parameter cannot be found that matches parameter name 'Whatif'/i
           # LCM returns an error if any of the resources do not support the opptional What-If
           Chef::Log::warn("Received error while testing configuration due to resource not supporting 'WhatIf'")
         elsif output_has_dsc_module_failure?(what_if_exception_output)


### PR DESCRIPTION
From output of Whatif-run, do not replace line break by space, as this breaks the match if the break was done within a word.
