### PR TITLE
Deprecation warning for 'knife cookbook test'

### DIFF
--- a/lib/chef/knife/cookbook_test.rb
+++ b/lib/chef/knife/cookbook_test.rb
@@ -43,6 +43,7 @@ class Chef
         :description => "Test all cookbooks, rather than just a single cookbook"
 
       def run
+        ui.warn("DEPRECATED: Please use ChefSpec or Rubocop to syntax-check cookbooks.")
         config[:cookbook_path] ||= Chef::Config[:cookbook_path]
 
         checked_a_cookbook = false


### PR DESCRIPTION
This PR is to address the comments in #2826 where client-core didn't want to take the whole removal of this feature for now.

I'd like to get this into an upcoming release (12.1.0?) so that we can merge #2826 after that.