### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
   - rvm: 2.0.0
   - rvm: 2.1.5
   - rvm: 2.2.0
+  - rvm: rbx-2
   - rvm: 2.1.5
     gemfile: pedant.gemfile
     script: bundle exec rake pedant
@@ -81,6 +82,8 @@ matrix:
     - secure: GTfrUVmMQSxho3Ia4Y1ONqKvVMD34GHF2/TJb8UdQV7iH+nVxVXpy3nWaCXa9ri7lRzMefkoVLy0gKK13YoVd7w3d2S3/IfNakC85XfN6VuOzK/FDkA0WoPrgKjcQ64I+3dQ6cgrMWWTieKwRZy+Ve24iRbnN055Hk+VRMu6OGw=
     - secure: SOMYGVfHLkHsH6koxpw68YQ4ydEo6YXPhHbrYGQbehUbFa6+OZzBcAJRJbKjyhD2AZRvNr2jB8XnjYKvVyDGQRpkWhGYZ7CpHqINpDsqKBsbiMe3/+KmKQqS+UKxNGefquoOvyQ1N8Xy77dkWYokRtGMEuR12RkZLonxiDW8Qyg=
     ### END TEST KITCHEN ONLY ###
+  allow_failures:
+    - rvm: rbx-2
 notifications:
   on_change: true
   on_failure: true


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I would like to ensure Chef builds on Rubinius. Thank you.