### PR TITLE
Policyfile Native API Support and ChefFS Policy Support

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -369,6 +369,11 @@ class Chef
           if path.length >= 3
             path[2] = "#{path[2]}.json"
           end
+        elsif path[0] == 'policies'
+          path = path.dup
+          if path.length >= 3
+            path[2] = "#{path[2]}.json"
+          end
         elsif path[0] == 'cookbooks'
           if path.length == 2
             raise ChefZero::DataStore::DataNotFoundError.new(path)
@@ -445,10 +450,13 @@ class Chef
       def with_dir(path)
         # Do not automatically create data bags
         create = !(path[0] == 'data' && path.size >= 2)
+
         begin
           yield get_dir(_to_chef_fs_path(path), create)
         rescue Chef::ChefFS::FileSystem::NotFoundError => e
-          raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+          err = ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+          err.set_backtrace(e.backtrace)
+          raise err
         end
       end
 

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -26,6 +26,25 @@ class Chef
     # objects representing the server and local repository, respectively).
     #
     class Config
+
+      # Not all of our object types pluralize by adding an 's', so we map them
+      # out here:
+      INFLECTIONS = {
+        "acls" => "acl",
+        "clients" => "client",
+        "cookbooks" => "cookbook",
+        "containers" => "container",
+        "data_bags" => "data_bag",
+        "environments" => "environment",
+        "groups" => "group",
+        "nodes" => "node",
+        "roles" => "role",
+        "users" => "user",
+        "policies" => "policy"
+      }
+      INFLECTIONS.each { |k,v| k.freeze; v.freeze }
+      INFLECTIONS.freeze
+
       #
       # Create a new Config object which can produce a chef_fs and local_fs.
       #
@@ -215,14 +234,16 @@ class Chef
           result = {}
           case @chef_config[:repo_mode]
           when 'static'
-            object_names = %w(cookbooks data_bags environments roles)
+            object_names = %w(cookbooks data_bags environments roles policies)
           when 'hosted_everything'
-            object_names = %w(acls clients cookbooks containers data_bags environments groups nodes roles)
+            object_names = %w(acls clients cookbooks containers data_bags environments groups nodes roles policies)
           else
-            object_names = %w(clients cookbooks data_bags environments nodes roles users)
+            object_names = %w(clients cookbooks data_bags environments nodes roles users policies)
           end
           object_names.each do |object_name|
-            variable_name = "#{object_name[0..-2]}_path" # cookbooks -> cookbook_path
+            # cookbooks -> cookbook_path
+            singular_name = INFLECTIONS[object_name] or raise "Unknown object name #{object_name}"
+            variable_name = "#{singular_name}_path"
             paths = Array(@chef_config[variable_name]).flatten
             result[object_name] = paths.map { |path| File.expand_path(path) }
           end

--- a/lib/chef/chef_fs/data_handler/policy_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/policy_data_handler.rb
@@ -4,6 +4,10 @@ class Chef
   module ChefFS
     module DataHandler
       class PolicyDataHandler < DataHandlerBase
+
+        def normalize(policy, entry)
+          policy
+        end
       end
     end
   end

--- a/lib/chef/chef_fs/data_handler/policy_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/policy_data_handler.rb
@@ -1,0 +1,11 @@
+require 'chef/chef_fs/data_handler/data_handler_base'
+
+class Chef
+  module ChefFS
+    module DataHandler
+      class PolicyDataHandler < DataHandlerBase
+      end
+    end
+  end
+end
+

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -379,7 +379,7 @@ class Chef
                   should_copy = true
                   src_value = nil
                 else
