### PR TITLE
Use Chef::ApiClient#from_hash in `knife client create` to avoid json_class requirement

### DIFF
--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -124,14 +124,21 @@ class Chef
       Chef::JSONCompat.to_json(to_hash, *a)
     end
 
-    def self.json_create(o)
-      client = Chef::ApiClient.new
-      client.name(o["name"] || o["clientname"])
-      client.private_key(o["private_key"]) if o.key?("private_key")
-      client.public_key(o["public_key"])
-      client.admin(o["admin"])
-      client.validator(o["validator"])
-      client
+    class << self
+      def from_hash(o)
+        client = Chef::ApiClient.new
+        client.name(o["name"] || o["clientname"])
+        client.private_key(o["private_key"]) if o.key?("private_key")
+        client.public_key(o["public_key"])
+        client.admin(o["admin"])
+        client.validator(o["validator"])
+        client
+      end
+      alias :json_create :from_hash
+
+      def from_json(j)
+        Chef::ApiClient.from_hash(Chef::JSONCompat.parse(j))
+      end
     end
 
     def self.http_api

--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -124,21 +124,22 @@ class Chef
       Chef::JSONCompat.to_json(to_hash, *a)
     end
 
-    class << self
-      def from_hash(o)
-        client = Chef::ApiClient.new
-        client.name(o["name"] || o["clientname"])
-        client.private_key(o["private_key"]) if o.key?("private_key")
-        client.public_key(o["public_key"])
-        client.admin(o["admin"])
-        client.validator(o["validator"])
-        client
-      end
-      alias :json_create :from_hash
+    def self.from_hash(o)
+      client = Chef::ApiClient.new
+      client.name(o["name"] || o["clientname"])
+      client.private_key(o["private_key"]) if o.key?("private_key")
+      client.public_key(o["public_key"])
+      client.admin(o["admin"])
+      client.validator(o["validator"])
+      client
+    end
 
-      def from_json(j)
-        Chef::ApiClient.from_hash(Chef::JSONCompat.parse(j))
-      end
+    def self.json_create(data)
+      from_hash(data)
+    end
+
+    def self.from_json(j)
+      from_hash(Chef::JSONCompat.parse(j))
     end
 
     def self.http_api

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -53,6 +53,7 @@ class Chef
     def_delegator :@ui, :format_for_display
     def_delegator :@ui, :format_cookbook_list_for_display
     def_delegator :@ui, :edit_data
+    def_delegator :@ui, :edit_hash
     def_delegator :@ui, :edit_object
     def_delegator :@ui, :confirm
 

--- a/lib/chef/knife/client_create.rb
+++ b/lib/chef/knife/client_create.rb
@@ -54,14 +54,16 @@ class Chef
           exit 1
         end
 
-        client = Chef::ApiClient.new
-        client.name(@client_name)
-        client.admin(config[:admin])
-        client.validator(config[:validator])
+        client_hash = {
+          "name" => @client_name,
+          "admin" => !!config[:admin],
+          "validator" => !!config[:validator]
+        }
 
-        output = edit_data(client)
+        output = Chef::ApiClient.from_hash(edit_hash(client_hash))
 
-        # Chef::ApiClient.save will try to create a client and if it exists will update it instead silently
+        # Chef::ApiClient.save will try to create a client and if it
+        # exists will update it instead silently.
         client = output.save
 
         # We only get a private_key on client creation, not on client update.
@@ -83,4 +85,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -163,9 +163,17 @@ class Chef
         end
       end
 
+
+      # Hash -> Hash
+      # Works the same as edit_data but
+      # returns a hash rather than a JSON string/Fully infated object
+      def edit_hash(hash)
+        raw = edit_data(hash, false)
+        Chef::JSONCompat.parse(raw)
+      end
+
       def edit_data(data, parse_output=true)
         output = Chef::JSONCompat.to_json_pretty(data)
-
         if (!config[:disable_editing])
           Tempfile.open([ 'knife-edit-', '.json' ]) do |tf|
             tf.sync = true

--- a/spec/unit/api_client_spec.rb
+++ b/spec/unit/api_client_spec.rb
@@ -129,43 +129,83 @@ describe Chef::ApiClient do
     end
   end
 
