### PR TITLE
suppress locale -a warnings on windows

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -632,7 +632,7 @@ class Chef
       #
       # For example, on CentOS 6 with ENV['LANG'] = "en_US.UTF-8",
       # `locale -a`.split fails with ArgumentError invalid UTF-8 encoding.
-      locales = shell_out_with_systems_locale("locale -a").stdout.split
+      locales = shell_out_with_systems_locale!("locale -a").stdout.split
       case
       when locales.include?('C.UTF-8')
         'C.UTF-8'

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -426,7 +426,7 @@ describe Chef::Config do
         let(:locales) { locale_array.join("\n") }
 
         before do
-          allow(Chef::Config).to receive(:shell_out_with_systems_locale).with("locale -a").and_return(shell_out)
+          allow(Chef::Config).to receive(:shell_out_with_systems_locale!).with("locale -a").and_return(shell_out)
         end
 
         shared_examples_for "a suitable locale" do
@@ -493,7 +493,7 @@ describe Chef::Config do
           let(:locale_array) { [] }
 
           before do
-            allow(Chef::Config).to receive(:shell_out_with_systems_locale).and_raise("THIS IS AN ERROR")
+            allow(Chef::Config).to receive(:shell_out_with_systems_locale!).and_raise("THIS IS AN ERROR")
           end
 
           it "should default to 'en_US.UTF-8'" do


### PR DESCRIPTION
need the '!' to throw exceptions, or else the rescue clause is
never run.
