### PR TITLE
Fix backups on windows for the file resource

### DIFF
--- a/lib/chef/util/backup.rb
+++ b/lib/chef/util/backup.rb
@@ -78,8 +78,16 @@ class Chef
         Chef::Log.info("#{@new_resource} removed backup at #{backup_file}")
       end
 
+      def unsorted_backup_files
+        # If you replace this with Dir[], you will probably break Windows.
+        fn = Regexp.escape(::File.basename(path))
+        Dir.entries(::File.dirname(backup_path)).select do |f|
+          !!(f =~ /\A#{fn}.chef-[0-9.]*\B/)
+        end.map {|f| ::File.join(::File.dirname(backup_path), f)}
+      end
+
       def sorted_backup_files
-        Dir[Chef::Util::PathHelper.escape_glob(prefix, ".#{path}") + ".chef-*"].sort { |a,b| b <=> a }
+        unsorted_backup_files.sort { |a,b| b <=> a }
       end
     end
   end

--- a/spec/functional/resource/file_spec.rb
+++ b/spec/functional/resource/file_spec.rb
@@ -86,6 +86,31 @@ describe Chef::Resource::File do
     end
   end
 
+
+  describe "when using backup" do
+    before do
+      Chef::Config[:file_backup_path] = CHEF_SPEC_BACKUP_PATH
+      resource_without_content.backup(1)
+      resource_without_content.run_action(:create)
+    end
+
+    let(:backup_glob) { File.join(CHEF_SPEC_BACKUP_PATH, test_file_dir.sub(/^([A-Za-z]:)/, ""), "#{file_base}*") }
+
+    let(:path) do
+      # Use native system path
+      ChefConfig::PathHelper.canonical_path(File.join(test_file_dir, make_tmpname(file_base)), false)
+    end
+
+    it "only stores the number of requested backups" do
+      resource_without_content.content('foo')
+      resource_without_content.run_action(:create)
+      resource_without_content.content('bar')
+      resource_without_content.run_action(:create)
+      expect(Dir.glob(backup_glob).length).to eq(1)
+    end
+
+  end
+
   # github issue 1842.
   describe "when running action :create on a relative path" do
     before do


### PR DESCRIPTION
The backup utility was using Dir.[], which on breaks with \ in
the path name. This code is replaces with listing the directory and
matching the correct files
Also, on windows, the creation part stripped the drive name, while the
part that searched for old backups did not.

This should solve #3394.