### PR TITLE
Add warnings to 'knife node run list remove ...' 

### DIFF
--- a/lib/chef/knife/node_run_list_remove.rb
+++ b/lib/chef/knife/node_run_list_remove.rb
@@ -42,7 +42,18 @@ class Chef
           entries = @name_args[1].split(',').map { |e| e.strip }
         end
 
-        entries.each { |e| node.run_list.remove(e) }
+        # iterate over the list of things to remove,
+        # warning if one of them was not found
+        entries.each do |e|
+          if node.run_list.find { |rli| e == rli.to_s }
+            node.run_list.remove(e)
+          else
+            ui.warn "#{e} is not in the run list"
+            unless e =~ /^(recipe|role)\[/
+              ui.warn '(did you forget recipe[] or role[] around it?)'
+            end
+          end
+        end
 
         node.save
 

--- a/spec/unit/knife/node_run_list_remove_spec.rb
+++ b/spec/unit/knife/node_run_list_remove_spec.rb
@@ -84,6 +84,23 @@ describe Chef::Knife::NodeRunListRemove do
         expect(@node.run_list).not_to include('role[monkey]')
         expect(@node.run_list).not_to include('recipe[duck::type]')
       end
+
+      it "should warn when the thing to remove is not in the runlist" do
+        @node.run_list << 'role[blah]'
+        @node.run_list << 'recipe[duck::type]'
+        @knife.name_args = [ 'adam', 'role[blork]' ]
+        expect(@knife.ui).to receive(:warn).with("role[blork] is not in the run list")
+        @knife.run
+      end
+
+      it "should warn even more when the thing to remove is not in the runlist and unqualified" do
+        @node.run_list << 'role[blah]'
+        @node.run_list << 'recipe[duck::type]'
+        @knife.name_args = [ 'adam', 'blork' ]
+        expect(@knife.ui).to receive(:warn).with("blork is not in the run list")
+        expect(@knife.ui).to receive(:warn).with(/did you forget recipe\[\] or role\[\]/)
+        @knife.run
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a warning when the item to be removed doesn't exist in the runlist.

A simple quality of life improvement for people who might try to remove an item without wrapping it in 'recipe[]'.  Previously, the feedback was the unchanged runlist without any reason why the remove operation didn't do anything.