### PR TITLE
add 14.04 to supported vagrant distros

### DIFF
--- a/kitchen-tests/.kitchen.yml
+++ b/kitchen-tests/.kitchen.yml
@@ -11,14 +11,20 @@ provisioner:
   branch: <%= %x(git rev-parse HEAD) %>
   require_chef_omnibus: true
   data_path: test/fixtures
+  client_rb:
+    diff_disabled: true
 
 platforms:
-#  - name: ubuntu-10.04
-#    run_list: apt::default
+  # upstream community mysql cookbook broken on 10.04
+  #- name: ubuntu-10.04
+  #  run_list: apt::default
   - name: ubuntu-12.04
     run_list: apt::default
-#  - name: ubuntu-13.04
-#    run_list: apt::default
+  - name: ubuntu-14.04
+    run_list: apt::default
+  # upstream community mysql cookbook also broken on 14.10
+  #- name: ubuntu-14.10
+  #  run_list: apt::default
   - name: centos-6.4
     run_list: yum-epel::default
   - name: centos-5.10

--- a/kitchen-tests/cookbooks/webapp/attributes/default.rb
+++ b/kitchen-tests/cookbooks/webapp/attributes/default.rb
@@ -1,7 +1,14 @@
 default['apache']['remote_host_ip'] = '127.0.0.1'
 
-default['mysql']['version'] = "5.5"
-
 default['webapp']['database'] = 'webapp'
 default['webapp']['db_username'] = 'webapp'
 default['webapp']['path'] = '/srv/webapp'
+
+# XXX: apache2 cookbook 2.0.0 has bugs around changing the mpm and then attempting a graceful restart
+# which fails and leaves the service down.
+case node['platform']
+when "ubuntu"
+  if node['platform_version'].to_f >= 14.04
+    default[:apache][:mpm] = 'event'
+  end
+end

--- a/kitchen-tests/test/fixtures/platforms/ubuntu/10.04.json
+++ b/kitchen-tests/test/fixtures/platforms/ubuntu/10.04.json
@@ -1,0 +1,14 @@
+{
+  "apache": {
+    "package": "apache2",
+    "service_name": "apache2"
+  },
+  "mysql": {
+    "server_package": "mysql-server-5.1",
+    "client_package": "mysql-client-5.1",
+    "service_name": "mysql"
+  },
+  "php" : {
+    "package": "php5"
+  }
+}

--- a/kitchen-tests/test/fixtures/platforms/ubuntu/14.04.json
+++ b/kitchen-tests/test/fixtures/platforms/ubuntu/14.04.json
@@ -1,0 +1,14 @@
+{
+  "apache": {
+    "package": "apache2",
+    "service_name": "apache2"
+  },
+  "mysql": {
+    "server_package": "mysql-server-5.5",
+    "client_package": "mysql-client-5.5",
+    "service_name": "mysql"
+  },
+  "php" : {
+    "package": "php5"
+  }
+}

--- a/kitchen-tests/test/fixtures/platforms/ubuntu/14.10.json
+++ b/kitchen-tests/test/fixtures/platforms/ubuntu/14.10.json
@@ -1,0 +1,14 @@
+{
+  "apache": {
+    "package": "apache2",
+    "service_name": "apache2"
+  },
+  "mysql": {
+    "server_package": "mysql-server-5.5",
+    "client_package": "mysql-client-5.5",
+    "service_name": "mysql"
+  },
+  "php" : {
+    "package": "php5"
+  }
+}


### PR DESCRIPTION
10.04 and 14.10 'documented' as broken in the upstream
mysql cookbook
