### PR TITLE
fix LWRP constant lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * `powershell_script` should now correctly get the exit code for scripts that it runs. See [Issue 2348](https://github.com/chef/chef/issues/2348)
 * Useradd functional tests fail randomly
 * Add comments to trusted_certs_content
+* fixes a bug where providers would not get defined if a top-level ruby constant with the same name was already defined (ark cookbook, chrome cookbook)
 
 ## 12.0.3
 * [**Phil Dibowitz**](https://github.com/jaymzh):

--- a/lib/chef/provider/lwrp_base.rb
+++ b/lib/chef/provider/lwrp_base.rb
@@ -86,7 +86,7 @@ class Chef
 
         class_name = convert_to_class_name(provider_name)
 
-        if Chef::Provider.const_defined?(class_name)
+        if Chef::Provider.const_defined?(class_name, false)
           Chef::Log.info("#{class_name} light-weight provider is already initialized -- Skipping loading #{filename}!")
           Chef::Log.debug("Overriding already defined LWRPs is not supported anymore starting with Chef 12.")
           provider_class = Chef::Provider.const_get(class_name)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -931,10 +931,6 @@ class Chef
       run_context.notifies_delayed(Notification.new(resource_spec, action, self))
     end
 
-    def self.strict_const_defined?(const)
-      const_defined?(const, false)
-    end
-
     class << self
       # back-compat
       # NOTE: that we do not support unregistering classes as descendents like

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -39,7 +39,7 @@ class Chef
         rname = filename_to_qualified_string(cookbook_name, filename)
 
         class_name = convert_to_class_name(rname)
-        if Resource.strict_const_defined?(class_name)
+        if Resource.const_defined?(class_name, false)
           Chef::Log.info("#{class_name} light-weight resource is already initialized -- Skipping loading #{filename}!")
           Chef::Log.debug("Overriding already defined LWRPs is not supported anymore starting with Chef 12.")
           resource_class = Resource.const_get(class_name)

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -36,6 +36,30 @@ describe "LWRP" do
       allow($stderr).to receive(:write)
     end
 
+    it "should not skip loading a resource when there's a top level symbol of the same name" do
+      Object.const_set('LwrpFoo', Class.new)
+      file = File.expand_path( "lwrp/resources/foo.rb", CHEF_SPEC_DATA)
+      expect(Chef::Log).not_to receive(:info).with(/Skipping/)
+      expect(Chef::Log).not_to receive(:debug).with(/anymore/)
+      Chef::Resource::LWRPBase.build_from_file("lwrp", file, nil)
+      Object.send(:remove_const, 'LwrpFoo')
+      Chef::Resource.send(:remove_const, 'LwrpFoo')
+    end
+
+    it "should not skip loading a provider when there's a top level symbol of the same name" do
+      Object.const_set('LwrpBuckPasser', Class.new)
+      file = File.expand_path( "lwrp/providers/buck_passer.rb", CHEF_SPEC_DATA)
+      expect(Chef::Log).not_to receive(:info).with(/Skipping/)
+      expect(Chef::Log).not_to receive(:debug).with(/anymore/)
+      Chef::Provider::LWRPBase.build_from_file("lwrp", file, nil)
+      Object.send(:remove_const, 'LwrpBuckPasser')
+      Chef::Provider.send(:remove_const, 'LwrpBuckPasser')
+    end
+
+    # @todo: we need a before block to manually remove_const all of the LWRPs that we
+    #        load in these tests.  we're threading state through these tests in LWRPs that
+    #        have already been loaded in prior tests, which probably renders some of them bogus
+
     it "should log if attempting to load resource of same name" do
       Dir[File.expand_path( "lwrp/resources/*", CHEF_SPEC_DATA)].each do |file|
         Chef::Resource::LWRPBase.build_from_file("lwrp", file, nil)


### PR DESCRIPTION
* providers had the same bug as CHEF-4117 on resources
* removed the strict_const_defined method on Chef::Resource since
  ruby 1.8.7 deprecation made that method entirely trivial
* added tests, verified the failure cases really work
* todo added since i think we're leaking state in-between tests

closes #2575 