### PR TITLE
Make ssh_port default to 22 for knife bootstrap.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -59,6 +59,7 @@ class Chef
         :short => "-p PORT",
         :long => "--ssh-port PORT",
         :description => "The ssh port",
+        :default => 22,
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_port] = key }
 
       option :ssh_gateway,


### PR DESCRIPTION
This is the behavior of knife-windows.