### PR TITLE
Support bootstrap attribute from json file ( replace of #3458 )

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -146,8 +146,8 @@ class Chef
       option :first_boot_attributes,
         :short => "-j JSON_ATTRIBS",
         :long => "--json-attributes",
-        :description => "A JSON string to be added to the first run of chef-client",
-        :proc => lambda { |o| Chef::JSONCompat.parse(o) },
+        :description => "A JSON string or @file to be added to the first run of chef-client",
+        :proc => lambda { |o| Chef::JSONCompat.parse(o.start_with?('@') ? File.read(o.delete('@')) : o) },
         :default => {}
 
       option :host_key_verify,

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -147,7 +147,7 @@ class Chef
         :short => "-j JSON_ATTRIBS",
         :long => "--json-attributes",
         :description => "A JSON string or @file to be added to the first run of chef-client",
-        :proc => lambda { |o| Chef::JSONCompat.parse(o.start_with?('@') ? File.read(o.delete('@')) : o) },
+        :proc => lambda { |o| Chef::JSONCompat.parse(o.start_with?('@') ? File.read(o[1..-1]) : o) },
         :default => {}
 
       option :host_key_verify,

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -235,9 +235,20 @@ describe Chef::Knife::Bootstrap do
       expect(knife.render_template).to eq('{"run_list":["role[base]","recipe[cupcakes]"]}')
     end
 
-    it "should have foo => {bar => baz} in the first_boot" do
+    it "should have foo => {bar => baz} in the first_boot from string" do
       knife.parse_options(["-j", '{"foo":{"bar":"baz"}}'])
       knife.merge_configs
+      expected_hash = FFI_Yajl::Parser.new.parse('{"foo":{"bar":"baz"},"run_list":[]}')
+      actual_hash = FFI_Yajl::Parser.new.parse(knife.render_template)
+      expect(actual_hash).to eq(expected_hash)
+    end
+
+    it "should have foo => {bar => baz} in the first_boot from @file" do
+      file = Tempfile.new (['node', '.json'])
+      File.open(file.path, "w") {|f| f.puts '{"foo":{"bar":"baz"}}' }
+      knife.parse_options(["-j", '@' + file.path])
+      knife.merge_configs
+      file.close
       expected_hash = FFI_Yajl::Parser.new.parse('{"foo":{"bar":"baz"},"run_list":[]}')
       actual_hash = FFI_Yajl::Parser.new.parse(knife.render_template)
       expect(actual_hash).to eq(expected_hash)


### PR DESCRIPTION
This PR is replace of #3458 .

When passed `@string` via --json-attributes, try read bootstrap attributes from file .