### PR TITLE
Adding Chef::Mixin::Command back to Package provider base class

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1008,7 +1008,8 @@ class Chef
           end
 
           if status.exitstatus > 0
-            status.error!
+            command_output = "STDOUT: #{status.stdout}\nSTDERR: #{status.stderr}"
+            raise Chef::Exceptions::Exec, "#{command} returned #{status.exitstatus}:\n#{command_output}"
           end
         end
 

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -18,7 +18,6 @@
 
 require 'chef/config'
 require 'chef/provider/package'
-require 'chef/mixin/command' # handle_command_failures
 require 'chef/mixin/shell_out'
 require 'chef/resource/package'
 require 'singleton'

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -984,7 +984,7 @@ class Chef
         end
 
         def yum_command(command)
-          status, stdout, stderr = output_of_command(command, {:timeout => Chef::Config[:yum_timeout]})
+          status = shell_out(command, {:timeout => Chef::Config[:yum_timeout]})
 
           # This is fun: rpm can encounter errors in the %post/%postun scripts which aren't
           # considered fatal - meaning the rpm is still successfully installed. These issue
@@ -996,21 +996,19 @@ class Chef
           # A cleaner solution would have to be done in python and better hook into
           # yum/rpm to handle exceptions as we see fit.
           if status.exitstatus == 1
-            stdout.each_line do |l|
+            status.stdout.each_line do |l|
               # rpm-4.4.2.3 lib/psm.c line 2182
               if l =~ %r{^error: %(post|postun)\(.*\) scriptlet failed, exit status \d+$}
                 Chef::Log.warn("#{@new_resource} caught non-fatal scriptlet issue: \"#{l}\". Can't trust yum exit status " +
                                "so running install again to verify.")
-                status, stdout, stderr = output_of_command(command, {:timeout => Chef::Config[:yum_timeout]})
+                status = shell_out(command, {:timeout => Chef::Config[:yum_timeout]})
                 break
               end
             end
           end
 
           if status.exitstatus > 0
-            command_output = "STDOUT: #{stdout}"
-            command_output << "STDERR: #{stderr}"
-            Chef::Mixin::Command.handle_command_failures(status, command_output, {})
+            status.error!
           end
         end
 

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -696,9 +696,9 @@ describe Chef::Provider::Package::Yum do
 
   describe "when running yum" do
     it "should run yum once if it exits with a return code of 0" do
-      @status = double("Status", :exitstatus => 0)
-      allow(@provider).to receive(:output_of_command).and_return([@status, "", ""])
-      expect(@provider).to receive(:output_of_command).once.with(
+      @status = double("Status", :exitstatus => 0, :stdout => "", :stderr => "")
+      allow(@provider).to receive(:shell_out).and_return(@status)
+      expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
         {:timeout => Chef::Config[:yum_timeout]}
       )
@@ -706,9 +706,9 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum once if it exits with a return code > 0 and no scriptlet failures" do
-      @status = double("Status", :exitstatus => 2)
-      allow(@provider).to receive(:output_of_command).and_return([@status, "failure failure", "problem problem"])
-      expect(@provider).to receive(:output_of_command).once.with(
+      @status = double("Status", :exitstatus => 2, :stdout => "failure failure", :stderr => "problem problem")
+      allow(@provider).to receive(:shell_out).and_return(@status)
+      expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
         {:timeout => Chef::Config[:yum_timeout]}
       )
@@ -716,9 +716,10 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum once if it exits with a return code of 1 and %pre scriptlet failures" do
-      @status = double("Status", :exitstatus => 1)
-      allow(@provider).to receive(:output_of_command).and_return([@status, "error: %pre(demo-1-1.el5.centos.x86_64) scriptlet failed, exit status 2", ""])
-      expect(@provider).to receive(:output_of_command).once.with(
+      @status = double("Status", :exitstatus => 1, :stdout => "error: %pre(demo-1-1.el5.centos.x86_64) scriptlet failed, exit status 2",
+                      :stderr => "")
+      allow(@provider).to receive(:shell_out).and_return(@status)
+      expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
         {:timeout => Chef::Config[:yum_timeout]}
       )
@@ -727,9 +728,10 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum twice if it exits with a return code of 1 and %post scriptlet failures" do
-      @status = double("Status", :exitstatus => 1)
-      allow(@provider).to receive(:output_of_command).and_return([@status, "error: %post(demo-1-1.el5.centos.x86_64) scriptlet failed, exit status 2", ""])
-      expect(@provider).to receive(:output_of_command).twice.with(
+      @status = double("Status", :exitstatus => 1, :stdout => "error: %post(demo-1-1.el5.centos.x86_64) scriptlet failed, exit status 2",
+                      :stderr => "")
+      allow(@provider).to receive(:shell_out).and_return(@status)
+      expect(@provider).to receive(:shell_out).twice.with(
         "yum -d0 -e0 -y install emacs-1.0",
         {:timeout => Chef::Config[:yum_timeout]}
       )


### PR DESCRIPTION
This was removed in #2924, however it breaks at least the yum
provider.

Without this patch, I was getting:
```
    NoMethodError
    -------------
    undefined method `output_of_command' for #<Chef::Provider::Package::Yum:0x00000003a5f278>
```
when trying to execute

```ruby
package "gdb" do
  action :install
end
```

on Centos 6.5

Chef was breaking in weird ways and it didn't produce a stacktrace.out,
which was a little concerning, however that's a different bug

This is required for Chef 12.1 as it a regression that would really suck to ship (it breaks the apache cookbook for sure).

cc @btm @lamont-granquist @jonlives 