### PR TITLE
provider/user/dscl: Set default gid to 20

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -257,10 +257,13 @@ user password using shadow hash.")
 
         #
         # Sets the group id for the user using dscl. Fails if a group doesn't
-        # exist on the system with given group id.
+        # exist on the system with given group id. If `gid` is not specified, it
+        # sets a default Mac user group "staff", with id 20.
         #
         def dscl_set_gid
-          unless @new_resource.gid && @new_resource.gid.to_s.match(/^\d+$/)
+          if @new_resource.gid.nil?
+            @new_resource.gid(20)
+          elsif !@new_resource.gid.to_s.match(/^\d+$/)
             begin
               possible_gid = run_dscl("read /Groups/#{@new_resource.gid} PrimaryGroupID").split(" ").last
             rescue Chef::Exceptions::DsclCommandFailed => e

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -789,6 +789,13 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
         expect { provider.dscl_set_gid }.to raise_error(Chef::Exceptions::GroupIDNotFound)
       end
     end
+
+    it "should set group ID to 20 if it's not specified" do
+      new_resource.gid nil
+      expect(provider).to receive(:run_dscl).with("create /Users/toor PrimaryGroupID '20'").ordered.and_return(true)
+      provider.dscl_set_gid
+      expect(new_resource.gid).to eq(20)
+    end
   end
 
   describe "when the user exists and chef is managing it" do


### PR DESCRIPTION
This PR sets a default value of `gid` attribute in Dscl provider to id 20, which means "staff", the default group for regular user accounts in OS X.

**Explanation:**
If `gid` attribute is not defined, then action `:create` will be completed successfully, but user account will not be able. The reason is this line (command):
https://github.com/chef/chef/blob/12.2.1/lib/chef/provider/user/dscl.rb#L271
```ruby
run_dscl("create /Users/#{@new_resource.username} PrimaryGroupID '#{@new_resource.gid}'")
```
Look at what happens if there is an empty string:
```
# dscl . -create /Users/integrator PrimaryGroupID ''
# echo $?
0
# id integrator
id: integrator: no such user
```
It causes that you can not use this account. The same thing happens if we try to do it without quotes (but with a trailing space). 
So, we always have to set a group ID explicitly:
```
# dscl . -create /Users/integrator PrimaryGroupID '20'
# echo $?
0
# id integrator
uid=500(integrator) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),100(_lpoperator)
```
