### PR TITLE
Prioritise manual ssh attribute over defaults

### DIFF
--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -165,7 +165,7 @@ describe Chef::Knife::Ssh do
 
       it "uses the ssh_attribute" do
         @knife.run
-        expect(@knife.config[:attribute]).to eq("ec2.public_hostname")
+        expect(@knife.get_ssh_attribute(Chef::Node.new)).to eq("ec2.public_hostname")
       end
     end
 
@@ -177,7 +177,7 @@ describe Chef::Knife::Ssh do
 
       it "uses the default" do
         @knife.run
-        expect(@knife.config[:attribute]).to eq("fqdn")
+        expect(@knife.get_ssh_attribute(Chef::Node.new)).to eq("fqdn")
       end
     end
 


### PR DESCRIPTION
PR to fix  https://github.com/chef/chef/issues/2325
and also https://tickets.opscode.com/browse/CHEF-4962?focusedCommentId=46454&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-46454

My argument for this is as follows:

all manual overrides should take priority over whatever the default/automatic lookups that exist.

the priority list for the host attribute is as follows:

1. command line
2. knife.rb :ssh_attribute value
3. cloud.public_hostname value
4. fqdn parameter

the last 2 are essentially defaults. 