### PR TITLE
Disable win32 memory leak tests

### DIFF
--- a/spec/stress/win32/file_spec.rb
+++ b/spec/stress/win32/file_spec.rb
@@ -24,12 +24,12 @@ describe 'Chef::ReservedNames::Win32::File', :windows_only do
     @path = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "data", "old_home_dir", "my-dot-emacs"))
   end
 
-  it "should not leak significant memory" do
+  it "should not leak significant memory", :volatile do
     test = lambda { Chef::ReservedNames::Win32::File.symlink?(@path) }
     expect(test).not_to leak_memory(:warmup => 50000, :iterations => 50000)
   end
 
-  it "should not leak handles" do
+  it "should not leak handles", :volatile do
     test = lambda { Chef::ReservedNames::Win32::File.symlink?(@path) }
     expect(test).not_to leak_handles(:warmup => 50, :iterations => 100)
   end


### PR DESCRIPTION
The values here are arbitrarily set and don't work well on ephemeral slaves
because they're not necesssairly stable when the tests start running.

So we'll mark them as volatile until someone decides what to do with them,
mostly to preserve the code.

Cherry-pick of a commit from #2662