### PR TITLE
value_for_platform should use Chef::VersionConstraint::Platform

### DIFF
--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -50,7 +50,7 @@ class Chef
 
         def value_for_node(node)
           platform, version = node[:platform].to_s, node[:platform_version].to_s
-          # Check if we match a version constraint via Chef::VersionConstraint and Chef::Version::Platform
+          # Check if we match a version constraint via Chef::VersionConstraint::Platform and Chef::Version::Platform
           matched_value = match_versions(node)
           if @values.key?(platform) && @values[platform].key?(version)
             @values[platform][version]
@@ -76,11 +76,11 @@ class Chef
             keys = @values[platform].keys
             keys.each do |k|
               begin
-                if Chef::VersionConstraint.new(k).include?(node_version)
+                if Chef::VersionConstraint::Platform.new(k).include?(node_version)
                   key_matches << k
                 end
               rescue Chef::Exceptions::InvalidVersionConstraint => e
-                Chef::Log.debug "Caught InvalidVersionConstraint. This means that a key in value_for_platform cannot be interpreted as a Chef::VersionConstraint."
+                Chef::Log.debug "Caught InvalidVersionConstraint. This means that a key in value_for_platform cannot be interpreted as a Chef::VersionConstraint::Platform."
                 Chef::Log.debug(e)
               end
             end

--- a/spec/support/shared/unit/platform_introspector.rb
+++ b/spec/support/shared/unit/platform_introspector.rb
@@ -32,6 +32,7 @@ shared_examples_for "a platform introspector" do
     # The following @platform_hash keys are used for testing version constraints
     @platform_hash['exact_match'] = { '1.2.3' => 'exact', '>= 1.0' => 'not exact'}
     @platform_hash['multiple_matches'] = { '~> 2.3.4' => 'matched ~> 2.3.4', '>= 2.3' => 'matched >=2.3' }
+    @platform_hash['invalid_cookbook_version'] = {'>= 21' => 'Matches a single number'}
     @platform_hash['successful_matches'] = { '< 3.0' => 'matched < 3.0', '>= 3.0' => 'matched >= 3.0' }
 
     @platform_family_hash = {
@@ -93,6 +94,12 @@ shared_examples_for "a platform introspector" do
     node.automatic_attrs[:platform] = 'multiple_matches'
     node.automatic_attrs[:platform_version] = '2.3.4'
     expect {platform_introspector.value_for_platform(@platform_hash)}.to raise_error(RuntimeError)
+  end
+
+  it 'should not require .0 to match >= 21.0' do
+    node.automatic_attrs[:platform] = 'invalid_cookbook_version'
+    node.automatic_attrs[:platform_version] = '21'
+    expect(platform_introspector.value_for_platform(@platform_hash)).to eq('Matches a single number')
   end
 
   it 'should return the value for that match' do


### PR DESCRIPTION
It currently uses `Chef::VersionConstraint`, which doesn't work with some platforms, such as Fedora, where versions are reported as a single number like `21`. When `value_for_node` tries to create
a `Chef::VersionConstraint` with a single digit version constraint, it throws `Chef::Exception::CookbookInvalidVersion` 