### PR TITLE
Modify windows package provider to allow url

### DIFF
--- a/lib/chef/mixin/uris.rb
+++ b/lib/chef/mixin/uris.rb
@@ -1,0 +1,33 @@
+#
+# Author:: Jay Mundrawala (<jdm@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'uri'
+
+class Chef
+  module Mixin
+    module Uris
+      def uri_scheme?(source)
+        begin
+          !URI.split(source).first.nil?
+        rescue URI::InvalidURIError
+          return false
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/mixin/uris.rb
+++ b/lib/chef/mixin/uris.rb
@@ -21,6 +21,9 @@ require 'uri'
 class Chef
   module Mixin
     module Uris
+      # uri_scheme? returns true if the string starts with
+      # scheme://
+      # For example, it will match http://foo.bar.com
       def uri_scheme?(source)
         # From open-uri
         !!(%r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ source)

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -19,6 +19,7 @@
 require 'chef/resource/windows_package'
 require 'chef/provider/package'
 require 'chef/util/path_helper'
+require 'uri'
 
 class Chef
   class Provider
@@ -36,19 +37,23 @@ class Chef
 
         # load_current_resource is run in Chef::Provider#run_action when not in whyrun_mode?
         def load_current_resource
-          @new_resource.source(Chef::Util::PathHelper.validate_path(@new_resource.source))
-
           @current_resource = Chef::Resource::WindowsPackage.new(@new_resource.name)
-          @current_resource.version(package_provider.installed_version)
-          @new_resource.version(package_provider.package_version)
-          @current_resource
+          if should_download?
+            Chef::Log.debug("We do not know the version of #{new_resource.source} because the file is not downloaded")
+            current_resource.version(:unknown.to_s)
+          else
+            current_resource.version(package_provider.installed_version)
+            new_resource.version(package_provider.package_version)
+          end
+
+          current_resource
         end
 
         def package_provider
           @package_provider ||= begin
             case installer_type
             when :msi
-              Chef::Provider::Package::Windows::MSI.new(@new_resource)
+              Chef::Provider::Package::Windows::MSI.new(resource_for_provider)
             else
               raise "Unable to find a Chef::Provider::Package::Windows provider for installer_type '#{installer_type}'"
             end
@@ -71,6 +76,14 @@ class Chef
           end
         end
 
+        def action_install
+          if should_download?
+            download_source_file
+            load_current_resource
+          end
+          super
+        end
+
         # Chef::Provider::Package action_install + action_remove call install_package + remove_package
         # Pass those calls to the correct sub-provider
         def install_package(name, version)
@@ -80,6 +93,63 @@ class Chef
         def remove_package(name, version)
           package_provider.remove_package(name, version)
         end
+
+        # @return [Array] new_version(s) as an array
+        def new_version_array
+          # Because the one in the parent caches things
+          [new_resource.version]
+        end
+
+        private
+
+        def should_download?
+          is_url?(new_resource.source) && !::File.exists?(source_location)
+        end
+
+        def resource_for_provider
+          @resource_for_provider = Chef::Resource::WindowsPackage.new(new_resource.name).tap do |r|
+            r.source(Chef::Util::PathHelper.validate_path(source_location))
+            r.timeout(new_resource.timeout)
+            r.returns(new_resource.returns)
+            r.options(new_resource.options)
+          end
+        end
+
+        def download_source_file
+          source_resource.run_action(:create)
+          Chef::Log.debug("#{@new_resource} fetched source file to #{source_resource.path}")
+        end
+
+        def source_resource
+          @remote_file ||= Chef::Resource::RemoteFile.new(source_location, run_context).tap do |r|
+            r.source(new_resource.source)
+            r.backup(false)
+          end
+        end
+
+        def source_location
+          @source_location ||= begin
+            if is_url?(new_resource.source)
+              uri = ::URI.parse(new_resource.source)
+              filename = ::File.basename(::URI.unescape(uri.path))
+              file_cache_dir = Chef::FileCache.create_cache_path("package/")
+              Chef::Util::PathHelper.cleanpath("#{file_cache_dir}/#{filename}")
+            else
+              Chef::Util::PathHelper.cleanpath(new_resource.source)
+            end
+          end
+        end
+
+        def is_url?(source)
+          begin
+            scheme = URI.split(source).first
+            return false unless scheme
+            %w(http https ftp file).include?(scheme.downcase)
+          rescue URI::InvalidURIError
+            return false
+          end
+        end
+
       end
     end
   end

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -41,7 +41,7 @@ class Chef
         # load_current_resource is run in Chef::Provider#run_action when not in whyrun_mode?
         def load_current_resource
           @current_resource = Chef::Resource::WindowsPackage.new(@new_resource.name)
