### PR TITLE
The knife bootstrap raises `ERROR: TypeError: no implicit conversion of nil into String`  when Chef::Config[:validation_key] is nil.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -313,7 +313,7 @@ class Chef
 
         # chef-vault integration must use the new client-side hawtness, otherwise to use the
         # new client-side hawtness, just delete your validation key.
-        if chef_vault_handler.doing_chef_vault? || !File.exist?(File.expand_path(Chef::Config[:validation_key]))
+        if chef_vault_handler.doing_chef_vault? || Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key]))
           client_builder.run
 
           chef_vault_handler.run(node_name: config[:chef_node_name])

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -593,6 +593,20 @@ describe Chef::Knife::Bootstrap do
         knife.run
       end
     end
+
+    context "when the validation_key is nil" do
+      before do
+        # this tests runs the old code path where we have a validation key, so we need to pass that check for some plugins
+        Chef::Config[:validation_key] = nil
+      end
+
+      it "creates the client (and possibly adds chef-vault items)" do
+        expect(knife_ssh).to receive(:run)
+        expect(knife.client_builder).not_to receive(:run)
+        expect(knife.chef_vault_handler).not_to receive(:run).with(node_name: knife.config[:chef_node_name])
+        knife.run
+      end
+    end
   end
 
   describe "specifying ssl verification" do


### PR DESCRIPTION
It will break compatibility of my plugin.

Please check that it is not nil before file existence check.