### PR TITLE
Separate audit and converge failures

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -253,6 +253,11 @@ class Chef::Application::Client < Chef::Application
     :description    => "Enable audit-mode with `enabled`. Disable audit-mode with `disabled`. Skip converge and only perform audits with `audit-only`",
     :proc           => lambda { |mo| mo.gsub("-", "_").to_sym }
 
+  option :audit_as_warning,
+    :long           => "--audit-as-warning",
+    :description    => "Interpret failed controls as warnings.",
+    :boolean        => true
+
   option :minimal_ohai,
     :long           => "--minimal-ohai",
     :description    => "Only run the bare minimum ohai plugins chef needs to function",

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -253,11 +253,6 @@ class Chef::Application::Client < Chef::Application
     :description    => "Enable audit-mode with `enabled`. Disable audit-mode with `disabled`. Skip converge and only perform audits with `audit-only`",
     :proc           => lambda { |mo| mo.gsub("-", "_").to_sym }
 
-  option :audit_as_warning,
-    :long           => "--audit-as-warning",
-    :description    => "Interpret failed controls as warnings.",
-    :boolean        => true
-
   option :minimal_ohai,
     :long           => "--minimal-ohai",
     :description    => "Only run the bare minimum ohai plugins chef needs to function",

--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -167,10 +167,6 @@ class Chef
       def iso8601ify(time)
         time.utc.iso8601.to_s
       end
-
-      def error_message_for_run_data(error)
-        "#{err.class.to_s}: #{err.message}\n#{err.backtrace.join("\n")}"
-      end
     end
   end
 end

--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -120,7 +120,11 @@ class Chef
 
         if @exception || error
           errors = [@exception, error].uniq.compact
-          errors_messages = errors.map  { |err| "#{err.class.to_s}: #{err.message}\n#{err.backtrace.join("\n")}" }
+          errors_messages = errors.map  do |err|
+            msg = "#{err.class.to_s}: #{err.message}"
+            msg << "\n#{err.backtrace.join("\n")}" if err.backtrace
+            msg
+          end
           run_data[:error] = errors_messages.join("\n")
         end
 

--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -34,7 +34,7 @@ class Chef
         @rest_client = rest_client
         # Ruby 1.9.3 and above "enumerate their values in the order that the corresponding keys were inserted."
         @ordered_control_groups = Hash.new
-        @exception = nil
+        @audit_phase_error = nil
       end
 
       def run_context
@@ -60,7 +60,7 @@ class Chef
       # known control groups.
       def audit_phase_failed(error)
         # The stacktrace information has already been logged elsewhere
-        @exception = error
+        @audit_phase_error = error
         Chef::Log.debug("Audit Reporter failed.")
         ordered_control_groups.each do |name, control_group|
           audit_data.add_control_group(control_group)
@@ -120,9 +120,9 @@ class Chef
         Chef::Log.debug("Sending audit report (run-id: #{audit_data.run_id})")
         run_data = audit_data.to_hash
 
-        if @exception
-          error_info = "#{@exception.class}: #{@exception.message}"
-          error_info << "\n#{@exception.backtrace.join("\n")}" if @exception.backtrace
+        if @audit_phase_error
+          error_info = "#{@audit_phase_error.class}: #{@audit_phase_error.message}"
+          error_info << "\n#{@audit_phase_error.backtrace.join("\n")}" if @audit_phase_error.backtrace
           run_data[:error] = error_info
         end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -511,8 +511,6 @@ class Chef
         raise error
       end
 
-      run_error = nil
-
       true
     end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -539,16 +539,13 @@ class Chef
     end
 
     def wrap_exceptions(converge_error, audit_error)
-      if audit_error && !(audit_error.is_a?(Chef::Exceptions::AuditsFailed) && Chef::Config[:audit_as_warning])
-        if converge_error
-          return Chef::Exceptions::RunFailedWrappingError.new(converge_error, audit_error)
-        else
-          return Chef::Exceptions::RunFailedWrappingError.new(audit_error)
-        end
+      err = if audit_error && !audit_error.is_a?(Chef::Exceptions::AuditsFailed)
+        Chef::Exceptions::RunFailedWrappingError.new(converge_error, audit_error)
       elsif converge_error
-        return Chef::Exceptions::RunFailedWrappingError.new(converge_error)
+        Chef::Exceptions::RunFailedWrappingError.new(converge_error)
       end
-      nil
+      err.fill_backtrace if err
+      err
     end
 
   end

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -51,4 +51,3 @@ class Chef
 
   end
 end
-

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -435,7 +435,7 @@ class Chef
         wrapped_errors.each_with_index do |e,i|
           backtrace << "#{i+1}) #{e.class} -  #{e.message}"
           backtrace += e.backtrace if e.backtrace
-          backtrace << ""
+          backtrace << "" unless i == wrapped_errors.length - 1
         end
         set_backtrace(backtrace)
       end

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -184,8 +184,10 @@ class Chef
         puts_line "Audit phase exception:"
         indent
         puts_line "#{error.message}"
-        error.backtrace.each do |l|
-          puts_line l
+        if error.backtrace
+          error.backtrace.each do |l|
+            puts_line l
+          end
         end
       end
 

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -213,7 +213,7 @@ class Chef
       # If we failed before we received the run_started callback, there's not much we can do
       # in terms of reporting
       if @run_status
-          post_reporting_data
+        post_reporting_data
       end
     end
 

--- a/spec/support/shared/context/client.rb
+++ b/spec/support/shared/context/client.rb
@@ -3,28 +3,28 @@ require 'spec_helper'
 
 # Stubs a basic client object
 shared_context "client" do
-  let(:hostname)    { "hostname" }
-  let(:machinename) { "machinename.example.org" }
-  let(:fqdn)        { "hostname.example.org" }
+  let(:fqdn)             { "hostname.example.org" }
+  let(:hostname)         { "hostname" }
+  let(:machinename)      { "machinename.example.org" }
+  let(:platform)         { "example-platform" }
+  let(:platform_version) { "example-platform-1.0" }
 
   let(:ohai_data) do
