### PR TITLE
Implement RFC 027 File Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Add --proxy-auth option to `knife raw`
 * added Chef::Org model class for Chef Organizations in Chef 12 Server
 * `powershell_script` should now correctly get the exit code for scripts that it runs. See [Issue 2348](https://github.com/chef/chef/issues/2348)
+* Add `verify` method to File resource per RFC027
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -6,6 +6,15 @@ Example Doc Change:
 Description of the required change.
 -->
 
+
+### File-like resources now accept a `verify` attribute
+
+The file, template, cookbook_file, and remote_file resources now all
+accept a `verify` attribute.  This file accepts a string or a block,
+similar to `only_if`.  A full specification can be found in RFC 027:
+
+https://github.com/opscode/chef-rfc/blob/master/rfc027-file-content-verification.md
+
 ### Chef now handles URI Schemes in a case insensitive manner
 
 Previously, when a URI scheme contained all uppercase letters, Chef would reject the URI as invalid. In compliance with RFC3986, Chef now treats URI schemes in a case insensitive manner. This applies to all resources which accept URIs such as remote_file etc.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,7 +62,16 @@ The package resource on OpenBSD is wired up to use the new OpenBSD package provi
 
 ## Case Insensitive URI Handling
 
-Previously, when a URI scheme contained all uppercase letters, Chef would reject the URI as invalid. In compliance with RFC3986, Chef now treats URI schemes in a case insensitive manner.
+Previously, when a URI scheme contained all uppercase letters, Chef
+would reject the URI as invalid. In compliance with RFC3986, Chef now
+treats URI schemes in a case insensitive manner.
+
+## File Content Verification (RFC 027)
+
+Per RFC 027, the file and file-like resources now accept a `verify`
+attribute.  This attribute accepts a string(shell command) or a ruby
+block (similar to `only_if`) which can be used to verify the contents
+of a rendered template before deploying it to disk.
 
 ## Drop SSL Warnings
 Now that the default for SSL checking is on, no more warning is emitted when SSL
@@ -439,7 +448,7 @@ powershell_script 'make_safe_backup' do
   code 'cp ~/data/nodes.json $env:systemroot/system32/data/nodes.bak'
 
   # cmd.exe (batch) guard below behaves differently in 32-bit vs. 64-bit processes
-  not_if 'if NOT EXIST %SYSTEMROOT%\\system32\\data\\nodes.bak exit /b 1' 
+  not_if 'if NOT EXIST %SYSTEMROOT%\\system32\\data\\nodes.bak exit /b 1'
 end
 ```
 
@@ -506,7 +515,7 @@ Information about these events can be found in `Chef::EventDispatch::Base`.
 
 ## Resource and Provider Resolution changes
 
-Resource resolution and provider resolution has been made more dynamic in Chef-12.  The `provides` syntax on the 
+Resource resolution and provider resolution has been made more dynamic in Chef-12.  The `provides` syntax on the
 Chef::Resource DSL (which has existed for 4 years) has been expanded to use platform_family and os and has been applied
 to most resources.  This does early switching at compile time between different resources based on the node data returned
 from ohai.  The effect is that previously the package resource on a CentOS machine invoked via `package "foo"` would be
@@ -523,4 +532,3 @@ inflexible since it cannot handle the case where an admin installs or removes a 
 handle the case where there may be multiple providers that handle different kinds of services (e.g. Upstart, SysV,
 etc).  This fixes the Ubuntu 14.04 service resource problems, and can handle arbitrarily complicated future distro
 and administrative preferences dynamically.
-

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -90,6 +90,7 @@ class Chef
     class ConflictingMembersInGroup < ArgumentError; end
     class InvalidResourceReference < RuntimeError; end
     class ResourceNotFound < RuntimeError; end
+    class VerificationNotFound < RuntimeError; end
 
     # Can't find a Resource of this type that is valid on this platform.
     class NoSuchResourceType < NameError

--- a/lib/chef/guard_interpreter.rb
+++ b/lib/chef/guard_interpreter.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Steven Danna (<steve@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/guard_interpreter/default_guard_interpreter'
+require 'chef/guard_interpreter/resource_guard_interpreter'
+
+class Chef
+  class GuardInterpreter
+    def self.for_resource(resource, command, command_opts)
+      if resource.guard_interpreter == :default
+        Chef::GuardInterpreter::DefaultGuardInterpreter.new(command, command_opts)
+      else
+        Chef::GuardInterpreter::ResourceGuardInterpreter.new(resource, command, command_opts)
+      end
+    end
+  end
+end

--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'chef/guard_interpreter/default_guard_interpreter'
+require 'chef/guard_interpreter'
 
 class Chef
   class GuardInterpreter

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -345,6 +345,14 @@ class Chef
         if new_resource.checksum && tempfile && ( new_resource.checksum != tempfile_checksum )
           raise Chef::Exceptions::ChecksumMismatch.new(short_cksum(new_resource.checksum), short_cksum(tempfile_checksum))
         end
+
+        if tempfile
+          new_resource.verify.each do |v|
+            if ! v.verify(tempfile.path)
+              raise Chef::Exceptions::ValidationFailed.new "Proposed content for #{new_resource.path} failed verification #{v}"
+            end
+          end
+        end
       end
 
       def do_unlink

--- a/lib/chef/resource/conditional.rb
+++ b/lib/chef/resource/conditional.rb
@@ -17,7 +17,7 @@
 #
 
 require 'chef/mixin/shell_out'
-require 'chef/guard_interpreter/resource_guard_interpreter'
+require 'chef/guard_interpreter'
 
 class Chef
   class Resource
@@ -56,7 +56,7 @@ class Chef
       def configure
         case @command
         when String,Array
-          @guard_interpreter = new_guard_interpreter(@parent_resource, @command, @command_opts, &@block)
+          @guard_interpreter = Chef::GuardInterpreter.for_resource(@parent_resource, @command, @command_opts)
           @block = nil
         when nil
           # We should have a block if we get here
@@ -122,17 +122,6 @@ class Chef
           "#{@positivity} { #code block }"
         end
       end
-
-      private
-
-      def new_guard_interpreter(parent_resource, command, opts)
-        if parent_resource.guard_interpreter == :default
-          guard_interpreter = Chef::GuardInterpreter::DefaultGuardInterpreter.new(command, opts)
-        else
-          guard_interpreter = Chef::GuardInterpreter::ResourceGuardInterpreter.new(parent_resource, command, opts)
-        end
-      end
-
     end
   end
 end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -20,6 +20,7 @@
 require 'chef/resource'
 require 'chef/platform/query_helpers'
 require 'chef/mixin/securable'
+require 'chef/resource/file/verification'
 
 class Chef
   class Resource
@@ -50,6 +51,7 @@ class Chef
         @force_unlink = false
         @manage_symlink_source = nil
         @diff = nil
+        @user_verifications = []
       end
 
       def content(arg=nil)
@@ -114,6 +116,18 @@ class Chef
           arg,
           :kind_of => [ TrueClass, FalseClass ]
         )
+      end
+
+      def verify(command=nil, opts={}, &block)
+        if ! (command.nil? || [String, Symbol].include?(command.class))
+          raise ArgumentError, "verify requires either a string, symbol, or a block"
+        end
+
+        if command || block_given?
+          @user_verifications << Verification.new(self, command, opts, &block)
+        else
+          @user_verifications
+        end
       end
     end
   end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -51,7 +51,7 @@ class Chef
         @force_unlink = false
         @manage_symlink_source = nil
         @diff = nil
-        @user_verifications = []
+        @verifications = []
       end
 
       def content(arg=nil)
@@ -124,9 +124,9 @@ class Chef
         end
 
         if command || block_given?
-          @user_verifications << Verification.new(self, command, opts, &block)
+          @verifications << Verification.new(self, command, opts, &block)
         else
-          @user_verifications
+          @verifications
         end
       end
     end

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/exceptions'
+require 'chef/guard_interpreter'
 require 'chef/mixin/descendants_tracker'
 
 class Chef
@@ -106,11 +107,7 @@ class Chef
         # the same set of options that the not_if/only_if blocks do
         def verify_command(path, opts)
           command = @command % {:file => path}
-          interpreter = if @parent_resource.guard_interpreter == :default
-                          Chef::GuardInterpreter::DefaultGuardInterpreter.new(command, @command_opts)
-                        else
-                          Chef::GuardInterpreter::ResourceGuardInterpreter.new(@parent_resource, command, @command_opts)
-                        end
+          interpreter = Chef::GuardInterpreter.for_resource(@parent_resource, command, @command_opts)
           interpreter.evaluate
         end
 

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -41,7 +41,7 @@ class Chef
       #
       # To create a registered verification, create a class that
       # inherits from Chef::Resource::File::Verification and use the
-      # register class method to give it name.  Registered
+      # provides class method to give it name.  Registered
       # verifications are expected to supply a verify instance method
       # that takes 2 arguments.
       #
@@ -96,6 +96,8 @@ class Chef
           end
         end
 
+        # opts is currently unused, but included in the API
+        # to support future extensions
         def verify_block(path, opts)
           @block.call(path)
         end

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -1,0 +1,118 @@
+#
+# Author:: Steven Danna (<steve@chef.io>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/exceptions'
+
+class Chef
+  class Resource
+    class File < Chef::Resource
+
+      #
+      # See RFC 027 for a full specification
+      #
+      # File verifications allow user-supplied commands a means of
+      # preventing file reosurce content deploys.  Their intended use
+      # is to verify the contents of a temporary file before it is
+      # deployed onto the system.
+      #
+      # Similar to not_if and only_if, file verifications can take a
+      # ruby block, which will be called, or a string, which will be
+      # executed as a Shell command.
+      #
+      # Additonally, Chef or third-party verifications can ship
+      # "registered verifications" that the user can use by specifying
+      # a :symbol as the command name.
+      #
+      # To create a registered verification, create a class that
+      # inherits from Chef::Resource::File::Verification and use the
+      # register class method to give it name.  Registered
+      # verifications are expected to supply a verify instance method
+      # that takes 2 arguments.
+      #
+      # Example:
+      # class Chef
+      #  class Resource
+      #    class File::Verification::Foo < Chef::Resource::File::Verification
+      #      register :noop
+      #      def verify(path, opts)
+      #        #yolo
+      #        true
+      #      end
+      #    end
+      #  end
+      # end
+      #
+      #
+
+      class Verification
+        @@registered_verifications = {}
+
+        def self.register(name)
+          @@registered_verifications[name] = self.name
+        end
+
+        def self.lookup(name)
+          c = @@registered_verifications[name]
+          if c.nil?
+            raise Chef::Exceptions::VerificationNotFound.new "No file verification for #{name} found."
+          end
+          Object.const_get(c)
+        end
+
+        def initialize(parent_resource, command, opts, &block)
+          @command, @command_opts = command, opts
+          @block = block
+          @parent_resource = parent_resource
+        end
+
+        def verify(path, opts={})
+          Chef::Log.debug("Running verification[#{self}] on #{path}")
+          if @block
+            verify_block(path, opts)
+          elsif @command.is_a?(Symbol)
+            verify_registered_verification(path, opts)
+          elsif @command.is_a?(String)
+            verify_command(path, opts)
+          end
+        end
+
+        def verify_block(path, opts)
+          @block.call(path)
+        end
+
+        # We reuse Chef::GuardInterpreter in order to support
+        # the same set of options that the not_if/only_if blocks do
+        def verify_command(path, opts)
+          command = @command % {:file => path}
+          interpreter = if @parent_resource.guard_interpreter == :default
+                          Chef::GuardInterpreter::DefaultGuardInterpreter.new(command, @command_opts)
+                        else
+                          Chef::GuardInterpreter::ResourceGuardInterpreter.new(@parent_resource, command, @command_opts)
+                        end
+          interpreter.evaluate
+        end
+
+        def verify_registered_verification(path, opts)
+          verification_class = Chef::Resource::File::Verification.lookup(@command)
+          v = verification_class.new(@parent_resource, @command, @command_opts, &@block)
+          v.verify(path, opts)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/guard_interpreter_spec.rb
+++ b/spec/unit/guard_interpreter_spec.rb
@@ -1,0 +1,41 @@
+#
+# Author:: Steven Danna (steve@chef.io)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::GuardInterpreter do
+  describe "#for_resource" do
+    let (:resource) { Chef::Resource.new("foo")}
+
+    it "returns a DefaultGuardInterpreter if the resource has guard_interpreter set to :default" do
+      resource.guard_interpreter :default
+      interpreter = Chef::GuardInterpreter.for_resource(resource, "", {})
+      expect(interpreter.class).to eq(Chef::GuardInterpreter::DefaultGuardInterpreter)
+    end
+
+    it "returns a ResourceGuardInterpreter if the resource has guard_interpreter set to !:default" do
+      resource.guard_interpreter :foobar
+      # Mock the resource guard interpreter to avoid having to set up a lot of state
+      # currently we are only testing that we get the correct class of object back
+      rgi = double("Chef::GuardInterpreter::ResourceGuardInterpreter")
+      allow(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:new).and_return(rgi)
+      interpreter = Chef::GuardInterpreter.for_resource(resource, "", {})
+      expect(interpreter).to eq(rgi)
+    end
+  end
+end

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -205,5 +205,4 @@ describe Chef::Resource::Conditional do
       end
     end
   end
-
 end

--- a/spec/unit/resource/file/verification_spec.rb
+++ b/spec/unit/resource/file/verification_spec.rb
@@ -70,7 +70,11 @@ describe Chef::Resource::File::Verification do
 
     context "with a verification command(String)" do
       it "substitutes \%{file} with the path" do
-        test_command = "test #{temp_path} = %{file}"
+        test_command = if windows?
+                         "if \"#{temp_path}\" == \"%{file}\" (exit 0) else (exit 1)"
+                       else
+                         "test #{temp_path} = %{file}"
+                       end
         v = Chef::Resource::File::Verification.new(parent_resource, test_command, {})
         expect(v.verify(temp_path)).to eq(true)
       end

--- a/spec/unit/resource/file/verification_spec.rb
+++ b/spec/unit/resource/file/verification_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Resource::File::Verification do
   describe "verification registration" do
     it "registers a verification for later use" do
       class Chef::Resource::File::Verification::Wombat < Chef::Resource::File::Verification
-        register :tabmow
+        provides :tabmow
       end
       expect(Chef::Resource::File::Verification.lookup(:tabmow)).to eq(Chef::Resource::File::Verification::Wombat)
     end
@@ -89,7 +89,7 @@ describe Chef::Resource::File::Verification do
     context "with a named verification(Symbol)" do
       before(:each) do
         class Chef::Resource::File::Verification::Turtle < Chef::Resource::File::Verification
-          register :cats
+          provides :cats
           def verify(path, opts)
           end
         end

--- a/spec/unit/resource/file/verification_spec.rb
+++ b/spec/unit/resource/file/verification_spec.rb
@@ -1,0 +1,107 @@
+#
+# Author:: Steven Danna (<steve@chef.io>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Resource::File::Verification do
+  let(:t_block) { Proc.new { true } }
+  let(:f_block) { Proc.new { false } }
+  let(:path_block) { Proc.new { |path| path }}
+  let(:temp_path) { "/tmp/foobar" }
+
+  describe "verification registration" do
+    it "registers a verification for later use" do
+      class Chef::Resource::File::Verification::Wombat < Chef::Resource::File::Verification
+        register :tabmow
+      end
+      expect(Chef::Resource::File::Verification.lookup(:tabmow)).to eq(Chef::Resource::File::Verification::Wombat)
+    end
+
+    it "raises an error if a verificationc can't be found" do
+      expect{Chef::Resource::File::Verification.lookup(:dne)}.to raise_error(Chef::Exceptions::VerificationNotFound)
+    end
+  end
+
+  describe "#verify" do
+    let(:parent_resource) { Chef::Resource.new("llama") }
+
+    it "expects a string argument" do
+      v = Chef::Resource::File::Verification.new(parent_resource, nil, {}) {}
+      expect{ v.verify("/foo/bar") }.to_not raise_error
+      expect{ v.verify }.to raise_error
+    end
+
+    it "accepts an options hash" do
+      v = Chef::Resource::File::Verification.new(parent_resource, nil, {}) {}
+      expect{ v.verify("/foo/bar", {:future => true}) }.to_not raise_error
+    end
+
+    context "with a verification block" do
+      it "passes a file path to the block" do
+        v = Chef::Resource::File::Verification.new(parent_resource, nil, {}, &path_block)
+        expect(v.verify(temp_path)).to eq(temp_path)
+      end
+
+      it "returns true if the block returned true" do
+        v = Chef::Resource::File::Verification.new(parent_resource, nil, {}, &t_block)
+        expect(v.verify(temp_path)).to eq(true)
+      end
+
+      it "returns false if the block returned false" do
+        v = Chef::Resource::File::Verification.new(parent_resource, nil, {}, &f_block)
+        expect(v.verify(temp_path)).to eq(false)
+      end
+    end
+
+    context "with a verification command(String)" do
+      it "substitutes \%{file} with the path" do
+        test_command = "test #{temp_path} = %{file}"
+        v = Chef::Resource::File::Verification.new(parent_resource, test_command, {})
+        expect(v.verify(temp_path)).to eq(true)
+      end
+
+      it "returns false if the command fails" do
+        v = Chef::Resource::File::Verification.new(parent_resource, "false", {})
+        expect(v.verify(temp_path)).to eq(false)
+      end
+
+      it "returns true if the command succeeds" do
+        v = Chef::Resource::File::Verification.new(parent_resource, "true", {})
+        expect(v.verify(temp_path)).to eq(true)
+      end
+    end
+
+    context "with a named verification(Symbol)" do
+      before(:each) do
+        class Chef::Resource::File::Verification::Turtle < Chef::Resource::File::Verification
+          register :cats
+          def verify(path, opts)
+          end
+        end
+      end
+
+      it "delegates to the registered verification" do
+        registered_verification = double()
+        allow(Chef::Resource::File::Verification::Turtle).to receive(:new).and_return(registered_verification)
+        v = Chef::Resource::File::Verification.new(parent_resource, :cats, {})
+        expect(registered_verification).to receive(:verify).with(temp_path, {})
+        v.verify(temp_path, {})
+      end
+    end
+  end
+end

--- a/spec/unit/resource/file/verification_spec.rb
+++ b/spec/unit/resource/file/verification_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Resource::File::Verification do
       expect(Chef::Resource::File::Verification.lookup(:tabmow)).to eq(Chef::Resource::File::Verification::Wombat)
     end
 
-    it "raises an error if a verificationc can't be found" do
+    it "raises an error if a verification can't be found" do
       expect{Chef::Resource::File::Verification.lookup(:dne)}.to raise_error(Chef::Exceptions::VerificationNotFound)
     end
   end

--- a/spec/unit/resource/file_spec.rb
+++ b/spec/unit/resource/file_spec.rb
@@ -66,6 +66,20 @@ describe Chef::Resource::File do
     expect { @resource.action :blues }.to raise_error(ArgumentError)
   end
 
+  it "should accept a block, symbol, or string for verify" do
+    expect {@resource.verify {}}.not_to raise_error
+    expect {@resource.verify ""}.not_to raise_error
+    expect {@resource.verify :json}.not_to raise_error
+    expect {@resource.verify true}.to raise_error
+    expect {@resource.verify false}.to raise_error
+  end
+
+  it "should accept multiple verify statements" do
+    @resource.verify "foo"
+    @resource.verify "bar"
+    @resource.verify.length == 2
+  end
+
   it "should use the object name as the path by default" do
     expect(@resource.path).to eql("fakey_fakerton")
   end


### PR DESCRIPTION
This implements user-suppliable file content verification per RFC
027. Users can supply a block, string, or symbol to the `verify`
resource attribute.  Blocks will be called, string will be executed as
shell commands (respecting the same options as not_if and only_if), and
symbols can be used to access built-in registered validations.