### PR TITLE
Convert wiki links to docs.chef.io links

### DIFF
--- a/distro/common/markdown/man1/chef-shell.mkd
+++ b/distro/common/markdown/man1/chef-shell.mkd
@@ -131,8 +131,8 @@ Recipe mode implements Chef's recipe DSL. Exhaustively documenting this
 DSL is outside the scope of this document. See the following pages in
 the Chef documentation for more information:
 
-  * <http://wiki.opscode.com/display/chef/Resources>
-  * <http://wiki.opscode.com/display/chef/Recipes>
+  * <http://docs.chef.io/resources.html>
+  * <http://docs.chef.io/recipes.html>
 
 Once you have defined resources in the recipe, you can trigger a
 convergence run via `run_chef`
@@ -176,7 +176,7 @@ libraries.
 ## SEE ALSO
 
   chef-client(8) knife(1)
-  <http://wiki.opscode.com/display/chef/Chef+Shell>
+  <http://docs.chef.io/ctl_chef_shell.html>
 
 ## AUTHOR
 
@@ -192,4 +192,4 @@ libraries.
 
 ## CHEF
 
-   chef-shell is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   chef-shell is distributed with Chef. <http://docs.chef.io>

--- a/distro/common/markdown/man1/knife-bootstrap.mkd
+++ b/distro/common/markdown/man1/knife-bootstrap.mkd
@@ -138,4 +138,4 @@ to other users via the process list using tools such as ps(1).
 
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>

--- a/distro/common/markdown/man1/knife-client.mkd
+++ b/distro/common/markdown/man1/knife-client.mkd
@@ -99,5 +99,5 @@ setting up a host for management with Chef.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-configure.mkd
+++ b/distro/common/markdown/man1/knife-configure.mkd
@@ -66,5 +66,5 @@ the specified _directory_.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-cookbook-site.mkd
+++ b/distro/common/markdown/man1/knife-cookbook-site.mkd
@@ -119,5 +119,5 @@ Uploading cookbooks to the Opscode cookbooks site:
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-cookbook.mkd
+++ b/distro/common/markdown/man1/knife-cookbook.mkd
@@ -236,7 +236,7 @@ to specify alternate files to be used on a specific OS platform or host.
 The default specificity setting is _default_, that is files in
 `COOKBOOK/files/default` will be used when a more specific copy is not
 available. Further documentation for this feature is available on the
-Chef wiki: <http://wiki.opscode.com/display/chef/File+Distribution#FileDistribution-FileSpecificity>
+Chef wiki: <https://docs.chef.io/resource_cookbook_file.html#file-specificity>
 
 Cookbooks also contain a metadata file that defines various properties
 of the cookbook. The most important of these are the _version_ and the
@@ -248,8 +248,8 @@ cookbook.
 
 ## SEE ALSO
    __knife-environment(1)__ __knife-cookbook-site(1)__
-   <http://wiki.opscode.com/display/chef/Cookbooks>
-   <http://wiki.opscode.com/display/chef/Metadata>
+   <http://docs.chef.io/cookbooks.html>
+   <http://docs.chef.io/cookbook_repo.html>
 
 ## AUTHOR
    Chef was written by Adam Jacob <adam@opscode.com> with many contributions from the community.
@@ -260,4 +260,4 @@ cookbook.
 
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>

--- a/distro/common/markdown/man1/knife-data-bag.mkd
+++ b/distro/common/markdown/man1/knife-data-bag.mkd
@@ -117,5 +117,5 @@ encryption keys.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. http://wiki.opscode.com/display/chef/Home
+   Knife is distributed with Chef. http://docs.chef.io/
 

--- a/distro/common/markdown/man1/knife-environment.mkd
+++ b/distro/common/markdown/man1/knife-environment.mkd
@@ -137,8 +137,8 @@ The Ruby format of an environment is as follows:
 
 ## SEE ALSO
    __knife-node(1)__ __knife-cookbook(1)__ __knife-role(1)__
-  <http://wiki.opscode.com/display/chef/Environments>
-  <http://wiki.opscode.com/display/chef/Version+Constraints>
+  <http://docs.chef.io/environments.html>
+  <http://docs.chef.io/cookbook_versions.html>
 
 ## AUTHOR
    Chef was written by Adam Jacob <adam@opscode.com> with many contributions from the community.
