### PR TITLE
add check for redirected/relocated git directory

### DIFF
--- a/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -130,13 +130,21 @@ class Chef
       private
 
       def git_repo?(directory)
-        if File.directory?(File.join(directory, '.git'))
+        possible_git_directory = File.join(directory, '.git')
+        if File.directory?(possible_git_directory)
+          return true
+        elsif File.exists?(possible_git_directory) and is_git_dir_redirect?(possible_git_directory)
           return true
         elsif File.dirname(directory) == directory
           return false
-        else
-          git_repo?(File.dirname(directory))
+        else 
+          git_repo?(File.dirname(directory))        
         end
+      end
+
+      def is_git_dir_redirect?(directory)
+        redirect_path = IO.read(directory).gsub('gitdir: ', '').strip
+        return File.directory?(redirect_path)
       end
 
       def apply_opts(opts)

--- a/spec/unit/knife/core/cookbook_scm_repo_spec.rb
+++ b/spec/unit/knife/core/cookbook_scm_repo_spec.rb
@@ -59,10 +59,23 @@ BRANCHES
 
       it "exits when there is no git repo" do
         allow(::File).to receive(:directory?).with(/.*\.git/).and_return(false)
+        allow(::File).to receive(:exists?).with(/.*\.git/).and_return(false)
         expect {@cookbook_repo.sanity_check}.to raise_error(SystemExit)
       end
+     
 
       describe "and the repo is a git repo" do
+
+        describe "and the repo has a redirected git folder" do
+          it "exits if the redirected folder does not exist" do          
+            allow(::File).to receive(:directory?).with(/.*\.git/).and_return(false)
+            allow(::File).to receive(:exists?).with(/.*\.git/).and_return(true)
+            allow(::IO).to receive(:read).with(/.*\.git/).and_return('gitdir: /Users/someone/gitrepos/thiscookbook')
+            allow(::File).to receive(:directory?).with('/Users/someone/gitrepos/thiscookbook').and_return(false)          
+            expect {@cookbook_repo.sanity_check}.to raise_error(SystemExit)
+          end    
+        end
+
         before do
           allow(::File).to receive(:directory?).with(File.join(@repo_path, '.git')).and_return(true)
         end
@@ -98,6 +111,8 @@ DIRTY
             it "passes the sanity check" do
               @cookbook_repo.sanity_check
             end
+
+
 
           end
         end


### PR DESCRIPTION
Fixes #2317 
knife cookbook site install just looked for .git directories, but if you relocate the git directory outside the folder being tracked, there is only a .git file that points to the folder structure holding all the git metadata.  This adds a check that type of file and verifies the folder exists.