### PR TITLE
Groups should not exist before managing groups that don't exist in tests

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -372,6 +372,11 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" }
     let(:tested_action) { :manage }
 
     describe "when there is no group" do
+      before(:each) do
+        group_resource.run_action(:remove)
+        group_should_not_exist(group_name)
+      end
+
       it "raises an error on modify" do
         expect { group_resource.run_action(:modify) }.to raise_error
       end


### PR DESCRIPTION
Attempting to solve an intermittent issue, or at least help identify it.

http://manhattan.ci.chef.co/view/Chef/job/chef-test/architecture=x86_64,platform=windows-2008r2,project=chef,role=tester/153/console

```
1) Chef::Resource::Group group manage action when there is no group does not raise an error on manage
     Failure/Error: expect { group_resource.run_action(:manage) }.not_to raise_error
       expected no Exception, got #<ArgumentError: group[t-2013] (dynamically defined) had an error: ArgumentError: A member could not be added to or removed from the local group because the member does not exist.> with backtrace:
         # ./lib/chef/util/windows/net_group.rb:38:in `modify_members'
         # ./lib/chef/util/windows/net_group.rb:89:in `local_set_members'
         # ./lib/chef/provider/group/windows.rb:78:in `manage_group'
         # ./lib/chef/provider/group.rb:154:in `block in action_manage'
         # ./lib/chef/mixin/why_run.rb:52:in `call'
         # ./lib/chef/mixin/why_run.rb:52:in `add_action'
         # ./lib/chef/provider.rb:170:in `converge_by'
         # ./lib/chef/provider/group.rb:153:in `action_manage'
         # ./lib/chef/provider.rb:135:in `run_action'
         # ./lib/chef/resource.rb:578:in `run_action'
         # ./spec/functional/resource/group_spec.rb:380:in `block (5 levels) in <top (required)>'
         # ./spec/functional/resource/group_spec.rb:380:in `block (4 levels) in <top (required)>'
     # ./spec/functional/resource/group_spec.rb:380:in `block (4 levels) in <top (required)>'
```