### PR TITLE
Support HTTP/FTP source on rpm_package

### DIFF
--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -54,7 +54,7 @@ class Chef
           @new_resource.version(nil)
 
           if @new_resource.source
-            unless ::File.exists?(@new_resource.source)
+            unless uri_scheme?(@new_resource.source) || ::File.exists?(@new_resource.source)
               @package_source_exists = false
               return
             end
@@ -107,6 +107,15 @@ class Chef
           end
         end
 
+        private
+
+        def uri_scheme?(str)
+          scheme = URI.split(str).first
+          return false unless scheme
+          %w(http https ftp file).include?(scheme.downcase)
+        rescue URI::InvalidURIError
+          return false
+        end
       end
     end
   end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -72,6 +72,32 @@ describe Chef::Provider::Package::Rpm do
       end
     end
 
+    context "source is uri formed" do
+      before(:each) do
+        allow(::File).to receive(:exists?).and_return(false)
+      end
+
+      %w(http HTTP https HTTPS ftp FTP).each do |scheme|
+        it "should accept uri formed source (#{scheme})" do
+          new_resource.source "#{scheme}://example.com/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
+          expect(provider.load_current_resource).not_to be_nil
+        end
+      end
+
+      %w(file FILE).each do |scheme|
+        it "should accept uri formed source (#{scheme})" do
+          new_resource.source "#{scheme}:///ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
+          expect(provider.load_current_resource).not_to be_nil
+        end
+      end
+
+      it "should raise an exception if an uri formed source is non-supported scheme" do
+        new_resource.source "foobar://example.com/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm"
+        expect(provider.load_current_resource).to be_nil
+        expect { provider.run_action(:any) }.to raise_error(Chef::Exceptions::Package)
+      end
+    end
+
     context "source is not defiend" do
       let(:new_resource) { Chef::Resource::Package.new("ImageMagick-c++") }
 


### PR DESCRIPTION
This patch enables to support HTTP/FTP source on rpm_package resource as rpm command does

```
rpm -U http://example.com/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm
```