### PR TITLE
Remove all RSpec test filters related to Ruby 1.8 and 1.9

### DIFF
--- a/lib/chef/encrypted_data_bag_item/assertions.rb
+++ b/lib/chef/encrypted_data_bag_item/assertions.rb
@@ -44,9 +44,6 @@ class Chef::EncryptedDataBagItem
     end
 
     def assert_aead_requirements_met!(algorithm)
-      unless OpenSSL::Cipher.method_defined?(:auth_data=)
-        raise EncryptedDataBagRequirementsFailure, "The used Encrypted Data Bags version requires Ruby >= 2.0"
-      end
       unless OpenSSL::Cipher.ciphers.include?(algorithm)
         raise EncryptedDataBagRequirementsFailure, "The used Encrypted Data Bags version requires an OpenSSL version with \"#{algorithm}\" algorithm support"
       end

--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -67,7 +67,7 @@ class Chef
           @current_resource.shell(user_info.shell)
           @current_resource.password(user_info.passwd)
 
-          if @new_resource.comment && user_info.gecos.respond_to?(:force_encoding)
+          if @new_resource.comment
             user_info.gecos.force_encoding(@new_resource.comment.encoding)
           end
           @current_resource.comment(user_info.gecos)

--- a/lib/chef/util/diff.rb
+++ b/lib/chef/util/diff.rb
@@ -176,10 +176,7 @@ class Chef
       end
 
       def encode_diff_for_json(diff_str)
-        if Object.const_defined? :Encoding
-          diff_str.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
-        end
-        return diff_str
+        diff_str.encode!('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
       end
 
     end

--- a/spec/functional/knife/exec_spec.rb
+++ b/spec/functional/knife/exec_spec.rb
@@ -41,9 +41,7 @@ describe Chef::Knife::Exec do
     @server.stop
   end
 
-  skip "executes a script in the context of the chef-shell main context", :ruby_18_only
-
-  it "executes a script in the context of the chef-shell main context", :ruby_gte_19_only do
+  it "executes a script in the context of the chef-shell main context" do
     @node = Chef::Node.new
     @node.name("ohai-world")
     response = {"rows" => [@node],"start" => 0,"total" => 1}

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -1069,7 +1069,7 @@ EOM
     end
 
     when_the_repository 'is empty' do
-      it 'knife download /cookbooks/x signs all requests', :ruby_gte_19_only do
+      it 'knife download /cookbooks/x signs all requests' do
 
         # Check that BasicClient.request() always gets called with X-OPS-USERID
         original_new = Chef::HTTP::BasicClient.method(:new)

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -83,8 +83,7 @@ end
 EOM
     end
 
-    # Ruby 1.8.7 doesn't have Process.spawn :(
-    it "while running solo concurrently", :ruby_gte_19_only => true do
+    it "while running solo concurrently" do
       file 'config/solo.rb', <<EOM
 cookbook_path "#{path_to('cookbooks')}"
 file_cache_path "#{path_to('config/cache')}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,18 +124,13 @@ RSpec.configure do |config|
   config.filter_run_excluding :aix_only => true unless aix?
   config.filter_run_excluding :supports_cloexec => true unless supports_cloexec?
   config.filter_run_excluding :selinux_only => true unless selinux_enabled?
-  config.filter_run_excluding :ruby_18_only => true unless ruby_18?
-  config.filter_run_excluding :ruby_19_only => true unless ruby_19?
-  config.filter_run_excluding :ruby_gte_19_only => true unless ruby_gte_19?
   config.filter_run_excluding :ruby_20_only => true unless ruby_20?
-  config.filter_run_excluding :ruby_gte_20_only => true unless ruby_gte_20?
   config.filter_run_excluding :requires_root => true unless root?
   config.filter_run_excluding :requires_root_or_running_windows => true unless (root? || windows?)
   config.filter_run_excluding :requires_unprivileged_user => true if root?
   config.filter_run_excluding :uses_diff => true unless has_diff?
-  config.filter_run_excluding :ruby_gte_20_and_openssl_gte_101 => true unless (ruby_gte_20? && openssl_gte_101?)
+  config.filter_run_excluding :openssl_gte_101 => true unless openssl_gte_101?
   config.filter_run_excluding :openssl_lt_101 => true unless openssl_lt_101?
-  config.filter_run_excluding :ruby_lt_20 => true unless ruby_lt_20?
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
 
   running_platform_arch = `uname -m`.strip

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -3,28 +3,8 @@ require 'chef/mixin/shell_out'
 
 include Chef::Mixin::ShellOut
 
-def ruby_gte_20?
-  RUBY_VERSION.to_f >= 2.0
-end
-
-def ruby_lt_20?
-  !ruby_gte_20?
-end
-
-def ruby_gte_19?
-  RUBY_VERSION.to_f >= 1.9
-end
-
 def ruby_20?
   !!(RUBY_VERSION =~ /^2.0/)
-end
-
-def ruby_19?
-  !!(RUBY_VERSION =~ /^1.9/)
-end
-
-def ruby_18?
-  !!(RUBY_VERSION =~ /^1.8/)
 end
 
 def windows?

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -124,14 +124,6 @@ describe Chef::EncryptedDataBagItem::Encryptor  do
     context "on unsupported platforms" do
       let(:aead_algorithm) { Chef::EncryptedDataBagItem::AEAD_ALGORITHM }
 
-      it "throws an error warning about the Ruby version if it has no GCM support" do
-        # Force OpenSSL with AEAD support
-        allow(OpenSSL::Cipher).to receive(:ciphers).and_return([ aead_algorithm ])
-        # Ruby without AEAD support
-        expect(OpenSSL::Cipher).to receive(:method_defined?).with(:auth_data=).and_return(false)
-        expect { encryptor }.to raise_error(Chef::EncryptedDataBagItem::EncryptedDataBagRequirementsFailure, /requires Ruby/)
-      end
-
       it "throws an error warning about the OpenSSL version if it has no GCM support" do
         # Force Ruby with AEAD support
         allow(OpenSSL::Cipher).to receive(:method_defined?).with(:auth_data=).and_return(true)
@@ -139,14 +131,6 @@ describe Chef::EncryptedDataBagItem::Encryptor  do
         expect(OpenSSL::Cipher).to receive(:ciphers).and_return([])
         expect { encryptor }.to raise_error(Chef::EncryptedDataBagItem::EncryptedDataBagRequirementsFailure, /requires an OpenSSL/)
       end
-
-      context "on platforms with old Ruby", :ruby_lt_20 do
-
-        it "throws an error warning about the Ruby version" do
-          expect { encryptor }.to raise_error(Chef::EncryptedDataBagItem::EncryptedDataBagRequirementsFailure, /requires Ruby/)
-        end
-
-      end # context on platforms with old Ruby
 
       context "on platforms with old OpenSSL", :openssl_lt_101 do
 
@@ -213,14 +197,6 @@ describe Chef::EncryptedDataBagItem::Decryptor do
           "cipher" => "aes-256-cbc",
         }
       end
