### PR TITLE
Add minimal ohai mode option flag

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -85,6 +85,11 @@ class Chef::Application::Apply < Chef::Application
     :default      => !Chef::Platform.windows?,
     :description  => "Use colored output, defaults to enabled"
 
+  option :minimal_ohai,
+    :long           => "--minimal-ohai",
+    :description    => "Only run the bare minimum ohai plugins chef needs to function",
+    :boolean        => true
+
   attr_reader :json_attribs
 
   def initialize

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -253,6 +253,11 @@ class Chef::Application::Client < Chef::Application
     :description    => "Enable audit-mode with `enabled`. Disable audit-mode with `disabled`. Skip converge and only perform audits with `audit-only`",
     :proc           => lambda { |mo| mo.gsub("-", "_").to_sym }
 
+  option :minimal_ohai,
+    :long           => "--minimal-ohai",
+    :description    => "Only run the bare minimum ohai plugins chef needs to function",
+    :boolean        => true
+
   IMMEDIATE_RUN_SIGNAL = "1".freeze
 
   attr_reader :chef_client_json

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -180,6 +180,11 @@ class Chef::Application::Solo < Chef::Application
     :description  => "Set maximum duration to wait for another client run to finish, default is indefinitely.",
     :proc         => lambda { |s| s.to_i }
 
+  option :minimal_ohai,
+    :long           => "--minimal-ohai",
+    :description    => "Only run the bare minimum ohai plugins chef needs to function",
+    :boolean        => true
+
   attr_reader :chef_client_json
 
   def initialize

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -272,7 +272,8 @@ class Chef
     end
 
     def run_ohai
-      ohai.all_plugins
+      filter = Chef::Config[:minimal_ohai] ? %w[fqdn machinename hostname platform platform_version os os_version] : nil
+      ohai.all_plugins(filter)
       @events.ohai_completed(node)
     end
 

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -333,6 +333,11 @@ class Chef
     # This can be removed when audit-mode is enabled by default.
     default :audit_mode, :disabled
 
+    # Chef only needs ohai to run the hostname plugin for the most basic
+    # functionality. If the rest of the ohai plugins are not needed (like in
+    # most of our testing scenarios)
+    default :minimal_ohai, false
+
     # Policyfile is an experimental feature where a node gets its run list and
     # cookbook version set from a single document on the server instead of
     # expanding the run list and having the server compute the cookbook version

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -45,7 +45,7 @@ describe "chef-client" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "ruby '#{chef_dir}/chef-client'" }
+  let(:chef_client) { "ruby '#{chef_dir}/chef-client' --minimal-ohai" }
 
   when_the_repository "has a cookbook with a no-op recipe" do
     before { file 'cookbooks/x/recipes/default.rb', '' }

--- a/spec/integration/client/ipv6_spec.rb
+++ b/spec/integration/client/ipv6_spec.rb
@@ -76,7 +76,7 @@ END_CLIENT_RB
 
   let(:chef_dir) { File.join(File.dirname(__FILE__), "..", "..", "..", "bin") }
 
-  let(:chef_client_cmd) { %Q[ruby '#{chef_dir}/chef-client' -c "#{path_to('config/client.rb')}" -lwarn] }
+  let(:chef_client_cmd) { %Q[ruby '#{chef_dir}/chef-client' --minimal-ohai -c "#{path_to('config/client.rb')}" -lwarn] }
 
   after do
     FileUtils.rm_rf(cache_path)

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -16,7 +16,7 @@ describe "LWRPs with inline resources" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "ruby '#{chef_dir}/chef-client'" }
+  let(:chef_client) { "ruby '#{chef_dir}/chef-client' --minimal-ohai" }
 
   when_the_repository "has a cookbook with a nested LWRP" do
     before do

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -15,6 +15,8 @@ describe "chef-solo" do
 
   let(:cookbook_ancient_100_metadata_rb) { cb_metadata("ancient", "1.0.0") }
 
+  let(:chef_solo) { "ruby bin/chef-solo --minimal-ohai" }
+
   when_the_repository "has a cookbook with a basic recipe" do
     before do
       file 'cookbooks/x/metadata.rb', cookbook_x_100_metadata_rb
@@ -26,7 +28,7 @@ describe "chef-solo" do
 cookbook_path "#{path_to('cookbooks')}"
 file_cache_path "#{path_to('config/cache')}"
 EOM
-      result = shell_out("ruby bin/chef-solo -c \"#{path_to('config/solo.rb')}\" -o 'x::default' -l debug", :cwd => chef_dir)
+      result = shell_out("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default' -l debug", :cwd => chef_dir)
       result.error!
       expect(result.stdout).to include("ITWORKS")
     end
@@ -41,7 +43,7 @@ EOM
 {"run_list":["x::default"]}
 E
 
-      result = shell_out("ruby bin/chef-solo -c \"#{path_to('config/solo.rb')}\" -j '#{path_to('config/node.json')}' -l debug", :cwd => chef_dir)
+      result = shell_out("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -j '#{path_to('config/node.json')}' -l debug", :cwd => chef_dir)
       result.error!
       expect(result.stdout).to include("ITWORKS")
     end
@@ -62,7 +64,7 @@ E
 cookbook_path "#{path_to('cookbooks')}"
 file_cache_path "#{path_to('config/cache')}"
 EOM
-      result = shell_out("ruby bin/chef-solo -c \"#{path_to('config/solo.rb')}\" -o 'x::default' -l debug", :cwd => chef_dir)
+      result = shell_out("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default' -l debug", :cwd => chef_dir)
       expect(result.exitstatus).to eq(0) # For CHEF-5120 this becomes 1
       expect(result.stdout).to include("WARN: MissingCookbookDependency")
     end
@@ -95,14 +97,14 @@ EOM
           chef_dir = File.join(File.dirname(__FILE__), "..", "..", "..")
 
           # Instantiate the first chef-solo run
-          s1 = Process.spawn("ruby bin/chef-solo -c \"#{path_to('config/solo.rb')}\" -o 'x::default' \
+          s1 = Process.spawn("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default' \
 -l debug -L #{path_to('logs/runs.log')}", :chdir => chef_dir)
 
           # Give it some time to progress
           sleep 1
 
           # Instantiate the second chef-solo run
-          s2 = Process.spawn("ruby bin/chef-solo -c \"#{path_to('config/solo.rb')}\" -o 'x::default' \
+          s2 = Process.spawn("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default' \
 -l debug -L #{path_to('logs/runs.log')}", :chdir => chef_dir)
 
           Process.waitpid(s1)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -78,6 +78,19 @@ describe Chef::Client do
     allow(Ohai::System).to receive(:new).and_return(ohai_system)
   end
 
+  context "when minimal ohai is configured" do
+    before do
+      Chef::Config[:minimal_ohai] = true
+    end
+
+    it "runs ohai with only the minimum required plugins" do
+      expected_filter = %w[fqdn machinename hostname platform platform_version os os_version]
+      expect(ohai_system).to receive(:all_plugins).with(expected_filter)
+      client.run_ohai
+    end
+
+  end
+
   describe "authentication protocol selection" do
     after do
       Chef::Config[:authentication_protocol_version] = "1.0"


### PR DESCRIPTION
:construction: needs specs, though it works in integration

Add a minimal ohai mode that skips most ohai plugins and reduces overall chef-client run time. This shaves a few seconds off of each integration test that runs chef-client, saving a few minutes overall. Results obviously will depend on a lot of factors.