### PR TITLE
For knife ssh: Do not try to use item[:cloud][:public_hostname] for the hostname if it is empty

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -175,7 +175,9 @@ class Chef
           if config[:attribute_from_cli]
             Chef::Log.debug("Using node attribute '#{config[:attribute_from_cli]}' from the command line as the ssh target")
             host = extract_nested_value(item, config[:attribute_from_cli])
-          elsif item[:cloud] && item[:cloud][:public_hostname]
+          elsif item[:cloud] &&
+                item[:cloud][:public_hostname] &&
+                !item[:cloud][:public_hostname].empty?
             Chef::Log.debug("Using node attribute 'cloud[:public_hostname]' automatically as the ssh target")
             host = item[:cloud][:public_hostname]
           else

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -96,6 +96,24 @@ describe Chef::Knife::Ssh do
         should_return_specified_attributes
       end
 
+      context "when cloud hostnames are available but empty" do
+        before do
+          @node_foo.automatic_attrs[:cloud][:public_hostname] = ''
+          @node_bar.automatic_attrs[:cloud][:public_hostname] = ''
+        end
+
+        it "returns an array of fqdns" do
+          configure_query([@node_foo, @node_bar])
+          expect(@knife).to receive(:session_from_list).with([
+            ['foo.example.org', nil],
+            ['bar.example.org', nil]
+          ])
+          @knife.configure_session
+        end
+
+        should_return_specified_attributes
+      end
+
       it "should raise an error if no host are found" do
           configure_query([ ])
           expect(@knife.ui).to receive(:fatal)


### PR DESCRIPTION
This supersedes #2935 which seems to have been abandoned before it was fixed (and also lacks the requisite unit test).