### PR TITLE
No longer wrap SystemExit errors

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -350,6 +350,7 @@ class Chef
           converge_exception = e
         end
       end
+      raise converge_exception if converge_exception.kind_of?(SystemExit)
       converge_exception
     end
 
@@ -367,6 +368,7 @@ class Chef
       rescue Exception => e
         Chef::Log.error("Audit phase failed with error message: #{e.message}")
         @events.audit_phase_failed(e)
+        raise e if e.kind_of?(SystemExit)
         audit_exception = e
       end
       audit_exception


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/3078

This allows users to `exit 250` in their recipe and have that correctly set the exit code to 250 for the chef-client process.  Supports CI systems that need to track program flow (EG, exit 250 to show the Windows system is rebooting and CI should wait until that occurs to continue testing).