### PR TITLE
Fix knife cookbook upload messages

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -130,7 +130,6 @@ class Chef
               upload_ok += 1
               version_constraints_to_update[cookbook_name] = cookbook.version
             rescue Exceptions::CookbookNotFoundInRepo => e
-              upload_failures += 1
               ui.error("Could not find cookbook #{cookbook_name} in your cookbook path, skipping it")
               Log.debug(e)
               upload_failures += 1

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -178,6 +178,7 @@ class Chef
                 Log.debug(e)
               end
             end
+            @name_args.uniq!
             upload_set
           end
       end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -184,11 +184,7 @@ E
       it "should upload all dependencies once" do
         allow(knife).to receive(:cookbook_names).and_return(["test_cookbook1", "test_cookbook2", "test_cookbook3"])
         expect(knife).to receive(:upload).exactly(3).times
-        expect do
-          Timeout::timeout(5) do
-            knife.run
-          end
-        end.not_to raise_error
+        expect { knife.run }.not_to raise_error
       end
 
       it 'should not print any error or warning' do
@@ -197,7 +193,7 @@ E
         expect(knife.ui).to_not receive(:error)
         expect(knife.ui).to_not receive(:warn)
         expect(knife.ui).to receive(:info).with(/Uploaded 3 cookbooks\./)
-        expect { Timeout::timeout(5) { knife.run } }.not_to raise_error
+        expect { knife.run }.not_to raise_error
       end
 
       context 'with upload errors' do
@@ -209,7 +205,7 @@ E
           allow(knife.ui).to receive(:error)
         end
         after do
-          expect { Timeout::timeout(5) { knife.run } }.to raise_error(SystemExit)
+          expect { knife.run }.to raise_error(SystemExit)
         end
 
         it 'should an error fo each cookbook' do

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -199,6 +199,39 @@ E
         expect(knife.ui).to receive(:info).with(/Uploaded 3 cookbooks\./)
         expect { Timeout::timeout(5) { knife.run } }.not_to raise_error
       end
+
+      context 'with upload errors' do
+        before do
+          expect(knife).to receive(:upload).exactly(3).times.and_raise(
+            Chef::Exceptions::CookbookNotFoundInRepo.new
+          )
+          allow(knife)
+            .to receive(:cookbook_names).and_return(%w(test_cookbook3))
+          allow(knife.ui).to receive(:error)
+        end
+        after do
+          expect { Timeout::timeout(5) { knife.run } }
+            .to raise_error(SystemExit)
+        end
+
+        it 'should an error fo each cookbook' do
+          (1..3).step.each do |i|
+            expect(knife.ui).to receive(:error).with(
+              "Could not find cookbook test_cookbook#{i} in your cookbook "\
+              'path, skipping it'
+            ).once
+          end
+        end
+
+        it 'should print an error with the failed cookbook count' do
+          expect(knife.ui)
+            .to receive(:error).with('Failed to upload 3 cookbooks.').once
+        end
+
+        it 'should not print successful upload message' do
+          expect(knife.ui).to_not receive(:info).with(/Uploaded 3 cookbooks\./)
+        end
+      end
     end
 
     describe 'when specifying a cookbook name with missing dependencies' do

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -205,13 +205,11 @@ E
           expect(knife).to receive(:upload).exactly(3).times.and_raise(
             Chef::Exceptions::CookbookNotFoundInRepo.new
           )
-          allow(knife)
-            .to receive(:cookbook_names).and_return(%w(test_cookbook3))
+          allow(knife).to receive(:cookbook_names).and_return(%w(test_cookbook3))
           allow(knife.ui).to receive(:error)
         end
         after do
-          expect { Timeout::timeout(5) { knife.run } }
-            .to raise_error(SystemExit)
+          expect { Timeout::timeout(5) { knife.run } }.to raise_error(SystemExit)
         end
 
         it 'should an error fo each cookbook' do
@@ -224,12 +222,11 @@ E
         end
 
         it 'should print an error with the failed cookbook count' do
-          expect(knife.ui)
-            .to receive(:error).with('Failed to upload 3 cookbooks.').once
+          expect(knife.ui).to receive(:error).with('Failed to upload 3 cookbooks.').once
         end
 
         it 'should not print successful upload message' do
-          expect(knife.ui).to_not receive(:info).with(/Uploaded 3 cookbooks\./)
+          expect(knife.ui).to_not receive(:info).with(/Uploaded[\s\d]+cookbooks\./)
         end
       end
     end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -179,8 +179,9 @@ E
         c
       end
 
+      before { knife.config[:depends] = true }
+
       it "should upload all dependencies once" do
