### PR TITLE
check for blank hostname in knife ssh

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -167,7 +167,7 @@ class Chef
           if config[:attribute_from_cli]
             Chef::Log.debug("Using node attribute '#{config[:attribute_from_cli]}' from the command line as the ssh target")
             host = extract_nested_value(item, config[:attribute_from_cli])
-          elsif item[:cloud] && item[:cloud][:public_hostname]
+          elsif item[:cloud] && item[:cloud][:public_hostname].present?
             Chef::Log.debug("Using node attribute 'cloud[:public_hostname]' automatically as the ssh target")
             host = item[:cloud][:public_hostname]
           else


### PR DESCRIPTION
Sometimes `item[:cloud][:public_hostname]` can be a blank string which causes knife ssh to fail.