### PR TITLE
Git provider should not force branch on master

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -157,8 +157,7 @@ class Chef
 
         converge_by("checkout ref #{sha_ref} branch #{@new_resource.revision}") do
           # checkout into a local branch rather than a detached HEAD
-          shell_out!("git branch -f #{@new_resource.checkout_branch} #{sha_ref}", run_options(:cwd => @new_resource.destination))
-          shell_out!("git checkout #{@new_resource.checkout_branch}", run_options(:cwd => @new_resource.destination))
+          shell_out!("git checkout -fB #{@new_resource.checkout_branch} #{sha_ref}", run_options(:cwd => @new_resource.destination))
           Chef::Log.info "#{@new_resource} checked out branch: #{@new_resource.revision} onto: #{@new_resource.checkout_branch} reference: #{sha_ref}"
         end
       end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -311,9 +311,7 @@ SHAS
   end
 
   it "runs a checkout command with default options" do
-    expect(@provider).to receive(:shell_out!).with('git branch -f deploy d35af14d41ae22b19da05d7d03a0bafc321b244c', :cwd => "/my/deploy/dir",
-                                                             :log_tag => "git[web2.0 app]").ordered
-    expect(@provider).to receive(:shell_out!).with('git checkout deploy', :cwd => "/my/deploy/dir",
+    expect(@provider).to receive(:shell_out!).with('git checkout -fB deploy d35af14d41ae22b19da05d7d03a0bafc321b244c', :cwd => "/my/deploy/dir",
                                                              :log_tag => "git[web2.0 app]").ordered
     @provider.checkout
   end


### PR DESCRIPTION
By default, git will check out the master branch when a repository is first
cloned (unless the repo specifies a different default branch). The git provider
will then attempt to force update to the `checkout_branch`, but will fail
because you can't force checkout a branch you are on.  An example on the
command line:

```
$ git checkout master
$ git branch -f master abcde12345
fatal: Cannot force update the current branch.
```

Instead, run:

```
$ git checkout -fB master abcde12345
```

Fixes #3025