### PR TITLE
provider_resolver migration from provider_mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * windows service now has a configurable timeout
 * `knife ssh` now has an --exit-on-error option that allows users to
   fail-fast rather than moving on to the next machine.
+* migrate macosx, windows, openbsd, and netbsd resources to dynamic resolution
+* migrate cron and mdadm resources to dynamic resolution
 
 ## 12.1.0
 

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -38,33 +38,16 @@ class Chef
           require 'chef/providers'
 
           {
-            :mac_os_x => {
-              :default => {
-                :package => Chef::Provider::Package::Homebrew,
-                :user => Chef::Provider::User::Dscl,
-                :group => Chef::Provider::Group::Dscl
-              }
-            },
-            :mac_os_x_server => {
-              :default => {
-                :package => Chef::Provider::Package::Homebrew,
-                :user => Chef::Provider::User::Dscl,
-                :group => Chef::Provider::Group::Dscl
-              }
-            },
             :freebsd => {
               :default => {
                 :group   => Chef::Provider::Group::Pw,
                 :user    => Chef::Provider::User::Pw,
-                :cron    => Chef::Provider::Cron
               }
             },
             :ubuntu   => {
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Debian,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               },
               ">= 11.10" => {
                 :ifconfig => Chef::Provider::Ifconfig::Debian
@@ -79,40 +62,30 @@ class Chef
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Debian,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :linaro   => {
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Debian,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :raspbian   => {
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Debian,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :linuxmint   => {
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Upstart,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :debian => {
               :default => {
                 :package => Chef::Provider::Package::Apt,
                 :service => Chef::Provider::Service::Debian,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               },
               ">= 6.0" => {
                 :service => Chef::Provider::Service::Insserv
@@ -124,25 +97,19 @@ class Chef
             :xenserver   => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :xcp   => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :centos   => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm,
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               },
               "< 7" => {
@@ -152,17 +119,13 @@ class Chef
             :amazon   => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :scientific => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm
               },
               "< 7" => {
                 :service => Chef::Provider::Service::Redhat
@@ -171,9 +134,7 @@ class Chef
             :fedora   => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm,
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               },
               "< 15" => {
@@ -183,7 +144,6 @@ class Chef
             :opensuse     => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Zypper,
                 :group => Chef::Provider::Group::Suse
               },
@@ -195,7 +155,6 @@ class Chef
             :suse     => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Zypper,
                 :group => Chef::Provider::Group::Gpasswd
               },
@@ -207,9 +166,7 @@ class Chef
             :oracle  => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm
               },
               "< 7" => {
                 :service => Chef::Provider::Service::Redhat
@@ -218,9 +175,7 @@ class Chef
             :redhat   => {
               :default => {
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm,
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               },
               "< 7" => {
@@ -230,27 +185,21 @@ class Chef
             :ibm_powerkvm   => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm,
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               }
             },
             :cloudlinux   => {
               :default => {
                 :service => Chef::Provider::Service::Redhat,
-                :cron => Chef::Provider::Cron,
                 :package => Chef::Provider::Package::Yum,
-                :mdadm => Chef::Provider::Mdadm,
                 :ifconfig => Chef::Provider::Ifconfig::Redhat
               }
             },
             :parallels   => {
                 :default => {
                     :service => Chef::Provider::Service::Redhat,
-                    :cron => Chef::Provider::Cron,
                     :package => Chef::Provider::Package::Yum,
-                    :mdadm => Chef::Provider::Mdadm,
                     :ifconfig => Chef::Provider::Ifconfig::Redhat
                 }
             },
@@ -258,46 +207,12 @@ class Chef
               :default => {
                 :package => Chef::Provider::Package::Portage,
                 :service => Chef::Provider::Service::Gentoo,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :arch   => {
               :default => {
                 :package => Chef::Provider::Package::Pacman,
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
-              }
-            },
-            :mswin => {
-              :default => {
-                :env =>  Chef::Provider::Env::Windows,
-                :user => Chef::Provider::User::Windows,
-                :group => Chef::Provider::Group::Windows,
-                :mount => Chef::Provider::Mount::Windows,
-                :batch => Chef::Provider::Batch,
-                :powershell_script => Chef::Provider::PowershellScript
-              }
-            },
-            :mingw32 => {
-              :default => {
-                :env =>  Chef::Provider::Env::Windows,
-                :user => Chef::Provider::User::Windows,
-                :group => Chef::Provider::Group::Windows,
-                :mount => Chef::Provider::Mount::Windows,
-                :batch => Chef::Provider::Batch,
-                :powershell_script => Chef::Provider::PowershellScript
-              }
-            },
-            :windows => {
-              :default => {
-                :env =>  Chef::Provider::Env::Windows,
-                :user => Chef::Provider::User::Windows,
-                :group => Chef::Provider::Group::Windows,
-                :mount => Chef::Provider::Mount::Windows,
-                :batch => Chef::Provider::Batch,
-                :powershell_script => Chef::Provider::PowershellScript
               }
             },
             :solaris  => {},
@@ -305,7 +220,6 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Ips,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod
               }
             },
@@ -313,7 +227,6 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Ips,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod
               }
             },
@@ -321,7 +234,6 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Solaris,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod
               }
             },
