### PR TITLE
Fix nil pointer for windows event logger

### DIFF
--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -88,15 +88,21 @@ class Chef
       #Exception message: %4
       #Exception backtrace: %5
       def run_failed(e)
+        data =
+          if @run_status
+            [@run_status.run_id,
+             @run_status.elapsed_time.to_s]
+          else
+            ["UNKNOWN", "UNKNOWN"]
+          end
+
         @eventlog.report_event(
           :event_type => ::Win32::EventLog::ERROR_TYPE,
           :source => SOURCE,
           :event_id => RUN_FAILED_EVENT_ID,
-          :data => [@run_status.run_id,
-                    @run_status.elapsed_time.to_s,
-                    e.class.name,
-                    e.message,
-                    e.backtrace.join("\n")]
+          :data => data + [e.class.name,
+                           e.message,
+                           e.backtrace.join("\n")]
         )
       end
 

--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -79,4 +79,18 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only, :not_supported_o
     end).to be_truthy
   end
 
+  it 'writes run_failed event with event_id 10003 even when run_status is not set' do
+    logger.run_failed(mock_exception)
+
+    expect(event_log.read(flags, offset).any? do |e|
+      e.source == 'Chef' && e.event_id == 10003 &&
+        e.string_inserts[0].include?("UNKNOWN") &&
+        e.string_inserts[1].include?("UNKNOWN") &&
+        e.string_inserts[2].include?(mock_exception.class.name) &&
+        e.string_inserts[3].include?(mock_exception.message) &&
+        e.string_inserts[4].include?(mock_exception.backtrace[0]) &&
+        e.string_inserts[4].include?(mock_exception.backtrace[1])
+    end).to be_truthy
+  end
+
 end


### PR DESCRIPTION
It is possible for the run to fail and no run_status to even have
been set. This resolves issue #2996