### PR TITLE
64-bit Windows functional script resource specs should not execute on 32-bit Windows

### DIFF
--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -95,7 +95,7 @@ shared_context Chef::Resource::WindowsScript do
       end
 
       let (:architecture) { :x86_64 }
-      it "should execute a 64-bit guard if the guard's architecture is specified as 64-bit" do
+      it "should execute a 64-bit guard if the guard's architecture is specified as 64-bit", :windows64_only do
         resource.only_if resource_guard_command, :architecture => :x86_64
         resource.run_action(:run)
         get_guard_process_architecture.should == 'amd64'


### PR DESCRIPTION
@jdmundrawala, @btm, can you take a look? I broke 32-bit Windows when I added extra shared examples as part of the `guard_interpreter` merge. The breaks aren't related to the new functionality, but were simply due to reusing some tests that were originally being run only on 64-bit Windows to run in additional contexts.
