### PR TITLE
update mode if group or owner change to keep suid bit

### DIFF
--- a/lib/chef/file_access_control/unix.rb
+++ b/lib/chef/file_access_control/unix.rb
@@ -197,6 +197,8 @@ class Chef
           # the user has specified a permission, and it does not match the file, so fix the permission
           Chef::Log.debug("found target_mode != current_mode, updating mode")
           return true
+        elsif suid_bit_set? and (should_update_group? or should_update_owner?)
+            return true
         else
           Chef::Log.debug("found target_mode == current_mode, not updating mode")
           # the user has specified a permission, but it matches the file, so behave idempotently
@@ -280,6 +282,9 @@ class Chef
         return nil
       end
 
+      def suid_bit_set?
+          return target_mode & 04000 > 0
+      end
     end
   end
 end

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -231,6 +231,24 @@ shared_examples_for "a securable resource with existing target" do
         expect(resource.updated_by_last_action?).to eq(expect_updated?)
       end
     end
+
+    describe "when setting the suid bit", :requires_root do
+        before do
+            @suid_mode = 04776
+            resource.mode @suid_mode
+            resource.run_action(:create)
+        end
+
+        it "should set the suid bit" do
+            expect(File.lstat(path).mode & 007777).to eq(@suid_mode & 007777)
+        end
+
+        it "should retain the suid bit when updating the user" do
+            resource.user 1338
+            resource.run_action(:create)
+            expect(File.lstat(path).mode & 007777).to eq(@suid_mode & 007777)
+        end
+    end
   end
 
   context "on Windows", :windows_only do


### PR DESCRIPTION
On Linux updating the group or owner unsets the suid bit for security
reasons, so check for group and owner updates whether or not to set the
mode.

This is in reference to issue #2951 