### PR TITLE
Rspec tests: make platform version optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,8 @@ Dir["spec/support/**/*.rb"].
 OHAI_SYSTEM = Ohai::System.new
 OHAI_SYSTEM.all_plugins("platform")
 TEST_PLATFORM = OHAI_SYSTEM["platform"].dup.freeze
-TEST_PLATFORM_VERSION = OHAI_SYSTEM["platform_version"].dup.freeze
+# TODO review this
+TEST_PLATFORM_VERSION = OHAI_SYSTEM["platform_version"].dup.freeze if OHAI_SYSTEM["platform_version"]
 
 RSpec.configure do |config|
   config.include(Matchers)
@@ -155,9 +156,11 @@ RSpec.configure do |config|
     type, target_provider = criteria.first
 
     platform = TEST_PLATFORM.dup
-    platform_version = TEST_PLATFORM_VERSION.dup
+    # TODO review this
+    platform_version = TEST_PLATFORM_VERSION.dup if TEST_PLATFORM_VERSION
 
     begin
+      # TODO figure out what to send to find_provider
       provider_for_running_platform = Chef::Platform.find_provider(platform, platform_version, type)
       provider_for_running_platform != target_provider
     rescue ArgumentError # no provider for platform

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ Dir["spec/support/**/*.rb"].
 OHAI_SYSTEM = Ohai::System.new
 OHAI_SYSTEM.all_plugins("platform")
 TEST_PLATFORM = OHAI_SYSTEM["platform"].dup.freeze
-# TODO review this
 TEST_PLATFORM_VERSION = OHAI_SYSTEM["platform_version"].dup.freeze if OHAI_SYSTEM["platform_version"]
 
 RSpec.configure do |config|
@@ -156,11 +155,9 @@ RSpec.configure do |config|
     type, target_provider = criteria.first
 
     platform = TEST_PLATFORM.dup
-    # TODO review this
     platform_version = TEST_PLATFORM_VERSION.dup if TEST_PLATFORM_VERSION
 
     begin
-      # TODO figure out what to send to find_provider
       provider_for_running_platform = Chef::Platform.find_provider(platform, platform_version, type)
       provider_for_running_platform != target_provider
     rescue ArgumentError # no provider for platform


### PR DESCRIPTION
This is to resolve #2843.

Running

    bundle exec rspec spec/unit/<some rspec test>

gave the following error:

    /home/rchipman/development/workspaces/chef/chef-dev/spec/spec_helper.rb:87:in `dup': can't dup NilClass (TypeError)

On archlinux (and, I would presume, any other rolling-release distro), there is no platform version, and so

    TEST_PLATFORM_VERSION = OHAI_SYSTEM["platform_version"].dup.freeze

(from spec/spec_helper.rb) threw the error I was seeing. The fix simply skips calling any methods on the platform version variable if it is nil.