### PR TITLE
add lazy require for 'chef/config'

### DIFF
--- a/lib/chef/server_api.rb
+++ b/lib/chef/server_api.rb
@@ -42,3 +42,5 @@ class Chef
     use Chef::HTTP::RemoteRequestID
   end
 end
+
+require 'chef/config'


### PR DESCRIPTION
this is probably pulled in by chef/http at the top, but make it
explict (lazy to break circular deps).