### PR TITLE
fix Lint/UnusedMethodArgument

### DIFF
--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -57,7 +57,7 @@ class Chef
       # that runs tests - normal errors are interpreted as EXAMPLE failures and captured.
       # We still want to send available audit information to the server so we process the
       # known control groups.
-      def audit_phase_failed(error)
+      def audit_phase_failed(_error)
         # The stacktrace information has already been logged elsewhere
         Chef::Log.debug("Audit Reporter failed.")
         ordered_control_groups.each do |name, control_group|
@@ -65,7 +65,7 @@ class Chef
         end
       end
 
-      def run_completed(node)
+      def run_completed(_node)
         post_auditing_data
       end
 

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -315,7 +315,7 @@ class Chef
         return path[0] == 'sandboxes' || path[0] == 'file_store' && path[1] == 'checksums' || path == [ 'environments', '_default' ]
       end
 
-      def write_cookbook(path, data, *options)
+      def write_cookbook(path, data, *_options)
         if chef_fs.versioned_cookbooks
           cookbook_path = File.join('cookbooks', "#{path[1]}-#{path[2]}")
         else

--- a/lib/chef/chef_fs/data_handler/acl_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/acl_data_handler.rb
@@ -4,7 +4,7 @@ class Chef
   module ChefFS
     module DataHandler
       class AclDataHandler < DataHandlerBase
