### PR TITLE
Using released chef-zero which uses ffi-yajl instead of JSON gem

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", "~> 2.1", ">= 2.1.4"
+  s.add_dependency "chef-zero", "~> 2.2", ">= 2.2.1"
   s.add_dependency "pry", "~> 0.9"
   s.add_dependency 'plist', '~> 3.1.0'
 


### PR DESCRIPTION
This (finally) finishes the changes I started a while ago to use ffi-yajl instead of JSON.  This time I'm using the chef-zero dependency I released yesterday.

^^^ @opscode/client-engineers @jkeiser 
