### PR TITLE
Cleanup user directories if state was leftover from previous run

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -82,7 +82,11 @@ describe Chef::Provider::User::Useradd, metadata do
       shell_out("rm", "-r", f)
     end
     ['cf-test'].each do |u|
-      shell_out("userdel", "-r", username)
+      if RUBY_PLATFORM =~ /freebsd/
+        shell_out("pw", "userdel", "-r", username)
+      else
+        shell_out("userdel", "-r", username)
+      end
     end
   end
 

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -78,7 +78,7 @@ describe Chef::Provider::User::Useradd, metadata do
   end
 
   def try_cleanup
-    ['/home/foo', '/home/bar'].each do |f|
+    ['/home/cheftestfoo', '/home/cheftestbar'].each do |f|
       shell_out("rm", "-r", f)
     end
 
@@ -400,18 +400,18 @@ describe Chef::Provider::User::Useradd, metadata do
       end
 
       context "and home directory is updated" do
-        let(:existing_home) { "/home/foo" }
-        let(:home) { "/home/bar" }
+        let(:existing_home) { "/home/cheftestfoo" }
+        let(:home) { "/home/cheftestbar" }
         it "ensures the home directory is set to the desired value" do
-          expect(pw_entry.home).to eq("/home/bar")
+          expect(pw_entry.home).to eq("/home/cheftestbar")
         end
 
         context "and manage_home is enabled" do
           let(:existing_manage_home) { true }
           let(:manage_home) { true }
           it "moves the home directory to the new location" do
-            expect(File).not_to exist("/home/foo")
-            expect(File).to exist("/home/bar")
+            expect(File).not_to exist("/home/cheftestfoo")
+            expect(File).to exist("/home/cheftestbar")
           end
         end
 
@@ -423,19 +423,19 @@ describe Chef::Provider::User::Useradd, metadata do
             # Inconsistent behavior. See: CHEF-2205
             it "created the home dir b/c of CHEF-2205 so it still exists" do
               # This behavior seems contrary to expectation and non-convergent.
-              expect(File).not_to exist("/home/foo")
-              expect(File).to exist("/home/bar")
+              expect(File).not_to exist("/home/cheftestfoo")
+              expect(File).to exist("/home/cheftestbar")
             end
           elsif ohai[:platform] == "aix"
             it "creates the home dir in the desired location" do
-              expect(File).not_to exist("/home/foo")
-              expect(File).to exist("/home/bar")
+              expect(File).not_to exist("/home/cheftestfoo")
+              expect(File).to exist("/home/cheftestbar")
             end
           else
             it "does not create the home dir in the desired location (XXX)" do
               # This behavior seems contrary to expectation and non-convergent.
-              expect(File).not_to exist("/home/foo")
-              expect(File).not_to exist("/home/bar")
+              expect(File).not_to exist("/home/cheftestfoo")
+              expect(File).not_to exist("/home/cheftestbar")
             end
           end
         end
@@ -446,8 +446,8 @@ describe Chef::Provider::User::Useradd, metadata do
 
           it "leaves the old home directory around (XXX)" do
             # Would it be better to remove the old home?
-            expect(File).to exist("/home/foo")
-            expect(File).not_to exist("/home/bar")
+            expect(File).to exist("/home/cheftestfoo")
+            expect(File).not_to exist("/home/cheftestbar")
           end
         end
       end

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -81,12 +81,11 @@ describe Chef::Provider::User::Useradd, metadata do
     ['/home/foo', '/home/bar'].each do |f|
       shell_out("rm", "-r", f)
     end
+
     ['cf-test'].each do |u|
-      if RUBY_PLATFORM =~ /freebsd/
-        shell_out("pw", "userdel", "-r", username)
-      else
-        shell_out("userdel", "-r", username)
-      end
+      r = Chef::Resource::User.new("DELETE USER", run_context)
+      r.username('cf-test')
+      r.run_action(:remove)
     end
   end
 

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -79,7 +79,7 @@ describe Chef::Provider::User::Useradd, metadata do
 
   def try_cleanup
     ['/home/cheftestfoo', '/home/cheftestbar'].each do |f|
-      shell_out("rm", "-r", f)
+      FileUtils.rm_rf(f) if File.exists? f
     end
 
     ['cf-test'].each do |u|

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -77,9 +77,19 @@ describe Chef::Provider::User::Useradd, metadata do
     end
   end
 
+  def try_cleanup
+    ['/home/foo', '/home/bar'].each do |f|
+      shell_out("rm", "-r", f)
+    end
+    ['cf-test'].each do |u|
+      shell_out("userdel", "-r", username)
+    end
+  end
+
   before do
     # Silence shell_out live stream
     Chef::Log.level = :warn
+    try_cleanup
   end
 
   after do


### PR DESCRIPTION
We are seeing failures in our CI relating to state not being cleaned
up in a previous run:

```
  1) Chef::Provider::User::Useradd action :create when the user already exists and home directory is updated and manage_home is enabled moves the home directory to the new location
     Failure/Error: user_resource.run_action(:create)
     Mixlib::ShellOut::ShellCommandFailed:
       user[TEST USER RESOURCE] (dynamically defined) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '12'
       ---- Begin output of ["usermod", "-d", "/home/bar", "-m", "cf-test"] ----
       STDOUT:
       STDERR: usermod: directory /home/bar exists
       ---- End output of ["usermod", "-d", "/home/bar", "-m", "cf-test"] ----
       Ran ["usermod", "-d", "/home/bar", "-m", "cf-test"] returned 12
     # ./lib/chef/mixin/shell_out.rb:56:in `shell_out!'
     # ./lib/chef/provider/user/useradd.rb:42:in `manage_user'
     # ./lib/chef/provider/user.rb:137:in `block in action_create'
     # ./lib/chef/mixin/why_run.rb:52:in `call'
     # ./lib/chef/mixin/why_run.rb:52:in `add_action'
     # ./lib/chef/provider.rb:180:in `converge_by'
     # ./lib/chef/provider/user.rb:136:in `action_create'
     # ./lib/chef/provider.rb:145:in `run_action'
     # ./lib/chef/resource.rb:561:in `run_action'
     # ./spec/functional/resource/user/useradd_spec.rb:336:in `block (4 levels) in <top (required)>'
```