### PR TITLE
Load LaunchAgents as console user, adding plist and session_type options

### DIFF
--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -58,8 +58,7 @@ class Chef
             @console_user = Etc.getlogin
             Chef::Log.debug("Console User: '#{@console_user}'")
             cmd = "su "
-            param = ''
-            param = "-l " if not node['platform_version'].include?('10.10')
+            param = !node['platform_version'].include?('10.10') ? '-l ' : ''
             @base_user_cmd = cmd + param + "#{@console_user} -c "
             # Default LauchAgent session should be Aqua
             @session_type = 'Aqua' if @session_type.nil?

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -48,9 +48,7 @@ class Chef
           @current_resource.service_name(@new_resource.service_name)
           @plist_size = 0
           @plist = @new_resource.plist ? @new_resource.plist : find_service_plist
-          Chef::Log.debug("#{new_resource} Plist: '#{@plist}'")
           @service_label = find_service_label
-          Chef::Log.debug("#{new_resource} service_label: '#{@service_label}'")
           # LauchAgents should be loaded as the console user.
           @console_user = @plist ? @plist.include?('LaunchAgents') : false
           @session_type = @new_resource.session_type
@@ -65,6 +63,7 @@ class Chef
             @session_type = 'Aqua' if @session_type.nil?
           end
 
+          Chef::Log.debug("#{new_resource} Plist: '#{@plist}' service_label: '#{@service_label}'")
           set_service_status
 
           @current_resource

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -70,7 +70,6 @@ class Chef
         end
 
         def define_resource_requirements
-          #super
           requirements.assert(:reload) do |a|
             a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
           end
@@ -88,7 +87,7 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             a.assertion { @plist_size > 0 }
-            # No failrue here in original code - so we also will not
+            # No failure here in original code - so we also will not
             # fail. Instead warn that the service is potentially missing
             a.whyrun "Assuming that the service would have been previously installed and is currently disabled." do
               @current_resource.enabled(false)

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -48,16 +48,16 @@ class Chef
           @current_resource.service_name(@new_resource.service_name)
           @plist_size = 0
           @plist = @new_resource.plist ? @new_resource.plist : find_service_plist
-          Chef::Log.debug("Plist: '#{@plist}'")
+          Chef::Log.debug("#{new_resource} Plist: '#{@plist}'")
           @service_label = find_service_label
-          Chef::Log.debug("Service_Label: '#{@service_label}'")
+          Chef::Log.debug("#{new_resource} service_label: '#{@service_label}'")
           # LauchAgents should be loaded as the console user.
           @console_user = @plist ? @plist.include?('LaunchAgents') : false
           @session_type = @new_resource.session_type
 
           if @console_user
             @console_user = Etc.getlogin
-            Chef::Log.debug("Console User: '#{@console_user}'")
+            Chef::Log.debug("#{new_resource} console_user: '#{@console_user}'")
             cmd = "su "
             param = !node['platform_version'].include?('10.10') ? '-l ' : ''
             @base_user_cmd = cmd + param + "#{@console_user} -c"

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -1,4 +1,3 @@
-# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
 # Author:: Igor Afonov <afonov@gmail.com>
 # Copyright:: Copyright (c) 2011 Igor Afonov

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -1,0 +1,55 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Author:: Mike Dodge (<mikedodge04@gmail.com>)
+# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource/service'
+
+class Chef
+  class Resource
+    class MacosxService < Chef::Resource::Service
+
+      provides :service, os: "darwin"
+      provides :macosx_service, os: "darwin"
+
+      def initialize(name, run_context=nil)
+        super
+        @plist = nil
+        @session_type = nil
+      end
+
+      # This will enable user to pass a plist in the case
+      # that the filename and label for the service dont match
+      def plist(arg=nil)
+        set_or_return(
+          :plist,
+          arg,
+          :kind_of => String
+        )
+      end
+
+      def session_type(arg=nil)
+        set_or_return(
+          :session_type,
+          arg,
+          :kind_of => String
+        )
+      end
+
+    end
+  end
+end

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -1,4 +1,3 @@
-# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
 # Author:: Mike Dodge (<mikedodge04@gmail.com>)
 # Copyright:: Copyright (c) 2009 Opscode, Inc.

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -26,8 +26,13 @@ class Chef
       provides :service, os: "darwin"
       provides :macosx_service, os: "darwin"
 
