### PR TITLE
Fix debug message

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1300,7 +1300,7 @@ class Chef
             new_package_name = packages.first.name
             new_package_version = packages.first.version.to_s
             debug_msg = "#{name}: Unable to match package '#{name}' but matched #{packages.size} "
-            debug_msg << packages.size == 1 ? "package" : "packages"
+            debug_msg << (packages.size == 1 ? "package" : "packages")
             debug_msg << ", selected '#{new_package_name}' version '#{new_package_version}'"
             Chef::Log.debug(debug_msg)
 


### PR DESCRIPTION
<< has higher precedence than == and ?:, so right now we have something like
=> "mdbtools >= 0.7.1: Unable to match package 'mdbtools >= 0.7.1' but matched 1 \u0001"
in debug_msg