-    { :fqdn             => fqdn,
-      :hostname         => hostname,
-      :machinename      => machinename,
-      :platform         => 'example-platform',
-      :platform_version => 'example-platform-1.0',
-      :data             => {}
+    {
+      :fqdn =>             fqdn,
+      :hostname =>         hostname,
+      :machinename =>      machinename,
+      :platform =>         platform,
+      :platform_version => platform_version
     }
   end
 
   let(:ohai_system) do
-    ohai_system = double( "Ohai::System",
-                          :all_plugins => true,
-                          :data => ohai_data)
-    allow(ohai_system).to receive(:[]) do |key|
-      ohai_data[key]
+    ohai = instance_double("Ohai::System", :all_plugins => true, :data => ohai_data)
+    allow(ohai).to receive(:[]) do |k|
+      ohai_data[k]
     end
-    ohai_system
+    ohai
   end
 
   let(:node) do

--- a/spec/support/shared/context/client.rb
+++ b/spec/support/shared/context/client.rb
@@ -1,0 +1,275 @@
+
+require 'spec_helper'
+
+# Stubs a basic client object
+shared_context "client" do
+  let(:hostname)    { "hostname" }
+  let(:machinename) { "machinename.example.org" }
+  let(:fqdn)        { "hostname.example.org" }
+
+  let(:ohai_data) do
+    { :fqdn             => fqdn,
+      :hostname         => hostname,
+      :machinename      => machinename,
+      :platform         => 'example-platform',
+      :platform_version => 'example-platform-1.0',
+      :data             => {}
+    }
+  end
+
+  let(:ohai_system) do
+    ohai_system = double( "Ohai::System",
+                          :all_plugins => true,
+                          :data => ohai_data)
+    allow(ohai_system).to receive(:[]) do |key|
+      ohai_data[key]
+    end
+    ohai_system
+  end
+
+  let(:node) do
+    Chef::Node.new.tap do |n|
+      n.name(fqdn)
+      n.chef_environment("_default")
+    end
+  end
+
+  let(:json_attribs) { nil }
+  let(:client_opts) { {} }
+
+  let(:client) do
+    Chef::Config[:event_loggers] = []
+    Chef::Client.new(json_attribs, client_opts).tap do |c|
+      c.node = node
+    end
+  end
+
+  before do
+    Chef::Log.logger = Logger.new(StringIO.new)
+
+    # Node/Ohai data
+    #Chef::Config[:node_name] = fqdn
+    allow(Ohai::System).to receive(:new).and_return(ohai_system)
+  end
+end
+
+# Stubs a client for a client run.
+# Requires a client object be defined in the scope of this included context.
+# e.g.:
+#   describe "some functionality" do
+#     include_context "client"
+#     include_context "a client run"
+#     ...
+#   end
+shared_context "a client run" do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  let(:api_client_exists?) { false }
+  let(:enable_fork)        { false }
+
+  let(:http_cookbook_sync) { double("Chef::REST (cookbook sync)") }
+  let(:http_node_load)     { double("Chef::REST (node)") }
+  let(:http_node_save)     { double("Chef::REST (node save)") }
+
+  let(:runner)       { instance_double("Chef::Runner") }
+  let(:audit_runner) { instance_double("Chef::Audit::Runner", :failed? => false) }
+
+  def stub_for_register
+    # --Client.register
+    #   Make sure Client#register thinks the client key doesn't
+    #   exist, so it tries to register and create one.
+    allow(File).to receive(:exists?).and_call_original
+    expect(File).to receive(:exists?).
+      with(Chef::Config[:client_key]).
+      exactly(:once).
+      and_return(api_client_exists?)
+
+    unless api_client_exists?
+      #   Client.register will register with the validation client name.
+      expect_any_instance_of(Chef::ApiClient::Registration).to receive(:run)
+    end
+  end
+
+  def stub_for_node_load
+    #   Client.register will then turn around create another
+    #   Chef::REST object, this time with the client key it got from the
+    #   previous step.
+    expect(Chef::REST).to receive(:new).
+      with(Chef::Config[:chef_server_url], fqdn, Chef::Config[:client_key]).
+      exactly(:once).
+      and_return(http_node_load)
+
+    # --Client#build_node
+    #   looks up the node, which we will return, then later saves it.
+    expect(Chef::Node).to receive(:find_or_create).with(fqdn).and_return(node)
+
+    # --ResourceReporter#node_load_completed
+    #   gets a run id from the server for storing resource history
+    #   (has its own tests, so stubbing it here.)
+    expect_any_instance_of(Chef::ResourceReporter).to receive(:node_load_completed)
+  end
+
+  def stub_for_sync_cookbooks
+    # --Client#setup_run_context
+    # ---Client#sync_cookbooks -- downloads the list of cookbooks to sync
+    #
+    expect_any_instance_of(Chef::CookbookSynchronizer).to receive(:sync_cookbooks)
+    expect(Chef::REST).to receive(:new).with(Chef::Config[:chef_server_url]).and_return(http_cookbook_sync)
+    expect(http_cookbook_sync).to receive(:post).
+      with("environments/_default/cookbook_versions", {:run_list => []}).
+      and_return({})
+  end
+
+  def stub_for_converge
+    # define me
+  end
+
+  def stub_for_audit
+    # define me
+  end
+
+  def stub_for_node_save
+    # define me
+  end
+
+  def stub_for_run
+    # define me
+  end
+
+  before do
+    Chef::Config[:client_fork] = enable_fork
+    Chef::Config[:cache_path] = windows? ? 'C:\chef' : '/var/chef'
+    Chef::Config[:why_run] = false
+    Chef::Config[:audit_mode] = :enabled
+
+    stub_const("Chef::Client::STDOUT_FD", stdout)
+    stub_const("Chef::Client::STDERR_FD", stderr)
+
+    stub_for_register
+    stub_for_node_load
+    stub_for_sync_cookbooks
+    stub_for_converge
+    stub_for_audit
+    stub_for_node_save
+
+    expect_any_instance_of(Chef::RunLock).to receive(:acquire)
+    expect_any_instance_of(Chef::RunLock).to receive(:save_pid)
+    expect_any_instance_of(Chef::RunLock).to receive(:release)
+
+    # Post conditions: check that node has been filled in correctly
+    expect(client).to receive(:run_started)
+
+    stub_for_run
+  end
+end
+
+shared_context "converge completed" do
+  def stub_for_converge
+    # --Client#converge
+    expect(Chef::Runner).to receive(:new).and_return(runner)
+    expect(runner).to receive(:converge).and_return(true)
+  end
+
+  def stub_for_node_save
+    allow(node).to receive(:data_for_save).and_return(node.for_json)
+
+    # --Client#save_updated_node
+    expect(Chef::REST).to receive(:new).with(Chef::Config[:chef_server_url], fqdn, Chef::Config[:client_key], validate_utf8: false).and_return(http_node_save)
+    expect(http_node_save).to receive(:put_rest).with("nodes/#{fqdn}", node.for_json).and_return(true)
+  end
+end
+
+shared_context "converge failed" do
+  let(:converge_error) do
+    err = Chef::Exceptions::UnsupportedAction.new("Action unsupported")
+    err.set_backtrace([ "/path/recipe.rb:15", "/path/recipe.rb:12" ])
+    err
+  end
+
+  def stub_for_converge
+    expect(Chef::Runner).to receive(:new).and_return(runner)
+    expect(runner).to receive(:converge).and_raise(converge_error)
+  end
+
+  def stub_for_node_save
+    expect(client).to_not receive(:save_updated_node)
+  end
+end
+
+shared_context "audit phase completed" do
+  def stub_for_audit
+    # -- Client#run_audits
+    expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
+    expect(audit_runner).to receive(:run).and_return(true)
+    expect(client.events).to receive(:audit_phase_complete)
+  end
+end
+
+shared_context "audit phase failed with error" do
+  let(:audit_error) do
+    err = RuntimeError.new("Unexpected audit error")
+    err.set_backtrace([ "/path/recipe.rb:57", "/path/recipe.rb:55" ])
+    err
+  end
+
+  def stub_for_audit
+    expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
+    expect(audit_runner).to receive(:run).and_raise(audit_error)
+    expect(client.events).to receive(:audit_phase_failed).with(audit_error)
+  end
+end
+
+shared_context "audit phase completed with failed controls" do
+  let(:audit_runner) { instance_double("Chef::Audit::Runner", :failed? => true,
+    :num_failed => 1, :num_total => 3) }
+
+  let(:audit_error) do
+    err = Chef::Exceptions::AuditsFailed.new(audit_runner.num_failed, audit_runner.num_total)
+    err.set_backtrace([ "/path/recipe.rb:108", "/path/recipe.rb:103" ])
+    err
+  end
+
+  def stub_for_audit
+    expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
+    expect(audit_runner).to receive(:run)
+    expect(Chef::Exceptions::AuditsFailed).to receive(:new).with(
+      audit_runner.num_failed, audit_runner.num_total
+    ).and_return(audit_error)
+    expect(client.events).to receive(:audit_phase_failed).with(audit_error)
+  end
+end
+
+shared_context "run completed" do
+  def stub_for_run
+    expect(client).to receive(:run_completed_successfully)
+
+    # --ResourceReporter#run_completed
+    #   updates the server with the resource history
+    #   (has its own tests, so stubbing it here.)
+    expect_any_instance_of(Chef::ResourceReporter).to receive(:run_completed)
+    # --AuditReporter#run_completed
+    #   posts the audit data to server.
+    #   (has its own tests, so stubbing it here.)
+    expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_completed)
+  end
+end
+
+shared_context "run failed" do
+  def stub_for_run
+    expect(client).to receive(:run_failed)
+
+    # --ResourceReporter#run_completed
+    #   updates the server with the resource history
+    #   (has its own tests, so stubbing it here.)
+    expect_any_instance_of(Chef::ResourceReporter).to receive(:run_failed)
+    # --AuditReporter#run_completed
+    #   posts the audit data to server.
+    #   (has its own tests, so stubbing it here.)
+    expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_failed)
+  end
+
+  before do
+    expect(Chef::Application).to receive(:debug_stacktrace).with an_instance_of(Chef::Exceptions::RunFailedWrappingError)
+  end
+end

