### PR TITLE
Disable the exitstatus 3 test

### DIFF
--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -305,10 +305,7 @@ describe Chef::Application::Client, "run_application", :unix_only do
         allow(Chef::Daemon).to receive(:daemonize).and_return(true)
       end
 
-      # In ChefDK builds this sometimes fails from `chef verify`.  If the test
-      # begins to fail for normal chef builds, change it to :volatile completely
-      # https://github.com/chef/chef/pull/3039
-      it "should exit hard with exitstatus 3", :volatile_from_verify do
+      it "should exit hard with exitstatus 3", :volatile do
         pid = fork do
           @app.run_application
         end


### PR DESCRIPTION
This relies on a timer and even though we increased it in #3039 we've
still seen intermittent failures from it. Mark it volatile and move on.