### PR TITLE
Multipackge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   Fix knife cookbook upload messages
 * [**David Crowder**] (https://github.com/david-crowder)
   refactor to use shell_out in rpm provider
+* [**Phil Dibowitz**](https://github.com/jaymzh):
+  Multi-package support
 
 ### Chef Contributions
 * ruby 1.9.3 support is dropped

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -39,3 +39,8 @@ This probably only needs to be a bullet point added to http://docs.getchef.com/n
 ## Drop SSL Warnings
 Now that the default for SSL checking is on, no more warning is emitted when SSL
 checking is off.
+
+## Multi-package Support
+The `package` provider has been extended to support multiple packages. This
+support is new and and not all subproviders yet support it. Full support for
+`apt` and `yum` has been implemented.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,11 @@ Previously, when a URI scheme contained all uppercase letters, Chef would reject
 Now that the default for SSL checking is on, no more warning is emitted when SSL
 checking is off.
 
+## Multi-package Support
+The `package` provider has been extended to support multiple packages. This
+support is new and and not all subproviders yet support it. Full support for
+`apt` and `yum` has been implemented.
+
 # Chef Client Release Notes 12.0.0:
 
 # Internal API Changes in this Release

--- a/lib/chef/mixin/get_source_from_package.rb
+++ b/lib/chef/mixin/get_source_from_package.rb
@@ -29,6 +29,7 @@ class Chef
     module GetSourceFromPackage
       def initialize(new_resource, run_context)
         super
+        return if new_resource.name.is_a?(Array)
         # if we're passed something that looks like a filesystem path, with no source, use it
         #  - require at least one '/' in the path to avoid gem_package "foo" breaking if a file named 'foo' exists in the cwd
         if new_resource.source.nil? && new_resource.package_name.match(/#{::File::SEPARATOR}/) && ::File.exists?(new_resource.package_name)

--- a/lib/chef/mixin/get_source_from_package.rb
+++ b/lib/chef/mixin/get_source_from_package.rb
@@ -29,7 +29,7 @@ class Chef
     module GetSourceFromPackage
       def initialize(new_resource, run_context)
         super
-        return if new_resource.name.is_a?(Array)
+        return if new_resource.package_name.is_a?(Array)
         # if we're passed something that looks like a filesystem path, with no source, use it
         #  - require at least one '/' in the path to avoid gem_package "foo" breaking if a file named 'foo' exists in the cwd
         if new_resource.source.nil? && new_resource.package_name.match(/#{::File::SEPARATOR}/) && ::File.exists?(new_resource.package_name)

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -40,6 +40,14 @@ class Chef
       def load_current_resource
       end
 
+      def package_name_array
+        [ new_resource.package_name ].flatten
+      end
+
+      def candidate_version_array
+        [ candidate_version ].flatten
+      end
+
       def define_resource_requirements
         requirements.assert(:install) do |a|
           a.assertion { ((@new_resource.version != nil) && !(target_version_already_installed?)) \
@@ -84,8 +92,7 @@ class Chef
       end
 
       def action_upgrade
-        if (@new_resource.package_name.is_a?(Array) && !candidate_version.any?) ||
-           (@new_resource.package_name.is_a?(String) && candidate_version.nil?)
+        if !candidate_version_array.any?
           Chef::Log.debug("#{@new_resource} no candidate version - nothing to do")
           return
         elsif @current_resource.version == candidate_version
@@ -113,14 +120,10 @@ class Chef
       end
 
       def removing_package?
-        if @current_resource.version.nil?
-          false # nothing to remove
-        elsif @current_resource.version.is_a?(Array) && !@current_resource.version.any?
+        if ![ @current_resource.version ].flatten.any?
           # ! any? means it's all nil's, which means nothing is installed
           false
-        elsif @new_resource.version.nil?
-          true # remove any version of a package
-        elsif @new_resource.version.is_a?(Array) && !@current_resource.version.any?
+        elsif ![ @new_resource.version ].flatten.any?
           true # remove any version of all packages
         elsif @new_resource.version == @current_resource.version
           true # remove the version we have

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -63,7 +63,7 @@ class Chef
       end
 
       def action_install
-        if !target_version_array.any?
+        unless target_version_array.any?
           Chef::Log.debug("#{@new_resource} is already installed - nothing to do")
           return
         end
@@ -417,7 +417,9 @@ class Chef
             missing = []
             each_package do |package_name, new_version, current_version, candidate_version|
               next if new_version.nil? || current_version.nil?
-              missing.push(package_name) if !target_version_already_installed?(current_version, new_version) && candidate_version.nil?
+              if !target_version_already_installed?(current_version, new_version) && candidate_version.nil?
+                missing.push(package_name)
+              end
             end
             missing
           end

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -25,9 +25,15 @@ class Chef
   class Provider
     class Package < Chef::Provider
 
+      # @todo: validate no subclasses need this and nuke it
       include Chef::Mixin::Command
 
+      #
+      # Hook that subclasses use to populate the candidate_version(s)
+      #
+      # @return [Array, String] candidate_version(s) may be a string or array
       attr_accessor :candidate_version
+
       def initialize(new_resource, run_context)
         super
         @candidate_version = nil
@@ -40,105 +46,88 @@ class Chef
       def load_current_resource
       end
 
-      def as_array(thing)
-        [ thing ].flatten
-      end
-
-      def package_name_array
-        [ new_resource.package_name ].flatten
-      end
-
-      def candidate_version_array
-        [ candidate_version ].flatten
-      end
-
-      def current_version_array
-        [ @current_resource.version ].flatten
-      end
-
-      def new_version_array
-        [ @new_resource.version ].flatten
-      end
-
       def define_resource_requirements
+        # XXX: upgrade with a specific version doesn't make a whole lot of sense, but why don't we throw this anyway if it happens?
+        # if not, shouldn't we raise to tell the user to use install instead of upgrade if they want to pin a version?
         requirements.assert(:install) do |a|
-          a.assertion { ((@new_resource.version != nil) && !(target_version_already_installed?)) \
-            || !(@current_resource.version.nil? && candidate_version.nil?)  }
-          a.failure_message(Chef::Exceptions::Package, "No version specified, and no candidate version available for #{@new_resource.package_name}")
-          a.whyrun("Assuming a repository that offers #{@new_resource.package_name} would have been configured")
+          a.assertion { candidates_exist_for_all_forced_changes? }
+          a.failure_message(Chef::Exceptions::Package, "No version specified, and no candidate version available for #{forced_packages_missing_candidates.join(", ")}")
+          a.whyrun("Assuming a repository that offers #{forced_packages_missing_candidates.join(", ")} would have been configured")
         end
 
-        requirements.assert(:upgrade) do |a|
-          # Can't upgrade what we don't have
-          a.assertion  { !(@current_resource.version.nil? && candidate_version.nil?) }
-          a.failure_message(Chef::Exceptions::Package, "No candidate version available for #{@new_resource.package_name}")
-          a.whyrun("Assuming a repository that offers #{@new_resource.package_name} would have been configured")
+        requirements.assert(:upgrade, :install) do |a|
+          a.assertion  { candidates_exist_for_all_uninstalled? }
+          a.failure_message(Chef::Exceptions::Package, "No candidate version available for #{packages_missing_candidates.join(", ")}")
+          a.whyrun("Assuming a repository that offers #{packages_missing_candidates.join(", ")} would have been configured")
         end
       end
 
       def action_install
-        # If we specified a version, and it's not the current version, move to the specified version
-        if new_version_array.any? && !(target_version_already_installed?)
-          install_version = @new_resource.version
-        # If it's not installed at all, install it
-        elsif current_version_array.include?(nil)
-          install_version = candidate_version
-        else
+        if !target_version_array.any?
           Chef::Log.debug("#{@new_resource} is already installed - nothing to do")
           return
         end
 
-        # We need to make sure we handle the preseed file
+        # @todo: move the preseed code out of the base class (and complete the fix for Array of preseeds? ugh...)
         if @new_resource.response_file
-          if preseed_file = get_preseed_file(@new_resource.package_name, install_version)
-            converge_by("preseed package #{@new_resource.package_name}") do
+          if preseed_file = get_preseed_file(package_names_for_targets, versions_for_targets)
+            converge_by("preseed package #{package_names_for_targets}") do
               preseed_package(preseed_file)
             end
           end
         end
-        description = install_version ? "version #{install_version} of" : ""
-        converge_by("install #{description} package #{@new_resource.package_name}") do
-          @new_resource.version(install_version)
-          install_package(@new_resource.package_name, install_version)
+
+        # XXX: mutating the new resource is generally bad
+        @new_resource.version(versions_for_new_resource)
+
+        converge_by(install_description) do
+          install_package(package_names_for_targets, versions_for_targets)
+          Chef::Log.info("#{@new_resource} installed #{package_names_for_targets} at #{versions_for_targets}")
         end
       end
 
-      def upgrade_text(name, oldversion, newversion)
-        if as_array(name).size == 1
-          return "upgraded #{name} from #{oldversion} to #{newversion}"
+      def install_description
+        description = []
+        target_version_array.each_with_index do |target_version, i|
+          next if target_version.nil?
+          package_name = package_name_array[i]
+          description << "install version #{target_version} of package #{package_name}"
         end
-
-        outs = []
-        name.zip(oldversion, newversion).each do |pkg, old, new|
-          next if old == new
-          outs << "#{pkg} from #{old} to #{new}"
-        end
-
-        "upgraded #{outs.join(', ')}"
+        description
       end
+
+      private :install_description
 
       def action_upgrade
-        if !candidate_version_array.any?
-          Chef::Log.debug("#{@new_resource} no candidate version - nothing to do")
-          return
-        elsif @current_resource.version == candidate_version
-          Chef::Log.debug("#{@new_resource} is at the latest version - nothing to do")
+        if !target_version_array.any?
+          Chef::Log.debug("#{@new_resource} no versions to upgrade - nothing to do")
           return
         end
-        @new_resource.version(candidate_version)
 
-        orig_version = []
-        current_version_array.each do |v|
-          orig_version << (v || "uninstalled")
-        end
-        orig_version = orig_version.size == 1 ? orig_version[0] : orig_version
+        # XXX: mutating the new resource is generally bad
+        @new_resource.version(versions_for_new_resource)
 
-        converge_by(upgrade_text(@new_resource.package_name, orig_version, candidate_version)) do
-          upgrade_package(@new_resource.package_name, candidate_version)
-          Chef::Log.info("#{@new_resource} upgraded from #{orig_version} to #{candidate_version}")
+        converge_by(upgrade_description) do
+          upgrade_package(package_names_for_targets, versions_for_targets)
+          Chef::Log.info("#{@new_resource} upgraded #{package_names_for_targets} to #{versions_for_targets}")
         end
       end
 
+      def upgrade_description
+        description = []
+        target_version_array.each_with_index do |target_version, i|
+          next if target_version.nil?
+          package_name = package_name_array[i]
+          candidate_version = candidate_version_array[i]
+          current_version = current_version_array[i] || "uninstalled"
+          description << "upgrade package #{package_name} from #{current_version} to #{candidate_version}"
+        end
+        description
+      end
+
+      private :upgrade_description
+
+      # @todo: ability to remove an array of packages
       def action_remove
         if removing_package?
           description = @new_resource.version ? "version #{@new_resource.version} of " :  ""
@@ -158,7 +147,7 @@ class Chef
         end
         f.any?
       end
-          
+
       def removing_package?
         if !current_version_array.any?
           # ! any? means it's all nil's, which means nothing is installed
@@ -172,6 +161,7 @@ class Chef
         end
       end
 
+      # @todo: ability to purge an array of packages
       def action_purge
         if removing_package?
           description = @new_resource.version ? "version #{@new_resource.version} of" : ""
@@ -182,6 +172,7 @@ class Chef
         end
       end
 
+      # @todo: ability to reconfigure an array of packages
       def action_reconfig
         if @current_resource.version == nil then
           Chef::Log.debug("#{@new_resource} is NOT installed - nothing to do")
@@ -204,6 +195,7 @@ class Chef
         end
       end
 
+      # @todo use composition rather than inheritance
       def install_package(name, version)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :install"
       end
@@ -228,6 +220,17 @@ class Chef
         raise( Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reconfig" )
       end
 
+      # this is heavily used by subclasses
+      def expand_options(options)
+        options ? " #{options}" : ""
+      end
+
+      # this is public and overridden by subclasses (rubygems package implements '>=' and '~>' operators)
+      def target_version_already_installed?(current_version, new_version)
+        new_version == current_version
+      end
+
+      # @todo: extract apt/dpkg specific preseeding to a helper class
       def get_preseed_file(name, version)
         resource = preseed_resource(name, version)
         resource.run_action(:create)
@@ -240,6 +243,7 @@ class Chef
         end
       end
 
+      # @todo: extract apt/dpkg specific preseeding to a helper class
       def preseed_resource(name, version)
         # A directory in our cache to store this cookbook's preseed files in
         file_cache_dir = Chef::FileCache.create_cache_path("preseed/#{@new_resource.cookbook_name}")
@@ -266,22 +270,207 @@ class Chef
         remote_file
       end
 
-      def expand_options(options)
-        options ? " #{options}" : ""
-      end
-
-      def target_version_already_installed?
-        new_version_array == current_version_array
+      # helper method used by subclasses
+      #
+      def as_array(thing)
+        [ thing ].flatten
       end
 
       private
 
-      def template_available?(path)
-        run_context.has_template_in_cookbook?(@new_resource.cookbook_name, path)
+      # Returns the package names which need to be modified.  If the resource was called with an array of packages
+      # then this will return an array of packages to update (may have 0 or 1 entries).  If the resource was called
+      # with a non-array package_name to manage then this will return a string rather than an Array.  The output
+      # of this is meant to be fed into subclass interfaces to install/upgrade packages and not all of them are
+      # Array-aware.
+      #
+      # @return [String, Array<String>] package_name(s) to actually update/install
+      def package_names_for_targets
+        package_names_for_targets = []
+        target_version_array.each_with_index do |target_version, i|
+          next if target_version.nil?
+          package_name = package_name_array[i]
+          package_names_for_targets.push(package_name)
+        end
+        multipackage? ? package_names_for_targets : package_names_for_targets[0]
       end
 
+      # Returns the package versions which need to be modified.  If the resource was called with an array of packages
+      # then this will return an array of versions to update (may have 0 or 1 entries).  If the resource was called
+      # with a non-array package_name to manage then this will return a string rather than an Array.  The output
+      # of this is meant to be fed into subclass interfaces to install/upgrade packages and not all of them are
+      # Array-aware.
+      #
+      # @return [String, Array<String>] package version(s) to actually update/install
+      def versions_for_targets
+        versions_for_targets = []
+        target_version_array.each_with_index do |target_version, i|
+          next if target_version.nil?
+          versions_for_targets.push(target_version)
+        end
+        multipackage? ? versions_for_targets : versions_for_targets[0]
+      end
+
+      # We need to mutate @new_resource.version() for some reason and this is a helper so that we inject the right
+      # class (String or Array) into that attribute based on if we're handling an array of package names or not.
+      #
+      # @return [String, Array<String>] target_versions coerced into the correct type for back-compat
+      def versions_for_new_resource
+        if multipackage?
+          target_version_array
+        else
+          target_version_array[0]
+        end
+      end
+
+      # Return an array indexed the same as *_version_array which contains either the target version to install/upgrade to
+      # or else nil if the package is not being modified.
+      #
+      # @return [Array<String,NilClass>] array of package versions which need to be upgraded (nil = not being upgraded)
+      def target_version_array
+        @target_version_array ||=
+          begin
+            target_version_array = []
+
+            each_package do |package_name, new_version, current_version, candidate_version|
+              case action
+              when :upgrade
+
+                if !candidate_version
+                  Chef::Log.debug("#{new_resource} #{package_name} has no candidate_version to upgrade to")
+                  target_version_array.push(nil)
+                elsif current_version == candidate_version
+                  Chef::Log.debug("#{new_resource} #{package_name} the #{candidate_version} is already installed")
+                  target_version_array.push(nil)
+                else
+                  Chef::Log.debug("#{new_resource} #{package_name} is out of date, will upgrade to #{candidate_version}")
+                  target_version_array.push(candidate_version)
+                end
+
+              when :install
+
+                if new_version
+                  if target_version_already_installed?(current_version, new_version)
+                    Chef::Log.debug("#{new_resource} #{package_name} #{current_version} satisifies #{new_version} requirement")
+                    target_version_array.push(nil)
+                  else
+                    Chef::Log.debug("#{new_resource} #{package_name} #{current_version} needs updating to #{new_version}")
+                    target_version_array.push(new_version)
+                  end
+                elsif current_version.nil?
+                  Chef::Log.debug("#{new_resource} #{package_name} not installed, installing #{candidate_version}")
+                  target_version_array.push(candidate_version)
+                else
+                  Chef::Log.debug("#{new_resource} #{package_name} #{current_version} already installed")
+                  target_version_array.push(nil)
+                end
+
+              else
+                # in specs please test the public interface provider.run_action(:install) instead of provider.action_install
+                raise "internal error - target_version_array in package provider does not understand this action"
+              end
+            end
+
+            target_version_array
+          end
+      end
+
+      # Check the list of current_version_array and candidate_version_array. For any of the
+      # packages if both versions are missing (uninstalled and no candidate) this will be an
+      # unsolvable error.
+      #
+      # @return [Boolean] valid candidates exist for all uninstalled packages
+      def candidates_exist_for_all_uninstalled?
+        packages_missing_candidates.empty?
+      end
+
+      # Returns array of all packages which are missing candidate versions.
+      #
+      # @return [Array<String>] names of packages missing candidates
+      def packages_missing_candidates
+        @packages_missing_candidates ||=
+          begin
+            missing = []
+            each_package do |package_name, new_version, current_version, candidate_version|
+              missing.push(package_name) if candidate_version.nil? && current_version.nil?
+            end
+            missing
+          end
+      end
+
+      # This looks for packages which have a new_version and a current_version, and they are
+      # different (a "forced change") and for which there is no candidate.  This is an edge
+      # condition that candidates_exist_for_all_uninstalled? does not catch since in this case
+      # it is not uninstalled but must be installed anyway and no version exists.
+      #
+      # @return [Boolean] valid candidates exist for all uninstalled packages
+      def candidates_exist_for_all_forced_changes?
+        forced_packages_missing_candidates.empty?
+      end
+
+      # Returns an array of all forced packages which are missing candidate versions
+      #
+      # @return [Array] names of packages missing candidates
+      def forced_packages_missing_candidates
+        @forced_packages_missing_candidates ||=
+          begin
+            missing = []
+            each_package do |package_name, new_version, current_version, candidate_version|
+              next if new_version.nil? || current_version.nil?
+              missing.push(package_name) if !target_version_already_installed?(current_version, new_version) && candidate_version.nil?
+            end
+            missing
+          end
+      end
+
+      # Helper to iterate over all the indexed *_array's in sync
+      #
+      # @yield [package_name, new_version, current_version, candidate_version] Description of block
+      def each_package
+        package_name_array.each_with_index do |package_name, i|
+          candidate_version = candidate_version_array[i]
+          current_version = current_version_array[i]
+          new_version = new_version_array[i]
+          yield package_name, new_version, current_version, candidate_version
+        end
+      end
+
+      # @return [Boolean] if we're doing a multipackage install or not
+      def multipackage?
+        new_resource.package_name.is_a?(Array)
+      end
+
+      # @return [Array] package_name(s) as an array
+      def package_name_array
+        [ new_resource.package_name ].flatten
+      end
+
+      # @return [Array] candidate_version(s) as an array
+      def candidate_version_array
+        [ candidate_version ].flatten
+      end
+
+      # @return [Array] current_version(s) as an array
+      def current_version_array
+        [ current_resource.version ].flatten
+      end
+
+      # @return [Array] new_version(s) as an array
+      def new_version_array
+        @new_version_array ||=
+            [ new_resource.version ].flatten.map do |v|
+              ( v.nil? || v.empty? ) ? nil : v
+            end
+      end
+
+      # @todo: extract apt/dpkg specific preseeding to a helper class
+      def template_available?(path)
+        run_context.has_template_in_cookbook?(new_resource.cookbook_name, path)
+      end
+
+      # @todo: extract apt/dpkg specific preseeding to a helper class
       def cookbook_file_available?(path)
-        run_context.has_cookbook_file_in_cookbook?(@new_resource.cookbook_name, path)
+        run_context.has_cookbook_file_in_cookbook?(new_resource.cookbook_name, path)
       end
 
     end

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -48,6 +48,14 @@ class Chef
         [ candidate_version ].flatten
       end
 
+      def current_version_array
+        [ @current_resource.version ].flatten
+      end
+
+      def new_version_array
+        [ @new_resource.version ].flatten
+      end
+
       def define_resource_requirements
         requirements.assert(:install) do |a|
           a.assertion { ((@new_resource.version != nil) && !(target_version_already_installed?)) \
@@ -120,10 +128,10 @@ class Chef
       end
 
       def removing_package?
-        if ![ @current_resource.version ].flatten.any?
+        if !current_version_array.any?
           # ! any? means it's all nil's, which means nothing is installed
           false
-        elsif ![ @new_resource.version ].flatten.any?
+        elsif !new_version_array.any?
           true # remove any version of all packages
         elsif @new_resource.version == @current_resource.version
           true # remove the version we have

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -417,7 +417,7 @@ class Chef
             missing = []
             each_package do |package_name, new_version, current_version, candidate_version|
               next if new_version.nil? || current_version.nil?
-              if !target_version_already_installed?(current_version, new_version) && candidate_version.nil?
+              if candidate_version.nil? && !target_version_already_installed?(current_version, new_version)
                 missing.push(package_name)
               end
             end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -51,17 +51,19 @@ class Chef
         end
 
         def check_package_state(package)
-          final_installed_version = []
-          final_candidate_version = []
-          final_installed = []
-          final_virtual = []
+          if package.is_a?(Array)
+            final_installed_version = []
+            final_candidate_version = []
+            final_installed = []
+            final_virtual = []
+          end
           installed = virtual = false
           installed_version = candidate_version = nil
 
           [package].flatten.each do |pkg|
             installed = virtual = false
             installed_version = candidate_version = nil
-            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}", {:timeout=>900}).stdout.each_line do |line|
+            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}").stdout.each_line do |line|
               case line
               when /^\s{2}Installed: (.+)$/
                 installed_version = $1
@@ -77,9 +79,9 @@ class Chef
                 if candidate_version == '(none)'
                   # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
                   virtual = true
-                  showpkg = shell_out!("apt-cache showpkg #{package}", {:timeout => 900}).stdout
+                  showpkg = shell_out!("apt-cache showpkg #{package}").stdout
                   providers = Hash.new
-                  showpkg.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line|
+                  showpkg.rpartition(/Reverse Provides:? #{$/}/)[2].each_line do |line|
                     provider, version = line.split
                     providers[provider] = version
                   end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -51,19 +51,17 @@ class Chef
         end
 
         def check_package_state(package)
-          if package.is_a?(Array)
-            final_installed_version = []
-            final_candidate_version = []
-            final_installed = []
-            final_virtual = []
-          end
+          final_installed_version = []
+          final_candidate_version = []
+          final_installed = []
+          final_virtual = []
           installed = virtual = false
           installed_version = candidate_version = nil
 
           [package].flatten.each do |pkg|
             installed = virtual = false
             installed_version = candidate_version = nil
-            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}").stdout.each_line do |line|
+            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}", {:timeout=>900}).stdout.each_line do |line|
               case line
               when /^\s{2}Installed: (.+)$/
                 installed_version = $1
@@ -79,9 +77,9 @@ class Chef
                 if candidate_version == '(none)'
                   # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
                   virtual = true
-                  showpkg = shell_out!("apt-cache showpkg #{package}").stdout
+                  showpkg = shell_out!("apt-cache showpkg #{package}", {:timeout => 900}).stdout
                   providers = Hash.new
-                  showpkg.rpartition(/Reverse Provides:? #{$/}/)[2].each_line do |line|
+                  showpkg.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line|
                     provider, version = line.split
                     providers[provider] = version
                   end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -51,54 +51,89 @@ class Chef
         end
 
         def check_package_state(package)
-          Chef::Log.debug("#{@new_resource} checking package status for #{package}")
-          installed = false
+          if package.is_a?(Array)
+            final_installed_version = []
+            final_candidate_version = []
+            final_installed = []
+            final_virtual = []
+          end
+          installed = virtual = false
+          installed_version = candidate_version = nil
 
-          shell_out!("apt-cache#{expand_options(default_release_options)} policy #{package}", :timeout => @new_resource.timeout).stdout.each_line do |line|
-            case line
-            when /^\s{2}Installed: (.+)$/
-              installed_version = $1
-              if installed_version == '(none)'
-                Chef::Log.debug("#{@new_resource} current version is nil")
-                @current_resource.version(nil)
-              else
-                Chef::Log.debug("#{@new_resource} current version is #{installed_version}")
-                @current_resource.version(installed_version)
-                installed = true
-              end
-            when /^\s{2}Candidate: (.+)$/
-              candidate_version = $1
-              if candidate_version == '(none)'
-                # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
-                @is_virtual_package = true
-                showpkg = shell_out!("apt-cache showpkg #{package}", :timeout => @new_resource.timeout).stdout
-                providers = Hash.new
-                # Returns all lines after 'Reverse Provides:'
-                showpkg.rpartition(/Reverse Provides:\s*#{$/}/)[2].each_line do |line|
-                  provider, version = line.split
-                  providers[provider] = version
+          [package].flatten.each do |pkg|
+            installed = virtual = false
+            installed_version = candidate_version = nil
+            shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}").stdout.each_line do |line|
+              case line
+              when /^\s{2}Installed: (.+)$/
+                installed_version = $1
+                if installed_version == '(none)'
+                  Chef::Log.debug("#{@new_resource} current version is nil")
+                  installed_version = nil
+                else
+                  Chef::Log.debug("#{@new_resource} current version is #{installed_version}")
+                  installed = true
                 end
-                # Check if the package providing this virtual package is installed
-                num_providers = providers.length
-                raise Chef::Exceptions::Package, "#{@new_resource.package_name} has no candidate in the apt-cache" if num_providers == 0
-                # apt will only install a virtual package if there is a single providing package
-                raise Chef::Exceptions::Package, "#{@new_resource.package_name} is a virtual package provided by #{num_providers} packages, you must explicitly select one to install" if num_providers > 1
-                # Check if the package providing this virtual package is installed
-                Chef::Log.info("#{@new_resource} is a virtual package, actually acting on package[#{providers.keys.first}]")
-                installed = check_package_state(providers.keys.first)
-              else
-                Chef::Log.debug("#{@new_resource} candidate version is #{$1}")
-                @candidate_version = $1
+              when /^\s{2}Candidate: (.+)$/
+                candidate_version = $1
+                if candidate_version == '(none)'
+                  # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
+                  virtual = true
+                  showpkg = shell_out!("apt-cache showpkg #{package}").stdout
+                  providers = Hash.new
+                  showpkg.rpartition(/Reverse Provides:? #{$/}/)[2].each_line do |line|
+                    provider, version = line.split
+                    providers[provider] = version
+                  end
+                  # Check if the package providing this virtual package is installed
+                  num_providers = providers.length
+                  raise Chef::Exceptions::Package, "#{@new_resource.package_name} has no candidate in the apt-cache" if num_providers == 0
+                  # apt will only install a virtual package if there is a single providing package
+                  raise Chef::Exceptions::Package, "#{@new_resource.package_name} is a virtual package provided by #{num_providers} packages, you must explicitly select one to install" if num_providers > 1
+                  # Check if the package providing this virtual package is installed
+                  Chef::Log.info("#{@new_resource} is a virtual package, actually acting on package[#{providers.keys.first}]")
+                  installed = check_package_state(providers.keys.first)
+                else
+                  Chef::Log.debug("#{@new_resource} candidate version is #{$1}")
+                end
               end
             end
+            if package.is_a?(Array)
+              final_installed_version << installed_version
+              final_candidate_version << candidate_version
+              final_installed << installed
+              final_virtual << virtual
+            else
+              final_installed_version = installed_version
+              final_candidate_version = candidate_version
+              final_installed = installed
+              final_virtual = virtual
+            end
           end
-
-          return installed
+          @candidate_version = final_candidate_version
+          @current_resource.version(final_installed_version)
+          @is_virtual_package = final_virtual
+ 
+          return final_installed.is_a?(Array) ? final_installed.any? : final_installed
         end
 
         def install_package(name, version)
-          package_name = "#{name}=#{version}"
-          package_name = name if @is_virtual_package
+          if name.is_a?(Array)
+            index = 0
+            package_name = name.zip(version).map do |x, y|
+              namestr = nil
+              if @is_virtual_package[index]
+                namestr = x
+              else
+                namestr = "#{x}=#{y}"
+              end
+              index += 1
+              namestr
+            end.join(' ')
+          else
+            package_name = "#{name}=#{version}"
+            package_name = name if @is_virtual_package
+          end
           run_noninteractive("apt-get -q -y#{expand_options(default_release_options)}#{expand_options(@new_resource.options)} install #{package_name}")
         end
 
@@ -107,12 +142,21 @@ class Chef
         end
 
         def remove_package(name, version)
-          package_name = "#{name}"
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = name
+          end
           run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} remove #{package_name}")
         end
 
         def purge_package(name, version)
-          run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} purge #{@new_resource.package_name}")
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = "#{name}"
+          end
+          run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} purge #{package_name}")
         end
 
         def preseed_package(preseed_file)
@@ -121,8 +165,13 @@ class Chef
         end
 
         def reconfig_package(name, version)
+          if name.is_a?(Array)
+            package_name = name.join(' ')
+          else
+            package_name = "#{name}"
+          end
           Chef::Log.info("#{@new_resource} reconfiguring")
-          run_noninteractive("dpkg-reconfigure #{name}")
+          run_noninteractive("dpkg-reconfigure #{package_name}")
         end
 
         private

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -55,8 +55,6 @@ class Chef
           final_candidate_version = []
           final_installed = []
           final_virtual = []
-          installed = virtual = false
-          installed_version = candidate_version = nil
 
           [package].flatten.each do |pkg|
             installed = virtual = false

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -484,7 +484,7 @@ class Chef
 
         def candidate_version
           @candidate_version ||= begin
-            if target_version_already_installed?
+            if target_version_already_installed?(@current_resource.version, @new_resource.version)
               nil
             elsif source_is_remote?
               @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
@@ -494,12 +494,11 @@ class Chef
           end
         end
 
-        def target_version_already_installed?
-          return false unless @current_resource && @current_resource.version
-          return false if @current_resource.version.nil?
-          return false if @new_resource.version.nil?
+        def target_version_already_installed?(current_version, new_version)
+          return false unless current_version
+          return false if new_version.nil?
 
-          Gem::Requirement.new(@new_resource.version).satisfied_by?(Gem::Version.new(@current_resource.version))
+          Gem::Requirement.new(new_version).satisfied_by?(Gem::Version.new(current_version))
         end
 
         ##

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1116,45 +1116,63 @@ class Chef
         def install_remote_package(name, version)
           # Work around yum not exiting with an error if a package doesn't exist
           # for CHEF-2062
-          if !name.is_a?(Array) && @yum.version_available?(name, version, arch)
-            method = "install"
-            log_method = "installing"
-
+          all_avail = as_array(name).zip(as_array(version)).any? do |n, v|
+            @yum.version_available?(n, v, arch)
+          end
+          method = log_method = nil
+          methods = []
+          if all_avail
             # More Yum fun:
             #
             # yum install of an old name+version will exit(1)
             # yum install of an old name+version+arch will exit(0) for some reason
             #
             # Some packages can be installed multiple times like the kernel
-            unless @yum.allow_multi_install.include?(name)
-              if RPMVersion.parse(@current_resource.version) > RPMVersion.parse(version)
-                # Unless they want this...
-                if allow_downgrade
-                  method = "downgrade"
-                  log_method = "downgrading"
-                else
-                  # we bail like yum when the package is older
-                  raise Chef::Exceptions::Package, "Installed package #{name}-#{@current_resource.version} is newer " +
-                                                   "than candidate package #{name}-#{version}"
+            as_array(name).zip(as_array(version)).each do |n, v|
+              method = "install"
+              log_method = "installing"
+              idx = package_name_array.index(n)
+              unless @yum.allow_multi_install.include?(n)
+                if RPMVersion.parse(current_version_array[idx]) > RPMVersion.parse(v)
+                  # We allow downgrading only in the evenit of single-package
+                  # rules where the user explicitly allowed it
+                  if allow_downgrade
+                    method = "downgrade"
+                    log_method = "downgrading"
+                  else
+                    # we bail like yum when the package is older
+                    raise Chef::Exceptions::Package, "Installed package #{name}-#{@current_resource.version} is newer " +
+                                                     "than candidate package #{n}-#{v}"
+                  end
                 end
               end
+              # methods don't count for packages we won't be touching
+              next if RPMVersion.parse(current_version_array[idx]) == RPMVersion.parse(v)
+              methods << method
             end
 
-            repo = @yum.package_repository(name, version, arch)
-            Chef::Log.info("#{@new_resource} #{log_method} #{name}-#{version}#{yum_arch} from #{repo} repository")
+            # We could split this up into two commands if we wanted to, but
+            # for now, just don't support this.
+            if methods.uniq.length > 1
+              raise Chef::Exceptions::Package, "Multipackage rule #{name} has a mix of upgrade and downgrade packages. Cannot proceed."
+            end
 
-            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} #{method} #{name}-#{version}#{yum_arch}")
-          elsif name.is_a?(Array)
+            repos = []
+            pkg_string_bits = []
             index = 0
-            pkg_string = name.zip(version).map do |x|
+            as_array(name).zip(as_array(version)).each do |n, v|
               s = ''
-              unless x[1] == @current_resource.version[index]
-                s = "#{x.join('-')}#{yum_arch}"
+              unless v == current_version_array[index]
+                s = "#{n}-#{v}#{yum_arch}"
+                repo = @yum.package_repository(n, v, arch)
+                repos << "#{s} from #{repo} repository"
+                pkg_string_bits << s
               end
               index += 1
-              s
-            end.join(' ')
-            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} install #{pkg_string}")
+            end
+            pkg_string = pkg_string_bits.join(' ')
+            Chef::Log.info("#{@new_resource} #{log_method} #{repos.join(' ')}")
+            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} #{method} #{pkg_string}")
           else
             raise Chef::Exceptions::Package, "Version #{version} of #{name} not found. Did you specify both version " +
                                              "and release? (version-release, e.g. 1.84-10.fc6)"

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1068,9 +1068,6 @@ class Chef
             parse_arch
           end
 