--- a/spec/support/shared/examples/client.rb
+++ b/spec/support/shared/examples/client.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 require 'spec/support/shared/context/client'
 
+# requires platform and platform_version be defined
 shared_examples "a completed run" do
   include_context "run completed"
 
@@ -10,8 +11,8 @@ shared_examples "a completed run" do
     expect(client.run).to be true
 
     # fork is stubbed, so we can see the outcome of the run
-    expect(node.automatic_attrs[:platform]).to eq("example-platform")
-    expect(node.automatic_attrs[:platform_version]).to eq("example-platform-1.0")
+    expect(node.automatic_attrs[:platform]).to eq(platform)
+    expect(node.automatic_attrs[:platform_version]).to eq(platform_version)
   end
 end
 

--- a/spec/support/shared/examples/client.rb
+++ b/spec/support/shared/examples/client.rb
@@ -1,0 +1,30 @@
+
+require 'spec_helper'
+require 'spec/support/shared/context/client'
+
+shared_examples "a completed run" do
+  include_context "run completed"
+
+  it "runs ohai, sets up authentication, loads node state, synchronizes policy, converges, and runs audits" do
+    # This is what we're testing.
+    expect(client.run).to be true
+
+    # fork is stubbed, so we can see the outcome of the run
+    expect(node.automatic_attrs[:platform]).to eq("example-platform")
+    expect(node.automatic_attrs[:platform_version]).to eq("example-platform-1.0")
+  end
+end
+
+shared_examples "a failed run" do
+  include_context "run failed"
+
+  it "skips node save and raises the error in a wrapping error" do
+    expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
+      expect(error.wrapped_errors.size).to eq(run_errors.size)
+      run_errors.each do |run_error|
+        expect(error.wrapped_errors).to include(run_error)
+        expect(error.backtrace).to include(*run_error.backtrace)
+      end
+    end
+  end
+end

--- a/spec/support/shared/examples/client.rb
+++ b/spec/support/shared/examples/client.rb
@@ -16,6 +16,28 @@ shared_examples "a completed run" do
   end
 end
 
+shared_examples "a completed run with audit failure" do
+  include_context "run completed"
+
+  before do
+    expect(Chef::Application).to receive(:debug_stacktrace).with an_instance_of(Chef::Exceptions::RunFailedWrappingError)
+  end
+
+  it "converges, runs audits, saves the node and raises the error in a wrapping error" do
+    expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
+      expect(error.wrapped_errors.size).to eq(run_errors.size)
+      run_errors.each do |run_error|
+        expect(error.wrapped_errors).to include(run_error)
+        expect(error.backtrace).to include(*run_error.backtrace)
+      end
+    end
+
+    # fork is stubbed, so we can see the outcome of the run
+    expect(node.automatic_attrs[:platform]).to eq(platform)
+    expect(node.automatic_attrs[:platform_version]).to eq(platform_version)
+  end
+end
+
 shared_examples "a failed run" do
   include_context "run failed"
 

