### PR TITLE
Move supermarket.getchef.com to supermarket.chef.io

### DIFF
--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -58,7 +58,7 @@ class Chef
 
       private
       def cookbooks_api_url
-        'https://supermarket.getchef.com/api/v1/cookbooks'
+        'https://supermarket.chef.io/api/v1/cookbooks'
       end
 
       def current_cookbook_data

--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -41,7 +41,7 @@ class Chef
       end
 
       def get_cookbook_list(items=10, start=0, cookbook_collection={})
-        cookbooks_url = "https://supermarket.getchef.com/api/v1/cookbooks?items=#{items}&start=#{start}"
+        cookbooks_url = "https://supermarket.chef.io/api/v1/cookbooks?items=#{items}&start=#{start}"
         cr = noauth_rest.get_rest(cookbooks_url)
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook

--- a/lib/chef/knife/cookbook_site_search.rb
+++ b/lib/chef/knife/cookbook_site_search.rb
@@ -29,7 +29,7 @@ class Chef
       end
 
       def search_cookbook(query, items=10, start=0, cookbook_collection={})
-        cookbooks_url = "https://supermarket.getchef.com/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
+        cookbooks_url = "https://supermarket.chef.io/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
         cr = noauth_rest.get_rest(cookbooks_url)
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -131,7 +131,7 @@ class Chef
       end
 
       def do_upload(cookbook_filename, cookbook_category, user_id, user_secret_filename)
-         uri = "https://supermarket.getchef.com/api/v1/cookbooks"
+         uri = "https://supermarket.chef.io/api/v1/cookbooks"
 
          category_string = Chef::JSONCompat.to_json({ 'category'=>cookbook_category })
 

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -31,14 +31,14 @@ class Chef
       def get_cookbook_data
         case @name_args.length
         when 1
-          noauth_rest.get_rest("https://supermarket.getchef.com/api/v1/cookbooks/#{@name_args[0]}")
+          noauth_rest.get_rest("https://supermarket.chef.io/api/v1/cookbooks/#{@name_args[0]}")
         when 2
-          noauth_rest.get_rest("https://supermarket.getchef.com/api/v1/cookbooks/#{@name_args[0]}/versions/#{name_args[1].gsub('.', '_')}")
+          noauth_rest.get_rest("https://supermarket.chef.io/api/v1/cookbooks/#{@name_args[0]}/versions/#{name_args[1].gsub('.', '_')}")
         end
       end
 
       def get_cookbook_list(items=10, start=0, cookbook_collection={})
-        cookbooks_url = "https://supermarket.getchef.com/api/v1/cookbooks?items=#{items}&start=#{start}"
+        cookbooks_url = "https://supermarket.chef.io/api/v1/cookbooks?items=#{items}&start=#{start}"
         cr = noauth_rest.get_rest(cookbooks_url)
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook

--- a/lib/chef/knife/cookbook_site_unshare.rb
+++ b/lib/chef/knife/cookbook_site_unshare.rb
@@ -41,7 +41,7 @@ class Chef
         confirm "Do you really want to unshare the cookbook #{@cookbook_name}"
 
         begin
-          rest.delete_rest "https://supermarket.getchef.com/api/v1/cookbooks/#{@name_args[0]}"
+          rest.delete_rest "https://supermarket.chef.io/api/v1/cookbooks/#{@name_args[0]}"
         rescue Net::HTTPServerException => e
           raise e unless e.message =~ /Forbidden/
           ui.error "Forbidden: You must be the maintainer of #{@cookbook_name} to unshare it."

--- a/spec/unit/knife/cookbook_site_download_spec.rb
+++ b/spec/unit/knife/cookbook_site_download_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Knife::CookbookSiteDownload do
       @knife.name_args  = ['apache2']
       @noauth_rest      = double('no auth rest')
       @stderr           = StringIO.new
-      @cookbook_api_url = 'https://supermarket.getchef.com/api/v1/cookbooks'
+      @cookbook_api_url = 'https://supermarket.chef.io/api/v1/cookbooks'
       @version          = '1.0.2'
       @version_us       = @version.gsub '.', '_'
       @current_data     = { 'deprecated'       => false,

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -170,8 +170,8 @@ describe Chef::Knife::CookbookSiteShare do
       allow(File).to receive(:open).and_return(true)
     end
 
-    it 'should post the cookbook to "https://supermarket.getchef.com"' do
-      response_text = Chef::JSONCompat.to_json({:uri => 'https://supermarket.getchef.com/cookbooks/cookbook_name'})
+    it 'should post the cookbook to "https://supermarket.chef.io"' do
+      response_text = Chef::JSONCompat.to_json({:uri => 'https://supermarket.chef.io/cookbooks/cookbook_name'})
       allow(@upload_response).to receive(:body).and_return(response_text)
       allow(@upload_response).to receive(:code).and_return(201)
       expect(Chef::CookbookSiteStreamingUploader).to receive(:post).with(/supermarket\.getchef\.com/, anything(), anything(), anything())

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -174,7 +174,7 @@ describe Chef::Knife::CookbookSiteShare do
       response_text = Chef::JSONCompat.to_json({:uri => 'https://supermarket.chef.io/cookbooks/cookbook_name'})
       allow(@upload_response).to receive(:body).and_return(response_text)
       allow(@upload_response).to receive(:code).and_return(201)
-      expect(Chef::CookbookSiteStreamingUploader).to receive(:post).with(/supermarket\.getchef\.com/, anything(), anything(), anything())
+      expect(Chef::CookbookSiteStreamingUploader).to receive(:post).with(/supermarket\.chef\.io/, anything(), anything(), anything())
       @knife.run
     end
 


### PR DESCRIPTION
Minimally-fix #2777 

While @lamont-granquist's comment on that issue is correct (about ripping & refactoring), at least we shouldn't leave these commands in a broken state.