### PR TITLE
Lcg/array name deuglification

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -139,7 +139,7 @@ class Chef
     # so that `package ["foo", "bar"]` becomes package[foo, bar] instead of the more
     # awkward `package[["foo", "bar"]]` that #to_s would produce.
     #
-    # @param name [String] The name to set.
+    # @param name [Object] The name to set, typically a String or Array
     # @return [String] The name of this Resource.
     #
     def name(name=nil)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -91,7 +91,7 @@ class Chef
     # @param run_context The context of the Chef run. Corresponds to #run_context.
     #
     def initialize(name, run_context=nil)
-      @name = name
+      name(name)
       @run_context = run_context
       @noop = nil
       @before = nil
@@ -138,8 +138,11 @@ class Chef
     #
     def name(name=nil)
       if !name.nil?
-        raise ArgumentError, "name must be a string!" unless name.kind_of?(String)
-        @name = name
+        if name.is_a?(Array)
+          @name = name.join(', ')
+        else
+          @name = name.to_s
+        end
       end
       @name
     end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -133,6 +133,12 @@ class Chef
     #
     # This is also used in to_s to show the resource name, e.g. `execute[Vitruvius]`.
     #
+    # This is also used for resource notifications and subscribes in the same manner.
+    #
+    # This will coerce any object into a string via #to_s.  Arrays are a special case
+    # so that `package ["foo", "bar"]` becomes package[foo, bar] instead of the more
+    # awkward `package[["foo", "bar"]]` that #to_s would produce.
+    #
     # @param name [String] The name to set.
     # @return [String] The name of this Resource.
     #

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -341,8 +341,8 @@ describe "LWRP" do
       Chef::Runner.new(@run_context).converge
 
       expect(@run_context.resource_collection[0]).to eql(injector)
-      expect(@run_context.resource_collection[1].name).to eql(:prepared_thumbs)
-      expect(@run_context.resource_collection[2].name).to eql(:twiddled_thumbs)
+      expect(@run_context.resource_collection[1].name).to eql('prepared_thumbs')
+      expect(@run_context.resource_collection[2].name).to eql('twiddled_thumbs')
       expect(@run_context.resource_collection[3]).to eql(dummy)
     end
 
@@ -365,12 +365,12 @@ describe "LWRP" do
       Chef::Runner.new(@run_context).converge
 
       expect(@run_context.resource_collection[0]).to eql(injector)
-      expect(@run_context.resource_collection[1].name).to eql(:prepared_thumbs)
-      expect(@run_context.resource_collection[2].name).to eql(:twiddled_thumbs)
+      expect(@run_context.resource_collection[1].name).to eql('prepared_thumbs')
+      expect(@run_context.resource_collection[2].name).to eql('twiddled_thumbs')
       expect(@run_context.resource_collection[3]).to eql(dummy)
       expect(@run_context.resource_collection[4]).to eql(injector2)
-      expect(@run_context.resource_collection[5].name).to eql(:prepared_eyes)
-      expect(@run_context.resource_collection[6].name).to eql(:dried_paint_watched)
+      expect(@run_context.resource_collection[5].name).to eql('prepared_eyes')
+      expect(@run_context.resource_collection[6].name).to eql('dried_paint_watched')
     end
 
     it "should properly handle a new_resource reference" do

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -1888,7 +1888,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
   describe "when loading the current system state" do
     it "should create a current resource with the name of the new_resource" do
       @provider.load_current_resource
-      expect(@provider.current_resource.name).to eq(['cups', 'vim'])
+      expect(@provider.current_resource.name).to eq('cups, vim')
     end
 
     it "should set the current resources package name to the new resources package name" do

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -539,7 +539,7 @@ describe "Chef::Provider::Package - Multi" do
     it "should upgrade the package if the current versions are not the candidate version" do
       @current_resource.version ['0.9', '6.1']
       expect(@provider).to receive(:upgrade_package).with(
-        @new_resource.name,
+        @new_resource.package_name,
         @provider.candidate_version
       ).and_return(true)
       @provider.run_action(:upgrade)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -194,12 +194,12 @@ describe Chef::Resource do
       expect(@resource.name).to eql("monkey")
     end
 
-    it "should not be valid without a name" do
-      expect { @resource.name false }.to raise_error(ArgumentError)
+    it "coerces arrays to names" do
+      expect(@resource.name ['a', 'b']).to eql('a, b')
     end
 
-    it "should always have a string for name" do
-      expect { @resource.name Hash.new }.to raise_error(ArgumentError)
+    it "should coerce objects to a string" do
+      expect(@resource.name Object.new).to be_a(String)
     end
   end
 
@@ -257,6 +257,12 @@ describe Chef::Resource do
       @resource.notifies_delayed(:restart, :service => "apache")
       expected_notification = Chef::Resource::Notification.new({:service => "apache"}, :restart, @resource)
       expect(@resource.delayed_notifications).to include(expected_notification)
+    end
+
+    it "notifies a resource with an array for its name via its prettified string name" do
+      @run_context.resource_collection << Chef::Resource::ZenMaster.new(["coffee", "tea"])
+      @resource.notifies :reload, @run_context.resource_collection.find(:zen_master => "coffee, tea")
+      expect(@resource.delayed_notifications.detect{|e| e.resource.name == "coffee, tea" && e.action == :reload}).not_to be_nil
     end
   end
 


### PR DESCRIPTION

- the constructor was bypassing the setter method and allowing random
  objects to be set as names when the intent is to only accept strings.
- failing on non-string objects would be a backwards incompatible
  change so the constructor was changed to coerce to a string (this has
  come up before with the log resource being passed an object).
- a special case was added for arrays so that the name arg of
  multipackage installs looks like:

```
  apt_package[lsof, bc]
```

  instead of:

```
  apt_package[["lsof", "bc"]]
```

- the special case for the array likely only affects the OnePerson(tm) out
  there who is passing an array to a resource (like log) already and using
  notifies or subscribes against it.  better to xkcd that person
  now than to have people start to build notification against the new
  multipackage syntax and then have to break a lot more people with
  Chef-13.
- this doesn't affect the internals of the multipackge stuff because the
  packge_name is set to the value the constructor gets (which is an
  array) so that the coercsion to string does not affect provider behavior,
  but will get notify/subscribe and other resource collection manipulation
  and reporting correct.