### PR TITLE
Issue #3455: powershell_script: do not allow suppression of syntax errors

### DIFF
--- a/spec/functional/resource/powershell_spec.rb
+++ b/spec/functional/resource/powershell_spec.rb
@@ -125,16 +125,16 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       expect { resource.run_action(:run) }.not_to raise_error
     end
 
-    it "raises an error if the script is not syntactically correct and returns is not set to 1" do
+    it "raises a Mixlib::ShellOut::ShellCommandFailed error if the script is not syntactically correct" do
       resource.code('if({)')
       resource.returns(0)
       expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 
-    it "returns 1 if the script provided to the code attribute is not syntactically correct" do
+    it "raises an error if the script is not syntactically correct even if returns is set to 1 which is what powershell.exe returns for syntactically invalid scripts" do
       resource.code('if({)')
       resource.returns(1)
-      expect { resource.run_action(:run) }.not_to raise_error
+      expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 
     # This somewhat ambiguous case, two failures of different types,


### PR DESCRIPTION
@ksubrama, @btm, @jdmundrawala  thanks for merging #3080. Here's an addendum based on a few pieces of feedback I didn't follow up on:

1. Took @jdmundrawala 's feedback that preserving behavior of other script resources that let you suppress syntax errors just added complexity at the expense of obscuring a much more likely scenario: user expects a (failure) return code of 1, but the script itself has a syntax error. In that case, the script needs to be fixed by the user, but the user isn't aware because Chef reports no error. The `powershell_script` resource hasn't been around long enough to need such strict backwards compatibility to justify the complexity in code (evidenced by numerous questions in the #3080 conversation) and the difficulty of the aforementioned scenario.
2. Feedback from @ksubrama and @jdmundrawala  around it not being obvious how we were actually doing the syntax check by embedding user code in a PowerShell script block. That's actually the core idea of the syntax validation, so to make that more obvious, I've restructured the code generation string so that instead of a terse one-liner, it's in multiple lines and looks closer to how you'd write idiomatic PowerShell code where the block was more obvious.