### PR TITLE
Fix cli issue with unset chef_repo_path

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -279,6 +279,12 @@ class Chef::Application::Client < Chef::Application
     Chef::Config[:chef_server_url] = config[:chef_server_url] if config.has_key? :chef_server_url
 
     Chef::Config.local_mode = config[:local_mode] if config.has_key?(:local_mode)
+
+    if Chef::Config.has_key?(:chef_repo_path) && Chef::Config.chef_repo_path.nil?
+      Chef::Config.delete(:chef_repo_path)
+      Chef::Log.warn "chef_repo_path was set in a config file but was empty. Assuming #{Chef::Config.chef_repo_path}"
+    end
+
     if Chef::Config.local_mode && !Chef::Config.has_key?(:cookbook_path) && !Chef::Config.has_key?(:chef_repo_path)
       Chef::Config.chef_repo_path = Chef::Config.find_chef_repo_path(Dir.pwd)
     end


### PR DESCRIPTION
Fixes issue for when environment variable is not set and chef_repo_path expects one.

tl;dr - if you have something like this in a config.rb/knife.rb:
```chef_repo_path ENV['SOMETHING']```
and $SOMETHING is not set, when running ```chef-client -z``` it will throw a wonderful error like so:
```[2015-05-22T13:11:58-07:00] FATAL: NoMethodError: undefined method `map' for nil:NilClass```
Which gives you nothing to go on. This issues a warning and resets the config to default value.