### PR TITLE
patch to always run exception handlers

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -152,7 +152,6 @@ class Chef
     def initialize(json_attribs=nil, args={})
       @json_attribs = json_attribs || {}
       @node = nil
-      @run_status = nil
       @runner = nil
       @ohai = Ohai::System.new
 
@@ -162,6 +161,7 @@ class Chef
       @events = EventDispatch::Dispatcher.new(*event_handlers)
       @override_runlist = args.delete(:override_runlist)
       @specific_recipes = args.delete(:specific_recipes)
+      @run_status = Chef::RunStatus.new(node, events)
 
       if new_runlist = args.delete(:runlist)
         @json_attribs["run_list"] = new_runlist

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -241,7 +241,8 @@ class Chef
     # Chef::Node:: The updated node object
     def build_node
       policy_builder.build_node
-      @run_status = Chef::RunStatus.new(node, events)
+      @run_status.node = node
+      @run_status.events = events
       node
     end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -242,7 +242,6 @@ class Chef
     def build_node
       policy_builder.build_node
       @run_status.node = node
-      @run_status.events = events
       node
     end
 

--- a/lib/chef/run_status.rb
+++ b/lib/chef/run_status.rb
@@ -23,7 +23,7 @@
 # Chef run.
 class Chef::RunStatus
 
-  attr_reader :events
+  attr_accessor :events
 
   attr_reader :run_context
 
@@ -39,13 +39,11 @@ class Chef::RunStatus
 
   attr_accessor :run_id
 
+  attr_accessor :node
+
   def initialize(node, events)
     @node = node
     @events = events
-  end
-
-  def node
-    @node
   end
 
   # sets +start_time+ to the current time.

--- a/lib/chef/run_status.rb
+++ b/lib/chef/run_status.rb
@@ -23,7 +23,7 @@
 # Chef run.
 class Chef::RunStatus
 
-  attr_accessor :events
+  attr_reader :events
 
   attr_reader :run_context
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -819,4 +819,24 @@ describe Chef::Client do
     end
 
   end
+
+  describe "should always attempt to run handlers" do
+    let(:e) { NoMethodError }
+    subject { client }
+    before do
+      # fail on the first thing in begin block
+      allow_any_instance_of(Chef::RunLock).to receive(:save_pid).and_raise(e)
+    end
+
+    it "should run exception handlers on early fail" do
+      expect(subject).to receive(:run_failed)
+      exception = nil
+      begin
+        subject.run
+      rescue e => ex
+        exception = ex
+      end
+      expect(exception).to be_instance_of(e)
+    end
+  end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -820,7 +820,7 @@ describe Chef::Client do
 
   end
 
-  describe "should always attempt to run handlers" do
+  describe "always attempt to run handlers" do
     let(:e) { NoMethodError }
     subject { client }
     before do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -829,11 +829,7 @@ describe Chef::Client do
 
     it "should run exception handlers on early fail" do
       expect(subject).to receive(:run_failed)
-       begin
-         subject.run
-       rescue => exception
-         expect(exception).to be_instance_of(NoMethodError)
-       end
+      expect { subject.run }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -821,22 +821,19 @@ describe Chef::Client do
   end
 
   describe "always attempt to run handlers" do
-    let(:e) { NoMethodError }
     subject { client }
     before do
       # fail on the first thing in begin block
-      allow_any_instance_of(Chef::RunLock).to receive(:save_pid).and_raise(e)
+      allow_any_instance_of(Chef::RunLock).to receive(:save_pid).and_raise(NoMethodError)
     end
 
     it "should run exception handlers on early fail" do
       expect(subject).to receive(:run_failed)
-      exception = nil
-      begin
-        subject.run
-      rescue e => ex
-        exception = ex
-      end
-      expect(exception).to be_instance_of(e)
+       begin
+         subject.run
+       rescue => exception
+         expect(exception).to be_instance_of(NoMethodError)
+       end
     end
   end
 end


### PR DESCRIPTION
Patch for issue https://github.com/chef/chef/issues/3180

Actual problem:
missing recipe present in run_list - exception handlers work as expected
missing role present in run_list - exception handlers do not fire.

Exception handlers require @run_status to be set.
Moving the declaration to initialisation block ensures it's always available.

'node' is nil at that stage and is set again here https://github.com/chef/chef/blob/master/lib/chef/client.rb#L244

big thanks to @jonlives, Coderanger and @thommay your help