### PR TITLE
RSpec isn't a bug database or kanban board

### DIFF
--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -147,7 +147,7 @@ class Chef
                 # some scripts support multiple instances through symlinks such as openvpn.
                 # We should get the service name from rcvar.
                 Chef::Log.debug("name=\"service\" not found at #{init_command}. falling back to rcvar")
-                sn = shell_out!("#{init_command} rcvar").stdout[/(\w+_enable)=/, 1]
+                shell_out!("#{init_command} rcvar").stdout[/(\w+_enable)=/, 1]
               else
                 # for why-run mode when the rcd_script is not there yet
                 new_resource.service_name

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -348,8 +348,7 @@ describe Chef::Resource::Link do
           end
           it_behaves_like 'delete errors out'
         end
-        context 'and the link already exists and is not writeable to this user', :skip => true do
-        end
+
         it_behaves_like 'a securable resource without existing target' do
           let(:path) { target_file }
           def allowed_acl(sid, expected_perms)
@@ -360,7 +359,7 @@ describe Chef::Resource::Link do
           end
           def parent_inheritable_acls
             dummy_file_path = File.join(test_file_dir, "dummy_file")
-            dummy_file = FileUtils.touch(dummy_file_path)
+            FileUtils.touch(dummy_file_path)
             dummy_desc = get_security_descriptor(dummy_file_path)
             FileUtils.rm_rf(dummy_file_path)
             dummy_desc
@@ -415,8 +414,6 @@ describe Chef::Resource::Link do
             include_context 'delete is noop'
           end
         end
-      end
-      context "when the link destination is not readable to this user", :skip => true do
       end
       context "when the link destination does not exist" do
         include_context 'create symbolic link succeeds'
@@ -518,8 +515,6 @@ describe Chef::Resource::Link do
           end
           it_behaves_like 'delete errors out'
         end
-        context "and the link already exists and is not writeable to this user", :skip => true do
-        end
         context "and specifies security attributes" do
           before(:each) do
             resource.owner(windows? ? 'Guest' : 'nobody')
@@ -559,10 +554,10 @@ describe Chef::Resource::Link do
           end
           context 'and the link does not yet exist' do
             it 'links to the target file' do
+              skip('OS X/FreeBSD/AIX symlink? and readlink working on hard links to symlinks') if (os_x? or freebsd? or aix?)
               resource.run_action(:create)
               expect(File.exists?(target_file)).to be_truthy
               # OS X gets angry about this sort of link.  Bug in OS X, IMO.
-              pending('OS X/FreeBSD/AIX symlink? and readlink working on hard links to symlinks') if (os_x? or freebsd? or aix?)
               expect(symlink?(target_file)).to be_truthy
               expect(readlink(target_file)).to eq(canonicalize(@other_target))
             end
@@ -578,7 +573,7 @@ describe Chef::Resource::Link do
           end
           context 'and the link does not yet exist' do
             it 'links to the target file' do
-              pending('OS X/FreeBSD/AIX fails to create hardlinks to broken symlinks') if (os_x? or freebsd? or aix?)
+              skip('OS X/FreeBSD/AIX fails to create hardlinks to broken symlinks') if (os_x? or freebsd? or aix?)
               resource.run_action(:create)
               # Windows and Unix have different definitions of exists? here, and that's OK.
               if windows?
@@ -593,8 +588,7 @@ describe Chef::Resource::Link do
           end
         end
       end
-      context "when the link destination is not readable to this user", :skip => true do
-      end
+
       context "when the link destination does not exist" do
         context 'and the link does not yet exist' do
           it 'create errors out' do

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -108,7 +108,7 @@ describe Chef::Provider::User::Useradd, metadata do
         break if status.exitstatus != 8
 
         sleep 1
-        max_retries = max_retries -1
+        max_retries = max_retries - 1
       rescue UserNotFound
         break
       end
@@ -169,7 +169,7 @@ describe Chef::Provider::User::Useradd, metadata do
     context "when the user does not exist beforehand" do
       before do
         if reason = skip