--- a/spec/unit/audit/audit_reporter_spec.rb
+++ b/spec/unit/audit/audit_reporter_spec.rb
@@ -88,6 +88,29 @@ describe Chef::Audit::AuditReporter do
         reporter.run_completed(node)
       end
 
+      context "when audit phase failed" do
+
+        let(:audit_error) { double("AuditError", :class => "Chef::Exceptions::AuditError",
+          :message => "Audit phase failed with error message: derpderpderp",
+          :backtrace => ["/path/recipe.rb:57", "/path/library.rb:106"]) }
+
+          before do
+            reporter.instance_variable_set(:@exception, audit_error)
+          end
+
+        it "reports an error" do
+          reporter.run_completed(node)
+          expect(run_data).to have_key(:error)
+          expect(run_data).to have_key(:error)
+          expect(run_data[:error]).to eq <<-EOM.strip!
+Chef::Exceptions::AuditError: Audit phase failed with error message: derpderpderp
+/path/recipe.rb:57
+/path/library.rb:106
+EOM
+        end
+
+      end
+
       context "when unable to post to server" do
 
         let(:error) do
@@ -215,9 +238,9 @@ describe Chef::Audit::AuditReporter do
     let(:audit_data) { Chef::Audit::AuditData.new(node.name, run_id) }
     let(:run_data) { audit_data.to_hash }
 
-    let(:error) { double("AuditError", :class => "Chef::Exception::AuditError",
-      :message => "Well that certainly didn't work",
-      :backtrace => ["line 0", "line 1", "line 2"]) }
+    let(:audit_error) { double("AuditError", :class => "Chef::Exceptions::AuditError",
+      :message => "Audit phase failed with error message: derpderpderp",
+      :backtrace => ["/path/recipe.rb:57", "/path/library.rb:106"]) }
 
     before do
       allow(reporter).to receive(:auditing_enabled?).and_return(true)
@@ -226,15 +249,60 @@ describe Chef::Audit::AuditReporter do
       allow(audit_data).to receive(:to_hash).and_return(run_data)
     end
 
-    it "adds the error information to the reported data" do
-      expect(rest).to receive(:create_url)
-      expect(rest).to receive(:post)
-      reporter.run_failed(error)
-      expect(run_data).to have_key(:error)
-      expect(run_data[:error]).to eq "Chef::Exception::AuditError: Well that certainly didn't work\n" +
-        "line 0\nline 1\nline 2"
+    context "when no prior exception is stored" do
+      it "reports the error" do
+        expect(rest).to receive(:create_url)
+        expect(rest).to receive(:post)
+        reporter.run_failed(audit_error)
+        expect(run_data).to have_key(:error)
+        expect(run_data[:error]).to eq <<-EOM.strip!
+Chef::Exceptions::AuditError: Audit phase failed with error message: derpderpderp
+/path/recipe.rb:57
+/path/library.rb:106
+EOM
+      end
     end
 
+    context "when some prior exception is stored" do
+      before do
+        reporter.instance_variable_set(:@exception, audit_error)
+      end
+
+      context "when the error is the same as the prior exception" do
+        it "reports one error" do
+          expect(rest).to receive(:create_url)
+          expect(rest).to receive(:post)
+          reporter.run_failed(audit_error)
+          expect(run_data).to have_key(:error)
+          expect(run_data[:error]).to eq <<-EOM.strip!
+Chef::Exceptions::AuditError: Audit phase failed with error message: derpderpderp
+/path/recipe.rb:57
+/path/library.rb:106
+EOM
+        end
+      end
+
+      context "when the error is not the same as the prior exception" do
+        let(:converge_error) { double("ConvergeError", :class => "Chef::Exceptions::ConvergeError",
+          :message => "Welp converge failed that's a bummer",
+          :backtrace => ["/path/recipe.rb:14", "/path/library.rb:5"]) }
+
+        it "reports both errors" do
+          expect(rest).to receive(:create_url)
+          expect(rest).to receive(:post)
+          reporter.run_failed(converge_error)
+          expect(run_data).to have_key(:error)
+          expect(run_data[:error]).to eq <<-EOM.strip!
+Chef::Exceptions::AuditError: Audit phase failed with error message: derpderpderp
+/path/recipe.rb:57
+/path/library.rb:106
+Chef::Exceptions::ConvergeError: Welp converge failed that's a bummer
+/path/recipe.rb:14
+/path/library.rb:5
+EOM
+        end
+      end
+    end
   end
 
   shared_context "audit data" do

--- a/spec/unit/audit/audit_reporter_spec.rb
+++ b/spec/unit/audit/audit_reporter_spec.rb
@@ -95,7 +95,7 @@ describe Chef::Audit::AuditReporter do
           :backtrace => ["/path/recipe.rb:57", "/path/library.rb:106"]) }
 
           before do
-            reporter.instance_variable_set(:@exception, audit_error)
+            reporter.instance_variable_set(:@audit_phase_error, audit_error)
           end
 
         it "reports an error" do
@@ -264,7 +264,7 @@ EOM
 
     context "when some prior exception is stored" do
       before do
-        reporter.instance_variable_set(:@exception, audit_error)
+        reporter.instance_variable_set(:@audit_phase_error, audit_error)
       end
 
       it "reports the prior error" do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -241,7 +241,7 @@ describe Chef::Client do
 
       describe "when audit phase errors" do
         include_context "audit phase failed with error"
-        include_examples "a failed run" do
+        include_examples "a completed run with audit failure" do
           let(:run_errors) { [audit_error] }
         end
       end
@@ -253,7 +253,9 @@ describe Chef::Client do
 
       describe "when audit phase completed with failed controls" do
         include_context "audit phase completed with failed controls"
-        include_examples "a completed run"
+        include_examples "a completed run with audit failure" do
+          let(:run_errors) { [audit_error] }
+        end
       end
     end
 
@@ -278,7 +280,7 @@ describe Chef::Client do
       describe "when audit phase completed with failed controls" do
         include_context "audit phase completed with failed controls"
         include_examples "a failed run" do
