### PR TITLE
fix dpkg regression

### DIFF
--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -61,10 +61,12 @@ class Chef
             if @source_exists
               # Get information from the package if supplied
               Chef::Log.debug("#{@new_resource} checking dpkg status")
+
               shell_out("dpkg-deb -W #{@new_resource.source}").stdout.each_line do |line|
                 if pkginfo = DPKG_INFO.match(line)
                   @current_resource.package_name(pkginfo[1])
                   @new_resource.version(pkginfo[2])
+                  @candidate_version = pkginfo[2]
                 end
               end
             else

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -55,6 +55,7 @@ describe Chef::Provider::Package::Dpkg do
         @provider.load_current_resource
         expect(@provider.current_resource.package_name).to eq("wget")
         expect(@new_resource.version).to eq(version)
+        expect(@provider.candidate_version).to eq(version)
       end
 
       it 'if short version provided' do


### PR DESCRIPTION
@btm @jdmundrawala this fixes a 12.1.0 regression.

not sure how this ever worked but dpkg_package was not setting candidate_version so the define_resource_requirements in the superclass package provider blew up.   i don't know if this got broken by the multipackage stuff becoming more strict or if this was a regression from some other edit to the dpkg provider.  this code should be correct tho.