### PR TITLE
Add an integration test of chef-client with empty ENV.

### DIFF
--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -47,6 +47,8 @@ describe "chef-client" do
   # cf. CHEF-4914
   let(:chef_client) { "ruby '#{chef_dir}/chef-client' --minimal-ohai" }
 
+  let(:critical_env_vars) { %w(PATH RUBYOPT BUNDLE_GEMFILE).map {|o| "#{o}=#{ENV[o]}"} .join(' ') }
+
   when_the_repository "has a cookbook with a no-op recipe" do
     before { file 'cookbooks/x/recipes/default.rb', '' }
 
@@ -56,8 +58,23 @@ local_mode true
 cookbook_path "#{path_to('cookbooks')}"
 EOM
 
-      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default'", :cwd => chef_dir)
-      result.error!
+      result = shell_out!("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default'", :cwd => chef_dir)
+    end
+
+    it "should complete successfully with no other environment variables", :skip => (Chef::Platform.windows?) do
+      file 'config/client.rb', <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+EOM
+
+      begin
+        result = shell_out("env -i #{critical_env_vars} #{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default'", :cwd => chef_dir)
+        result.error!
+      rescue
+        Chef::Log.info "Bare invocation will have the following load-path."
+        Chef::Log.info shell_out!("env -i #{critical_env_vars} ruby -e 'puts $:'").stdout
+        raise
+      end
     end
 
     it "should complete successfully with --no-listen" do


### PR DESCRIPTION
This is an integration test to catch the chef-12.2.0 regression that caused #3153 .  This was one of the identified corrective actions.