### PR TITLE
Remove non-default defaults from mdadm resource

### DIFF
--- a/lib/chef/provider/mdadm.rb
+++ b/lib/chef/provider/mdadm.rb
@@ -48,8 +48,8 @@ class Chef
         unless @current_resource.exists
           converge_by("create RAID device #{new_resource.raid_device}") do
             command = "yes | mdadm --create #{@new_resource.raid_device} --level #{@new_resource.level}"
-            command << " --chunk=#{@new_resource.chunk}" if @new_resource.chunk and @new_resource.level != 1
-            command << " --metadata=#{@new_resource.metadata}" if @new_resource.metadata
+            command << " --chunk=#{@new_resource.chunk}" unless @new_resource.level == 1
+            command << " --metadata=#{@new_resource.metadata}"
             command << " --bitmap=#{@new_resource.bitmap}" if @new_resource.bitmap
             command << " --raid-devices #{@new_resource.devices.length} #{@new_resource.devices.join(" ")}"
             Chef::Log.debug("#{@new_resource} mdadm command: #{command}")

--- a/lib/chef/provider/mdadm.rb
+++ b/lib/chef/provider/mdadm.rb
@@ -48,8 +48,8 @@ class Chef
         unless @current_resource.exists
           converge_by("create RAID device #{new_resource.raid_device}") do
             command = "yes | mdadm --create #{@new_resource.raid_device} --level #{@new_resource.level}"
-            command << " --chunk=#{@new_resource.chunk}" unless @new_resource.level == 1
-            command << " --metadata=#{@new_resource.metadata}"
+            command << " --chunk=#{@new_resource.chunk}" if @new_resource.chunk and @new_resource.level != 1
+            command << " --metadata=#{@new_resource.metadata}" if @new_resource.metadata
             command << " --bitmap=#{@new_resource.bitmap}" if @new_resource.bitmap
             command << " --raid-devices #{@new_resource.devices.length} #{@new_resource.devices.join(" ")}"
             Chef::Log.debug("#{@new_resource} mdadm command: #{command}")

--- a/lib/chef/provider/mdadm.rb
+++ b/lib/chef/provider/mdadm.rb
@@ -48,8 +48,8 @@ class Chef
         unless @current_resource.exists
           converge_by("create RAID device #{new_resource.raid_device}") do
             command = "yes | mdadm --create #{@new_resource.raid_device} --level #{@new_resource.level}"
-            command << " --chunk=#{@new_resource.chunk}" unless @new_resource.level == 1
-            command << " --metadata=#{@new_resource.metadata}"
+            command << " --chunk=#{@new_resource.chunk}" if @new_resource.chunk && @new_resource.level != 1
+            command << " --metadata=#{@new_resource.metadata}" if @new_resource.metadata
             command << " --bitmap=#{@new_resource.bitmap}" if @new_resource.bitmap
             command << " --raid-devices #{@new_resource.devices.length} #{@new_resource.devices.join(" ")}"
             Chef::Log.debug("#{@new_resource} mdadm command: #{command}")

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -150,8 +150,8 @@ class Chef
           "resource if the mdadm default is not desired. This future change "\
           "will only impact newly created md devices."
 
-        Chef::Log.warn(metadata_warn_msg) unless @user_set_metadata
-        Chef::Log.warn(chunk_warn_msg) unless @user_set_chunk
+        Chef::Log.deprecation(metadata_warn_msg) unless @user_set_metadata
+        Chef::Log.deprecation(chunk_warn_msg) unless @user_set_chunk
       end
     end
   end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -154,8 +154,8 @@ class Chef
           "resource if the mdadm default is not desired. This future change "\
           "will only impact newly created md devices."
 
-        Chef.log_deprecation(metadata_warn_msg) unless @user_set_metadata
-        Chef.log_deprecation(chunk_warn_msg) unless @user_set_chunk
+        Chef.log_deprecation(metadata_warn_msg) unless @user_set_metadata or @mdadm_defaults
+        Chef.log_deprecation(chunk_warn_msg) unless @user_set_chunk or @mdadm_defaults
       end
     end
   end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -40,6 +40,14 @@ class Chef
         @metadata = "0.90"
         @bitmap = nil
         @raid_device = name
