### PR TITLE
FIX data_bag_item.rb:161: warning: circular argument reference - data_bag

### DIFF
--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -158,7 +158,7 @@ class Chef
       end
     end
 
-    def destroy(data_bag=data_bag, databag_item=name)
+    def destroy(data_bag=data_bag(), databag_item=name)
       chef_server_rest.delete_rest("data/#{data_bag}/#{databag_item}")
     end
 

--- a/spec/unit/chef_fs/file_pattern_spec.rb
+++ b/spec/unit/chef_fs/file_pattern_spec.rb
@@ -355,7 +355,7 @@ describe Chef::ChefFS::FilePattern do
     it 'could_match_children? /abc** returns false for /xyz' do
       pending 'Make could_match_children? more rigorous'
       # At the moment, we return false for this, but in the end it would be nice to return true:
-      pattern.could_match_children?('/xyz').should be_falsey
+      expect(pattern.could_match_children?('/xyz')).to be_falsey
     end
     it 'exact_child_name_under' do
       expect(pattern.exact_child_name_under('/')).to eq(nil)

--- a/spec/unit/data_bag_item_spec.rb
+++ b/spec/unit/data_bag_item_spec.rb
@@ -214,6 +214,7 @@ describe Chef::DataBagItem do
       @data_bag_item.raw_data = raw_data
       @data_bag_item.data_bag("books")
     end
+
     it "should update the item when it already exists" do
       expect(@rest).to receive(:put_rest).with("data/books/heart_of_darkness", @data_bag_item)
       @data_bag_item.save
@@ -225,6 +226,7 @@ describe Chef::DataBagItem do
       expect(@rest).to receive(:post_rest).with("data/books", @data_bag_item)
       @data_bag_item.save
     end
+
     describe "when whyrun mode is enabled" do
       before do
         Chef::Config[:why_run] = true
@@ -232,6 +234,7 @@ describe Chef::DataBagItem do
       after do
         Chef::Config[:why_run] = false
       end
+
       it "should not save" do
         expect(@rest).not_to receive(:put_rest)
         expect(@rest).not_to receive(:post_rest)
@@ -240,7 +243,24 @@ describe Chef::DataBagItem do
       end
     end
 
+  end
 
+  describe "destroy" do
+    let(:server) { instance_double(Chef::REST) }
+
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item.data_bag('a_baggy_bag')
+      data_bag_item.raw_data = { "id" => "some_id" }
+      data_bag_item
+    }
+
+    it "should set default parameters" do
+      expect(Chef::REST).to receive(:new).and_return(server)
+      expect(server).to receive(:delete_rest).with("data/a_baggy_bag/data_bag_item_a_baggy_bag_some_id")
+
+      data_bag_item.destroy
+    end
   end
 
   describe "when loading" do

--- a/spec/unit/data_bag_item_spec.rb
+++ b/spec/unit/data_bag_item_spec.rb
@@ -20,86 +20,86 @@ require 'spec_helper'
 require 'chef/data_bag_item'
 
 describe Chef::DataBagItem do
-  before(:each) do
-    @data_bag_item = Chef::DataBagItem.new
-  end
+  let(:data_bag_item) { Chef::DataBagItem.new }
 
   describe "initialize" do
     it "should be a Chef::DataBagItem" do
-      expect(@data_bag_item).to be_a_kind_of(Chef::DataBagItem)
+      expect(data_bag_item).to be_a_kind_of(Chef::DataBagItem)
     end
   end
 
   describe "data_bag" do
     it "should let you set the data_bag to a string" do
-      expect(@data_bag_item.data_bag("clowns")).to eq("clowns")
+      expect(data_bag_item.data_bag("clowns")).to eq("clowns")
     end
 
     it "should return the current data_bag type" do
-      @data_bag_item.data_bag "clowns"
-      expect(@data_bag_item.data_bag).to eq("clowns")
+      data_bag_item.data_bag "clowns"
+      expect(data_bag_item.data_bag).to eq("clowns")
     end
 
     it "should not accept spaces" do
-      expect { @data_bag_item.data_bag "clown masters" }.to raise_error(ArgumentError)
+      expect { data_bag_item.data_bag "clown masters" }.to raise_error(ArgumentError)
     end
 
     it "should throw an ArgumentError if you feed it anything but a string" do
-      expect { @data_bag_item.data_bag Hash.new }.to raise_error(ArgumentError)
+      expect { data_bag_item.data_bag Hash.new }.to raise_error(ArgumentError)
     end
   end
 
   describe "raw_data" do
     it "should let you set the raw_data with a hash" do
