### PR TITLE
Update knife missing gem message for ChefDK

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -269,7 +269,8 @@ class Chef
         list_commands(category_commands)
       elsif missing_plugin = ( OFFICIAL_PLUGINS.find {|plugin| plugin == args[0]} )
         ui.info("The #{missing_plugin} commands were moved to plugins in Chef 0.10")
-        ui.info("You can install the plugin with `(sudo) gem install knife-#{missing_plugin}")
+        ui.info("You can install the plugin with `(sudo) gem install knife-#{missing_plugin}`")
+        ui.info("Use `chef gem install knife-#{missing_plugin}` instead if using ChefDK")
       else
         list_commands
       end


### PR DESCRIPTION
Just a trivial message that I came across today. I mainly see value in updating this so ChefDK users don't start sudoing their gem commands and introduce issues for themselves later.