### PR TITLE
Fix 'knife cookbook show' to work on root files

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -450,7 +450,11 @@ class Chef
         end
         relative_search_path.map {|relative_path| File.join(segment.to_s, relative_path)}
       else
-        [File.join(segment, path)]
+        if segment.to_sym == :root_files
+          [] << path
+        else
+          [File.join(segment, path)]
+        end
       end
     end
     private :preferences_for_path


### PR DESCRIPTION
Currently trying to show the contents of files in the root of a cookbook will fail. For example `knife cookbook show nginx 0.1.4 root_files metadata.rb` will fail with FileNotFound exception. This PR fixes that.