### PR TITLE
Allow :nothing action for reboot, ips_package, paludis_package resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Useradd functional tests fail randomly
 * Add comments to trusted_certs_content
 * fixes a bug where providers would not get defined if a top-level ruby constant with the same name was already defined (ark cookbook, chrome cookbook)
+* Fix a bug in `reboot`, `ips_package`, `paludis_package` resources where `action :nothing` was not permitted
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 * Useradd functional tests fail randomly
 * Add comments to trusted_certs_content
 * fixes a bug where providers would not get defined if a top-level ruby constant with the same name was already defined (ark cookbook, chrome cookbook)
-* Fix a bug in `reboot`, `ips_package`, `paludis_package` resources where `action :nothing` was not permitted
+* Fix a bug in `reboot`, `ips_package`, `paludis_package`, `windows_package` resources where `action :nothing` was not permitted
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/resource/ips_package.rb
+++ b/lib/chef/resource/ips_package.rb
@@ -28,7 +28,7 @@ class Chef
       def initialize(name, run_context = nil)
         super(name, run_context)
         @resource_name = :ips_package
-        @allowed_actions = [ :install, :remove, :upgrade ]
+        @allowed_actions.push(:install, :remove, :upgrade)
         @accept_license = false
       end
 

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -28,7 +28,7 @@ class Chef
       def initialize(name, run_context=nil)
         super(name, run_context)
         @resource_name = :paludis_package
-        @allowed_actions = [ :install, :remove, :upgrade ]
+        @allowed_actions.push(:install, :remove, :upgrade)
         @timeout = 3600
       end
     end

--- a/lib/chef/resource/reboot.rb
+++ b/lib/chef/resource/reboot.rb
@@ -28,7 +28,7 @@ class Chef
         super
         @resource_name = :reboot
         @provider = Chef::Provider::Reboot
-        @allowed_actions = [:request_reboot, :reboot_now, :cancel]
+        @allowed_actions.push(:request_reboot, :reboot_now, :cancel)
 
         @reason = "Reboot by Chef"
         @delay_mins = 0

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -29,7 +29,7 @@ class Chef
 
       def initialize(name, run_context=nil)
         super
-        @allowed_actions = [ :install, :remove ]
+        @allowed_actions.push(:install, :remove)
         @resource_name = :windows_package
         @source ||= source(@package_name)
 


### PR DESCRIPTION
Without a `:nothing` action as inherited from the superclass, you can't have the `reboot` resource get notified by some other resource, i.e. the [code in our docs](https://github.com/chef/chef-docs/blame/master/step_resource/step_resource_service_reboot_immediately.rst#L7-L11) doesn't work.

Is there ever a situation in which `:nothing` shouldn't be a valid action? I see a couple other resource declarations in here that are redefining the `@allowed_actions` ivar instead of pushing actions onto it.