@@ -148,4 +148,4 @@ The Ruby format of an environment is as follows:
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>

--- a/distro/common/markdown/man1/knife-exec.mkd
+++ b/distro/common/markdown/man1/knife-exec.mkd
@@ -39,4 +39,4 @@ description of the commands available.
 
 ## CHEF
 
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>

--- a/distro/common/markdown/man1/knife-index.mkd
+++ b/distro/common/markdown/man1/knife-index.mkd
@@ -26,5 +26,5 @@ time for all objects to be indexed and available for search.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-node.mkd
+++ b/distro/common/markdown/man1/knife-node.mkd
@@ -126,5 +126,5 @@ When adding a recipe to a run list, there are several valid formats:
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-role.mkd
+++ b/distro/common/markdown/man1/knife-role.mkd
@@ -70,8 +70,8 @@ run\_list.
 
 ## SEE ALSO
    __knife-node(1)__ __knife-environment(1)__
-   <http://wiki.opscode.com/display/chef/Roles>
-   <http://wiki.opscode.com/display/chef/Attributes>
+   <http://docs.chef.io/roles.html>
+   <http://docs.chef.io/attributes.html>
 
 ## AUTHOR
    Chef was written by Adam Jacob <adam@opscode.com> with many contributions from the community.
@@ -81,5 +81,5 @@ run\_list.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife-search.mkd
+++ b/distro/common/markdown/man1/knife-search.mkd
@@ -164,7 +164,7 @@ Find all nodes running CentOS in the production environment:
 
 ## SEE ALSO
    __knife-ssh__(1)