-          # normalize internal representation as an array
-          @new_resource.package_name(as_array(@new_resource.package_name))
-
           @current_resource = Chef::Resource::Package.new(@new_resource.name)
           @current_resource.package_name(@new_resource.package_name)
 
@@ -1103,12 +1100,12 @@ class Chef
             installed_version << @yum.installed_version(pkg, arch)
             @candidate_version << @yum.candidate_version(pkg, arch)
           end
-          #if installed_version.size == 1
-          #  @current_resource.version(installed_version[0])
-          #  @candidate_version = @candidate_version[0]
-          #else
-            @current_resource.version(installed_version.flatten)
-          #end
+          if installed_version.size == 1
+            @current_resource.version(installed_version[0])
+            @candidate_version = @candidate_version[0]
+          else
+            @current_resource.version(installed_version)
+          end
 
           Chef::Log.debug("#{@new_resource} installed version: #{installed_version || "(none)"} candidate version: " +
                           "#{@candidate_version || "(none)"}")
@@ -1119,62 +1116,45 @@ class Chef
         def install_remote_package(name, version)
           # Work around yum not exiting with an error if a package doesn't exist
           # for CHEF-2062
-          all_avail = as_array(name).zip(as_array(version)).any? do |n, v|
-            @yum.version_available?(n, v, arch)
-          end
-          method = log_method = nil
-          methods = []
-          if all_avail
+          if !name.is_a?(Array) && @yum.version_available?(name, version, arch)
+            method = "install"
+            log_method = "installing"
+
             # More Yum fun:
             #
             # yum install of an old name+version will exit(1)
             # yum install of an old name+version+arch will exit(0) for some reason
             #
             # Some packages can be installed multiple times like the kernel