-
-      context "on platforms with old Ruby", :ruby_lt_20 do
-
-        it "throws an error warning about the Ruby version" do
-          expect { decryptor }.to raise_error(Chef::EncryptedDataBagItem::EncryptedDataBagRequirementsFailure, /requires Ruby/)
-        end
-
-      end # context on platforms with old Ruby
 
       context "on platforms with old OpenSSL", :openssl_lt_101 do
 

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -91,7 +91,7 @@ describe Chef::Provider::User do
       expect(@current_resource.username).to eq(@new_resource.username)
     end
 
-    it "should change the encoding of gecos to the encoding of the new resource", :ruby_gte_19_only do
+    it "should change the encoding of gecos to the encoding of the new resource" do
       @pw_user.gecos.force_encoding('ASCII-8BIT')
       @provider.load_current_resource
       expect(@provider.current_resource.comment.encoding).to eq(@new_resource.comment.encoding)

--- a/spec/unit/util/diff_spec.rb
+++ b/spec/unit/util/diff_spec.rb
@@ -105,7 +105,7 @@ shared_examples_for "a diff util" do
     end
   end
 
-  describe "when the default external encoding is UTF-8", :ruby_gte_19_only  do
+  describe "when the default external encoding is UTF-8" do
 
     before do
       @saved_default_external = Encoding.default_external
@@ -170,7 +170,7 @@ shared_examples_for "a diff util" do
 
   end
 
-  describe "when the default external encoding is Latin-1", :ruby_gte_19_only  do
+  describe "when the default external encoding is Latin-1" do
 
     before do
       @saved_default_external = Encoding.default_external
@@ -234,7 +234,7 @@ shared_examples_for "a diff util" do
     end
 
   end
-  describe "when the default external encoding is Shift_JIS", :ruby_gte_19_only  do
+  describe "when the default external encoding is Shift_JIS" do
 
     before do
       @saved_default_external = Encoding.default_external
@@ -411,7 +411,7 @@ shared_examples_for "a diff util" do
       end
     end
 
-    describe "when the default external encoding is UTF-8", :ruby_gte_19_only  do
+    describe "when the default external encoding is UTF-8" do
 
       before do
         @saved_default_external = Encoding.default_external
@@ -456,7 +456,7 @@ shared_examples_for "a diff util" do
 
     end
 
-    describe "when the default external encoding is Latin-1", :ruby_gte_19_only do
+    describe "when the default external encoding is Latin-1" do
 
       before do
         @saved_default_external = Encoding.default_external
@@ -500,7 +500,7 @@ shared_examples_for "a diff util" do
       end
     end
 
-    describe "when the default external encoding is Shift-JIS", :ruby_gte_19_only do
+    describe "when the default external encoding is Shift-JIS" do
 
       before do
         @saved_default_external = Encoding.default_external

--- a/spec/unit/util/path_helper_spec.rb
+++ b/spec/unit/util/path_helper_spec.rb
@@ -189,16 +189,8 @@ describe Chef::Util::PathHelper do
     end
 
     context "not on windows", :unix_only  do
-      context "ruby is at least 1.9", :ruby_gte_19_only do
-        it "returns a canonical path" do
-          expect(PathHelper.canonical_path("/etc//apache.d/sites-enabled/../sites-available/default")).to eq("/etc/apache.d/sites-available/default")
-        end
-      end
-
-      context "ruby is less than 1.9", :ruby_18_only do
-        it "returns a canonical path" do
-          expect { PathHelper.canonical_path("/etc//apache.d/sites-enabled/../sites-available/default") }.to raise_error(NotImplementedError)
-        end
+      it "returns a canonical path" do
+        expect(PathHelper.canonical_path("/etc//apache.d/sites-enabled/../sites-available/default")).to eq("/etc/apache.d/sites-available/default")
       end
     end
   end


### PR DESCRIPTION
Removes all RSpec filters used with Ruby `< 2` and some related `lib/` code.

I left all the tests using `RUBY_VERSION` for another future PR.

Fixes from #2497:
> * [ ] spec/support/platform_helpers.rb#L26-L28