-          if download_file_missing?
+          if downloadable_file_missing?
             Chef::Log.debug("We do not know the version of #{new_resource.source} because the file is not downloaded")
             current_resource.version(:unknown.to_s)
           else
@@ -108,7 +108,7 @@ class Chef
 
         private
 
-        def download_file_missing?
+        def downloadable_file_missing?
           uri_scheme?(new_resource.source) && !::File.exists?(source_location)
         end
 

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef/mixin/uris'
 require 'chef/resource/package'
 require 'chef/provider/package/windows'
 require 'chef/win32/error' if RUBY_PLATFORM =~ /mswin|mingw|windows/
@@ -23,6 +24,7 @@ require 'chef/win32/error' if RUBY_PLATFORM =~ /mswin|mingw|windows/
 class Chef
   class Resource
     class WindowsPackage < Chef::Resource::Package
+      include Chef::Mixin::Uris
 
       provides :package, os: "windows"
       provides :windows_package, os: "windows"
@@ -69,23 +71,11 @@ class Chef
           @source
         else
           raise ArgumentError, "Bad type for WindowsPackage resource, use a String" unless arg.is_a?(String)
-          if is_url?(arg)
+          if uri_scheme?(arg)
             @source = arg
           else
             @source = ::File.absolute_path(arg).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR)
           end
-        end
-      end
-
-      private
-
-      def is_url?(source)
-        begin
-          scheme = URI.split(source).first
-          return false unless scheme
-          %w(http https ftp file).include?(scheme.downcase)
-        rescue URI::InvalidURIError
-          return false
         end
       end
 

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -69,10 +69,26 @@ class Chef
           @source
         else
           raise ArgumentError, "Bad type for WindowsPackage resource, use a String" unless arg.is_a?(String)
-          Chef::Log.debug("#{package_name}: sanitizing source path '#{arg}'")
-          @source = ::File.absolute_path(arg).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR)
+          if is_url?(arg)
+            @source = arg
+          else
+            @source = ::File.absolute_path(arg).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR)
+          end
         end
       end
+
+      private
+
+      def is_url?(source)
+        begin
+          scheme = URI.split(source).first
+          return false unless scheme
+          %w(http https ftp file).include?(scheme.downcase)
+        rescue URI::InvalidURIError
+          return false
+        end
+      end
+
     end
   end
 end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -79,6 +79,14 @@ class Chef
         end
       end
 
+      def remote_file_attributes(arg=nil)
+        set_or_return(
+          :remote_file_attributes,
+          arg,
+          :kind_of => [ Hash ]
+        )
+      end
+
     end
   end
 end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -74,7 +74,7 @@ class Chef
           if uri_scheme?(arg)
             @source = arg
           else
-            @source = ::File.absolute_path(arg).gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR)
+            @source = Chef::Util::PathHelper.canonical_path(arg, false)
           end
         end
       end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -79,6 +79,14 @@ class Chef
         end
       end
 
