### PR TITLE
The windows package provider should inherit from Chef::Provider::Package

### DIFF
--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -24,7 +24,7 @@ class Chef
   class Provider
     class Package
       class Windows
-        class MSI
+        class MSI < Chef::Provider::Package
           include Chef::ReservedNames::Win32::API::Installer if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 
           def initialize(resource)
@@ -54,7 +54,7 @@ class Chef
             Chef::Log.debug("#{@new_resource} installing MSI package '#{@new_resource.source}'")
             shell_out!("msiexec /qn /i \"#{@new_resource.source}\" #{expand_options(@new_resource.options)}", {:timeout => @new_resource.timeout, :returns => @new_resource.returns})
           end
-  
+
           def remove_package(name, version)
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             Chef::Log.debug("#{@new_resource} removing MSI package '#{@new_resource.source}'")


### PR DESCRIPTION
https://github.com/opscode/chef/issues/2625 is caused by the fact that the windows package provider does not inherit from the provider base class, thus shell_out! is not included.

This replaces https://github.com/opscode/chef/pull/2626

cc @opscode/client-engineers 
