### PR TITLE
allow_downgrade in rpm_package

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -109,18 +109,20 @@ class Chef
 
         converge_by(upgrade_description) do
           upgrade_package(package_names_for_targets, versions_for_targets)
-          Chef::Log.info("#{@new_resource} upgraded #{package_names_for_targets} to #{versions_for_targets}")
+          log_allow_downgrade = allow_downgrade ? '(allow_downgrade)' : ''
+          Chef::Log.info("#{@new_resource} upgraded#{log_allow_downgrade} #{package_names_for_targets} to #{versions_for_targets}")
         end
       end
 
       def upgrade_description
+        log_allow_downgrade = allow_downgrade ? '(allow_downgrade)' : ''
         description = []
         target_version_array.each_with_index do |target_version, i|
           next if target_version.nil?
           package_name = package_name_array[i]
           candidate_version = candidate_version_array[i]
           current_version = current_version_array[i] || "uninstalled"
-          description << "upgrade package #{package_name} from #{current_version} to #{candidate_version}"
+          description << "upgrade#{log_allow_downgrade} package #{package_name} from #{current_version} to #{candidate_version}"
         end
         description
       end
@@ -475,6 +477,13 @@ class Chef
         run_context.has_cookbook_file_in_cookbook?(new_resource.cookbook_name, path)
       end
 
+      def allow_downgrade
+        if @new_resource.respond_to?("allow_downgrade")
+          @new_resource.allow_downgrade
+        else
+          false
+        end
+      end
     end
   end
 end

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -93,7 +93,11 @@ class Chef
           unless @current_resource.version
             shell_out!( "rpm #{@new_resource.options} -i #{@new_resource.source}" )
           else
-            shell_out!( "rpm #{@new_resource.options} -U #{@new_resource.source}" )
+            if allow_downgrade
+              shell_out!( "rpm #{@new_resource.options} -U --oldpackage #{@new_resource.source}" )
+            else
+              shell_out!( "rpm #{@new_resource.options} -U #{@new_resource.source}" )
+            end
           end
         end
 

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -976,14 +976,6 @@ class Chef
           end
         end
 
-        def allow_downgrade
-          if @new_resource.respond_to?("allow_downgrade")
-            @new_resource.allow_downgrade
-          else
-            false
-          end
-        end
-
         # Helpers
         #
 

--- a/lib/chef/resource/rpm_package.rb
+++ b/lib/chef/resource/rpm_package.rb
@@ -28,6 +28,15 @@ class Chef
       def initialize(name, run_context=nil)
         super
         @resource_name = :rpm_package
+        @allow_downgrade = false
+      end
+
+      def allow_downgrade(arg=nil)
+        set_or_return(
+          :allow_downgrade,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
+        )
       end
 
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -129,6 +129,18 @@ describe Chef::Provider::Package::Rpm do
         provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
+      context "allowing downgrade" do
+        let(:new_resource) { Chef::Resource::RpmPackage.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm") }
+        let(:current_resource) { Chef::Resource::RpmPackage.new("ImageMagick-c++") }
+
+        it "should run rpm -U --oldpackage with the package source to downgrade" do
+          new_resource.allow_downgrade(true)
+          current_resource.version("21.4-19.el5")
+          expect(provider).to receive(:shell_out!).with("rpm  -U --oldpackage /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
+        end
+      end
+
       context "installing when the name is a path" do
         let(:new_resource) { Chef::Resource::Package.new("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm") }
         let(:current_resource) { Chef::Resource::Package.new("ImageMagick-c++") }

--- a/spec/unit/resource/rpm_package_spec.rb
+++ b/spec/unit/resource/rpm_package_spec.rb
@@ -32,3 +32,15 @@ describe Chef::Resource::RpmPackage, "initialize" do
   end
 
 end
+
+describe Chef::Resource::RpmPackage, "allow_downgrade" do
+  before(:each) do
+    @resource = Chef::Resource::RpmPackage.new("foo")
+  end
+
+  it "should allow you to specify whether allow_downgrade is true or false" do
+    expect { @resource.allow_downgrade true }.not_to raise_error
+    expect { @resource.allow_downgrade false }.not_to raise_error
+    expect { @resource.allow_downgrade "monkey" }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
This patch enables us to downgrade rpm by supporting `allow_downgrade` option for `rpm_package` resource as `yum_package` resource does. 

```
rpm_package "foo" do
  source "ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
  allow_downgrade true
end
```