-      expect { @data_bag_item.raw_data = { "id" => "octahedron" } }.not_to raise_error
+      expect { data_bag_item.raw_data = { "id" => "octahedron" } }.not_to raise_error
     end
 
     it "should let you set the raw_data from a mash" do
-      expect { @data_bag_item.raw_data = Mash.new({ "id" => "octahedron" }) }.not_to raise_error
+      expect { data_bag_item.raw_data = Mash.new({ "id" => "octahedron" }) }.not_to raise_error
     end
 
     it "should raise an exception if you set the raw data without a key" do
-      expect { @data_bag_item.raw_data = { "monkey" => "pants" } }.to raise_error(ArgumentError)
+      expect { data_bag_item.raw_data = { "monkey" => "pants" } }.to raise_error(ArgumentError)
     end
 
     it "should raise an exception if you set the raw data to something other than a hash" do
-      expect { @data_bag_item.raw_data = "katie rules" }.to raise_error(ArgumentError)
+      expect { data_bag_item.raw_data = "katie rules" }.to raise_error(ArgumentError)
     end
 
     it "should accept alphanum/-/_ for the id" do
-      expect { @data_bag_item.raw_data = { "id" => "h1-_" } }.not_to raise_error
+      expect { data_bag_item.raw_data = { "id" => "h1-_" } }.not_to raise_error
     end
 
     it "should accept alphanum.alphanum for the id" do
-      expect { @data_bag_item.raw_data = { "id" => "foo.bar" } }.not_to raise_error
+      expect { data_bag_item.raw_data = { "id" => "foo.bar" } }.not_to raise_error
     end
 
     it "should accept .alphanum for the id" do
-      expect { @data_bag_item.raw_data = { "id" => ".bozo" } }.not_to raise_error
+      expect { data_bag_item.raw_data = { "id" => ".bozo" } }.not_to raise_error
     end
 
     it "should raise an exception if the id contains anything but alphanum/-/_" do
-      expect { @data_bag_item.raw_data = { "id" => "!@#" } }.to raise_error(ArgumentError)
+      expect { data_bag_item.raw_data = { "id" => "!@#" } }.to raise_error(ArgumentError)
     end
 
     it "should return the raw data" do
-      @data_bag_item.raw_data = { "id" => "highway_of_emptiness" }
-      expect(@data_bag_item.raw_data).to eq({ "id" => "highway_of_emptiness" })
+      data_bag_item.raw_data = { "id" => "highway_of_emptiness" }
+      expect(data_bag_item.raw_data).to eq({ "id" => "highway_of_emptiness" })
     end
 
     it "should be a Mash by default" do
-      expect(@data_bag_item.raw_data).to be_a_kind_of(Mash)
+      expect(data_bag_item.raw_data).to be_a_kind_of(Mash)
     end
   end
 
   describe "object_name" do
-    before(:each) do
-      @data_bag_item.data_bag("dreams")
-      @data_bag_item.raw_data = { "id" => "the_beatdown" }
-    end
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item.data_bag("dreams")
+      data_bag_item.raw_data = { "id" => "the_beatdown" }
+      data_bag_item
+    }
 
     it "should return an object name based on the bag name and the raw_data id" do
-      expect(@data_bag_item.object_name).to eq("data_bag_item_dreams_the_beatdown")
+      expect(data_bag_item.object_name).to eq("data_bag_item_dreams_the_beatdown")
     end
   end
 
@@ -110,17 +110,19 @@ describe Chef::DataBagItem do
   end
 
   describe "when used like a Hash" do
-    before(:each) do
-      @data_bag_item.raw_data = { "id" => "journey", "trials" => "been through" }
-    end
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item.raw_data = { "id" => "journey", "trials" => "been through" }
+      data_bag_item
+    }
 
     it "responds to keys" do
-      expect(@data_bag_item.keys).to include("id")
-      expect(@data_bag_item.keys).to include("trials")
+      expect(data_bag_item.keys).to include("id")
+      expect(data_bag_item.keys).to include("trials")
     end
 
     it "supports element reference with []" do
-      expect(@data_bag_item["id"]).to eq("journey")
+      expect(data_bag_item["id"]).to eq("journey")
     end
 
     it "implements all the methods of Hash" do
@@ -131,100 +133,111 @@ describe Chef::DataBagItem do
       :invert, :update, :replace, :merge!, :merge, :has_key?, :has_value?,
       :key?, :value?]
       methods.each do |m|
