### PR TITLE
Updating to use audit syntax rather than control

### DIFF
--- a/lib/chef/audit/audit_event_proxy.rb
+++ b/lib/chef/audit/audit_event_proxy.rb
@@ -17,15 +17,15 @@ class Chef
 
       def example_group_started(notification)
         if notification.group.parent_groups.size == 1
-          # top level controls block
+          # top level `controls` block
           desc = notification.group.description
-          Chef::Log.debug("Entered controls block named #{desc}")
+          Chef::Log.debug("Entered `controls` block named #{desc}")
           events.control_group_started(desc)
         end
       end
 
       def stop(notification)
-        Chef::Log.info("Successfully executed all controls blocks and contained examples")
+        Chef::Log.info("Successfully executed all `controls` blocks and contained examples")
         notification.examples.each do |example|
           control_group_name, control_data = build_control_from(example)
           e = example.exception

--- a/lib/chef/audit/runner.rb
+++ b/lib/chef/audit/runner.rb
@@ -141,7 +141,7 @@ class Chef
       # or use example group filters.
       def register_controls
         add_example_group_methods
-        run_context.controls.each do |name, group|
+        run_context.audits.each do |name, group|
           ctl_grp = RSpec::Core::ExampleGroup.__controls__(*group[:args], &group[:block])
           RSpec.world.register(ctl_grp)
         end

--- a/lib/chef/dsl/audit.rb
+++ b/lib/chef/dsl/audit.rb
@@ -34,7 +34,7 @@ class Chef
           raise Chef::Exceptions::AuditControlGroupDuplicate.new(name)
         end
 
-        run_context.controls[name] = { :args => args, :block => block }
+        run_context.audits[name] = { :args => args, :block => block }
       end
 
     end

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -50,8 +50,8 @@ class Chef
     # recipes, which is triggered by #load. (See also: CookbookCompiler)
     attr_accessor :resource_collection
 
-    # The list of control groups to execute during the audit phase
-    attr_accessor :controls
+    # The list of audits (control groups) to execute during the audit phase
+    attr_accessor :audits
 
     # A Hash containing the immediate notifications triggered by resources
     # during the converge phase of the chef run.
@@ -76,7 +76,7 @@ class Chef
       @node = node
       @cookbook_collection = cookbook_collection
       @resource_collection = Chef::ResourceCollection.new
-      @controls = {}
+      @audits = {}
       @immediate_notification_collection = Hash.new {|h,k| h[k] = []}
       @delayed_notification_collection = Hash.new {|h,k| h[k] = []}
       @definitions = Hash.new


### PR DESCRIPTION
I'm questioning whether we even need this change - I tried to find more opportunities to switch from using `control` to using `audit` but it didn't make sense.  We already have `audit` and `control_group` event notifications and updating both to `audit` seemed more confusing.

@sersut @mcquin let me know if you think I should just dump these changes.

Its making me realize that `audit` refers more to the phase and `control_group` refers to the items we perform in the audit phase.