-        knife.config[:depends] = true
         allow(knife).to receive(:cookbook_names).and_return(["test_cookbook1", "test_cookbook2", "test_cookbook3"])
         expect(knife).to receive(:upload).exactly(3).times
         expect do
@@ -188,6 +189,15 @@ E
             knife.run
           end
         end.not_to raise_error
+      end
+
+      it 'should not print any error or warning' do
+        allow(knife).to receive(:cookbook_names).and_return(%w(test_cookbook3))
+        expect(knife).to receive(:upload).exactly(3).times
+        expect(knife.ui).to_not receive(:error)
+        expect(knife.ui).to_not receive(:warn)
+        expect(knife.ui).to receive(:info).with(/Uploaded 3 cookbooks\./)
+        expect { Timeout::timeout(5) { knife.run } }.not_to raise_error
       end
     end
 

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -38,15 +38,16 @@ describe Chef::Knife::CookbookUpload do
 
   let(:cookbook_uploader) { double(:upload_cookbooks => nil) }
 
-  let(:output) { StringIO.new }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:stdin) { StringIO.new }
 
   let(:name_args) { ['test_cookbook'] }
 
   let(:knife) do
     k = Chef::Knife::CookbookUpload.new
     k.name_args = name_args
-    allow(k.ui).to receive(:stdout).and_return(output)
-    allow(k.ui).to receive(:stderr).and_return(output)
+    k.ui = Chef::Knife::UI.new(stdout, stderr, stdin, {})
     k
   end
 
@@ -89,8 +90,8 @@ describe Chef::Knife::CookbookUpload do
 
       it 'should report on success' do
         expect(knife).to receive(:upload).once
-        expect(knife.ui).to receive(:info).with(/Uploaded 1 cookbook/)
         knife.run
+        expect(stderr.string).to include('Uploaded 1 cookbook')
       end
     end
 
@@ -112,18 +113,21 @@ describe Chef::Knife::CookbookUpload do
 
       it "emits a warning" do
         knife.run
-        expected_message=<<-E
+        expected_stdout = <<-STDOUT
+test_cookbook:
+  /path/one/test_cookbook
+  /path/two/test_cookbook
+STDOUT
+        expected_stderr = <<-STDERR
 WARNING: The cookbooks: test_cookbook exist in multiple places in your cookbook_path.
 A composite version of these cookbooks has been compiled for uploading.
 
 IMPORTANT: In a future version of Chef, this behavior will be removed and you will no longer
 be able to have the same version of a cookbook in multiple places in your cookbook_path.
 WARNING: The affected cookbooks are located:
-test_cookbook:
-  /path/one/test_cookbook
-  /path/two/test_cookbook
-E
-        expect(output.string).to include(expected_message)
+STDERR
+        expect(stdout.string).to include(expected_stdout)
+        expect(stderr.string).to include(expected_stderr)
       end
     end
 
@@ -190,10 +194,8 @@ E
       it 'should not print any error or warning' do
         allow(knife).to receive(:cookbook_names).and_return(%w(test_cookbook3))
         expect(knife).to receive(:upload).exactly(3).times
-        expect(knife.ui).to_not receive(:error)
-        expect(knife.ui).to_not receive(:warn)
-        expect(knife.ui).to receive(:info).with(/Uploaded 3 cookbooks\./)
         expect { knife.run }.not_to raise_error
+        expect(stderr.string).to include('Uploaded 3 cookbooks.')
       end
 
       context 'with upload errors' do
@@ -202,27 +204,24 @@ E
             Chef::Exceptions::CookbookNotFoundInRepo.new
           )
           allow(knife).to receive(:cookbook_names).and_return(%w(test_cookbook3))
-          allow(knife.ui).to receive(:error)
-        end
-        after do
           expect { knife.run }.to raise_error(SystemExit)
         end
 
         it 'should an error fo each cookbook' do
           (1..3).step.each do |i|
-            expect(knife.ui).to receive(:error).with(
+            expect(stderr.string).to include(
               "Could not find cookbook test_cookbook#{i} in your cookbook "\
               'path, skipping it'
-            ).once
+            )
           end
         end
 
         it 'should print an error with the failed cookbook count' do
-          expect(knife.ui).to receive(:error).with('Failed to upload 3 cookbooks.').once
+          expect(stderr.string).to include('Failed to upload 3 cookbooks.')
         end
 
         it 'should not print successful upload message' do
-          expect(knife.ui).to_not receive(:info).with(/Uploaded[\s\d]+cookbooks\./)
+          expect(stdout).to_not include(/Uploaded[\s\d]+cookbooks\./)
         end
       end
     end