-        expect(@data_bag_item).to respond_to(m)
+        expect(data_bag_item).to respond_to(m)
       end
     end
-
   end
 
   describe "to_hash" do
-    before(:each) do
-      @data_bag_item.data_bag("still_lost")
-      @data_bag_item.raw_data = { "id" => "whoa", "i_know" => "kung_fu" }
-      @to_hash = @data_bag_item.to_hash
-    end
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item.data_bag("still_lost")
+      data_bag_item.raw_data = { "id" => "whoa", "i_know" => "kung_fu" }
+      data_bag_item
+    }
+
+    let(:to_hash) { data_bag_item.to_hash }
 
     it "should return a hash" do
-      expect(@to_hash).to be_a_kind_of(Hash)
+      expect(to_hash).to be_a_kind_of(Hash)
     end
 
     it "should have the raw_data keys as top level keys" do
-      expect(@to_hash["id"]).to eq("whoa")
-      expect(@to_hash["i_know"]).to eq("kung_fu")
+      expect(to_hash["id"]).to eq("whoa")
+      expect(to_hash["i_know"]).to eq("kung_fu")
     end
 
     it "should have the chef_type of data_bag_item" do
-      expect(@to_hash["chef_type"]).to eq("data_bag_item")
+      expect(to_hash["chef_type"]).to eq("data_bag_item")
     end
 
     it "should have the data_bag set" do
-      expect(@to_hash["data_bag"]).to eq("still_lost")
+      expect(to_hash["data_bag"]).to eq("still_lost")
     end
   end
 
   describe "when deserializing from JSON" do
-    before(:each) do
-      @data_bag_item.data_bag('mars_volta')
-      @data_bag_item.raw_data = { "id" => "octahedron", "snooze" => { "finally" => :world_will }}
-      @deserial = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(@data_bag_item))
-    end
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item.data_bag('mars_volta')
+      data_bag_item.raw_data = { "id" => "octahedron", "snooze" => { "finally" => :world_will } }
+      data_bag_item
+    }
+
+    let(:deserial) { Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(data_bag_item)) }
+
 
     it "should deserialize to a Chef::DataBagItem object" do
-      expect(@deserial).to be_a_kind_of(Chef::DataBagItem)
+      expect(deserial).to be_a_kind_of(Chef::DataBagItem)
     end
 
     it "should have a matching 'data_bag' value" do
-      expect(@deserial.data_bag).to eq(@data_bag_item.data_bag)
+      expect(deserial.data_bag).to eq(data_bag_item.data_bag)
     end
 
     it "should have a matching 'id' key" do
-      expect(@deserial["id"]).to eq("octahedron")
+      expect(deserial["id"]).to eq("octahedron")
     end
 
     it "should have a matching 'snooze' key" do
-      expect(@deserial["snooze"]).to eq({ "finally" => "world_will" })
+      expect(deserial["snooze"]).to eq({ "finally" => "world_will" })
     end
 
     include_examples "to_json equalivent to Chef::JSONCompat.to_json" do
-      let(:jsonable) { @data_bag_item }
+      let(:jsonable) { data_bag_item }
     end
   end
 
   describe "when converting to a string" do
     it "converts to a string in the form data_bag_item[ID]" do
-      @data_bag_item['id'] = "heart of darkness"
-      expect(@data_bag_item.to_s).to eq('data_bag_item[heart of darkness]')
+      data_bag_item['id'] = "heart of darkness"
+      expect(data_bag_item.to_s).to eq('data_bag_item[heart of darkness]')
     end
 
     it "inspects as data_bag_item[BAG, ID, RAW_DATA]" do
       raw_data = {"id" => "heart_of_darkness", "author" => "Conrad"}
-      @data_bag_item.raw_data = raw_data
-      @data_bag_item.data_bag("books")
+      data_bag_item.raw_data = raw_data
+      data_bag_item.data_bag("books")
 
-      expect(@data_bag_item.inspect).to eq("data_bag_item[\"books\", \"heart_of_darkness\", #{raw_data.inspect}]")
+      expect(data_bag_item.inspect).to eq("data_bag_item[\"books\", \"heart_of_darkness\", #{raw_data.inspect}]")
     end
   end
 
   describe "save" do
+    let(:server) { instance_double(Chef::REST) }
+
+    let(:data_bag_item) {
+      data_bag_item = Chef::DataBagItem.new
+      data_bag_item['id'] = "heart of darkness"
+      data_bag_item.raw_data = {"id" => "heart_of_darkness", "author" => "Conrad"}
+      data_bag_item.data_bag("books")
+      data_bag_item
+    }
+
     before do
