### PR TITLE
Bug #2625: Include ShellOut mixin in msi package provider

### DIFF
--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -19,6 +19,7 @@
 # TODO: Allow @new_resource.source to be a Product Code as a GUID for uninstall / network install
 
 require 'chef/win32/api/installer' if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+require 'chef/mixin/shell_out'
 
 class Chef
   class Provider
@@ -26,6 +27,7 @@ class Chef
       class Windows
         class MSI
           include Chef::ReservedNames::Win32::API::Installer if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+          include Chef::Mixin::ShellOut
 
           def initialize(resource)
             @new_resource = resource


### PR DESCRIPTION
Fix for bug #2625 

Chef blows up when installing msi packages on my machine, due to NoMethodError on 'shell_out!' in Chef::Provider::Package::Windows::MSI
