### PR TITLE
dscl specs should only run on mac

### DIFF
--- a/spec/functional/resource/user/dscl_spec.rb
+++ b/spec/functional/resource/user/dscl_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 require 'chef/mixin/shell_out'
 
 metadata = {
-  :unix_only => true,
+  :mac_osx_only => true,
   :requires_root => true,
   :not_supported_on_mac_osx_106 => true,
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,6 +115,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?
   config.filter_run_excluding :not_supported_on_mac_osx_106 => true if mac_osx_106?
   config.filter_run_excluding :not_supported_on_mac_osx=> true if mac_osx?
+  config.filter_run_excluding :mac_osx_only=> true if !mac_osx?
   config.filter_run_excluding :not_supported_on_win2k3 => true if windows_win2k3?
   config.filter_run_excluding :not_supported_on_solaris => true if solaris?
   config.filter_run_excluding :win2k3_only => true unless windows_win2k3?


### PR DESCRIPTION
Not sure why travis didn't catch this, but i've broken specs on everything except mac.