+      def checksum(arg=nil)
+        set_or_return(
+          :checksum,
+          arg,
+          :kind_of => [ String ]
+        )
+      end
+
       def remote_file_attributes(arg=nil)
         set_or_return(
           :remote_file_attributes,

--- a/spec/unit/mixin/uris_spec.rb
+++ b/spec/unit/mixin/uris_spec.rb
@@ -16,15 +16,30 @@
 # limitations under the License.
 #
 
-require 'uri'
+require 'spec_helper'
+require 'chef/mixin/uris'
 
-class Chef
-  module Mixin
-    module Uris
-      def uri_scheme?(source)
-        # From open-uri
-        !!(%r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ source)
-      end
-    end
+class Chef::UrisTest
+  include Chef::Mixin::Uris
+end
+
+describe Chef::Mixin::Uris do
+  let (:uris) { Chef::UrisTest.new }
+
+  it "matches 'scheme://foo.com'" do
+    expect(uris.uri_scheme?('scheme://foo.com')).to eq(true)
   end
+
+  it "does not match 'c:/foo.com'" do
+    expect(uris.uri_scheme?('c:/foo.com')).to eq(false)
+  end
+
+  it "does not match '/usr/bin/foo.com'" do
+    expect(uris.uri_scheme?('/usr/bin/foo.com')).to eq(false)
+  end
+
+  it "does not match 'c:/foo.com://bar.com'" do
+    expect(uris.uri_scheme?('c:/foo.com://bar.com')).to eq(false)
+  end
+
 end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -47,14 +47,14 @@ describe Chef::Provider::Package::Windows, :windows_only do
       provider.load_current_resource
       expect(provider.new_resource.version).to eql("2.0")
     end
-
-    it "checks that the source path is valid" do
-      expect(Chef::Util::PathHelper).to receive(:validate_path)
-      provider.load_current_resource
-    end
   end
 
   describe "package_provider" do
+    it "checks that the source path is valid" do
+      expect(Chef::Util::PathHelper).to receive(:validate_path)
+      provider.package_provider
+    end
+
     it "sets the package provider to MSI if the the installer type is :msi" do
       allow(provider).to receive(:installer_type).and_return(:msi)
       expect(provider.package_provider).to be_a(Chef::Provider::Package::Windows::MSI)

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -76,6 +76,19 @@ describe Chef::Provider::Package::Windows, :windows_only do
         end
         it_behaves_like "a local file"
       end
+
+      context "when remote_file_attributes are provided" do
+        let (:remote_file_attributes) { {:path => 'C:\\foobar.msi'} }
+        before(:each) do
+          new_resource.remote_file_attributes(remote_file_attributes)
+        end
+
+        it 'should override the attributes of the remote file resource used' do
+          expect(::File).to receive(:exists?).with(remote_file_attributes[:path])
+          provider.load_current_resource
+        end
+
+      end
     end
 
     context "when source is a local file" do

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -62,7 +62,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
 
       context "when the source has not been downloaded" do
         before(:each) do
-          allow(provider).to receive(:should_download?).and_return(true)
+          allow(provider).to receive(:download_file_missing?).and_return(true)
         end
         it "sets the current version to unknown" do
           provider.load_current_resource
@@ -72,7 +72,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
 
       context "when the source has been downloaded" do
         before(:each) do
-          allow(provider).to receive(:should_download?).and_return(false)
+          allow(provider).to receive(:download_file_missing?).and_return(false)
         end
         it_behaves_like "a local file"
       end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -19,50 +19,116 @@
 require 'spec_helper'
 
 describe Chef::Provider::Package::Windows, :windows_only do
+  before(:each) do
+    allow(Chef::Util::PathHelper).to receive(:windows?).and_return(true)
+    allow(Chef::FileCache).to receive(:create_cache_path).with("package/").and_return(cache_path)
+  end
+
   let(:node) { double('Chef::Node') }
   let(:events) { double('Chef::Events').as_null_object }  # mock all the methods
   let(:run_context) { double('Chef::RunContext', :node => node, :events => events) }
-  let(:new_resource) { Chef::Resource::WindowsPackage.new("calculator.msi") }
+  let(:resource_source) { 'calculator.msi' }
+  let(:new_resource) { Chef::Resource::WindowsPackage.new(resource_source) }
   let(:provider) { Chef::Provider::Package::Windows.new(new_resource, run_context) }
+  let(:cache_path) { 'c:\\cache\\' }
 
   describe "load_current_resource" do
-    before(:each) do
-      allow(Chef::Util::PathHelper).to receive(:validate_path)
-      allow(provider).to receive(:package_provider).and_return(double('package_provider',
+    shared_examples "a local file" do
+      before(:each) do
+        allow(Chef::Util::PathHelper).to receive(:validate_path)
+        allow(provider).to receive(:package_provider).and_return(double('package_provider',
           :installed_version => "1.0", :package_version => "2.0"))
+      end
+
+      it "creates a current resource with the name of the new resource" do
+        provider.load_current_resource
+        expect(provider.current_resource).to be_a(Chef::Resource::WindowsPackage)
+        expect(provider.current_resource.name).to eql(resource_source)
+      end
+
+      it "sets the current version if the package is installed" do
+        provider.load_current_resource
+        expect(provider.current_resource.version).to eql("1.0")
+      end
+
+      it "sets the version to be installed" do
+        provider.load_current_resource
+        expect(provider.new_resource.version).to eql("2.0")
+      end
     end
 
-    it "creates a current resource with the name of the new resource" do
-      provider.load_current_resource
-      expect(provider.current_resource).to be_a(Chef::Resource::WindowsPackage)
-      expect(provider.current_resource.name).to eql("calculator.msi")
+    context "when the source is a uri" do
+      let(:resource_source) { 'https://foo.bar/calculator.msi' }
+
+      context "when the source has not been downloaded" do
+        before(:each) do
+          allow(provider).to receive(:should_download?).and_return(true)
+        end
+        it "sets the current version to unknown" do
+          provider.load_current_resource
+          expect(provider.current_resource.version).to eql("unknown")
+        end
+      end
+
+      context "when the source has been downloaded" do
+        before(:each) do
+          allow(provider).to receive(:should_download?).and_return(false)
+        end
+        it_behaves_like "a local file"
+      end
     end
 
-    it "sets the current version if the package is installed" do
-      provider.load_current_resource
-      expect(provider.current_resource.version).to eql("1.0")
-    end
-
-    it "sets the version to be installed" do
-      provider.load_current_resource
-      expect(provider.new_resource.version).to eql("2.0")
+    context "when source is a local file" do
+      it_behaves_like "a local file"
     end
   end
 
   describe "package_provider" do
-    it "checks that the source path is valid" do
-      expect(Chef::Util::PathHelper).to receive(:validate_path)
-      provider.package_provider
+    shared_examples "a local file" do
+      it "checks that the source path is valid" do
+        expect(Chef::Util::PathHelper).to receive(:validate_path)
+        provider.package_provider
+      end
+
+      it "sets the package provider to MSI if the the installer type is :msi" do
+        allow(provider).to receive(:installer_type).and_return(:msi)
+        expect(provider.package_provider).to be_a(Chef::Provider::Package::Windows::MSI)
+      end
+
+      it "raises an error if the installer_type is unknown" do
+        allow(provider).to receive(:installer_type).and_return(:apt_for_windows)
+        expect { provider.package_provider }.to raise_error
+      end
     end
 
-    it "sets the package provider to MSI if the the installer type is :msi" do
-      allow(provider).to receive(:installer_type).and_return(:msi)
-      expect(provider.package_provider).to be_a(Chef::Provider::Package::Windows::MSI)
+    context "when the source is a uri" do
+      let(:resource_source) { 'https://foo.bar/calculator.msi' }
+
+      context "when the source has not been downloaded" do
+        before(:each) do
+          allow(provider).to receive(:should_download?).and_return(true)
+        end
+
+        it "should create a package provider with source pointing at the local file" do
+          expect(Chef::Provider::Package::Windows::MSI).to receive(:new) do |r|
+            expect(r.source).to eq("#{cache_path}#{::File.basename(resource_source)}")
+          end
+          provider.package_provider
+        end
+
+        it_behaves_like "a local file"
+      end
+
+      context "when the source has been downloaded" do
+        before(:each) do
+          allow(provider).to receive(:should_download?).and_return(false)
+        end
+        it_behaves_like "a local file"
+      end
     end
 
-    it "raises an error if the installer_type is unknown" do
-      allow(provider).to receive(:installer_type).and_return(:apt_for_windows)
-      expect { provider.package_provider }.to raise_error
+    context "when source is a local file" do
+      it_behaves_like "a local file"
     end
   end
 

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -62,7 +62,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
 
       context "when the source has not been downloaded" do
         before(:each) do
-          allow(provider).to receive(:download_file_missing?).and_return(true)
+          allow(provider).to receive(:downloadable_file_missing?).and_return(true)
         end
         it "sets the current version to unknown" do
           provider.load_current_resource
@@ -72,7 +72,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
 
       context "when the source has been downloaded" do
         before(:each) do
-          allow(provider).to receive(:download_file_missing?).and_return(false)
+          allow(provider).to receive(:downloadable_file_missing?).and_return(false)
         end
         it_behaves_like "a local file"
       end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -78,4 +78,13 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     # it's a little late to stub out File.absolute_path
     expect(resource.source).to include("solitaire.msi")
   end
+
+  context 'when a URL is used' do
+    let(:resource_source) { 'https://foo.bar/solitare.msi' }
+    let(:resource) { Chef::Resource::WindowsPackage.new(resource_source) }
+
+    it "should return the source unmodified" do
+      expect(resource.source).to eq(resource_source)
+    end
+  end
 end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -63,9 +63,9 @@ describe Chef::Resource::WindowsPackage, "initialize" do
   end
 
   it "coverts a source to an absolute path" do
-    allow(::File).to receive(:absolute_path).and_return("c:\\Files\\frost.msi")
+    allow(::File).to receive(:absolute_path).and_return("c:\\files\\frost.msi")
     resource.source("frost.msi")
-    expect(resource.source).to eql "c:\\Files\\frost.msi"
+    expect(resource.source).to eql "c:\\files\\frost.msi"
   end
 
   it "converts slashes to backslashes in the source path" do

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -79,6 +79,11 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     expect(resource.source).to include("solitaire.msi")
   end
 
+  it "supports the checksum attribute" do
+    resource.checksum('somechecksum')
+    expect(resource.checksum).to eq('somechecksum')
+  end
+
   context 'when a URL is used' do
     let(:resource_source) { 'https://foo.bar/solitare.msi' }
     let(:resource) { Chef::Resource::WindowsPackage.new(resource_source) }


### PR DESCRIPTION
This patch allows people to specify a url for source for the `windows_package` resource.

cc @btm @smurawski @ksubrama