### PR TITLE
pin rspec to 3.1.x for now

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'plist', '~> 3.1.0'
 
   # Audit mode requires these, so they are non-developmental dependencies now
-  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.1" }
+  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.1.0" }
   s.add_dependency "rspec_junit_formatter", "~> 0.2.0"
   s.add_dependency "serverspec", "~> 2.7"
   s.add_dependency "specinfra", "~> 2.10"


### PR DESCRIPTION
rspec 3.2.0 release changed some private APIs in rspec that we were using for audit
mode and broke our master (kind of expected/understandable).