### PR TITLE
Allow tags to be set on a node during bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -143,6 +143,12 @@ class Chef
         :proc => lambda { |o| o.split(/[\s,]+/) },
         :default => []
 
+      option :tags,
+        :long => "--tags TAGS",
+        :description => "Comma separated list of tags to apply to the node",
+        :proc => lambda { |o| o.split(/[\s,]+/) },
+        :default => []
+
       option :first_boot_attributes,
         :short => "-j JSON_ATTRIBS",
         :long => "--json-attributes",

--- a/lib/chef/knife/bootstrap/client_builder.rb
+++ b/lib/chef/knife/bootstrap/client_builder.rb
@@ -140,6 +140,9 @@ class Chef
               node.run_list(normalized_run_list)
               node.normal_attrs = first_boot_attributes if first_boot_attributes
               node.environment(environment) if environment
+              (knife_config[:tags] || []).each do |tag|
+                node.tags << tag
+              end
               node
             end
         end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -163,11 +163,14 @@ CONFIG
         end
 
         def first_boot
-          (@config[:first_boot_attributes] || {}).merge(:run_list => @run_list)
+          (@config[:first_boot_attributes] || {}).tap do |attributes|
+            attributes.merge!(:run_list => @run_list)
+            attributes.merge!(:tags => @config[:tags]) if @config[:tags] && !@config[:tags].empty?
+          end
         end
 
         private
-       
+
         # Returns a string for copying the trusted certificates on the workstation to the system being bootstrapped
         # This string should contain both the commands necessary to both create the files, as well as their content
         def trusted_certs_content

--- a/spec/unit/knife/bootstrap/client_builder_spec.rb
+++ b/spec/unit/knife/bootstrap/client_builder_spec.rb
@@ -149,6 +149,22 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
       client_builder.run
     end
 
+    it "does not add tags by default" do
+      allow(node).to receive(:run_list).with([])
+      expect(node).to_not receive(:tags)
+      client_builder.run
+    end
+
+    it "adds tags to the node when given" do
+      tag_receiver = []
+
+      knife_config[:tags] = %w[foo bar]
+      allow(node).to receive(:run_list).with([])
+      allow(node).to receive(:tags).and_return(tag_receiver)
+      client_builder.run
+      expect(tag_receiver).to eq %w[foo bar]
+    end
+
     it "builds a node when the run_list is a string" do
       knife_config[:run_list] = "role[base],role[app]"
       expect(node).to receive(:run_list).with(["role[base]", "role[app]"])

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -97,6 +97,13 @@ EXPECTED
     end
   end
 
+  describe "when tags are given" do
+    let(:config) { {:tags => [ "unicorn" ] } }
+    it "adds the attributes to first_boot" do
+      expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json({:run_list => run_list, :tags => ["unicorn"]}))
+    end
+  end
+
   describe "when JSON attributes are given" do
     let(:config) { {:first_boot_attributes => {:baz => :quux}} }
     it "adds the attributes to first_boot" do


### PR DESCRIPTION
I can set attributes, environment, and run_list during a `knife bootstrap`, but why not tags?

Some of our recipes are driven off of tags, such as for sudo access or
membership in a load balancing pool.

If this patch is accepted then I will add the corresponding feature to
[knife-vsphere](https://github.com/ezrapagel/knife-vsphere).