### PR TITLE
Disable Travis CI container infrastructure due to broken IPv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 
-sudo: false
 # Early warning system to catch if Rubygems breaks something
 before_install:
   gem update --system


### PR DESCRIPTION
I think our IPv6 tests are failing on Travis because of this: https://github.com/travis-ci/travis-ci/issues/3302

Thoughts?