### PR TITLE
Issue 2391 - Check cookbooks exist in path(s) before attempting to upload them with --all

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -118,7 +118,8 @@ class Chef
             end
             ui.info("Uploaded all cookbooks.")
           else
-            ui.warn('Could not find any cookbooks in your cookbook path. Use --cookbook-path to specify the desired path.')
+            cookbook_path = config[:cookbook_path].respond_to?(:join) ? config[:cookbook_path].join(', ') : config[:cookbook_path]
+            ui.warn("Could not find any cookbooks in your cookbook path: #{cookbook_path}. Use --cookbook-path to specify the desired path.")
           end
         else
           if @name_args.empty?

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -110,12 +110,16 @@ class Chef
             cookbook.freeze_version if config[:freeze]
             version_constraints_to_update[cookbook_name] = cookbook.version
           end
-          begin
-            upload(cbs, justify_width)
-          rescue Exceptions::CookbookFrozen
-            ui.warn("Not updating version constraints for some cookbooks in the environment as the cookbook is frozen.")
+          if cbs.any?
+            begin
+              upload(cbs, justify_width)
+            rescue Exceptions::CookbookFrozen
+              ui.warn("Not updating version constraints for some cookbooks in the environment as the cookbook is frozen.")
+            end
+            ui.info("Uploaded all cookbooks.")
+          else
+            ui.warn('Could not find any cookbooks in your cookbook path. Use --cookbook-path to specify the desired path.')
           end
-          ui.info("Uploaded all cookbooks.")
         else
           if @name_args.empty?
             show_usage
@@ -204,7 +208,7 @@ class Chef
         # because cookbooks are lazy-loaded, we have to force the loader
         # to load the cookbooks the user intends to upload here:
         cookbooks_to_upload
-        
+
         unless cookbook_repo.merged_cookbooks.empty?
           ui.warn "* " * 40
           ui.warn(<<-WARNING)

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -104,15 +104,15 @@ class Chef
         justify_width = @server_side_cookbooks.map {|name| name.size}.max.to_i + 2
         if config[:all]
           cookbook_repo.load_cookbooks
-          cbs = []
+          cookbooks_for_upload = []
           cookbook_repo.each do |cookbook_name, cookbook|
-            cbs << cookbook
+            cookbooks_for_upload << cookbook
             cookbook.freeze_version if config[:freeze]
             version_constraints_to_update[cookbook_name] = cookbook.version
           end
-          if cbs.any?
+          if cookbooks_for_upload.any?
             begin
-              upload(cbs, justify_width)
+              upload(cookbooks_for_upload, justify_width)
             rescue Exceptions::CookbookFrozen
               ui.warn("Not updating version constraints for some cookbooks in the environment as the cookbook is frozen.")
             end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -286,7 +286,6 @@ E
         end
 
         it 'should warn users that no cookbooks exist' do
-          expect(knife).to_not receive(:upload)
           expect(knife.ui).to receive(:warn).with(/Could not find any cookbooks in your cookbook path\. Use --cookbook-path to specify the desired path\./)
           knife.run
         end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -285,9 +285,22 @@ E
           knife.run
         end
 
-        it 'should warn users that no cookbooks exist' do
-          expect(knife.ui).to receive(:warn).with(/Could not find any cookbooks in your cookbook path\. Use --cookbook-path to specify the desired path\./)
-          knife.run
+        context 'when cookbook path is an array' do
+          it 'should warn users that no cookbooks exist' do
+            knife.config[:cookbook_path] = ['/chef-repo/cookbooks', '/home/user/cookbooks']
+            expect(knife.ui).to receive(:warn).with(
+              /Could not find any cookbooks in your cookbook path: #{knife.config[:cookbook_path].join(', ')}\. Use --cookbook-path to specify the desired path\./)
+            knife.run
+          end
+        end
+
+        context 'when cookbook path is a string' do
+          it 'should warn users that no cookbooks exist' do
+            knife.config[:cookbook_path] = '/chef-repo/cookbooks'
+            expect(knife.ui).to receive(:warn).with(
+              /Could not find any cookbooks in your cookbook path: #{knife.config[:cookbook_path]}\. Use --cookbook-path to specify the desired path\./)
+            knife.run
+          end
         end
       end
     end


### PR DESCRIPTION
Made this change in response to #2391

* Added a check to make sure cookbooks exist in the path(s) before attempting to upload them all
* Added warning if no cookbooks exist
* Added tests for new logic