### PR TITLE
Removing ole_initialize/uninitialize

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -35,13 +35,10 @@ class Chef
         # CHEF-4888: Work around ruby #2618, expected to be fixed in Ruby 2.1.0
         # https://github.com/ruby/ruby/commit/588504b20f5cc880ad51827b93e571e32446e5db
         # https://github.com/ruby/ruby/commit/27ed294c7134c0de582007af3c915a635a6506cd
-        WIN32OLE.ole_initialize
 
         wmi = WmiLite::Wmi.new
         host = wmi.first_of('Win32_OperatingSystem')
         is_server_2003 = (host['version'] && host['version'].start_with?("5.2"))
-
-        WIN32OLE.ole_uninitialize
 
         is_server_2003
       end

--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -126,13 +126,9 @@ class Chef
         # https://github.com/ruby/ruby/commit/588504b20f5cc880ad51827b93e571e32446e5db
         # https://github.com/ruby/ruby/commit/27ed294c7134c0de582007af3c915a635a6506cd
 
-        WIN32OLE.ole_initialize
-
         wmi = WmiLite::Wmi.new
         os_info = wmi.first_of('Win32_OperatingSystem')
         os_version = os_info['version']
-
-        WIN32OLE.ole_uninitialize
 
         # The operating system version is a string in the following form
         # that can be split into components based on the '.' delimiter:


### PR DESCRIPTION
This seems to stop ruby from seg faulting on Windows when we use ruby 2.x

@adamedx might be able to explain more why as it was his idea to try this.

cc @opscode/client-engineers 