### PR TITLE
skip expensive spec tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,15 @@ branches:
   - 11-stable
   - 12-stable
 
-script: bundle exec rspec --color --format progress
+# do not run expensive spec tests on PRs, only on branches
+script: "
+echo '--color\n-fp' > .rspec;
+if [ ${TRAVIS_PULL_REQUEST} = 'false' ];
+then
+  bundle exec rake spec:all;
+else
+  bundle exec rake spec;
+fi"
 
 env:
   global:


### PR DESCRIPTION
- `rake spec` skips knife integration tests
- `rake spec:all` includes them
- PRs only get `rake spec`
- master (and 10/11/12-stable) get `rake spec:all`
- `rspec` and `rspec spec` are still essentially `rake spec:all`
