### PR TITLE
provider/user/dscl: Set "comment" default value

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -195,9 +195,10 @@ user password using shadow hash.")
 
         #
         # Saves the specified Chef user `comment` into RealName attribute
-        # of Mac user.
+        # of Mac user. If `comment` is not specified, it takes `username` value.
         #
         def dscl_create_comment
+          @new_resource.comment(@new_resource.username) if @new_resource.comment.nil?
           run_dscl("create /Users/#{@new_resource.username} RealName '#{@new_resource.comment}'")
         end
 

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -760,6 +760,13 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
         provider.dscl_create_comment
       end
 
+      it "sets the comment field to username" do
+        new_resource.comment nil
+        expect(provider).to receive(:run_dscl).with("create /Users/toor RealName '#mockssuck'").and_return(true)
+        provider.dscl_create_comment
+        expect(new_resource.comment).to eq("#mockssuck")
+      end
+
       it "should run run_dscl with create /Users/user PrimaryGroupID to set the users primary group" do
         expect(provider).to receive(:run_dscl).with("create /Users/toor PrimaryGroupID '1001'").and_return(true)
         provider.dscl_set_gid


### PR DESCRIPTION
I suggest to set `comment` attribute to the value of `username` if it isn't specified (in Dscl provider only).

It is not critical thing in OS X, but if `comment` is not set, then this command will set "RealName" to the empty string:
https://github.com/chef/chef/blob/12.2.1/lib/chef/provider/user/dscl.rb#L201
```
run_dscl("create /Users/#{@new_resource.username} RealName '#{@new_resource.comment}'")
```
And it looks bad in OS X gui:
![os_x_empty_realname](https://cloud.githubusercontent.com/assets/4846154/6998082/86965822-dbdd-11e4-84f9-e085afa9962c.jpg)

So, it will be better to prevent this case and guarantee that RealName will be always set to the readable value.