-  describe "when deserializing from JSON" do
-    before(:each) do
-      client = {
-      "name" => "black",
-      "public_key" => "crowes",
-      "private_key" => "monkeypants",
-      "admin" => true,
-      "validator" => true,
-      "json_class" => "Chef::ApiClient"
-      }
-      @client = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(client))
+  describe "when deserializing from JSON (string) using ApiClient#from_json" do
+    let(:client_string) do
+      "{\"name\":\"black\",\"public_key\":\"crowes\",\"private_key\":\"monkeypants\",\"admin\":true,\"validator\":true}"
+    end
+
+    let(:client) do
+      Chef::ApiClient.from_json(client_string)
+    end
+
+    it "does not require a 'json_class' string" do
+      expect(Chef::JSONCompat.parse(client_string)["json_class"]).to eq(nil)
     end
 
     it "should deserialize to a Chef::ApiClient object" do
-      expect(@client).to be_a_kind_of(Chef::ApiClient)
+      expect(client).to be_a_kind_of(Chef::ApiClient)
     end
 
     it "preserves the name" do
-      expect(@client.name).to eq("black")
+      expect(client.name).to eq("black")
     end
 
     it "preserves the public key" do
-      expect(@client.public_key).to eq("crowes")
+      expect(client.public_key).to eq("crowes")
     end
 
     it "preserves the admin status" do
-      expect(@client.admin).to be_truthy
+      expect(client.admin).to be_truthy
     end
 
     it "preserves the 'validator' status" do
-      expect(@client.validator).to be_truthy
+      expect(client.validator).to be_truthy
     end
 
     it "includes the private key if present" do
-      expect(@client.private_key).to eq("monkeypants")
+      expect(client.private_key).to eq("monkeypants")
+    end
+  end
+
+  describe "when deserializing from JSON (hash) using JSONCompat#from_json" do
+    let(:client_hash) do
+      {
+        "name" => "black",
+        "public_key" => "crowes",
+        "private_key" => "monkeypants",
+        "admin" => true,
+        "validator" => true,
+        "json_class" => "Chef::ApiClient"
+      }
     end
 
+    let(:client) do
+      Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(client_hash))
+    end
+
+    it "should deserialize to a Chef::ApiClient object" do
+      expect(client).to be_a_kind_of(Chef::ApiClient)
+    end
+
+    it "preserves the name" do
+      expect(client.name).to eq("black")
+    end
+
+    it "preserves the public key" do
+      expect(client.public_key).to eq("crowes")
+    end
+
+    it "preserves the admin status" do
+      expect(client.admin).to be_truthy
+    end
+
+    it "preserves the 'validator' status" do
+      expect(client.validator).to be_truthy
+    end
+
+    it "includes the private key if present" do
+      expect(client.private_key).to eq("monkeypants")
+    end
   end
 
   describe "when loading from JSON" do
@@ -306,5 +346,3 @@ describe Chef::ApiClient do
     end
   end
 end
-
-

--- a/spec/unit/knife/client_create_spec.rb
+++ b/spec/unit/knife/client_create_spec.rb
@@ -21,82 +21,96 @@ require 'spec_helper'
 Chef::Knife::ClientCreate.load_deps
 
 describe Chef::Knife::ClientCreate do
+  let(:stderr) { StringIO.new }
+
+  let(:default_client_hash) do
+    {
+      "name" => "adam",
+      "validator" => false,
+      "admin" => false
+    }
+  end
+
+  let(:client) do
+    c = double("Chef::ApiClient")
+    allow(c).to receive(:save).and_return({"private_key" => ""})
+    allow(c).to receive(:to_s).and_return("client[adam]")
+    c
+  end
+
+  let(:knife) do
+    k = Chef::Knife::ClientCreate.new
+    k.name_args = [ "adam" ]
+    k.ui.config[:disable_editing] = true
+    allow(k.ui).to receive(:stderr).and_return(stderr)
+    allow(k.ui).to receive(:stdout).and_return(stderr)
+    k
+  end
+
   before(:each) do
     Chef::Config[:node_name]  = "webmonkey.example.com"
