### PR TITLE
Constrain version of database cookbook

### DIFF
--- a/kitchen-tests/cookbooks/webapp/metadata.rb
+++ b/kitchen-tests/cookbooks/webapp/metadata.rb
@@ -7,6 +7,6 @@ long_description 'Installs/Configures webapp'
 version          '0.1.0'
 
 depends 'apache2'
-depends 'database'
+depends 'database', '~> 2.3.1'
 depends 'mysql'
 depends 'php'


### PR DESCRIPTION
A release of mysql-chef_gem broke the database cookbook because
it removed the default recipe which the database cookbook was using.
Since the database cookbook did not lock versions of mysql-chef_gem,
it pulls the latest mysql-chef_gem cookbook and fails.

An update to the database cookbook was released to fix this, however
Berks dep solving is getting the latest mysql-chef_gem and an older database
cookbook for the webapp test cookbook.

More info at https://github.com/opscode-cookbooks/database/issues/99

cc @mcquin @opscode/client-engineers 
