### PR TITLE
chef_gem_compile_time's nil is the same as true

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -627,7 +627,7 @@ class Chef
     #
     default :no_lazy_load, true
 
-    # Default for the chef_gem compile_time attribute.  Nil is the same as false but will emit
+    # Default for the chef_gem compile_time attribute.  Nil is the same as true but will emit
     # warnings on every use of chef_gem prompting the user to be explicit.  If the user sets this to
     # true then the user will get backcompat behavior but with a single nag warning that cookbooks
     # may break with this setting in the future.  The false setting is the recommended setting and


### PR DESCRIPTION
according to lib/chef/resource/chef_gem.rb#after_created, `true` and `nil` are the same.

```ruby
if compile_time || compile_time.nil?
  Array(action).each do |action|
    self.run_action(action)
  end
  Gem.clear_paths
end
```