### PR TITLE
Remove superfluous local variable setting.

### DIFF
--- a/lib/chef/chef_fs/file_system/acl_dir.rb
+++ b/lib/chef/chef_fs/file_system/acl_dir.rb
@@ -30,8 +30,8 @@ class Chef
 
         def child(name)
           result = @children.select { |child| child.name == name }.first if @children
-          result ||= can_have_child?(name, false) ?
-                     AclEntry.new(name, self) : NonexistentFSObject.new(name, self)
+          result || can_have_child?(name, false) ?
+                    AclEntry.new(name, self) : NonexistentFSObject.new(name, self)
         end
 
         def can_have_child?(name, is_dir)


### PR DESCRIPTION
The variable `result` was being set and returned, but the variable isn't being used elsewhere. That means it doesn't need to be set with `||=`, just returned with `||`.

Obvious fix.