### PR TITLE
Support bootstrap attribute from json file

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -146,8 +146,15 @@ class Chef
       option :first_boot_attributes,
         :short => "-j JSON_ATTRIBS",
         :long => "--json-attributes",
-        :description => "A JSON string to be added to the first run of chef-client",
-        :proc => lambda { |o| Chef::JSONCompat.parse(o) },
+        :description => "A JSON string or file to be added to the first run of chef-client",
+        :proc => lambda { |o|
+          begin
+            Chef::JSONCompat.parse(o)
+          rescue Chef::Exceptions::JSON::ParseError => e
+            return Chef::JSONCompat.parse(File.read(o)) if File.exists?(o)
+            raise Chef::Exceptions::JSON::ParseError, "No such file `#{o}` and #{e.message}"
+          end
+        },
         :default => {}
 
       option :host_key_verify,

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -235,9 +235,20 @@ describe Chef::Knife::Bootstrap do
       expect(knife.render_template).to eq('{"run_list":["role[base]","recipe[cupcakes]"]}')
     end
 
-    it "should have foo => {bar => baz} in the first_boot" do
+    it "should have foo => {bar => baz} in the first_boot from string" do
       knife.parse_options(["-j", '{"foo":{"bar":"baz"}}'])
       knife.merge_configs
+      expected_hash = FFI_Yajl::Parser.new.parse('{"foo":{"bar":"baz"},"run_list":[]}')
+      actual_hash = FFI_Yajl::Parser.new.parse(knife.render_template)
+      expect(actual_hash).to eq(expected_hash)
+    end
+
+    it "should have foo => {bar => baz} in the first_boot from file" do
+      file = Tempfile.new (['node', '.json'])
+      File.open(file.path, "w") {|f| f.puts '{"foo":{"bar":"baz"}}' }
+      knife.parse_options(["-j", file.path])
+      knife.merge_configs
+      file.close
       expected_hash = FFI_Yajl::Parser.new.parse('{"foo":{"bar":"baz"},"run_list":[]}')
       actual_hash = FFI_Yajl::Parser.new.parse(knife.render_template)
       expect(actual_hash).to eq(expected_hash)


### PR DESCRIPTION
Hi, I add support bootstrap attribute from json file.

When give --json-attributes option to bootstrap.

1. First, try parse as json.
2. Next, if fails parse, then check file path to passed string and try load as json.