-            as_array(name).zip(as_array(version)).each do |n, v|
-              method = "install"
-              log_method = "installing"
-              idx = package_name_array.index(n)
-              unless @yum.allow_multi_install.include?(n)
-                if RPMVersion.parse(current_version_array[idx]) > RPMVersion.parse(v)
-                  # We allow downgrading only in the evenit of single-package
-                  # rules where the user explicitly allowed it
-                  if allow_downgrade
-                    method = "downgrade"
-                    log_method = "downgrading"
-                  else
-                    # we bail like yum when the package is older
-                    raise Chef::Exceptions::Package, "Installed package #{name}-#{@current_resource.version} is newer " +
-                                                     "than candidate package #{name}-#{version}"
-                  end
+            unless @yum.allow_multi_install.include?(name)
+              if RPMVersion.parse(@current_resource.version) > RPMVersion.parse(version)
+                # Unless they want this...
+                if allow_downgrade
+                  method = "downgrade"
+                  log_method = "downgrading"
+                else
+                  # we bail like yum when the package is older
+                  raise Chef::Exceptions::Package, "Installed package #{name}-#{@current_resource.version} is newer " +
+                                                   "than candidate package #{name}-#{version}"
                 end
               end
-              # methods don't count for packages we won't be touching
-              next if RPMVersion.parse(current_version_array[idx]) == RPMVersion.parse(v)
-              methods << method
-            end
-            # We could split this up into two commands if we wanted to, but
-            # for now, just don't support this.
-            if methods.uniq.length > 1
-              raise Chef::Exceptions::Package, "Multipackage rule #{name} has a mix of upgrade and downgrade packages. Cannot proceed."
             end
 
