### PR TITLE
Issue 2247: powershell_script exit status should be nonzero for syntax errors

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -39,6 +39,11 @@ class Chef
         is_server_2003
       end
 
+      def supports_powershell_execution_bypass?(node)
+        node[:languages] && node[:languages][:powershell] &&
+          node[:languages][:powershell][:version].to_i >= 3
+      end
+
       def supports_dsc?(node)
         node[:languages] && node[:languages][:powershell] &&
           node[:languages][:powershell][:version].to_i >= 4

--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -91,7 +91,9 @@ $chefscriptresult =
  $global:lastcmdlet = $?
 }.invokereturnasis()
 
-$exitstatus = 0
+# Assume failure status of 1 -- success cases
+# will have to override this
+$exitstatus = 1
 
 # If convert_boolean_return is enabled, the block's return value
 # gets precedence in determining our exit status
@@ -112,11 +114,6 @@ elseif ( $LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0 )
   # will be set to $false whenever a Win32 process returns a non-zero
   # status.
   $exitstatus = $LASTEXITCODE
-}
-else
-{
-  # We just have a failed cmdlet, we should return 1
-  $exitstatus = 1
 }
 
 # If this script is launched with -File, the process exit

--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -99,7 +99,13 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
     it "returns 1 if the last command was a cmdlet that failed and was preceded by a successfully executed non-cmdlet Windows binary" do
       resource.code([windows_process_exit_code_success_content, cmdlet_exit_code_not_found_content].join(';'))
       resource.returns(1)
-      resource.run_action(:run)
+      expect { resource.run_action(:run) }.not_to raise_error
+    end
+
+    it "raises an error if the script is not syntactically correct and returns is not set to 1" do
+      resource.code('if({)')
+      resource.returns(0)
+      expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 
     it "returns 1 if the script provided to the code attribute is not syntactically correct" do

--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -102,6 +102,12 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       resource.run_action(:run)
     end
 
+    it "returns 1 if the script provided to the code attribute is not syntactically correct" do
+      resource.code('if({)')
+      resource.returns(1)
+      resource.run_action(:run)
+    end
+
     # This somewhat ambiguous case, two failures of different types,
     # seems to violate the principle of returning the status of the
     # last line executed -- in this case, we return the status of the

--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -134,7 +134,7 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
     it "returns 1 if the script provided to the code attribute is not syntactically correct" do
       resource.code('if({)')
       resource.returns(1)
-      resource.run_action(:run)
+      expect { resource.run_action(:run) }.not_to raise_error
     end
 
     # This somewhat ambiguous case, two failures of different types,

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -114,7 +114,7 @@ shared_context Chef::Resource::WindowsScript do
 
     describe "when the run action is invoked on Windows" do
       it "executes the script code" do
-        resource.code("@whoami > #{script_output_path}")
+        resource.code("whoami > #{script_output_path}")
         resource.returns(0)
         resource.run_action(:run)
       end


### PR DESCRIPTION
See #2247 @jdmundrawala, @smurawski, @btm, @carpnick.

