### PR TITLE
Not consistent behavior of methods `default_action` in `Chef::Resource::LWRPBase` class and `action` in `Chef::Resource` class.

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -89,7 +89,7 @@ class Chef
           else
             action = action_name.to_sym
             @actions.push(action) unless @actions.include?(action)
-            @default_action = action
+            @default_action = [action]
           end
         end
 

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -131,7 +131,7 @@ describe "LWRP" do
     end
 
     it "should set the specified action as the default action" do
-      expect(Chef::Resource::LwrpFoo.new("blah").action).to eq(:pass_buck)
+      expect(Chef::Resource::LwrpFoo.new("blah").action).to eq([:pass_buck])
     end
 
     it "should create a method for each attribute" do
@@ -235,7 +235,7 @@ describe "LWRP" do
         end
 
         it "delegates #default_action to the parent" do
-          expect(child.default_action).to eq(:eat)
+          expect(child.default_action).to eq([:eat])
         end
       end
 
@@ -252,7 +252,7 @@ describe "LWRP" do
         end
 
         it "does not delegate #default_action to the parent" do
-          expect(child.default_action).to eq(:dont_eat)
+          expect(child.default_action).to eq([:dont_eat])
         end
       end
 


### PR DESCRIPTION
This PR fixes different behavior in cases then we set action during resource call and then actions sets from default_action method.

If we call resource and set action directly:
```
foo_resource 'bar' do
  action :add
end
```
variable ```@action``` will be always an array, no matter if we gave an array or a symbol to the method action.

If we call resource without action:
```
foo_resource 'bar'
```
and in its declaration contains:
```
default_action :add
```
variable ```@action``` will be an array if we gave an array to the method default_action or a symbol if we gave a symbol.

I fixed this difference so that the variable ```@action``` always has been an array.