### PR TITLE
Correctly assign a_value for return of Chef::ChefFS::FileSystem#self.compare

### DIFF
--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -242,7 +242,7 @@ class Chef
         if are_same.nil?
           are_same, b_value, a_value = b.compare_to(a)
         end
-        if are_same.nil?
+        if !are_same.nil?
           # TODO these reads can be parallelized
           begin
             a_value = a.read if a_value.nil?


### PR DESCRIPTION
Previously this was breaking the output of higher abstractions like Chef::ChefFS::CommandLine#diff_entries and friends.
Both the `a.compare_to(b)` and `b.compare_to(a)` statements were overwriting one of the return values (to `nil`) on each call.
That was compounded by the second `if are_same.nil?` statement, resulting in the `*_value` statement never getting returned when evaluating 2 Chef::ChefFS entries.