@@ -329,7 +241,6 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Ips,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod,
                 :user => Chef::Provider::User::Solaris,
               }
@@ -338,14 +249,12 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Ips,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod,
                 :user => Chef::Provider::User::Solaris,
               },
               "< 5.11" => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::Solaris,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod,
                 :user => Chef::Provider::User::Solaris,
               }
@@ -354,20 +263,7 @@ class Chef
               :default => {
                 :mount => Chef::Provider::Mount::Solaris,
                 :package => Chef::Provider::Package::SmartOS,
-                :cron => Chef::Provider::Cron::Solaris,
                 :group => Chef::Provider::Group::Usermod
-              }
-            },
-            :netbsd => {
-              :default => {
-                :group => Chef::Provider::Group::Groupmod
-              }
-            },
-            :openbsd => {
-              :default => {
-                :group => Chef::Provider::Group::Usermod,
-                :package => Chef::Provider::Package::Openbsd,
-                :service => Chef::Provider::Service::Openbsd
               }
             },
             :hpux => {
@@ -380,7 +276,6 @@ class Chef
                 :group => Chef::Provider::Group::Aix,
                 :mount => Chef::Provider::Mount::Aix,
                 :ifconfig => Chef::Provider::Ifconfig::Aix,
-                :cron => Chef::Provider::Cron::Aix,
                 :package => Chef::Provider::Package::Aix,
                 :user => Chef::Provider::User::Aix,
                 :service => Chef::Provider::Service::Aix
@@ -390,8 +285,6 @@ class Chef
               :default => {
                 :package => Chef::Provider::Package::Paludis,
                 :service => Chef::Provider::Service::Systemd,
-                :cron => Chef::Provider::Cron,
-                :mdadm => Chef::Provider::Mdadm
               }
             },
             :default => {

--- a/lib/chef/provider/batch.rb
+++ b/lib/chef/provider/batch.rb
@@ -22,6 +22,8 @@ class Chef
   class Provider
     class Batch < Chef::Provider::WindowsScript
 
+      provides :batch, os: "windows"
+
       def initialize (new_resource, run_context)
         super(new_resource, run_context, '.bat')
       end

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -25,6 +25,8 @@ class Chef
     class Cron < Chef::Provider
       include Chef::Mixin::Command
 
+      provides :cron, os: "!aix"
+
       SPECIAL_TIME_VALUES = [:reboot, :yearly, :annually, :monthly, :weekly, :daily, :midnight, :hourly]
       CRON_ATTRIBUTES = [:minute, :hour, :day, :month, :weekday, :time, :command, :mailto, :path, :shell, :home, :environment]
       WEEKDAY_SYMBOLS = [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday]

--- a/lib/chef/provider/cron/aix.rb
+++ b/lib/chef/provider/cron/aix.rb
@@ -23,6 +23,8 @@ class Chef
     class Cron
       class Aix < Chef::Provider::Cron::Unix
 
+        provides :cron, os: "aix"
+
         private
 
         # For AIX we ignore env vars/[ :mailto, :path, :shell, :home ]

--- a/lib/chef/provider/env.rb
+++ b/lib/chef/provider/env.rb
@@ -26,6 +26,8 @@ class Chef
       include Chef::Mixin::Command
       attr_accessor :key_exists
 
+      provides :env, os: "!windows"
+
       def initialize(new_resource, run_context)
         super
         @key_exists = true

--- a/lib/chef/provider/env/windows.rb
+++ b/lib/chef/provider/env/windows.rb
@@ -24,6 +24,8 @@ class Chef
       class Windows < Chef::Provider::Env
         include Chef::Mixin::WindowsEnvHelper
 
+        provides :env, os: "windows"
+
         def create_env
           obj = env_obj(@new_resource.key_name)
           unless obj

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -21,6 +21,8 @@ class Chef
     class Group
       class Dscl < Chef::Provider::Group
 
+        provides :group, os: "darwin"
+
         def dscl(*args)
           host = "."
           stdout_result = ""; stderr_result = ""; cmd = "dscl #{host} -#{args.join(' ')}"

--- a/lib/chef/provider/group/groupmod.rb
+++ b/lib/chef/provider/group/groupmod.rb
@@ -21,6 +21,8 @@ class Chef
     class Group
       class Groupmod < Chef::Provider::Group
 
+        provides :group, os: "netbsd"
+
         def load_current_resource
           super
           [ "group", "user" ].each do |binary|

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -23,6 +23,8 @@ class Chef
     class Group
       class Usermod < Chef::Provider::Group::Groupadd
 
+        provides :group, os: "openbsd"
+
         def load_current_resource
           super
         end

--- a/lib/chef/provider/group/windows.rb
+++ b/lib/chef/provider/group/windows.rb
@@ -26,6 +26,8 @@ class Chef
     class Group
       class Windows < Chef::Provider::Group
 
+        provides :group, os: "windows"
+
         def initialize(new_resource,run_context)
           super
           @net_group = Chef::Util::Windows::NetGroup.new(@new_resource.group_name)

--- a/lib/chef/provider/mdadm.rb
+++ b/lib/chef/provider/mdadm.rb
@@ -23,6 +23,8 @@ class Chef
   class Provider
     class Mdadm < Chef::Provider
 
+      provides :mdadm
+
       def popen4
         raise Exception, "deprecated"
       end

--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -27,6 +27,8 @@ class Chef
     class Mount
       class Windows < Chef::Provider::Mount
 
+        provides :mount, os: "windows"
+
         def is_volume(name)
           name =~ /^\\\\\?\\Volume\{[\w-]+\}\\$/ ? true : false
         end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -27,7 +27,7 @@ class Chef
       class Homebrew < Chef::Provider::Package
 
         provides :homebrew_package
-        provides :package, os: ["mac_os_x", "darwin"]
+        provides :package, os: "darwin"
 
         include Chef::Mixin::HomebrewUser
 

--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -22,6 +22,8 @@ class Chef
   class Provider
     class PowershellScript < Chef::Provider::WindowsScript
 
+      provides :powershell_script, os: "windows"
+
       protected
       EXIT_STATUS_EXCEPTION_HANDLER = "\ntrap [Exception] {write-error -exception ($_.Exception.Message);exit 1}".freeze
       EXIT_STATUS_NORMALIZATION_SCRIPT = "\nif ($? -ne $true) { if ( $LASTEXITCODE ) {exit $LASTEXITCODE} else { exit 1 }}".freeze

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -44,6 +44,8 @@ class Chef
       # This provider only supports Mac OSX versions 10.7 and above
       class Dscl < Chef::Provider::User
 
+        provides :user, os: "darwin"
+
         def define_resource_requirements
           super
 

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -27,6 +27,8 @@ class Chef
     class User
       class Windows < Chef::Provider::User
 
+        provides :user, os: "windows"
+
         def initialize(new_resource,run_context)
           super
           @net_user = Chef::Util::Windows::NetUser.new(@new_resource.username)

--- a/lib/chef/resource/batch.rb
+++ b/lib/chef/resource/batch.rb
@@ -22,6 +22,8 @@ class Chef
   class Resource
     class Batch < Chef::Resource::WindowsScript
 
+      provides :batch, os: "windows"
+
       def initialize(name, run_context=nil)
         super(name, run_context, :batch, "cmd.exe")
       end

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -27,6 +27,8 @@ class Chef
 
       state_attrs :minute, :hour, :day, :month, :weekday, :user
 
+      provides :cron
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :cron
@@ -138,7 +140,7 @@ class Chef
           :kind_of => [String, Symbol]
         )
       end