-        def normalize(acl, entry)
+        def normalize(acl, _entry)
           # Normalize the order of the keys for easier reading
           result = normalize_hash(acl, {
             'create' => {},

--- a/lib/chef/chef_fs/data_handler/data_handler_base.rb
+++ b/lib/chef/chef_fs/data_handler/data_handler_base.rb
@@ -38,7 +38,7 @@ class Chef
         # Return true if minimize() should preserve a key even if it is the same
         # as the default.  Often used for ids and names.
         #
-        def preserve_key?(key)
+        def preserve_key?(_key)
           false
         end
 
@@ -123,7 +123,7 @@ class Chef
         #
         # Write out the Ruby file for this instance.  (Like roles/x.rb)
         #
-        def to_ruby(object)
+        def to_ruby(_object)
           raise NotImplementedError
         end
 

--- a/lib/chef/chef_fs/data_handler/organization_invites_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/organization_invites_data_handler.rb
@@ -4,11 +4,11 @@ class Chef
   module ChefFS
     module DataHandler
       class OrganizationInvitesDataHandler < DataHandlerBase
-        def normalize(invites, entry)
+        def normalize(invites, _entry)
           invites.map { |invite| invite.is_a?(Hash) ? invite['username'] : invite }.sort.uniq
         end
 
-        def minimize(invites, entry)
+        def minimize(invites, _entry)
           invites
         end
       end

--- a/lib/chef/chef_fs/data_handler/organization_members_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/organization_members_data_handler.rb
@@ -4,11 +4,11 @@ class Chef
   module ChefFS
     module DataHandler
       class OrganizationMembersDataHandler < DataHandlerBase
-        def normalize(members, entry)
+        def normalize(members, _entry)
           members.map { |member| member.is_a?(Hash) ? member['user']['username'] : member }.sort.uniq
         end
 
-        def minimize(members, entry)
+        def minimize(members, _entry)
           members
         end
       end

--- a/lib/chef/chef_fs/data_handler/policy_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/policy_data_handler.rb
@@ -5,7 +5,7 @@ class Chef
     module DataHandler
       class PolicyDataHandler < DataHandlerBase
 
-        def normalize(policy, entry)
+        def normalize(policy, _entry)
           policy
         end
       end

--- a/lib/chef/chef_fs/file_system/acl_dir.rb
+++ b/lib/chef/chef_fs/file_system/acl_dir.rb
@@ -47,7 +47,7 @@ class Chef
           @children
         end
 
-        def create_child(name, file_contents)
+        def create_child(_name, _file_contents)
           raise OperationNotAllowedError.new(:create_child, self), "ACLs can only be updated, and can only be created when the corresponding object is created."
         end
 

--- a/lib/chef/chef_fs/file_system/acl_entry.rb
+++ b/lib/chef/chef_fs/file_system/acl_entry.rb
@@ -31,7 +31,7 @@ class Chef
           "#{super}/_acl"
         end
 
-        def delete(recurse)
+        def delete(_recurse)
           raise Chef::ChefFS::FileSystem::OperationNotAllowedError.new(:delete, self), "ACLs cannot be deleted."
         end
 

--- a/lib/chef/chef_fs/file_system/base_fs_dir.rb
+++ b/lib/chef/chef_fs/file_system/base_fs_dir.rb
@@ -36,7 +36,7 @@ class Chef
           children.select { |child| child.name == name }.first || NonexistentFSObject.new(name, self)
         end
 
-        def can_have_child?(name, is_dir)
+        def can_have_child?(_name, _is_dir)
           true
         end
 

--- a/lib/chef/chef_fs/file_system/base_fs_object.rb
+++ b/lib/chef/chef_fs/file_system/base_fs_object.rb
@@ -73,14 +73,14 @@ class Chef
         #       other_value = entry.read if other_value.nil?
         #       are_same = (value == other_value)
         #     end
-        def compare_to(other)
+        def compare_to(_other)
           nil
         end
 
         # Override can_have_child? to report whether a given file *could* be added
         # to this directory.  (Some directories can't have subdirs, some can only have .json
         # files, etc.)
-        def can_have_child?(name, is_dir)
+        def can_have_child?(_name, _is_dir)
           false
         end
 
@@ -116,14 +116,14 @@ class Chef
         # NOTE: create_child_from is an optional method that can also be added to
         # your entry class, and will be called without actually reading the
         # file_contents.  This is used for knife upload /cookbooks/cookbookname.
-        def create_child(name, file_contents)
+        def create_child(_name, _file_contents)
           raise NotFoundError.new(self) if !exists?
           raise OperationNotAllowedError.new(:create_child, self)
         end
 
         # Delete this item, possibly recursively.  Entries MUST NOT delete a
         # directory unless recurse is true.
-        def delete(recurse)
+        def delete(_recurse)
           raise NotFoundError.new(self) if !exists?
           raise OperationNotAllowedError.new(:delete, self)
         end
@@ -164,7 +164,7 @@ class Chef
         end
 
         # Write the contents of this file entry.
-        def write(file_contents)
+        def write(_file_contents)
           raise NotFoundError.new(self) if !exists?
           raise OperationNotAllowedError.new(:write, self)
         end

--- a/lib/chef/chef_fs/file_system/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/cookbooks_dir.rb
@@ -145,7 +145,7 @@ class Chef
           Chef::Config.cookbook_path = old_cookbook_path
         end
 
-        def upload_cookbook!(uploader, options = {})
+        def upload_cookbook!(uploader, _options = {})
           if uploader.respond_to?(:upload_cookbook)
             uploader.upload_cookbook
           else

--- a/lib/chef/chef_fs/file_system/data_bag_dir.rb
+++ b/lib/chef/chef_fs/file_system/data_bag_dir.rb
@@ -25,7 +25,7 @@ class Chef
   module ChefFS
     module FileSystem
       class DataBagDir < RestListDir
-        def initialize(name, parent, exists = nil)
+        def initialize(name, parent, _exists = nil)
           super(name, parent, nil, Chef::ChefFS::DataHandler::DataBagItemDataHandler.new)
           @exists = nil
         end

--- a/lib/chef/chef_fs/file_system/data_bags_dir.rb
+++ b/lib/chef/chef_fs/file_system/data_bags_dir.rb
@@ -48,11 +48,11 @@ class Chef
           end
         end
 
-        def can_have_child?(name, is_dir)
+        def can_have_child?(_name, is_dir)
           is_dir
         end
 
-        def create_child(name, file_contents)
+        def create_child(name, _file_contents)
           begin
             rest.post(api_path, { 'name' => name })
           rescue Timeout::Error => e

--- a/lib/chef/chef_fs/file_system/environments_dir.rb
+++ b/lib/chef/chef_fs/file_system/environments_dir.rb
@@ -44,12 +44,12 @@ class Chef
             @exists = exists
           end
 
-          def delete(recurse)
+          def delete(_recurse)
             raise NotFoundError.new(self) if !exists?
             raise DefaultEnvironmentCannotBeModifiedError.new(:delete, self), "#{path_for_printing} cannot be deleted."
           end
 
-          def write(file_contents)
+          def write(_file_contents)
             raise NotFoundError.new(self) if !exists?
             raise DefaultEnvironmentCannotBeModifiedError.new(:write, self), "#{path_for_printing} cannot be updated."
           end

--- a/lib/chef/chef_fs/file_system/memory_dir.rb
+++ b/lib/chef/chef_fs/file_system/memory_dir.rb
@@ -21,7 +21,7 @@ class Chef
           @children.push(child)
         end
 
-        def can_have_child?(name, is_dir)
+        def can_have_child?(name, _is_dir)
           root.cannot_be_in_regex ? (name !~ root.cannot_be_in_regex) : true
         end
 

--- a/lib/chef/chef_fs/file_system/org_entry.rb
+++ b/lib/chef/chef_fs/file_system/org_entry.rb
@@ -25,7 +25,7 @@ class Chef
           parent.exists?
         end
 
-        def delete(recurse)
+        def delete(_recurse)
           raise Chef::ChefFS::FileSystem::OperationNotAllowedError.new(:delete, self)
         end
       end

--- a/lib/chef/chef_fs/file_system/organization_invites_entry.rb
+++ b/lib/chef/chef_fs/file_system/organization_invites_entry.rb
@@ -30,7 +30,7 @@ class Chef
           parent.exists?
         end
 
-        def delete(recurse)
+        def delete(_recurse)
           raise Chef::ChefFS::FileSystem::OperationNotAllowedError.new(:delete, self)
         end
 

--- a/lib/chef/chef_fs/file_system/organization_members_entry.rb
+++ b/lib/chef/chef_fs/file_system/organization_members_entry.rb
@@ -30,7 +30,7 @@ class Chef
           parent.exists?
         end
 
-        def delete(recurse)
+        def delete(_recurse)
           raise Chef::ChefFS::FileSystem::OperationNotAllowedError.new(:delete, self)
         end
 

--- a/lib/chef/chef_fs/file_system/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/rest_list_entry.rb
@@ -66,7 +66,7 @@ class Chef
           @exists
         end
 
-        def delete(recurse)
+        def delete(_recurse)
           begin
             rest.delete(api_path)
           rescue Timeout::Error => e

--- a/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb
+++ b/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb
@@ -129,7 +129,7 @@ class Chef
               @parallel_enumerable.restricted_copy(input)
             end
 
-            def method_missing(method, *args, &block)
+            def method_missing(_method, *args, &block)
               @actual_lazy.send(:method, *args, &block)
             end
           end

--- a/lib/chef/cookbook/chefignore.rb
+++ b/lib/chef/cookbook/chefignore.rb
@@ -65,7 +65,7 @@ class Chef
         end
       end
 
-      def readable_file_or_symlink?(path)
+      def readable_file_or_symlink?(_path)
         File.exist?(@ignore_file) && File.readable?(@ignore_file) &&
           (File.file?(@ignore_file) || File.symlink?(@ignore_file))
       end

--- a/lib/chef/cookbook/file_vendor.rb
+++ b/lib/chef/cookbook/file_vendor.rb
@@ -63,7 +63,7 @@ class Chef
       #
       # Subclasses are responsible for determining exactly how the
       # files are obtained and where they are stored.
-      def get_filename(filename)
+      def get_filename(_filename)
         raise NotImplemented, "Subclasses must implement this method"
       end
 

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -189,7 +189,7 @@ class Chef
       end
 
       # read the specified amount from the stream
-      def read(offset, how_much)
+      def read(_offset, how_much)
         @stream.read(how_much)
       end
     end

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -481,7 +481,7 @@ class Chef
       cookbook_manifest.to_hash
     end
 
-    def to_json(*a)
+    def to_json(*_a)
       # TODO: this should become deprecated when the API for CookbookManifest becomes stable
       cookbook_manifest.to_json
     end

--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -80,7 +80,7 @@ class Chef::EncryptedDataBagItem
     end
   end
 
-  def []=(key, value)
+  def []=(_key, _value)
     raise ArgumentError, "assignment not supported for #{self.class}"
   end
 

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -29,70 +29,70 @@ class Chef
     class Base
 
       # Called at the very start of a Chef Run
-      def run_start(version)
+      def run_start(_version)
       end
 
-      def run_started(run_status)
+      def run_started(_run_status)
       end
 
       # Called at the end a successful Chef run.
-      def run_completed(node)
+      def run_completed(_node)
       end
 
       # Called at the end of a failed Chef run.
-      def run_failed(exception)
+      def run_failed(_exception)
       end
 
       # Called right after ohai runs.
-      def ohai_completed(node)
+      def ohai_completed(_node)
       end
 
       # Already have a client key, assuming this node has registered.
-      def skipping_registration(node_name, config)
+      def skipping_registration(_node_name, _config)
       end
 
       # About to attempt to register as +node_name+
-      def registration_start(node_name, config)
+      def registration_start(_node_name, _config)
       end
 
       def registration_completed
       end
 
       # Failed to register this client with the server.
-      def registration_failed(node_name, exception, config)
+      def registration_failed(_node_name, _exception, _config)
       end
 
       # Called before Chef client loads the node data from the server
-      def node_load_start(node_name, config)
+      def node_load_start(_node_name, _config)
       end
 
       # TODO: def node_run_list_overridden(*args)
 
       # Failed to load node data from the server
-      def node_load_failed(node_name, exception, config)
+      def node_load_failed(_node_name, _exception, _config)
       end
 
       # Error expanding the run list
-      def run_list_expand_failed(node, exception)
+      def run_list_expand_failed(_node, _exception)
       end
 
       # Called after Chef client has loaded the node data.
       # Default and override attrs from roles have been computed, but not yet applied.
       # Normal attrs from JSON have been added to the node.
-      def node_load_completed(node, expanded_run_list, config)
+      def node_load_completed(_node, _expanded_run_list, _config)
       end
 
       # Called before the cookbook collection is fetched from the server.
-      def cookbook_resolution_start(expanded_run_list)
+      def cookbook_resolution_start(_expanded_run_list)
       end
 
       # Called when there is an error getting the cookbook collection from the
       # server.
-      def cookbook_resolution_failed(expanded_run_list, exception)
+      def cookbook_resolution_failed(_expanded_run_list, _exception)
       end
 
       # Called when the cookbook collection is returned from the server.
-      def cookbook_resolution_complete(cookbook_collection)
+      def cookbook_resolution_complete(_cookbook_collection)
       end
 
       # Called before unneeded cookbooks are removed
@@ -102,7 +102,7 @@ class Chef
       # Called after the file at +path+ is removed. It may be removed if the
       # cookbook containing it was removed from the run list, or if the file was
       # removed from the cookbook.
-      def removed_cookbook_file(path)
+      def removed_cookbook_file(_path)
       end
 
       # Called when cookbook cleaning is finished.
@@ -110,19 +110,19 @@ class Chef
       end
 
       # Called before cookbook sync starts
-      def cookbook_sync_start(cookbook_count)
+      def cookbook_sync_start(_cookbook_count)
       end
 
       # Called when cookbook +cookbook_name+ has been sync'd
-      def synchronized_cookbook(cookbook_name)
+      def synchronized_cookbook(_cookbook_name)
       end
 
       # Called when an individual file in a cookbook has been updated
-      def updated_cookbook_file(cookbook_name, path)
+      def updated_cookbook_file(_cookbook_name, _path)
       end
 
       # Called when an error occurs during cookbook sync
-      def cookbook_sync_failed(cookbooks, exception)
+      def cookbook_sync_failed(_cookbooks, _exception)
       end
 
       # Called after all cookbooks have been sync'd.
@@ -134,15 +134,15 @@ class Chef
       ## TODO: add callbacks for overall cookbook eval start and complete.
 
       # Called when library file loading starts
-      def library_load_start(file_count)
+      def library_load_start(_file_count)
       end
 
       # Called when library file has been loaded
-      def library_file_loaded(path)
+      def library_file_loaded(_path)
       end
 
       # Called when a library file has an error on load.
-      def library_file_load_failed(path, exception)
+      def library_file_load_failed(_path, _exception)
       end
 
       # Called when library file loading has finished
@@ -150,15 +150,15 @@ class Chef
       end
 
       # Called when LWRP loading starts
-      def lwrp_load_start(lwrp_file_count)
+      def lwrp_load_start(_lwrp_file_count)
       end
 
       # Called after a LWR or LWP has been loaded
-      def lwrp_file_loaded(path)
+      def lwrp_file_loaded(_path)
       end
 
       # Called after a LWR or LWP file errors on load
-      def lwrp_file_load_failed(path, exception)
+      def lwrp_file_load_failed(_path, _exception)
       end
 
       # Called when LWRPs are finished loading
@@ -166,15 +166,15 @@ class Chef
       end
 
       # Called before attribute files are loaded
-      def attribute_load_start(attribute_file_count)
+      def attribute_load_start(_attribute_file_count)
       end
 
       # Called after the attribute file is loaded
-      def attribute_file_loaded(path)
+      def attribute_file_loaded(_path)
       end
 
       # Called when an attribute file fails to load.
-      def attribute_file_load_failed(path, exception)
+      def attribute_file_load_failed(_path, _exception)
       end
 
       # Called when attribute file loading is finished
@@ -182,15 +182,15 @@ class Chef
       end
 
       # Called before resource definitions are loaded
-      def definition_load_start(definition_file_count)
+      def definition_load_start(_definition_file_count)
       end
 
       # Called when a resource definition has been loaded
-      def definition_file_loaded(path)
+      def definition_file_loaded(_path)
       end
 
       # Called when a resource definition file fails to load
-      def definition_file_load_failed(path, exception)
+      def definition_file_load_failed(_path, _exception)
       end
 
       # Called when resource definitions are done loading
@@ -198,19 +198,19 @@ class Chef
       end
 
       # Called before recipes are loaded
-      def recipe_load_start(recipe_count)
+      def recipe_load_start(_recipe_count)
       end
 
       # Called after the recipe has been loaded
-      def recipe_file_loaded(path)
+      def recipe_file_loaded(_path)
       end
 
       # Called after a recipe file fails to load
-      def recipe_file_load_failed(path, exception)
+      def recipe_file_load_failed(_path, _exception)
       end
 
       # Called when a recipe cannot be resolved
-      def recipe_not_found(exception)
+      def recipe_not_found(_exception)
       end
 
       # Called when recipes have been loaded.
@@ -218,7 +218,7 @@ class Chef
       end
 
       # Called before convergence starts
-      def converge_start(run_context)
+      def converge_start(_run_context)
       end
 
       # Called when the converge phase is finished.
@@ -226,7 +226,7 @@ class Chef
       end
 
       # Called if the converge phase fails
-      def converge_failed(exception)
+      def converge_failed(_exception)
       end
 
       ##################################
@@ -235,7 +235,7 @@ class Chef
       ##################################
 
       # Called before audit phase starts
-      def audit_phase_start(run_status)
+      def audit_phase_start(_run_status)
       end
 
       # Called when audit phase successfully finishes
@@ -245,19 +245,19 @@ class Chef
       # Called if there is an uncaught exception during the audit phase.  The audit runner should
       # be catching and handling errors from the examples, so this is only uncaught errors (like
       # bugs in our handling code)
-      def audit_phase_failed(exception)
+      def audit_phase_failed(_exception)
       end
 
       # Signifies the start of a `control_group` block with a defined name
-      def control_group_started(name)
+      def control_group_started(_name)
       end
 
       # An example in a `control_group` block completed successfully
-      def control_example_success(control_group_name, example_data)
+      def control_example_success(_control_group_name, _example_data)
       end
 
       # An example in a `control_group` block failed with the provided error
-      def control_example_failure(control_group_name, example_data, error)
+      def control_example_failure(_control_group_name, _example_data, _error)
       end
 
       # TODO: need events for notification resolve?
@@ -265,73 +265,73 @@ class Chef
       # end
 
       # Called before action is executed on a resource.
-      def resource_action_start(resource, action, notification_type=nil, notifier=nil)
+      def resource_action_start(_resource, _action, _notification_type=nil, _notifier=nil)
       end
 
       # Called when a resource fails, but will retry.
-      def resource_failed_retriable(resource, action, retry_count, exception)
+      def resource_failed_retriable(_resource, _action, _retry_count, _exception)
       end
 
       # Called when a resource fails and will not be retried.
-      def resource_failed(resource, action, exception)
+      def resource_failed(_resource, _action, _exception)
       end
 
       # Called when a resource action has been skipped b/c of a conditional
-      def resource_skipped(resource, action, conditional)
+      def resource_skipped(_resource, _action, _conditional)
       end
 
       # Called when a resource action has been completed
-      def resource_completed(resource)
+      def resource_completed(_resource)
       end
 
       # Called after #load_current_resource has run.
-      def resource_current_state_loaded(resource, action, current_resource)
+      def resource_current_state_loaded(_resource, _action, _current_resource)
       end
 
       # Called when resource current state load is skipped due to the provider
       # not supporting whyrun mode.
-      def resource_current_state_load_bypassed(resource, action, current_resource)
+      def resource_current_state_load_bypassed(_resource, _action, _current_resource)
       end
 
       # Called when evaluating a resource that does not support whyrun in whyrun mode
-      def resource_bypassed(resource, action, current_resource)
+      def resource_bypassed(_resource, _action, _current_resource)
       end
 
       # Called when a resource has no converge actions, e.g., it was already correct.
-      def resource_up_to_date(resource, action)
+      def resource_up_to_date(_resource, _action)
       end
 
       # Called when a change has been made to a resource. May be called multiple
       # times per resource, e.g., a file may have its content updated, and then
       # its permissions updated.
-      def resource_update_applied(resource, action, update)
+      def resource_update_applied(_resource, _action, _update)
       end
 
       # Called after a resource has been completely converged, but only if
       # modifications were made.
-      def resource_updated(resource, action)
+      def resource_updated(_resource, _action)
       end
 
       # A stream has opened.
-      def stream_opened(stream, options = {})
+      def stream_opened(_stream, _options = {})
       end
 
       # A stream has closed.
-      def stream_closed(stream, options = {})
+      def stream_closed(_stream, _options = {})
       end
 
       # A chunk of data from a stream.  The stream is managed by "stream," which
       # can be any tag whatsoever.  Data in different "streams" may not be placed
       # on the same line or even sent to the same console.
-      def stream_output(stream, output, options = {})
+      def stream_output(_stream, _output, _options = {})
       end
 
       # Called before handlers run
-      def handlers_start(handler_count)
+      def handlers_start(_handler_count)
       end
 
       # Called after an individual handler has run
-      def handler_executed(handler)
+      def handler_executed(_handler)
       end
 
       # Called after all handlers have executed
@@ -339,12 +339,12 @@ class Chef
       end
 
       # Called when an assertion declared by a provider fails
-      def provider_requirement_failed(action, resource, exception, message)
+      def provider_requirement_failed(_action, _resource, _exception, _message)
       end
 
       # Called when a provider makes an assumption after a failed assertion
       # in whyrun mode, in order to allow execution to continue
-      def whyrun_assumption(action, resource, message)
+      def whyrun_assumption(_action, _resource, _message)
       end
 
       ## TODO: deprecation warning. this way we can queue them up and present
@@ -355,7 +355,7 @@ class Chef
       # there's no semantic information about the content or importance of the
       # message. That means that if you're using this too often, you should add a
       # callback for it.
-      def msg(message)
+      def msg(_message)
       end
 
     end

--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -74,7 +74,7 @@ class Chef
         )
       end
 
-      def run_completed(node)
+      def run_completed(_node)
         @eventlog.report_event(
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,

--- a/lib/chef/formatters/base.rb
+++ b/lib/chef/formatters/base.rb
@@ -146,7 +146,7 @@ class Chef
       # Formatters::Base can implement #file_loaded to do the same thing for
       # every kind of file that Chef loads from a recipe instead of
       # implementing all the per-filetype callbacks.
-      def file_loaded(path)
+      def file_loaded(_path)
       end
 
       # Generic callback for any attribute/library/lwrp/recipe file throwing an

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -40,7 +40,7 @@ class Chef
         successful_audits + failed_audits
       end
 
-      def run_completed(node)
+      def run_completed(_node)
         @end_time = Time.now
         if Chef::Config[:why_run]
           puts_line "Chef Client finished, #{@updated_resources}/#{total_resources} resources would have been updated"
@@ -52,7 +52,7 @@ class Chef
         end
       end
 
-      def run_failed(exception)
+      def run_failed(_exception)
         @end_time = Time.now
         if Chef::Config[:why_run]
           puts_line "Chef Client failed. #{@updated_resources} resources would have been updated"
@@ -65,22 +65,22 @@ class Chef
       end
 
       # Called right after ohai runs.
-      def ohai_completed(node)
+      def ohai_completed(_node)
       end
 
       # Already have a client key, assuming this node has registered.
-      def skipping_registration(node_name, config)
+      def skipping_registration(_node_name, _config)
       end
 
       # About to attempt to register as +node_name+
-      def registration_start(node_name, config)
+      def registration_start(node_name, _config)
         puts_line "Creating a new client identity for #{node_name} using the validator key."
       end
 
       def registration_completed
       end
 
-      def node_load_start(node_name, config)
+      def node_load_start(_node_name, _config)
       end
 
       # Failed to load node data from the server
@@ -90,7 +90,7 @@ class Chef
 
       # Default and override attrs from roles have been computed, but not yet applied.
       # Normal attrs from JSON have been added to the node.
-      def node_load_completed(node, expanded_run_list, config)
+      def node_load_completed(_node, _expanded_run_list, _config)
       end
 
       # Called before the cookbook collection is fetched from the server.
@@ -105,7 +105,7 @@ class Chef
       end
 
       # Called when the cookbook collection is returned from the server.
-      def cookbook_resolution_complete(cookbook_collection)
+      def cookbook_resolution_complete(_cookbook_collection)
       end
 
       # Called before unneeded cookbooks are removed
@@ -115,7 +115,7 @@ class Chef
       # Called after the file at +path+ is removed. It may be removed if the
       # cookbook containing it was removed from the run list, or if the file was
       # removed from the cookbook.
-      def removed_cookbook_file(path)
+      def removed_cookbook_file(_path)
       end
 
       # Called when cookbook cleaning is finished.
@@ -123,7 +123,7 @@ class Chef
       end
 
       # Called before cookbook sync starts
-      def cookbook_sync_start(cookbook_count)
+      def cookbook_sync_start(_cookbook_count)
         puts_line "Synchronizing Cookbooks:"
         indent
       end
@@ -134,7 +134,7 @@ class Chef
       end
 
       # Called when an individual file in a cookbook has been updated
-      def updated_cookbook_file(cookbook_name, path)
+      def updated_cookbook_file(_cookbook_name, _path)
       end
 
       # Called after all cookbooks have been sync'd.
@@ -143,12 +143,12 @@ class Chef
       end
 
       # Called when cookbook loading starts.
-      def library_load_start(file_count)
+      def library_load_start(_file_count)
         puts_line "Compiling Cookbooks..."
       end
 
       # Called after a file in a cookbook is loaded.
-      def file_loaded(path)
+      def file_loaded(_path)
       end
 
       # Called when recipes have been loaded.
@@ -165,13 +165,13 @@ class Chef
         unindent if @current_recipe
       end
 
-      def converge_failed(e)
+      def converge_failed(_e)
         # Currently a failed converge is handled the same way as a successful converge
         converge_complete
       end
 
       # Called before audit phase starts
-      def audit_phase_start(run_status)
+      def audit_phase_start(_run_status)
         puts_line "Starting audit phase"
       end
 
@@ -189,16 +189,16 @@ class Chef
         end
       end
 
-      def control_example_success(control_group_name, example_data)
+      def control_example_success(_control_group_name, _example_data)
         @successful_audits += 1
       end
 
-      def control_example_failure(control_group_name, example_data, error)
+      def control_example_failure(_control_group_name, _example_data, _error)
         @failed_audits += 1
       end
 
       # Called before action is executed on a resource.
-      def resource_action_start(resource, action, notification_type=nil, notifier=nil)
+      def resource_action_start(resource, action, _notification_type=nil, _notifier=nil)
         if resource.cookbook_name && resource.recipe_name
           resource_recipe = "#{resource.cookbook_name}::#{resource.recipe_name}"
         else
@@ -217,7 +217,7 @@ class Chef
       end
 
       # Called when a resource fails, but will retry.
-      def resource_failed_retriable(resource, action, retry_count, exception)
+      def resource_failed_retriable(_resource, _action, _retry_count, _exception)
       end
 
       # Called when a resource fails and will not be retried.
@@ -227,36 +227,36 @@ class Chef
       end
 
       # Called when a resource action has been skipped b/c of a conditional
-      def resource_skipped(resource, action, conditional)
+      def resource_skipped(resource, _action, conditional)
         # TODO: more info about conditional
         puts " (skipped due to #{conditional.short_description})", :stream => resource
         unindent
       end
 
       # Called after #load_current_resource has run.
-      def resource_current_state_loaded(resource, action, current_resource)
+      def resource_current_state_loaded(_resource, _action, _current_resource)
       end
 
       # Called when a resource has no converge actions, e.g., it was already correct.
-      def resource_up_to_date(resource, action)
+      def resource_up_to_date(resource, _action)
         @up_to_date_resources+= 1
         puts " (up to date)", :stream => resource
         unindent
       end
 
-      def resource_bypassed(resource, action, provider)
+      def resource_bypassed(resource, _action, provider)
         puts " (Skipped: whyrun not supported by provider #{provider.class.name})", :stream => resource
         unindent
       end
 
-      def output_record(line)
+      def output_record(_line)
 
       end
 
       # Called when a change has been made to a resource. May be called multiple
       # times per resource, e.g., a file may have its content updated, and then
       # its permissions updated.
-      def resource_update_applied(resource, action, update)
+      def resource_update_applied(_resource, _action, update)
         prefix = Chef::Config[:why_run] ? "Would " : ""
         Array(update).each do |line|
           next if line.nil?
@@ -274,7 +274,7 @@ class Chef
       end
 
       # Called after a resource has been completely converged.
-      def resource_updated(resource, action)
+      def resource_updated(_resource, _action)
         @updated_resources += 1
         unindent
         puts "\n"
@@ -282,7 +282,7 @@ class Chef
 
       # Called when resource current state load is skipped due to the provider
       # not supporting whyrun mode.
-      def resource_current_state_load_bypassed(resource, action, current_resource)
+      def resource_current_state_load_bypassed(resource, _action, _current_resource)
         puts_line("* Whyrun not supported for #{resource}, bypassing load.", :yellow)
       end
 
@@ -291,7 +291,7 @@ class Chef
       end
 
       # Called before handlers run
-      def handlers_start(handler_count)
+      def handlers_start(_handler_count)
         puts ''
         puts "Running handlers:"
         indent
@@ -310,7 +310,7 @@ class Chef
 
       # Called when a provider makes an assumption after a failed assertion
       # in whyrun mode, in order to allow execution to continue
-      def whyrun_assumption(action, resource, message)
+      def whyrun_assumption(_action, _resource, message)
         return unless message
         [ message ].flatten.each do |line|
           start_line("* #{line}", :yellow)
@@ -318,7 +318,7 @@ class Chef
       end
 
       # Called when an assertion declared by a provider fails
-      def provider_requirement_failed(action, resource, exception, message)
+      def provider_requirement_failed(_action, _resource, _exception, message)
         return unless message
         color = Chef::Config[:why_run] ? :yellow : :red
         [ message ].flatten.each do |line|

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -33,25 +33,25 @@ class Chef
       end
 
       # Called at the end of the Chef run.
-      def run_completed(node)
+      def run_completed(_node)
         puts "chef client finished, #{@updated_resources.size} resources updated"
       end
 
       # called at the end of a failed run
-      def run_failed(exception)
+      def run_failed(_exception)
         puts "chef client failed. #{@updated_resources.size} resources updated"
       end
 
       # Called right after ohai runs.
-      def ohai_completed(node)
+      def ohai_completed(_node)
       end
 
       # Already have a client key, assuming this node has registered.
-      def skipping_registration(node_name, config)
+      def skipping_registration(_node_name, _config)
       end
 
       # About to attempt to register as +node_name+
-      def registration_start(node_name, config)
+      def registration_start(_node_name, _config)
       end
 
       def registration_completed
@@ -62,16 +62,16 @@ class Chef
         super
       end
 
-      def node_load_start(node_name, config)
+      def node_load_start(_node_name, _config)
       end
 
       # Failed to load node data from the server
-      def node_load_failed(node_name, exception, config)
+      def node_load_failed(_node_name, _exception, _config)
       end
 
       # Default and override attrs from roles have been computed, but not yet applied.
       # Normal attrs from JSON have been added to the node.
-      def node_load_completed(node, expanded_run_list, config)
+      def node_load_completed(_node, _expanded_run_list, _config)
       end
 
       # Called before the cookbook collection is fetched from the server.
@@ -81,11 +81,11 @@ class Chef
 
       # Called when there is an error getting the cookbook collection from the
       # server.
-      def cookbook_resolution_failed(expanded_run_list, exception)
+      def cookbook_resolution_failed(_expanded_run_list, _exception)
       end
 
       # Called when the cookbook collection is returned from the server.
-      def cookbook_resolution_complete(cookbook_collection)
+      def cookbook_resolution_complete(_cookbook_collection)
       end
 
       # Called before unneeded cookbooks are removed
@@ -97,7 +97,7 @@ class Chef
       # Called after the file at +path+ is removed. It may be removed if the
       # cookbook containing it was removed from the run list, or if the file was
       # removed from the cookbook.
-      def removed_cookbook_file(path)
+      def removed_cookbook_file(_path)
       end
 
       # Called when cookbook cleaning is finished.
@@ -105,17 +105,17 @@ class Chef
       end
 
       # Called before cookbook sync starts
-      def cookbook_sync_start(cookbook_count)
+      def cookbook_sync_start(_cookbook_count)
         puts "Synchronizing cookbooks"
       end
 
       # Called when cookbook +cookbook_name+ has been sync'd
-      def synchronized_cookbook(cookbook_name)
+      def synchronized_cookbook(_cookbook_name)
         print "."
       end
 
       # Called when an individual file in a cookbook has been updated
-      def updated_cookbook_file(cookbook_name, path)
+      def updated_cookbook_file(_cookbook_name, _path)
       end
 
       # Called after all cookbooks have been sync'd.
@@ -124,12 +124,12 @@ class Chef
       end
 
       # Called when cookbook loading starts.
-      def library_load_start(file_count)
+      def library_load_start(_file_count)
         puts "Compiling cookbooks"
       end
 
       # Called after a file in a cookbook is loaded.
-      def file_loaded(path)
+      def file_loaded(_path)
         print '.'
       end
 
@@ -167,28 +167,28 @@ class Chef
       end
 
       # Called before action is executed on a resource.
-      def resource_action_start(resource, action, notification_type=nil, notifier=nil)
+      def resource_action_start(_resource, _action, _notification_type=nil, _notifier=nil)
       end
 
       # Called when a resource fails, but will retry.
-      def resource_failed_retriable(resource, action, retry_count, exception)
+      def resource_failed_retriable(_resource, _action, _retry_count, _exception)
       end
 
       # Called when a resource fails and will not be retried.
-      def resource_failed(resource, action, exception)
+      def resource_failed(_resource, _action, _exception)
       end
 
       # Called when a resource action has been skipped b/c of a conditional
-      def resource_skipped(resource, action, conditional)
+      def resource_skipped(_resource, _action, _conditional)
         print "S"
       end
 
       # Called after #load_current_resource has run.
-      def resource_current_state_loaded(resource, action, current_resource)
+      def resource_current_state_loaded(_resource, _action, _current_resource)
       end
 
       # Called when a resource has no converge actions, e.g., it was already correct.
-      def resource_up_to_date(resource, action)
+      def resource_up_to_date(_resource, _action)
         print "."
       end
 
@@ -199,22 +199,22 @@ class Chef
       # Called when a change has been made to a resource. May be called multiple
       # times per resource, e.g., a file may have its content updated, and then
       # its permissions updated.
-      def resource_update_applied(resource, action, update)
+      def resource_update_applied(resource, _action, update)
         @updates_by_resource[resource.name] << Array(update)[0]
       end
 
       # Called after a resource has been completely converged.
-      def resource_updated(resource, action)
+      def resource_updated(resource, _action)
         updated_resources << resource
         print "U"
       end
 
       # Called before handlers run
-      def handlers_start(handler_count)
+      def handlers_start(_handler_count)
       end
 
       # Called after an individual handler has run
-      def handler_executed(handler)
+      def handler_executed(_handler)
       end
 
       # Called after all handlers have executed
@@ -226,7 +226,7 @@ class Chef
       # there's no semantic information about the content or importance of the
       # message. That means that if you're using this too often, you should add a
       # callback for it.
-      def msg(message)
+      def msg(_message)
       end
 
     end

--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -22,7 +22,7 @@ class Chef
   class GuardInterpreter
     class ResourceGuardInterpreter < DefaultGuardInterpreter
 
-      def initialize(parent_resource, command, opts, &block)
+      def initialize(parent_resource, command, opts, &_block)
         super(command, opts)
         @parent_resource = parent_resource
         @resource = get_interpreter_resource(parent_resource)

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -158,7 +158,7 @@ class Chef
     #
     # If no block is given, the tempfile is returned, which means it's up to
     # you to unlink the tempfile when you're done with it.
-    def streaming_request(path, headers={}, &block)
+    def streaming_request(path, headers={}, &_block)
       url = create_url(path)
       response, rest_request, return_value = nil, nil, nil
       tempfile = nil
@@ -358,7 +358,7 @@ class Chef
       response['location']
     end
 
-    def build_headers(method, url, headers={}, json_body=false)
+    def build_headers(_method, _url, headers={}, json_body=false)
       headers                 = @default_headers.merge(headers)
       headers['Content-Length'] = json_body.bytesize.to_s if json_body
       headers.merge!(Chef::Config[:custom_http_headers]) if Chef::Config[:custom_http_headers]

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -48,7 +48,7 @@ class Chef
         [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         nil
       end
 

--- a/lib/chef/http/cookie_manager.rb
+++ b/lib/chef/http/cookie_manager.rb
@@ -27,7 +27,7 @@ class Chef
     # it, so it's included with Chef::REST
     class CookieManager
 
-      def initialize(options={})
+      def initialize(_options={})
         @cookies = CookieJar.instance
       end
 
@@ -46,7 +46,7 @@ class Chef
         [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         nil
       end
 

--- a/lib/chef/http/json_input.rb
+++ b/lib/chef/http/json_input.rb
@@ -25,7 +25,7 @@ class Chef
     # Middleware that takes json input and turns it into raw text
     class JSONInput
 
-      def initialize(opts={})
+      def initialize(_opts={})
       end
 
       def handle_request(method, url, headers={}, data=false)
@@ -45,7 +45,7 @@ class Chef
         [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         nil
       end
 

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -69,7 +69,7 @@ class Chef
         [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         nil
       end
 

--- a/lib/chef/http/remote_request_id.rb
+++ b/lib/chef/http/remote_request_id.rb
@@ -21,7 +21,7 @@ class Chef
   class HTTP
     class RemoteRequestID
 
-      def initialize(opts={})
+      def initialize(_opts={})
       end
 
       def handle_request(method, url, headers={}, data=false)
@@ -33,7 +33,7 @@ class Chef
         [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         nil
       end
 

--- a/lib/chef/http/validate_content_length.rb
+++ b/lib/chef/http/validate_content_length.rb
@@ -41,7 +41,7 @@ class Chef
         end
       end
 
-      def initialize(opts={})
+      def initialize(_opts={})
       end
 
       def handle_request(method, url, headers={}, data=false)
@@ -66,7 +66,7 @@ class Chef
         return [http_response, rest_request, return_value]
       end
 
-      def stream_response_handler(response)
+      def stream_response_handler(_response)
         @content_length_counter = ContentLengthCounter.new
       end
 

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -106,7 +106,7 @@ class Chef
 
       end
 
-      def get_category(cookbook_name)
+      def get_category(_cookbook_name)
         begin
           data = noauth_rest.get_rest("http://cookbooks.opscode.com/api/v1/cookbooks/#{@name_args[0]}")
           if !data["category"] && data["error_code"]

--- a/lib/chef/mixin/deprecation.rb
+++ b/lib/chef/mixin/deprecation.rb
@@ -60,7 +60,7 @@ class Chef
       end
 
       class DeprecatedInstanceVariable < DeprecatedObjectProxyBase
-        def initialize(target, ivar_name, level=nil)
+        def initialize(target, ivar_name, _level=nil)
           @target, @ivar_name = target, ivar_name
           @level ||= :warn
         end

--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -34,7 +34,7 @@ class Chef
       class ConvergeActions
         attr_reader :actions
 
-        def initialize(resource, run_context, action)
+        def initialize(resource, run_context, _action)
           @resource, @run_context = resource, run_context
           @actions = []
         end

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -443,7 +443,7 @@ class Chef
          end
        end
 
-       def []=(key, value)
+       def []=(_key, _value)
          raise Exceptions::ImmutableAttributeModification
        end
 

--- a/lib/chef/null_logger.rb
+++ b/lib/chef/null_logger.rb
@@ -27,25 +27,25 @@ class Chef
   # probably expected a real logger and not this "fake" one.
   class NullLogger
 
-    def fatal(message, &block)
+    def fatal(_message, &_block)
     end
 
-    def error(message, &block)
+    def error(_message, &_block)
     end
 
-    def warn(message, &block)
+    def warn(_message, &_block)
     end
 
-    def info(message, &block)
+    def info(_message, &_block)
     end
 
-    def debug(message, &block)
+    def debug(_message, &_block)
     end
 
-    def add(severity, message=nil, progname=nil)
+    def add(_severity, _message=nil, _progname=nil)
     end
 
-    def <<(message)
+    def <<(_message)
     end
 
     def fatal?

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -364,7 +364,7 @@ class Chef
         provider
       end
 
-      def provider_for_node(node, resource_type)
+      def provider_for_node(_node, _resource_type)
         raise NotImplementedError, "#{self.class.name} no longer supports #provider_for_node"
       end
 
@@ -450,7 +450,7 @@ class Chef
 
       private
 
-        def explicit_provider(platform, version, resource_type)
+        def explicit_provider(_platform, _version, resource_type)
           resource_type.kind_of?(Chef::Resource) ? resource_type.provider : nil
         end
 
@@ -460,7 +460,7 @@ class Chef
           pmap.has_key?(rtkey) ? pmap[rtkey] : nil
         end
 
-        def resource_matching_provider(platform, version, resource_type)
+        def resource_matching_provider(_platform, _version, resource_type)
           if resource_type.kind_of?(Chef::Resource)
             begin
               Chef::Provider.const_get(resource_type.class.to_s.split('::').last)

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -153,7 +153,7 @@ class Chef
         raise
       end
 
-      def setup_run_context(specific_recipes=nil)
+      def setup_run_context(_specific_recipes=nil)
         Chef::Cookbook::FileVendor.fetch_from_remote(http_api)
         sync_cookbooks
         cookbook_collection = Chef::CookbookCollection.new(cookbooks_to_sync)

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -47,7 +47,7 @@ class Chef
       end
 
       # supports the given resource and action (late binding)
-      def supports?(resource, action)
+      def supports?(_resource, _action)
         true
       end
     end

--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -354,14 +354,14 @@ class Chef
       # Override if you need to keep state externally.
       # Note that YOU are responsible for implementing whyrun-friendly behavior
       # in any actions you take in this callback.
-      def release_created(release_path)
+      def release_created(_release_path)
       end
 
       # Note that YOU are responsible for using appropriate whyrun nomenclature
       # Override if you need to keep state externally.
       # Note that YOU are responsible for implementing whyrun-friendly behavior
       # in any actions you take in this callback.
-      def release_deleted(release_path)
+      def release_deleted(_release_path)
       end
 
       def release_slug

--- a/lib/chef/provider/env.rb
+++ b/lib/chef/provider/env.rb
@@ -47,7 +47,7 @@ class Chef
         @current_resource
       end
 
-      def env_value(key_name)
+      def env_value(_key_name)
         raise Chef::Exceptions::Env, "#{self.to_s} provider does not implement env_value!"
       end
 

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -95,15 +95,15 @@ class Chef
           end
         end
 
-        def add_member(member)
+        def add_member(_member)
           raise Chef::Exceptions::Group, "you must override add_member in #{self.to_s}"
         end
 
-        def remove_member(member)
+        def remove_member(_member)
           raise Chef::Exceptions::Group, "you must override remove_member in #{self.to_s}"
         end
 
-        def set_members(members)
+        def set_members(_members)
           raise Chef::Exceptions::Group, "you must override set_members in #{self.to_s}"
         end
 

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -69,7 +69,7 @@ class Chef
           shell_out!("usermod #{append_flags} #{@new_resource.group_name} #{member}")
         end
 
-        def remove_member(member)
+        def remove_member(_member)
           # This provider only supports adding members with
           # append. This function should never be called.
           raise Chef::Exceptions::UnsupportedAction, "Removing members members is not supported by #{self.to_s}"

--- a/lib/chef/provider/lwrp_base.rb
+++ b/lib/chef/provider/lwrp_base.rb
@@ -80,7 +80,7 @@ class Chef
       include Chef::DSL::PlatformIntrospection
       include Chef::DSL::DataQuery
 
-      def self.build_from_file(cookbook_name, filename, run_context)
+      def self.build_from_file(cookbook_name, filename, _run_context)
         provider_class = nil
         provider_name = filename_to_qualified_string(cookbook_name, filename)
 

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -201,27 +201,27 @@ class Chef
       end
 
       # @todo use composition rather than inheritance
-      def install_package(name, version)
+      def install_package(_name, _version)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :install"
       end
 
-      def upgrade_package(name, version)
+      def upgrade_package(_name, _version)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :upgrade"
       end
 
-      def remove_package(name, version)
+      def remove_package(_name, _version)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :remove"
       end
 
-      def purge_package(name, version)
+      def purge_package(_name, _version)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :purge"
       end
 
-      def preseed_package(file)
+      def preseed_package(_file)
         raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support pre-seeding package install/upgrade instructions"
       end
 
-      def reconfig_package(name, version)
+      def reconfig_package(_name, _version)
         raise( Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reconfig" )
       end
 

--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -106,7 +106,7 @@ class Chef
         # options of installp.
         # So far, the code has been tested only with standalone packages.
         #
-        def install_package(name, version)
+        def install_package(_name, _version)
           Chef::Log.debug("#{@new_resource} package install options: #{@new_resource.options}")
           if @new_resource.options.nil?
             shell_out!( "installp -aYF -d #{@new_resource.source} #{@new_resource.package_name}" )
@@ -119,7 +119,7 @@ class Chef
 
         alias_method :upgrade_package, :install_package
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           if @new_resource.options.nil?
             shell_out!( "installp -u #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -148,12 +148,12 @@ class Chef
           install_package(name, version)
         end
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           package_name = [ name ].flatten.join(' ')
           run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} remove #{package_name}")
         end
 
-        def purge_package(name, version)
+        def purge_package(name, _version)
           package_name = [ name ].flatten.join(' ')
           run_noninteractive("apt-get -q -y#{expand_options(@new_resource.options)} purge #{package_name}")
         end
@@ -163,7 +163,7 @@ class Chef
           run_noninteractive("debconf-set-selections #{preseed_file}")
         end
 
-        def reconfig_package(name, version)
+        def reconfig_package(name, _version)
           package_name = [ name ].flatten.join(' ')
           Chef::Log.info("#{@new_resource} reconfiguring")
           run_noninteractive("dpkg-reconfigure #{package_name}")

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -99,21 +99,21 @@ class Chef
           @current_resource
         end
 
-        def install_package(name, version)
+        def install_package(_name, _version)
           Chef::Log.info("#{@new_resource} installing #{@new_resource.source}")
           run_noninteractive(
             "dpkg -i#{expand_options(@new_resource.options)} #{@new_resource.source}"
           )
         end
 
-        def remove_package(name, version)
+        def remove_package(_name, _version)
           Chef::Log.info("#{@new_resource} removing #{@new_resource.package_name}")
           run_noninteractive(
             "dpkg -r#{expand_options(@new_resource.options)} #{@new_resource.package_name}"
           )
         end
 
-        def purge_package(name, version)
+        def purge_package(_name, _version)
           Chef::Log.info("#{@new_resource} purging #{@new_resource.package_name}")
           run_noninteractive(
             "dpkg -P#{expand_options(@new_resource.options)} #{@new_resource.package_name}"
@@ -129,7 +129,7 @@ class Chef
           run_noninteractive("debconf-set-selections #{preseed_file}")
         end
 
-        def reconfig_package(name, version)
+        def reconfig_package(name, _version)
           Chef::Log.info("#{@new_resource} reconfiguring")
           run_noninteractive("dpkg-reconfigure #{name}")
         end

--- a/lib/chef/provider/package/easy_install.rb
+++ b/lib/chef/provider/package/easy_install.rb
@@ -120,7 +120,7 @@ class Chef
           install_package(name, version)
         end
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           run_command(:command => "#{easy_install_binary_path }#{expand_options(@new_resource.options)} -m #{name}")
         end
 

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -29,7 +29,7 @@ class Chef
         class Pkg < Base
           include PortsHelper
 
-          def install_package(name, version)
+          def install_package(_name, _version)
             unless @current_resource.version
               case @new_resource.source
               when /^http/, /^ftp/
@@ -50,7 +50,7 @@ class Chef
             end
           end
 
-          def remove_package(name, version)
+          def remove_package(_name, version)
             shell_out!("pkg_delete #{package_name}-#{version || @current_resource.version}", :env => nil).status
           end
 

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -24,7 +24,7 @@ class Chef
       module Freebsd
         class Pkgng < Base
 
-          def install_package(name, version)
+          def install_package(name, _version)
             unless @current_resource.version
               case @new_resource.source
               when /^(http|ftp|\/)/

--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -25,11 +25,11 @@ class Chef
         class Port < Base
           include PortsHelper
 
-          def install_package(name, version)
+          def install_package(_name, _version)
             shell_out!("make -DBATCH install clean", :timeout => 1800, :env => nil, :cwd => port_dir).status
           end
 
-          def remove_package(name, version)
+          def remove_package(_name, _version)
             shell_out!("make deinstall", :timeout => 300, :env => nil, :cwd => port_dir).status
           end
 

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -60,7 +60,7 @@ class Chef
           end
         end
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           if current_resource.version
             brew('uninstall', new_resource.options, name)
           end

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -84,7 +84,7 @@ class Chef
 
         end
 
-        def install_package(name, version)
+        def install_package(name, _version)
           shell_out!( "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
         end
 
@@ -92,7 +92,7 @@ class Chef
           install_package(name, version)
         end
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           shell_out!( "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
         end
 

--- a/lib/chef/provider/package/paludis.rb
+++ b/lib/chef/provider/package/paludis.rb
@@ -68,7 +68,7 @@ class Chef
           install_package(name, version)
         end
 
-        def remove_package(name, version)
+        def remove_package(_name, version)
           if(version)
             pkg = "=#{@new_resource.package_name}-#{version}"
           else

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -119,7 +119,7 @@ class Chef
           install_package(name, version)
         end
 
-        def remove_package(name, version)
+        def remove_package(_name, version)
           if(version)
             pkg = "=#{@new_resource.package_name}-#{version}"
           else

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -88,7 +88,7 @@ class Chef
           @current_resource
         end
 
-        def install_package(name, version)
+        def install_package(_name, _version)
           unless @current_resource.version
             shell_out!( "rpm #{@new_resource.options} -i #{@new_resource.source}" )
           else

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -158,7 +158,7 @@ class Chef
           # Gem::Version  a singular gem version object is returned if the gem
           #               is available
           # nil           returns nil if the gem could not be found
-          def candidate_version_from_remote(gem_dependency, *sources)
+          def candidate_version_from_remote(_gem_dependency, *_sources)
             raise NotImplementedError
           end
 

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -102,7 +102,7 @@ class Chef
           @candidate_version
         end
 
-        def install_package(name, version)
+        def install_package(_name, _version)
           Chef::Log.debug("#{@new_resource} package install options: #{@new_resource.options}")
           if @new_resource.options.nil?
             if ::File.directory?(@new_resource.source) # CHEF-4469
@@ -123,7 +123,7 @@ class Chef
           end
         end
 
-        def remove_package(name, version)
+        def remove_package(name, _version)
           if @new_resource.options.nil?
             shell_out!( "pkgrm -n #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -51,13 +51,13 @@ class Chef
             get_product_property(@new_resource.source, "ProductVersion")
           end
 
-          def install_package(name, version)
+          def install_package(_name, _version)
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             Chef::Log.debug("#{@new_resource} installing MSI package '#{@new_resource.source}'")
             shell_out!("msiexec /qn /i \"#{@new_resource.source}\" #{expand_options(@new_resource.options)}", {:timeout => @new_resource.timeout, :returns => @new_resource.returns})
           end
   
-          def remove_package(name, version)
+          def remove_package(_name, _version)
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             Chef::Log.debug("#{@new_resource} removing MSI package '#{@new_resource.source}'")
             shell_out!("msiexec /qn /x \"#{@new_resource.source}\" #{expand_options(@new_resource.options)}", {:timeout => @new_resource.timeout, :returns => @new_resource.returns})

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -147,7 +147,7 @@ class Chef
         end
 
         #adapted from buildr/lib/buildr/core/transports.rb via chef/rest/rest_client.rb
-        def proxy_uri(uri)
+        def proxy_uri(_uri)
           proxy = Chef::Config["ftp_proxy"]
           proxy = URI.parse(proxy) if String === proxy
           if Chef::Config["ftp_proxy_user"]

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -28,7 +28,7 @@ class Chef
         attr_reader :uri
         attr_reader :new_resource
 
-        def initialize(uri, new_resource, current_resource)
+        def initialize(uri, new_resource, _current_resource)
           @new_resource = new_resource
           @uri = uri
         end

--- a/lib/chef/provider/service/arch.rb
+++ b/lib/chef/provider/service/arch.rb
@@ -22,7 +22,7 @@ class Chef::Provider::Service::Arch < Chef::Provider::Service::Init
 
   provides :service, platform_family: "arch"
 
-  def self.supports?(resource, action)
+  def self.supports?(resource, _action)
     Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:etc_rcd)
   end
 

--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -31,7 +31,7 @@ class Chef
           super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:debian)
         end
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:initd)
         end
 

--- a/lib/chef/provider/service/init.rb
+++ b/lib/chef/provider/service/init.rb
@@ -28,7 +28,7 @@ class Chef
 
         provides :service, os: "!windows"
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:initd)
         end
 

--- a/lib/chef/provider/service/insserv.rb
+++ b/lib/chef/provider/service/insserv.rb
@@ -30,7 +30,7 @@ class Chef
           super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:insserv)
         end
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:initd)
         end
 

--- a/lib/chef/provider/service/invokercd.rb
+++ b/lib/chef/provider/service/invokercd.rb
@@ -29,7 +29,7 @@ class Chef
           super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:invokercd)
         end
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:initd)
         end
 

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -32,7 +32,7 @@ class Chef
           super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
         end
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:initd)
         end
 

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -32,7 +32,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
   end
 
-  def self.supports?(resource, action)
+  def self.supports?(resource, _action)
     Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:systemd)
   end
 

--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -33,7 +33,7 @@ class Chef
           super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart)
         end
 
-        def self.supports?(resource, action)
+        def self.supports?(resource, _action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:upstart)
         end
 

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -257,7 +257,7 @@ EOS
     Chef::Util::PathHelper.canonical_path("#{Dir.tmpdir}/service_logon_policy-#{clean_username_for_path(username)}-#{$$}.inf", prefix=false)
   end
 
-  def grant_dbfile_name(username)
+  def grant_dbfile_name(_username)
     "#{ENV['TEMP']}\\secedit.sdb"
   end
 

--- a/lib/chef/provider_resolver.rb
+++ b/lib/chef/provider_resolver.rb
@@ -68,7 +68,7 @@ class Chef
     end
 
     # try dynamically finding a provider based on querying the providers to see what they support
-    def maybe_dynamic_provider_resolution(resource, action)
+    def maybe_dynamic_provider_resolution(resource, _action)
       # log this so we know what providers will work for the generic resource on the node (early cut)
       Chef::Log.debug "providers for generic #{resource.resource_name} resource enabled on node include: #{enabled_handlers}"
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -617,7 +617,7 @@ class Chef
     # as_json does most of the to_json heavy lifted. It exists here in case activesupport
     # is loaded. activesupport will call as_json and skip over to_json. This ensure
     # json is encoded as expected
-    def as_json(*a)
+    def as_json(*_a)
       safe_ivars = instance_variables.map { |ivar| ivar.to_sym } - FORBIDDEN_IVARS
       instance_vars = Hash.new
       safe_ivars.each do |iv|

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class Breakpoint < Chef::Resource
 
-      def initialize(action="break", *args)
+      def initialize(_action="break", *args)
         @name = caller.first
         super(@name, *args)
         @action = "break"

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -140,7 +140,7 @@ class Chef
         @class_inherited_attributes = inherited_attributes
       end
 
-      def self.guard_inherited_attributes(*inherited_attributes)
+      def self.guard_inherited_attributes(*_inherited_attributes)
         # Similar to patterns elsewhere, return attributes from this
         # class and superclasses as a form of inheritance
         ancestor_attributes = []

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -99,13 +99,13 @@ class Chef
 
         # opts is currently unused, but included in the API
         # to support future extensions
-        def verify_block(path, opts)
+        def verify_block(path, _opts)
           @block.call(path)
         end
 
         # We reuse Chef::GuardInterpreter in order to support
         # the same set of options that the not_if/only_if blocks do
-        def verify_command(path, opts)
+        def verify_command(path, _opts)
           command = @command % {:file => path}
           interpreter = Chef::GuardInterpreter.for_resource(@parent_resource, command, @command_opts)
           interpreter.evaluate

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -43,7 +43,7 @@ class Chef
       # default for this resource, this method can be removed since
       # guard context and recipe resource context will have the
       # same behavior.
-      def self.get_default_attributes(opts)
+      def self.get_default_attributes(_opts)
         {:convert_boolean_return => true}
       end
     end

--- a/lib/chef/resource_collection/resource_list.rb
+++ b/lib/chef/resource_collection/resource_list.rb
@@ -76,7 +76,7 @@ class Chef
         @resources
       end
 
-      def execute_each_resource(&resource_exec_block)
+      def execute_each_resource(&_resource_exec_block)
         @iterator = ResourceCollection::StepableIterator.for_collection(@resources)
         @iterator.each_with_index do |resource, idx|
           @insert_after_idx = idx

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -177,17 +177,17 @@ class Chef
       end
     end
 
-    def resource_up_to_date(new_resource, action)
+    def resource_up_to_date(new_resource, _action)
       @total_res_count += 1
       @pending_update = nil unless nested_resource?(new_resource)
     end
 
-    def resource_skipped(resource, action, conditional)
+    def resource_skipped(resource, _action, _conditional)
       @total_res_count += 1
       @pending_update = nil unless nested_resource?(resource)
     end
 
-    def resource_updated(new_resource, action)
+    def resource_updated(_new_resource, _action)
       @total_res_count += 1
     end
 
@@ -209,7 +209,7 @@ class Chef
       end
     end
 
-    def run_completed(node)
+    def run_completed(_node)
       @status = "success"
       post_reporting_data
     end

--- a/lib/chef/run_list/run_list_expansion.rb
+++ b/lib/chef/run_list/run_list_expansion.rb
@@ -113,7 +113,7 @@ class Chef
       end
 
       # In subclasses, this method will fetch the role from the data source.
-      def fetch_role(name, included_by)
+      def fetch_role(_name, _included_by)
         raise NotImplementedError
       end
 

--- a/lib/chef/shell/model_wrapper.rb
+++ b/lib/chef/shell/model_wrapper.rb
@@ -59,7 +59,7 @@ module Shell
 
     alias :load :show
 
-    def transform(what_to_transform, &block)
+    def transform(what_to_transform, &_block)
       if what_to_transform == :all
         objects_to_transform = list_objects
       else

--- a/lib/chef/util/dsc/local_configuration_manager.rb
+++ b/lib/chef/util/dsc/local_configuration_manager.rb
@@ -72,7 +72,7 @@ class Chef::Util::DSC
       status
     end
 
-    def lcm_command_code(configuration_path, test_only_parameters)
+    def lcm_command_code(_configuration_path, test_only_parameters)
       <<-EOH
 $ProgressPreference = 'SilentlyContinue';start-dscconfiguration -path #{@configuration_path} -wait -erroraction 'continue' -force #{test_only_parameters}
 EOH


### PR DESCRIPTION
prepends '_' to all unused method arguments, autogenerated from rubocop.