### PR TITLE
Fix rubygems provider to use https instead of http.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ Contributions go through a review process to improve code quality and avoid regr
 Our primary shipping vehicle is operating system specific packages that includes
   all the requirements of Chef. We call these [Omnibus packages](https://github.com/opscode/omnibus-ruby)
 
-We also release our software as gems to [Rubygems](http://rubygems.org/) but we strongly
+We also release our software as gems to [Rubygems](https://rubygems.org/) but we strongly
   recommend using Chef packages since they are the only combination of native libraries &
   gems required by Chef that we test throughly.
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -534,7 +534,7 @@ class Chef
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
           else
-            src = @new_resource.source && "  --source=#{@new_resource.source} --source=http://rubygems.org"
+            src = @new_resource.source && "  --source=#{@new_resource.source} --source=https://rubygems.org"
           end
           if version
             shell_out!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -90,7 +90,7 @@ describe Chef::Provider::Package::Rubygems::CurrentGemEnvironment do
     dep = Gem::Dependency.new('rspec', '>= 0')
     dep_installer = Gem::DependencyInstaller.new
     allow(@gem_env).to receive(:dependency_installer).and_return(dep_installer)
-    latest = [[gemspec("rspec", Gem::Version.new("1.3.0")), "http://rubygems.org/"]]
+    latest = [[gemspec("rspec", Gem::Version.new("1.3.0")), "https://rubygems.org/"]]
     expect(dep_installer).to receive(:find_gems_with_sources).with(dep).and_return(latest)
     expect(@gem_env.candidate_version_from_remote(Gem::Dependency.new('rspec', '>= 0'))).to eq(Gem::Version.new('1.3.0'))
   end
@@ -156,7 +156,7 @@ describe Chef::Provider::Package::Rubygems::CurrentGemEnvironment do
 
   it "finds a matching gem from a specific gemserver when explicit sources are given" do
     dep = Gem::Dependency.new('rspec', '>= 0')
-    latest = [[gemspec("rspec", Gem::Version.new("1.3.0")), "http://rubygems.org/"]]
+    latest = [[gemspec("rspec", Gem::Version.new("1.3.0")), "https://rubygems.org/"]]
 
     expect(@gem_env).to receive(:with_gem_sources).with('http://gems.example.com').and_yield
     dep_installer = Gem::DependencyInstaller.new
@@ -291,9 +291,9 @@ RubyGems Environment:
      - "install" => "--env-shebang"
      - "update" => "--env-shebang"
      - "gem" => "--no-rdoc --no-ri"
-     - :sources => ["http://rubygems.org/", "http://gems.github.com/"]
+     - :sources => ["https://rubygems.org/", "http://gems.github.com/"]
   - REMOTE SOURCES:
-     - http://rubygems.org/
+     - https://rubygems.org/
      - http://gems.github.com/
 JRUBY_GEM_ENV
     expect(@gem_env).to receive(:shell_out!).with('/usr/weird/bin/gem env').and_return(double('jruby_gem_env', :stdout => gem_env_out))
@@ -332,10 +332,10 @@ RubyGems Environment:
      - :benchmark => false
      - :backtrace => false
      - :bulk_threshold => 1000
-     - :sources => ["http://rubygems.org/", "http://gems.github.com/"]
+     - :sources => ["https://rubygems.org/", "http://gems.github.com/"]
      - "gem" => "--no-rdoc --no-ri"
   - REMOTE SOURCES:
-     - http://rubygems.org/
+     - https://rubygems.org/
      - http://gems.github.com/
 RBX_GEM_ENV
     expect(@gem_env).to receive(:shell_out!).with('/usr/weird/bin/gem env').and_return(double('rbx_gem_env', :stdout => gem_env_out))


### PR DESCRIPTION
### Version:

All
### Environment:

Any that utilizes chef_gems from rubygems.org
### Scenario:

Installing any chef_gem results in a message from rubygems that http access is deprecated and should not be used.
### Steps to Reproduce:

Install a chef_gem and observe the provider output.
### Expected Result:

It should install with no warning from rubygems.
### Actual Result:

Rubygems states that http access is deprecated and all connections should use https.