-      @rest = double("Chef::REST")
-      allow(Chef::REST).to receive(:new).and_return(@rest)
-      @data_bag_item['id'] = "heart of darkness"
-      raw_data = {"id" => "heart_of_darkness", "author" => "Conrad"}
-      @data_bag_item.raw_data = raw_data
-      @data_bag_item.data_bag("books")
+      expect(Chef::REST).to receive(:new).and_return(server)
     end
 
     it "should update the item when it already exists" do
-      expect(@rest).to receive(:put_rest).with("data/books/heart_of_darkness", @data_bag_item)
-      @data_bag_item.save
+      expect(server).to receive(:put_rest).with("data/books/heart_of_darkness", data_bag_item)
+      data_bag_item.save
     end
 
     it "should create if the item is not found" do
       exception = double("404 error", :code => "404")
-      expect(@rest).to receive(:put_rest).and_raise(Net::HTTPServerException.new("foo", exception))
-      expect(@rest).to receive(:post_rest).with("data/books", @data_bag_item)
-      @data_bag_item.save
+      expect(server).to receive(:put_rest).and_raise(Net::HTTPServerException.new("foo", exception))
+      expect(server).to receive(:post_rest).with("data/books", data_bag_item)
+      data_bag_item.save
     end
 
     describe "when whyrun mode is enabled" do
@@ -236,10 +249,10 @@ describe Chef::DataBagItem do
       end
 
       it "should not save" do
-        expect(@rest).not_to receive(:put_rest)
-        expect(@rest).not_to receive(:post_rest)
-        @data_bag_item.data_bag("books")
-        @data_bag_item.save
+        expect(server).not_to receive(:put_rest)
+        expect(server).not_to receive(:post_rest)
+        data_bag_item.data_bag("books")
+        data_bag_item.save
       end
     end
 
@@ -265,28 +278,29 @@ describe Chef::DataBagItem do
 
   describe "when loading" do
     before do
-      @data_bag_item.raw_data = {"id" => "charlie", "shell" => "zsh", "ssh_keys" => %w{key1 key2}}
-      @data_bag_item.data_bag("users")
+      data_bag_item.raw_data = {"id" => "charlie", "shell" => "zsh", "ssh_keys" => %w{key1 key2}}
+      data_bag_item.data_bag("users")
     end
 
     describe "from an API call" do
+      let(:http_client) { double("Chef::REST") }
+
       before do
-        @http_client = double("Chef::REST")
-        allow(Chef::REST).to receive(:new).and_return(@http_client)
+        allow(Chef::REST).to receive(:new).and_return(http_client)
       end
 
       it "converts raw data to a data bag item" do
-        expect(@http_client).to receive(:get_rest).with("data/users/charlie").and_return(@data_bag_item.to_hash)
+        expect(http_client).to receive(:get_rest).with("data/users/charlie").and_return(data_bag_item.to_hash)
         item = Chef::DataBagItem.load(:users, "charlie")
         expect(item).to be_a_kind_of(Chef::DataBagItem)
-        expect(item).to eq(@data_bag_item)
+        expect(item).to eq(data_bag_item)
       end
 
       it "does not convert when a DataBagItem is returned from the API call" do
-        expect(@http_client).to receive(:get_rest).with("data/users/charlie").and_return(@data_bag_item)
+        expect(http_client).to receive(:get_rest).with("data/users/charlie").and_return(data_bag_item)
         item = Chef::DataBagItem.load(:users, "charlie")
         expect(item).to be_a_kind_of(Chef::DataBagItem)
-        expect(item).to equal(@data_bag_item)
+        expect(item).to equal(data_bag_item)
       end
     end
 
@@ -300,13 +314,11 @@ describe Chef::DataBagItem do
       end
 
       it "converts the raw data to a data bag item" do
-        expect(Chef::DataBag).to receive(:load).with('users').and_return({'charlie' => @data_bag_item.to_hash})
+        expect(Chef::DataBag).to receive(:load).with('users').and_return({'charlie' => data_bag_item.to_hash})
         item = Chef::DataBagItem.load('users', 'charlie')
         expect(item).to be_a_kind_of(Chef::DataBagItem)
-        expect(item).to eq(@data_bag_item)
+        expect(item).to eq(data_bag_item)
       end
     end
-
   end
-
 end


### PR DESCRIPTION
This fixes a warning in Ruby 2.2 about circular argument references in data_bag_item.rb

See this ruby issue for more details: https://bugs.ruby-lang.org/issues/10314