### PR TITLE
Able to use custom ssl certificates when uploading to Supermarket

### DIFF
--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -146,6 +146,13 @@ class Chef
           http.use_ssl = true
           http.verify_mode = verify_mode
         end
+
+        if Chef::Config[:ssl_cert_file]
+          http.cert_store = OpenSSL::X509::Store.new
+          http.cert_store.set_default_paths
+          http.cert_store.add_file(Chef::Config[:ssl_cert_file])
+        end
+
         res = http.request(req)
         #res = http.start {|http_proc| http_proc.request(req) }
 


### PR DESCRIPTION
More and more users are spinning up private versions of the Supermarket community cookbooks sites.  Private Supermarkets use a self signed ssl certificate.  Though this is easy to pull down onto a local workstation through knife ssl fetch, it's currently not possible to tell Chef to use that certificate when trying to upload to the private Supermarket.

This pull request will allow a user to define an ssl_cert_file to use in their knife.rb file like this:
```bash
  ssl_cert_file '/root/.chef/trusted_certs/nell-supermarket-server.crt'
```
Then, when the user tries to upload a cookbook, Chef will use this ssl_cert_file to authenticate to the Private Chef Server.