+      identity_attr :service_name
+
+      state_attrs :enabled, :running
+
       def initialize(name, run_context=nil)
         super
+        @resource_name = :macosx_service
         @plist = nil
         @session_type = nil
       end

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Mike Dodge (<mikedodge04@gmail.com>)
-# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# Copyright:: Copyright (c) 2015 Facebook, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,7 @@ class Chef
       # This will enable user to pass a plist in the case
       # that the filename and label for the service dont match
       def plist(arg=nil)
+        assert_path_exists(arg) unless arg.nil?
         set_or_return(
           :plist,
           arg,

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -39,7 +39,6 @@ class Chef
       # This will enable user to pass a plist in the case
       # that the filename and label for the service dont match
       def plist(arg=nil)
-        assert_path_exists(arg) unless arg.nil?
         set_or_return(
           :plist,
           arg,

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -1,4 +1,3 @@
-# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
 # Author:: Tyler Cloke (<tyler@opscode.com>)

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -1,3 +1,4 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
 # Author:: Tyler Cloke (<tyler@opscode.com>)

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -159,22 +159,6 @@ SVC_LIST
               end
 
               describe "running unsupported actions" do
-                let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
-{
-  "LimitLoadToSessionType" = "System";
-  "Label" = "io.redis.redis-server";
-  "TimeOut" = 30;
-  "OnDemand" = false;
-  "LastExitStatus" = 0;
-  "PID" = 62803;
-  "Program" = "do_some.sh";
-  "ProgramArguments" = (
-    "path/to/do_something.sh";
-    "-f";
-  );
-};
-SVC_LIST
-
                 before do
                   allow(Dir).to receive(:glob).and_return(["#{plist}"], [])
                 end

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -161,6 +161,7 @@ SVC_LIST
               describe "running unsupported actions" do
                 before do
                   allow(Dir).to receive(:glob).and_return(["#{plist}"], [])
+                  allow(File).to receive(:exists?).and_return([true], [])
                 end
                 it "should throw an exception when reload action is attempted" do
                   expect {provider.run_action(:reload)}.to raise_error(Chef::Exceptions::UnsupportedAction)

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -81,6 +81,7 @@ XML
                     with(/(#{su_cmd} '#{cmd}'|#{cmd})/).
                     and_return(double("Status",
                                     :stdout => launchctl_stdout, :exitstatus => 0))
+            allow(File).to receive(:exists?).and_return([true], [])
             allow(provider).to receive(:shell_out_with_systems_locale!).
                     with(/plutil -convert xml1 -o/).
                     and_return(double("Status", :stdout => plutil_stdout))
@@ -106,6 +107,7 @@ XML
 
                 before do
                   allow(Dir).to receive(:glob).and_return([])
+                  allow(File).to receive(:exists?).and_return([true], [])
                   allow(provider).to receive(:shell_out!).
                           with(/plutil -convert xml1 -o/).
                           and_raise(Mixlib::ShellOut::ShellCommandFailed)

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -59,70 +59,77 @@ describe Chef::Provider::Service::Macosx do
 XML
 
     ["Daemon", "Agent"].each do |service_type|
-      before do
-        @service_name = 'io.redis.redis-server'
-        @plist = '/Library/LaunchDaemons/io.redis.redis-server.plist'
-        if service_type.include?('Agent')
-          @plist = '/Library/LaunchAgents/io.redis.redis-server.plist'
-        end
-        allow(node).to receive(:[]).with("platform_version").and_return('10.10')
-        allow(Etc).to receive(:getlogin).and_return('igor')
-        allow(Dir).to receive(:glob).and_return([@plist], [])
-        @su_cmd = 'su igor -c'
-        cmd = "launchctl list #{@service_name}"
-        allow(provider).to receive(:shell_out_with_systems_locale).
-                 with(/(#{@su_cmd} '#{cmd}'|#{cmd})/).
-                 and_return(double("Status",
-                                 :stdout => launchctl_stdout, :exitstatus => 0))
-        allow(provider).to receive(:shell_out_with_systems_locale!).
-                 with(/plutil -convert xml1 -o/).
-                 and_return(double("Status", :stdout => plutil_stdout))
-      end
-
-      context "#{@service_name}" do
-        let(:new_resource) { Chef::Resource::MacosxService.new(@service_name) }
-        let!(:current_resource) { Chef::Resource::MacosxService.new(@service_name) }
-
-        describe "#load_current_resource" do
-
-          # CHEF-5223 "you can't glob for a file that hasn't been converged
-          # onto the node yet."
-          context "when the plist doesn't exist" do
-
-            def run_resource_setup_for_action(action)
-              new_resource.action(action)
-              provider.action = action
-              provider.load_current_resource
-              provider.define_resource_requirements
-              provider.process_resource_requirements
-            end
-
-            before do
-              allow(Dir).to receive(:glob).and_return([])
-              allow(provider).to receive(:shell_out!).
-                       with(/plutil -convert xml1 -o/).
-                       and_raise(Mixlib::ShellOut::ShellCommandFailed)
-            end
-
-            it "works for action :nothing" do
-              expect { run_resource_setup_for_action(:nothing) }.not_to raise_error
-            end
-
-            it "works for action :start" do
-              expect { run_resource_setup_for_action(:start) }.not_to raise_error
-            end
-
-            it "errors if action is :enable" do
-              expect { run_resource_setup_for_action(:enable) }.to raise_error(Chef::Exceptions::Service)
-            end
-
-            it "errors if action is :disable" do
-              expect { run_resource_setup_for_action(:disable) }.to raise_error(Chef::Exceptions::Service)
+      ["redis-server", "io.redis.redis-server"].each do |service_name|
+        ["10.9", "10.10"].each do |platform_version|
+          let(:plist) {'/Library/LaunchDaemons/io.redis.redis-server.plist'}
+          let(:session) { StringIO.new }
+          if service_type == 'Agent'
+            let(:plist) {'/Library/LaunchAgents/io.redis.redis-server.plist'}
+            let(:session) {'-S Aqua '}
+            let(:su_cmd) {'su igor -c'}
+            if platform_version != "10.10"
+              let(:su_cmd) {'su -l igor -c'}
             end
           end
+          let(:service_label) {'io.redis.redis-server'}
+          before do
+            allow(Dir).to receive(:glob).and_return([plist], [])
+            allow(Etc).to receive(:getlogin).and_return('igor')
+            allow(node).to receive(:[]).with("platform_version").and_return(platform_version)
+            cmd = "launchctl list #{service_label}"
+            allow(provider).to receive(:shell_out_with_systems_locale).
+                    with(/(#{su_cmd} '#{cmd}'|#{cmd})/).
+                    and_return(double("Status",
+                                    :stdout => launchctl_stdout, :exitstatus => 0))
+            allow(provider).to receive(:shell_out_with_systems_locale!).
+                    with(/plutil -convert xml1 -o/).
+                    and_return(double("Status", :stdout => plutil_stdout))
+          end
 
-          context "when launchctl returns pid in service list" do
-            let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
+          context "#{service_name} that is a #{service_type} running Osx #{platform_version}" do
+            let(:new_resource) { Chef::Resource::MacosxService.new(service_name) }
+            let!(:current_resource) { Chef::Resource::MacosxService.new(service_name) }
+
+            describe "#load_current_resource" do
+
+              # CHEF-5223 "you can't glob for a file that hasn't been converged
+              # onto the node yet."
+              context "when the plist doesn't exist" do
+
+                def run_resource_setup_for_action(action)
+                  new_resource.action(action)
+                  provider.action = action
+                  provider.load_current_resource
+                  provider.define_resource_requirements
+                  provider.process_resource_requirements
+                end
+
+                before do
+                  allow(Dir).to receive(:glob).and_return([])
+                  allow(provider).to receive(:shell_out!).
+                          with(/plutil -convert xml1 -o/).
+                          and_raise(Mixlib::ShellOut::ShellCommandFailed)
+                end
+
+                it "works for action :nothing" do
+                  expect { run_resource_setup_for_action(:nothing) }.not_to raise_error
+                end
+
+                it "works for action :start" do
+                  expect { run_resource_setup_for_action(:start) }.not_to raise_error
+                end
+
+                it "errors if action is :enable" do
+                  expect { run_resource_setup_for_action(:enable) }.to raise_error(Chef::Exceptions::Service)
+                end
+
+                it "errors if action is :disable" do
+                  expect { run_resource_setup_for_action(:disable) }.to raise_error(Chef::Exceptions::Service)
+                end
+              end
+
+              context "when launchctl returns pid in service list" do
+                let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
 {
   "LimitLoadToSessionType" = "System";
   "Label" = "io.redis.redis-server";
@@ -138,21 +145,21 @@ XML
 };
 SVC_LIST
 
-            before do
-              provider.load_current_resource
-            end
+                before do
+                  provider.load_current_resource
+                end
 
-            it "sets resource running state to true" do
-              expect(provider.current_resource.running).to be_truthy
-            end
+                it "sets resource running state to true" do
+                  expect(provider.current_resource.running).to be_truthy
+                end
 
-            it "sets resouce enabled state to true" do
-              expect(provider.current_resource.enabled).to be_truthy
-            end
-          end
+                it "sets resouce enabled state to true" do
+                  expect(provider.current_resource.enabled).to be_truthy
+                end
+              end
 
-          describe "running unsupported actions" do
-            let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
+              describe "running unsupported actions" do
+                let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
 {
   "LimitLoadToSessionType" = "System";
   "Label" = "io.redis.redis-server";
@@ -168,15 +175,15 @@ SVC_LIST
 };
 SVC_LIST
 
-            before do
-              allow(Dir).to receive(:glob).and_return(["#{@plist}"], [])
-            end
-            it "should throw an exception when reload action is attempted" do
-              expect {provider.run_action(:reload)}.to raise_error(Chef::Exceptions::UnsupportedAction)
-            end
-          end
-          context "when launchctl returns empty service pid" do
-            let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
+                before do
+                  allow(Dir).to receive(:glob).and_return(["#{plist}"], [])
+                end
+                it "should throw an exception when reload action is attempted" do
+                  expect {provider.run_action(:reload)}.to raise_error(Chef::Exceptions::UnsupportedAction)
+                end
+              end
+              context "when launchctl returns empty service pid" do
+                let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
 {
   "LimitLoadToSessionType" = "System";
   "Label" = "io.redis.redis-server";
@@ -191,147 +198,148 @@ SVC_LIST
 };
 SVC_LIST
 
-            before do
-              provider.load_current_resource
+                before do
+                  provider.load_current_resource
+                end
+
+                it "sets resource running state to false" do
+                  expect(provider.current_resource.running).to be_falsey
+                end
+
+                it "sets resouce enabled state to true" do
+                  expect(provider.current_resource.enabled).to be_truthy
+                end
+              end
+
+              context "when launchctl doesn't return service entry at all" do
+                let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
+Could not find service "io.redis.redis-server" in domain for system
+SVC_LIST
+
+                it "sets service running state to false" do
+                  provider.load_current_resource
+                  expect(provider.current_resource.running).to be_falsey
+                end
+
+                context "and plist for service is not available" do
+                  before do
+                    allow(Dir).to receive(:glob).and_return([])
+                    provider.load_current_resource
+                  end
+
+                  it "sets resouce enabled state to false" do
+                    expect(provider.current_resource.enabled).to be_falsey
+                  end
+                end
+
+                context "and plist for service is available" do
+                  before do
+                    allow(Dir).to receive(:glob).and_return(["#{plist}"], [])
+                    provider.load_current_resource
+                  end
+
+                  it "sets resouce enabled state to true" do
+                    expect(provider.current_resource.enabled).to be_truthy
+                  end
+                end
+
+                describe "and several plists match service name" do
+                  it "throws exception" do
+                    allow(Dir).to receive(:glob).and_return(["#{plist}",
+                                                "/Users/wtf/something.plist"])
+                    provider.load_current_resource
+                    provider.define_resource_requirements
+                    expect { provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
+                  end
+                end
+              end
             end
-
-            it "sets resource running state to false" do
-              expect(provider.current_resource.running).to be_falsey
-            end
-
-            it "sets resouce enabled state to true" do
-              expect(provider.current_resource.enabled).to be_truthy
-            end
-          end
-
-          context "when launchctl doesn't return service entry at all" do
-            let(:launchctl_stdout) { StringIO.new <<-SVC_LIST }
-  Could not find service "io.redis.redis-server" in domain for system
-  SVC_LIST
-
-            it "sets service running state to false" do
-              provider.load_current_resource
-              expect(provider.current_resource.running).to be_falsey
-            end
-
-            context "and plist for service is not available" do
+            describe "#start_service" do
               before do
-                allow(Dir).to receive(:glob).and_return([])
+                allow(Chef::Resource::MacosxService).to receive(:new).and_return(current_resource)
                 provider.load_current_resource
+                allow(current_resource).to receive(:running).and_return(false)
               end
 
-              it "sets resouce enabled state to false" do
-                expect(provider.current_resource.enabled).to be_falsey
+              it "calls the start command if one is specified and service is not running" do
+                allow(new_resource).to receive(:start_command).and_return("cowsay dirty")
+
+                expect(provider).to receive(:shell_out_with_systems_locale!).with("cowsay dirty")
+                provider.start_service
+              end
+
+              it "shows warning message if service is already running" do
+                allow(current_resource).to receive(:running).and_return(true)
+                expect(Chef::Log).to receive(:debug).with("macosx_service[#{service_name}] already running, not starting")
+
+                provider.start_service
+              end
+
+              it "starts service via launchctl if service found" do
+                cmd = 'launchctl load -w ' + session + plist
+                expect(provider).to receive(:shell_out_with_systems_locale).
+                        with(/(#{su_cmd} .#{cmd}.|#{cmd})/).
+                        and_return(0)
+
+                provider.start_service
               end
             end
 
-            context "and plist for service is available" do
+            describe "#stop_service" do
               before do
-                allow(Dir).to receive(:glob).and_return(["#{@plist}"], [])
+                allow(Chef::Resource::MacosxService).to receive(:new).and_return(current_resource)
+
                 provider.load_current_resource
+                allow(current_resource).to receive(:running).and_return(true)
               end
 
-              it "sets resouce enabled state to true" do
-                expect(provider.current_resource.enabled).to be_truthy
+              it "calls the stop command if one is specified and service is running" do
+                allow(new_resource).to receive(:stop_command).and_return("kill -9 123")
+
+                expect(provider).to receive(:shell_out_with_systems_locale!).with("kill -9 123")
+                provider.stop_service
+              end
+
+              it "shows warning message if service is not running" do
+                allow(current_resource).to receive(:running).and_return(false)
+                expect(Chef::Log).to receive(:debug).with("macosx_service[#{service_name}] not running, not stopping")
+
+                provider.stop_service
+              end
+
+              it "stops the service via launchctl if service found" do
+                cmd = 'launchctl unload -w '+ plist
+                expect(provider).to receive(:shell_out_with_systems_locale).
+                        with(/(#{su_cmd} .#{cmd}.|#{cmd})/).
+                        and_return(0)
+
+                provider.stop_service
               end
             end
 
-            describe "and several plists match service name" do
-              it "throws exception" do
-                allow(Dir).to receive(:glob).and_return(["#{@plist}",
-                                             "/Users/wtf/something.plist"])
+            describe "#restart_service" do
+              before do
+                allow(Chef::Resource::Service).to receive(:new).and_return(current_resource)
+
                 provider.load_current_resource
-                provider.define_resource_requirements
-                expect { provider.process_resource_requirements }.to raise_error(Chef::Exceptions::Service)
+                allow(current_resource).to receive(:running).and_return(true)
+                allow(provider).to receive(:sleep)
+              end
+
+              it "issues a command if given" do
+                allow(new_resource).to receive(:restart_command).and_return("reload that thing")
+
+                expect(provider).to receive(:shell_out_with_systems_locale!).with("reload that thing")
+                provider.restart_service
+              end
+
+              it "stops and then starts service" do
+                expect(provider).to receive(:unload_service)
+                expect(provider).to receive(:load_service);
+
+                provider.restart_service
               end
             end
-          end
-        end
-        describe "#start_service" do
-          before do
-            allow(Chef::Resource::Service).to receive(:new).and_return(current_resource)
-            provider.load_current_resource
-            allow(current_resource).to receive(:running).and_return(false)
-          end
-
-          it "calls the start command if one is specified and service is not running" do
-            allow(new_resource).to receive(:start_command).and_return("cowsay dirty")
-
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("cowsay dirty")
-            provider.start_service
-          end
-
-          it "shows warning message if service is already running" do
-            allow(current_resource).to receive(:running).and_return(true)
-            expect(Chef::Log).to receive(:debug).with("macosx_service[#{@service_name}] already running, not starting")
-
-            provider.start_service
-          end
-
-          it "starts service via launchctl if service found" do
-            session_type = @plist.include?('Agent') ? "-S Aqua " : ''
-            cmd = 'launchctl load -w ' + session_type + @plist
-            expect(provider).to receive(:shell_out_with_systems_locale).
-                     with(/(#{@su_cmd} .#{cmd}.|#{cmd})/).
-                     and_return(0)
-
-            provider.start_service
-          end
-        end
-
-        describe "#stop_service" do
-          before do
-            allow(Chef::Resource::Service).to receive(:new).and_return(current_resource)
-
-            provider.load_current_resource
-            allow(current_resource).to receive(:running).and_return(true)
-          end
-
-          it "calls the stop command if one is specified and service is running" do
-            allow(new_resource).to receive(:stop_command).and_return("kill -9 123")
-
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("kill -9 123")
-            provider.stop_service
-          end
-
-          it "shows warning message if service is not running" do
-            allow(current_resource).to receive(:running).and_return(false)
-            expect(Chef::Log).to receive(:debug).with("macosx_service[#{@service_name}] not running, not stopping")
-
-            provider.stop_service
-          end
-
-          it "stops the service via launchctl if service found" do
-            cmd = "launchctl unload -w #{@plist}"
-            expect(provider).to receive(:shell_out_with_systems_locale).
-                     with(/(#{@su_cmd} .#{cmd}.|#{cmd})/).
-                     and_return(0)
-
-            provider.stop_service
-          end
-        end
-
-        describe "#restart_service" do
-          before do
-            allow(Chef::Resource::Service).to receive(:new).and_return(current_resource)
-
-            provider.load_current_resource
-            allow(current_resource).to receive(:running).and_return(true)
-            allow(provider).to receive(:sleep)
-          end
-
-          it "issues a command if given" do
-            allow(new_resource).to receive(:restart_command).and_return("reload that thing")
-
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("reload that thing")
-            provider.restart_service
-          end
-
-          it "stops and then starts service" do
-            expect(provider).to receive(:unload_service)
-            expect(provider).to receive(:load_service);
-
-            provider.restart_service
           end
         end
       end


### PR DESCRIPTION
Proposed changes to chef mac osx service provider. This adds two
resource parameters, @plist and @session_type and changes logic to Load
LaunchAgents as Console user.

@plist: Adds the logic to handle
(https://github.com/chef/chef/issues/2200) by Giving the user the
option to pass a plist, in the case that the plist name and label name
don't match.

@session_type to help account launching
the service as the console user with a different session type.

( Im a Facebook employee and PhilD will do the final merge. )