### PR TITLE
Cache service_resource_providers for the duration of the run.

### DIFF
--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -42,34 +42,34 @@ class Chef
         # different services is NOT a design concern of this module.
         #
         def service_resource_providers
-          service_resource_providers = []
+          @service_resource_providers ||= [].tap do |service_resource_providers|
 
-          if ::File.exist?("/usr/sbin/update-rc.d")
-            service_resource_providers << :debian
+            if ::File.exist?("/usr/sbin/update-rc.d")
+              service_resource_providers << :debian
+            end
+
+            if ::File.exist?("/usr/sbin/invoke-rc.d")
+              service_resource_providers << :invokercd
+            end
+
+            if ::File.exist?("/sbin/insserv")
+              service_resource_providers << :insserv
+            end
+
+            # debian >= 6.0 has /etc/init but does not have upstart
+            if ::File.exist?("/etc/init") && ::File.exist?("/sbin/start")
+              service_resource_providers << :upstart
+            end
+
+            if ::File.exist?("/sbin/chkconfig")
+              service_resource_providers << :redhat
+            end
+
+            if systemd_sanity_check?
+              service_resource_providers << :systemd
+            end
+
           end
-
-          if ::File.exist?("/usr/sbin/invoke-rc.d")
-            service_resource_providers << :invokercd
-          end
-
-          if ::File.exist?("/sbin/insserv")
-            service_resource_providers << :insserv
-          end
-
-          # debian >= 6.0 has /etc/init but does not have upstart
-          if ::File.exist?("/etc/init") && ::File.exist?("/sbin/start")
-            service_resource_providers << :upstart
-          end
-
-          if ::File.exist?("/sbin/chkconfig")
-            service_resource_providers << :redhat
-          end
-
-          if systemd_sanity_check?
-            service_resource_providers << :systemd
-          end
-
-          service_resource_providers
         end
 
         def config_for_service(service_name)


### PR DESCRIPTION
Which system-level service providers are available is really unlikely to change during a run as it is pretty much tied to the OS. This will save around 6 stat calls each time after the first, which isn't much but this method is called from provides? on a lot of the service resources which happens ~5 times every time run_action is called on a service resource. If you have a dozen or so service resources, that means removing several hundred stats.

The downside would be people using cookbooks to install upstart or systemd on a system that doesn't normally use them, but that seems not hugely likely.