### PR TITLE
fix AIX package installs using a 'source' attribute

### DIFF
--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -60,6 +60,7 @@ class Chef
                   @new_resource.version(fields[2])
                 end
               end
+              raise Chef::Exceptions::Package, "package source #{@new_resource.source} does not provide package #{@new_resource.package_name}" unless @new_resource.version
             end
           end
 

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -36,23 +36,27 @@ describe Chef::Provider::Package::Aix do
      @bffinfo ="/usr/lib/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:
  /etc/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:"
 
-      @status = double("Status", :stdout => "", :exitstatus => 0)
+     @empty_status = double("Status", :stdout => "", :exitstatus => 0)
     end
 
     it "should create a current resource with the name of new_resource" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("samba.base")
     end
 
     it "should set the current resource bff package name to the new resource bff package name" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("samba.base")
     end
 
     it "should raise an exception if a source is supplied but not found" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out).and_return(@empty_status)
       allow(::File).to receive(:exists?).and_return(false)
       @provider.load_current_resource
       @provider.define_resource_requirements
@@ -62,7 +66,7 @@ describe Chef::Provider::Package::Aix do
     it "should get the source package version from lslpp if provided" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("samba.base")
@@ -73,7 +77,7 @@ describe Chef::Provider::Package::Aix do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       @stdout = StringIO.new(@bffinfo)
       @stdin, @stderr = StringIO.new, StringIO.new
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
       expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("3.3.12.0")
@@ -94,11 +98,19 @@ describe Chef::Provider::Package::Aix do
     end
 
     it "should return a current resource with a nil version if the package is not found" do
-      status = double(:stdout => "", :exitstatus => 0)
+      status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
+    end
+
+    it "should raise an exception if the source doesn't provide the requested package" do
+      wrongbffinfo = "/usr/lib/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:
+/etc/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:"
+      status = double("Status", :stdout => wrongbffinfo, :exitstatus => 0)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
+      expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
   end
 


### PR DESCRIPTION
Raise exception if a BFF provided by 'source' doesn't actually provide that package

Fixes #3108 