-   <http://wiki.opscode.com/display/chef/Attributes>
+   <http://docs.chef.io/attributes.html>
    [Lucene Query Parser Syntax](http://lucene.apache.org/java/2_3_2/queryparsersyntax.html)
 
 ## AUTHOR
@@ -175,6 +175,6 @@ Find all nodes running CentOS in the production environment:
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 
 

--- a/distro/common/markdown/man1/knife-ssh.mkd
+++ b/distro/common/markdown/man1/knife-ssh.mkd
@@ -64,6 +64,6 @@ The available multiplexers are:
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 
 

--- a/distro/common/markdown/man1/knife-status.mkd
+++ b/distro/common/markdown/man1/knife-status.mkd
@@ -31,6 +31,6 @@ may not be publicly reachable.
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 
 

--- a/distro/common/markdown/man1/knife-tag.mkd
+++ b/distro/common/markdown/man1/knife-tag.mkd
@@ -35,5 +35,5 @@ Lists the tags applied to _node_
    Permission is granted to copy, distribute and / or modify this document under the terms of the Apache 2.0 License.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io>
 

--- a/distro/common/markdown/man1/knife.mkd
+++ b/distro/common/markdown/man1/knife.mkd
@@ -186,7 +186,7 @@ recommended though, and git fits with a lot of the workflow paradigms.
   __knife-node(1)__ __knife-recipe(1)__ __knife-role(1)__
   __knife-search(1)__ __knife-ssh(1)__ __knife-tag(1)__
 
-  Complete Chef documentation is available online: <http://wiki.opscode.com/display/chef/Home/>
+  Complete Chef documentation is available online: <http://docs.chef.io/>
 
   JSON is JavaScript Object Notation <http://json.org/>
 
@@ -209,5 +209,5 @@ recommended though, and git fits with a lot of the workflow paradigms.
    On some systems, the complete text of the Apache 2.0 License may be found in `/usr/share/common-licenses/Apache-2.0`.
 
 ## CHEF
-   Knife is distributed with Chef. <http://wiki.opscode.com/display/chef/Home>
+   Knife is distributed with Chef. <http://docs.chef.io/>
 

--- a/distro/common/markdown/man8/chef-client.mkd
+++ b/distro/common/markdown/man8/chef-client.mkd
@@ -59,8 +59,7 @@ are largely services that exist only to provide the Client with information.
 
 ## SEE ALSO
 
-Full  documentation  for  Chef  and  chef-client is located on the Chef
-wiki, http://wiki.opscode.com/display/chef/Home.
+Full  documentation  for  Chef  and  chef-client is located on docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-expander.mkd
+++ b/distro/common/markdown/man8/chef-expander.mkd
@@ -67,8 +67,7 @@ See __chef-expanderctl__(8) for details.
 __chef-expanderctl__(8)
 __chef-solr__(8)
 
-Full documentation for Chef and chef-server is located on the Chef
-wiki, http://wiki.opscode.com/display/chef/Home.
+Full documentation for Chef and chef-server is located on docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-expanderctl.mkd
+++ b/distro/common/markdown/man8/chef-expanderctl.mkd
@@ -43,8 +43,7 @@ be restarted by the master process.
 __chef-expander-cluster__(8)
 __chef-solr__(8)
 
-Full documentation for Chef and chef-server is located on the Chef
-wiki, http://wiki.opscode.com/display/chef/Home.
+Full documentation for Chef and chef-server is located on docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-server-webui.mkd
+++ b/distro/common/markdown/man8/chef-server-webui.mkd
@@ -106,7 +106,7 @@ The default credentials are:
 ## SEE ALSO
 
 Full documentation for Chef and chef-server-webui (Management Console)
-is located on the Chef wiki, http://wiki.opscode.com/display/chef/Home.
+is located on the Chef docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-server.mkd
+++ b/distro/common/markdown/man8/chef-server.mkd
@@ -106,8 +106,7 @@ __chef-client__(8)
 __chef-server-webui__(8)
 __knife__(1)
 
-Full documentation for Chef and chef-server is located on the Chef
-wiki, http://wiki.opscode.com/display/chef/Home.
+Full documentation for Chef and chef-server is located on docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-solo.mkd
+++ b/distro/common/markdown/man8/chef-solo.mkd
@@ -92,8 +92,8 @@ and use the run_list from ~/node.json.
 
 ## SEE ALSO
 
-Full documentation for Chef and  chef-solo  is  located  on  the  Chef  wiki,
-http://wiki.opscode.com/display/chef/Home.
+Full documentation for Chef and  chef-solo  is  located  on  the  Chef  docs site,
+http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/distro/common/markdown/man8/chef-solr.mkd
+++ b/distro/common/markdown/man8/chef-solr.mkd
@@ -75,7 +75,7 @@ when prompted for confirmation. The process should look like this:
 __chef-expander-cluster__(8)
 
 Full documentation for Chef and chef-server is located on the Chef
-wiki, http://wiki.opscode.com/display/chef/Home.
+Docs site, http://docs.chef.io/.
 
 ## AUTHOR
 

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -603,7 +603,7 @@ class Chef
           msg=<<-OBSOLETED
 The dependency specification syntax you are using is no longer valid. You may not
 specify more than one version constraint for a particular cookbook.
-Consult http://wiki.opscode.com/display/chef/Metadata for the updated syntax.
+Consult https://docs.chef.io/config_rb_metadata.html for the updated syntax.
 
 Called by: #{caller_name} '#{dep_name}', #{version_constraints.map {|vc| vc.inspect}.join(", ")}
 Called from:
@@ -622,7 +622,7 @@ OBSOLETED
 The version constraint syntax you are using is not valid. If you recently
 upgraded to Chef 0.10.0, be aware that you no may longer use "<<" and ">>" for
 'less than' and 'greater than'; use '<' and '>' instead.
-Consult http://wiki.opscode.com/display/chef/Metadata for more information.
+Consult https://docs.chef.io/config_rb_metadata.html for more information.
 
 Called by: #{caller_name} '#{dep_name}', '#{constraint_str}'
 Called from:

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -106,7 +106,7 @@ class Chef
       if @cookbooks_by_name.has_key?(cookbook.to_sym) or load_cookbook(cookbook.to_sym)
         @cookbooks_by_name[cookbook.to_sym]
       else
-        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook.to_s}; did you forget to add metadata to a cookbook? (http://wiki.opscode.com/display/chef/Metadata)"
+        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook.to_s}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html"
       end
     end
 

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -106,7 +106,7 @@ class Chef
       if @cookbooks_by_name.has_key?(cookbook.to_sym) or load_cookbook(cookbook.to_sym)
         @cookbooks_by_name[cookbook.to_sym]
       else
-        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook.to_s}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html"
+        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook.to_s}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html)"
       end
     end
 


### PR DESCRIPTION
I ran into an error message that still referenced the wiki site.  Seemed like a good idea to nuke all the old links