### PR TITLE
Only include chef-service-manager on windows

### DIFF
--- a/chef-x86-mingw32.gemspec
+++ b/chef-x86-mingw32.gemspec
@@ -15,4 +15,6 @@ gemspec.add_dependency "win32-service", "0.8.2"
 gemspec.add_dependency "win32-mmap", "0.4.0"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 
+gemspec.executables += %w( chef-service-manager chef-windows-service )
+
 gemspec

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -46,10 +46,7 @@ Gem::Specification.new do |s|
   %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_development_dependency gem, "~> 2.14.0" }
 
   s.bindir       = "bin"
-  # chef-service-manager is a windows only executable.
-  # However gemspec doesn't give us a way to have this executable only
-  # on windows. So we're including this in all platforms.
-  s.executables  = %w( chef-client chef-solo knife chef-shell shef chef-apply chef-service-manager chef-windows-service )
+  s.executables  = %w( chef-client chef-solo knife chef-shell shef chef-apply )
 
   s.require_path = 'lib'
   s.files = %w(Rakefile LICENSE README.md CONTRIBUTING.md) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }


### PR DESCRIPTION
Is there anything wrong with only including windows specific bins in the x86-mingw gemspec?

cc @sersut @adamedx @opscode/client-engineers 
