### PR TITLE
Allow for the chef gem installation to succeed without elevated privileges

### DIFF
--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -41,10 +41,14 @@ end
 task :register => EVT_SHARED_OBJECT do
   require 'win32/eventlog'
   dll_file = File.expand_path(EVT_SHARED_OBJECT)
-  Win32::EventLog.add_event_source(
-    :source => "Application",
-    :key_name => "Chef",
-    :event_message_file => dll_file,
-    :category_message_file => dll_file
-  )
+  begin
+    Win32::EventLog.add_event_source(
+      :source => "Application",
+      :key_name => "Chef",
+      :event_message_file => dll_file,
+      :category_message_file => dll_file
+    )
+  rescue Errno::EIO => e
+    puts "Skipping event log registration due to missing privileges: #{e}"
+  end
 end


### PR DESCRIPTION
As discussed in #3125 the registration in the windows event log requires elevated privileges, which prevents the installation of the chef gem under a standard user account.

With this PR we do a best-effort approach and continue even if the registration in the event log fails.

/cc @jdmundrawala 