### PR TITLE
remote_file support for windows network shares

### DIFF
--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -45,7 +45,11 @@ class Chef
           sources = sources.dup
           source = sources.shift
           begin
-            uri = URI.parse(source)
+            uri = if Chef::Provider::RemoteFile::Fetcher.network_share?(source)
+              source
+            else
+              URI.parse(source)
+            end
             raw_file = grab_file_from_uri(uri)
           rescue SocketError, Errno::ECONNREFUSED, Errno::ENOENT, Errno::EACCES, Timeout::Error, Net::HTTPServerException, Net::HTTPFatalError, Net::FTPError => e
             Chef::Log.warn("#{@new_resource} cannot be downloaded from #{source}: #{e.to_s}")

--- a/lib/chef/provider/remote_file/fetcher.rb
+++ b/lib/chef/provider/remote_file/fetcher.rb
@@ -23,15 +23,29 @@ class Chef
       class Fetcher
 
         def self.for_resource(uri, new_resource, current_resource)
-          case uri.scheme
-          when "http", "https"
-            Chef::Provider::RemoteFile::HTTP.new(uri, new_resource, current_resource)
-          when "ftp"
-            Chef::Provider::RemoteFile::FTP.new(uri, new_resource, current_resource)
-          when "file"
-            Chef::Provider::RemoteFile::LocalFile.new(uri, new_resource, current_resource)
+          if network_share?(uri)
+            Chef::Provider::RemoteFile::NetworkFile.new(uri, new_resource, current_resource)
           else
-            raise ArgumentError, "Invalid uri, Only http(s), ftp, and file are currently supported"
+            case uri.scheme
+            when "http", "https"
+              Chef::Provider::RemoteFile::HTTP.new(uri, new_resource, current_resource)
+            when "ftp"
+              Chef::Provider::RemoteFile::FTP.new(uri, new_resource, current_resource)
+            when "file"
+              Chef::Provider::RemoteFile::LocalFile.new(uri, new_resource, current_resource)
+            else
+              raise ArgumentError, "Invalid uri, Only http(s), ftp, and file are currently supported"
+            end
+          end
+        end
+
+        # Windows network share: \\computername\share\file
+        def self.network_share?(source)
+          case source
+          when String
+            !!(%r{\A\\\\[A-Za-z][A-Za-z0-9+\-\.]*} =~ source)
+          else
+            false
           end
         end
 

--- a/lib/chef/provider/remote_file/fetcher.rb
+++ b/lib/chef/provider/remote_file/fetcher.rb
@@ -43,7 +43,7 @@ class Chef
         def self.network_share?(source)
           case source
           when String
-            !!(%r{\A\\\\[A-Za-z][A-Za-z0-9+\-\.]*} =~ source)
+            !!(%r{\A\\\\[A-Za-z0-9+\-\.]+} =~ source)
           else
             false
           end

--- a/lib/chef/provider/remote_file/network_file.rb
+++ b/lib/chef/provider/remote_file/network_file.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Jesse Campbell (<hikeit@gmail.com>)
+# Copyright:: Copyright (c) 2013 Jesse Campbell
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'uri'
+require 'tempfile'
+require 'chef/provider/remote_file'
+
+class Chef
+  class Provider
+    class RemoteFile
+      class NetworkFile
+
+        attr_reader :new_resource
+
+        def initialize(source, new_resource, current_resource)
+          @new_resource = new_resource
+          @source = source
+        end
+
+        # Fetches the file on a network share, returning a Tempfile-like File handle
+        # windows only
+        def fetch
+          tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
+          Chef::Log.debug("#{new_resource} staging #{@source} to #{tempfile.path}")
+          FileUtils.cp(@source, tempfile.path)
+          tempfile.close if tempfile
+          tempfile
+        end
+
+      end
+    end
+  end
+end

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -122,6 +122,7 @@ require 'chef/provider/deploy/timestamped'
 require 'chef/provider/remote_file/ftp'
 require 'chef/provider/remote_file/http'
 require 'chef/provider/remote_file/local_file'
+require 'chef/provider/remote_file/network_file'
 require 'chef/provider/remote_file/fetcher'
 
 require "chef/provider/lwrp_base"

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -140,7 +140,7 @@ class Chef
       end
 
       def absolute_uri?(source)
-        source.kind_of?(String) and URI.parse(source).absolute?
+        Chef::Provider::RemoteFile::Fetcher.network_share?(source) or (source.kind_of?(String) and URI.parse(source).absolute?) 
       rescue URI::InvalidURIError
         false
       end

--- a/spec/unit/provider/remote_file/fetcher_spec.rb
+++ b/spec/unit/provider/remote_file/fetcher_spec.rb
@@ -25,13 +25,22 @@ describe Chef::Provider::RemoteFile::Fetcher do
   let(:fetcher_instance) { double("fetcher") }
 
   describe "when passed a network share" do
