### PR TITLE
Windows event logger no longer imports into the global namespace.

### DIFF
--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -26,7 +26,6 @@ if Chef::Platform::windows? and not Chef::Platform::windows_server_2003?
   end
 
   require 'win32/eventlog'
-  include Win32
 end
 
 class Chef
@@ -51,12 +50,12 @@ class Chef
       end
 
       def initialize
-        @eventlog = EventLog::open('Application')
+        @eventlog = ::Win32::EventLog::open('Application')
       end
 
       def run_start(version)
         @eventlog.report_event(
-          :event_type => EventLog::INFO_TYPE,
+          :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_START_EVENT_ID,
           :data => [version]
@@ -66,7 +65,7 @@ class Chef
       def run_started(run_status)
         @run_status = run_status
         @eventlog.report_event(
-          :event_type => EventLog::INFO_TYPE,
+          :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_STARTED_EVENT_ID,
           :data => [run_status.run_id]
@@ -75,7 +74,7 @@ class Chef
 
       def run_completed(node)
         @eventlog.report_event(
-          :event_type => EventLog::INFO_TYPE,
+          :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_COMPLETED_EVENT_ID,
           :data => [@run_status.run_id, @run_status.elapsed_time.to_s]
@@ -88,7 +87,7 @@ class Chef
       #Exception backtrace: %5
       def run_failed(e)
         @eventlog.report_event(
-          :event_type => EventLog::ERROR_TYPE,
+          :event_type => ::Win32::EventLog::ERROR_TYPE,
           :source => SOURCE,
           :event_id => RUN_FAILED_EVENT_ID,
           :data => [@run_status.run_id,


### PR DESCRIPTION
This was causing problems with the windows cookbook trying to redefine
one of those constants.
This patch solves https://github.com/opscode-cookbooks/windows/issues/141

cc @opscode/client-engineers @juliandunn 
