### PR TITLE
Fix useradd on centos when manage_home is false.

### DIFF
--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -121,6 +121,8 @@ class Chef
                 else
                   Chef::Log.debug("#{new_resource} setting home to #{new_resource.home}")
                   opts << "-d" << new_resource.home
+                  opts << "-M" if ['centos'].include?(node[:platform])
+
                 end
               end
               opts << "-o" if new_resource.non_unique || new_resource.supports[:non_unique]


### PR DESCRIPTION
On Centos 6.4/6.5/6.6/7.0 using this code block fails, provided that the
/tmp/foo directory doesn't exist.

    user 'my_test' do
      supports :manage_home => false
      home '/tmp/foo/bar'
    end

    [2015-01-03T05:54:03+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
    Chef Client failed. 0 resources updated in 1.425418119 seconds
    [2015-01-03T05:54:03+00:00] ERROR: user[my_test] (test::default line 1) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '12'
    ---- Begin output of ["useradd", "-d", "/tmp/foo/bar", "my_test"] ----
    STDOUT:
    STDERR: useradd: cannot create directory /tmp/foo/bar
    ---- End output of ["useradd", "-d", "/tmp/foo/bar", "my_test"] ----
    Ran ["useradd", "-d", "/tmp/foo/bar", "my_test"] returned 12
    [2015-01-03T05:54:04+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)

This code runs properly on ubuntu/debian.

Adding the "-M" flag solves the problem.