### PR TITLE
Mark failing test as pending on versions of powershell < 4

### DIFF
--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -56,7 +56,8 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       resource.run_action(:run)
     end
 
-    it "returns the -27 for a powershell script that exits with -27" do
+    it "returns the -27 for a powershell script that exits with -27", :windows_powershell_dsc_only do
+      # This is broken on Powershell < 4.0
       file = Tempfile.new(['foo', '.ps1'])
       begin
         file.write "exit -27"


### PR DESCRIPTION
This case has never worked before 6c724e866274a728bc66740ab352db7da7d7958f.
It was fixed for 4, however it seems that does not apply to versions < 4.

cc @smurawski @btm 