### PR TITLE
Fix installer_version_string to be an array on prerelease parameter.

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -135,7 +135,7 @@ CONFIG
         def latest_current_chef_version_string
           installer_version_string = nil
           if @config[:prerelease]
-            installer_version_string = "-p"
+            installer_version_string = ["-p"]
           else
             chef_version_string = if knife_config[:bootstrap_version]
               knife_config[:bootstrap_version]

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -205,4 +205,18 @@ EXPECTED
     end
   end
 
+  describe "prerelease" do
+    it "isn't set in the config_content by default" do
+      expect(bootstrap_context.config_content).not_to include("prerelease")
+    end
+
+    describe "when configured via cli" do
+      let(:config) {{:prerelease => true}}
+
+      it "uses CLI value" do
+        expect(bootstrap_context.latest_current_chef_version_string).to eq("-p")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
I hit this problem when I was trying to provision some new servers with Chef 12. Whenever I used --prerelease or knife[:prerelease] I would get the following:

```
>> knife bootstrap chef-network -x ubuntu -N chef-network --sudo
Connecting to chef-network
ERROR: knife encountered an unexpected error
This may be a bug in the 'bootstrap' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `join' for "-p":String
```

I was not too familiar with the code, but after some digging, and editing files. I realized the simple fix. When prerelease is set, you set the installer_version_string to a string, but then after the if/else you try to join it. Since its not an array, it fails. I changed it to an array, much like how you have it in the else block for other things.

After making the change, everything works.

Its a super simple fix, but I wasn't sure if this was an "obvious fix" so I didn't mark it as such.
