### PR TITLE
Disable eventlogger on win2k3

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -458,7 +458,7 @@ class Chef
     default :disable_event_loggers, false
     default :event_loggers do
       evt_loggers = []
-      if Chef::Platform::windows?
+      if Chef::Platform::windows? and not Chef::Platform::windows_server_2003?
         evt_loggers << :win_evt
       end
       evt_loggers


### PR DESCRIPTION
win32-eventlog does not work on windows 2k3.
cc @sersut 
