### PR TITLE
Renamed output_has_dsc_module_failure to dsc_module_import_failure

### DIFF
--- a/lib/chef/util/dsc/local_configuration_manager.rb
+++ b/lib/chef/util/dsc/local_configuration_manager.rb
@@ -82,14 +82,14 @@ EOH
         if what_if_exception_output.gsub(/\s+/, ' ') =~ /A parameter cannot be found that matches parameter name 'Whatif'/i
           # LCM returns an error if any of the resources do not support the opptional What-If
           Chef::Log::warn("Received error while testing configuration due to resource not supporting 'WhatIf'")
-        elsif output_has_dsc_module_failure?(what_if_exception_output)
+        elsif dsc_module_import_failure?(what_if_exception_output)
           Chef::Log::warn("Received error while testing configuration due to a module for an imported resource possibly not being fully installed:\n#{what_if_exception_output.gsub(/\s+/, ' ')}")
         else
           Chef::Log::warn("Received error while testing configuration:\n#{what_if_exception_output.gsub(/\s+/, ' ')}")
         end
     end
 
-    def output_has_dsc_module_failure?(what_if_output)
+    def dsc_module_import_failure?(what_if_output)
       !! (what_if_output =~ /\sCimException/ &&
         what_if_output =~ /ProviderOperationExecutionFailure/ &&
         what_if_output =~ /\smodule\s+is\s+installed/)

--- a/spec/unit/util/dsc/local_configuration_manager_spec.rb
+++ b/spec/unit/util/dsc/local_configuration_manager_spec.rb
@@ -92,7 +92,7 @@ EOH
 
         it 'should log a warning if the message is formatted as expected when a resource import failure occurs' do
           expect(Chef::Log).to receive(:warn)
-          expect(lcm).to receive(:output_has_dsc_module_failure?).and_call_original
+          expect(lcm).to receive(:dsc_module_import_failure?).and_call_original
           test_configuration_result = nil
           expect {test_configuration_result = lcm.test_configuration('config')}.not_to raise_error
         end
@@ -112,22 +112,22 @@ EOH
 
         it 'should log a warning' do
           expect(Chef::Log).to receive(:warn)
-          expect(lcm).to receive(:output_has_dsc_module_failure?).and_call_original
+          expect(lcm).to receive(:dsc_module_import_failure?).and_call_original
           expect {lcm.test_configuration('config')}.not_to raise_error
         end
       end
     end
 
     it 'should identify a correctly formatted error message as a resource import failure' do
-      expect(lcm.send(:output_has_dsc_module_failure?, dsc_resource_import_failure_output)).to be(true)
+      expect(lcm.send(:dsc_module_import_failure?, dsc_resource_import_failure_output)).to be(true)
     end
 
     it 'should not identify an incorrectly formatted error message as a resource import failure' do
-      expect(lcm.send(:output_has_dsc_module_failure?, dsc_resource_import_failure_output.gsub('module', 'gibberish'))).to be(false)
+      expect(lcm.send(:dsc_module_import_failure?, dsc_resource_import_failure_output.gsub('module', 'gibberish'))).to be(false)
     end
 
     it 'should not identify a message without a CimException reference as a resource import failure' do
-      expect(lcm.send(:output_has_dsc_module_failure?, dsc_resource_import_failure_output.gsub('CimException', 'ArgumentException'))).to be(false)
+      expect(lcm.send(:dsc_module_import_failure?, dsc_resource_import_failure_output.gsub('CimException', 'ArgumentException'))).to be(false)
     end
   end
 end


### PR DESCRIPTION
Renaming variables based on Adam's and Chris' comments
@adamedx @randomcamel