-            repos = []
-            pkg_string_bits = []
+            repo = @yum.package_repository(name, version, arch)
+            Chef::Log.info("#{@new_resource} #{log_method} #{name}-#{version}#{yum_arch} from #{repo} repository")
+
+            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} #{method} #{name}-#{version}#{yum_arch}")
+          elsif name.is_a?(Array)
             index = 0
-            as_array(name).zip(as_array(version)).each do |n, v|
+            pkg_string = name.zip(version).map do |x|
               s = ''
-              unless v == current_version_array[index]
-                s = "#{n}-#{v}#{yum_arch}"
-                repo = @yum.package_repository(n, v, arch)
-                repos << "#{s} from #{repo} repository"
-                pkg_string_bits << s
+              unless x[1] == @current_resource.version[index]
+                s = "#{x.join('-')}#{yum_arch}"
               end
               index += 1
-            end
-            pkg_string = pkg_string_bits.join(' ')
-            Chef::Log.info("#{@new_resource} #{log_method} #{repos.join(' ')}")
-            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} #{method} #{pkg_string}")
+              s
+            end.join(' ')
+            yum_command("yum -d0 -e0 -y#{expand_options(@new_resource.options)} install #{pkg_string}")
           else
             raise Chef::Exceptions::Package, "Version #{version} of #{name} not found. Did you specify both version " +
                                              "and release? (version-release, e.g. 1.84-10.fc6)"

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -987,10 +987,6 @@ class Chef
         # Helpers
         #
 
