### PR TITLE
Configure serverspec correctly on windows.

### DIFF
--- a/lib/chef/audit/runner.rb
+++ b/lib/chef/audit/runner.rb
@@ -144,6 +144,7 @@ class Chef
       def configure_specinfra
         if Chef::Platform.windows?
           Specinfra.configuration.backend = :cmd
+          Specinfra.configuration.os = { :family => 'windows' }
         else
           Specinfra.configuration.backend = :exec
         end


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/3234.

According to [serverspec documentation](https://github.com/serverspec/serverspec/blob/master/WINDOWS_SUPPORT.md) we need to make below configuration on windows:

```
set :backend, :cmd
set :os, :family => 'windows'
```

Looks like we have missed one line.

/cc: @mcquin, @juliandunn, @chef/client-windows 