### PR TITLE
Remove some simple Ruby 1.8 and 1.9 code

### DIFF
--- a/lib/chef/event_dispatch/dispatcher.rb
+++ b/lib/chef/event_dispatch/dispatcher.rb
@@ -25,11 +25,9 @@ class Chef
 
       # Define a method that will be forwarded to all
       def self.def_forwarding_method(method_name)
-        class_eval(<<-END_OF_METHOD, __FILE__, __LINE__)
-          def #{method_name}(*args)
-            @subscribers.each {|s| s.#{method_name}(*args)}
-          end
-        END_OF_METHOD
+        define_method(method_name) do |*args|
+          @subscribers.each { |s| s.send(method_name, *args) }
+        end
       end
 
       (Base.instance_methods - Object.instance_methods).each do |method_name|

--- a/lib/chef/mixin/command/windows.rb
+++ b/lib/chef/mixin/command/windows.rb
@@ -18,11 +18,7 @@
 # limitations under the License.
 #
 
-if RUBY_VERSION =~ /^1\.8/
-  require 'win32/open3'
-else
-  require 'open3'
-end
+require 'open3'
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -111,10 +111,7 @@ class Chef
 
           # equivalent to something like:
           # def rights(permissions=nil, principals=nil, args_hash=nil)
-          define_method(name) do |*args|
-            raise ArgumentError.new("wrong number of arguments (#{args.length} for 3)") if args.length >= 4
-            permissions, principals, args_hash = args
-
+          define_method(name) do |permissions=nil, principals=nil, args_hash=nil|
             rights = self.instance_variable_get("@#{name.to_s}".to_sym)
             unless permissions.nil?
               input = {

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -112,11 +112,8 @@ class Chef
           # equivalent to something like:
           # def rights(permissions=nil, principals=nil, args_hash=nil)
           define_method(name) do |*args|
-            # Ruby 1.8 compat: default the arguments
-            permissions = args.length >= 1 ? args[0] : nil
-            principals = args.length >= 2 ? args[1] : nil
-            args_hash = args.length >= 3 ? args[2] : nil
             raise ArgumentError.new("wrong number of arguments (#{args.length} for 3)") if args.length >= 4
+            permissions, principals, args_hash = args
 
             rights = self.instance_variable_get("@#{name.to_s}".to_sym)
             unless permissions.nil?

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -23,18 +23,6 @@ class Chef
   module Mixin
     module Template
 
-      # A compatibility wrapper around IO.binread so it works on Ruby 1.8.7.
-      # --
-      # Used in the TemplateContext class, but that method namespace is shared
-      # with user code, so we want to avoid adding methods there when possible.
-      def self.binread(file)
-        if IO.respond_to?(:binread)
-          IO.binread(file)
-        else
-          File.open(file, "rb") {|f| f.read }
-        end
-      end
-
       # == ChefContext
       # ChefContext was previously used to mix behavior into Erubis::Context so
       # that it would be available to templates. This behavior has now moved to
@@ -105,11 +93,11 @@ class Chef
           partial_context._extend_modules(@_extension_modules)
 
           template_location = @template_finder.find(partial_name, options)
-          _render_template(Mixin::Template.binread(template_location), partial_context)
+          _render_template(IO.binread(template_location), partial_context)
         end
 
         def render_template(template_location)
-          _render_template(Mixin::Template.binread(template_location), self)
+          _render_template(IO.binread(template_location), self)
         end
 
         def render_template_from_string(template)

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -138,11 +138,9 @@ class Chef
        :values,
        :values_at,
        :zip].each do |delegated_method|
-         class_eval(<<-METHOD_DEFN)
-            def #{delegated_method}(*args, &block)
-              merged_attributes.send(:#{delegated_method}, *args, &block)
-            end
-         METHOD_DEFN
+         define_method(delegated_method) do |*args, &block|
+           merged_attributes.send(delegated_method, *args, &block)
+         end
        end
 
        # return the cookbook level default attribute component

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -61,12 +61,10 @@ class Chef
       # also invalidate the cached merged_attributes on the root
       # Node::Attribute object.
       MUTATOR_METHODS.each do |mutator|
-        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
-          def #{mutator}(*args, &block)
-            root.reset_cache(root.top_level_breadcrumb)
-            super
-          end
-        METHOD_DEFN
+        define_method(mutator) do |*args, &block|
+          root.reset_cache(root.top_level_breadcrumb)
+          super(*args, &block)
+        end
       end
 
       attr_reader :root
@@ -126,12 +124,10 @@ class Chef
       # also invalidate the cached `merged_attributes` on the root Attribute
       # object.
       MUTATOR_METHODS.each do |mutator|
-        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
-          def #{mutator}(*args, &block)
-            root.reset_cache(root.top_level_breadcrumb)
-            super
-          end
-        METHOD_DEFN
+        define_method(mutator) do |*args, &block|
+          root.reset_cache(root.top_level_breadcrumb)
+          super(*args, &block)
+        end
       end
 
       def initialize(root, data={})

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -75,12 +75,9 @@ class Chef
       # Redefine all of the methods that mutate a Hash to raise an error when called.
       # This is the magic that makes this object "Immutable"
       DISALLOWED_MUTATOR_METHODS.each do |mutator_method_name|
-        # Ruby 1.8 blocks can't have block arguments, so we must use string eval:
-        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
-          def #{mutator_method_name}(*args, &block)
-            raise Exceptions::ImmutableAttributeModification
-          end
-        METHOD_DEFN
+        define_method(mutator_method_name) do |*args, &block|
+          raise Exceptions::ImmutableAttributeModification
+        end
       end
 
       # For elements like Fixnums, true, nil...
@@ -164,12 +161,9 @@ class Chef
       # Redefine all of the methods that mutate a Hash to raise an error when called.
       # This is the magic that makes this object "Immutable"
       DISALLOWED_MUTATOR_METHODS.each do |mutator_method_name|
-        # Ruby 1.8 blocks can't have block arguments, so we must use string eval:
-        class_eval(<<-METHOD_DEFN, __FILE__, __LINE__)
-        def #{mutator_method_name}(*args, &block)
+        define_method(mutator_method_name) do |*args, &block|
           raise Exceptions::ImmutableAttributeModification
         end
-        METHOD_DEFN
       end
 
       def method_missing(symbol, *args)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -137,14 +137,8 @@ F
     extend Chef::Mixin::ConvertToClassName
     extend Chef::Mixin::DescendantsTracker
 
-    if Module.method(:const_defined?).arity == 1
-      def self.strict_const_defined?(const)
-        const_defined?(const)
-      end
-    else
-      def self.strict_const_defined?(const)
-        const_defined?(const, false)
-      end
+    def self.strict_const_defined?(const)
+      const_defined?(const, false)
     end
 
     class << self

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -73,17 +73,9 @@ class Chef
       # Define an attribute on this resource, including optional validation
       # parameters.
       def self.attribute(attr_name, validation_opts={})
-        # Ruby 1.8 doesn't support default arguments to blocks, but we have to
-        # use define_method with a block to capture +validation_opts+.
-        # Workaround this by defining two methods :(
-        class_eval(<<-SHIM, __FILE__, __LINE__)
-          def #{attr_name}(arg=nil)
-            _set_or_return_#{attr_name}(arg)
-          end
-        SHIM
-
-        define_method("_set_or_return_#{attr_name.to_s}".to_sym) do |arg|
-          set_or_return(attr_name.to_sym, arg, validation_opts)
+        define_method(attr_name) do |*args|
+          raise ArgumentError.new("wrong number of arguments (#{args.length} for 1)") if args.length > 1
+          set_or_return(attr_name.to_sym, args.first, validation_opts)
         end
       end
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -73,9 +73,8 @@ class Chef
       # Define an attribute on this resource, including optional validation
       # parameters.
       def self.attribute(attr_name, validation_opts={})
-        define_method(attr_name) do |*args|
-          raise ArgumentError.new("wrong number of arguments (#{args.length} for 0 or 1)") if args.length > 1
-          set_or_return(attr_name.to_sym, args.first, validation_opts)
+        define_method(attr_name) do |arg=nil|
+          set_or_return(attr_name.to_sym, arg, validation_opts)
         end
       end
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -74,7 +74,7 @@ class Chef
       # parameters.
       def self.attribute(attr_name, validation_opts={})
         define_method(attr_name) do |*args|
-          raise ArgumentError.new("wrong number of arguments (#{args.length} for 1)") if args.length > 1
+          raise ArgumentError.new("wrong number of arguments (#{args.length} for 0 or 1)") if args.length > 1
           set_or_return(attr_name.to_sym, args.first, validation_opts)
         end
       end

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -102,9 +102,8 @@ class Chef
       #
       # ==== Method Arguments:
       # Helper methods can also take arguments. The syntax available for
-      # argument specification will be dependent on ruby version. Ruby 1.8 only
-      # supports a subset of the argument specification syntax available for
-      # method definition, whereas 1.9 supports the full syntax.
+      # argument specification supports full syntax available for method
+      # definition.
       #
       # Continuing the above example of simplifying attribute access, we can
       # define a helper to look up app-specific attributes like this:

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -194,7 +194,7 @@ ERROR_MESSAGE
     end
 
     # An Array of all recipes that have been loaded. This is stored internally
-    # as a Hash, so ordering is preserved.
+    # as a Hash, so ordering is predictable.
     #
     # Recipe names are given in fully qualified form, e.g., the recipe "nginx"
     # will be given as "nginx::default"
@@ -205,7 +205,7 @@ ERROR_MESSAGE
     end
 
     # An Array of all attributes files that have been loaded. Stored internally
-    # using a Hash, so order is preserved.
+    # using a Hash, so order is predictable.
     #
     # Attribute file names are given in fully qualified form, e.g.,
     # "nginx::default" instead of "nginx".

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -194,7 +194,7 @@ ERROR_MESSAGE
     end
 
     # An Array of all recipes that have been loaded. This is stored internally
-    # as a Hash, so ordering is not preserved when using ruby 1.8.
+    # as a Hash, so ordering is preserved.
     #
     # Recipe names are given in fully qualified form, e.g., the recipe "nginx"
     # will be given as "nginx::default"
@@ -205,7 +205,7 @@ ERROR_MESSAGE
     end
 
     # An Array of all attributes files that have been loaded. Stored internally
-    # using a Hash, so order is not preserved on ruby 1.8.
+    # using a Hash, so order is preserved.
     #
     # Attribute file names are given in fully qualified form, e.g.,
     # "nginx::default" instead of "nginx".

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -132,8 +132,7 @@ class Chef
 
       # new search api that allows for a cleaner implementation of things like return filters
       # (formerly known as 'partial search').
-      # Also args should never be nil, but that is required for Ruby 1.8 compatibility
-      def do_search(type, query="*:*", args=nil, &block)
+      def do_search(type, query="*:*", args, &block)
         query_string = create_query_string(type, query, args)
         response = call_rest_service(query_string, args)
         unless block.nil?

--- a/lib/chef/util/path_helper.rb
+++ b/lib/chef/util/path_helper.rb
@@ -101,9 +101,6 @@ class Chef
 
       # Produces a comparable path.
       def self.canonical_path(path, add_prefix=true)
-        # Rather than find an equivalent for File.absolute_path on 1.8.7, just bail out
-        raise NotImplementedError, "This feature is not supported on Ruby versions < 1.9" if RUBY_VERSION.to_f < 1.9
-
         # First remove extra separators and resolve any relative paths
         abs_path = File.absolute_path(path)
 

--- a/spec/functional/file_content_management/deploy_strategies_spec.rb
+++ b/spec/functional/file_content_management/deploy_strategies_spec.rb
@@ -20,15 +20,6 @@ require 'spec_helper'
 
 shared_examples_for "a content deploy strategy" do
 
-  # Ruby 1.8 has no binread
-  def binread(file)
-    if IO.respond_to?(:binread)
-      IO.binread(file)
-    else
-      IO.read(file)
-    end
-  end
-
   def normalize_mode(mode_int)
     ( mode_int & 07777).to_s(8)
   end
@@ -160,7 +151,7 @@ shared_examples_for "a content deploy strategy" do
 
     it "updates the target with content from staged" do
       content_deployer.deploy(staging_file_path, target_file_path)
-      expect(binread(target_file_path)).to eq(staging_file_content)
+      expect(IO.binread(target_file_path)).to eq(staging_file_content)
     end
 
     context "when the owner of the target file is not the owner of the staging file", :requires_root do


### PR DESCRIPTION
I think these are the safest to remove from `lib/`:

* Remove `IO::binread` implementations.
* Use `#define_method` instead of `#class_eval` to create methods.
* Remove `RUBY_VERSION < 2` comparisons.
* Not needed code related with method args default values.
* Some comments updated.

Some parts from #2497 are fixed with this:
> * [x] lib/chef/mixin/securable.rb#L115-L119
> * [x] lib/chef/mixin/template.rb#L26-L36
> * [x] lib/chef/node/immutable_collections.rb#L78-L83
> * [x] lib/chef/resource/lwrp_base.rb#L76-L87
> * [x] lib/chef/resource/template.rb#L105-L107
> * [x] lib/chef/run_context.rb#L197-L208
> * [x] lib/chef/search/query.rb#L135-L136
> * [x] lib/chef/util/path_helper.rb#L104-L106
> * [x] lib/chef/mixin/command/windows.rb:21

I hope I have not broken anything :pray: