### PR TITLE
chef-shell checks platform when looking for client.rb and solo.rb.

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -308,9 +308,17 @@ FOOTER
       elsif ENV['HOME'] && ::File.exist?(File.join(ENV['HOME'], '.chef', 'chef_shell.rb'))
         File.join(ENV['HOME'], '.chef', 'chef_shell.rb')
       elsif config[:solo]
-        "/etc/chef/solo.rb"
+        if Chef::Platform.windows?
+          "C:\\chef\\solo.rb"
+        else
+          "/etc/chef/solo.rb"
+        end
       elsif config[:client]
-        "/etc/chef/client.rb"
+        if Chef::Platform.windows?
+          "C:\\chef\\client.rb"
+        else
+          "/etc/chef/client.rb"
+        end
       else
         nil
       end


### PR DESCRIPTION
https://github.com/opscode/chef/issues/2380 pointed out that on
windows, -c is required with the -z flag because it would assume
nix and look in /etc/chef for client.rb
