### PR TITLE
Escape string inside regex

### DIFF
--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -63,7 +63,7 @@ class Chef
         def recipe_snippet
           return nil if dynamic_resource?
           @snippet ||= begin
-            if file = resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1] and line = resource.source_line[/^#{Regexp.escape(file)}:([\d]+)/,1].to_i
+            if file = parse_source and line = parse_line(file)
               return nil unless ::File.exists?(file)
               lines = IO.readlines(file)
 
@@ -110,6 +110,16 @@ class Chef
           line_nr_string = (line_nr + 1).to_s.rjust(3) + ": "
           line_nr_string + line
         end
+
+        def parse_source
+          resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1]
+        end
+
+        def parse_line(source)
+          resource.source_line[/^#{Regexp.escape(source)}:([\d]+)/,1].to_i
+        end
+
+
 
       end
     end

--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -63,7 +63,7 @@ class Chef
         def recipe_snippet
           return nil if dynamic_resource?
           @snippet ||= begin
-            if file = resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1] and line = resource.source_line[/^#{file}:([\d]+)/,1].to_i
+            if file = resource.source_line[/^(([\w]:)?[^:]+):([\d]+)/,1] and line = resource.source_line[/^#{Regexp.escape(file)}:([\d]+)/,1].to_i
               return nil unless ::File.exists?(file)
               lines = IO.readlines(file)
 

--- a/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/resource_failure_inspector_spec.rb
@@ -126,6 +126,13 @@ describe Chef::Formatters::ErrorInspectors::ResourceFailureInspector do
         expect(@inspector.recipe_snippet).to match(/^# In C:\/Users\/btm/)
       end
 
+      it "parses a Windows path" do
+        source_line = "C:\\Windows\\Temp\\packer\\cookbooks\\fake_file.rb:2: undefined local variable or method `non_existent' for main:Object (NameError)"
+        @resource.source_line = source_line
+        @inspector = Chef::Formatters::ErrorInspectors::ResourceFailureInspector.new(@resource, :create, @exception)
+        expect(@inspector.recipe_snippet).to match(/^# In C:\\Windows\\Temp\\packer\\/)
+      end
+
       it "parses a unix path" do
         source_line = "/home/btm/src/chef/chef/spec/unit/fake_file.rb:2: undefined local variable or method `non_existent' for main:Object (NameError)"
         @resource.source_line = source_line


### PR DESCRIPTION
Should fix #3055
The unit tests repros the issue, but does not fail. Ruby seems to be logging a warning somewhere internally