### PR TITLE
Add missing require

### DIFF
--- a/lib/chef/guard_interpreter/default_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/default_guard_interpreter.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+require 'chef/mixin/shell_out'
+
 class Chef
   class GuardInterpreter
     class DefaultGuardInterpreter


### PR DESCRIPTION
This should fix the issue where doing
```ruby
require 'chef/resource'
```
throws an exception because Chef::Mixin::ShellOut is not loaded