### PR TITLE
Check if proxy env_var is empty

### DIFF
--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -101,12 +101,16 @@ class Chef
                 env["#{url.scheme.upcase}_PROXY"] || env["#{url.scheme}_proxy"]
 
         # Check if the proxy string contains a scheme. If not, add the url's scheme to the
-        # proxy before parsing. The regex /^.*:\/\// matches, for example, http://.
-        proxy = if proxy.match(/^.*:\/\//)
-          URI.parse(proxy)
-        else
-          URI.parse("#{url.scheme}://#{proxy}")
-        end if String === proxy
+        # proxy before parsing. The regex /^.*:\/\// matches, for example, http://. Reusing proxy
+        # here since we are really just trying to get the string built correctly.
+        if String === proxy && !proxy.strip.empty?
+          if proxy.match(/^.*:\/\//)
+           proxy = URI.parse(proxy.strip)
+          else
+           proxy = URI.parse("#{url.scheme}://#{proxy.strip}")
+          end 
+        end
+        
         no_proxy = Chef::Config[:no_proxy] || env['NO_PROXY'] || env['no_proxy']
         excludes = no_proxy.to_s.split(/\s*,\s*/).compact
         excludes = excludes.map { |exclude| exclude =~ /:\d+$/ ? exclude : "#{exclude}:*" }

--- a/spec/unit/http/basic_client_spec.rb
+++ b/spec/unit/http/basic_client_spec.rb
@@ -109,5 +109,21 @@ describe "HTTP Connection" do
       end
 
     end
+
+    context "when an empty proxy is set by the environment" do
+      let(:env) do
+        {
+          "https_proxy" => ""
+        }
+      end
+
+      before do
+        allow(subject).to receive(:env).and_return(env)
+      end
+
+      it "to not fail with URI parse exception" do
+        expect { subject.proxy_uri }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
We need to check if the env variable is set to empty string. If we don't we can get in an edge case where we blow up trying to call URI.parse.