-        def as_array(thing)
-          [ thing ].flatten
-        end
-
         def yum_arch
           arch ? ".#{arch}" : nil
         end

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1060,7 +1060,7 @@ class Chef
               dep = parse_dependency(n)
               if dep
                 if @new_resource.package_name.is_a?(Array)
-                  @new_resource.package_name(package_name_array + [dep])
+                  @new_resource.package_name(package_name_array - [n] + [dep])
                 else
                   @new_resource.package_name(dep)
                 end

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -46,7 +46,7 @@ class Chef
         set_or_return(
           :package_name,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, Array ]
         )
       end
 
@@ -54,7 +54,7 @@ class Chef
         set_or_return(
           :version,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, Array ]
         )
       end
 

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -54,8 +54,8 @@ describe Chef::Provider::Package::Aix do
     it "should raise an exception if a source is supplied but not found" do
       allow(@provider).to receive(:popen4).and_return(@status)
       allow(::File).to receive(:exists?).and_return(false)
-      @provider.define_resource_requirements
       @provider.load_current_resource
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Package)
     end
 

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -198,6 +198,11 @@ mpg123 1.12.1-0ubuntu1
 
         it "raises an exception if a source is specified (CHEF-5113)" do
           @new_resource.source "pluto"
+          expect(@provider).to receive(:shell_out!).with(
+            "apt-cache policy #{@new_resource.package_name}",
+            :timeout => @timeout
+          ).and_return(@shell_out)
+          @provider.load_current_resource
           @provider.define_resource_requirements
           expect(@provider).to receive(:shell_out!).with("apt-cache policy irssi", {:timeout=>900}).and_return(@shell_out)
           expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
@@ -307,8 +312,7 @@ mpg123 1.12.1-0ubuntu1
           end
 
           it "should get the full path to the preseed response file" do
-            expect(@provider).to receive(:get_preseed_file).with("irssi", "0.8.12-7").and_return("/tmp/irssi-0.8.12-7.seed")
-            file = @provider.get_preseed_file("irssi", "0.8.12-7")
+            file = "/tmp/irssi-0.8.12-7.seed"
 
             expect(@provider).to receive(:shell_out!).with(
               "debconf-set-selections /tmp/irssi-0.8.12-7.seed",

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -88,8 +88,8 @@ describe Chef::Provider::Package::Dpkg do
     it "should raise an exception if the source is not set but we are installing" do
       @new_resource = Chef::Resource::Package.new("wget")
       @provider.new_resource = @new_resource
-      @provider.define_resource_requirements
       @provider.load_current_resource
+      @provider.define_resource_requirements
       expect { @provider.run_action(:install)}.to raise_error(Chef::Exceptions::Package)
     end
 

--- a/spec/unit/provider/package/ips_spec.rb
+++ b/spec/unit/provider/package/ips_spec.rb
@@ -190,9 +190,8 @@ REMOTE
 
       expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local)
       expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote)
-      @provider.load_current_resource
       expect(@provider).to receive(:install_package).exactly(0).times
-      @provider.action_install
+      @provider.run_action(:install)
     end
 
     context "when accept_license is true" do

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -552,7 +552,7 @@ describe Chef::Provider::Package::Rubygems do
 
           it "installs the gem by shelling out when options are provided but no version is given" do
             @new_resource.options('-i /alt/install/location')
-            expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"3.1.7\" -i /alt/install/location"
+            expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" -i /alt/install/location"
             expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
             @provider.run_action(:install)
             expect(@new_resource).to be_updated_by_last_action

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -552,7 +552,7 @@ describe Chef::Provider::Package::Rubygems do
 
           it "installs the gem by shelling out when options are provided but no version is given" do
             @new_resource.options('-i /alt/install/location')
-            expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" -i /alt/install/location"
+            expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"#{@provider.candidate_version}\" -i /alt/install/location"
             expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
             @provider.run_action(:install)
             expect(@new_resource).to be_updated_by_last_action

--- a/spec/unit/provider/package/solaris_spec.rb
+++ b/spec/unit/provider/package/solaris_spec.rb
@@ -64,8 +64,8 @@ PKGINFO
     it "should raise an exception if a source is supplied but not found" do
       allow(@provider).to receive(:popen4).and_return(@status)
       allow(::File).to receive(:exists?).and_return(false)
-      @provider.define_resource_requirements
       @provider.load_current_resource
+      @provider.define_resource_requirements
       expect { @provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Package)
     end
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -373,7 +373,7 @@ describe Chef::Provider::Package::Yum do
 
     it "installs the package with the options given in the resource" do
       @provider.load_current_resource
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
@@ -488,7 +488,7 @@ describe Chef::Provider::Package::Yum do
   describe "when upgrading a package" do
     it "should run yum install if the package is installed and a version is given" do
       @provider.load_current_resource
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y install cups-11"
@@ -499,7 +499,7 @@ describe Chef::Provider::Package::Yum do
     it "should run yum install if the package is not installed" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y install cups-11"
@@ -528,42 +528,41 @@ describe Chef::Provider::Package::Yum do
     # Test our little workaround, some crossover into Chef::Provider::Package territory
     it "should call action_upgrade in the parent if the current resource version is nil" do
       allow(@yum_cache).to receive(:installed_version).and_return(nil)
-      @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       expect(@provider).to receive(:upgrade_package).with(
         "cups",
         "11"
       )
-      @provider.action_upgrade
+      @provider.run_action(:upgrade)
     end
 
     it "should call action_upgrade in the parent if the candidate version is nil" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = nil
+      allow(@provider).to receive(:candidate_version).and_return(nil)
       expect(@provider).not_to receive(:upgrade_package)
-      @provider.action_upgrade
+      @provider.run_action(:upgrade)
     end
 
     it "should call action_upgrade in the parent if the candidate is newer" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       expect(@provider).to receive(:upgrade_package).with(
         "cups",
         "11"
       )