-          let(:run_errors) { [converge_error] }
+          let(:run_errors) { [converge_error, audit_error] }
         end
       end
     end
@@ -512,7 +514,10 @@ describe Chef::Client do
 
     it "should run exception handlers on early fail" do
       expect(subject).to receive(:run_failed)
-      expect { subject.run }.to raise_error(NoMethodError)
+      expect { subject.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
+        expect(error.wrapped_errors.size).to eq 1
+        expect(error.wrapped_errors).to include(NoMethodError)
+      end
     end
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -253,24 +253,7 @@ describe Chef::Client do
 
       describe "when audit phase completed with failed controls" do
         include_context "audit phase completed with failed controls"
-
-        context "with :audit_as_warning true" do
-          before do
-            Chef::Config[:audit_as_warning] = true
-          end
-
-          include_examples "a completed run"
-        end
-
-        context "with :audit_as_warning false" do
-          before do
-            Chef::Config[:audit_as_warning] = false
-          end
-
-          include_examples "a failed run" do
-            let(:run_errors) { [audit_error] }
-          end
-        end
+        include_examples "a completed run"
       end
     end
 
@@ -294,25 +277,8 @@ describe Chef::Client do
 
       describe "when audit phase completed with failed controls" do
         include_context "audit phase completed with failed controls"
-
-        context "with :audit_as_warning true" do
-          before do
-            Chef::Config[:audit_as_warning] = true
-          end
-
-          include_examples "a failed run" do
-            let(:run_errors) { [converge_error] }
-          end
-        end
-
-        context "with :audit_as_warning false" do
-          before do
-            Chef::Config[:audit_as_warning] = false
-          end
-
-          include_examples "a failed run" do
-            let(:run_errors) { [converge_error, audit_error] }
-          end
+        include_examples "a failed run" do
+          let(:run_errors) { [converge_error] }
         end
       end
     end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -19,6 +19,8 @@
 #
 
 require 'spec_helper'
+require 'spec/support/shared/context/client'
+require 'spec/support/shared/examples/client'
 
 require 'chef/run_context'
 require 'chef/rest'
@@ -28,55 +30,7 @@ class FooError < RuntimeError
 end
 
 describe Chef::Client do
-
-  let(:hostname) { "hostname" }
-  let(:machinename) { "machinename.example.org" }
-  let(:fqdn) { "hostname.example.org" }
-
-  let(:ohai_data) do
-    { :fqdn             => fqdn,
-      :hostname         => hostname,
-      :machinename      => machinename,
-      :platform         => 'example-platform',
-      :platform_version => 'example-platform-1.0',
-      :data             => {}
-    }
-  end
-
-  let(:ohai_system) do
-    ohai_system = double( "Ohai::System",
-                          :all_plugins => true,
-                          :data => ohai_data)
-    allow(ohai_system).to receive(:[]) do |key|
-      ohai_data[key]
-    end
-    ohai_system
-  end
-
-  let(:node) do
-    Chef::Node.new.tap do |n|
-      n.name(fqdn)
-      n.chef_environment("_default")
-    end
-  end
-
-  let(:json_attribs) { nil }
-  let(:client_opts) { {} }
-
-  let(:client) do
-    Chef::Config[:event_loggers] = []
-    Chef::Client.new(json_attribs, client_opts).tap do |c|
-      c.node = node
-    end
-  end
-
-  before do
-    Chef::Log.logger = Logger.new(StringIO.new)
-
-    # Node/Ohai data
-    #Chef::Config[:node_name] = fqdn
-    allow(Ohai::System).to receive(:new).and_return(ohai_system)
-  end
+  include_context "client"
 
   context "when minimal ohai is configured" do
     before do
@@ -88,7 +42,6 @@ describe Chef::Client do
       expect(ohai_system).to receive(:all_plugins).with(expected_filter)
       client.run_ohai
     end
-
   end
 
   describe "authentication protocol selection" do
@@ -117,7 +70,6 @@ describe Chef::Client do
 
   describe "configuring output formatters" do
     context "when no formatter has been configured" do
-
       context "and STDOUT is a TTY" do
         before do
           allow(STDOUT).to receive(:tty?).and_return(true)
@@ -203,135 +155,12 @@ describe Chef::Client do
   end
 
   describe "a full client run" do
-    shared_context "a client run" do
-      let(:http_node_load) { double("Chef::REST (node)") }
-      let(:http_cookbook_sync) { double("Chef::REST (cookbook sync)") }
-      let(:http_node_save) { double("Chef::REST (node save)") }
-      let(:runner) { double("Chef::Runner") }
-      let(:audit_runner) { instance_double("Chef::Audit::Runner", :failed? => false) }
-
-      let(:api_client_exists?) { false }
-
-      let(:stdout) { StringIO.new }
-      let(:stderr) { StringIO.new }
-
-      let(:enable_fork) { false }
-
-      def stub_for_register
-        # --Client.register
-        #   Make sure Client#register thinks the client key doesn't
-        #   exist, so it tries to register and create one.
-        allow(File).to receive(:exists?).and_call_original
-        expect(File).to receive(:exists?).
-          with(Chef::Config[:client_key]).
-          exactly(:once).
-          and_return(api_client_exists?)
-
-        unless api_client_exists?
-          #   Client.register will register with the validation client name.
-          expect_any_instance_of(Chef::ApiClient::Registration).to receive(:run)
-        end
-      end
-
-      def stub_for_node_load
-        #   Client.register will then turn around create another
-        #   Chef::REST object, this time with the client key it got from the
-        #   previous step.
-        expect(Chef::REST).to receive(:new).
-          with(Chef::Config[:chef_server_url], fqdn, Chef::Config[:client_key]).
-          exactly(:once).
-          and_return(http_node_load)
-
-        # --Client#build_node
-        #   looks up the node, which we will return, then later saves it.
-        expect(Chef::Node).to receive(:find_or_create).with(fqdn).and_return(node)
-
-        # --ResourceReporter#node_load_completed
-        #   gets a run id from the server for storing resource history
-        #   (has its own tests, so stubbing it here.)
-        expect_any_instance_of(Chef::ResourceReporter).to receive(:node_load_completed)
-      end
-
-      def stub_for_sync_cookbooks
-        # --Client#setup_run_context
-        # ---Client#sync_cookbooks -- downloads the list of cookbooks to sync
-        #
-        expect_any_instance_of(Chef::CookbookSynchronizer).to receive(:sync_cookbooks)
-        expect(Chef::REST).to receive(:new).with(Chef::Config[:chef_server_url]).and_return(http_cookbook_sync)
-        expect(http_cookbook_sync).to receive(:post).
-          with("environments/_default/cookbook_versions", {:run_list => []}).
-          and_return({})
-      end
-
-      def stub_for_converge
-        # --Client#converge
-        expect(Chef::Runner).to receive(:new).and_return(runner)
-        expect(runner).to receive(:converge).and_return(true)
-      end
-
-      def stub_for_audit
-        # -- Client#run_audits
-        expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
-        expect(audit_runner).to receive(:run).and_return(true)
-      end
-
-      def stub_for_node_save
-        allow(node).to receive(:data_for_save).and_return(node.for_json)
-
-        # --Client#save_updated_node
-        expect(Chef::REST).to receive(:new).with(Chef::Config[:chef_server_url], fqdn, Chef::Config[:client_key], validate_utf8: false).and_return(http_node_save)
-        expect(http_node_save).to receive(:put_rest).with("nodes/#{fqdn}", node.for_json).and_return(true)
-      end
-
-      def stub_for_run
-        expect_any_instance_of(Chef::RunLock).to receive(:acquire)
-        expect_any_instance_of(Chef::RunLock).to receive(:save_pid)
-        expect_any_instance_of(Chef::RunLock).to receive(:release)
-
-        # Post conditions: check that node has been filled in correctly
-        expect(client).to receive(:run_started)
-        expect(client).to receive(:run_completed_successfully)
-
-        # --ResourceReporter#run_completed
-        #   updates the server with the resource history
-        #   (has its own tests, so stubbing it here.)
-        expect_any_instance_of(Chef::ResourceReporter).to receive(:run_completed)
-        # --AuditReporter#run_completed
-        #   posts the audit data to server.
-        #   (has its own tests, so stubbing it here.)
-        expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_completed)
-      end
-
-      before do
-        Chef::Config[:client_fork] = enable_fork
-        Chef::Config[:cache_path] = windows? ? 'C:\chef' : '/var/chef'
-        Chef::Config[:why_run] = false
-        Chef::Config[:audit_mode] = :enabled
-
-        stub_const("Chef::Client::STDOUT_FD", stdout)
-        stub_const("Chef::Client::STDERR_FD", stderr)
-
-        stub_for_register
-        stub_for_node_load
-        stub_for_sync_cookbooks
-        stub_for_converge
-        stub_for_audit
-        stub_for_node_save
-        stub_for_run
-      end
-    end
-
     shared_examples_for "a successful client run" do
       include_context "a client run"
