### PR TITLE
Fix Digester to require its dependencies

### DIFF
--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -19,6 +19,7 @@
 #
 
 require 'openssl'
+require 'singleton'
 
 class Chef
   class Digester


### PR DESCRIPTION
Without thus using rspec gets you:

```
uninitialized constant Chef::Digester::Singleton
```
