### PR TITLE
Make native mode the default for policyfiles

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -339,15 +339,22 @@ module ChefConfig
     # most of our testing scenarios)
     default :minimal_ohai, false
 
-    # Policyfile is an experimental feature where a node gets its run list and
-    # cookbook version set from a single document on the server instead of
-    # expanding the run list and having the server compute the cookbook version
-    # set based on environment constraints.
-    #
-    # Because this feature is experimental, it is not recommended for
-    # production use. Developent/release of this feature may not adhere to
-    # semver guidelines.
+    # Policyfile is a feature where a node gets its run list and cookbook
+    # version set from a single document on the server instead of expanding the
+    # run list and having the server compute the cookbook version set based on
+    # environment constraints.
     default :use_policyfile, false
+
+    # Policyfiles can be used in a native mode (default) or compatibility mode.
+    # Native mode requires Chef Server 12.1 (it can be enabled via feature flag
+    # on some prior versions). In native mode, policies and associated
+    # cookbooks are accessed via feature-specific APIs. In compat mode,
+    # policies are stored as data bags and cookbooks are stored at the
+    # cookbooks/ endpoint. Compatibility mode can be dangerous on existing Chef
+    # Servers; it's recommended to upgrade your Chef Server rather than use
+    # compatibility mode. Compatibility mode remains available so you can use
+    # policyfiles with servers that don't yet support the native endpoints.
+    default :policy_document_native_api, true
 
     # Set these to enable SSL authentication / mutual-authentication
     # with the server

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -30,10 +30,19 @@ describe Chef::Knife do
 
   let(:knife) { Chef::Knife.new }
 
+  let(:config_location) { File.expand_path("~/.chef/config.rb") }
+
+  let(:config_loader) do
+    instance_double("WorkstationConfigLoader", load: nil, no_config_found?: false, config_location: config_location)
+  end
+
   before(:each) do
     Chef::Log.logger = Logger.new(StringIO.new)
 
     Chef::Config[:node_name]  = "webmonkey.example.com"
+
+    allow(Chef::WorkstationConfigLoader).to receive(:new).and_return(config_loader)
+    allow(config_loader).to receive(:explicit_config_file=)
 
     # Prevent gratuitous code reloading:
     allow(Chef::Knife).to receive(:load_commands)

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -166,12 +166,16 @@ describe Chef::PolicyBuilder::Policyfile do
     end
 
     before do
-      # TODO: agree on this name and logic.
+      Chef::Config[:policy_document_native_api] = false
       Chef::Config[:deployment_group] = "example-policy-stage"
       allow(policy_builder).to receive(:http_api).and_return(http_api)
     end
 
     describe "when using compatibility mode (policy_document_native_api == false)" do
+
+      before do
+        Chef::Config[:deployment_group] = "example-policy-stage"
+      end
 
       context "when the deployment group cannot be loaded" do
         let(:error404) { Net::HTTPServerException.new("404 message", :body) }


### PR DESCRIPTION
Policyfile APIs are going to be enabled by default in the next Chef Server release (and they're enabled in hosted now). This should be the default. Technically this is a breaking change but this has been labeled an experimental feature since the beginning so IMO we can follow the pre-1.0 semver rules.

@chef/client-core 