+      include_context "converge completed"
+      include_context "audit phase completed"
 
-      it "runs ohai, sets up authentication, loads node state, synchronizes policy, converges, and runs audits" do
-        # This is what we're testing.
-        client.run
-
-        # fork is stubbed, so we can see the outcome of the run
-        expect(node.automatic_attrs[:platform]).to eq("example-platform")
-        expect(node.automatic_attrs[:platform_version]).to eq("example-platform-1.0")
-      end
+      include_examples "a completed run"
     end
 
     describe "when running chef-client without fork" do
@@ -339,24 +168,19 @@ describe Chef::Client do
     end
 
     describe "when the client key already exists" do
-      let(:api_client_exists?) { true }
-      include_examples "a successful client run"
+      include_examples "a successful client run" do
+        let(:api_client_exists?) { true }
+      end
     end
 
-    describe "when an override run list is given" do
-      let(:client_opts) { {:override_runlist => "recipe[override_recipe]"} }
-
-      it "should permit spaces in overriding run list" do
+    context "when an override run list is given" do
+      it "permits spaces in overriding run list" do
         Chef::Client.new(nil, :override_runlist => 'role[a], role[b]')
       end
 
-      describe "when running the client" do
+      describe "calling run" do
         include_examples "a successful client run" do
-
-          before do
-            # Client will try to compile and run override_recipe
-            expect_any_instance_of(Chef::RunContext::CookbookCompiler).to receive(:compile)
-          end
+          let(:client_opts) { {:override_runlist => "recipe[override_recipe]"} }
 
           def stub_for_sync_cookbooks
             # --Client#setup_run_context
@@ -373,13 +197,22 @@ describe Chef::Client do
             # Expect NO node save
             expect(node).not_to receive(:save)
           end
+
+          before do
+            # Client will try to compile and run override_recipe
+            expect_any_instance_of(Chef::RunContext::CookbookCompiler).to receive(:compile)
+          end
         end
       end
     end
 
     describe "when a permanent run list is passed as an option" do
-      include_examples "a successful client run" do
+      it "sets the new run list on the node" do
+        client.run
+        expect(node.run_list).to eq(Chef::RunList.new(new_runlist))
+      end
 
+      include_examples "a successful client run" do
         let(:new_runlist) { "recipe[new_run_list_recipe]" }
         let(:client_opts) { {:runlist => new_runlist} }
 
@@ -399,272 +232,93 @@ describe Chef::Client do
           # do not create a fixture for this.
           expect_any_instance_of(Chef::RunContext::CookbookCompiler).to receive(:compile)
         end
-
-        it "sets the new run list on the node" do
-          client.run
-          expect(node.run_list).to eq(Chef::RunList.new(new_runlist))
-        end
       end
     end
 
-    context "when converge errors" do
-      include_context "a client run" do
+    describe "when converge completes successfully" do
+      include_context "a client run"
+      include_context "converge completed"
 
