### PR TITLE
Reduce the levels of timeouts in execute timeout test

### DIFF
--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -137,9 +137,16 @@ describe Chef::Resource::Execute do
     end
   end
 
+  # Ensure that CommandTimeout is raised, and is caused by resource.timeout really expiring.
+  # https://github.com/chef/chef/issues/2985
+  #
+  # resource.timeout should be short, this is what we're testing
+  # resource.command ruby sleep timer should be longer than resource.timeout to give us something to timeout
+  # Timeout::timeout should be longer than resource.timeout, but less than the resource.command ruby sleep timer,
+  #   so we fail if we finish on resource.command instead of resource.timeout, but raise CommandTimeout anyway (#2175).
   it "times out when a timeout is set on the resource" do
-    Timeout::timeout(5) do
-      resource.command %{ruby -e 'sleep 600'}
+    Timeout::timeout(30) do
+      resource.command %{ruby -e 'sleep 300'}
       resource.timeout 0.1
       expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::CommandTimeout)
     end


### PR DESCRIPTION
Issue #2175 found that execute resource timeouts weren't working on Windows
but we were waiting 600 seconds for the test to fail. #2686 added a Timeout
to make sure we didn't run too long, but this option simplifies the test by
reducing the number of timeouts involved.

We're currently seeing intermittant failures on a FreeBSD tester, which is
likely a performance issue. But it's possible that we're seeing another issue
that we don't yet understand, so I don't want to throw away the regression
test yet.