### PR TITLE
Mitigating "No route to host" errors produced by 'knife ssh'

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -111,8 +111,23 @@ class Chef
         :boolean => true,
         :proc => Proc.new { :raise }
 
+      option :ssh_timeout,
+        :short => "-T TIMEOUT",
+        :long => "--ssh-socket-timeout TIMEOUT",
+        :description => "SSH socket timeout (default is 0)",
+        :default => 0, # This is principle-of-least-surprise default in Net::SSH
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_socket_timeout] = key.strip }
+
+      option :ssh_retries,
+        :short => "-R THIS_MANY_TIMES",
+        :long => "--ssh-socket-retries THIS_MANY_TIMES",
+        :description => "SSH socket retries (default is 0)",
+        :default => 0,
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_socket_retries] = key.strip }
+
       def session
         config[:on_error] ||= :skip
+        config[:on_error] = :retry_times unless config[:ssh_retries].to_i.zero?
         ssh_error_handler = Proc.new do |server|
           case config[:on_error]
           when :skip
@@ -121,10 +136,12 @@ class Chef
           when :raise
             #Net::SSH::Multi magic to force exception to be re-raised.
             throw :go, :raise
+          when :retry_times
+            throw :go, :retry_times
           end
         end
 
-        @session ||= Net::SSH::Multi.start(:concurrent_connections => config[:concurrency], :on_error => ssh_error_handler)
+        @session ||= Net::SSH::Multi.start(:concurrent_connections => config[:concurrency], :on_error => ssh_error_handler, :retries_max => config[:ssh_retries].to_i)
       end
 
       def configure_gateway
@@ -213,6 +230,17 @@ class Chef
                                 Chef::Config[:knife][:ssh_port] ||
                                 ssh_config[:port]
           session_opts[:logger] = Chef::Log.logger if Chef::Log.level == :debug
+          #
+          # Net::SSH socket open code is wrapped in Ruby's Timeout and
+          # and it's set to 0 by default(principle of least surprise). With home
+          # inernet or overloaded boxes, this is often not a good idea.
+          # And, more importantly, frequently results in misleading errors
+          # like "No route to host" or "Name or service not known"
+          #
+          # By default, code behaviour shouldn't change (default :ssh_timeout is 0).
+          # But in conjunction with :ssh_retries it allows some mitigation
+          # of aforementioned errors.
+          session_opts[:timeout] = config[:ssh_timeout].to_i
 
           if !config[:host_key_verify]
             session_opts[:paranoid] = false


### PR DESCRIPTION
At least on OSX Yosemite (although i have observed this same issue on older OSX versions), 'knife ssh' produces errors like 'No route to host' when SSH-ing to 100-200 hosts at once. That error results in nodes being skipped, while those nodes are definitely up and accessible.  I've traced this to TCPSocket's internal connect(2) failing for some weird reason, and to the fact that Net::SSH::Transport::Session initializer wraps TCPSocket.open() call into a ruby Timeout() which by default is 0 seconds (the latter contributes to the problem, is not it's source). Limiting session concurrency definitely reduces the scope of the problem( # of skipped nodes per run ), but doesn't solve it completely.

Proposed changes introduce 2 options for 'knife ssh' which allow to customize timeout and retry ssh connection to a node for N times. Latter requires implementation of new :on_error strategy, which in turn requires changes to already existing net-ssh-multi monkeypatch.

Those two options, in conjunction with concurrency limiting, seem to band-air the problem - at least in my case, i was able to 'knife ssh' into all 254 nodes repeatedly with only one retry needed for 2-5 nodes per run.

Lastly, the changes do not change default behavior of 'knife ssh'.
