### PR TITLE
Merge pull request #2387 from opscode/sersut/revert-attr-nil-override

### DIFF
--- a/lib/chef/mixin/deep_merge.rb
+++ b/lib/chef/mixin/deep_merge.rb
@@ -29,6 +29,7 @@ class Chef
 
       class InvalidSubtractiveMerge < ArgumentError; end
 
+
       OLD_KNOCKOUT_PREFIX = "!merge:".freeze
 
       # Regex to match the "knockout prefix" that was used to indicate
@@ -85,12 +86,8 @@ class Chef
         when Hash
           if dest.kind_of?(Hash)
             source.each do |src_key, src_value|
-              if dest.has_key? src_key
-                if dest[src_key].nil?
-                  dest[src_key] = nil
-                else
-                  dest[src_key] = deep_merge!(src_value, dest[src_key])
-                end
+              if dest[src_key]
+                dest[src_key] = deep_merge!(src_value, dest[src_key])
               else # dest[src_key] doesn't exist so we take whatever source has
                 raise_if_knockout_used!(src_value)
                 dest[src_key] = src_value

--- a/spec/unit/mixin/deep_merge_spec.rb
+++ b/spec/unit/mixin/deep_merge_spec.rb
@@ -236,20 +236,6 @@ describe Chef::Mixin::DeepMerge, "deep_merge!" do
     @dm.deep_merge!(hash_src, hash_dst)
     hash_dst.should == {"item" => "orange"}
   end
-
-  it 'should overwrite hashes with nil' do
-    hash_src = {"item" => { "1" => "2"}, "other" => true }
-    hash_dst = {"item" => nil }
-    @dm.deep_merge!(hash_src, hash_dst)
-    hash_dst.should == {"item" => nil, "other" => true }
-  end
-
-  it 'should overwrite strings with nil' do
-    hash_src = {"item" => "to_overwrite", "other" => false }
-    hash_dst = {"item" => nil }
-    @dm.deep_merge!(hash_src, hash_dst)
-    hash_dst.should == {"item" => nil, "other" => false }
-  end
 end # deep_merge!
 
 # Chef specific


### PR DESCRIPTION
This reverts commit 972bc2f61685979e5b76f5481e3b1af2bd010d0e. This commit needs to be reverted in favor of newly merge attr changes that makes it possible to delete attr & attr subtrees.

Conflicts:
    spec/unit/mixin/deep_merge_spec.rb
