### PR TITLE
Fix installation of yum packages with version constraints

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -464,10 +464,7 @@ class Chef
 
       # @return [Array] new_version(s) as an array
       def new_version_array
-        @new_version_array ||=
-            [ new_resource.version ].flatten.map do |v|
-              ( v.nil? || v.empty? ) ? nil : v
-            end
+        [ new_resource.version ].flatten.map { |v| v.to_s.empty? ? nil : v }
       end
 
       # @todo: extract apt/dpkg specific preseeding to a helper class

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1370,7 +1370,7 @@ class Chef
             new_package_name = packages.first.name
             new_package_version = packages.first.version.to_s
             debug_msg = "#{name}: Unable to match package '#{name}' but matched #{packages.size} "
-            debug_msg << packages.size == 1 ? "package" : "packages"
+            debug_msg << (packages.size == 1 ? "package" : "packages")
             debug_msg << ", selected '#{new_package_name}' version '#{new_package_version}'"
             Chef::Log.debug(debug_msg)
 


### PR DESCRIPTION
Right now `yum_package 'pkg >= 1.0` doesn't work if pkg < 1.0 is already installed.

Fixes #2778.