-      @provider.action_upgrade
+      @provider.run_action(:upgrade)
     end
 
     it "should not call action_upgrade in the parent if the candidate is older" do
       allow(@yum_cache).to receive(:installed_version).and_return("12")
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      allow(@provider).to receive(:candidate_version).and_return('11')
       expect(@provider).not_to receive(:upgrade_package)
-      @provider.action_upgrade
+      @provider.run_action(:upgrade)
     end
   end
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -50,23 +50,23 @@ describe Chef::Provider::Package::Yum do
 
     it "should set the current resources package name to the new resources package name" do
       @provider.load_current_resource
-      expect(@provider.current_resource.package_name).to eq("cups")
+      expect(@provider.current_resource.package_name).to eq(["cups"])
     end
 
     it "should set the installed version to nil on the current resource if no installed package" do
-      allow(@yum_cache).to receive(:installed_version).and_return(nil)
+      allow(@yum_cache).to receive(:installed_version).and_return([nil])
       @provider.load_current_resource
-      expect(@provider.current_resource.version).to be_nil
+      expect(@provider.current_resource.version).to eq([nil])
     end
 
     it "should set the installed version if yum has one" do
       @provider.load_current_resource
-      expect(@provider.current_resource.version).to eq("1.2.4-11.18.el5")
+      expect(@provider.current_resource.version).to eq(["1.2.4-11.18.el5"])
     end
 
     it "should set the candidate version if yum info has one" do
       @provider.load_current_resource
-      expect(@provider.candidate_version).to eql("1.2.4-11.18.el5_2.3")
+      expect(@provider.candidate_version).to eql(["1.2.4-11.18.el5_2.3"])
     end
 
     it "should return the current resouce" do
@@ -96,14 +96,14 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing")
+        expect(@provider.new_resource.package_name).to eq(["testing"])
         expect(@provider.new_resource.arch).to eq("noarch")
         expect(@provider.arch).to eq("noarch")
 
         @new_resource = Chef::Resource::YumPackage.new('testing.more.noarch')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.more")
+        expect(@provider.new_resource.package_name).to eq(["testing.more"])
         expect(@provider.new_resource.arch).to eq("noarch")
         expect(@provider.arch).to eq("noarch")
       end
@@ -131,14 +131,14 @@ describe Chef::Provider::Package::Yum do
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         # annoying side effect of the fun stub'ing above
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.beta3")
+        expect(@provider.new_resource.package_name).to eq(["testing.beta3"])
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
 
         @new_resource = Chef::Resource::YumPackage.new('testing.beta3.more')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.beta3.more")
+        expect(@provider.new_resource.package_name).to eq(["testing.beta3.more"])
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
       end
@@ -161,14 +161,14 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.beta3")
+        expect(@provider.new_resource.package_name).to eq(["testing.beta3"])
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
 
         @new_resource = Chef::Resource::YumPackage.new('testing.beta3.more')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.beta3.more")
+        expect(@provider.new_resource.package_name).to eq(["testing.beta3.more"])
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
       end
@@ -196,7 +196,7 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq("testing.i386")
+        expect(@provider.new_resource.package_name).to eq(["testing.i386"])
         expect(@provider.new_resource.arch).to eq("x86_64")
       end
     end
@@ -247,7 +247,7 @@ describe Chef::Provider::Package::Yum do
       expect(@yum_cache).to receive(:packages_from_require).and_return([pkg])
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq("test-package")
+      expect(@new_resource.package_name).to eq(["test-package"])
     end
 
     it "should search provides if package name can't be found, warn about multiple matches, but use the first one" do
@@ -268,7 +268,7 @@ describe Chef::Provider::Package::Yum do
       expect(Chef::Log).to receive(:warn).exactly(1).times.with(%r{matched multiple Provides})
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq("test-package-x")
+      expect(@new_resource.package_name).to eq(["test-package-x"])
     end
 
     it "should search provides if no package is available - if no match in installed provides then load the complete set" do
@@ -328,7 +328,7 @@ describe Chef::Provider::Package::Yum do
       expect(@yum_cache).to receive(:packages_from_require).twice.and_return([])
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq("cups")
+      expect(@new_resource.package_name).to eq(["cups"])
     end
   end
 
@@ -337,9 +337,9 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5"
       )
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package(["cups"], ["1.2.4-11.19.el5"])
     end
 
     it "should run yum localinstall if given a path to an rpm" do
@@ -347,7 +347,7 @@ describe Chef::Provider::Package::Yum do
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
-      @provider.install_package("emacs", "21.4-20.el5")
+      @provider.install_package(["emacs"], ["21.4-20.el5"])
     end
 
     it "should run yum localinstall if given a path to an rpm as the package" do
@@ -358,7 +358,7 @@ describe Chef::Provider::Package::Yum do
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
-      @provider.install_package("/tmp/emacs-21.4-20.el5.i386.rpm", "21.4-20.el5")
+      @provider.install_package(["/tmp/emacs-21.4-20.el5.i386.rpm"], ["21.4-20.el5"])
     end
 
     it "should run yum install with the package name, version and arch" do
@@ -366,14 +366,14 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-21.4-20.el5.i386"
+        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5.i386"
       )
-      @provider.install_package("emacs", "21.4-20.el5")
+      @provider.install_package(["cups"], ["1.2.4-11.19.el5"])
     end
 
     it "installs the package with the options given in the resource" do
       @provider.load_current_resource
-      @provider.candidate_version = '11'
+      @provider.candidate_version = ['11']
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
@@ -467,10 +467,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).to receive(:reload).once
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package("cups", "1.2.4-11.15.el5")
     end
 
     it "should run yum install then not flush the cache if :after is false" do
@@ -478,10 +478,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).not_to receive(:reload)
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package("cups", "1.2.4-11.15.el5")
     end
   end
 
@@ -530,10 +530,10 @@ describe Chef::Provider::Package::Yum do
       allow(@yum_cache).to receive(:installed_version).and_return(nil)
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      @provider.candidate_version = ['11']
       expect(@provider).to receive(:upgrade_package).with(
-        "cups",
-        "11"
+        ["cups"],
+        ["11"]
       )
       @provider.action_upgrade
     end
@@ -541,7 +541,7 @@ describe Chef::Provider::Package::Yum do
     it "should call action_upgrade in the parent if the candidate version is nil" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = nil
+      @provider.candidate_version = [nil]
       expect(@provider).not_to receive(:upgrade_package)
       @provider.action_upgrade
     end
@@ -549,10 +549,10 @@ describe Chef::Provider::Package::Yum do
     it "should call action_upgrade in the parent if the candidate is newer" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      @provider.candidate_version = ['11']
       expect(@provider).to receive(:upgrade_package).with(
-        "cups",
-        "11"
+        ["cups"],
+        ["11"]
       )
       @provider.action_upgrade
     end
@@ -561,7 +561,7 @@ describe Chef::Provider::Package::Yum do
       allow(@yum_cache).to receive(:installed_version).and_return("12")
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = '11'
+      @provider.candidate_version = ['11']
       expect(@provider).not_to receive(:upgrade_package)
       @provider.action_upgrade
     end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -50,23 +50,23 @@ describe Chef::Provider::Package::Yum do
 
     it "should set the current resources package name to the new resources package name" do
       @provider.load_current_resource
-      expect(@provider.current_resource.package_name).to eq(["cups"])
+      expect(@provider.current_resource.package_name).to eq("cups")
     end
 
     it "should set the installed version to nil on the current resource if no installed package" do
-      allow(@yum_cache).to receive(:installed_version).and_return([nil])
+      allow(@yum_cache).to receive(:installed_version).and_return(nil)
       @provider.load_current_resource
-      expect(@provider.current_resource.version).to eq([nil])
+      expect(@provider.current_resource.version).to be_nil
     end
 
     it "should set the installed version if yum has one" do
       @provider.load_current_resource
-      expect(@provider.current_resource.version).to eq(["1.2.4-11.18.el5"])
+      expect(@provider.current_resource.version).to eq("1.2.4-11.18.el5")
     end
 
     it "should set the candidate version if yum info has one" do
       @provider.load_current_resource
-      expect(@provider.candidate_version).to eql(["1.2.4-11.18.el5_2.3"])
+      expect(@provider.candidate_version).to eql("1.2.4-11.18.el5_2.3")
     end
 
     it "should return the current resouce" do
@@ -96,14 +96,14 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing"])
+        expect(@provider.new_resource.package_name).to eq("testing")
         expect(@provider.new_resource.arch).to eq("noarch")
         expect(@provider.arch).to eq("noarch")
 
         @new_resource = Chef::Resource::YumPackage.new('testing.more.noarch')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.more"])
+        expect(@provider.new_resource.package_name).to eq("testing.more")
         expect(@provider.new_resource.arch).to eq("noarch")
         expect(@provider.arch).to eq("noarch")
       end
@@ -131,14 +131,14 @@ describe Chef::Provider::Package::Yum do
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         # annoying side effect of the fun stub'ing above
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.beta3"])
+        expect(@provider.new_resource.package_name).to eq("testing.beta3")
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
 
         @new_resource = Chef::Resource::YumPackage.new('testing.beta3.more')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.beta3.more"])
+        expect(@provider.new_resource.package_name).to eq("testing.beta3.more")
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
       end
