### PR TITLE
[11-stable] Multipackge support

### DIFF
--- a/lib/chef/mixin/get_source_from_package.rb
+++ b/lib/chef/mixin/get_source_from_package.rb
@@ -29,6 +29,7 @@ class Chef
     module GetSourceFromPackage
       def initialize(new_resource, run_context)
         super
+        return if new_resource.name.is_a?(Array)
         # if we're passed something that looks like a filesystem path, with no source, use it
         #  - require at least one '/' in the path to avoid gem_package "foo" breaking if a file named 'foo' exists in the cwd
         if new_resource.source.nil? && new_resource.package_name.match(/#{::File::SEPARATOR}/) && ::File.exists?(new_resource.package_name)

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -84,17 +84,19 @@ class Chef
       end
 
       def action_upgrade
-        if candidate_version.nil?
+        if (@new_resource.package_name.is_a?(Array) && !candidate_version.any?) ||
+            (@new_resource.package_name.is_a?(String) && candidate_version.nil?)
           Chef::Log.debug("#{@new_resource} no candidate version - nothing to do")
+          return
         elsif @current_resource.version == candidate_version
           Chef::Log.debug("#{@new_resource} is at the latest version - nothing to do")
-        else
-          @new_resource.version(candidate_version)
-          orig_version = @current_resource.version || "uninstalled"
-          converge_by("upgrade package #{@new_resource.package_name} from #{orig_version} to #{candidate_version}") do
-            upgrade_package(@new_resource.package_name, candidate_version)
-            Chef::Log.info("#{@new_resource} upgraded from #{orig_version} to #{candidate_version}")
-          end
+          return
+        end
+        @new_resource.version(candidate_version)
+        orig_version = @current_resource.version || "uninstalled"
+        converge_by("upgrade package #{@new_resource.package_name} from #{orig_version} to #{candidate_version}") do
+          upgrade_package(@new_resource.package_name, candidate_version)
+          Chef::Log.info("#{@new_resource} upgraded from #{orig_version} to #{candidate_version}")
         end
       end
 
@@ -111,10 +113,16 @@ class Chef
       end
 
       def removing_package?
+        print "DEBUG: #{@new_resource.version} vs #{@current_resource.version}"
         if @current_resource.version.nil?
           false # nothing to remove
+        elsif @current_resource.version.is_a?(Array) && !@current_resource.version.any?
+          # ! any? means it's all nil's, which means nothing is installed
+          false
         elsif @new_resource.version.nil?
           true # remove any version of a package
+        elsif @new_resource.version.is_a?(Array) && !@current_resource.version.any?
+          true # remove any version of all packages
         elsif @new_resource.version == @current_resource.version
           true # remove the version we have
         else

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -53,53 +53,91 @@ class Chef
 
         def check_package_state(package)
           Chef::Log.debug("#{@new_resource} checking package status for #{package}")
-          installed = false
+          if package.is_a?(Array)
+            final_installed_version = []
+            final_candidate_version = []
+            final_installed = []
+            final_virtual = []
+          end
+          installed = virtual = false
+          installed_version = candidate_version = nil
 
-          shell_out!("apt-cache#{expand_options(default_release_options)} policy #{package}", :timeout => @new_resource.timeout).stdout.each_line do |line|
-            case line
-            when /^\s{2}Installed: (.+)$/
-              installed_version = $1
-              if installed_version == '(none)'
-                Chef::Log.debug("#{@new_resource} current version is nil")
-                @current_resource.version(nil)
-              else
-                Chef::Log.debug("#{@new_resource} current version is #{installed_version}")
-                @current_resource.version(installed_version)
-                installed = true
-              end
-            when /^\s{2}Candidate: (.+)$/
-              candidate_version = $1
-              if candidate_version == '(none)'
-                # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
-                @is_virtual_package = true
-                showpkg = shell_out!("apt-cache showpkg #{package}", :timeout => @new_resource.timeout).stdout
-                providers = Hash.new
-                # Returns all lines after 'Reverse Provides:'
-                showpkg.rpartition(/Reverse Provides:\s*#{$/}/)[2].each_line do |line|
-                  provider, version = line.split
-                  providers[provider] = version
+
+          [package].flatten.each do |pkg|
+            installed = virtual = false
+            installed_version = candidate_version = nil
+            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}", :timeout => @new_resource.timeout).stdout.each_line do |line|
+              case line
+              when /^\s{2}Installed: (.+)$/
+                installed_version = $1
+                if installed_version == '(none)'
+                  Chef::Log.debug("#{@new_resource} current version is nil")
+                  installed_version = nil
+                else
+                  Chef::Log.debug("#{@new_resource} current version is #{installed_version}")
+                  installed = true
                 end
-                # Check if the package providing this virtual package is installed
-                num_providers = providers.length
-                raise Chef::Exceptions::Package, "#{@new_resource.package_name} has no candidate in the apt-cache" if num_providers == 0
-                # apt will only install a virtual package if there is a single providing package
-                raise Chef::Exceptions::Package, "#{@new_resource.package_name} is a virtual package provided by #{num_providers} packages, you must explicitly select one to install" if num_providers > 1
-                # Check if the package providing this virtual package is installed
-                Chef::Log.info("#{@new_resource} is a virtual package, actually acting on package[#{providers.keys.first}]")
-                installed = check_package_state(providers.keys.first)
+              when /^\s{2}Candidate: (.+)$/
+                candidate_version = $1
+                if candidate_version == '(none)'
+                  # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
+                  virtual = true
+                  showpkg = shell_out!("apt-cache showpkg #{package}", :timeout => @new_resource.timeout).stdout
+                  providers = Hash.new
+                  # Returns all lines after 'Reverse Provides:'
+                  showpkg.rpartition(/Reverse Provides:\s*#{$/}/)[2].each_line do |line|
+                    provider, version = line.split
+                    providers[provider] = version
+                  end
+                  # Check if the package providing this virtual package is installed
+                  num_providers = providers.length
+                  raise Chef::Exceptions::Package, "#{@new_resource.package_name} has no candidate in the apt-cache" if num_providers == 0
+                  # apt will only install a virtual package if there is a single providing package
+                  raise Chef::Exceptions::Package, "#{@new_resource.package_name} is a virtual package provided by #{num_providers} packages, you must explicitly select one to install" if num_providers > 1
+                  # Check if the package providing this virtual package is installed
+                  Chef::Log.info("#{@new_resource} is a virtual package, actually acting on package[#{providers.keys.first}]")
+                  installed = check_package_state(providers.keys.first)
+                else
+                  Chef::Log.debug("#{@new_resource} candidate version is #{$1}")
+                end
+              end
+              if package.is_a?(Array)
+                final_installed_version << installed_version
+                final_candidate_version << candidate_version
+                final_installed << installed
+                final_virtual << virtual
               else
-                Chef::Log.debug("#{@new_resource} candidate version is #{$1}")
-                @candidate_version = $1
+                final_installed_version = installed_version
+                final_candidate_version = candidate_version
+                final_installed = installed
+                final_virtual = virtual
               end
             end
           end
+          @candidate_version = final_candidate_version
+          @current_resource.version(final_installed_version)
+          @is_virtual_package = final_virtual
 
-          return installed
+          return final_installed.is_a?(Array) ? final_installed.any? : final_installed
         end
 
         def install_package(name, version)
-          package_name = "#{name}=#{version}"
-          package_name = name if @is_virtual_package
+          if name.is_a?(Array)
+            index = 0
+            package_name = name.zip(version).map do |x, y|
+              namestr = nil
+              if @is_virtual_package[index]
+                namestr = x
+              else
+                namestr = "#{x}=#{y}"
+              end
+              index += 1
+              namestr
+            end.join(' ')
+          else
+            package_name = "#{name}=#{version}"
+            package_name = name if @is_virtual_package
+          end
           run_noninteractive("apt-get -q -y#{expand_options(default_release_options)}#{expand_options(@new_resource.options)} install #{package_name}")
         end
 
@@ -108,12 +146,21 @@ class Chef
         end
 
         def remove_package(name, version)
-          package_name = "#{name}"
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = name
+          end
           run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} remove #{package_name}")
         end
 
         def purge_package(name, version)
-          run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} purge #{@new_resource.package_name}")
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = name
+          end
+          run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} purge #{package_name}")
         end
 
         def preseed_package(preseed_file)
@@ -122,8 +169,13 @@ class Chef
         end
 
         def reconfig_package(name, version)
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = name
+          end
           Chef::Log.info("#{@new_resource} reconfiguring")
-          run_noninteractive("dpkg-reconfigure #{name}")
+          run_noninteractive("dpkg-reconfigure #{package_name}")
         end
 
         private

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -46,7 +46,7 @@ class Chef
         set_or_return(
           :package_name,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, Array ]
         )
       end
 
@@ -54,7 +54,7 @@ class Chef
         set_or_return(
           :version,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, Array ]
         )
       end
 


### PR DESCRIPTION
Allow the `package` provider to take an array of packages to handle in one
transaction.

This solves two large problems:
- There are times when you cannot install two packages in sequence, like when a
  binary is moving between two packages - they _must_ be done in the same
  transaction.
- When using Chef to install the vast majority of your base system, it
  can make imaging take a very, very long time because executing yum or apt once
  for every single package is painfully slow.

This solves both. The scaffolding is all there in the Package HWRP, plus the
underlying implementation for both apt and yum, the two I have access to test.

This is the 11-stable version.

PLEASE do the initial code-review on the 10-stable PR (#2253) since it's easiest for me to test, I'll then forward-port those here and then we can do another round of review here.
