### PR TITLE
Fix. Make sure that scheme part of the URI is treated in a case-insensit...

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -203,7 +203,7 @@ class Chef
 
     def create_url(path)
       return path if path.is_a?(URI)
-      if path =~ /^(http|https):\/\//
+      if path =~ /^(http|https):\/\//i
         URI.parse(path)
       elsif path.nil? or path.empty?
         URI.parse(@url)

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -44,6 +44,13 @@ describe Chef::HTTP do
       expect(http.create_url('///api/endpoint?url=http://foo.bar')).to eql(URI.parse('http://www.getchef.com/organization/org/api/endpoint?url=http://foo.bar'))
     end
 
+    # As per: https://github.com/opscode/chef/issues/2500
+    it 'should treat scheme part of the URI in a case-insensitive manner' do
+      http = Chef::HTTP.allocate # Calling Chef::HTTP::new sets @url, don't want that.
+      expect { http.create_url('HTTP://www1.chef.io/') }.not_to raise_error
+      expect(http.create_url('HTTP://www2.chef.io/')).to eql(URI.parse('http://www2.chef.io/'))
+    end
+
   end # create_url
 
   describe "head" do


### PR DESCRIPTION
...ive manner.

This is as per http://en.wikipedia.org/wiki/URI_scheme, and solves some
edges i.e., following (30x) URL from the "Location" header where we
have to deal with "HTTP://".

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
