### PR TITLE
Policyfile erchef integration

### DIFF
--- a/lib/chef/cookbook/remote_file_vendor.rb
+++ b/lib/chef/cookbook/remote_file_vendor.rb
@@ -30,7 +30,7 @@ class Chef
 
       def initialize(manifest, rest)
         @manifest = manifest
-        @cookbook_name = @manifest[:cookbook_name]
+        @cookbook_name = @manifest[:cookbook_name] || @manifest[:name]
         @rest = rest
       end
 

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -78,6 +78,16 @@ class Chef
 
     attr_accessor :chef_server_rest
 
+    # The `identifier` field is used for cookbook_artifacts, which are
+    # organized on the chef server according to their content. If the
+    # policy_mode option to CookbookManifest is set to true it will include
+    # this field in the manifest Hash and in the upload URL.
+    #
+    # This field may be removed or have different behavior in the future, don't
+    # use it in 3rd party code.
+    # @api private
+    attr_accessor :identifier
+
     # The first root path is the primary cookbook dir, from which metadata is loaded
     def root_dir
       root_paths[0]
@@ -455,6 +465,15 @@ class Chef
       cookbook_version.manifest["metadata"] = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json(cookbook_version.metadata))
 
       cookbook_version.freeze_version if o["frozen?"]
+      cookbook_version
+    end
+
+    def self.from_cb_artifact_data(o)
+      cookbook_version = new(o["name"])
+      # We want the Chef::Cookbook::Metadata object to always be inflated
+      cookbook_version.metadata = Chef::Cookbook::Metadata.from_hash(o["metadata"])
+      cookbook_version.manifest = o
+      cookbook_version.identifier = o["identifier"]
       cookbook_version
     end
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -239,7 +239,7 @@ class Chef
       def policyfile_location
         if Chef::Config[:policy_document_native_api]
           validate_policy_config!
-          "policies/#{policy_group}/#{policy_name}"
+          "policy_groups/#{policy_group}/policies/#{policy_name}"
         else
           "data/policyfiles/#{deployment_group}"
         end
@@ -368,11 +368,11 @@ class Chef
       end
 
       def artifact_manifest_for(cookbook_name, lock_data)
-        xyz_version = lock_data["dotted_decimal_identifier"]
-        rel_url = "cookbook_artifacts/#{cookbook_name}/#{xyz_version}"
+        identifier = lock_data["identifier"]
+        rel_url = "cookbook_artifacts/#{cookbook_name}/#{identifier}"
         http_api.get(rel_url)
       rescue Exception => e
-        message = "Error loading cookbook #{cookbook_name} at version #{xyz_version} from #{rel_url}: #{e.class} - #{e.message}"
+        message = "Error loading cookbook #{cookbook_name} with identifier #{identifier} from #{rel_url}: #{e.class} - #{e.message}"
         err = Chef::Exceptions::CookbookNotFound.new(message)
         err.set_backtrace(e.backtrace)
         raise err

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -370,12 +370,16 @@ class Chef
       def artifact_manifest_for(cookbook_name, lock_data)
         identifier = lock_data["identifier"]
         rel_url = "cookbook_artifacts/#{cookbook_name}/#{identifier}"
-        http_api.get(rel_url)
+        inflate_cbv_object(http_api.get(rel_url))
       rescue Exception => e
         message = "Error loading cookbook #{cookbook_name} with identifier #{identifier} from #{rel_url}: #{e.class} - #{e.message}"
         err = Chef::Exceptions::CookbookNotFound.new(message)
         err.set_backtrace(e.backtrace)
         raise err
+      end
+
+      def inflate_cbv_object(raw_manifest)
+        Chef::CookbookVersion.from_cb_artifact_data(raw_manifest)
       end
 
     end

--- a/spec/unit/cookbook/file_vendor_spec.rb
+++ b/spec/unit/cookbook/file_vendor_spec.rb
@@ -21,9 +21,6 @@ describe Chef::Cookbook::FileVendor do
 
   let(:file_vendor_class) { Class.new(described_class) }
 
-  # A manifest is a Hash of the format defined by Chef::CookbookVersion#manifest
-  let(:manifest) { {:cookbook_name => "bob"} }
-
   context "when configured to fetch files over http" do
 
     let(:http) { double("Chef::REST") }
@@ -40,18 +37,41 @@ describe Chef::Cookbook::FileVendor do
       expect(file_vendor_class.initialization_options).to eq(http)
     end
 
-    it "creates a RemoteFileVendor for a given manifest" do
-      file_vendor = file_vendor_class.create_from_manifest(manifest)
-      expect(file_vendor).to be_a_kind_of(Chef::Cookbook::RemoteFileVendor)
-      expect(file_vendor.rest).to eq(http)
-      expect(file_vendor.cookbook_name).to eq("bob")
+    context "with a manifest from a cookbook version" do
+
+      # A manifest is a Hash of the format defined by Chef::CookbookVersion#manifest
+      let(:manifest) { {:cookbook_name => "bob", :name => "bob-1.2.3"} }
+
+      it "creates a RemoteFileVendor for a given manifest" do
+        file_vendor = file_vendor_class.create_from_manifest(manifest)
+        expect(file_vendor).to be_a_kind_of(Chef::Cookbook::RemoteFileVendor)
+        expect(file_vendor.rest).to eq(http)
+        expect(file_vendor.cookbook_name).to eq("bob")
+      end
+
     end
 
