### PR TITLE
gem_package should install to the systemwide Ruby when using ChefDK.

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -401,7 +401,7 @@ class Chef
         end
 
         def is_omnibus?
-          if RbConfig::CONFIG['bindir'] =~ %r!/opt/(opscode|chef|chefdk)/embedded/bin!
+          if RbConfig::CONFIG['bindir'] =~ %r!/(opscode|chef|chefdk)/embedded/bin!
             Chef::Log.debug("#{@new_resource} detected omnibus installation in #{RbConfig::CONFIG['bindir']}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -401,7 +401,7 @@ class Chef
         end
 
         def is_omnibus?
-          if RbConfig::CONFIG['bindir'] =~ %r!/opt/(opscode|chef)/embedded/bin!
+          if RbConfig::CONFIG['bindir'] =~ %r!/opt/(opscode|chef|chefdk)/embedded/bin!
             Chef::Log.debug("#{@new_resource} detected omnibus installation in #{RbConfig::CONFIG['bindir']}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -403,6 +403,24 @@ describe Chef::Provider::Package::Rubygems do
       expect(provider.gem_env.gem_binary_location).to eq('/usr/weird/bin/gem')
     end
 
+    it "recognizes chef as omnibus" do
+      allow(RbConfig::CONFIG).to receive(:[]).with('bindir').and_return("/opt/chef/embedded/bin")
+      provider = Chef::Provider::Package::Rubygems.new(@new_resource, @run_context)
+      expect(provider.is_omnibus?).to be true
+    end
+
+    it "recognizes opscode as omnibus" do
+      allow(RbConfig::CONFIG).to receive(:[]).with('bindir').and_return("/opt/opscode/embedded/bin")
+      provider = Chef::Provider::Package::Rubygems.new(@new_resource, @run_context)
+      expect(provider.is_omnibus?).to be true
+    end
+
+    it "recognizes chefdk as omnibus" do
+      allow(RbConfig::CONFIG).to receive(:[]).with('bindir').and_return("/opt/chefdk/embedded/bin")
+      provider = Chef::Provider::Package::Rubygems.new(@new_resource, @run_context)
+      expect(provider.is_omnibus?).to be true
+    end
+
     it "searches for a gem binary when running on Omnibus on Unix" do
       platform_mock :unix do
         allow(RbConfig::CONFIG).to receive(:[]).with('bindir').and_return("/opt/chef/embedded/bin")


### PR DESCRIPTION
This fixes #3382. Let me know if I should add a test to `spec/unit/provider/package/rubygems_spec.rb`, and if so, what it should look like.

Thanks!