### PR TITLE
Make sure that we have a valid object before calling close!

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -382,7 +382,7 @@ class Chef
       tf.close
       tf
     rescue Exception
-      tf.close!
+      tf.close! if tf
       raise
     end
 


### PR DESCRIPTION
This fixes [#2171](https://github.com/opscode/chef/issues/2171) when a
tempfile cannot be created or proper filesystem permissions do not
exist. This allows the proper exception to be thrown.