+    context "with a manifest from a cookbook artifact" do
+
+      # A manifest is a Hash of the format defined by Chef::CookbookVersion#manifest
+      let(:manifest) { {:name => "bob"} }
+
+      it "creates a RemoteFileVendor for a given manifest" do
+        file_vendor = file_vendor_class.create_from_manifest(manifest)
+        expect(file_vendor).to be_a_kind_of(Chef::Cookbook::RemoteFileVendor)
+        expect(file_vendor.rest).to eq(http)
+        expect(file_vendor.cookbook_name).to eq("bob")
+      end
+
+    end
   end
 
   context "when configured to load files from disk" do
 
     let(:cookbook_path) { %w[/var/chef/cookbooks /var/chef/other_cookbooks] }
+
+    # A manifest is a Hash of the format defined by Chef::CookbookVersion#manifest
+    let(:manifest) { {:cookbook_name => "bob"} }
 
     before do
       file_vendor_class.fetch_from_disk(cookbook_path)

--- a/spec/unit/cookbook_manifest_spec.rb
+++ b/spec/unit/cookbook_manifest_spec.rb
@@ -24,6 +24,8 @@ describe Chef::CookbookManifest do
 
   let(:version) { "1.2.3" }
 
+  let(:identifier) { "9e10455ce2b4a4e29424b7064b1d67a1a25c9d3b" }
+
   let(:metadata) do
     Chef::Cookbook::Metadata.new.tap do |m|
       m.version(version)
@@ -35,6 +37,7 @@ describe Chef::CookbookManifest do
   let(:cookbook_version) do
     Chef::CookbookVersion.new("tatft", cookbook_root).tap do |c|
       c.metadata = metadata
+      c.identifier = identifier
     end
   end
 
@@ -212,12 +215,26 @@ describe Chef::CookbookManifest do
 
       let(:policy_mode) { true }
 
+      let(:cookbook_manifest_hash) { cookbook_manifest.to_hash }
+
+      it "sets the identifier in the manifest data" do
+        expect(cookbook_manifest_hash["identifier"]).to eq("9e10455ce2b4a4e29424b7064b1d67a1a25c9d3b")
+      end
+
+      it "sets the name to just the name" do
+        expect(cookbook_manifest_hash["name"]).to eq("tatft")
+      end
+
+      it "does not set a 'cookbook_name' field" do
+        expect(cookbook_manifest_hash).to_not have_key("cookbook_name")
+      end
+
       it "gives the save URL" do
-        expect(cookbook_manifest.save_url).to eq("cookbook_artifacts/tatft/1.2.3")
+        expect(cookbook_manifest.save_url).to eq("cookbook_artifacts/tatft/9e10455ce2b4a4e29424b7064b1d67a1a25c9d3b")
       end
 
       it "gives the force save URL" do
-        expect(cookbook_manifest.force_save_url).to eq("cookbook_artifacts/tatft/1.2.3?force=true")
+        expect(cookbook_manifest.force_save_url).to eq("cookbook_artifacts/tatft/9e10455ce2b4a4e29424b7064b1d67a1a25c9d3b?force=true")
       end
 
     end

--- a/spec/unit/cookbook_uploader_spec.rb
+++ b/spec/unit/cookbook_uploader_spec.rb
@@ -25,10 +25,16 @@ describe Chef::CookbookUploader do
   let(:cookbook_loader) do
     loader = Chef::CookbookLoader.new(File.join(CHEF_SPEC_DATA, "cookbooks"))
     loader.load_cookbooks
+    loader.cookbooks_by_name["apache2"].identifier = apache2_identifier
+    loader.cookbooks_by_name["java"].identifier = java_identifier
     loader
   end
 
+  let(:apache2_identifier) { "6644e6cb2ade90b8aff2ebb44728958fbc939ebf" }
+
   let(:apache2_cookbook) { cookbook_loader.cookbooks_by_name["apache2"] }
+
+  let(:java_identifier) { "edd40c30c4e0ebb3658abde4620597597d2e9c17" }
 
   let(:java_cookbook) { cookbook_loader.cookbooks_by_name["java"] }
 
@@ -175,7 +181,7 @@ describe Chef::CookbookUploader do
       let(:policy_mode) { true }
 
       def expected_save_url(cookbook)
-        "cookbook_artifacts/#{cookbook.name}/#{cookbook.version}"
+        "cookbook_artifacts/#{cookbook.name}/#{cookbook.identifier}"
       end
 
       it "uploads all files in a sandbox transaction, then creates cookbooks on the server using cookbook_artifacts API" do


### PR DESCRIPTION
In conjunction with https://github.com/chef/oc_erchef/pull/119 and forthcoming ChefDK PR, this gets policyfiles into a demo-able state with Erchef.

Most of the changes are confined to policyfile-specific code paths, which you need to opt-in to with a feature flag, so it should be pretty safe. The RemoteFileVendor change touches a pretty important code path, which is why I went with the ugly but simple change. I'll follow up with another PR that improves the file vendor API so it doesn't rely on the format of the manifest hash so much.

@chef/client-core @jdmundrawala 