### PR TITLE
Fix issue where ps_credential does not work over winrm

### DIFF
--- a/lib/chef/win32/crypto.rb
+++ b/lib/chef/win32/crypto.rb
@@ -29,7 +29,7 @@ class Chef
 
       def self.encrypt(str, &block)
         data_blob = CRYPT_INTEGER_BLOB.new
-        unless CryptProtectData(CRYPT_INTEGER_BLOB.new(str.to_wstring), nil, nil, nil, nil, 0, data_blob)
+        unless CryptProtectData(CRYPT_INTEGER_BLOB.new(str.to_wstring), nil, nil, nil, nil, CRYPTPROTECT_LOCAL_MACHINE, data_blob)
           Chef::ReservedNames::Win32::Error.raise!
         end
         bytes = data_blob[:pbData].get_bytes(0, data_blob[:cbData])


### PR DESCRIPTION
The issue here is the user profile does not get loaded when
running over winrm / as a service. This user profile is needed
to use the DPAPI to encrypt the data for the current user.

Should fix #3246 

The other solution is to call `LoadUserProfile` and `UnloadUserProfile` for the current user. This is complicated as it is slow and requires managing the profile handle through the entire chef run as we need to clean it up after we are done. The benefit is that in order to decrypt the data, you need to control the account. With `CRYPTPROTECT_LOCAL_MACHINE`, logging onto the machine is sufficient the decrypt.

cc @smurawski @btm @adamedx @ksubrama 