### PR TITLE
Ensure that a search query makes progress

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -89,7 +89,7 @@ WARNDEP
         if block
           response["rows"].each { |row| block.call(row) if row }
           unless (response["start"] + response["rows"].length) >= response["total"]
-            args_h[:start] = response["start"] + (args_h[:rows] || 0)
+            args_h[:start] = response["start"] + response["rows"].length
             search(type, query, args_h, &block)
           end
           true


### PR DESCRIPTION
If a search doesn't return a full result, and there was no row
limit specified, then increment the start pointer by the number
of rows returned, not zero.

This should fix #3099