+        
+        # Can be removed once the chunk member defaults to nil
+        @user_set_chunk = false
+        # Can be removed once the metadata member defaults to nil
+        @user_set_metadata = false
+
+        @action = :create
+        @allowed_actions.push(:create, :assemble, :stop)
       end
 
       def chunk(arg = nil)
@@ -49,6 +57,7 @@ class Chef
             "the default chunk size."
           Chef::Log.warn(warn_msg)
         end
+        @user_set_chunk = true
         set_or_return(
           :chunk,
           arg,
@@ -87,6 +96,7 @@ class Chef
             "default metadata version."
           Chef::Log.warn(warn_msg)
         end
+        @user_set_metadata = true
         set_or_return(
           :metadata,
           arg,
@@ -110,6 +120,23 @@ class Chef
         )
       end
 
+      # Can be removed once metadata and chunk defaults are set to nil
+      def user_set_metadata(arg=nil)
+        set_or_return(
+          :exists,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
+        )
+      end
+
+      # Can be removed once metadata and chunk defaults are set to nil
+      def user_set_chunk(arg=nil)
+        set_or_return(
+          :exists,
+          arg,
+          :kind_of => [ TrueClass, FalseClass ]
+        )
+      end
     end
   end
 end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -114,7 +114,8 @@ class Chef
         )
       end
 
-      # Can be removed once metadata and chunk defaults are set to nil
+      # Track if user set metadata attribute which is used in after_create
+      # method to facilitate proper behavior of the mdadm_defaults attribute
       def user_set_metadata(arg = nil)
         set_or_return(
           :exists,
@@ -123,7 +124,8 @@ class Chef
         )
       end
 