-        let(:converge_error) do
-          err = Chef::Exceptions::UnsupportedAction.new("Action unsupported")
-          err.set_backtrace([ "/path/recipe.rb:15", "/path/recipe.rb:12" ])
-          err
-        end
-
-        def stub_for_converge
-          expect(Chef::Runner).to receive(:new).and_return(runner)
-          expect(runner).to receive(:converge).and_raise(converge_error)
-        end
-
-        def stub_for_node_save
-          expect(client).to_not receive(:save_updated_node)
-        end
-
-        def stub_for_run
-          expect_any_instance_of(Chef::RunLock).to receive(:acquire)
-          expect_any_instance_of(Chef::RunLock).to receive(:save_pid)
-          expect_any_instance_of(Chef::RunLock).to receive(:release)
-
-          # Post conditions: check that node has been filled in correctly
-          expect(client).to receive(:run_started)
-          expect(client).to receive(:run_failed)
-
-          expect_any_instance_of(Chef::ResourceReporter).to receive(:run_failed)
-          expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_failed)
-        end
-
-        before do
-          expect(Chef::Application).to receive(:debug_stacktrace).with an_instance_of(Chef::Exceptions::RunFailedWrappingError)
-        end
-
-        context "without audit phase errors" do
-          it "skips node save and raises the converge error in a wrapping error" do
-            expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-              expect(error.wrapped_errors.size).to eq(1)
-              expect(error.wrapped_errors).to include(converge_error)
-              expect(error.backtrace).to include(*converge_error.backtrace)
-            end
-          end
-        end
-
-        context "when audit phase errors" do
-          context "with failed audits" do
-
-            let(:audit_error) do
-              err = Chef::Exceptions::AuditsFailed.new(num_failed, num_total)
-              err.set_backtrace([ "/path/recipe.rb:57", "/path/recipe.rb:55" ])
-              err
-            end
-
-            let(:num_failed) { 1 }
-
-            let(:num_total) { 5 }
-
-            def stub_for_audit
-              expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
-              expect(audit_runner).to receive(:run)
-              expect(audit_runner).to receive(:failed?).and_return(true)
-              expect(Chef::Exceptions::AuditsFailed).to receive(:new).with(num_failed, num_total).and_return(audit_error)
-              allow(audit_runner).to receive(:num_failed).and_return(num_failed)
-              allow(audit_runner).to receive(:num_total).and_return(num_total)
-            end
-
-            context "with audit_as_warning true" do
-              before do
-                Chef::Config[:audit_as_warning] = true
-              end
-
-              it "skips node save and raises the converge error in a wrapping error" do
-                expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                  expect(error.wrapped_errors.size).to eq(1)
-                  expect(error.wrapped_errors[0]).to eq(converge_error)
-                end
-              end
-            end
-
-            context "with audit_as_warning false" do
-
-              before do
-                Chef::Config[:audit_as_warning] = false
-              end
-
-              it "skips node save and raises converge and audit errors in a wrapping error" do
-                expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                  expect(error.wrapped_errors.size).to eq(2)
-                  expect(error.wrapped_errors).to include(converge_error)
-                  expect(error.wrapped_errors).to include(audit_error)
-                  expect(error.backtrace).to include(*converge_error.backtrace)
-                  expect(error.backtrace).to include(*audit_error.backtrace)
-                end
-              end
-            end
-          end
-
-          context "with unexpected error" do
-
-            let(:audit_error) do
-              err = RuntimeError.new("Unexpected audit error")
-              err.set_backtrace([ "/path/recipe.rb:57", "/path/recipe.rb:55" ])
-              err
-            end
-
-            def stub_for_audit
-              expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
-              expect(audit_runner).to receive(:run).and_raise(audit_error)
-            end
-
-            context "with audit_as_warning true" do
-              it "skips node save and raises converge and audit errors in a wrapping error" do
-                expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                  expect(error.wrapped_errors.size).to eq(2)
-                  expect(error.wrapped_errors).to include(converge_error)
-                  expect(error.wrapped_errors).to include(audit_error)
-                  expect(error.backtrace).to include(*converge_error.backtrace)
-                  expect(error.backtrace).to include(*audit_error.backtrace)
-                end
-              end
-            end
-
-            context "with audit_as_warning false" do
-              it "skips node save and raises converge and audit errors in a wrapping error" do
-                expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                  expect(error.wrapped_errors.size).to eq(2)
-                  expect(error.wrapped_errors).to include(converge_error)
-                  expect(error.wrapped_errors).to include(audit_error)
-                  expect(error.backtrace).to include(*converge_error.backtrace)
-                  expect(error.backtrace).to include(*audit_error.backtrace)
-                end
-              end
-            end
-          end
+      describe "when audit phase errors" do
+        include_context "audit phase failed with error"
+        include_examples "a failed run" do
+          let(:run_errors) { [audit_error] }
         end
       end
-    end
 
-    context "when audit phase errors" do
-      include_context "a client run" do
+      describe "when audit phase completed" do
+        include_context "audit phase completed"
+        include_examples "a completed run"
+      end
 
-        def stub_for_run
-          expect_any_instance_of(Chef::RunLock).to receive(:acquire)
-          expect_any_instance_of(Chef::RunLock).to receive(:save_pid)
-          expect_any_instance_of(Chef::RunLock).to receive(:release)
+      describe "when audit phase completed with failed controls" do
+        include_context "audit phase completed with failed controls"
 
-          # Post conditions: check that node has been filled in correctly
-          expect(client).to receive(:run_started)
-        end
-
-        context "with failed audits" do
-
-          let(:audit_error) do
-            err = Chef::Exceptions::AuditsFailed.new(num_failed, num_total)
-            err.set_backtrace([ "/path/recipe.rb:57", "/path/recipe.rb:55" ])
-            err
-          end
-
-          let(:num_failed) { 1 }
-
-          let(:num_total) { 5 }
-
-          def stub_for_audit
-            expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
-            expect(audit_runner).to receive(:run)
-            expect(audit_runner).to receive(:failed?).and_return(true)
-            expect(Chef::Exceptions::AuditsFailed).to receive(:new).with(num_failed, num_total).and_return(audit_error)
-            allow(audit_runner).to receive(:num_failed).and_return(num_failed)
-            allow(audit_runner).to receive(:num_total).and_return(num_total)
-          end
-
-          context "with audit_as_warning true" do
-            before do
-              Chef::Config[:audit_as_warning] = true
-            end
-
-            it "saves the node and completes the run successfully" do
-              expect(client).to receive(:run_completed_successfully)
-              expect_any_instance_of(Chef::ResourceReporter).to receive(:run_completed)
-              expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_completed)
-              client.run
-            end
-          end
-
-          context "with audit_as_warning false" do
-
-            before do
-              Chef::Config[:audit_as_warning] = false
-              expect(Chef::Application).to receive(:debug_stacktrace).with an_instance_of(Chef::Exceptions::RunFailedWrappingError)
-            end
-
-            it "saves the node and raises audit error in a wrapping error" do
-              expect(client).to receive(:run_failed)
-              expect_any_instance_of(Chef::ResourceReporter).to receive(:run_failed)
-              expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_failed)
-
-              expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                expect(error.wrapped_errors.size).to eq(1)
-                expect(error.wrapped_errors).to include(audit_error)
-                expect(error.backtrace).to include(*audit_error.backtrace)
-              end
-            end
-          end
-        end
-
-        context "with unexpected error" do
-
-          let(:audit_error) do
-            err = RuntimeError.new("Unexpected audit error")
-            err.set_backtrace([ "/path/recipe.rb:57", "/path/recipe.rb:55" ])
-            err
-          end
-
-          def stub_for_audit
-            expect(Chef::Audit::Runner).to receive(:new).and_return(audit_runner)
-            expect(audit_runner).to receive(:run).and_raise(audit_error)
-          end
-
+        context "with :audit_as_warning true" do
           before do
