### PR TITLE
Fix dsc_resource to work with wmf5 april preview

### DIFF
--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -121,7 +121,14 @@ class Chef
         # however Invoke-DscResource is not correctly writing to that
         # stream and instead just dumping to stdout
         @converge_description = result.stdout
-        result.return_value[0]["InDesiredState"]
+
+        if result.return_value.is_a?(Array)
+          # WMF Feb 2015 Preview
+          result.return_value[0]["InDesiredState"]
+        else
+          # WMF April 2015 Preview
+          result.return_value["InDesiredState"]
+        end
       end
 
       def set_resource


### PR DESCRIPTION
It looks like the April preview returns data in a different structure than the February preview