If a script processed by the `powershell_script` resource has a syntax error, we are returning 0, i.e. success, and the chef-client run will continue with no error even though the script did not actually execute (#2247).

To address this issue, we're going to add an explicit "syntax verification-only" similar to what was proposed in #2247.

### Root cause description

The root cause of this entire issue centers around the desire to preserve the quite useful conventions around script exit codes honored by the Unix script interpreters and their associated resources, and even honored by cmd.exe: the interpreter exits with a non-zero error code if the last command (internal or external) executed by the script returned a nonzero exit code OR if the script itself is invalid. The PowerShell interpreter violates this in multiple ways:

1.  `powershell.exe -command` correctly returns a non-zero exit status (`1`) if the script is not well-formed, but does not propagate non-zero process exit codes from Win32 processes -- those exit codes are always returned as `1`, even if a script is terminated explicitly via PowerShell's `exit` statement with a specific exit code. There is a pretty large dependency in existing Windows (and non-Windows) cookbooks on exit codes being propagated with full fidelity specifically because this is a very useful convention and there is a significant body administration practice built on it over decades.
2.  `powershell.exe -file` correctly handles Win32 exit statuses -- if the `exit` statement is used in the script to set the exit status. Also, it does not propagate cmdlet exit status (i.e the value of `$?`) nor does it return a non-zero exit for non well-formed scripts. In both cases it will return 0.
3.  `powershell.exe` in either the `-command` or `-file` cases does not support the idea of returning a status code based on a boolean test result as can be done with Unix shells like `sh` with `test` and related commands -- this is the feature enabled by the `convert_boolean_return` attribute for the `powershell_script` resource.

All of these issues requirements around returning useful status codes according to conventions supported by other interpreters / Chef script resources require explicit code in the `powershell_script` resource to implement these desired behaviors. Workarounds for all these issues are implemented there, except for the syntax issue, which is addressed by this pull request.

### Implementation notes

The following options were considered as solutions:

1. Continue to launch powershell.exe with `-file` and find a way to evaluate the syntax without executing the script more than once.
 <p>a. The script can be placed inside a script block and then evaluated in a separate `powershell.exe` invocation. **This is the solution implemented in this pull request.**</p>
 <p>b. The script can be placed inside a separate file, and then "dot-sourced" via the `.` operator in PowerShell inside the script that Chef actually executes.</p>
2. Switch to `-command` for launching the script and implement workarounds for other limitations of `-command` such as the inability to propagate exit codes.

The drawback of 1a is that it executes two PowerShell processes for each resource invocation instead of one. Advantages are that the `-File` invocation is also used in currently released versions of Chef Client, so we don't hae to account for regressions due to iodiosyncrasies of `-Command`, and the fact that this is conceptually simple -- we check the syntax explicitly prior to running the script.

As implied above, a drawback of 2 is that `-Command` has some subtle differences compared to `-File`, and there is a risk of those differences causing regressions even if all current specifications pass cleanly. Another issue is that to get the Win32 exit status, we would most likely not be able to rely on Mixlib::Shellout to raise an exception for unexpected return codes; we'd have to simulate such exceptions outside of Mixlib::Shellout in Chef.

Regardless, we can consider how a solution involving `-Command` would work; it would probably involve doing the following:

1. Continue using a wrapper script as we do currently.
2. Insert the user's code into a script block (we do this currently) AND add a line to capture $LASTEXITCODE in a global variable.
3. Ensure that all exit points of the wrapper script write out $LASTEXITCODE to a file if needed.
4. After the script is executed by Mixlib::Shellout, retrieve the Win32 exit status from the file
5. If necessary, from Chef raise the exceptions that Mixlib::Shellout would raise if the `returns` attribute on the `powershell_script` resource did not match the process exit code, including what we leared about Win32 exit status from reading the file. This would require simulating the relevant exception behavior from Mixlib::Shellout in Chef.

While approach 1a has the performance drawback of executing PowerShell twice, it has less complexity compared to the `-Command` approach which has to explicitly replicate Mixlib::Shellout's exception behavior.

### Future simplifications

In hindsight, combining the Win32 exit status and other statuses (cmdlet status and boolean result) in the single exit status of the interpreter when executed by Mixlib::Shellout was not worth the complexity it introduced in merging those concepts to make it seem "easy." Instead, the Win32 status should have been tested against a different attribute than `returns`, say `last_exit_code`. This would have matched PowerShell's design decision to keep these separate, and would have allowed us the benefits of using `-Command`, which handles the syntax check while still allowing failed Win32 exit statuses to return a failing (i.e. non-zero) exit code, which is the most common case. The separate attribute would then allow users with the need to test for specific statuses to explicitly test for a particular status code.

So in the future such an attribute could be introduced alongside existing functionality. Then the existing "combined" status could become deprecated and available only in some form of compatibility mode. Eventually, the old combined status could be removed. 


