### PR TITLE
Add comments to trusted_certs_content

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -49,6 +49,8 @@ class Chef
           @secret
         end
 
+        # Contains commands and content, see trusted_certs_content
+        # TODO: Rename to trusted_certs_script
         def trusted_certs
           @trusted_certs ||= trusted_certs_content
         end
@@ -159,6 +161,9 @@ CONFIG
         end
 
         private
+       
+        # Returns a string for copying the trusted certificates on the workstation to the system being bootstrapped
+        # This string should contain both the commands necessary to both create the files, as well as their content
         def trusted_certs_content
           content = ""
           if @chef_config[:trusted_certs_dir]


### PR DESCRIPTION
It's initially confusing why #trusted_certs has commands embedded in the certificates.
I've added comments to try to reduce that confusion for the next person.