### PR TITLE
Add check_resource_semantics! lifecycle method to provider

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -83,6 +83,9 @@ class Chef
       new_resource.cookbook_name
     end
 
+    def check_resource_semantics!
+    end
+
     def load_current_resource
       raise Chef::Exceptions::Override, "You must override load_current_resource in #{self.to_s}"
     end
@@ -107,6 +110,8 @@ class Chef
 
       # TODO: it would be preferable to get the action to be executed in the
       # constructor...
+
+      check_resource_semantics!
 
       # user-defined LWRPs may include unsafe load_current_resource methods that cannot be run in whyrun mode
       if !whyrun_mode? || whyrun_supported?

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -43,6 +43,12 @@ class Chef
         true
       end
 
+      def check_resource_semantics!
+        if new_resource.package_name.is_a?(Array) && new_resource.source != nil
+          raise Chef::Exceptions::InvalidResourceSpecification, "You may not specify both multipackage and source"
+        end
+      end
+
       def load_current_resource
       end
 

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -37,6 +37,12 @@ describe Chef::Provider::Package do
       allow(@provider).to receive(:install_package).and_return(true)
     end
 
+    it "raises a Chef::Exceptions::InvalidResourceSpecification if both multipackage and source are provided" do
+      @new_resource.package_name(['a', 'b'])
+      @new_resource.source('foo')
+      expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
+    end
+
     it "should raise a Chef::Exceptions::Package if no version is specified, and no candidate is available" do
       @provider.candidate_version = nil
       expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -49,6 +49,13 @@ class ConvergeActionDemonstrator < Chef::Provider
   end
 end
 
+class CheckResourceSemanticsDemonstrator < ConvergeActionDemonstrator
+  def check_resource_semantics!
+    raise Chef::Exceptions::InvalidResourceSpecification.new("check_resource_semantics!")
+  end
+end
+
+
 describe Chef::Provider do
   before(:each) do
     @cookbook_collection = Chef::CookbookCollection.new([])
@@ -87,6 +94,10 @@ describe Chef::Provider do
 
   it "should not support whyrun by default" do
     expect(@provider.send(:whyrun_supported?)).to eql(false)
+  end
+
+  it "should do nothing for check_resource_semantics! by default" do
+    expect { @provider.check_resource_semantics! }.not_to raise_error
   end
 
   it "should return true for action_nothing" do
@@ -175,6 +186,15 @@ describe Chef::Provider do
         expect(@resource).not_to be_updated
         expect(@resource).not_to be_updated_by_last_action
       end
+    end
+
+    describe "and the resource is invalid" do
+      let(:provider) { CheckResourceSemanticsDemonstrator.new(@resource, @run_context) }
+
+      it "fails with InvalidResourceSpecification when run" do
+        expect { provider.run_action(:foo) }.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
+      end
+
     end
   end
 


### PR DESCRIPTION
Added a lifecycle method to check if the resource makes sense for the provider. That way, we can fail before loading it. Will add specs if we want to solve the problem this way :)
Fixed #3075 as an example

cc @jaymzh @chef/client-core 