### PR TITLE
Missing require - causes `missing Constant` error when files are loaded in unexpected order

### DIFF
--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -20,6 +20,7 @@
 require 'chef/mixin/convert_to_class_name'
 require 'chef/exceptions'
 require 'chef/resource_builder'
+require 'chef/mixin/shell_out'
 
 class Chef
   module DSL


### PR DESCRIPTION
As they are in Cheffish.  The include is a couple of lines below what the Github diff shows.

\cc @chef/client-core 