### PR TITLE
Adding Chef::Command::Mixin back into the package provider

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -25,6 +25,7 @@ require 'chef/platform'
 class Chef
   class Provider
     class Package < Chef::Provider
+      include Chef::Mixin::Command
       include Chef::Mixin::ShellOut
 
       #


### PR DESCRIPTION
I think we should add this back in. I don't like that we changed the public interface of the package provider.
Thoughts?

This fixes https://github.com/chef/chef/issues/3011

cc @chef/client-core @chef/client-engineers