### PR TITLE
Fixed issue #3175

### DIFF
--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -79,26 +79,18 @@ class Chef
         end
 
         def start_service
-          if @current_resource.running
-            Chef::Log.debug("#{@new_resource} already running, not starting")
+          if @new_resource.start_command
+            super
           else
-            if @new_resource.start_command
-              super
-            else
-              shell_out_with_systems_locale!("launchctl load -w '#{@plist}'", :user => @owner_uid, :group => @owner_gid)
-            end
+            shell_out_with_systems_locale!("launchctl load -w '#{@plist}'", :user => @owner_uid, :group => @owner_gid)
           end
         end
 
         def stop_service
-          unless @current_resource.running
-            Chef::Log.debug("#{@new_resource} not running, not stopping")
+          if @new_resource.stop_command
+            super
           else
-            if @new_resource.stop_command
-              super
-            else
-              shell_out_with_systems_locale!("launchctl unload '#{@plist}'", :user => @owner_uid, :group => @owner_gid)
-            end
+            shell_out_with_systems_locale!("launchctl unload '#{@plist}'", :user => @owner_uid, :group => @owner_gid)
           end
         end
 

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -230,13 +230,6 @@ SVC_LIST
             provider.start_service
           end
 
-          it "shows warning message if service is already running" do
-            allow(current_resource).to receive(:running).and_return(true)
-            expect(Chef::Log).to receive(:debug).with("service[#{service_name}] already running, not starting")
-
-            provider.start_service
-          end
-
           it "starts service via launchctl if service found" do
             expect(provider).to receive(:shell_out_with_systems_locale!).
                      with("launchctl load -w '/Users/igor/Library/LaunchAgents/io.redis.redis-server.plist'",
@@ -259,13 +252,6 @@ SVC_LIST
             allow(new_resource).to receive(:stop_command).and_return("kill -9 123")
 
             expect(provider).to receive(:shell_out_with_systems_locale!).with("kill -9 123")
-            provider.stop_service
-          end
-
-          it "shows warning message if service is not running" do
-            allow(current_resource).to receive(:running).and_return(false)
-            expect(Chef::Log).to receive(:debug).with("service[#{service_name}] not running, not stopping")
-
             provider.stop_service
           end
 


### PR DESCRIPTION
Removed unnecessary checks to the status of the service when start or stop methods are called from the service provider for MacOSX.
Removed tests related to these checks.