### PR TITLE
Remove comments of a service being enabled/disabled in FreeBSD

### DIFF
--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -180,7 +180,7 @@ class Chef
         def set_service_enable(value)
           lines = read_rc_conf
           # Remove line that set the old value
-          lines.delete_if { |line| line =~ /^#{Regexp.escape(service_enable_variable_name)}=/ }
+          lines.delete_if { |line| line =~ /^\#?\s*#{Regexp.escape(service_enable_variable_name)}=/ }
           # And append the line that sets the new value at the end
           lines << "#{service_enable_variable_name}=\"#{value}\""
           write_rc_conf(lines)

--- a/spec/unit/provider/service/freebsd_service_spec.rb
+++ b/spec/unit/provider/service/freebsd_service_spec.rb
@@ -580,6 +580,13 @@ EOF
       expect(provider).not_to receive(:write_rc_conf)
       provider.enable_service
     end
+
+    it "should remove commented out versions of it being enabled" do
+      allow(current_resource).to receive(:enabled).and_return(false)
+      expect(provider).to receive(:read_rc_conf).and_return([ "foo", "bar", "\# #{new_resource.service_name}_enable=\"YES\"", "\# #{new_resource.service_name}_enable=\"NO\""])
+      expect(provider).to receive(:write_rc_conf).with(["foo", "bar", "#{new_resource.service_name}_enable=\"YES\""])
+      provider.enable_service()
+    end
   end
 
   describe Chef::Provider::Service::Freebsd, "disable_service" do
@@ -605,6 +612,13 @@ EOF
     it "should not disable the service if it is already disabled" do
       allow(current_resource).to receive(:enabled).and_return(false)
       expect(provider).not_to receive(:write_rc_conf)
+      provider.disable_service()
+    end
+
+    it "should remove commented out versions of it being disabled or enabled" do
+      allow(current_resource).to receive(:enabled).and_return(true)
+      expect(provider).to receive(:read_rc_conf).and_return([ "foo", "bar", "\# #{new_resource.service_name}_enable=\"YES\"", "\# #{new_resource.service_name}_enable=\"NO\""])
+      expect(provider).to receive(:write_rc_conf).with(["foo", "bar", "#{new_resource.service_name}_enable=\"NO\""])
       provider.disable_service()
     end
   end


### PR DESCRIPTION
When a service is being enabled or disabled, currently the service provider will leave in comments of the service being enabled or disabled. This change removes the commented out version.

closes #1791 