### PR TITLE
make audit terminology consistent

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -451,9 +451,9 @@ class Chef::Application::Client < Chef::Application
 
   def audit_mode_experimental_message
     msg = if Chef::Config[:audit_mode] == :audit_only
-      "Chef-client has been configured to skip converge and run only audits."
+      "Chef-client has been configured to skip converge and only audit."
     else
-      "Chef-client has been configured to run audits after it converges."
+      "Chef-client has been configured to audit after it converges."
     end
     msg += " Audit mode is an experimental feature currently under development. API changes may occur. Use at your own risk."
     msg += audit_mode_settings_explaination

--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -105,7 +105,7 @@ class Chef
         end
 
         unless run_status
-          Chef::Log.debug("Run failed before audits were initialized, not sending audit report to server")
+          Chef::Log.debug("Run failed before audit mode was initialized, not sending audit report to server")
           return
         end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -450,7 +450,7 @@ class Chef
 
         if Chef::Config[:why_run] == true
           # why_run should probably be renamed to why_converge
-          Chef::Log.debug("Not running audits in 'why_run' mode - this mode is used to see potential converge changes")
+          Chef::Log.debug("Not running controls in 'why_run' mode - this mode is used to see potential converge changes")
         elsif Chef::Config[:audit_mode] != :disabled
           audit_error = run_audits(run_context)
         end

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -399,18 +399,18 @@ class Chef
 
     class AuditControlGroupDuplicate < RuntimeError
       def initialize(name)
-        super "Audit control group with name '#{name}' has already been defined"
+        super "Control group with name '#{name}' has already been defined"
       end
     end
     class AuditNameMissing < RuntimeError; end
     class NoAuditsProvided < RuntimeError
       def initialize
-        super "You must provide a block with audits"
+        super "You must provide a block with controls"
       end
     end
     class AuditsFailed < RuntimeError
       def initialize(num_failed, num_total)
-        super "Audit phase found failures - #{num_failed}/#{num_total} audits failed"
+        super "Audit phase found failures - #{num_failed}/#{num_total} controls failed"
       end
     end
 

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -47,7 +47,7 @@ class Chef
         else
           puts_line "Chef Client finished, #{@updated_resources}/#{total_resources} resources updated in #{elapsed_time} seconds"
           if total_audits > 0
-            puts_line "  #{successful_audits}/#{total_audits} Audits succeeded"
+            puts_line "  #{successful_audits}/#{total_audits} controls succeeded"
           end
         end
       end
@@ -59,7 +59,7 @@ class Chef
         else
           puts_line "Chef Client failed. #{@updated_resources} resources updated in #{elapsed_time} seconds"
           if total_audits > 0
-            puts_line "  #{successful_audits} Audits succeeded"
+            puts_line "  #{successful_audits} controls succeeded"
           end
         end
       end

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -50,7 +50,7 @@ class Chef
     # recipes, which is triggered by #load. (See also: CookbookCompiler)
     attr_accessor :resource_collection
 
-    # The list of audits (control groups) to execute during the audit phase
+    # The list of control groups to execute during the audit phase
     attr_accessor :audits
 
     # A Hash containing the immediate notifications triggered by resources

--- a/spec/unit/audit/audit_reporter_spec.rb
+++ b/spec/unit/audit/audit_reporter_spec.rb
@@ -203,7 +203,7 @@ describe Chef::Audit::AuditReporter do
       it "doesn't send reports" do
         expect(reporter).to receive(:auditing_enabled?).and_return(true)
         expect(reporter).to receive(:run_status).and_return(nil)
-        expect(Chef::Log).to receive(:debug).with("Run failed before audits were initialized, not sending audit report to server")
+        expect(Chef::Log).to receive(:debug).with("Run failed before audit mode was initialized, not sending audit report to server")
         reporter.run_completed(node)
       end
 


### PR DESCRIPTION
We have been a little inconsistent in the use of the term "audit" versus "control" or "control group" in audit mode. This will confuse customers, particularly those who are security-oriented, so I'd like to fix it. To wit:

* A "control" is a condition you define about system correctness
* A "control_group" is a list of one or more controls
* An "audit" is an operation you run to test your "controls". Hence, "audit mode" is correctly named. However, it makes no sense to have "audits" fail. What we actually mean is that one or more controls failed, which caused the audit as a whole to fail. You also don't "run audits" -- you perform an audit (singular), which runs one or more controls.

I'll leave it to the team to decide whether the ivars, class names, etc. should be renamed. For example, an ivar named `:audits` makes no sense; what you really mean is `:controls`.

/cc @mcquin @jamesc 