### PR TITLE
Enable caching of rubygems in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,10 @@ branches:
     - master
     - 12-stable
 
+cache:
+  - C:\Ruby200\lib\ruby\gems\2.0.0
+  - C:\Ruby200\bin
+
 install:
   - winrm quickconfig -q
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,10 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
+  - gem install bundler --quiet --no-ri --no-rdoc
   - gem install rubygems-pkg/rubygems-update-2.4.6.gem
   - update_rubygems
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
 
 build_script:


### PR DESCRIPTION
Based on
* http://help.appveyor.com/discussions/questions/585-what-setup-for-build-cache-is-require-for-bundle-install
* http://www.appveyor.com/docs/installed-software

I think these are the right settings for caching rubygems.