### PR TITLE
Migrated deploy resource to use shell_out instead of run_command

### DIFF
--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -201,7 +201,7 @@ class Chef
 
           converge_by("execute migration command #{@new_resource.migration_command}") do
             Chef::Log.info "#{@new_resource} migrating #{@new_resource.user} with environment #{env_info}"
-            run_command(run_options(:command => @new_resource.migration_command, :cwd=>release_path, :log_level => :info))
+            shell_out!(@new_resource.migration_command,run_options(:cwd=>release_path, :log_level => :info))
           end
         end
       end
@@ -221,7 +221,7 @@ class Chef
           else
             converge_by("restart app using command #{@new_resource.restart_command}") do
               Chef::Log.info("#{@new_resource} restarting app")
-              run_command(run_options(:command => @new_resource.restart_command, :cwd => @new_resource.current_path))
+              shell_out!(@new_resource.restart_command,run_options(:cwd=>@new_resource.current_path))
             end
           end
         end

--- a/spec/functional/resource/deploy_revision_spec.rb
+++ b/spec/functional/resource/deploy_revision_spec.rb
@@ -819,7 +819,7 @@ describe Chef::Resource::DeployRevision, :unix_only => true do
       end
 
       before do
-        expect { deploy_that_fails.run_action(:deploy) }.to raise_error(Chef::Exceptions::Exec)
+        expect { deploy_that_fails.run_action(:deploy) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
         deploy_to_latest_with_callback_tracking.run_action(:deploy)
       end
 

--- a/spec/unit/provider/deploy_spec.rb
+++ b/spec/unit/provider/deploy_spec.rb
@@ -362,7 +362,7 @@ describe Chef::Provider::Deploy do
 
   it "skips the migration when resource.migrate => false but runs symlinks before migration" do
     @resource.migrate false
-    expect(@provider).not_to receive :run_command
+    expect(@provider).not_to receive :shell_out!
     expect(@provider).to receive :run_symlinks_before_migrate
     @provider.migrate
   end
@@ -378,7 +378,7 @@ describe Chef::Provider::Deploy do
 
     allow(STDOUT).to receive(:tty?).and_return(true)
     allow(Chef::Log).to receive(:info?).and_return(true)
-    expect(@provider).to receive(:run_command).with(:command => "migration_foo", :cwd => @expected_release_dir,
+    expect(@provider).to receive(:shell_out!).with("migration_foo",:cwd => @expected_release_dir,
                                                 :user => "deployNinja", :group => "deployNinjas",
                                                 :log_level => :info, :live_stream => STDOUT,
                                                 :log_tag => "deploy[/my/deploy/dir]",
@@ -445,13 +445,13 @@ describe Chef::Provider::Deploy do
   end
 
   it "does nothing for restart if restart_command is empty" do
-    expect(@provider).not_to receive(:run_command)
+    expect(@provider).not_to receive(:shell_out!)
     @provider.restart
   end
 
   it "runs the restart command in the current application dir when the resource has a restart_command" do
     @resource.restart_command "restartcmd"
-    expect(@provider).to receive(:run_command).with(:command => "restartcmd", :cwd => "/my/deploy/dir/current", :log_tag => "deploy[/my/deploy/dir]", :log_level => :debug)
+    expect(@provider).to receive(:shell_out!).with("restartcmd", :cwd => "/my/deploy/dir/current", :log_tag => "deploy[/my/deploy/dir]", :log_level => :debug)
     @provider.restart
   end
 
@@ -509,7 +509,7 @@ describe Chef::Provider::Deploy do
   it "shouldn't give a no method error on migrate if the environment is nil" do
     allow(@provider).to receive(:enforce_ownership)
     allow(@provider).to receive(:run_symlinks_before_migrate)
-    allow(@provider).to receive(:run_command)
+    allow(@provider).to receive(:shell_out!)
     @provider.migrate
 
   end


### PR DESCRIPTION
Should help with troubleshooting failed migrations

Solves [CHEF-2861](https://tickets.opscode.com/browse/CHEF-2861)