### PR TITLE
Update `dpkg` provider to remove `DPKG_INFO` regular expression and let `dpkg-dep` handle package name.

### DIFF
--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -26,7 +26,7 @@ class Chef
     class Package
       class Dpkg < Chef::Provider::Package
         # http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
-        DPKG_INFO = /([a-z\d\-\+\.]+)\t([\w\d.~:-]+)/
+        DPKG_INFO = /([a-z\d\-\+\.]+)\t([\w\d\.\+\-:~]+)/
         DPKG_INSTALLED = /^Status: install ok installed/
         DPKG_VERSION = /^Version: (.+)$/
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -85,6 +85,13 @@ describe Chef::Provider::Package::Dpkg do
       expect(@provider.current_resource.package_name).to eq("f.o.o-pkg++2")
     end
 
+    it "gets the source package version from dpkg-deb correctly when the package version has `~', `-', `+' or `.' characters" do
+      @stdout = StringIO.new("b.a.r-pkg++1\t1.2.3+3141592-1ubuntu1~lucid")
+      allow(@provider).to receive(:popen4).and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @provider.load_current_resource
+      expect(@provider.new_resource.version).to eq('1.2.3+3141592-1ubuntu1~lucid')
+    end
+
     it "should raise an exception if the source is not set but we are installing" do
       @new_resource = Chef::Resource::Package.new("wget")
       @provider.new_resource = @new_resource


### PR DESCRIPTION
This is as per the "Debian Policy Manual, Chapter 5 - Control files and their fields", see:

  https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version

Fixes #2417.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>