### PR TITLE
Improve Error Messages for SSL Errors in Knife

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -428,6 +428,13 @@ class Chef
         raise # make sure exit passes through.
       when Net::HTTPServerException, Net::HTTPFatalError
         humanize_http_exception(e)
+      when OpenSSL::SSL::SSLError
+        ui.error "Could not establish a secure connection to the server."
+        ui.info "Use `knife ssl check` to troubleshoot your SSL configuration."
+        ui.info "If your Chef Server uses a self-signed certificate, you can use"
+        ui.info "`knife ssl fetch` to make knife trust the server's certificates."
+        ui.info ""
+        ui.info  "Original Exception: #{e.class.name}: #{e.message}"
       when Errno::ECONNREFUSED, Timeout::Error, Errno::ETIMEDOUT, SocketError
         ui.error "Network Error: #{e.message}"
         ui.info "Check your knife configuration and network settings"

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -435,6 +435,21 @@ describe Chef::Knife do
       expect(stderr.string).to match(%r[Check your knife configuration and network settings])
     end
 
+    it "formats SSL errors nicely and suggests to use `knife ssl check` and `knife ssl fetch`" do
+      error = OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed")
+      allow(knife).to receive(:run).and_raise(error)
+
+      knife.run_with_pretty_exceptions
+
+      expected_message=<<-MSG
+ERROR: Could not establish a secure connection to the server.
+Use `knife ssl check` to troubleshoot your SSL configuration.
+If your Chef Server uses a self-signed certificate, you can use
+`knife ssl fetch` to make knife trust the server's certificates.
+MSG
+      expect(stderr.string).to include(expected_message)
+    end
+
   end
 
 end


### PR DESCRIPTION
Adds a case for SSL errors to `knife`'s error handling, which points users to the `knife ssl check` and `knife ssl fetch` commands.

@opscode/client-core @opscode/client-engineers 