-    @knife = Chef::Knife::ClientCreate.new
-    @knife.config = {
-      :file => nil,
-      :admin => false,
-      :validator => false
-    }
-    @knife.name_args = [ "adam" ]
-    @client = Chef::ApiClient.new
-    allow(@client).to receive(:save).and_return({ 'private_key' => '' })
-    allow(@knife).to receive(:edit_data).and_return(@client)
-    allow(@knife).to receive(:puts)
-    allow(Chef::ApiClient).to receive(:new).and_return(@client)
-    @stderr = StringIO.new
-    allow(@knife.ui).to receive(:stderr).and_return(@stderr)
   end
 
   describe "run" do
-    it "should create a new Client" do
-      expect(Chef::ApiClient).to receive(:new).and_return(@client)
-      @knife.run
-      expect(@stderr.string).to match /created client.+adam/i
+    it "should create and save the ApiClient" do
+      expect(Chef::ApiClient).to receive(:from_hash).and_return(client)
+      expect(client).to receive(:save)
+      knife.run
+    end
+
+    it "should print a message upon creation" do
+      expect(Chef::ApiClient).to receive(:from_hash).and_return(client)
+      expect(client).to receive(:save)
+      knife.run
+      expect(stderr.string).to match /Created client.*adam/i
     end
 
     it "should set the Client name" do
-      expect(@client).to receive(:name).with("adam")
-      @knife.run
+      expect(Chef::ApiClient).to receive(:from_hash).with(hash_including("name" => "adam")).and_return(client)
+      knife.run
     end
 
     it "by default it is not an admin" do
-      expect(@client).to receive(:admin).with(false)
-      @knife.run
+      expect(Chef::ApiClient).to receive(:from_hash).with(hash_including("admin" => false)).and_return(client)
+      knife.run
     end
 
     it "by default it is not a validator" do
-      expect(@client).to receive(:validator).with(false)
-      @knife.run
+      expect(Chef::ApiClient).to receive(:from_hash).with(hash_including("validator" => false)).and_return(client)
+      knife.run
     end
 
     it "should allow you to edit the data" do
-      expect(@knife).to receive(:edit_data).with(@client)
-      @knife.run
-    end
-
-    it "should save the Client" do
-      expect(@client).to receive(:save)
-      @knife.run
+      expect(knife).to receive(:edit_hash).with(default_client_hash).and_return(default_client_hash)
+      allow(Chef::ApiClient).to receive(:from_hash).and_return(client)
+      knife.run
     end
 
     describe "with -f or --file" do
       it "should write the private key to a file" do
-        @knife.config[:file] = "/tmp/monkeypants"
-        allow(@client).to receive(:save).and_return({ 'private_key' => "woot" })
+        knife.config[:file] = "/tmp/monkeypants"
+        allow_any_instance_of(Chef::ApiClient).to receive(:save).and_return({ 'private_key' => "woot" })
         filehandle = double("Filehandle")
         expect(filehandle).to receive(:print).with('woot')
         expect(File).to receive(:open).with("/tmp/monkeypants", "w").and_yield(filehandle)
-        @knife.run
+        knife.run
       end
     end
 
     describe "with -a or --admin" do
       it "should create an admin client" do
-        @knife.config[:admin] = true
-        expect(@client).to receive(:admin).with(true)
-        @knife.run
+        knife.config[:admin] = true
+        expect(Chef::ApiClient).to receive(:from_hash).with(hash_including("admin" => true)).and_return(client)
+        knife.run
       end
     end
 
     describe "with --validator" do
       it "should create an validator client" do
-        @knife.config[:validator] = true
-        expect(@client).to receive(:validator).with(true)
-        @knife.run
+        knife.config[:validator] = true
+        expect(Chef::ApiClient).to receive(:from_hash).with(hash_including("validator" => true)).and_return(client)
+        knife.run
       end
     end
-
   end
 end


### PR DESCRIPTION
This changeset resolves #2542 by explicitly creating a Chef::ApiClient rather than relying on JSONCompat to create one based on json_class.