### PR TITLE
Add --proxy-auth option to `knife raw`

### DIFF
--- a/spec/unit/knife/raw_spec.rb
+++ b/spec/unit/knife/raw_spec.rb
@@ -18,21 +18,26 @@
 require 'spec_helper'
 
 describe Chef::Knife::Raw do
-  before(:each) do
-    @rest = double('Chef::Knife::Raw::RawInputServerAPI')
-    allow(Chef::Knife::Raw::RawInputServerAPI).to receive(:new).and_return(@rest)
-    @knife = Chef::Knife::Raw.new
-    @knife.config[:method] = "GET"
-    @knife.name_args = [ "/nodes" ]
+  let(:rest) do
+    r = double('Chef::Knife::Raw::RawInputServerAPI')
+    allow(Chef::Knife::Raw::RawInputServerAPI).to receive(:new).and_return(r)
+    r
+  end
+
+  let(:knife) do
+    k = Chef::Knife::Raw.new
+    k.config[:method] = "GET"
+    k.name_args = [ "/nodes" ]
+    k
   end
 
   describe "run" do
     it "should set the x-ops-request-source header when --proxy-auth is set" do
-      @knife.config[:proxy_auth] = true
-      expect(@rest).to receive(:request).with(:GET, "/nodes",
+      knife.config[:proxy_auth] = true
+      expect(rest).to receive(:request).with(:GET, "/nodes",
                                               { 'Content-Type' => 'application/json',
                                                 'x-ops-request-source' => 'web'}, false)
-      @knife.run
+      knife.run
     end
   end
 end

--- a/spec/unit/knife/raw_spec.rb
+++ b/spec/unit/knife/raw_spec.rb
@@ -1,0 +1,38 @@
+#
+# Author:: Steven Danna (<steve@getchef.com>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe Chef::Knife::Raw do
+  before(:each) do
+    @rest = double('Chef::Knife::Raw::RawInputServerAPI')
+    allow(Chef::Knife::Raw::RawInputServerAPI).to receive(:new).and_return(@rest)
+    @knife = Chef::Knife::Raw.new
+    @knife.config[:method] = "GET"
+    @knife.name_args = [ "/nodes" ]
+  end
+
+  describe "run" do
+    it "should set the x-ops-request-source header when --proxy-auth is set" do
+      @knife.config[:proxy_auth] = true
+      expect(@rest).to receive(:request).with(:GET, "/nodes",
+                                              { 'Content-Type' => 'application/json',
+                                                'x-ops-request-source' => 'web'}, false)
+      @knife.run
+    end
+  end
+end


### PR DESCRIPTION
Chef Server 12 and Enterprise Chef Server allow requests made on
behalf of other users by setting the x-ops-request-source HTTP header
to web and signing the request with a particular key (often known as
the "webui key").

This scheme allows the management console to make requests to the API
on behalf of the logged in user.  However, it is also useful for
administrators attempting to debug their Chef Servers or helping their
users in large Chef Server installations.

For example, using the webui_key and this option, an adminstrator can
list nodes in different orgs, without access to a particular user's
key.

    > knife raw /organizations/wonderbolts/nodes -k webui_priv.pem \
      -u soarin -s https://api.opscode.piab --proxy-auth

    {

    }

    > knife raw /organizations/acme/nodes -k webui_priv.pem
      -u wei -s https://api.opscode.piab --proxy-auth

    {

    }

The webui key exists on the Chef Server itself and is only accessible
to an administrator with root access.  As such, this is typically an
advanced debugging tool and isn't likely needed in other knife
subcommands.