### PR TITLE
gem_package, chef_gem should not shell out to using https://rubygems.org

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -533,6 +533,8 @@ class Chef
         def install_via_gem_command(name, version)
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
+          elsif source_is_remote?
+            src = @new_resource.source && "  --source=#{@new_resource.source}"
           else
             src = @new_resource.source && "  --source=#{@new_resource.source} --source=https://rubygems.org"
           end

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -533,10 +533,10 @@ class Chef
         def install_via_gem_command(name, version)
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
-          elsif source_is_remote?
-            src = @new_resource.source && "  --source=#{@new_resource.source}"
+#          elsif source_is_remote?
+#            src = @new_resource.source && "  --source=#{@new_resource.source}"
           else
-            src = @new_resource.source && "  --source=#{@new_resource.source} --source=https://rubygems.org"
+            src = @new_resource.source && " --source=#{@new_resource.source} --source=https://rubygems.org"
           end
           if !version.nil? && version.length > 0
             shell_out!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -533,8 +533,9 @@ class Chef
         def install_via_gem_command(name, version)
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
-#          elsif source_is_remote?
-#            src = @new_resource.source && "  --source=#{@new_resource.source}"
+          elsif @new_resource.clear_sources
+            src = ' --clear-sources'
+            src << (@new_resource.source && " --source=#{@new_resource.source}" || '')
           else
             src = @new_resource.source && " --source=#{@new_resource.source} --source=https://rubygems.org"
           end

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -27,10 +27,15 @@ class Chef
       def initialize(name, run_context=nil)
         super
         @resource_name = :gem_package
+        @clear_sources = false
       end
 
       def source(arg=nil)
         set_or_return(:source, arg, :kind_of => [ String, Array ])
+      end
+
+      def clear_sources(arg=nil)
+        set_or_return(:clear_sources, arg, :kind_of => [ TrueClass, FalseClass ])
       end
 
       # Sets a custom gem_binary to run for gem commands.

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -556,6 +556,16 @@ describe Chef::Provider::Package::Rubygems do
           expect(@new_resource).to be_updated_by_last_action
         end
 
+        it "installs the gem with cleared sources and explict source when specified" do
+          @new_resource.gem_binary('/foo/bar')
+          @new_resource.source('http://mirror.ops.rhcloud.com/mirror/ruby')
+          @new_resource.clear_sources(true)
+          expected ="/foo/bar install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" --clear-sources --source=#{@new_resource.source}"
+          expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+          @provider.run_action(:install)
+          expect(@new_resource).to be_updated_by_last_action
+        end
+
         context "when no version is given" do
           let(:target_version) { nil }
 

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -547,6 +547,15 @@ describe Chef::Provider::Package::Rubygems do
           expect(@new_resource).to be_updated_by_last_action
         end
 
+        it "installs the gem with rubygems.org as an added source" do
+          @new_resource.gem_binary('/foo/bar')
+          @new_resource.source('http://mirror.ops.rhcloud.com/mirror/ruby')
+          expected ="/foo/bar install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" --source=#{@new_resource.source} --source=https://rubygems.org"
+          expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+          @provider.run_action(:install)
+          expect(@new_resource).to be_updated_by_last_action
+        end
+
         context "when no version is given" do
           let(:target_version) { nil }
 


### PR DESCRIPTION
Some users will not be able to use rubygems.org and will specify the remote source. If their source doesn't have the gem, then `gem` will try the next source. If DNS resolves, then you'll get timeouts. 

Or even if they are able to use rubygems.org, they may be unpleasantly surprised when the 'rubygems.org' version of a gem appears unexpectedly.

I've not added any specs for this, pending discussion, but I will if this seems like the right way to go.

Also, given that Hash options provides better control of gem_package options, should we issue a warning when shelling out?

--Peter
