### PR TITLE
Enforce passing a node name with validatorless bootstrapping

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -316,6 +316,12 @@ class Chef
         # new client-side hawtness, just delete your validation key.
         if chef_vault_handler.doing_chef_vault? || 
             (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
+
+          unless config[:chef_node_name]
+            ui.error("You must pass a node name with -N when bootstrapping with user credentials")
+            exit 1
+          end
+
           client_builder.run
 
           chef_vault_handler.run(node_name: config[:chef_node_name])

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -531,6 +531,7 @@ describe Chef::Knife::Bootstrap do
   describe "when running the bootstrap" do
     let(:knife_ssh) do
       knife.name_args = ["foo.example.com"]
+      knife.config[:chef_node_name] = "foo.example.com"
       knife.config[:ssh_user]      = "rooty"
       knife.config[:identity_file] = "~/.ssh/me.rsa"
       allow(knife).to receive(:render_template).and_return("")
@@ -590,6 +591,12 @@ describe Chef::Knife::Bootstrap do
         expect(knife.chef_vault_handler).not_to receive(:run).with(node_name: knife.config[:chef_node_name])
         knife.run
       end
+
+      it "raises an exception if the config[:chef_node_name] is not present" do
+        knife.config[:chef_node_name] = nil
+
+        expect { knife.run }.to raise_error(SystemExit)
+      end
     end
 
     context "when the validation key is not present" do
@@ -603,6 +610,12 @@ describe Chef::Knife::Bootstrap do
         expect(knife.client_builder).to receive(:run)
         expect(knife.chef_vault_handler).to receive(:run).with(node_name: knife.config[:chef_node_name])
         knife.run
+      end
+
+      it "raises an exception if the config[:chef_node_name] is not present" do
+        knife.config[:chef_node_name] = nil
+
+        expect { knife.run }.to raise_error(SystemExit)
       end
     end
 


### PR DESCRIPTION
When bootstrapping with chef-vault or with user credentials we create
the node and client on the Chef Server before we bootstrap the node. As
it is possible to specify a server address that is not the node name we
need to enforce that the user pass a node name with -N.

At present if you omit the the node name you'll be prompted to delete
nonexistent clients and nodes.

cc @lamont-granquist 

closes #3204 