### PR TITLE
Deprecation warnings as errors

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -499,9 +499,6 @@ class Chef
     # Deprecated:
     default(:cache_options) { { :path => PathHelper.join(file_cache_path, "checksums") } }
 
-    # Set to false to silence Chef 11 deprecation warnings:
-    default :chef11_deprecation_warnings, true
-
     # knife configuration data
     config_context :knife do
       default :ssh_port, nil

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -499,6 +499,21 @@ class Chef
     # Deprecated:
     default(:cache_options) { { :path => PathHelper.join(file_cache_path, "checksums") } }
 
+    # Whether errors should be raised for deprecation warnings. When set to
+    # `false` (the default setting), a warning is emitted but code using
+    # deprecated methods/features/etc. should work normally otherwise. When set
+    # to `true`, usage of deprecated methods/features will raise a
+    # `DeprecatedFeatureError`. This is used by Chef's tests to ensure that
+    # deprecated functionality is not used internally by Chef.  End users
+    # should generally leave this at the default setting (especially in
+    # production), but it may be useful when testing cookbooks or other code if
+    # the user wishes to aggressively address deprecations.
+    default(:treat_deprecation_warnings_as_errors) do
+      # Using an environment variable allows this setting to be inherited in
+      # tests that spawn new processes.
+      ENV.key?("CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS")
+    end
+
     # knife configuration data
     config_context :knife do
       default :ssh_port, nil

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -212,6 +212,8 @@ class Chef
 
     class NoProviderAvailable < RuntimeError; end
 
+    class DeprecatedFeatureError < RuntimeError; end
+
     class MissingRole < RuntimeError
       NULL = Object.new
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -164,6 +164,12 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Chef::Config.reset
+
+    # By default, treat deprecation warnings as errors in tests.
+    Chef::Config.treat_deprecation_warnings_as_errors(true)
+
+    # Set environment variable so the setting persists in child processes
+    ENV['CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS'] = "1"
   end
 
   config.before(:suite) do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -508,4 +508,43 @@ describe Chef::Config do
       end
     end
   end
+
+  describe "Treating deprecation warnings as errors" do
+
+    context "when using our default RSpec configuration" do
+
+      it "defaults to treating deprecation warnings as errors" do
+        expect(Chef::Config[:treat_deprecation_warnings_as_errors]).to be(true)
+      end
+
+      it "sets CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS environment variable" do
+        expect(ENV['CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS']).to eq("1")
+      end
+
+      it "treats deprecation warnings as errors in child processes when testing" do
+        # Doing a full integration test where we launch a child process is slow
+        # and liable to break for weird reasons (bundler env stuff, etc.), so
+        # we're just checking that the presence of the environment variable
+        # causes treat_deprecation_warnings_as_errors to be set to true after a
+        # config reset.
+        Chef::Config.reset
+        expect(Chef::Config[:treat_deprecation_warnings_as_errors]).to be(true)
+      end
+
+    end
+
+    context "outside of our test environment" do
+
+      before do
+        ENV.delete('CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS')
+        Chef::Config.reset
+      end
+
+      it "defaults to NOT treating deprecation warnings as errors" do
+        expect(Chef::Config[:treat_deprecation_warnings_as_errors]).to be(false)
+      end
+    end
+
+
+  end
 end


### PR DESCRIPTION
Adds infrastructure so we can treat deprecation warnings as errors. In a feature I'm working on currently, I am deprecating some stuff that's used in a few places in Chef (conversion of cookbooks to JSON for uploads), and I needed a way to make sure that Chef wasn't triggering deprecation warnings from itself.

To address this, I've added a config option to treat deprecation warnings as errors, which defaults to false. It can be set to true directly, or by setting the environment variable `CHEF_TREAT_DEPRECATION_WARNINGS_AS_ERRORS`. In the spec helper, both of these are set, so when you're running tests, any usage of deprecated behavior will be an error. The environment variable makes this setting persist in child processes, such as when the integration tests run `chef-client` or `knife`.

Though this feature is mostly designed for internal use, it's also helpful for end users who wish to aggressively fix deprecation warnings; they could set this flag only during local development.

@lamont-granquist @jkeiser @chef/client-core 