### PR TITLE
use same fix for upload as install metadata.json

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -267,10 +267,35 @@ WARNING
         end
       end
 
+      # Get the preferred metadata path on disk. Chef prefers the metadata.rb
+      # over the metadata.json.
+      #
+      # @raise if there is no metadata in the cookbook
+      #
+      # @return [Chef::Cookbook::Metadata]
+      def preferred_metadata
+        md = Chef::Cookbook::Metadata.new
+
+        rb   = File.join(@install_path, @cookbook_name, "metadata.rb")
+        if File.exist?(rb)
+          md.from_file(rb)
+          return md
+        end
+
+        json = File.join(@install_path, @cookbook_name, "metadata.json")
+        if File.exist?(json)
+          json = IO.read(json)
+          md.from_json(json)
+          return md
+        end
+
+        raise Chef::Exceptions::MetadataNotFound.new(@install_path, @cookbook_name)
+      end
+
       def check_for_dependencies!(cookbook)
         # for all dependencies, check if the version is on the server, or
         # the version is in the cookbooks being uploaded. If not, exit and warn the user.
-        missing_dependencies = cookbook.metadata.dependencies.reject do |cookbook_name, version|
+        missing_dependencies = preferred_metadata.dependencies.reject do |cookbook_name, version|
           check_server_side_cookbooks(cookbook_name, version) || check_uploading_cookbooks(cookbook_name, version)
         end
 


### PR DESCRIPTION
metadata.json is a datafile, created by metadata.rb.
for whatever reason, the inclusion of one or the other is now a free choice.
This means that sometimes cookbooks may come with one and not the other.

Including the resulting DATA and not the CODE is now supported by prior changes when using the "knife cookbook site install"
However, that change was not incorporated globally and so we find that  "knife cookbook upload" continues to fail.

example failure:
```
+ echo 'Uploading consul to chef servers'
Uploading consul to chef servers
+ cd ..
+ which knife
/usr/bin/knife
+ knife -v
Chef: 12.1.2
+ knife cookbook upload consul -o .
Uploading consul         [0.6.0]
ERROR: Cookbook consul depends on cookbooks which are not currently
ERROR: being uploaded and cannot be found on the server.
ERROR: The missing cookbook(s) are: 'golang' version '~> 1.3.0'
```

The failure here is that the consul cookbook from supermarket does not come with metadata.rb, the code required to generate said metadata.json, and which is looked for by the "knife cookbook upload" command. A fix was put in place for "knife cookbook site install"

now, i can use knife cookbook metadata to generate a metadata.json, however there is no option for reverse engineering the metadata.rb from the data.

I've added the same logic to make upload work.
this supporting routine most likely belongs else where, however, for its true global reach.

I still question that it can be correct to exclude the CODE (metadata.rb) and include the DATA (metadata.json).
this feels broken to me with this PR being a hack on top of a bug to dress-up the bug.