### PR TITLE
PathHelper.dirname should always return an absolute path

### DIFF
--- a/lib/chef/util/path_helper.rb
+++ b/lib/chef/util/path_helper.rb
@@ -37,7 +37,7 @@ class Chef
             end
           end
         else
-          ::File.dirname(path)
+          ::File.expand_path(::File.dirname(path))
         end
       end
 


### PR DESCRIPTION
This is a fix for #2875