### PR TITLE
alter messages generated by group provider to show group_name

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -125,13 +125,13 @@ class Chef
       def action_create
         case @group_exists
         when false
-          converge_by("create #{@new_resource}") do
+          converge_by("create #{@new_resource.group_name}") do
             create_group
             Chef::Log.info("#{@new_resource} created")
           end
         else
           if compare_group
-            converge_by(["alter group #{@new_resource}"] + change_desc) do
+            converge_by(["alter group #{@new_resource.group_name}"] + change_desc) do
               manage_group
               Chef::Log.info("#{@new_resource} altered")
             end
@@ -141,7 +141,7 @@ class Chef
 
       def action_remove
         if @group_exists
-          converge_by("remove group #{@new_resource}") do
+          converge_by("remove group #{@new_resource.group_name}") do
             remove_group
             Chef::Log.info("#{@new_resource} removed")
           end
@@ -150,7 +150,7 @@ class Chef
 
       def action_manage
         if @group_exists && compare_group
-          converge_by(["manage group #{@new_resource}"] + change_desc) do
+          converge_by(["manage group #{@new_resource.group_name}"] + change_desc) do
             manage_group
             Chef::Log.info("#{@new_resource} managed")
           end
@@ -159,7 +159,7 @@ class Chef
 
       def action_modify
         if compare_group
-          converge_by(["modify group #{@new_resource}"] + change_desc) do
+          converge_by(["modify group #{@new_resource.group_name}"] + change_desc) do
             manage_group
             Chef::Log.info("#{@new_resource} modified")
           end


### PR DESCRIPTION
Given these resources

``` ruby
user = 'dave'
group = 'operations'
hasaccess = true

# create user
user "Create account #{user}" do
  username user
  home "/home/#{user}"
  gid 'voxer'
  action :create
end

# lock or unlock user depending on access level
user "Manage account #{user}" do
  username user
  action hasaccess ? :unlock : :lock
end

# add the user to the necessary groups
group "Add #{user} to group #{group}" do
  group_name group
  members user
  append true
  action :modify
end
```

This currently generates output like this (using a variation of the minimal formatter)

```
* user[Create account dave]
     - create user dave
   
* user[Manage account dave]
     - unlock user dave
   
* group[Add dave to group operations]
     - modify group group[Add dave to group operations]
```

with this patch, the output becomes

```
* user[Create account dave]
     - create user dave
   
* user[Manage account dave]
     - unlock user dave
   
* group[Add dave to group operations]
     - modify group operations
```

The difference can be seen in the last resource, where currently it shows `modify group group[Add dave to group operations]` and with this patch it simply states `modify group operations`