-                  are_same, src_value, dest_value = compare(src_entry, dest_entry)
+                  are_same, src_value, _dest_value = compare(src_entry, dest_entry)
                   should_copy = !are_same
                 end
                 if should_copy

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_policies_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_policies_dir.rb
@@ -1,0 +1,38 @@
+#
+# Author:: John Keiser (<jkeiser@opscode.com>)
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/chef_fs/file_system/chef_repository_file_system_entry'
+require 'chef/chef_fs/data_handler/policy_data_handler'
+
+class Chef
+  module ChefFS
+    module FileSystem
+
+      class ChefRepositoryFileSystemPoliciesDir < ChefRepositoryFileSystemEntry
+        def initialize(name, parent, path = nil)
+          super(name, parent, path, Chef::ChefFS::DataHandler::PolicyDataHandler.new)
+        end
+
+        def can_have_child?(name, is_dir)
+          is_dir && !name.start_with?('.')
+        end
+      end
+    end
+  end
+end
+

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
@@ -21,12 +21,12 @@ require 'chef/chef_fs/file_system/chef_repository_file_system_entry'
 require 'chef/chef_fs/file_system/chef_repository_file_system_acls_dir'
 require 'chef/chef_fs/file_system/chef_repository_file_system_cookbooks_dir'
 require 'chef/chef_fs/file_system/chef_repository_file_system_data_bags_dir'
+require 'chef/chef_fs/file_system/chef_repository_file_system_policies_dir'
 require 'chef/chef_fs/file_system/multiplexed_dir'
 require 'chef/chef_fs/data_handler/client_data_handler'
 require 'chef/chef_fs/data_handler/environment_data_handler'
 require 'chef/chef_fs/data_handler/node_data_handler'
 require 'chef/chef_fs/data_handler/role_data_handler'
-require 'chef/chef_fs/data_handler/policy_data_handler'
 require 'chef/chef_fs/data_handler/user_data_handler'
 require 'chef/chef_fs/data_handler/group_data_handler'
 require 'chef/chef_fs/data_handler/container_data_handler'
@@ -34,6 +34,7 @@ require 'chef/chef_fs/data_handler/container_data_handler'
 class Chef
   module ChefFS
     module FileSystem
+
       #
       # Represents the root of a local Chef repository, with directories for
       # nodes, cookbooks, roles, etc. under it.
@@ -158,6 +159,8 @@ class Chef
             dirs = paths.map { |path| ChefRepositoryFileSystemCookbooksDir.new(name, self, path) }
           elsif name == 'data_bags'
             dirs = paths.map { |path| ChefRepositoryFileSystemDataBagsDir.new(name, self, path) }
+          elsif name == 'policies'
+            dirs = paths.map { |path| ChefRepositoryFileSystemPoliciesDir.new(name, self, path) }
           elsif name == 'acls'
             dirs = paths.map { |path| ChefRepositoryFileSystemAclsDir.new(name, self, path) }
           else
@@ -170,8 +173,6 @@ class Chef
                 Chef::ChefFS::DataHandler::NodeDataHandler.new
               when 'roles'
                 Chef::ChefFS::DataHandler::RoleDataHandler.new
-              when 'policies'
-                Chef::ChefFS::DataHandler::PolicyDataHandler.new
               when 'users'
                 Chef::ChefFS::DataHandler::UserDataHandler.new
               when 'groups'

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_root_dir.rb
@@ -26,6 +26,7 @@ require 'chef/chef_fs/data_handler/client_data_handler'
 require 'chef/chef_fs/data_handler/environment_data_handler'
 require 'chef/chef_fs/data_handler/node_data_handler'
 require 'chef/chef_fs/data_handler/role_data_handler'
+require 'chef/chef_fs/data_handler/policy_data_handler'
 require 'chef/chef_fs/data_handler/user_data_handler'
 require 'chef/chef_fs/data_handler/group_data_handler'
 require 'chef/chef_fs/data_handler/container_data_handler'
@@ -169,6 +170,8 @@ class Chef
                 Chef::ChefFS::DataHandler::NodeDataHandler.new
               when 'roles'
                 Chef::ChefFS::DataHandler::RoleDataHandler.new
+              when 'policies'
+                Chef::ChefFS::DataHandler::PolicyDataHandler.new
               when 'users'
                 Chef::ChefFS::DataHandler::UserDataHandler.new
               when 'groups'

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -203,6 +203,10 @@ class Chef
     # Does not apply to Enterprise Chef commands.
     default(:user_path) { derive_path_from_chef_repo_path('users') }
 
