### PR TITLE
Chef-DK nightlies on debian and el6 have been failing on these timing-based tests, doing a quick fix

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,7 @@ RSpec.configure do |config|
   # Tests that randomly fail, but may have value.
   config.filter_run_excluding :volatile => true
   config.filter_run_excluding :volatile_on_solaris => true if solaris?
+  config.filter_run_excluding :volatile_from_verify => false
 
   # Add jruby filters here
   config.filter_run_excluding :windows_only => true unless windows?

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -293,7 +293,7 @@ describe Chef::Application::Client, "run_application", :unix_only do
     allow(Chef::Client).to receive(:new).and_return(@client)
     allow(@client).to receive(:run) do
       @pipe[1].puts 'started'
-      sleep 1
+      sleep 6
       @pipe[1].puts 'finished'
     end
   end
@@ -320,9 +320,9 @@ describe Chef::Application::Client, "run_application", :unix_only do
         end
         expect(@pipe[0].gets).to eq("started\n")
         Process.kill("TERM", pid)
-        Process.wait
-        sleep 1 # Make sure we give the converging child process enough time to finish
-        expect(IO.select([@pipe[0]], nil, nil, 0)).not_to be_nil
+        Process.wait(pid)
+        # The timeout value needs to be large enough for the child process to finish
+        expect(IO.select([@pipe[0]], nil, nil, 15)).not_to be_nil
         expect(@pipe[0].gets).to eq("finished\n")
       end
     end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -293,7 +293,7 @@ describe Chef::Application::Client, "run_application", :unix_only do
     allow(Chef::Client).to receive(:new).and_return(@client)
     allow(@client).to receive(:run) do
       @pipe[1].puts 'started'
-      sleep 6
+      sleep 1
       @pipe[1].puts 'finished'
     end
   end
@@ -305,7 +305,9 @@ describe Chef::Application::Client, "run_application", :unix_only do
         allow(Chef::Daemon).to receive(:daemonize).and_return(true)
       end
 
-      it "should exit hard with exitstatus 3" do
+      # In ChefDK builds this sometimes fails from `chef verify`
+      # https://github.com/chef/chef/pull/3039
+      it "should exit hard with exitstatus 3", :volatile_from_verify do
         pid = fork do
           @app.run_application
         end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -305,7 +305,8 @@ describe Chef::Application::Client, "run_application", :unix_only do
         allow(Chef::Daemon).to receive(:daemonize).and_return(true)
       end
 
-      # In ChefDK builds this sometimes fails from `chef verify`
+      # In ChefDK builds this sometimes fails from `chef verify`.  If the test
+      # begins to fail for normal chef builds, change it to :volatile completely
       # https://github.com/chef/chef/pull/3039
       it "should exit hard with exitstatus 3", :volatile_from_verify do
         pid = fork do


### PR DESCRIPTION
I built an omnibus-chef package and didn't see the failures we have seen for the past few days.  Failure:

```
Failures:

  1) Chef::Application::Client run_application when sent SIGTERM when converging in forked process should exit hard with exitstatus 3
     Failure/Error: expect(result.exitstatus).to eq(3)
       
       expected: 3
            got: 0
       
       (compared using ==)
     # ./spec/unit/application/client_spec.rb:314:in `block (4 levels) in <top (required)>'
```

My theory is that the machine is slow and only waiting 1 second doesn't give enough time for the Kill statement to propagate.

\cc @chef/client-core 