### PR TITLE
Pin bundler to 1.9.2 in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - echo %PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler -v 1.9.2 --quiet --no-ri --no-rdoc
   - bundler --version
 
 build_script:


### PR DESCRIPTION
I broke universal gems in https://github.com/bundler/bundler/pull/3553

We can unpin once a fix is released