### PR TITLE
Use Random instead of SecureRandom in request_id

### DIFF
--- a/lib/chef/request_id.rb
+++ b/lib/chef/request_id.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-require 'securerandom'
 require 'singleton'
 
 class Chef
@@ -31,7 +30,11 @@ class Chef
     end
 
     def generate_request_id
-      SecureRandom.uuid
+      ary = Random.new.bytes(16).unpack("NnnnnN")
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
     end
+
   end
 end


### PR DESCRIPTION
SecureRandom is quite a bit slower on Windows

Does RequestID need to use SecureRandom?

cc @lamont-granquist @stevendanna @chef/client-core 