-            expect(Chef::Application).to receive(:debug_stacktrace).with an_instance_of(Chef::Exceptions::RunFailedWrappingError)
+            Chef::Config[:audit_as_warning] = true
           end
 
-          context "with audit_as_warning true" do
-            it "saves the node and raises audit error in a wrapping error" do
-              expect(client).to receive(:run_failed)
-              expect_any_instance_of(Chef::ResourceReporter).to receive(:run_failed)
-              expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_failed)
+          include_examples "a completed run"
+        end
 
-              expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                expect(error.wrapped_errors.size).to eq(1)
-                expect(error.wrapped_errors).to include(audit_error)
-                expect(error.backtrace).to include(*audit_error.backtrace)
-              end
-            end
+        context "with :audit_as_warning false" do
+          before do
+            Chef::Config[:audit_as_warning] = false
           end
 
-          context "with audit_as_warning false" do
-            it "skips node save and raises converge and audit errors in a wrapping error" do
-              expect(client).to receive(:run_failed)
-              expect_any_instance_of(Chef::ResourceReporter).to receive(:run_failed)
-              expect_any_instance_of(Chef::Audit::AuditReporter).to receive(:run_failed)
-
-              expect{ client.run }.to raise_error(Chef::Exceptions::RunFailedWrappingError) do |error|
-                expect(error.wrapped_errors.size).to eq(1)
-                expect(error.wrapped_errors).to include(audit_error)
-                expect(error.backtrace).to include(*audit_error.backtrace)
-              end
-            end
+          include_examples "a failed run" do
+            let(:run_errors) { [audit_error] }
           end
         end
       end
+    end
 
+    describe "when converge errors" do
+      include_context "a client run"
+      include_context "converge failed"
+
+      describe "when audit phase errors" do
+        include_context "audit phase failed with error"
+        include_examples "a failed run" do
+          let(:run_errors) { [converge_error, audit_error] }
+        end
+      end
+
+      describe "when audit phase completed" do
+        include_context "audit phase completed"
+        include_examples "a failed run" do
+          let(:run_errors) { [converge_error] }
+        end
+      end
+
+      describe "when audit phase completed with failed controls" do
+        include_context "audit phase completed with failed controls"
+
+        context "with :audit_as_warning true" do
+          before do
+            Chef::Config[:audit_as_warning] = true
+          end
+
+          include_examples "a failed run" do
+            let(:run_errors) { [converge_error] }
+          end
+        end
+
+        context "with :audit_as_warning false" do
+          before do
+            Chef::Config[:audit_as_warning] = false
+          end
+
+          include_examples "a failed run" do
+            let(:run_errors) { [converge_error, audit_error] }
+          end
+        end
+      end
     end
   end
 
   describe "when handling run failures" do
-
     it "should remove the run_lock on failure of #load_node" do
       @run_lock = double("Chef::RunLock", :acquire => true)
       allow(Chef::RunLock).to receive(:new).and_return(@run_lock)
@@ -837,6 +491,7 @@ describe Chef::Client do
       Chef::Config[:solo] = true
       Chef::Config[:cookbook_path] = ["/path/to/invalid/cookbook_path"]
     end
+
     context "when any directory of cookbook_path contains no cookbook" do
       it "raises CookbookNotFound error" do
         expect do

--- a/spec/unit/exceptions_spec.rb
+++ b/spec/unit/exceptions_spec.rb
@@ -113,7 +113,7 @@ describe Chef::Exceptions do
     context "initialized with 1 error and nil" do
       let(:e) { Chef::Exceptions::RunFailedWrappingError.new(RuntimeError.new("foo"), nil)  }
       let(:num_errors) { 1 }
-      let(:backtrace) { ["1) RuntimeError -  foo", ""] }
+      let(:backtrace) { ["1) RuntimeError -  foo"] }
 
       include_examples "RunFailedWrappingError expectations"
     end
@@ -121,7 +121,7 @@ describe Chef::Exceptions do
     context "initialized with 2 errors" do
       let(:e) { Chef::Exceptions::RunFailedWrappingError.new(RuntimeError.new("foo"), RuntimeError.new("bar"))  }
       let(:num_errors) { 2 }
-      let(:backtrace) { ["1) RuntimeError -  foo", "", "2) RuntimeError -  bar", ""] }
+      let(:backtrace) { ["1) RuntimeError -  foo", "", "2) RuntimeError -  bar"] }
 
       include_examples "RunFailedWrappingError expectations"
     end


### PR DESCRIPTION
Separate converge failures from run failures. The audit reporter only reports failed audits and audit phase exceptions, the resource reporter only reported converge and run failures. Audit, converge, and unexpected run failures are wrapped together and raised at the end of the run for remaining handling and exit status.

---
Previously, on LOST:
Adds a new configuration option `:audit_as_warning`

From [chef/config.rb](https://github.com/chef/chef/blob/377174723c2a5dbc9959abdaab213fd67899c6ea/lib/chef/config.rb#L356-L360):
```ruby
# When set to true (and audit mode is :enabled or :audit_only), one or more
# failed controls will cause the client run to be marked as failed.
# When set to false, only converge or unexpected errors will cause the chef
# client run to be marked as failed.
default :audit_as_warning, false
```

Additionally, failures which occur during the audit phase (that aren't non-passing controls) will cause the run to fail.

Q: Does this need a CLI option?