### PR TITLE
use group_name when checking if the group exists on mac osx with dscl

### DIFF
--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -41,10 +41,10 @@ class Chef
 
         def load_current_resource
           @current_resource = Chef::Resource::Group.new(@new_resource.name)
-          @current_resource.group_name(@new_resource.name)
+          @current_resource.group_name(@new_resource.group_name)
           group_info = nil
           begin
-            group_info = safe_dscl("read /Groups/#{@new_resource.name}")
+            group_info = safe_dscl("read /Groups/#{@new_resource.group_name}")
           rescue Chef::Exceptions::Group
             @group_exists = false
             Chef::Log.debug("#{@new_resource} group does not exist")

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -252,7 +252,7 @@ describe Chef::Provider::Group::Dscl do
       lambda { @provider.process_resource_requirements }.should_not raise_error
     end
   end
- 
+
   describe "when creating the group" do
     it "creates the group, password field, gid, and sets group membership" do
       @provider.should_receive(:set_gid).and_return(true)
@@ -301,7 +301,8 @@ describe 'Test DSCL loading' do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::Group.new("aj")
+    @new_resource = Chef::Resource::Group.new("group name aj")
+    @new_resource.group_name("aj")
     @provider = Chef::Provider::Group::Dscl.new(@new_resource, @run_context)
     @output = <<-EOF
 AppleMetaNodeLocation: /Local/Default


### PR DESCRIPTION
The group resource on mac osx platforms is currently ignoring the group_name attribute when checking if the group already exists on the system. This pull request fixes the issue by using new_resource's group_name when loading the current_resource and when checking for the group's existence in the system.
