### PR TITLE
Show trace for RecipeNotFound errors when it originates from include recipe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
-  - gem update --system
+  - gem update --system --quiet --no-ri --no-rdoc
   - gem --version
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version

--- a/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
@@ -96,6 +96,10 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
           inspector.add_explanation(description)
         end
 
+        it "reports the error was not located within cookbooks" do
+          expect(inspector.found_error_in_cookbooks?).to be(true)
+        end
+
         it "finds the line number of the error from the stacktrace" do
           expect(inspector.culprit_line).to eq(14)
         end
@@ -136,6 +140,10 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
 
       it "does not error when displaying the error" do
         expect { description.display(outputter) }.to_not raise_error
+      end
+
+      it "reports the error was not located within cookbooks" do
+        expect(inspector.found_error_in_cookbooks?).to be(false)
       end
 
     end
@@ -184,6 +192,10 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
 
       let(:full_path_to_failed_file) { "C:/opscode/chef#{path_to_failed_file}" }
 
+      it "reports the error was not located within cookbooks" do
+        expect(inspector.found_error_in_cookbooks?).to be(true)
+      end
+
       it "finds the culprit recipe name" do
         expect(inspector.culprit_file).to eq("C:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
       end
@@ -204,6 +216,10 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
       end
 
       let(:full_path_to_failed_file) { "c:/opscode/chef#{path_to_failed_file}" }
+
+      it "reports the error was not located within cookbooks" do
+        expect(inspector.found_error_in_cookbooks?).to be(true)
+      end
 
       it "finds the culprit recipe name from the stacktrace" do
         expect(inspector.culprit_file).to eq("c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")

--- a/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
@@ -37,69 +37,81 @@ end
 E
 
 describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
-  before do
-    @node_name = "test-node.example.com"
-    @description = Chef::Formatters::ErrorDescription.new("Error Evaluating File:")
-    @exception = NoMethodError.new("undefined method `this_is_not_a_valid_method' for Chef::Resource::File")
 
-    @outputter = Chef::Formatters::IndentableOutputStream.new(StringIO.new, STDERR)
-    #@outputter = Chef::Formatters::IndentableOutputStream.new(STDOUT, STDERR)
+  let(:node_name) { "test-node.example.com" }
+
+  let(:description) { Chef::Formatters::ErrorDescription.new("Error Evaluating File:") }
+
+  let(:exception) do
+    e = NoMethodError.new("undefined method `this_is_not_a_valid_method' for Chef::Resource::File")
+    e.set_backtrace(trace)
+    e
   end
 
-  describe "when scrubbing backtraces" do
-    it "shows backtrace lines from cookbook files" do
-      # Error inspector originally used file_cache_path which is incorrect on
-      # chef-solo. Using cookbook_path should do the right thing for client and
-      # solo.
-      allow(Chef::Config).to receive(:cookbook_path).and_return([ "/home/someuser/dev-laptop/cookbooks" ])
-      @trace = [
-        "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:14:in `from_file'",
-        "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:11:in `from_file'",
-        "/home/someuser/.multiruby/gems/chef/lib/chef/client.rb:123:in `run'"
-      ]
-      @exception.set_backtrace(@trace)
-      @path = "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb"
-      @inspector = described_class.new(@path, @exception)
+  # Change to $stdout to print error messages for manual inspection
+  let(:stdout) { StringIO.new }
 
-      @expected_filtered_trace = [
-        "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:14:in `from_file'",
-        "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:11:in `from_file'",
-      ]
-      expect(@inspector.filtered_bt).to eq(@expected_filtered_trace)
-    end
-  end
+  let(:outputter) { Chef::Formatters::IndentableOutputStream.new(StringIO.new, STDERR) }
 
-  describe "when explaining an error in the compile phase" do
-    before do
-      allow(Chef::Config).to receive(:cookbook_path).and_return([ "/var/chef/cache/cookbooks" ])
-      recipe_lines = BAD_RECIPE.split("\n").map {|l| l << "\n" }
-      expect(IO).to receive(:readlines).with("/var/chef/cache/cookbooks/syntax-err/recipes/default.rb").and_return(recipe_lines)
-      @trace = [
-        "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb:14:in `from_file'",
-        "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb:11:in `from_file'",
-        "/usr/local/lib/ruby/gems/chef/lib/chef/client.rb:123:in `run'" # should not display
-      ]
-      @exception.set_backtrace(@trace)
-      @path = "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb"
-      @inspector = described_class.new(@path, @exception)
-      @inspector.add_explanation(@description)
+  subject(:inspector) { described_class.new(path_to_failed_file, exception) }
+
+  describe "finding the code responsible for the error" do
+
+    context "when the stacktrace includes cookbook files" do
+
+      let(:trace) do
+        [
+          "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:14:in `from_file'",
+          "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:11:in `from_file'",
+          "/home/someuser/.multiruby/gems/chef/lib/chef/client.rb:123:in `run'"
+        ]
+      end
+
+      let(:expected_filtered_trace) do
+        [
+          "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:14:in `from_file'",
+          "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb:11:in `from_file'",
+        ]
+      end
+
+      let(:path_to_failed_file) { "/home/someuser/dev-laptop/cookbooks/syntax-err/recipes/default.rb" }
+
+      before do
+        # Error inspector originally used file_cache_path which is incorrect on
+        # chef-solo. Using cookbook_path should do the right thing for client and
+        # solo.
+        allow(Chef::Config).to receive(:cookbook_path).and_return([ "/home/someuser/dev-laptop/cookbooks" ])
+      end
+
+      describe "when scrubbing backtraces" do
+        it "shows backtrace lines from cookbook files" do
+          expect(inspector.filtered_bt).to eq(expected_filtered_trace)
+        end
+      end
+
+      describe "when explaining an error in the compile phase" do
+        before do
+          recipe_lines = BAD_RECIPE.split("\n").map {|l| l << "\n" }
+          expect(IO).to receive(:readlines).with(path_to_failed_file).and_return(recipe_lines)
+          inspector.add_explanation(description)
+        end
+
+        it "finds the line number of the error from the stacktrace" do
+          expect(inspector.culprit_line).to eq(14)
+        end
+
+        it "prints a pretty message" do
+          description.display(outputter)
+        end
+      end
     end
 
-    it "finds the line number of the error from the stacktrace" do
-      expect(@inspector.culprit_line).to eq(14)
-    end
-
-    it "prints a pretty message" do
-      @description.display(@outputter)
-    end
   end
 
   describe "when explaining an error on windows" do
-    before do
-      allow(Chef::Config).to receive(:cookbook_path).and_return([ "C:/opscode/chef/var/cache/cookbooks" ])
-      recipe_lines = BAD_RECIPE.split("\n").map {|l| l << "\n" }
-      expect(IO).to receive(:readlines).at_least(1).times.with(/:\/opscode\/chef\/var\/cache\/cookbooks\/foo\/recipes\/default.rb/).and_return(recipe_lines)
-      @trace = [
+
+    let(:trace_with_upcase_drive) do
+      [
         "C:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb:14 in `from_file'",
         "C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:144:in `rescue in block in load_libraries'",
         "C:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:138:in `block in load_libraries'",
@@ -122,81 +134,57 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
         "C:/opscode/chef/bin/chef-client:19:in `load'",
         "C:/opscode/chef/bin/chef-client:19:in `<main>'"
       ]
-      @exception.set_backtrace(@trace)
-      @path = "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb"
-      @inspector = described_class.new(@path, @exception)
-      @inspector.add_explanation(@description)
     end
 
+    let(:trace) { trace_with_upcase_drive }
 
-    describe "and examining the stack trace for a recipe" do
-      it "find the culprit recipe name when the drive letter is upper case" do
-        expect(@inspector.culprit_file).to eq("C:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
-      end
+    let(:path_to_failed_file) { "/var/cache/cookbooks/foo/recipes/default.rb" }
 
-      it "find the culprit recipe name when the drive letter is lower case" do
-        @trace.each { |line| line.gsub!(/^C:/, "c:") }
-        @exception.set_backtrace(@trace)
-        @inspector = described_class.new(@path, @exception)
-        @inspector.add_explanation(@description)
-        expect(@inspector.culprit_file).to eq("c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
-      end
-    end
-
-    it "finds the line number of the error from the stack trace" do
-      expect(@inspector.culprit_line).to eq(14)
-    end
-
-    it "prints a pretty message" do
-      @description.display(@outputter)
-    end
-  end
-
-  describe "when explaining an error on windows, and the backtrace lowercases the drive letter" do
     before do
       allow(Chef::Config).to receive(:cookbook_path).and_return([ "C:/opscode/chef/var/cache/cookbooks" ])
       recipe_lines = BAD_RECIPE.split("\n").map {|l| l << "\n" }
-      expect(IO).to receive(:readlines).with("c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb").and_return(recipe_lines)
-      @trace = [
-        "c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb:14 in `from_file'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:144:in `rescue in block in load_libraries'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:138:in `block in load_libraries'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:230:in `call'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:230:in `block (2 levels) in foreach_cookbook_load_segment'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:229:in `each'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:229:in `block in foreach_cookbook_load_segment'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:227:in `each'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:227:in `foreach_cookbook_load_segment'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:137:in `load_libraries'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:62:in `load'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/client.rb:198:in `setup_run_context'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/client.rb:418:in `do_run'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/client.rb:176:in `run'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/application/client.rb:283:in `block in run_application'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/application/client.rb:270:in `loop'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/application/client.rb:270:in `run_application'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/application.rb:70:in `run'",
-        "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/bin/chef-client:26:in `<top (required)>'",
-        "c:/opscode/chef/bin/chef-client:19:in `load'",
-        "c:/opscode/chef/bin/chef-client:19:in `<main>'"
-      ]
-      @exception.set_backtrace(@trace)
-      @path = "/var/chef/cache/cookbooks/syntax-err/recipes/default.rb"
-      @inspector = described_class.new(@path, @exception)
-      @inspector.add_explanation(@description)
+      expect(IO).to receive(:readlines).at_least(1).times.with(full_path_to_failed_file).and_return(recipe_lines)
+      inspector.add_explanation(description)
     end
 
-    it "finds the culprit recipe name from the stacktrace" do
-      expect(@inspector.culprit_file).to eq("c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
+    context "when the drive letter in the path is uppercase" do
+
+      let(:full_path_to_failed_file) { "C:/opscode/chef#{path_to_failed_file}" }
+
+      it "finds the culprit recipe name" do
+        expect(inspector.culprit_file).to eq("C:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
+      end
+
+      it "finds the line number of the error from the stack trace" do
+        expect(inspector.culprit_line).to eq(14)
+      end
+
+      it "prints a pretty message" do
+        description.display(outputter)
+      end
     end
 
-    it "finds the line number of the error from the stack trace" do
-      expect(@inspector.culprit_line).to eq(14)
+    context "when the drive letter in the path is lowercase" do
+
+      let(:trace) do
+        trace_with_upcase_drive.map { |line| line.gsub(/^C:/, "c:") }
+      end
+
+      let(:full_path_to_failed_file) { "c:/opscode/chef#{path_to_failed_file}" }
+
+      it "finds the culprit recipe name from the stacktrace" do
+        expect(inspector.culprit_file).to eq("c:/opscode/chef/var/cache/cookbooks/foo/recipes/default.rb")
+      end
+
+      it "finds the line number of the error from the stack trace" do
+        expect(inspector.culprit_line).to eq(14)
+      end
+
+      it "prints a pretty message" do
+        description.display(outputter)
+      end
     end
 
-    it "prints a pretty message" do
-      @description.display(@outputter)
-    end
   end
 
 end

--- a/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/compile_error_inspector_spec.rb
@@ -106,6 +106,39 @@ describe Chef::Formatters::ErrorInspectors::CompileErrorInspector do
       end
     end
 
+    context "when the error does not contain any lines from cookbooks" do
+
+      let(:trace) do
+        [
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:144:in `rescue in block in load_libraries'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:138:in `block in load_libraries'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:230:in `call'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:230:in `block (2 levels) in foreach_cookbook_load_segment'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:229:in `each'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:229:in `block in foreach_cookbook_load_segment'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:227:in `each'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:227:in `foreach_cookbook_load_segment'",
+          "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.14.0/lib/chef/run_context.rb:137:in `load_libraries'"
+        ]
+      end
+
+      let(:exception) do
+        e = Chef::Exceptions::RecipeNotFound.new("recipe nope:nope not found")
+        e.set_backtrace(trace)
+        e
+      end
+
+      let(:path_to_failed_file) { nil }
+
+      it "gives a full, non-filtered trace" do
+        expect(inspector.filtered_bt).to eq(trace)
+      end
+
+      it "does not error when displaying the error" do
+        expect { description.display(outputter) }.to_not raise_error
+      end
+
+    end
   end
 
   describe "when explaining an error on windows" do


### PR DESCRIPTION
If you have code like `include_recipe "cookbook_exists::RECIPE_DOESNT_EXIST"`, you don't get the cookbook trace or error context because `RecipeNotFound` is assumed to have originated from a bad run list in chef-solo (I think). What we should be checking for is whether we are able to locate the proper recipe context or not. I found this relevant commit https://github.com/chef/chef/commit/abefd661954fd533c227e17ff74065bf114e8b24, but didn't find the PR it was from, so I could not locate the original bug report. I added a regression test for what I suspect the original bug was, so I think this should not regress the original issue.

@chef/client-core 