### PR TITLE
Properly load FreeBSD service status

### DIFF
--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -46,6 +46,7 @@ class Chef
 
           Chef::Log.debug("#{current_resource} found at #{init_command}")
 
+          @status_load_success = true
           determine_current_status!  # see Chef::Provider::Service::Simple
 
           determine_enabled_status!


### PR DESCRIPTION
Service status in `Chef::Provider::Service::Freebsd` is determined by `determine_current_status` defined in `Chef::Provider::Service::Simple`. This method assumes the current status to be `true` and only sets it to `false` if it fails. It seems `Chef::Provider::Service::Freebsd` mistakenly does not set the current status to true before determining the status. This fixes that and prevents why-run from complaining about service status not available when the service is actually running.