-          pending(reason)
+          skip(reason)
         end
         user_resource.run_action(:create)
         expect(user_resource).to be_updated_by_last_action
@@ -342,7 +342,7 @@ describe Chef::Provider::User::Useradd, metadata do
 
       before do
         if reason = skip
-          pending(reason)
+          skip(reason)
         end
         existing_user.run_action(:create)
         expect(existing_user).to be_updated_by_last_action
@@ -535,7 +535,7 @@ describe Chef::Provider::User::Useradd, metadata do
 
     def aix_user_lock_status
       lock_info = shell_out!("lsuser -a account_locked #{username}")
-      status = /\S+\s+account_locked=(\S+)/.match(lock_info.stdout)[1]
+      /\S+\s+account_locked=(\S+)/.match(lock_info.stdout)[1]
     end
 
     def user_account_should_be_locked

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -592,10 +592,6 @@ shared_examples_for "a configured file resource" do
             File.open(path, "wb") { |f| f.write(wrong_content) }
           end
 
-          it "updates the source file content" do
-            skip
-          end
-
           it "marks the resource as updated" do
             resource.run_action(:create)
             expect(resource).to be_updated_by_last_action

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -163,9 +163,6 @@ shared_examples_for "a securable resource with existing target" do
     let(:desired_gid) { 1337 }
     let(:expected_gid) { 1337 }
 
-    skip "should set an owner (Rerun specs under root)", :requires_unprivileged_user => true
-    skip "should set a group (Rerun specs under root)",  :requires_unprivileged_user => true
-
     describe "when setting the owner", :requires_root do
       before do
         resource.owner expected_user_name
@@ -205,11 +202,6 @@ shared_examples_for "a securable resource with existing target" do
         resource.run_action(:create)
       end
 
-      it "should set permissions as specified" do
-        pending("Linux does not support lchmod")
-        expect{ File.lstat(path).mode & 007777 }.to eq(@mode_string.oct & 007777)
-      end
-
       it "is marked as updated only if changes are made" do
         expect(resource.updated_by_last_action?).to eq(expect_updated?)
       end
@@ -220,11 +212,6 @@ shared_examples_for "a securable resource with existing target" do
         @mode_integer = 0776
         resource.mode @mode_integer
         resource.run_action(:create)
-      end
-
-      it "should set permissions in numeric form as a ruby-interpreted octal" do
-        pending('Linux does not support lchmod')
-        expect{ File.lstat(path).mode & 007777 }.to eq(@mode_integer & 007777)
       end
 
       it "is marked as updated only if changes are made" do
@@ -306,10 +293,6 @@ shared_examples_for "a securable resource without existing target" do
 
   include_context "diff disabled"
 
-  context "on Unix", :unix_only do
-    skip "if we need any securable resource tests on Unix without existing target resource."
-  end
-
   context "on Windows", :windows_only do
     include_context "use Windows permissions"
 
@@ -364,13 +347,6 @@ shared_examples_for "a securable resource without existing target" do
 
     it "fails to set group when group has invalid characters" do
       expect { resource.group 'Lance "The Nose" Glindenberry III' }.to raise_error(Chef::Exceptions::ValidationFailed)
-    end
-
-    it "sets group when group is specified with a \\" do
-      pending("Need to find a group containing a backslash that is on most peoples' machines")
-      resource.group "#{ENV['COMPUTERNAME']}\\Administrators"
-      resource.run_action(:create)
-      expect{ descriptor.group }.to eq(SID.Everyone)
     end
 
     it "leaves group alone if group is not specified and resource already exists" do

--- a/spec/support/shared/functional/securable_resource_with_reporting.rb
+++ b/spec/support/shared/functional/securable_resource_with_reporting.rb
@@ -279,14 +279,14 @@ shared_examples_for "a securable resource with reporting" do
       end
 
       it "has empty values for file metadata in 'current_resource'" do
-        pending "windows reporting not yet fully supported"
+        skip "windows reporting not yet fully supported"
         expect(current_resource.owner).to be_nil
         expect(current_resource.expanded_rights).to be_nil
       end
 
       context "and no security metadata is specified in new_resource" do
         before do