@@ -161,14 +161,14 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.beta3"])
+        expect(@provider.new_resource.package_name).to eq("testing.beta3")
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
 
         @new_resource = Chef::Resource::YumPackage.new('testing.beta3.more')
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.beta3.more"])
+        expect(@provider.new_resource.package_name).to eq("testing.beta3.more")
         expect(@provider.new_resource.arch).to eq(nil)
         expect(@provider.arch).to eq(nil)
       end
@@ -196,7 +196,7 @@ describe Chef::Provider::Package::Yum do
         allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
         @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
         @provider.load_current_resource
-        expect(@provider.new_resource.package_name).to eq(["testing.i386"])
+        expect(@provider.new_resource.package_name).to eq("testing.i386")
         expect(@provider.new_resource.arch).to eq("x86_64")
       end
     end
@@ -247,7 +247,7 @@ describe Chef::Provider::Package::Yum do
       expect(@yum_cache).to receive(:packages_from_require).and_return([pkg])
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq(["test-package"])
+      expect(@new_resource.package_name).to eq("test-package")
     end
 
     it "should search provides if package name can't be found, warn about multiple matches, but use the first one" do
@@ -268,7 +268,7 @@ describe Chef::Provider::Package::Yum do
       expect(Chef::Log).to receive(:warn).exactly(1).times.with(%r{matched multiple Provides})
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq(["test-package-x"])
+      expect(@new_resource.package_name).to eq("test-package-x")
     end
 
     it "should search provides if no package is available - if no match in installed provides then load the complete set" do
@@ -328,7 +328,7 @@ describe Chef::Provider::Package::Yum do
       expect(@yum_cache).to receive(:packages_from_require).twice.and_return([])
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
-      expect(@new_resource.package_name).to eq(["cups"])
+      expect(@new_resource.package_name).to eq("cups")
     end
   end
 
@@ -337,9 +337,9 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5"
+        "yum -d0 -e0 -y install emacs-1.0"
       )
-      @provider.install_package(["cups"], ["1.2.4-11.19.el5"])
+      @provider.install_package("emacs", "1.0")
     end
 
     it "should run yum localinstall if given a path to an rpm" do
@@ -347,7 +347,7 @@ describe Chef::Provider::Package::Yum do
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
-      @provider.install_package(["emacs"], ["21.4-20.el5"])
+      @provider.install_package("emacs", "21.4-20.el5")
     end
 
     it "should run yum localinstall if given a path to an rpm as the package" do
@@ -358,7 +358,7 @@ describe Chef::Provider::Package::Yum do
       expect(@provider).to receive(:yum_command).with(
         "yum -d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
-      @provider.install_package(["/tmp/emacs-21.4-20.el5.i386.rpm"], ["21.4-20.el5"])
+      @provider.install_package("/tmp/emacs-21.4-20.el5.i386.rpm", "21.4-20.el5")
     end
 
     it "should run yum install with the package name, version and arch" do
@@ -366,14 +366,14 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5.i386"
+        "yum -d0 -e0 -y install emacs-21.4-20.el5.i386"
       )
-      @provider.install_package(["cups"], ["1.2.4-11.19.el5"])
+      @provider.install_package("emacs", "21.4-20.el5")
     end
 
     it "installs the package with the options given in the resource" do
       @provider.load_current_resource
-      @provider.candidate_version = ['11']
+      @provider.candidate_version = '11'
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
@@ -467,10 +467,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
+        "yum -d0 -e0 -y install emacs-1.0"
       )
       expect(@yum_cache).to receive(:reload).once
-      @provider.install_package("cups", "1.2.4-11.15.el5")
+      @provider.install_package("emacs", "1.0")
     end
 
     it "should run yum install then not flush the cache if :after is false" do
@@ -478,10 +478,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
+        "yum -d0 -e0 -y install emacs-1.0"
       )
       expect(@yum_cache).not_to receive(:reload)
-      @provider.install_package("cups", "1.2.4-11.15.el5")
+      @provider.install_package("emacs", "1.0")
     end
   end
 
@@ -530,10 +530,10 @@ describe Chef::Provider::Package::Yum do
       allow(@yum_cache).to receive(:installed_version).and_return(nil)
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = ['11']
+      @provider.candidate_version = '11'
       expect(@provider).to receive(:upgrade_package).with(
-        ["cups"],
-        ["11"]
+        "cups",
+        "11"
       )
       @provider.action_upgrade
     end
@@ -541,7 +541,7 @@ describe Chef::Provider::Package::Yum do
     it "should call action_upgrade in the parent if the candidate version is nil" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = [nil]
+      @provider.candidate_version = nil
       expect(@provider).not_to receive(:upgrade_package)
       @provider.action_upgrade
     end
@@ -549,10 +549,10 @@ describe Chef::Provider::Package::Yum do
     it "should call action_upgrade in the parent if the candidate is newer" do
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = ['11']
+      @provider.candidate_version = '11'
       expect(@provider).to receive(:upgrade_package).with(
-        ["cups"],
-        ["11"]
+        "cups",
+        "11"
       )
       @provider.action_upgrade
     end
@@ -561,7 +561,7 @@ describe Chef::Provider::Package::Yum do
       allow(@yum_cache).to receive(:installed_version).and_return("12")
       @provider.load_current_resource
       @current_resource = Chef::Resource::Package.new('cups')
-      @provider.candidate_version = ['11']
+      @provider.candidate_version = '11'
       expect(@provider).not_to receive(:upgrade_package)
       @provider.action_upgrade
     end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -337,9 +337,9 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5"
       )
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package("cups", "1.2.4-11.19.el5")
     end
 
     it "should run yum localinstall if given a path to an rpm" do
@@ -366,9 +366,9 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-21.4-20.el5.i386"
+        "yum -d0 -e0 -y install cups-1.2.4-11.19.el5.i386"
       )
-      @provider.install_package("emacs", "21.4-20.el5")
+      @provider.install_package("cups", "1.2.4-11.19.el5")
     end
 
     it "installs the package with the options given in the resource" do
@@ -467,10 +467,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).to receive(:reload).once
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package("cups", "1.2.4-11.15.el5")
     end
 
     it "should run yum install then not flush the cache if :after is false" do
@@ -478,10 +478,10 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "yum -d0 -e0 -y install emacs-1.0"
+        "yum -d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).not_to receive(:reload)
-      @provider.install_package("emacs", "1.0")
+      @provider.install_package("cups", "1.2.4-11.15.el5")
     end
   end
 

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -152,7 +152,7 @@ describe Chef::Provider::Package do
 
     it "should print the word 'uninstalled' if there was no original version" do
       allow(@current_resource).to receive(:version).and_return(nil)
-      expect(Chef::Log).to receive(:info).with("package[emacs] upgraded from uninstalled to 1.0")
+      expect(Chef::Log).to receive(:info).with("package[emacs] upgraded emacs to 1.0")
       @provider.run_action(:upgrade)
       expect(@new_resource).to be_updated_by_last_action
     end
@@ -444,39 +444,89 @@ describe "Chef::Provider::Package - Multi" do
       allow(@provider).to receive(:install_package).and_return(true)
     end
 
-    it "should install the candidate versions when none are installed" do
+    it "installs the candidate versions when none are installed" do
+      expect(@provider).to receive(:install_package).with(
+        ["emacs", "vi"],
+        ["1.0", "6.2"]
+      ).and_return(true)
       @provider.run_action(:install)
       expect(@new_resource).to be_updated
     end
 
-    it "should install the candidate versions when some are installed" do
+    it "installs the candidate versions when some are installed" do
       expect(@provider).to receive(:install_package).with(
-        @new_resource.name,
-        @provider.candidate_version
+        [ 'vi' ],
+        [ '6.2' ]
       ).and_return(true)
       @current_resource.version(['1.0', nil])
       @provider.run_action(:install)
       expect(@new_resource).to be_updated
     end
 
-    it "should install the specified version when some are out of date" do
+    it "installs the specified version when some are out of date" do
       @current_resource.version(['1.0', '6.2'])
       @new_resource.version(['1.0', '6.1'])
       @provider.run_action(:install)
       expect(@new_resource).to be_updated
     end
 
-    it "should not install any version if all are installed at the right version" do
+    it "does not install any version if all are installed at the right version" do
       @current_resource.version(['1.0', '6.2'])
       @new_resource.version(['1.0', '6.2'])
       @provider.run_action(:install)
       expect(@new_resource).not_to be_updated_by_last_action
     end
 
-    it "should not install any version if all are installed, and no version was specified" do
+    it "does not install any version if all are installed, and no version was specified" do
       @current_resource.version(['1.0', '6.2'])
       @provider.run_action(:install)
       expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+    it "raises an exception if both are not installed and no caondidates are available" do
