### PR TITLE
Revert "Macports provider - provide package"

### DIFF
--- a/lib/chef/platform/provider_priority_map.rb
+++ b/lib/chef/platform/provider_priority_map.rb
@@ -67,7 +67,6 @@ class Chef
         #
 
         priority :service, Chef::Provider::Service::Macosx, os: "darwin"
-        priority :package, Chef::Provider::Package::Homebrew, os: "darwin"
       end
 
       def priority_map

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -4,7 +4,6 @@ class Chef
       class Macports < Chef::Provider::Package
 
         provides :macports_package
-        provides :package, os: "darwin"
 
         def load_current_resource
           @current_resource = Chef::Resource::Package.new(@new_resource.name)

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -21,7 +21,6 @@ class Chef
     class MacportsPackage < Chef::Resource::Package
 
       provides :macports_package
-      provides :package, os: "darwin"
 
       def initialize(name, run_context=nil)
         super


### PR DESCRIPTION
This reverts commit c793d2d5a4fe69c3e636239145139c0afb02fec1.

Fixes #3022.

Homebrew became the default package provider in Chef 12 via #1709, but some
users wanted to keep macports as their default provider so they didn't have
to update all their recipes for Chef 12. #2722 attempted to allow you to easily
change the defaults, but that caused a regression due to which resource was
being loaded, which was filed as #3022.