+    # Location of policies on disk. String or array of strings.
+    # Defaults to <chef_repo_path>/policies.
+    default(:policy_path) { derive_path_from_chef_repo_path('policies') }
+
     # Turn on "path sanity" by default. See also: http://wiki.opscode.com/display/chef/User+Environment+PATH+Sanity
     default :enforce_path_sanity, true
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -237,7 +237,12 @@ class Chef
       end
 
       def policyfile_location
-        "data/policyfiles/#{deployment_group}"
+        if Chef::Config[:policy_document_native_api]
+          validate_policy_config!
+          "policies/#{policy_group}/#{policy_name}"
+        else
+          "data/policyfiles/#{deployment_group}"
+        end
       end
 
       # Do some mimimal validation of the policyfile we fetched from the
@@ -279,6 +284,22 @@ class Chef
       def deployment_group
         Chef::Config[:deployment_group] or
           raise ConfigurationError, "Setting `deployment_group` is not configured."
+      end
+
+      def validate_policy_config!
+        policy_group or
+          raise ConfigurationError, "Setting `policy_group` is not configured."
+
+        policy_name or
+          raise ConfigurationError, "Setting `policy_name` is not configured."
+      end
+
+      def policy_group
+        Chef::Config[:policy_group]
+      end
+
+      def policy_name
+        Chef::Config[:policy_name]
       end
 
       # Builds a 'cookbook_hash' map of the form

--- a/spec/unit/chef_fs/config_spec.rb
+++ b/spec/unit/chef_fs/config_spec.rb
@@ -55,4 +55,56 @@ describe Chef::ChefFS::Config do
       Chef::ChefFS::Config.new(base_config, Dir.pwd, {}, ui)
     end
   end
+
+  describe "local FS configuration" do
+
+    let(:chef_config) do
+      Mash.new({
+        client_path: "/base_path/clients",
+        cookbook_path: "/base_path/cookbooks",
+        data_bag_path: "/base_path/data_bags",
+        environment_path: "/base_path/environments",
+        node_path: "/base_path/nodes",
+        role_path: "/base_path/roles",
+        user_path: "/base_path/users",
+        policy_path: "/base_path/policies"
+      })
+    end
+
+    let(:chef_fs_config)  { Chef::ChefFS::Config.new(chef_config, Dir.pwd) }
+
+    subject(:local_fs) { chef_fs_config.local_fs }
+
+    def platform_path(*args)
+      File.expand_path(*args)
+    end
+
+    it "sets the correct nodes path on the local FS object" do
+      expect(local_fs.child_paths["nodes"]).to eq([platform_path("/base_path/nodes")])
+    end
+
+    it "sets the correct cookbook path on the local FS object" do
+      expect(local_fs.child_paths["cookbooks"]).to eq([platform_path("/base_path/cookbooks")])
+    end
+
+    it "sets the correct data bag path on the local FS object" do
+      expect(local_fs.child_paths["data_bags"]).to eq([platform_path("/base_path/data_bags")])
+    end
+
+    it "sets the correct environment path on the local FS object" do
+      expect(local_fs.child_paths["environments"]).to eq([platform_path("/base_path/environments")])
+    end
+
+    it "sets the correct role path on the local FS object" do
+      expect(local_fs.child_paths["roles"]).to eq([platform_path("/base_path/roles")])
+    end
+
+    it "sets the correct user path on the local FS object" do
+      expect(local_fs.child_paths["users"]).to eq([platform_path("/base_path/users")])
+    end
+
+    it "sets the correct policy path on the local FS object" do
+      expect(local_fs.child_paths["policies"]).to eq([platform_path("/base_path/policies")])
+    end
+  end
 end


### PR DESCRIPTION
* Adds support for the native policy API. Since this won't be released in Chef Server for a while, it's disabled by default. Setting `policy_document_native_api true` in the appropriate config file enables it.
* Adds policy storage to ChefFS. Using this with https://github.com/opscode/chef-zero/pull/111 I am able to create and update policies with persistent/file-based storage.

ChefFS has no unit tests. I will look into the integration tests, but I'm not sure if stuff like `knife upload` will work with policies, since the current iteration of the policies API is simplified (uses PUT for create and update, for example). I plan to propose an updated policies API as a RFC soon.

@chef/delivery @chef/client-engineers 