### PR TITLE
Use opscode.com rather than chef.io in the bootstrap script.

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -22,7 +22,7 @@ exists() {
 <% if knife_config[:bootstrap_install_command] %>
   <%= knife_config[:bootstrap_install_command] %>
 <% else %>
-  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://www.chef.io/chef/install.sh" %>"
+  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://www.opscode.com/chef/install.sh" %>"
   if ! exists /usr/bin/chef-client; then
     echo "Installing Chef Client..."
     if exists wget; then


### PR DESCRIPTION
chef.io is served by a CDN.  The SSL certificate served will have
*.chef.io as a Subject-Alternative-Name. Unfortunately, the wget
version contained in RHEL5 (and potentially other old OS versions)
does not support SAN.

If we want to stay with chef.io, some alternative approaches include:

- Documenting that users of RHEL5 should use --bootstrap-url if their
  OS image contains wget [0]

- Prefering other download methods to wget.

[0] EC2s stock RHEl5 images do not contain wget, but our bento-box
images do.