### PR TITLE
Fix broken powershell_script resource

### DIFF
--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -43,7 +43,7 @@ class Chef
                         code.to_s +
                         EXIT_STATUS_NORMALIZATION_SCRIPT )
         convert_boolean_return = @new_resource.convert_boolean_return
-        @code = <<EOH
+        self.code = <<EOH
 new-variable -name interpolatedexitcode -visibility private -value $#{convert_boolean_return}
 new-variable -name chefscriptresult -visibility private
 $chefscriptresult = {
@@ -52,7 +52,7 @@ $chefscriptresult = {
 if ($interpolatedexitcode -and $chefscriptresult.gettype().name -eq 'boolean') { exit [int32](!$chefscriptresult) } else { exit 0 }
 EOH
         Chef::Log.debug("powershell_script provider called with script code:\n\n#{code}\n")
-        Chef::Log.debug("powershell_script provider will execute transformed code:\n\n#{@code}\n")
+        Chef::Log.debug("powershell_script provider will execute transformed code:\n\n#{self.code}\n")
       end
 
       public
@@ -86,10 +86,6 @@ EOH
         end
 
         interpreter_flags
-      end
-
-      def code
-        @code
       end
     end
   end

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -32,10 +32,13 @@ class Chef
       provides :ruby
       provides :script
 
-      def_delegators :@new_resource, :code, :interpreter, :flags
+      def_delegators :@new_resource, :interpreter, :flags
+
+      attr_accessor :code
 
       def initialize(new_resource, run_context)
         super
+        self.code = new_resource.code
       end
 
       def command


### PR DESCRIPTION
The powershell commands were not being guarded by our code that
checks for for exit codes

The regression happened at https://github.com/opscode/chef/commit/1b3705ca383b64092c9ef54d7e46201fab6271c7#diff-59352d07d2bfdded1139103819565cfaL38

cc @opscode/client-engineers 