@@ -237,8 +236,6 @@ E
             "dependency" => cookbook_dependency}[ckbk]
         end
         allow(knife).to receive(:cookbook_names).and_return(["cookbook_dependency", "test_cookbook"])
-        @stdout, @stderr, @stdin = StringIO.new, StringIO.new, StringIO.new
-        knife.ui = Chef::Knife::UI.new(@stdout, @stderr, @stdin, {})
       end
 
       it 'should exit and not upload the cookbook' do
@@ -250,9 +247,9 @@ E
 
       it 'should output a message for a single missing dependency' do
         expect {knife.run}.to raise_error(SystemExit)
-        expect(@stderr.string).to include('Cookbook test_cookbook depends on cookbooks which are not currently')
-        expect(@stderr.string).to include('being uploaded and cannot be found on the server.')
-        expect(@stderr.string).to include("The missing cookbook(s) are: 'dependency' version '>= 0.0.0'")
+        expect(stderr.string).to include('Cookbook test_cookbook depends on cookbooks which are not currently')
+        expect(stderr.string).to include('being uploaded and cannot be found on the server.')
+        expect(stderr.string).to include("The missing cookbook(s) are: 'dependency' version '>= 0.0.0'")
       end
 
       it 'should output a message for a multiple missing dependencies which are concatenated' do
@@ -265,11 +262,11 @@ E
         end
         allow(knife).to receive(:cookbook_names).and_return(["dependency", "dependency2", "test_cookbook"])
         expect {knife.run}.to raise_error(SystemExit)
-        expect(@stderr.string).to include('Cookbook test_cookbook depends on cookbooks which are not currently')
-        expect(@stderr.string).to include('being uploaded and cannot be found on the server.')
-        expect(@stderr.string).to include("The missing cookbook(s) are:")
-        expect(@stderr.string).to include("'dependency' version '>= 0.0.0'")
-        expect(@stderr.string).to include("'dependency2' version '>= 0.0.0'")
+        expect(stderr.string).to include('Cookbook test_cookbook depends on cookbooks which are not currently')
+        expect(stderr.string).to include('being uploaded and cannot be found on the server.')
+        expect(stderr.string).to include("The missing cookbook(s) are:")
+        expect(stderr.string).to include("'dependency' version '>= 0.0.0'")
+        expect(stderr.string).to include("'dependency2' version '>= 0.0.0'")
       end
     end
 
@@ -295,8 +292,8 @@ E
 
       it 'should report on success' do
         expect(knife).to receive(:upload).once
-        expect(knife.ui).to receive(:info).with(/Uploaded all cookbooks/)
         knife.run
+        expect(stderr.string).to include('Uploaded all cookbooks')
       end
 
       it 'should update the version constraints for an environment' do


### PR DESCRIPTION
Fixes two errors when using `knife upload cookbook`:

#### Upload message on successful uploads with `--include-dependencies`

Some correct uploads are detected as failed:

```
$ knife cookbook upload --include-dependencies owncloud
Uploading owncloud       [0.5.0]
Uploading apache2        [2.0.0]
Uploading apt            [2.6.0]
Uploading database       [2.3.0]
Uploading mysql          [5.5.4]
Uploading nginx          [2.7.4]
Uploading openssl        [2.0.0]
Uploading php            [1.4.6]
Uploading php-fpm        [0.6.10]
Uploading postfix        [3.6.0]
Uploading postgresql     [3.4.2]
Uploading iptables       [0.14.0]
Uploading logrotate      [1.7.0]
Uploading pacman         [1.1.1]
Uploading aws            [2.4.0]
Uploading xfs            [1.1.0]
Uploading mysql-chef_gem [0.0.2]
Uploading yum-mysql-community [0.1.10]
Uploading bluepill       [2.3.1]
Uploading build-essential [2.0.6]
Uploading ohai           [2.0.1]
Uploading runit          [1.5.11]
Uploading yum-epel       [0.5.1]
Uploading chef-sugar     [2.2.0]
Uploading xml            [1.2.6]
Uploading windows        [1.34.2]
Uploading iis            [2.1.5]
Uploading yum            [3.3.2]
Uploading rsyslog        [1.12.2]
Uploading chef_handler   [1.1.6]
WARNING: Uploaded 30 cookbooks ok but 20 cookbooks upload failed.
```

#### Failed count message on failures

Failures in uploads are counted wrong:

```
$ knife cookbook upload --include-dependencies test_cookbook3
ERROR: Could not find cookbook test_cookbook2 in your cookbook path, skipping it
ERROR: Could not find cookbook test_cookbook3 in your cookbook path, skipping it
ERROR: Could not find cookbook test_cookbook1 in your cookbook path, skipping it
ERROR: Failed to upload 6 cookbooks.
```