### PR TITLE
Remove experimental warning on audit mode.

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -320,12 +320,6 @@ class Chef::Application::Client < Chef::Application
       unless expected_modes.include?(mode)
         Chef::Application.fatal!(unrecognized_audit_mode(mode))
       end
-
-      unless mode == :disabled
-        # This should be removed when audit-mode is enabled by default/no longer
-        # an experimental feature.
-        Chef::Log.warn(audit_mode_experimental_message)
-      end
     end
   end
 
@@ -448,7 +442,7 @@ class Chef::Application::Client < Chef::Application
     "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
   end
 
-  def audit_mode_settings_explaination
+  def audit_mode_settings_explanation
     "\n* To enable audit mode after converge, use command line option `--audit-mode enabled` or set `:audit_mode = :enabled` in your config file." +
     "\n* To disable audit mode, use command line option `--audit-mode disabled` or set `:audit_mode = :disabled` in your config file." +
     "\n* To only run audit mode, use command line option `--audit-mode audit-only` or set `:audit_mode = :audit_only` in your config file." +
@@ -456,18 +450,7 @@ class Chef::Application::Client < Chef::Application
   end
 
   def unrecognized_audit_mode(mode)
-    "Unrecognized setting #{mode} for audit mode." + audit_mode_settings_explaination
-  end
-
-  def audit_mode_experimental_message
-    msg = if Chef::Config[:audit_mode] == :audit_only
-      "Chef-client has been configured to skip converge and only audit."
-    else
-      "Chef-client has been configured to audit after it converges."
-    end
-    msg += " Audit mode is an experimental feature currently under development. API changes may occur. Use at your own risk."
-    msg += audit_mode_settings_explaination
-    return msg
+    "Unrecognized setting #{mode} for audit mode." + audit_mode_settings_explanation
   end
 
   def fetch_recipe_tarball(url, path)

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -165,11 +165,6 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       before do
         allow(Chef::Log).to receive(:warn)
       end
-
-      it "emits a warning that audit mode is an experimental feature" do
-        expect(Chef::Log).to receive(:warn).with(/Audit mode is an experimental feature/)
-        app.reconfigure
-      end
     end
 
     shared_examples "unrecognized setting" do


### PR DESCRIPTION
I'm going to suggest we remove this to avoid freaking out customers since we have been shipping this mode for some time.

/cc @chef/analytics-data-integrations 