### PR TITLE
windows_package is idempotent again

### DIFF
--- a/lib/chef/win32/api/installer.rb
+++ b/lib/chef/win32/api/installer.rb
@@ -158,7 +158,7 @@ UINT MsiCloseHandle(
             raise Chef::Exceptions::Package, msg
           end
 
-          version
+          version.chomp(0.chr)
         end
       end
     end


### PR DESCRIPTION
This was broken in #3034. The issue is that the package does not get detected
as installed because the version that is installed has \x00 at the end,
while the version from the msi does not. This fails comparison, and we fall
into code that does not use source and thus requires candidate version and we
die. (Or something like that)

Solves #3316