-      
+
       def time(arg=nil)
         set_or_return(
           :time,
@@ -214,5 +216,3 @@ class Chef
     end
   end
 end
-
-

--- a/lib/chef/resource/env.rb
+++ b/lib/chef/resource/env.rb
@@ -25,6 +25,8 @@ class Chef
 
       state_attrs :value
 
+      provides :env, os: "windows"
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :env

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -25,6 +25,8 @@ class Chef
 
       state_attrs :members
 
+      provides :group
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :group

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -26,7 +26,7 @@ class Chef
     class HomebrewPackage < Chef::Resource::Package
 
       provides :homebrew_package
-      provides :package, os: ["mac_os_x", "darwin"]
+      provides :package, os: "darwin"
 
       def initialize(name, run_context=nil)
         super

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -27,6 +27,8 @@ class Chef
 
       state_attrs :devices, :level, :chunk
 
+      provides :mdadm
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :mdadm

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -27,6 +27,8 @@ class Chef
 
       state_attrs :mount_point, :device_type, :fstype, :username, :password, :domain
 
+      provides :mount
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :mount

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class PowershellScript < Chef::Resource::WindowsScript
 
+      provides :powershell_script, os: "windows"
+
       def initialize(name, run_context=nil)
         super(name, run_context, :powershell_script, "powershell.exe")
         @convert_boolean_return = false

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -26,6 +26,8 @@ class Chef
 
       state_attrs :uid, :gid, :home
 
+      provides :user
+
       def initialize(name, run_context=nil)
         super
         @resource_name = :user

--- a/spec/functional/resource/env_spec.rb
+++ b/spec/functional/resource/env_spec.rb
@@ -29,14 +29,15 @@ describe Chef::Resource::Env, :windows_only do
     let(:env_value_expandable) { '%SystemRoot%' }
     let(:test_run_context) {
       node = Chef::Node.new
+      node.default['os'] = 'windows'
       node.default['platform'] = 'windows'
       node.default['platform_version'] = '6.1'
       empty_events = Chef::EventDispatch::Dispatcher.new
       Chef::RunContext.new(node, {}, empty_events)
     }
-    let(:test_resource) { 
-      Chef::Resource::Env.new('unknown', test_run_context) 
-    } 
+    let(:test_resource) {
+      Chef::Resource::Env.new('unknown', test_run_context)
+    }
 
     before(:each) do
       resource_lower = Chef::Resource::Env.new(chef_env_test_lower_case, test_run_context)

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -20,8 +20,6 @@ require 'spec_helper'
 
 describe "Chef::Platform supports" do
   [
-    :mac_os_x,
-    :mac_os_x_server,
     :freebsd,
     :ubuntu,
     :debian,
@@ -34,9 +32,6 @@ describe "Chef::Platform supports" do
     :gentoo,
     :arch,
     :solaris,
-    :mswin,
-    :mingw32,
-    :windows,
     :gcel,
     :ibm_powerkvm
   ].each do |platform|

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -452,6 +452,137 @@ describe Chef::ProviderResolver do
 
   end
 
+  describe "for the package provider" do
+    let(:resource_name) { :package }
+
+    before do
+      expect(provider_resolver).not_to receive(:maybe_chef_platform_lookup)
+    end
+
+    %w{mac_os_x mac_os_x_server}.each do |platform|
+      describe "on #{platform}" do
+        let(:os) { "darwin" }
+        let(:platform) { platform }
+        let(:platform_family) { "mac_os_x" }
+        let(:platform_version) { "10.9.2" }
+
+
+        it "returns a Chef::Provider::Package::Homebrew provider" do
+          expect(resolved_provider).to eql(Chef::Provider::Package::Homebrew)
+        end
+      end
+    end
+  end
+
+  hash = {
+    "mac_os_x" => {
+      :package => Chef::Provider::Package::Homebrew,
+      :user => Chef::Provider::User::Dscl,
+      :group => Chef::Provider::Group::Dscl,
+    },
+    "mac_os_x_server" => {
+      :package => Chef::Provider::Package::Homebrew,
+      :user => Chef::Provider::User::Dscl,
+      :group => Chef::Provider::Group::Dscl,
+    },
+    "mswin" => {
+      :env =>  Chef::Provider::Env::Windows,
+      :user => Chef::Provider::User::Windows,
+      :group => Chef::Provider::Group::Windows,
+      :mount => Chef::Provider::Mount::Windows,
+      :batch => Chef::Provider::Batch,
+      :powershell_script => Chef::Provider::PowershellScript,
+    },
+    "mingw32" => {
+      :env =>  Chef::Provider::Env::Windows,
+      :user => Chef::Provider::User::Windows,
+      :group => Chef::Provider::Group::Windows,
+      :mount => Chef::Provider::Mount::Windows,
+      :batch => Chef::Provider::Batch,
+      :powershell_script => Chef::Provider::PowershellScript,
+    },
+    "windows" => {
+      :env =>  Chef::Provider::Env::Windows,
+      :user => Chef::Provider::User::Windows,
+      :group => Chef::Provider::Group::Windows,
+      :mount => Chef::Provider::Mount::Windows,
+      :batch => Chef::Provider::Batch,
+      :powershell_script => Chef::Provider::PowershellScript,
+    },
+    "aix" => {
+      :cron => Chef::Provider::Cron::Aix,
+    },
+    "netbsd"=> {
+      :group => Chef::Provider::Group::Groupmod,
+    },
+    "openbsd" => {
+      :group => Chef::Provider::Group::Usermod,
+      :package => Chef::Provider::Package::Openbsd,
+    },
+  }
+
+  def self.do_platform(platform_hash)
+    platform_hash.each do |resource, provider|
+      describe "for #{resource}" do
+        let(:resource_name) { resource }
+
+        it "resolves to a #{provider}" do
+          expect(resolved_provider).to eql(provider)
+        end
+      end
+    end
+  end
+
+  describe "individual platform mappings" do
+    let(:resource_name) { :user }
+
+    before do
+      expect(provider_resolver).not_to receive(:maybe_chef_platform_lookup)
+    end
+
+    %w{mac_os_x mac_os_x_server}.each do |platform|
+      describe "on #{platform}" do
+        let(:os) { "darwin" }
+        let(:platform) { platform }
+        let(:platform_family) { "mac_os_x" }
+        let(:platform_version) { "10.9.2" }
+
+        do_platform(hash[platform])
+      end
+    end
+
+    %w{mswin mingw32 windows}.each do |platform|
+      describe "on #{platform}" do
+        let(:os) { "windows" }
+        let(:platform) { platform }
+        let(:platform_family) { "windows" }
+        let(:platform_version) { "10.9.2" }
+
+        do_platform(hash[platform])
+      end
+    end
+
+    describe "on AIX" do
+      let(:os) { "aix" }
+      let(:platform) { "aix" }
+      let(:platform_family) { "aix" }
+      let(:platform_version) { "6.2" }
+
+      do_platform(hash['aix'])
+    end
+
+    %w{netbsd openbsd}.each do |platform|
+      describe "on #{platform}" do
+        let(:os) { platform }
+        let(:platform) { platform }
+        let(:platform_family) { platform }
+        let(:platform_version) { "10.0-RELEASE" }
+
+        do_platform(hash[platform])
+      end
+    end
+  end
+
   describe "resolving static providers" do
     def resource_class(resource)
       Chef::Resource.const_get(convert_to_class_name(resource.to_s))
@@ -481,6 +612,7 @@ describe Chef::ProviderResolver do
         link:  Chef::Provider::Link,
         log:  Chef::Provider::Log::ChefLog,
         macports_package:  Chef::Provider::Package::Macports,
+        mdadm:  Chef::Provider::Mdadm,
         pacman_package: Chef::Provider::Package::Pacman,
         paludis_package: Chef::Provider::Package::Paludis,
         perl: Chef::Provider::Script,

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -474,7 +474,7 @@ describe Chef::ProviderResolver do
     end
   end
 
-  hash = {
+  provider_mapping = {
     "mac_os_x" => {
       :package => Chef::Provider::Package::Homebrew,
       :user => Chef::Provider::User::Dscl,
@@ -547,7 +547,7 @@ describe Chef::ProviderResolver do
         let(:platform_family) { "mac_os_x" }
         let(:platform_version) { "10.9.2" }
 
-        do_platform(hash[platform])
+        do_platform(provider_mapping[platform])
       end
     end
 
@@ -558,7 +558,7 @@ describe Chef::ProviderResolver do
         let(:platform_family) { "windows" }
         let(:platform_version) { "10.9.2" }
 
-        do_platform(hash[platform])
+        do_platform(provider_mapping[platform])
       end
     end
 
@@ -568,7 +568,7 @@ describe Chef::ProviderResolver do
       let(:platform_family) { "aix" }
       let(:platform_version) { "6.2" }
 
-      do_platform(hash['aix'])
+      do_platform(provider_mapping['aix'])
     end
 
     %w{netbsd openbsd}.each do |platform|
@@ -578,7 +578,7 @@ describe Chef::ProviderResolver do
         let(:platform_family) { platform }
         let(:platform_version) { "10.0-RELEASE" }
 
-        do_platform(hash[platform])
+        do_platform(provider_mapping[platform])
       end
     end
   end


### PR DESCRIPTION
- move macosx providers to dynamic resolution
- move windows providers to dynamic resolution
- move openbsd/netbsd providers to dynamic resolution
- move all cron providers to dynamic resolution
- move mdadm to static mapping