### PR TITLE
bumping ffi-yajl to pick up 2.x

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0"
   s.add_dependency "ohai", "~> 8.0"
 
-  s.add_dependency "ffi-yajl", "~> 1.2"
+  s.add_dependency "ffi-yajl", ">= 1.2", "< 3.0"
   s.add_dependency "net-ssh", "~> 2.6"
   s.add_dependency "net-ssh-multi", "~> 1.1"
   # CHEF-3027: The knife-cloud plugins require newer features from highline, core chef should not.


### PR DESCRIPTION
1.x still works fine, so leaving the lower floor in place.