### PR TITLE
Change cookbook_path precedence

### DIFF
--- a/spec/data/config.rb
+++ b/spec/data/config.rb
@@ -2,5 +2,5 @@
 # Sample Chef Config File
 # 
 
-cookbook_path "/etc/chef/cookbook", "/etc/chef/site-cookbook"
+cookbook_path "/etc/chef/site-cookbook", "/etc/chef/cookbook"
 


### PR DESCRIPTION
`site-cookbooks` should take precedence by default so that a new user using `knife cookbook create xyz` should find that `xyz` cookbook created in `site-cookbooks` folder not in `cookbooks` because `site-cookbooks` contains user creations which must take precedence/override `cookbooks`. Hence the PR to change the defaults.

See this reference PR in `knife-solo` https://github.com/matschaffer/knife-solo/pull/423 Thank you.