### PR TITLE
Remove trailing null character from msi properties

### DIFF
--- a/lib/chef/win32/api/installer.rb
+++ b/lib/chef/win32/api/installer.rb
@@ -108,7 +108,7 @@ UINT MsiCloseHandle(
           end
 
           msi_close_handle(pkg_ptr.read_pointer)
-          return buffer
+          return buffer.chomp(0.chr)
         end
 
         # Opens a Microsoft Installer (MSI) file from an absolute path and returns a pointer to a handle


### PR DESCRIPTION
When reading properties from an MSI, variables are returned with a trailing null byte. I don't think that should happen.

Results in compiled windows_package resources with an incorrect version string, for example.