### PR TITLE
Fix #2663 - refactor to use shell_out in rpm provider

### DIFF
--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -76,7 +76,7 @@ class Chef
           end
 
           Chef::Log.debug("#{@new_resource} checking install state")
-          @rpm_status = shell_out("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
+          @rpm_status = shell_out!("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
           @rpm_status.stdout.each_line do |line|
             case line
             when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -59,14 +59,13 @@ class Chef
             end
 
             Chef::Log.debug("#{@new_resource} checking rpm status")
-            status = popen4("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}") do |pid, stdin, stdout, stderr|
-              stdout.each do |line|
-                case line
-                when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
-                  @current_resource.package_name($1)
-                  @new_resource.version($2)
-                  @candidate_version = $2
-                end
+            status = shell_out("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}")
+            status.stdout.split('\n').each do |line|
+              case line
+              when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
+                @current_resource.package_name($1)
+                @new_resource.version($2)
+                @candidate_version = $2
               end
             end
           else
@@ -77,13 +76,12 @@ class Chef
           end
 
           Chef::Log.debug("#{@new_resource} checking install state")
-          @rpm_status = popen4("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}") do |pid, stdin, stdout, stderr|
-            stdout.each do |line|
-              case line
-              when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
-                Chef::Log.debug("#{@new_resource} current version is #{$2}")
-                @current_resource.version($2)
-              end
+          @rpm_status = shell_out("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
+          @rpm_status.stdout.split('\n').each do |line|
+            case line
+            when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
+              Chef::Log.debug("#{@new_resource} current version is #{$2}")
+              @current_resource.version($2)
             end
           end
 

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -17,6 +17,7 @@
 #
 require 'chef/provider/package'
 require 'chef/mixin/command'
+require 'chef/mixin/shell_out'
 require 'chef/resource/package'
 require 'chef/mixin/get_source_from_package'
 

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -59,8 +59,8 @@ class Chef
             end
 
             Chef::Log.debug("#{@new_resource} checking rpm status")
-            status = shell_out("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}")
-            status.stdout.split('\n').each do |line|
+            status = shell_out!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}")
+            status.stdout.each_line do |line|
               case line
               when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
                 @current_resource.package_name($1)
@@ -77,7 +77,7 @@ class Chef
 
           Chef::Log.debug("#{@new_resource} checking install state")
           @rpm_status = shell_out("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
-          @rpm_status.stdout.split('\n').each do |line|
+          @rpm_status.stdout.each_line do |line|
             case line
             when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
               Chef::Log.debug("#{@new_resource} current version is #{$2}")

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -19,9 +19,7 @@
 require 'spec_helper'
 
 describe Chef::Provider::Package::Rpm do
-
-  subject(:provider) { Chef::Provider::Package::Rpm.new(new_resource, run_context) }
-
+  let(:provider) { Chef::Provider::Package::Rpm.new(new_resource, run_context) }
   let(:node) { Chef::Node.new }
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
@@ -33,22 +31,19 @@ describe Chef::Provider::Package::Rpm do
   let(:exitstatus) { 0 }
   let(:stdout) { String.new('') }
   let(:status) { double('Process::Status', exitstatus: exitstatus, stdout: stdout) }
-  let(:exitstatus) { 0 }
 
   before(:each) do
     allow(::File).to receive(:exists?).and_return(true)
+    allow(provider).to receive(:shell_out!).and_return(status)
   end
 
   describe "when determining the current state of the package" do
-
     it "should create a current resource with the name of new_resource" do
-      allow(provider).to receive(:shell_out!).and_return(status)
       provider.load_current_resource
       expect(provider.current_resource.name).to eq("ImageMagick-c++")
     end
 
     it "should set the current reource package name to the new resource package name" do
-      allow(provider).to receive(:shell_out!).and_return(status)
       provider.load_current_resource
       expect(provider.current_resource.package_name).to eq('ImageMagick-c++')
     end
@@ -58,52 +53,57 @@ describe Chef::Provider::Package::Rpm do
       expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
-    it "should get the source package version from rpm if provided" do
-      stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
-      status = double("Status", :exitstatus => 0, :stdout => stdout)
-      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
-      provider.load_current_resource
-      expect(provider.current_resource.package_name).to eq("ImageMagick-c++")
-      expect(provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
+    context "installation exists" do
+      let(:stdout) { "ImageMagick-c++ 6.5.4.7-7.el6_5" }
+
+      it "should get the source package version from rpm if provided" do
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+        provider.load_current_resource
+        expect(provider.current_resource.package_name).to eq("ImageMagick-c++")
+        expect(provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
+      end
+
+      it "should return the current version installed if found by rpm" do
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+        provider.load_current_resource
+        expect(provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
+      end
     end
 
-    it "should return the current version installed if found by rpm" do
-      stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
-      status = double("Status", :exitstatus => 0, :stdout => stdout)
-      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
-      provider.load_current_resource
-      expect(provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
+    context "source is not defiend" do
+      let(:new_resource) { Chef::Resource::Package.new("ImageMagick-c++") }
+
+      it "should raise an exception if the source is not set but we are installing" do
+        expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
+      end
     end
 
-    it "should raise an exception if the source is not set but we are installing" do
-      new_resource = Chef::Resource::Package.new("ImageMagick-c++")
-      provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
-      expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
-    end
+    context "installation does not exist" do
+      let(:stdout) { String.new("package openssh-askpass is not installed") }
+      let(:exitstatus) { -1 }
+      let(:new_resource) do
+        Chef::Resource::Package.new("openssh-askpass").tap do |resource|
+          resource.source "openssh-askpass"
+        end
+      end
 
-    it "should raise an exception if rpm fails to run" do
-      status = double("Status", :exitstatus => -1, :stdout => stdout)
-      allow(provider).to receive(:shell_out!).and_return(status)
-      expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
-    end
+      it "should raise an exception if rpm fails to run" do
+        allow(provider).to receive(:shell_out!).and_return(status)
+        expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
+      end
 
-    it "should not detect the package name as version when not installed" do
-      stdout = "package openssh-askpass is not installed"
-      status = double("Status", :exitstatus => -1, :stdout => stdout)
-      new_resource = Chef::Resource::Package.new("openssh-askpass")
-      new_resource.source 'openssh-askpass'
-      provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
-      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
-      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
-      provider.load_current_resource
-      expect(provider.current_resource.version).to be_nil
+      it "should not detect the package name as version when not installed" do
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+        provider.load_current_resource
+        expect(provider.current_resource.version).to be_nil
+      end
     end
   end
 
   describe "after the current resource is loaded" do
-
     let(:current_resource) { Chef::Resource::Package.new("ImageMagick-c++") }
     let(:provider) do
       Chef::Provider::Package::Rpm.new(new_resource, run_context).tap do |provider|
@@ -129,25 +129,24 @@ describe Chef::Provider::Package::Rpm do
         provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
-      it "should install from a path when the package is a path and the source is nil" do
-        new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
-        expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        current_resource = Chef::Resource::Package.new("ImageMagick-c++")
-        provider.current_resource = current_resource
-        expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
-      end
+      context "installing when the name is a path" do
+        let(:new_resource) { Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm") }
+        let(:current_resource) { Chef::Resource::Package.new("ImageMagick-c++") }
 
-      it "should uprgrade from a path when the package is a path and the source is nil" do
-        new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
-        expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        current_resource = Chef::Resource::Package.new("ImageMagick-c++")
-        current_resource.version("21.4-19.el5")
-        provider.current_resource = current_resource
-        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
+        it "should install from a path when the package is a path and the source is nil" do
+          expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          provider.current_resource = current_resource
+          expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
+        end
+
+        it "should uprgrade from a path when the package is a path and the source is nil" do
+          expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          current_resource.version("21.4-19.el5")
+          provider.current_resource = current_resource
+          expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
+        end
       end
 
       it "installs with custom options specified in the resource" do

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -29,20 +29,21 @@ describe Chef::Provider::Package::Rpm do
 
     @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
 
-    @status = double("Status", :exitstatus => 0)
+    @stdout = ''
+    @status = double("Status", :exitstatus => 0, :stdout => @stdout)
     allow(::File).to receive(:exists?).and_return(true)
   end
 
   describe "when determining the current state of the package" do
 
     it "should create a current resource with the name of new_resource" do
-      allow(@provider).to receive(:popen4).and_return(@status)
+      allow(@provider).to receive(:shell_out).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("ImageMagick-c++")
     end
 
     it "should set the current reource package name to the new resource package name" do
-      allow(@provider).to receive(:popen4).and_return(@status)
+      allow(@provider).to receive(:shell_out).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq('ImageMagick-c++')
     end
@@ -53,18 +54,20 @@ describe Chef::Provider::Package::Rpm do
     end
 
     it "should get the source package version from rpm if provided" do
-      @stdout = StringIO.new("ImageMagick-c++ 6.5.4.7-7.el6_5")
-      expect(@provider).to receive(:popen4).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
-      expect(@provider).to receive(:popen4).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
+      @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
+      @status = double("Status", :exitstatus => 0, :stdout => @stdout)
+      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("ImageMagick-c++")
       expect(@provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
     end
 
     it "should return the current version installed if found by rpm" do
-      @stdout = StringIO.new("ImageMagick-c++ 6.5.4.7-7.el6_5")
-      expect(@provider).to receive(:popen4).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
-      expect(@provider).to receive(:popen4).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+      @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
+      @status = double("Status", :exitstatus => 0, :stdout => @stdout)
+      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
     end
@@ -76,19 +79,19 @@ describe Chef::Provider::Package::Rpm do
     end
 
     it "should raise an exception if rpm fails to run" do
-      status = double("Status", :exitstatus => -1)
-      allow(@provider).to receive(:popen4).and_return(status)
+      @status = double("Status", :exitstatus => -1, :stdout => @stdout)
+      allow(@provider).to receive(:shell_out).and_return(@status)
       expect { @provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should not detect the package name as version when not installed" do
-      @status = double("Status", :exitstatus => -1)
-      @stdout = StringIO.new("package openssh-askpass is not installed")
+      @stdout = "package openssh-askpass is not installed"
+      @status = double("Status", :exitstatus => -1, :stdout => @stdout)
       @new_resource = Chef::Resource::Package.new("openssh-askpass")
       @new_resource.source 'openssh-askpass'
       @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-      expect(@provider).to receive(:popen4).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
-      expect(@provider).to receive(:popen4).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -62,7 +62,7 @@ describe Chef::Provider::Package::Rpm do
       stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
       status = double("Status", :exitstatus => 0, :stdout => stdout)
       expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
       provider.load_current_resource
       expect(provider.current_resource.package_name).to eq("ImageMagick-c++")
       expect(provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
@@ -72,7 +72,7 @@ describe Chef::Provider::Package::Rpm do
       stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
       status = double("Status", :exitstatus => 0, :stdout => stdout)
       expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
       provider.load_current_resource
       expect(provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
     end
@@ -96,7 +96,7 @@ describe Chef::Provider::Package::Rpm do
       new_resource.source 'openssh-askpass'
       provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
       expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
-      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+      expect(provider).to receive(:shell_out!).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
       provider.load_current_resource
       expect(provider.current_resource.version).to be_nil
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -19,141 +19,149 @@
 require 'spec_helper'
 
 describe Chef::Provider::Package::Rpm do
+
+  subject(:provider) { Chef::Provider::Package::Rpm.new(new_resource, run_context) }
+
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:new_resource) do
+    Chef::Resource::Package.new("ImageMagick-c++").tap do |resource|
+      resource.source "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
+    end
+  end
+  let(:exitstatus) { 0 }
+  let(:stdout) { String.new('') }
+  let(:status) { double('Process::Status', exitstatus: exitstatus, stdout: stdout) }
+  let(:exitstatus) { 0 }
+
   before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-
-    @new_resource = Chef::Resource::Package.new("ImageMagick-c++")
-    @new_resource.source "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
-
-    @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-
-    @stdout = ''
-    @status = double("Status", :exitstatus => 0, :stdout => @stdout)
     allow(::File).to receive(:exists?).and_return(true)
   end
 
   describe "when determining the current state of the package" do
 
     it "should create a current resource with the name of new_resource" do
-      allow(@provider).to receive(:shell_out!).and_return(@status)
-      @provider.load_current_resource
-      expect(@provider.current_resource.name).to eq("ImageMagick-c++")
+      allow(provider).to receive(:shell_out!).and_return(status)
+      provider.load_current_resource
+      expect(provider.current_resource.name).to eq("ImageMagick-c++")
     end
 
     it "should set the current reource package name to the new resource package name" do
-      allow(@provider).to receive(:shell_out!).and_return(@status)
-      @provider.load_current_resource
-      expect(@provider.current_resource.package_name).to eq('ImageMagick-c++')
+      allow(provider).to receive(:shell_out!).and_return(status)
+      provider.load_current_resource
+      expect(provider.current_resource.package_name).to eq('ImageMagick-c++')
     end
 
     it "should raise an exception if a source is supplied but not found" do
       allow(::File).to receive(:exists?).and_return(false)
-      expect { @provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
+      expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should get the source package version from rpm if provided" do
-      @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
-      @status = double("Status", :exitstatus => 0, :stdout => @stdout)
-      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
-      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
-      @provider.load_current_resource
-      expect(@provider.current_resource.package_name).to eq("ImageMagick-c++")
-      expect(@provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
+      stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
+      status = double("Status", :exitstatus => 0, :stdout => stdout)
+      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
+      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+      provider.load_current_resource
+      expect(provider.current_resource.package_name).to eq("ImageMagick-c++")
+      expect(provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
     end
 
     it "should return the current version installed if found by rpm" do
-      @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
-      @status = double("Status", :exitstatus => 0, :stdout => @stdout)
-      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
-      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
-      @provider.load_current_resource
-      expect(@provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
+      stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
+      status = double("Status", :exitstatus => 0, :stdout => stdout)
+      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
+      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+      provider.load_current_resource
+      expect(provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
     end
 
     it "should raise an exception if the source is not set but we are installing" do
       new_resource = Chef::Resource::Package.new("ImageMagick-c++")
-      provider = Chef::Provider::Package::Rpm.new(new_resource, @run_context)
+      provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
       expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should raise an exception if rpm fails to run" do
-      status = double("Status", :exitstatus => -1, :stdout => @stdout)
-      allow(@provider).to receive(:shell_out!).and_return(status)
-      expect { @provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
+      status = double("Status", :exitstatus => -1, :stdout => stdout)
+      allow(provider).to receive(:shell_out!).and_return(status)
+      expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should not detect the package name as version when not installed" do
-      @stdout = "package openssh-askpass is not installed"
-      @status = double("Status", :exitstatus => -1, :stdout => @stdout)
-      @new_resource = Chef::Resource::Package.new("openssh-askpass")
-      @new_resource.source 'openssh-askpass'
-      @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
-      expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
-      @provider.load_current_resource
-      expect(@provider.current_resource.version).to be_nil
+      stdout = "package openssh-askpass is not installed"
+      status = double("Status", :exitstatus => -1, :stdout => stdout)
+      new_resource = Chef::Resource::Package.new("openssh-askpass")
+      new_resource.source 'openssh-askpass'
+      provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
+      expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+      expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+      provider.load_current_resource
+      expect(provider.current_resource.version).to be_nil
     end
   end
 
   describe "after the current resource is loaded" do
-    before do
-      @current_resource = Chef::Resource::Package.new("ImageMagick-c++")
-      @provider.current_resource = @current_resource
+
+    let(:current_resource) { Chef::Resource::Package.new("ImageMagick-c++") }
+    let(:provider) do
+      Chef::Provider::Package::Rpm.new(new_resource, run_context).tap do |provider|
+        provider.current_resource = current_resource
+      end
     end
 
     describe "when installing or upgrading" do
       it "should run rpm -i with the package source to install" do
-        expect(@provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.install_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
+        expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.install_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
       it "should run rpm -U with the package source to upgrade" do
-        @current_resource.version("21.4-19.el5")
-        expect(@provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
+        current_resource.version("21.4-19.el5")
+        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
       it "should install package if missing and set to upgrade" do
-        @current_resource.version("ImageMagick-c++")
-        expect(@provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
+        current_resource.version("ImageMagick-c++")
+        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
       it "should install from a path when the package is a path and the source is nil" do
-        @new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-        expect(@new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @current_resource = Chef::Resource::Package.new("ImageMagick-c++")
-        @provider.current_resource = @current_resource
-        expect(@provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
+        new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
+        expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        current_resource = Chef::Resource::Package.new("ImageMagick-c++")
+        provider.current_resource = current_resource
+        expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
       end
 
       it "should uprgrade from a path when the package is a path and the source is nil" do
-        @new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-        expect(@new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @current_resource = Chef::Resource::Package.new("ImageMagick-c++")
-        @current_resource.version("21.4-19.el5")
-        @provider.current_resource = @current_resource
-        expect(@provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
+        new_resource = Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider = Chef::Provider::Package::Rpm.new(new_resource, run_context)
+        expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        current_resource = Chef::Resource::Package.new("ImageMagick-c++")
+        current_resource.version("21.4-19.el5")
+        provider.current_resource = current_resource
+        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
       end
 
       it "installs with custom options specified in the resource" do
-        @provider.candidate_version = '11'
-        @new_resource.options("--dbpath /var/lib/rpm")
-        expect(@provider).to receive(:shell_out!).with("rpm --dbpath /var/lib/rpm -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
-        @provider.install_package(@new_resource.name, @provider.candidate_version)
+        provider.candidate_version = '11'
+        new_resource.options("--dbpath /var/lib/rpm")
+        expect(provider).to receive(:shell_out!).with("rpm --dbpath /var/lib/rpm -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        provider.install_package(new_resource.name, provider.candidate_version)
       end
     end
 
     describe "when removing the package" do
       it "should run rpm -e to remove the package" do
-        expect(@provider).to receive(:shell_out!).with("rpm  -e ImageMagick-c++-6.5.4.7-7.el6_5")
-        @provider.remove_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
+        expect(provider).to receive(:shell_out!).with("rpm  -e ImageMagick-c++-6.5.4.7-7.el6_5")
+        provider.remove_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
     end
   end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -37,13 +37,13 @@ describe Chef::Provider::Package::Rpm do
   describe "when determining the current state of the package" do
 
     it "should create a current resource with the name of new_resource" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out!).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("ImageMagick-c++")
     end
 
     it "should set the current reource package name to the new resource package name" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out!).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq('ImageMagick-c++')
     end
@@ -56,7 +56,7 @@ describe Chef::Provider::Package::Rpm do
     it "should get the source package version from rpm if provided" do
       @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
       @status = double("Status", :exitstatus => 0, :stdout => @stdout)
-      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
+      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
       expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("ImageMagick-c++")
@@ -66,7 +66,7 @@ describe Chef::Provider::Package::Rpm do
     it "should return the current version installed if found by rpm" do
       @stdout = "ImageMagick-c++ 6.5.4.7-7.el6_5"
       @status = double("Status", :exitstatus => 0, :stdout => @stdout)
-      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
+      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(@status)
       expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
@@ -79,8 +79,8 @@ describe Chef::Provider::Package::Rpm do
     end
 
     it "should raise an exception if rpm fails to run" do
-      @status = double("Status", :exitstatus => -1, :stdout => @stdout)
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      status = double("Status", :exitstatus => -1, :stdout => @stdout)
+      allow(@provider).to receive(:shell_out!).and_return(status)
       expect { @provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
     end
 
@@ -90,7 +90,7 @@ describe Chef::Provider::Package::Rpm do
       @new_resource = Chef::Resource::Package.new("openssh-askpass")
       @new_resource.source 'openssh-askpass'
       @provider = Chef::Provider::Package::Rpm.new(@new_resource, @run_context)
-      expect(@provider).to receive(:shell_out).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
+      expect(@provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
       expect(@provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil


### PR DESCRIPTION
Fixes #2663 by using shell_out instead of popen4