### PR TITLE
don't mutate the new resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 * Convert bootstrap template to use sh #2877
 * [Issue #3316](https://github.com/chef/chef/issues/3316) Fix idempotency issues with the `windows_package` resource
+* [pr#3295](https://github.com/chef/chef/pull/3295): Stop mutating `new_resource.checksum` in file providers.  Fixes some ChecksumMismatch exceptions like [issue#3168](https://github.com/chef/chef/issues/3168)
 
 ## 12.3.0
+
 * [pr#3160](https://github.com/chef/chef/pull/3160): Use Chef Zero in
   socketless mode for local mode, add `--no-listen` flag to disable port
   binding

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -388,9 +388,6 @@ class Chef
         do_backup unless needs_creating?
         deployment_strategy.deploy(tempfile.path, ::File.realpath(@new_resource.path))
         Chef::Log.info("#{@new_resource} updated file contents #{@new_resource.path}")
-        if managing_content?
-          @new_resource.checksum(checksum(@new_resource.path)) # for reporting
-        end
       end
 
       def do_contents_changes

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -386,8 +386,12 @@ class Chef
 
       def update_file_contents
         do_backup unless needs_creating?
-        deployment_strategy.deploy(tempfile.path, ::File.realpath(@new_resource.path))
-        Chef::Log.info("#{@new_resource} updated file contents #{@new_resource.path}")
+        deployment_strategy.deploy(tempfile.path, ::File.realpath(new_resource.path))
+        Chef::Log.info("#{new_resource} updated file contents #{new_resource.path}")
+        if managing_content?
+          # save final checksum for reporting.
+          new_resource.final_checksum = checksum(new_resource.path)
+        end
       end
 
       def do_contents_changes

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -467,12 +467,21 @@ class Chef
     #
     # @return [Hash{Symbol => Object}] A Hash of attribute => value for the
     #   Resource class's `state_attrs`.
-    def state
+    def state_for_resource_reporter
       self.class.state_attrs.inject({}) do |state_attrs, attr_name|
         state_attrs[attr_name] = send(attr_name)
         state_attrs
       end
     end
+
+    #
+    # Since there are collisions with LWRP parameters named 'state' this
+    # method is not used by the resource_reporter and is most likely unused.
+    # It certainly cannot be relied upon and cannot be fixed.
+    #
+    # @deprecated
+    #
+    alias_method :state, :state_for_resource_reporter
 
     #
     # The value of the identity attribute, if declared. Falls back to #name if

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -38,6 +38,15 @@ class Chef
 
       attr_writer :checksum
 
+      #
+      # The checksum of the rendered file.  This has to be saved on the
+      # new_resource for the 'after' state for reporting but we cannot
+      # mutate the new_resource.checksum which would change the
+      # user intent in the new_resource if the resource is reused.
+      #
+      # @returns [String] Checksum of the file we actually rendered
+      attr_accessor :final_checksum
+
       provides :file
 
       def initialize(name, run_context=nil)
@@ -128,6 +137,15 @@ class Chef
         else
           @verifications
         end
+      end
+
+      def state_for_resource_reporter
+        state_attrs = super()
+        # fix up checksum state with final_checksum saved by the provider
+        if checksum.nil? && final_checksum
+          state_attrs['checksum'] = final_checksum
+        end
+        state_attrs
       end
     end
   end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -143,7 +143,7 @@ class Chef
         state_attrs = super()
         # fix up checksum state with final_checksum saved by the provider
         if checksum.nil? && final_checksum
-          state_attrs['checksum'] = final_checksum
+          state_attrs[:checksum] = final_checksum
         end
         state_attrs
       end

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -62,8 +62,8 @@ class Chef
         as_hash["type"]   = new_resource.class.dsl_name
         as_hash["name"]   = new_resource.name.to_s
         as_hash["id"]     = new_resource.identity.to_s
-        as_hash["after"]  = state(new_resource)
-        as_hash["before"] = current_resource ? state(current_resource) : {}
+        as_hash["after"]  = new_resource.state_for_resource_reporter
+        as_hash["before"] = current_resource ? current_resource.state_for_resource_reporter : {}
         as_hash["duration"] = (elapsed_time * 1000).to_i.to_s
         as_hash["delta"]  = new_resource.diff if new_resource.respond_to?("diff")
         as_hash["delta"]  = "" if as_hash["delta"].nil?
@@ -88,13 +88,6 @@ class Chef
 
       def success?
         !self.exception
-      end
-
-      def state(r)
-        r.class.state_attrs.inject({}) do |state_attrs, attr_name|
-          state_attrs[attr_name] = r.send(attr_name)
-          state_attrs
-        end
       end
     end # End class ResouceReport
 

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -529,9 +529,10 @@ shared_examples_for Chef::Provider::File do
                                   :for_reporting => diff_for_reporting )
             allow(diff).to receive(:diff).with(resource_path, tempfile_path).and_return(true)
             expect(provider).to receive(:diff).at_least(:once).and_return(diff)
-            expect(provider).to receive(:managing_content?).at_least(:once).and_return(true)
             expect(provider).to receive(:checksum).with(tempfile_path).and_return(tempfile_sha256)
-            expect(provider).to receive(:checksum).with(resource_path).and_return(tempfile_sha256)
+            allow(provider).to receive(:managing_content?).and_return(true)
+            allow(provider).to receive(:checksum).with(resource_path).and_return(tempfile_sha256)
+            expect(resource).not_to receive(:checksum)  # do not mutate the new resource
             expect(provider.deployment_strategy).to receive(:deploy).with(tempfile_path, normalized_path)
           end
           context "when the file was created" do

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -532,7 +532,7 @@ shared_examples_for Chef::Provider::File do
             expect(provider).to receive(:checksum).with(tempfile_path).and_return(tempfile_sha256)
             allow(provider).to receive(:managing_content?).and_return(true)
             allow(provider).to receive(:checksum).with(resource_path).and_return(tempfile_sha256)
-            expect(resource).not_to receive(:checksum)  # do not mutate the new resource
+            expect(resource).not_to receive(:checksum).with(tempfile_sha256)  # do not mutate the new resource
             expect(provider.deployment_strategy).to receive(:deploy).with(tempfile_path, normalized_path)
           end
           context "when the file was created" do
@@ -541,6 +541,7 @@ shared_examples_for Chef::Provider::File do
               expect(provider).not_to receive(:do_backup)
               provider.send(:do_contents_changes)
               expect(resource.diff).to be_nil
+              expect(resource.state_for_resource_reporter[:checksum]).to eql(tempfile_sha256)
             end
           end
           context "when the file was not created" do
@@ -549,6 +550,7 @@ shared_examples_for Chef::Provider::File do
               expect(provider).to receive(:do_backup)
               provider.send(:do_contents_changes)
               expect(resource.diff).to eq(diff_for_reporting)
+              expect(resource.state_for_resource_reporter[:checksum]).to eql(tempfile_sha256)
             end
           end
         end


### PR DESCRIPTION
this line violates the rule that we never mutate the new resource.

in Chef 12 this causes real problems because if a file resource is
notified (run twice) then the rendered content is loaded into the
new resource and if the file resource content changes (i.e. its a
template with logic which changes when its notified) then it will
cause a failure because the rendered content will not match the
'requested' checksum.  where the 'requested' checksum is actually
the checksum loaded by this line.

fundamentally we have three different states that we're trying to
track:

- current state
- initial state
- requested state

the removed line tries to use the @new_resource for reporting initial
state, which then bleeds over into what chef thinks is requested state
in the next invokation.

without constructing a third @initial_resource and using that for
resource reporting comparison we can't solve this problem "right".

the tradeoff is we either break reporting here or break chef-client
runs.  this patch sacrifices reporting in order to make chef-client
work.

fixes #3168 