### PR TITLE
Allow spaces in files for remote_file

### DIFF
--- a/lib/chef/mixin/uris.rb
+++ b/lib/chef/mixin/uris.rb
@@ -28,6 +28,17 @@ class Chef
         # From open-uri
         !!(%r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ source)
       end
+
+
+      def as_uri(source)
+        begin
+          URI.parse(source)
+        rescue URI::InvalidURIError
+          Chef::Log.warn("#{source} was an invalid URI. Trying to escape invalid characters")
+          URI.parse(URI.escape(source))
+        end
+      end
+
     end
   end
 end

--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -20,6 +20,7 @@
 require 'uri'
 require 'tempfile'
 require 'chef/file_content_management/content_base'
+require 'chef/mixin/uris'
 
 class Chef
   class Provider
@@ -27,6 +28,8 @@ class Chef
       class Content < Chef::FileContentManagement::ContentBase
 
         private
+
+        include Chef::Mixin::Uris
 
         def file_for_provider
           Chef::Log.debug("#{@new_resource} checking for changes")
@@ -48,7 +51,7 @@ class Chef
             uri = if Chef::Provider::RemoteFile::Fetcher.network_share?(source)
               source
             else
-              URI.parse(source)
+              as_uri(source)
             end
             raw_file = grab_file_from_uri(uri)
           rescue SocketError, Errno::ECONNREFUSED, Errno::ENOENT, Errno::EACCES, Timeout::Error, Net::HTTPServerException, Net::HTTPFatalError, Net::FTPError => e

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -38,13 +38,15 @@ class Chef
           path.gsub(/^\/([a-zA-Z]:)/,'\1')
         end
 
-        def uri_path
-          URI.unescape(uri.path)
+        def source_path
+          @source_path ||= begin
+            path = URI.unescape(uri.path)
+            Chef::Platform.windows? ? fix_windows_path(path) : path
+          end
         end
 
         # Fetches the file at uri, returning a Tempfile-like File handle
         def fetch
-          source_path = Chef::Platform.windows? ? fix_windows_path(uri_path) : uri_path
           tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
           Chef::Log.debug("#{new_resource} staging #{source_path} to #{tempfile.path}")
           FileUtils.cp(source_path, tempfile.path)

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -32,15 +32,19 @@ class Chef
           @new_resource = new_resource
           @uri = uri
         end
-        
+
         # CHEF-4472: Remove the leading slash from windows paths that we receive from a file:// URI
-        def fix_windows_path(path) 
-          path.gsub(/^\/([a-zA-Z]:)/,'\1')  
+        def fix_windows_path(path)
+          path.gsub(/^\/([a-zA-Z]:)/,'\1')
+        end
+
+        def uri_path
+          URI.unescape(uri.path)
         end
 
         # Fetches the file at uri, returning a Tempfile-like File handle
         def fetch
-          source_path = Chef::Platform.windows? ? fix_windows_path(uri.path) : uri.path
+          source_path = Chef::Platform.windows? ? fix_windows_path(uri_path) : uri_path
           tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
           Chef::Log.debug("#{new_resource} staging #{source_path} to #{tempfile.path}")
           FileUtils.cp(source_path, tempfile.path)

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -21,6 +21,7 @@ require 'uri'
 require 'chef/resource/file'
 require 'chef/provider/remote_file'
 require 'chef/mixin/securable'
+require 'chef/mixin/uris'
 
 class Chef
   class Resource
@@ -127,6 +128,8 @@ class Chef
 
       private
 
+      include Chef::Mixin::Uris
+
       def validate_source(source)
         source = Array(source).flatten
         raise ArgumentError, "#{resource_name} has an empty source" if source.empty?
@@ -140,7 +143,7 @@ class Chef
       end
 
       def absolute_uri?(source)
-        Chef::Provider::RemoteFile::Fetcher.network_share?(source) or (source.kind_of?(String) and URI.parse(source).absolute?) 
+        Chef::Provider::RemoteFile::Fetcher.network_share?(source) or (source.kind_of?(String) and as_uri(source).absolute?)
       rescue URI::InvalidURIError
         false
       end

--- a/spec/unit/mixin/uris_spec.rb
+++ b/spec/unit/mixin/uris_spec.rb
@@ -26,20 +26,22 @@ end
 describe Chef::Mixin::Uris do
   let (:uris) { Chef::UrisTest.new }
 
-  it "matches 'scheme://foo.com'" do
-    expect(uris.uri_scheme?('scheme://foo.com')).to eq(true)
-  end
+  describe "#uri_scheme?" do
+    it "matches 'scheme://foo.com'" do
+      expect(uris.uri_scheme?('scheme://foo.com')).to eq(true)
+    end
 
-  it "does not match 'c:/foo.com'" do
-    expect(uris.uri_scheme?('c:/foo.com')).to eq(false)
-  end
+    it "does not match 'c:/foo.com'" do
+      expect(uris.uri_scheme?('c:/foo.com')).to eq(false)
+    end
 
-  it "does not match '/usr/bin/foo.com'" do
-    expect(uris.uri_scheme?('/usr/bin/foo.com')).to eq(false)
-  end
+    it "does not match '/usr/bin/foo.com'" do
+      expect(uris.uri_scheme?('/usr/bin/foo.com')).to eq(false)
+    end
 
-  it "does not match 'c:/foo.com://bar.com'" do
-    expect(uris.uri_scheme?('c:/foo.com://bar.com')).to eq(false)
+    it "does not match 'c:/foo.com://bar.com'" do
+      expect(uris.uri_scheme?('c:/foo.com://bar.com')).to eq(false)
+    end
   end
 
 end

--- a/spec/unit/mixin/uris_spec.rb
+++ b/spec/unit/mixin/uris_spec.rb
@@ -44,4 +44,14 @@ describe Chef::Mixin::Uris do
     end
   end
 
+  describe "#as_uri" do
+    it "parses a file scheme uri with spaces" do
+      expect{ uris.as_uri("file:///c:/foo bar.txt") }.not_to raise_exception
+    end
+
+    it "returns a URI object" do
+      expect( uris.as_uri("file:///c:/foo bar.txt") ).to be_a(URI)
+    end
+  end
+
 end

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -60,6 +60,11 @@ describe Chef::Resource::RemoteFile do
       expect(@resource.source).to eql([ "\\\\fakey\\fakerton\\fake.txt" ])
     end
 
+    it 'should accept file URIs with spaces' do
+      @resource.source("file:///C:/foo bar")
+      expect(@resource.source).to eql(["file:///C:/foo bar"])
+    end
+
     it "should accept a delayed evalutator (string) for the remote file source" do
       @resource.source Chef::DelayedEvaluator.new {"http://opscode.com/"}
       expect(@resource.source).to eql([ "http://opscode.com/" ])


### PR DESCRIPTION
Fixes #1848 

The following example now works
```ruby
remote_file "c:\\nospaces" do
  source "file:///c:/foo bar"
end
```
cc @chef/client-windows @sean-horn 