### PR TITLE
Add privacy flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [**Renan Vicente**](https://github.com/renanvicente):
   [pr#3771](https://github.com/chef/chef/pull/3771) add depth property for deploy resource
 
+* [pr#2460](https://github.com/chef/chef/pull/2460) add privacy flag
 * [pr#1259](https://github.com/chef/chef/pull/1259) CHEF-5012: add methods for template breadcrumbs
 * [pr#3656](https://github.com/chef/chef/pull/3656) remove use of self.provides?
 * [pr#3455](https://github.com/chef/chef/pull/3455) powershell\_script: do not allow suppression of syntax errors

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -54,12 +54,13 @@ class Chef
       VERSION                = 'version'.freeze
       SOURCE_URL             = 'source_url'.freeze
       ISSUES_URL             = 'issues_url'.freeze
+      PRIVACY                = 'privacy'.freeze
 
       COMPARISON_FIELDS = [ :name, :description, :long_description, :maintainer,
                             :maintainer_email, :license, :platforms, :dependencies,
                             :recommendations, :suggestions, :conflicting, :providing,
                             :replacing, :attributes, :groupings, :recipes, :version,
-                            :source_url, :issues_url ]
+                            :source_url, :issues_url, :privacy ]
 
       VERSION_CONSTRAINTS = {:depends     => DEPENDENCIES,
                              :recommends  => RECOMMENDATIONS,
@@ -116,6 +117,7 @@ class Chef
         @version = Version.new("0.0.0")
         @source_url = ''
         @issues_url = ''
+        @privacy = false
 
         @errors = []
       end
@@ -454,7 +456,8 @@ class Chef
             :recipes => { :kind_of => [ Array ], :default => [] },
             :default => { :kind_of => [ String, Array, Hash, Symbol, Numeric, TrueClass, FalseClass ] },
             :source_url => { :kind_of => String },
-            :issues_url => { :kind_of => String }
+            :issues_url => { :kind_of => String },
+            :privacy => { :kind_of => [ TrueClass, FalseClass ] }
           }
         )
         options[:required] = remap_required_attribute(options[:required]) unless options[:required].nil?
@@ -498,7 +501,8 @@ class Chef
           RECIPES                => self.recipes,
           VERSION                => self.version,
           SOURCE_URL             => self.source_url,
-          ISSUES_URL             => self.issues_url
+          ISSUES_URL             => self.issues_url,
+          PRIVACY                => self.privacy
         }
       end
 
@@ -532,6 +536,7 @@ class Chef
         @version                      = o[VERSION] if o.has_key?(VERSION)
         @source_url                   = o[SOURCE_URL] if o.has_key?(SOURCE_URL)
         @issues_url                   = o[ISSUES_URL] if o.has_key?(ISSUES_URL)
+        @privacy                      = o[PRIVACY] if o.has_key?(PRIVACY)
         self
       end
 
@@ -587,6 +592,23 @@ class Chef
           :issues_url,
           arg,
           :kind_of => [ String ]
+        )
+      end
+
+      #
+      # Sets the cookbook's privacy flag, or returns it.
+      #
+      # === Parameters
+      # privacy<TrueClass,FalseClass>:: Whether this cookbook is private or not
+      #
+      # === Returns
+      # privacy<TrueClass,FalseClass>:: Whether this cookbook is private or not
+      #
+      def privacy(arg=nil)
+        set_or_return(
+          :privacy,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Cookbook::Metadata do
                   :maintainer_email, :license, :platforms, :dependencies,
                   :recommendations, :suggestions, :conflicting, :providing,
                   :replacing, :attributes, :groupings, :recipes, :version,
-                  :source_url, :issues_url ]
+                  :source_url, :issues_url, :privacy ]
     end
 
     it "does not depend on object identity for equality" do
@@ -148,6 +148,10 @@ describe Chef::Cookbook::Metadata do
     it "has an empty issues_url string" do
       expect(metadata.issues_url).to eq('')
     end
+
+    it "is not private" do
+      expect(metadata.privacy).to eq(false)
+    end
   end
 
   describe "validation" do
@@ -198,7 +202,8 @@ describe Chef::Cookbook::Metadata do
       :long_description => "Much Longer\nSeriously",
       :version => "0.6.0",
       :source_url => "http://example.com",
-      :issues_url => "http://example.com/issues"
+      :issues_url => "http://example.com/issues",
+      :privacy => true
     }
     params.sort { |a,b| a.to_s <=> b.to_s }.each do |field, field_value|
       describe field do
@@ -360,7 +365,8 @@ describe Chef::Cookbook::Metadata do
         "recipes" => [ "mysql::server", "mysql::master" ],
         "default" => [ ],
         "source_url" => "http://example.com",
-        "issues_url" => "http://example.com/issues"
+        "issues_url" => "http://example.com/issues",
+        "privacy" => true
       }
       expect(metadata.attribute("/db/mysql/databases", attrs)).to eq(attrs)
     end
@@ -398,6 +404,18 @@ describe Chef::Cookbook::Metadata do
       }.not_to raise_error
       expect {
         metadata.attribute("db/mysql/databases", :issues_url => Hash.new)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "should not accept anything but true or false for the privacy flag" do
+      expect {
+        metadata.attribute("db/mysql/databases", :privacy => true)
+      }.not_to raise_error
+      expect {
+        metadata.attribute("db/mysql/databases", :privacy => false)
+      }.not_to raise_error
+      expect {
+        metadata.attribute("db/mysql/databases", :privacy => 'true')
       }.to raise_error(ArgumentError)
     end
 
@@ -699,6 +717,7 @@ describe Chef::Cookbook::Metadata do
         version
         source_url
         issues_url
+        privacy
       }.each do |t|
         it "should include '#{t}'" do
           expect(deserialized_metadata[t]).to eq(metadata.send(t.to_sym))
@@ -734,6 +753,7 @@ describe Chef::Cookbook::Metadata do
         version
         source_url
         issues_url
+        privacy
       }.each do |t|
         it "should match '#{t}'" do
           expect(deserialized_metadata.send(t.to_sym)).to eq(metadata.send(t.to_sym))


### PR DESCRIPTION
This adds a `privacy` flag to `metadata.rb` which will mark a cookbook as private (or not).  If you try to upload a cookbook marked private to Supermarket, and Supermarket is configured to enforce privacy, then the upload will fail.

Here is the original issue this was spawned from:  https://github.com/opscode/supermarket/issues/832
Here is the matching PR to Supermarket itself:  https://github.com/opscode/supermarket/pull/912

I tested this by doing `knife cookbook upload` of a cookbook with the `privacy` attribute set to true, against Chef Server 12.2.0.dev.0 running in a local VM and it succeeded.

Is there any further testing I should do or anything I've overlooked here?