### PR TITLE
Run `gem install` tasks w/o bundler's env

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,9 +108,19 @@ Dir[File.expand_path("../*gemspec", __FILE__)].reverse.each do |gemspec_path|
   Gem::PackageTask.new(gemspec).define
 end
 
+def with_clean_env(&block)
+  if defined?(Bundler)
+    Bundler.with_clean_env(&block)
+  else
+    block.call
+  end
+end
+
 desc "Build and install a chef gem"
 task :install => [:package] do
-  sh %{gem install pkg/#{GEM_NAME}-#{VERSION}.gem --no-rdoc --no-ri}
+  with_clean_env do
+    sh %{gem install pkg/#{GEM_NAME}-#{VERSION}.gem --no-rdoc --no-ri}
+  end
 end
 
 task :uninstall do

--- a/chef-config/Rakefile
+++ b/chef-config/Rakefile
@@ -8,9 +8,19 @@ Dir[File.expand_path("../*gemspec", __FILE__)].reverse.each do |gemspec_path|
   Gem::PackageTask.new(gemspec).define
 end
 
+def with_clean_env(&block)
+  if defined?(Bundler)
+    Bundler.with_clean_env(&block)
+  else
+    block.call
+  end
+end
+
 desc "Build and install a chef-config gem"
 task :install => [:package] do
-  sh %{gem install pkg/chef-config-#{ChefConfig::VERSION}.gem --no-rdoc --no-ri}
+  with_clean_env do
+    sh(%{gem install pkg/chef-config-#{ChefConfig::VERSION}.gem --no-rdoc --no-ri}, verbose: true)
+  end
 end
 
 task :default => :spec


### PR DESCRIPTION
When bundler 1.10 is installed, running these tasks w/ bundler causes
`gem install` to fail with no output

@chef/client-core 