### PR TITLE
Revert rubygems 2.2.0 with bundler 1.5 with Ruby 1.8.7 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Early warning system to catch if Rubygems breaks something
+before_install:
+  gem update --system
+
 branches:
   only:
   - master


### PR DESCRIPTION
Bug has been fixed plus we don't care about Ruby 1.8.7 now.
