### PR TITLE
Add install_components task for forward compat w/ 12

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,13 @@ task :install => :package do
   sh %{gem install pkg/#{GEM_NAME}-#{Chef::VERSION}.gem --no-rdoc --no-ri}
 end
 
+# In Chef 12.4, some parts of Chef Client are moved to subprojects in the same
+# git repo. Omnibus calls `rake install_components` to build these. This rake
+# task makes 11-stable forward compatible.
+task :install_components do
+  true
+end
+
 task :uninstall do
   sh %{gem uninstall #{GEM_NAME} -x -v #{Chef::VERSION} }
 end


### PR DESCRIPTION
When https://github.com/chef/chef/pull/3270 is accepted, we will need to update omnibus to build subprojects in Chef's git repo, as implemented in https://github.com/chef/omnibus-software/pull/430

For future builds of Chef 11 to work, either omnibus needs to build 11 and 12 differently, or 11 needs to be forward compatible with 12 as far as build commands. This patch makes Chef 11 forward compatible, as it's the cleaner easier solution.

@chef/client-core 