### PR TITLE
Giving an error when a host is unaccessible, instead of a warning

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -110,7 +110,7 @@ class Chef
           when :skip
             ui.fatal("Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}")
             $!.backtrace.each { |l| Chef::Log.debug(l) }
-            exit 65
+            raise Exception, 'Connection Failed'
           when :raise
             #Net::SSH::Multi magic to force exception to be re-raised.
             throw :go, :raise

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -108,8 +108,9 @@ class Chef
         ssh_error_handler = Proc.new do |server|
           case config[:on_error]
           when :skip
-            ui.warn "Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}"
+            ui.fatal("Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}")
             $!.backtrace.each { |l| Chef::Log.debug(l) }
+            exit 65
           when :raise
             #Net::SSH::Multi magic to force exception to be re-raised.
             throw :go, :raise


### PR DESCRIPTION
knife ssh command would fail if it cannot ssh.
Any job that does a knife ssh will fail, so it doesn't give a false impression that it succeeded when the hosts didn't actually get the changes desired.