-    let(:source) { "\\\\foohost\\fooshare\\Foo.tar.gz" }
-
     before do
       expect(Chef::Provider::RemoteFile::NetworkFile).to receive(:new).and_return(fetcher_instance)
     end
-    it "returns a network file fetcher" do
-      expect(described_class.for_resource(source, new_resource, current_resource)).to eq(fetcher_instance)
+
+    context "when host is a name" do
+      let(:source) { "\\\\foohost\\fooshare\\Foo.tar.gz" }
+      it "returns a network file fetcher" do
+        expect(described_class.for_resource(source, new_resource, current_resource)).to eq(fetcher_instance)
+      end
+    end
+
+    context "when host is an ip" do
+      let(:source) { "\\\\127.0.0.1\\fooshare\\Foo.tar.gz" }
+      it "returns a network file fetcher" do
+        expect(described_class.for_resource(source, new_resource, current_resource)).to eq(fetcher_instance)
+      end
     end
   end
 

--- a/spec/unit/provider/remote_file/fetcher_spec.rb
+++ b/spec/unit/provider/remote_file/fetcher_spec.rb
@@ -24,6 +24,17 @@ describe Chef::Provider::RemoteFile::Fetcher do
   let(:new_resource) { double("new resource") }
   let(:fetcher_instance) { double("fetcher") }
 
+  describe "when passed a network share" do
+    let(:source) { "\\\\foohost\\fooshare\\Foo.tar.gz" }
+
+    before do
+      expect(Chef::Provider::RemoteFile::NetworkFile).to receive(:new).and_return(fetcher_instance)
+    end
+    it "returns a network file fetcher" do
+      expect(described_class.for_resource(source, new_resource, current_resource)).to eq(fetcher_instance)
+    end
+  end
+
   describe "when passed an http url" do
     let(:uri) { double("uri", :scheme => "http" ) }
     before do
@@ -72,4 +83,3 @@ describe Chef::Provider::RemoteFile::Fetcher do
   end
 
 end
-

--- a/spec/unit/provider/remote_file/network_file_spec.rb
+++ b/spec/unit/provider/remote_file/network_file_spec.rb
@@ -1,0 +1,45 @@
+#
+# Author:: Jay Mundrawala (<jdm@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Provider::RemoteFile::NetworkFile do
+
+  let(:source) { "\\\\foohost\\fooshare\\Foo.tar.gz" }
+
+  let(:new_resource) { Chef::Resource::RemoteFile.new("network file (new_resource)") }
+  let(:current_resource) { Chef::Resource::RemoteFile.new("network file (current_resource)") }
+  subject(:fetcher) { Chef::Provider::RemoteFile::NetworkFile.new(source, new_resource, current_resource) }
+
+  describe "when fetching the object" do
+
+    let(:tempfile) { double("Tempfile", :path => "/tmp/foo/bar/Foo.tar.gz", :close => nil) }
+    let(:chef_tempfile) { double("Chef::FileContentManagement::Tempfile", :tempfile => tempfile) }
+
+    it "stages the local file to a temporary file" do
+      expect(Chef::FileContentManagement::Tempfile).to receive(:new).with(new_resource).and_return(chef_tempfile)
+      expect(::FileUtils).to receive(:cp).with(source, tempfile.path)
+      expect(tempfile).to receive(:close)
+
+      result = fetcher.fetch
+      expect(result).to eq(tempfile)
+    end
+
+  end
+
+end

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -39,6 +39,11 @@ describe Chef::Resource::RemoteFile do
     expect(Chef::Platform.find_provider(:noplatform, 'noversion', @resource)).to eq(Chef::Provider::RemoteFile)
   end
 
+  it "says its provider is RemoteFile when the source is a network share" do
+    @resource.source("\\\\fakey\\fakerton\\fake.txt")
+    expect(@resource.provider).to eq(Chef::Provider::RemoteFile)
+    expect(Chef::Platform.find_provider(:noplatform, 'noversion', @resource)).to eq(Chef::Provider::RemoteFile)
+  end
 
   describe "source" do
     it "does not have a default value for 'source'" do
@@ -48,6 +53,11 @@ describe Chef::Resource::RemoteFile do
     it "should accept a URI for the remote file source" do
       @resource.source "http://opscode.com/"
       expect(@resource.source).to eql([ "http://opscode.com/" ])
+    end
+
+    it "should accept a windows network share source" do
+      @resource.source "\\\\fakey\\fakerton\\fake.txt"
+      expect(@resource.source).to eql([ "\\\\fakey\\fakerton\\fake.txt" ])
     end
 
     it "should accept a delayed evalutator (string) for the remote file source" do


### PR DESCRIPTION
```ruby
remote_file 'C:\Foo.tar.gz' do
  source "\\\\foohost\\fooshare\\Foo.tar.gz"
end
```

cc @btm @ksubrama @smurawski 