-          pending "windows reporting not yet fully supported"
+          skip "windows reporting not yet fully supported"
         end
 
         it "sets the metadata values on the new_resource as strings after creating" do
@@ -322,7 +322,7 @@ shared_examples_for "a securable resource with reporting" do
         let(:expected_user_name) { 'domain\user' }
 
         before do
-          pending "windows reporting not yet fully supported"
+          skip "windows reporting not yet fully supported"
           resource.owner(expected_user_name)
           resource.run_action(:create)
         end
@@ -336,7 +336,7 @@ shared_examples_for "a securable resource with reporting" do
 
     context "when the target file exists" do
       before do
-        pending "windows reporting not yet fully supported"
+        skip "windows reporting not yet fully supported"
         FileUtils.touch(resource.path)
         resource.action(:create)
       end

--- a/spec/unit/chef_fs/file_pattern_spec.rb
+++ b/spec/unit/chef_fs/file_pattern_spec.rb
@@ -157,7 +157,7 @@ describe Chef::ChefFS::FilePattern do
     end
   end
 
-  context 'with simple pattern "a\*\b"', :pending => (Chef::Platform.windows?) do
+  context 'with simple pattern "a\*\b"', :skip => (Chef::Platform.windows?) do
     let(:pattern) { Chef::ChefFS::FilePattern.new('a\*\b') }
     it 'match?' do
       expect(pattern.match?('a*b')).to be_truthy
@@ -264,7 +264,7 @@ describe Chef::ChefFS::FilePattern do
     end
   end
 
-  context 'with star pattern "/abc/d[a-z][0-9]f/ghi"', :pending => (Chef::Platform.windows?) do
+  context 'with star pattern "/abc/d[a-z][0-9]f/ghi"', :skip => (Chef::Platform.windows?) do
     let(:pattern) { Chef::ChefFS::FilePattern.new('/abc/d[a-z][0-9]f/ghi') }
     it 'match?' do
       expect(pattern.match?('/abc/de1f/ghi')).to be_truthy
@@ -352,11 +352,7 @@ describe Chef::ChefFS::FilePattern do
       expect(pattern.could_match_children?('/abc/def/ghi')).to be_truthy
       expect(pattern.could_match_children?('abc')).to be_falsey
     end
-    it 'could_match_children? /abc** returns false for /xyz' do
-      pending 'Make could_match_children? more rigorous'
-      # At the moment, we return false for this, but in the end it would be nice to return true:
-      expect(pattern.could_match_children?('/xyz')).to be_falsey
-    end
+
     it 'exact_child_name_under' do
       expect(pattern.exact_child_name_under('/')).to eq(nil)
       expect(pattern.exact_child_name_under('/abc')).to eq(nil)
@@ -439,14 +435,6 @@ describe Chef::ChefFS::FilePattern do
       expect(p('/.').normalized_pattern).to eq('/')
       expect(p('/.').exact_path).to eq('/')
       expect(p('/.').match?('/')).to be_truthy
-    end
-    it 'handles dot by itself', :pending => "decide what to do with dot by itself" do
-      expect(p('.').normalized_pattern).to eq('.')
-      expect(p('.').exact_path).to eq('.')
-      expect(p('.').match?('.')).to be_truthy
-      expect(p('./').normalized_pattern).to eq('.')
-      expect(p('./').exact_path).to eq('.')
-      expect(p('./').match?('.')).to be_truthy
     end
     it 'handles dotdot' do
       expect(p('abc/../def').normalized_pattern).to eq('def')

--- a/spec/unit/cookbook_spec.rb
+++ b/spec/unit/cookbook_spec.rb
@@ -59,15 +59,6 @@ describe Chef::CookbookVersion do
     expect(@cookbook.fully_qualified_recipe_names.include?("openldap::three")).to eq(true)
   end
 
-  it "should find a preferred file" do
-    skip
-  end
-
-  it "should not return an unchanged preferred file" do
-    pending
-    expect(@cookbook.preferred_filename(@node, :files, 'a-filename', 'the-checksum')).to be_nil
-  end
-
   it "should raise an ArgumentException if you try to load a bad recipe name" do
     expect { @cookbook.load_recipe("doesnt_exist", @node) }.to raise_error(ArgumentError)
   end

