### PR TITLE
Only try to auto-decrypt if a secret is provided.

### DIFF
--- a/lib/chef/dsl/data_query.rb
+++ b/lib/chef/dsl/data_query.rb
@@ -60,7 +60,7 @@ class Chef
         DataBagItem.validate_id!(item)
 
         item = DataBagItem.load(bag, item)
-        if encrypted?(item.raw_data)
+        if encrypted?(item.raw_data) && secret
           Log.debug("Data bag item looks encrypted: #{bag.inspect} #{item.inspect}")
 
           # Try to load the data bag item secret, if secret is not provided.


### PR DESCRIPTION
### Version:

Chef 12
### Environment:

Chef-Solo
### Scenario:

Chef-solo is breaking now because Chef 12 tries to auto-detect data bags and determine whether they are using encrypted data bags. Because of changes to /opt/chef/embedded/apps/chef/lib/chef/dsl/data_query.rb it will now die during data bag searches because it tries to decrypt before attempting to lookup whether it matches the appropriate ID. 

We had a situation where we had some data bags that were encrypted.  We left other data bags for non production environments un-encrypted.  Chef-Solo tries to search through all entries in the
data bag and dies if no secret was provided.
### Steps to Reproduce:
1. Create a data bag and encrypt it.
2. Create a data bag in the same dir and leave it unencrypted.
3. Run chef-solo without any encrypted secret.
### Expected Result:

Chef-solo should find the unencrypted data bag correctly and use it.
### Actual Result:

```
Generated at 2014-12-10 15:16:18 +0000
ArgumentError: No secret specified and no secret found at /etc/chef/encrypted_data_bag_secret
/opt/chef/embedded/apps/chef/lib/chef/encrypted_data_bag_item.rb:131:in `load_secret'
/opt/chef/embedded/apps/chef/lib/chef/dsl/data_query.rb:69:in `data_bag_item'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search/overrides.rb:122:in `load_data_bag'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search/overrides.rb:128:in `block in search_data_bag'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search/overrides.rb:127:in `each'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search/overrides.rb:127:in `search_data_bag'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search/overrides.rb:53:in `search'
/home/vagrant/projects/hearsay-chef/cookbooks/other/chef-solo-search/libraries/search.rb:69:in `search'
```
