### PR TITLE
Apply changes from #3126 to 12.2-stable branch

### DIFF
--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -41,10 +41,14 @@ end
 task :register => EVT_SHARED_OBJECT do
   require 'win32/eventlog'
   dll_file = File.expand_path(EVT_SHARED_OBJECT)
-  Win32::EventLog.add_event_source(
-    :source => "Application",
-    :key_name => "Chef",
-    :event_message_file => dll_file,
-    :category_message_file => dll_file
-  )
+  begin
+    Win32::EventLog.add_event_source(
+      :source => "Application",
+      :key_name => "Chef",
+      :event_message_file => dll_file,
+      :category_message_file => dll_file
+    )
+  rescue Errno::EIO => e
+    puts "Skipping event log registration due to missing privileges: #{e}"
+  end
 end


### PR DESCRIPTION
Applying the changes from #3126 to the 12.2-stable branch so the chef gem becomes installable again on Windows within the 12.2.x line of releases already.

If you see this as a non-risk change it would be nice to have that with 12.2.x already. No idea when 12.3 is about to be released, but 12.2.2 might be quite a bit earlier?