### PR TITLE
remove chef/shell_out dep

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -15,10 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# chef/shell_out has been deprecated in favor of mixlib/shellout
-# chef/shell_out is still required here to ensure backward compatibility
-require 'chef/shell_out'
-
 require 'mixlib/shellout'
 
 class Chef


### PR DESCRIPTION
seems like we can drop this require for chef-12