--- a/spec/unit/cookbook_version_spec.rb
+++ b/spec/unit/cookbook_version_spec.rb
@@ -306,26 +306,6 @@ describe Chef::CookbookVersion do
 
     subject(:cbv) { Chef::CookbookVersion.new("version validation", '/tmp/blah') }
 
-    describe "HTTP Resource behaviors", pending: "will be deprected when CookbookManifest API is stablized" do
-
-      it "errors on #save_url" do
-        expect { cbv.save_url }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-      end
-
-      it "errors on #force_save_url" do
-        expect { cbv.force_save_url }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-      end
-
-      it "errors on #to_hash" do
-        expect { cbv.to_hash }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-      end
-
-      it "errors on #to_json" do
-        expect { cbv.to_json }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-      end
-
-    end
-
     it "errors on #status and #status=" do
       expect { cbv.status = :wat }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
       expect { cbv.status }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)

--- a/spec/unit/mixin/command_spec.rb
+++ b/spec/unit/mixin/command_spec.rb
@@ -22,7 +22,7 @@ describe Chef::Mixin::Command, :volatile do
 
   if windows?
 
-    pending("TODO MOVE: this is a platform specific integration test.")
+    skip("TODO MOVE: this is a platform specific integration test.")
 
   else
 
@@ -61,7 +61,6 @@ describe Chef::Mixin::Command, :volatile do
 
         it "returns immediately after the first child process exits" do
           expect {Timeout.timeout(10) do
-            pid, stdin,stdout,stderr = nil,nil,nil,nil
             evil_forker="exit if fork; 10.times { sleep 1}"
             popen4("ruby -e '#{evil_forker}'") do |pid,stdin,stdout,stderr|
             end

--- a/spec/unit/provider/ifconfig/debian_spec.rb
+++ b/spec/unit/provider/ifconfig/debian_spec.rb
@@ -144,11 +144,6 @@ EOF
           expect(IO.read(tempfile.path)).to eq(expected_string)
         end
 
-        it "should not mark the resource as updated" do
-          provider.run_action(:add)
-          pending "superclass ifconfig provider is not idempotent"
-          expect(new_resource.updated_by_last_action?).to be_falsey
-        end
       end
 
       context "when the /etc/network/interfaces file does not have the source line" do
@@ -280,11 +275,6 @@ another line
             expect(IO.read(tempfile.path)).to eq(expected_string)
           end
 
-          it "should not mark the resource as updated" do
-            provider.run_action(:add)
-            pending "superclass ifconfig provider is not idempotent"
-            expect(new_resource.updated_by_last_action?).to be_falsey
-          end
         end
 
         context "when the /etc/network/interfaces file does not have the source line" do

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -50,18 +50,6 @@ describe Chef::Provider::Package::Openbsd do
 
       context 'when there is a single candidate' do
 
-        context 'when installing from source' do
-          it 'should run the installation command' do
-            pending('Installing from source is not supported yet')
-            # This is a consequence of load_current_resource being called before define_resource_requirements
-            # It can be deleted once an implementation is provided
-            allow(provider).to receive(:shell_out!).with("pkg_info -I \"#{name}\"", anything()).and_return(
-              instance_double('shellout', :stdout => "#{name}-#{version}\n"))
-            new_resource.source('/some/path/on/disk.tgz')
-            provider.run_action(:install)
-          end
-        end
-
         context 'when source is not provided' do
           it 'should run the installation command' do
             expect(provider).to receive(:shell_out!).with("pkg_info -I \"#{name}\"", anything()).and_return(
@@ -106,15 +94,6 @@ describe Chef::Provider::Package::Openbsd do
             end
           end
 
-          context 'if a version is specified' do
-            it 'runs the installation command' do
-              pending('Specifying both a version and flavor is not supported')
-              new_resource.version(version)
-              allow(provider).to receive(:shell_out!).with(/pkg_info -e/, anything()).and_return(instance_double('shellout', :stdout => ''))
-              allow(provider).to receive(:candidate_version).and_return("#{package_name}-#{version}-#{flavor}")
-              provider.run_action(:install)
-            end
-          end
         end
 
         context 'if a version is specified' do

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -222,8 +222,6 @@ describe Chef::Provider::Package::Rubygems::AlternateGemEnvironment do
   end
 
   it "uses the cached result for gem paths when available" do
-    gem_env_output = ['/path/to/gems', '/another/path/to/gems'].join(File::PATH_SEPARATOR)
-    shell_out_result = OpenStruct.new(:stdout => gem_env_output)
     expect(@gem_env).not_to receive(:shell_out!)
     expected = ['/path/to/gems', '/another/path/to/gems']
     Chef::Provider::Package::Rubygems::AlternateGemEnvironment.gempath_cache['/usr/weird/bin/gem']= expected
@@ -261,7 +259,7 @@ describe Chef::Provider::Package::Rubygems::AlternateGemEnvironment do
     else
       `which gem`.strip
     end
-    pending("cant find your gem executable") if path_to_gem.empty?
+    skip("cant find your gem executable") if path_to_gem.empty?
     gem_env = Chef::Provider::Package::Rubygems::AlternateGemEnvironment.new(path_to_gem)
     expected = ['rspec-core', Gem::Version.new(RSpec::Core::Version::STRING)]
     actual = gem_env.installed_versions(Gem::Dependency.new('rspec-core', nil)).map { |s| [s.name, s.version] }

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -194,8 +194,8 @@ describe Chef::Provider::RemoteDirectory do
 
             expect(::File.exist?(symlinked_dir_path)).to be_falsey
             expect(::File.exist?(tmp_dir)).to be_truthy
-          rescue Chef::Exceptions::Win32APIError => e
-            pending "This must be run as an Administrator to create symlinks"
+          rescue Chef::Exceptions::Win32APIError
+            skip "This must be run as an Administrator to create symlinks"
           end
         end
       end

--- a/spec/unit/provider/service/freebsd_service_spec.rb
+++ b/spec/unit/provider/service/freebsd_service_spec.rb
@@ -189,18 +189,6 @@ PS_SAMPLE
         expect(provider.status_load_success).to be_nil
       end
 
-      context "when ps command is nil" do
-        before do
-          node.automatic_attrs[:command] = {:ps => nil}
-        end
-
-        it "should set running to nil" do
-          pending "superclass raises no conversion of nil to string which seems broken"
-          provider.determine_current_status!
-          expect(current_resource.running).to be_nil
-        end
-      end
-
       context "when ps is empty string" do
         before do
           node.automatic_attrs[:command] = {:ps => ""}

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -143,8 +143,8 @@ describe Chef::Provider::User do
         begin
           require 'rubygems'
           require 'shadow'
-        rescue LoadError => e
-          pending "ruby-shadow gem not installed for dynamic load test"
+        rescue LoadError
+          skip "ruby-shadow gem not installed for dynamic load test"
           true
         else
           false
@@ -161,7 +161,7 @@ describe Chef::Provider::User do
 
       unless shadow_lib_unavail?
         context "and we have the ruby-shadow gem" do
-          pending "and we are not root (rerun this again as root)", :requires_unprivileged_user => true
+          skip "and we are not root (rerun this again as root)", :requires_unprivileged_user => true
 
           context "and we are root", :requires_root => true do
             it "should pass assertions when ruby-shadow can be loaded" do

--- a/spec/unit/resource/template_spec.rb
+++ b/spec/unit/resource/template_spec.rb
@@ -98,7 +98,7 @@ describe Chef::Resource::Template do
 
     context "on windows", :windows_only do
       # according to Chef::Resource::File, windows state attributes are rights + deny_rights
-      pending "it describes its state"
+      skip "it describes its state"
     end
 
     it "returns the file path as its identity" do


### PR DESCRIPTION
Mass purge of pending specs. These have been around and not been worked on for a very long time, so they're an unfunded mandate that vomit a bunch of test output and don't do much else.

@chef/client-core 