### PR TITLE
Fix up powershell script

### DIFF
--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -24,8 +24,8 @@ class Chef
 
       protected
       EXIT_STATUS_EXCEPTION_HANDLER = "\ntrap [Exception] {write-error -exception ($_.Exception.Message);exit 1}".freeze
-      EXIT_STATUS_NORMALIZATION_SCRIPT = "\nif ($? -ne $true) { if ( $LASTEXITCODE -ne 0) {exit $LASTEXITCODE} else { exit 1 }}".freeze
-      EXIT_STATUS_RESET_SCRIPT = "\n$LASTEXITCODE=0".freeze
+      EXIT_STATUS_NORMALIZATION_SCRIPT = "\nif ($? -ne $true) { if ( $LASTEXITCODE ) {exit $LASTEXITCODE} else { exit 1 }}".freeze
+      EXIT_STATUS_RESET_SCRIPT = "\n$global:LASTEXITCODE=$null".freeze
 
       # Process exit codes are strange with PowerShell. Unless you
       # explicitly call exit in Powershell, the powershell.exe

--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -56,6 +56,21 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       resource.run_action(:run)
     end
 
+    it "returns the -27 for a powershell script that exits with -27" do
+      file = Tempfile.new(['foo', '.ps1'])
+      begin
+        file.write "exit -27"
+        file.close
+        resource.code(". \"#{file.path}\"")
+        resource.returns(-27)
+        resource.run_action(:run)
+      ensure
+        file.close
+        file.unlink
+      end
+    end
+
+
     it "returns the process exit code" do
       resource.code(arbitrary_nonzero_process_exit_code_content)
       resource.returns(arbitrary_nonzero_process_exit_code)


### PR DESCRIPTION
1.) You can't set $LASTEXITCODE directly, doing so creates a local
    variable. I've changed it to $global:LASTEXITCODE
2.) $LASTEXITCODE can be $null. No longer using `-ne 0` to compare

This should resolve Issue #2348 

cc @btm @smurawski @ksubrama