### PR TITLE
Apply an SSL Policy to CookbookSiteStreamingUploader, fixing SSL errors uploading to private Supermarkets

### DIFF
--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -142,13 +142,8 @@ class Chef
         req.content_type = 'multipart/form-data; boundary=' + boundary unless parts.empty?
         req.body_stream = body_stream
 
-        http = Net::HTTP.new(url.host, url.port)
-        if url.scheme == "https"
-          http.use_ssl = true
-          Chef::HTTP::DefaultSSLPolicy.apply_to(http)
-        end
+        http = Chef::HTTP::BasicClient.new(url).http_client
         res = http.request(req)
-        #res = http.start {|http_proc| http_proc.request(req) }
 
         # alias status to code and to_s to body for test purposes
         # TODO: stop the following madness!

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -22,7 +22,6 @@ require 'uri'
 require 'net/http'
 require 'mixlib/authentication/signedheaderauth'
 require 'openssl'
-require 'chef/http/ssl_policies'
 
 class Chef
   # == Chef::CookbookSiteStreamingUploader

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -22,6 +22,7 @@ require 'uri'
 require 'net/http'
 require 'mixlib/authentication/signedheaderauth'
 require 'openssl'
+require 'chef/http/ssl_policies'
 
 class Chef
   # == Chef::CookbookSiteStreamingUploader
@@ -106,7 +107,7 @@ class Chef
 
         url = URI.parse(to_url)
 
-        Chef::Log.logger.debug("Signing: method: #{http_verb}, path: #{url.path}, file: #{content_file}, User-id: #{user_id}, Timestamp: #{timestamp}")
+        Chef::Log.logger.debug("Signing: method: #{http_verb}, url: #{url}, file: #{content_file}, User-id: #{user_id}, Timestamp: #{timestamp}")
 
         # We use the body for signing the request if the file parameter
         # wasn't a valid file or wasn't included. Extract the body (with
@@ -145,6 +146,7 @@ class Chef
         if url.scheme == "https"
           http.use_ssl = true
           http.verify_mode = verify_mode
+          Chef::HTTP::DefaultSSLPolicy.apply_to(http)
         end
         res = http.request(req)
         #res = http.start {|http_proc| http_proc.request(req) }

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -145,7 +145,6 @@ class Chef
         http = Net::HTTP.new(url.host, url.port)
         if url.scheme == "https"
           http.use_ssl = true
-          http.verify_mode = verify_mode
           Chef::HTTP::DefaultSSLPolicy.apply_to(http)
         end
         res = http.request(req)
@@ -166,17 +165,6 @@ class Chef
           end
         end
         res
-      end
-
-      private
-
-      def verify_mode
-        verify_mode = Chef::Config[:ssl_verify_mode]
-        if verify_mode == :verify_none
-          OpenSSL::SSL::VERIFY_NONE
-        elsif verify_mode == :verify_peer
-          OpenSSL::SSL::VERIFY_PEER
-        end
       end
 
     end

--- a/spec/unit/cookbook_site_streaming_uploader_spec.rb
+++ b/spec/unit/cookbook_site_streaming_uploader_spec.rb
@@ -121,27 +121,6 @@ describe Chef::CookbookSiteStreamingUploader do
       })
     end
 
-    describe "http verify mode" do
-      before do
-        @uri = "https://cookbooks.dummy.com/api/v1/cookbooks"
-        uri_info = URI.parse(@uri)
-        @http = Net::HTTP.new(uri_info.host, uri_info.port)
-        expect(Net::HTTP).to receive(:new).with(uri_info.host, uri_info.port).and_return(@http)
-      end
-
-      it "should be VERIFY_NONE when ssl_verify_mode is :verify_none" do
-        Chef::Config[:ssl_verify_mode] = :verify_none
-        Chef::CookbookSiteStreamingUploader.make_request(:post, @uri, 'bill', @secret_filename)
-        expect(@http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
-      end
-
-      it "should be VERIFY_PEER when ssl_verify_mode is :verify_peer" do
-        Chef::Config[:ssl_verify_mode] = :verify_peer
-        Chef::CookbookSiteStreamingUploader.make_request(:post, @uri, 'bill', @secret_filename)
-        expect(@http.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
-      end
-    end
-
   end # make_request
 
   describe "StreamPart" do


### PR DESCRIPTION
This change provides a simple fix to the SSL errors encountered in this issue: https://github.com/chef/chef/pull/3324  by using `Chef::HTTP::BasicClient` instead of `Net::HTTP` directly.  

Without this fix, initial connections to Private Supermarket work fine but the cookbook upload stage mysteriously fails.

ChangeLog-Entry: Fix SSL policy and Proxy handling in CookbookSiteStreamingUploader to work like other components in Chef.

For review by: @chef/client-core 