### PR TITLE
cleanup cookbook path from stale files

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -191,6 +191,8 @@ class Chef::Application::Solo < Chef::Application
       cookbooks_path = Array(Chef::Config[:cookbook_path]).detect{|e| e =~ /\/cookbooks\/*$/ }
       recipes_path = File.expand_path(File.join(cookbooks_path, '..'))
 
+      Chef::Log.debug "Cleanup path #{recipes_path} before extract recipes into it"
+      FileUtils.rm_rf(recipes_path, :secure => true)
       Chef::Log.debug "Creating path #{recipes_path} to extract recipes into"
       FileUtils.mkdir_p(recipes_path)
       tarball_path = File.join(recipes_path, 'recipes.tgz')

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -94,6 +94,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       before do
         Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
         Chef::Config[:recipe_url] = "http://junglist.gen.nz/recipes.tgz"
+        allow(FileUtils).to receive(:rm_rf).and_return(true)
         allow(FileUtils).to receive(:mkdir_p).and_return(true)
         @tarfile = StringIO.new("remote_tarball_content")
         allow(@app).to receive(:open).with("http://junglist.gen.nz/recipes.tgz").and_yield(@tarfile)
@@ -135,6 +136,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       Chef::Config[:json_attribs] = json_source
       Chef::Config[:recipe_url] = "http://icanhas.cheezburger.com/lolcats"
       Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
+      allow(FileUtils).to receive(:rm_rf).and_return(true)
       allow(FileUtils).to receive(:mkdir_p).and_return(true)
       allow(Chef::Mixin::Command).to receive(:run_command).and_return(true)
     end


### PR DESCRIPTION
Sometimes recipes have library/resources/providers.
Without this patch, chef preserve old files that automatic included
and can bring unpredictable errors.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
