### PR TITLE
Merge pull request #2634 from BackSlasher/repair-subversion-command

### DIFF
--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -62,7 +62,7 @@ class Chef
       def action_checkout
         if target_dir_non_existent_or_empty?
           converge_by("perform checkout of #{@new_resource.repository} into #{@new_resource.destination}") do
-            shell_out!(run_options(command: checkout_command))
+            shell_out!(checkout_command, run_options)
           end
         else
           Chef::Log.debug "#{@new_resource} checkout destination #{@new_resource.destination} already exists or is a non-empty directory - nothing to do"
@@ -79,7 +79,7 @@ class Chef
 
       def action_force_export
         converge_by("export #{@new_resource.repository} into #{@new_resource.destination}") do
-          shell_out!(run_options(command: export_command))
+          shell_out!(export_command, run_options)
         end
       end
 
@@ -90,7 +90,7 @@ class Chef
           Chef::Log.debug "#{@new_resource} current revision: #{current_rev} target revision: #{revision_int}"
           unless current_revision_matches_target_revision?
             converge_by("sync #{@new_resource.destination} from #{@new_resource.repository}") do
-              shell_out!(run_options(command: sync_command))
+              shell_out!(sync_command, run_options)
               Chef::Log.info "#{@new_resource} updated to revision: #{revision_int}"
             end
           end

--- a/spec/unit/provider/subversion_spec.rb
+++ b/spec/unit/provider/subversion_spec.rb
@@ -198,7 +198,7 @@ describe Chef::Provider::Subversion do
   it "runs an export with the --force option" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn export --force -q  -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(command: expected_cmd)
+    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
     @provider.run_action(:force_export)
     expect(@resource).to be_updated
   end
@@ -206,7 +206,7 @@ describe Chef::Provider::Subversion do
   it "runs the checkout command for action_checkout" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn checkout -q  -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(command: expected_cmd)
+    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
     @provider.run_action(:checkout)
     expect(@resource).to be_updated
   end
@@ -230,7 +230,7 @@ describe Chef::Provider::Subversion do
     @resource.user "whois"
     @resource.group "thisis"
     expected_cmd = "svn checkout -q  -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(command: expected_cmd, user: "whois", group: "thisis")
+    expect(@provider).to receive(:shell_out!).with(expected_cmd, {user: "whois", group: "thisis"})
     @provider.run_action(:checkout)
     expect(@resource).to be_updated
   end
@@ -255,7 +255,7 @@ describe Chef::Provider::Subversion do
     allow(@provider).to receive(:find_current_revision).and_return("11410")
     allow(@provider).to receive(:current_revision_matches_target_revision?).and_return(false)
     expected_cmd = "svn update -q  -r12345 /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(command: expected_cmd)
+    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
     @provider.run_action(:sync)
     expect(@resource).to be_updated
   end
@@ -272,7 +272,7 @@ describe Chef::Provider::Subversion do
   it "runs the export_command on action_export" do
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)
     expected_cmd = "svn export --force -q  -r12345 http://svn.example.org/trunk/ /my/deploy/dir"
-    expect(@provider).to receive(:shell_out!).with(command: expected_cmd)
+    expect(@provider).to receive(:shell_out!).with(expected_cmd, {})
     @provider.run_action(:export)
     expect(@resource).to be_updated
   end


### PR DESCRIPTION
Subversion failes with "option ':command' is not a valid option for Mixlib::ShellOut"
