### PR TITLE
Add --exit-on-error option to knife ssh

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -103,6 +103,13 @@ class Chef
         :boolean => true,
         :default => true
 
+      option :on_error,
+        :short => '-e',
+        :long => '--exit-on-error',
+        :description => "Immediately exit if an error is encountered",
+        :boolean => true,
+        :proc => Proc.new { :raise }
+
       def session
         config[:on_error] ||= :skip
         ssh_error_handler = Proc.new do |server|


### PR DESCRIPTION
Currently, if something goes wrong in a `knife ssh` session we'll swallow the exception and exit status and move on.  This commit retains backwards compatibility but adds the option to exit if something goes wrong.  This has been previously discussed on [CHEF-2627](https://tickets.opscode.com/browse/CHEF-2627) and reported via support on [ZD 2760](https://getchef.zendesk.com/agent/tickets/2760)

```shell
ryan@~/c/oc/chef(ryan/knife_ssh_on_error):> knife ssh name:test* "some command"; echo $?
WARNING: Failed to connect to test-standalone.localdomain -- SocketError: getaddrinfo: nodename nor servname provided, or not known
0
ryan@~/c/oc/chef(ryan/knife_ssh_on_error):> knife ssh name:test* "some command" -e; echo $?
ERROR: Network Error: getaddrinfo: nodename nor servname provided, or not known
Check your knife configuration and network settings
100
```