-      # Can be removed once metadata and chunk defaults are set to nil
+      # Track if user set chunk attribute which is used in after_create
+      # method to facilitate proper behavior of the mdadm_defaults attribute
       def user_set_chunk(arg = nil)
         set_or_return(
           :exists,
@@ -133,6 +135,8 @@ class Chef
       end
 
       def after_created
+        # Once the mdadm_defaults defaults to true the nil's below will need
+        # to be replaced with 16 and "0.90"
         if @mdadm_defaults
           @chunk = nil unless @user_set_chunk
           @metadata = nil unless @user_set_metadata

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -154,8 +154,8 @@ class Chef
           "resource if the mdadm default is not desired. This future change "\
           "will only impact newly created md devices."
 
-        Chef.log_deprecation(metadata_warn_msg) unless @user_set_metadata or @mdadm_defaults
-        Chef.log_deprecation(chunk_warn_msg) unless @user_set_chunk or @mdadm_defaults
+        Chef.log_deprecation(metadata_warn_msg) unless @user_set_metadata || @mdadm_defaults
+        Chef.log_deprecation(chunk_warn_msg) unless @user_set_chunk || @mdadm_defaults
       end
     end
   end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -33,11 +33,11 @@ class Chef
       def initialize(name, run_context = nil)
         super
 
-        @chunk = 16
+        @chunk = nil
         @devices = []
         @exists = false
         @level = 1
-        @metadata = "0.90"
+        @metadata = nil
         @bitmap = nil
         @raid_device = name
       end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :mdadm_defaults,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -120,7 +120,7 @@ class Chef
         set_or_return(
           :exists,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -130,7 +130,7 @@ class Chef
         set_or_return(
           :exists,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -154,8 +154,8 @@ class Chef
           "resource if the mdadm default is not desired. This future change "\
           "will only impact newly created md devices."
 
-        Chef::Log.deprecation(metadata_warn_msg) unless @user_set_metadata
-        Chef::Log.deprecation(chunk_warn_msg) unless @user_set_chunk
+        Chef.log_deprecation(metadata_warn_msg) unless @user_set_metadata
+        Chef.log_deprecation(chunk_warn_msg) unless @user_set_chunk
       end
     end
   end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -51,13 +51,7 @@ class Chef
       end
 
       def chunk(arg = nil)
-        unless arg
-          warn_msg = "The default chunk size of 16k will be removed in a "\
-            "future release.  This change will allow mdadm to choose "\
-            "the default chunk size."
-          Chef::Log.warn(warn_msg)
-        end
-        @user_set_chunk = true
+        @user_set_chunk = true unless arg.nil?
         set_or_return(
           :chunk,
           arg,
@@ -90,13 +84,7 @@ class Chef
       end
 
       def metadata(arg = nil)
-        unless arg
-          warn_msg = "The default metadata version of 0.90 will be removed in "\
-            "a future release. This change will allow mdadm to choose the "\
-            "default metadata version."
-          Chef::Log.warn(warn_msg)
-        end
-        @user_set_metadata = true
+        @user_set_metadata = true unless arg.nil?
         set_or_return(
           :metadata,
           arg,
@@ -136,6 +124,23 @@ class Chef
           arg,
           :kind_of => [ TrueClass, FalseClass ]
         )
+      end
+      
+      def after_created
+        metadata_warn_msg = "#{self} the default metadata version of 0.90 "\
+          "will be removed in a future release. To maintain backwards "\
+          "compatibility please explicitly specify the metadata version that "\
+          "you desire on the the mdadm resource if the mdadm default is not "\
+          "desired. This future change will only impact newly created md "\
+          "devices."
+        chunk_warn_msg = "#{self} default chunk size of 16k will be removed "\
+          "in a future release. To maintain backwards compatibility please "\
+          "explicitly specify the chunk size that you desire on the the mdadm "\
+          "resource if the mdadm default is not desired. This future change "\
+          "will only impact newly created md devices."
+
+        Chef::Log.warn(metadata_warn_msg) unless @user_set_metadata
+        Chef::Log.warn(chunk_warn_msg) unless @user_set_chunk
       end
     end
   end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :mdadm_defaults,
           arg,
-          :kind_of => [ TrueClass, FalseClass ]
+          :kind_of => [ TrueClass, FalseClass ],
         )
       end
 
@@ -115,20 +115,20 @@ class Chef
       end
 
       # Can be removed once metadata and chunk defaults are set to nil
-      def user_set_metadata(arg=nil)
+      def user_set_metadata(arg = nil)
         set_or_return(
           :exists,
           arg,
-          :kind_of => [ TrueClass, FalseClass ]
+          :kind_of => [ TrueClass, FalseClass ],
         )
       end
 
       # Can be removed once metadata and chunk defaults are set to nil
-      def user_set_chunk(arg=nil)
+      def user_set_chunk(arg = nil)
         set_or_return(
           :exists,
           arg,
-          :kind_of => [ TrueClass, FalseClass ]
+          :kind_of => [ TrueClass, FalseClass ],
         )
       end
 

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -33,16 +33,22 @@ class Chef
       def initialize(name, run_context = nil)
         super
 
-        @chunk = nil
+        @chunk = 16
         @devices = []
         @exists = false
         @level = 1
-        @metadata = nil
+        @metadata = "0.90"
         @bitmap = nil
         @raid_device = name
       end
 
       def chunk(arg = nil)
+        unless arg
+          warn_msg = "The default chunk size of 16k will be removed in a "\
+            "future release.  This change will allow mdadm to choose "\
+            "the default chunk size."
+          Chef::Log.warn(warn_msg)
+        end
         set_or_return(
           :chunk,
           arg,
@@ -75,6 +81,12 @@ class Chef
       end
 
       def metadata(arg = nil)
+        unless arg
+          warn_msg = "The default metadata version of 0.90 will be removed in "\
+            "a future release. This change will allow mdadm to choose the "\
+            "default metadata version."
+          Chef::Log.warn(warn_msg)
+        end
         set_or_return(
           :metadata,
           arg,

--- a/spec/unit/provider/mdadm_spec.rb
+++ b/spec/unit/provider/mdadm_spec.rb
@@ -88,6 +88,7 @@ describe Chef::Provider::Mdadm do
       it "should not specify a chunksize or metadata version if mdadm_defaults is true and user hasn't explicity set them" do
         @current_resource.exists(false)
         @new_resource.mdadm_defaults(true)
+        expect(Chef::Log).to receive(:deprecation).exactly(2).times
         @new_resource.after_created
         expected_command = "yes | mdadm --create /dev/md1 --level 5 --raid-devices 3 /dev/sdz1 /dev/sdz2 /dev/sdz3"
         expect(@provider).to receive(:shell_out!).with(expected_command)

--- a/spec/unit/provider/mdadm_spec.rb
+++ b/spec/unit/provider/mdadm_spec.rb
@@ -88,7 +88,6 @@ describe Chef::Provider::Mdadm do
       it "should not specify a chunksize or metadata version if mdadm_defaults is true and user hasn't explicity set them" do
         @current_resource.exists(false)
         @new_resource.mdadm_defaults(true)
-        expect(Chef::Log).to receive(:deprecation).exactly(2).times
         @new_resource.after_created
         expected_command = "yes | mdadm --create /dev/md1 --level 5 --raid-devices 3 /dev/sdz1 /dev/sdz2 /dev/sdz3"
         expect(@provider).to receive(:shell_out!).with(expected_command)

--- a/spec/unit/provider/mdadm_spec.rb
+++ b/spec/unit/provider/mdadm_spec.rb
@@ -85,6 +85,28 @@ describe Chef::Provider::Mdadm do
         expect(@new_resource).to be_updated_by_last_action
       end
 
+      it "should not specify a chunksize or metadata version if mdadm_defaults is true and user hasn't explicity set them" do
+        @current_resource.exists(false)
+        @new_resource.mdadm_defaults(true)
+        @new_resource.after_created
+        expected_command = "yes | mdadm --create /dev/md1 --level 5 --raid-devices 3 /dev/sdz1 /dev/sdz2 /dev/sdz3"
+        expect(@provider).to receive(:shell_out!).with(expected_command)
+        @provider.run_action(:create)
+        expect(@new_resource).to be_updated_by_last_action
+      end
+
+      it "should include chunksize and metadata version if mdadm_defaults is true and user has explicity set them" do
+        @current_resource.exists(false)
+        @new_resource.mdadm_defaults(true)
+        @new_resource.metadata "1.2"
+        @new_resource.chunk 256
+        @new_resource.after_created
+        expected_command = "yes | mdadm --create /dev/md1 --level 5 --chunk=256 --metadata=1.2 --raid-devices 3 /dev/sdz1 /dev/sdz2 /dev/sdz3"
+        expect(@provider).to receive(:shell_out!).with(expected_command)
+        @provider.run_action(:create)
+        expect(@new_resource).to be_updated_by_last_action
+      end
+
       it "should not create the raid device if it does exist" do
         @current_resource.exists(true)
         expect(@provider).not_to receive(:shell_out!)

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -108,22 +108,22 @@ describe Chef::Resource::Mdadm do
   end
 
   describe "deprecation messages about upcoming changes to defaults" do
-    it "should display the warning message for metadata" do
+    it "should display the deprecation message for metadata" do
       resource.chunk(16)
-      expect(Chef::Log).to receive(:deprecation).with(/metadata/)
+      expect(Chef).to receive(:log_deprecation).with(/metadata/)
       resource.after_created
     end
 
-    it "should display the warning message for chunk size" do
+    it "should display the deprecation message for chunk size" do
       resource.metadata("1.2")
-      expect(Chef::Log).to receive(:deprecation).with(/chunk/)
+      expect(Chef).to receive(:log_deprecation).with(/chunk/)
       resource.after_created
     end
 
     it "should not display any warning messages" do
       resource.chunk(16)
       resource.metadata("1.2")
-      expect(Chef::Log).to_not receive(:deprecation)
+      expect(Chef).to_not receive(:log_deprecation)
       resource.after_created
     end
   end
@@ -136,14 +136,14 @@ describe Chef::Resource::Mdadm do
 
     it "should set chunk to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
-      expect(Chef::Log).to receive(:deprecation).exactly(2).times
+      expect(Chef).to receive(:log_deprecation).exactly(2).times
       resource.after_created
       expect(resource.chunk).to eql(nil)
     end
 
     it "should set metadata to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
-      expect(Chef::Log).to receive(:deprecation).exactly(2).times
+      expect(Chef).to receive(:log_deprecation).exactly(2).times
       resource.after_created
       expect(resource.metadata).to eql(nil)
     end
@@ -151,7 +151,7 @@ describe Chef::Resource::Mdadm do
     it "should allow chunk to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.chunk(256)
-      expect(Chef::Log).to receive(:deprecation).exactly(1).times
+      expect(Chef).to receive(:log_deprecation).exactly(1).times
       resource.after_created
       expect(resource.chunk).to eql(256)
     end
@@ -159,7 +159,7 @@ describe Chef::Resource::Mdadm do
     it "should allow metadata to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.metadata("1.2")
-      expect(Chef::Log).to receive(:deprecation).exactly(1).times
+      expect(Chef).to receive(:log_deprecation).exactly(1).times
       resource.after_created
       expect(resource.metadata).to eq("1.2")
     end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -21,81 +21,81 @@ require "spec_helper"
 
 describe Chef::Resource::Mdadm do
 
-  before(:each) do
-    @resource = Chef::Resource::Mdadm.new("fakey_fakerton")
+  let(:resource) do
+    Chef::Resource::Mdadm.new("fakey_fakerton", run_context)
   end
 
   it "should create a new Chef::Resource::Mdadm" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Mdadm)
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Mdadm)
   end
 
   it "should have a resource name of :mdadm" do
-    expect(@resource.resource_name).to eql(:mdadm)
+    expect(resource.resource_name).to eql(:mdadm)
   end
 
   it "should have a default action of create" do
-    expect(@resource.action).to eql([:create])
+    expect(resource.action).to eql([:create])
   end
 
   it "should accept create, assemble, stop as actions" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :assemble }.not_to raise_error
-    expect { @resource.action :stop }.not_to raise_error
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :assemble }.not_to raise_error
+    expect { resource.action :stop }.not_to raise_error
   end
 
   it "should allow you to set the raid_device attribute" do
-    @resource.raid_device "/dev/md3"
-    expect(@resource.raid_device).to eql("/dev/md3")
+    resource.raid_device "/dev/md3"
+    expect(resource.raid_device).to eql("/dev/md3")
   end
 
   it "should allow you to set the chunk attribute" do
-    @resource.chunk 256
-    expect(@resource.chunk).to eql(256)
+    resource.chunk 256
+    expect(resource.chunk).to eql(256)
   end
 
   it "should allow you to set the level attribute" do
-    @resource.level 1
-    expect(@resource.level).to eql(1)
+    resource.level 1
+    expect(resource.level).to eql(1)
   end
 
   it "should allow you to set the metadata attribute" do
-    @resource.metadata "1.2"
-    expect(@resource.metadata).to eql("1.2")
+    resource.metadata "1.2"
+    expect(resource.metadata).to eql("1.2")
   end
 
   it "should allow you to set the bitmap attribute" do
-    @resource.metadata "internal"
-    expect(@resource.metadata).to eql("internal")
+    resource.bitmap "internal"
+    expect(resource.bitmap).to eql("internal")
   end
 
   it "should allow you to set the devices attribute" do
-    @resource.devices ["/dev/sda", "/dev/sdb"]
-    expect(@resource.devices).to eql(["/dev/sda", "/dev/sdb"])
+    resource.devices ["/dev/sda", "/dev/sdb"]
+    expect(resource.devices).to eql(["/dev/sda", "/dev/sdb"])
   end
 
   it "should allow you to set the exists attribute" do
-    @resource.exists true
-    expect(@resource.exists).to eql(true)
+    resource.exists true
+    expect(resource.exists).to eql(true)
   end
 
   describe "when it has devices, level, and chunk" do
     before do
-      @resource.raid_device("raider")
-      @resource.devices(%w{device1 device2})
-      @resource.level(1)
-      @resource.chunk(42)
+      resource.raid_device("raider")
+      resource.devices(%w{device1 device2})
+      resource.level(1)
+      resource.chunk(42)
     end
 
     it "describes its state" do
-      state = @resource.state
+      state = resource.state
       expect(state[:devices]).to eql(%w{device1 device2})
       expect(state[:level]).to eq(1)
       expect(state[:chunk]).to eq(42)
     end
 
     it "returns the raid device as its identity" do
-      expect(@resource.identity).to eq("raider")
+      expect(resource.identity).to eq("raider")
     end
   end
 

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -136,14 +136,12 @@ describe Chef::Resource::Mdadm do
 
     it "should set chunk to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
-      expect(Chef).to receive(:log_deprecation).exactly(2).times
       resource.after_created
       expect(resource.chunk).to eql(nil)
     end
 
     it "should set metadata to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
-      expect(Chef).to receive(:log_deprecation).exactly(2).times
       resource.after_created
       expect(resource.metadata).to eql(nil)
     end
@@ -151,7 +149,6 @@ describe Chef::Resource::Mdadm do
     it "should allow chunk to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.chunk(256)
-      expect(Chef).to receive(:log_deprecation).exactly(1).times
       resource.after_created
       expect(resource.chunk).to eql(256)
     end
@@ -159,7 +156,6 @@ describe Chef::Resource::Mdadm do
     it "should allow metadata to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.metadata("1.2")
-      expect(Chef).to receive(:log_deprecation).exactly(1).times
       resource.after_created
       expect(resource.metadata).to eq("1.2")
     end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -99,4 +99,25 @@ describe Chef::Resource::Mdadm do
     end
   end
 
+  describe "warning messages about upcoming changes to defaults" do
+    it "should display the warning message for metadata" do
+      resource.chunk(16)
+      expect(Chef::Log).to receive(:warn).with(/metadata/)
+      resource.after_created
+    end
+
+    it "should display the warning message for chunk size" do
+      resource.metadata("1.2")
+      expect(Chef::Log).to receive(:warn).with(/chunk/)
+      resource.after_created
+    end
+
+    it "should not display any warning messages" do
+      resource.chunk(16)
+      resource.metadata("1.2")
+      expect(Chef::Log).to_not receive(:warn)
+      resource.after_created
+    end
+  end
+
 end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -99,23 +99,23 @@ describe Chef::Resource::Mdadm do
     end
   end
 
-  describe "warning messages about upcoming changes to defaults" do
+  describe "deprecation messages about upcoming changes to defaults" do
     it "should display the warning message for metadata" do
       resource.chunk(16)
-      expect(Chef::Log).to receive(:warn).with(/metadata/)
+      expect(Chef::Log).to receive(:deprecation).with(/metadata/)
       resource.after_created
     end
 
     it "should display the warning message for chunk size" do
       resource.metadata("1.2")
-      expect(Chef::Log).to receive(:warn).with(/chunk/)
+      expect(Chef::Log).to receive(:deprecation).with(/chunk/)
       resource.after_created
     end
 
     it "should not display any warning messages" do
       resource.chunk(16)
       resource.metadata("1.2")
-      expect(Chef::Log).to_not receive(:warn)
+      expect(Chef::Log).to_not receive(:deprecation)
       resource.after_created
     end
   end
@@ -128,12 +128,14 @@ describe Chef::Resource::Mdadm do
 
     it "should set chunk to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
+      expect(Chef::Log).to receive(:deprecation).exactly(2).times
       resource.after_created
       expect(resource.chunk).to eql(nil)
     end
 
     it "should set metadata to return nil when not explicitly set and mdadm_defaults is true" do
       resource.mdadm_defaults(true)
+      expect(Chef::Log).to receive(:deprecation).exactly(2).times
       resource.after_created
       expect(resource.metadata).to eql(nil)
     end
@@ -141,6 +143,7 @@ describe Chef::Resource::Mdadm do
     it "should allow chunk to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.chunk(256)
+      expect(Chef::Log).to receive(:deprecation).exactly(1).times
       resource.after_created
       expect(resource.chunk).to eql(256)
     end
@@ -148,6 +151,7 @@ describe Chef::Resource::Mdadm do
     it "should allow metadata to be explicitly set when mdadm_defaults is true" do
       resource.mdadm_defaults(true)
       resource.metadata("1.2")
+      expect(Chef::Log).to receive(:deprecation).exactly(1).times
       resource.after_created
       expect(resource.metadata).to eq("1.2")
     end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -83,7 +83,7 @@ describe Chef::Resource::Mdadm do
     expect(resource.mdadm_defaults).to eq(false)
   end
 
-  it "should have default mdadm_defaults of true", :chef_gte_13_only do
+  it "should have default mdadm_defaults of true in Chef-13", chef: ">= 13" do
     expect(resource.mdadm_defaults).to eq(true)
   end
 

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -79,6 +79,14 @@ describe Chef::Resource::Mdadm do
     expect(resource.exists).to eql(true)
   end
 
+  it "should have default mdadm_defaults of false" do
+    expect(resource.mdadm_defaults).to eq(false)
+  end
+
+  it "should have default mdadm_defaults of true", :chef_gte_13_only do
+    expect(resource.mdadm_defaults).to eq(true)
+  end
+
   describe "when it has devices, level, and chunk" do
     before do
       resource.raid_device("raider")

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -120,4 +120,37 @@ describe Chef::Resource::Mdadm do
     end
   end
 
+  describe "mdadm defaults" do
+    it "should allow you to enable mdadm_defaults" do
+      resource.mdadm_defaults(true)
+      expect(resource.mdadm_defaults).to eql(true)
+    end
+
+    it "should set chunk to return nil when not explicitly set and mdadm_defaults is true" do
+      resource.mdadm_defaults(true)
+      resource.after_created
+      expect(resource.chunk).to eql(nil)
+    end
+
+    it "should set metadata to return nil when not explicitly set and mdadm_defaults is true" do
+      resource.mdadm_defaults(true)
+      resource.after_created
+      expect(resource.metadata).to eql(nil)
+    end
+
+    it "should allow chunk to be explicitly set when mdadm_defaults is true" do
+      resource.mdadm_defaults(true)
+      resource.chunk(256)
+      resource.after_created
+      expect(resource.chunk).to eql(256)
+    end
+
+    it "should allow metadata to be explicitly set when mdadm_defaults is true" do
+      resource.mdadm_defaults(true)
+      resource.metadata("1.2")
+      resource.after_created
+      expect(resource.metadata).to eq("1.2")
+    end
+  end
+
 end


### PR DESCRIPTION
The purpose of this commit is to start a conversation about the current default values for the mdadm resource.  Which currently chooses some default values for optional parameters.  It seems odd for Chef to choose defaults for optional parameters where the underlaying OS/application has it's own defaults.

As a result this commit does not modify or extend the rspec tests to cover these changes.  I'll address this in a future commit pending the discussion.

This commit removes the default values for the following optional parameters when creating an mdadm device.

* chunk size: Chef 16k, mdadm 512k
* metadata version: Chef 0.90, mdadm 1.2

The metadata version has 3 notable impacts.

1. 0.90 is limited to 28 devices per RAID volume.
2. Max device size of 2TB.
3. Some older versions of grub and lilo only support RAID1 md devices with metadata 0.90 as a boot device.