+      @current_resource.version([nil, nil])
+      @provider.candidate_version = [nil, nil]
+      expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "raises an exception if one is not installed and no candidates are available" do
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = ['1.0', nil]
+      expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "does not raise an exception if the packages are installed or have a candidate" do
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = [nil, '6.2']
+      expect { @provider.run_action(:install) }.not_to raise_error
+    end
+
+    it "raises an exception if an explicit version is asked for, an old version is installed, but no candidate" do
+      @new_resource.version ['1.0', '6.2']
+      @current_resource.version(['1.0', '6.1'])
+      @provider.candidate_version = ['1.0', nil]
+      expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "does not raise an exception if an explicit version is asked for, and is installed, but no candidate" do
+      @new_resource.version ['1.0', '6.2']
+      @current_resource.version(['1.0', '6.2'])
+      @provider.candidate_version = ['1.0', nil]
+      expect { @provider.run_action(:install) }.not_to raise_error
+    end
+
+    it "raise an exception if an explicit version is asked for, and is not installed, and no candidate" do
+      @new_resource.version ['1.0', '6.2']
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = ['1.0', nil]
+      expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "does not raise an exception if an explicit version is asked for, and is not installed, and there is a candidate" do
+      @new_resource.version ['1.0', '6.2']
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = ['1.0', '6.2']
+      expect { @provider.run_action(:install) }.not_to raise_error
     end
   end
 
@@ -499,8 +549,8 @@ describe "Chef::Provider::Package - Multi" do
     it "should upgrade the package if some of current versions are not the candidate versions" do
       @current_resource.version ['1.0', '6.1']
       expect(@provider).to receive(:upgrade_package).with(
-        @new_resource.name,
-        @provider.candidate_version
+        ["vi"],
+        ["6.2"]
       ).and_return(true)
       @provider.run_action(:upgrade)
       expect(@new_resource).to be_updated_by_last_action
@@ -511,6 +561,30 @@ describe "Chef::Provider::Package - Multi" do
       expect(@provider).not_to receive(:upgrade_package)
       @provider.run_action(:upgrade)
       expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+    it "should raise an exception if both are not installed and no caondidates are available" do
+      @current_resource.version([nil, nil])
+      @provider.candidate_version = [nil, nil]
+      expect { @provider.run_action(:upgrade) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "should raise an exception if one is not installed and no candidates are available" do
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = ['1.0', nil]
+      expect { @provider.run_action(:upgrade) }.to raise_error(Chef::Exceptions::Package)
+    end
+
+    it "should not raise an exception if the packages are installed or have a candidate" do
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = [nil, '6.2']
+      expect { @provider.run_action(:upgrade) }.not_to raise_error
+    end
+
+    it "should not raise an exception if the packages are installed or have a candidate" do
+      @current_resource.version(['1.0', nil])
+      @provider.candidate_version = [nil, '6.2']
+      expect { @provider.run_action(:upgrade) }.not_to raise_error
     end
   end
 

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -425,3 +425,203 @@ describe Chef::Provider::Package do
 
   end
 end
+
+describe "Chef::Provider::Package - Multi" do
+  before do
+    @node = Chef::Node.new
+    @events = Chef::EventDispatch::Dispatcher.new
+    @run_context = Chef::RunContext.new(@node, {}, @events)
+    @new_resource = Chef::Resource::Package.new(['emacs', 'vi'])
+    @current_resource = Chef::Resource::Package.new(['emacs', 'vi'])
+    @provider = Chef::Provider::Package.new(@new_resource, @run_context)
+    @provider.current_resource = @current_resource
+    @provider.candidate_version = ['1.0', '6.2']
+  end
+
+  describe "when installing multiple packages" do
+    before(:each) do
+      @provider.current_resource = @current_resource
+      allow(@provider).to receive(:install_package).and_return(true)
+    end
+
+    it "should install the candidate versions when none are installed" do
+      @provider.run_action(:install)
+      expect(@new_resource).to be_updated
+    end
+
+    it "should install the candidate versions when some are installed" do
+      expect(@provider).to receive(:install_package).with(
+        @new_resource.name,
+        @provider.candidate_version
+      ).and_return(true)
+      @current_resource.version(['1.0', nil])
+      @provider.run_action(:install)
+      expect(@new_resource).to be_updated
+    end
+
+    it "should install the specified version when some are out of date" do
+      @current_resource.version(['1.0', '6.2'])
+      @new_resource.version(['1.0', '6.1'])
+      @provider.run_action(:install)
+      expect(@new_resource).to be_updated
+    end
+
+    it "should not install any version if all are installed at the right version" do
+      @current_resource.version(['1.0', '6.2'])
+      @new_resource.version(['1.0', '6.2'])
+      @provider.run_action(:install)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+    it "should not install any version if all are installed, and no version was specified" do
+      @current_resource.version(['1.0', '6.2'])
+      @provider.run_action(:install)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+  end
+
+  describe "when upgrading multiple packages" do
+    before(:each) do
+      @provider.current_resource = @current_resource
+      allow(@provider).to receive(:upgrade_package).and_return(true)
+    end
+
+    it "should upgrade the package if the current versions are not the candidate version" do
+      @current_resource.version ['0.9', '6.1']
+      expect(@provider).to receive(:upgrade_package).with(
+        @new_resource.name,
+        @provider.candidate_version
+      ).and_return(true)
+      @provider.run_action(:upgrade)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should upgrade the package if some of current versions are not the candidate versions" do
+      @current_resource.version ['1.0', '6.1']
+      expect(@provider).to receive(:upgrade_package).with(
+        @new_resource.name,
+        @provider.candidate_version
+      ).and_return(true)
+      @provider.run_action(:upgrade)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should not install the package if the current versions are the candidate version" do
+      @current_resource.version ['1.0', '6.2']
+      expect(@provider).not_to receive(:upgrade_package)
+      @provider.run_action(:upgrade)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+  end
+
+  describe "When removing multiple packages " do
+    before(:each) do
+      allow(@provider).to receive(:remove_package).and_return(true)
+      @current_resource.version ['1.0', '6.2']
+    end
+
+    it "should remove the packages if all are installed" do
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:remove_package).with(['emacs', 'vi'], nil)
+      @provider.run_action(:remove)
+      expect(@new_resource).to be_updated
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should remove the packages if some are installed" do
+      @current_resource.version ['1.0', nil]
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:remove_package).with(['emacs', 'vi'], nil)
+      @provider.run_action(:remove)
+      expect(@new_resource).to be_updated
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should remove the packages at a specific version if they are installed at that version" do
+      @new_resource.version ['1.0', '6.2']
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:remove_package).with(['emacs', 'vi'], ['1.0', '6.2'])
+      @provider.run_action(:remove)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should remove the packages at a specific version any are is installed at that version" do
+      @new_resource.version ['0.5', '6.2']
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:remove_package).with(['emacs', 'vi'], ['0.5', '6.2'])
+      @provider.run_action(:remove)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should not remove the packages at a specific version if they are not installed at that version" do
+      @new_resource.version ['0.5', '6.0']
+      expect(@provider).not_to be_removing_package
+      expect(@provider).not_to receive(:remove_package)
+      @provider.run_action(:remove)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+    it "should not remove the packages if they are not installed" do
+      expect(@provider).not_to receive(:remove_package)
+      allow(@current_resource).to receive(:version).and_return(nil)
+      @provider.run_action(:remove)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+  end
+
+  describe "When purging multiple packages " do
+    before(:each) do
+      allow(@provider).to receive(:purge_package).and_return(true)
+      @current_resource.version ['1.0', '6.2']
+    end
+
+    it "should purge the packages if all are installed" do
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:purge_package).with(['emacs', 'vi'], nil)
+      @provider.run_action(:purge)
+      expect(@new_resource).to be_updated
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should purge the packages if some are installed" do
+      @current_resource.version ['1.0', nil]
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:purge_package).with(['emacs', 'vi'], nil)
+      @provider.run_action(:purge)
+      expect(@new_resource).to be_updated
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should purge the packages at a specific version if they are installed at that version" do
+      @new_resource.version ['1.0', '6.2']
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:purge_package).with(['emacs', 'vi'], ['1.0', '6.2'])
+      @provider.run_action(:purge)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should purge the packages at a specific version any are is installed at that version" do
+      @new_resource.version ['0.5', '6.2']
+      expect(@provider).to be_removing_package
+      expect(@provider).to receive(:purge_package).with(['emacs', 'vi'], ['0.5', '6.2'])
+      @provider.run_action(:purge)
+      expect(@new_resource).to be_updated_by_last_action
+    end
+
+    it "should not purge the packages at a specific version if they are not installed at that version" do
+      @new_resource.version ['0.5', '6.0']
+      expect(@provider).not_to be_removing_package
+      expect(@provider).not_to receive(:purge_package)
+      @provider.run_action(:purge)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+
+    it "should not purge the packages if they are not installed" do
+      expect(@provider).not_to receive(:purge_package)
+      allow(@current_resource).to receive(:version).and_return(nil)
+      @provider.run_action(:purge)
+      expect(@new_resource).not_to be_updated_by_last_action
+    end
+  end
+end


### PR DESCRIPTION
Allow the `package` provider to take an array of packages to handle in one
transaction.

This solves two large problems:
* There are times when you cannot install two packages in sequence, like when a
  binary is moving between two packages - they *must* be done in the same
  transaction.
* When using Chef to install the vast majority of your base system, it
  can make imaging take a very, very long time because executing yum or apt once
  for every single package is painfully slow.

This solves both. The scaffolding is all there in the Package HWRP, plus the
underlying implementation for both apt and yum, the two I have access to test.