### PR TITLE
Guard resources are executed in why_run mode

### DIFF
--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -95,6 +95,7 @@ class Chef
         empty_events = Chef::EventDispatch::Dispatcher.new
         anonymous_run_context = Chef::RunContext.new(parent_resource.node, {}, empty_events)
         interpreter_resource = resource_class.new('Guard resource', anonymous_run_context)
+        interpreter_resource.is_guard_interpreter = true
 
         interpreter_resource
       end

--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -48,7 +48,7 @@ class Chef
         # block/proc that implements the action.
         def add_action(descriptions, &block)
           @actions << [descriptions, block]
-          if !Chef::Config[:why_run]
+          if (@resource.respond_to?(:is_guard_interpreter) && @resource.is_guard_interpreter) || !Chef::Config[:why_run]
             block.call
           end
           events.resource_update_applied(@resource, @action, descriptions)

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -26,6 +26,12 @@ class Chef
 
       identity_attr :command
 
+      # The ResourceGuardInterpreter wraps a resource's guards in another resource.  That inner resource
+      # needs to behave differently during (for example) why_run mode, so we flag it here. For why_run mode
+      # we still want to execute the guard resource even if we are not executing the wrapping resource.
+      # Only execute resources (and subclasses) can be guard interpreters.
+      attr_accessor :is_guard_interpreter
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :execute
@@ -43,6 +49,7 @@ class Chef
         @allowed_actions.push(:run)
         @umask = nil
         @default_guard_interpreter = :execute
+        @is_guard_interpreter = false
       end
 
       def umask(arg=nil)

--- a/spec/unit/resource/execute_spec.rb
+++ b/spec/unit/resource/execute_spec.rb
@@ -28,4 +28,8 @@ describe Chef::Resource::Execute do
     expect(execute_resource.guard_interpreter).to be(:execute)
   end
 
+  it "defaults to not being a guard interpreter" do
+    expect(execute_resource.is_guard_interpreter).to eq(false)
+  end
+
 end


### PR DESCRIPTION
The fix for https://github.com/opscode/chef/issues/2694.  The idea is that we're now marking guard resources as able to converge even during why_run mode.

\cc @opscode/client-core @opscode/client-engineers 

I need to cherry pick this into 12-stable after reviewing.