### PR TITLE
Allow directory resource to accept arrays for paths

### DIFF
--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -54,7 +54,7 @@ class Chef
         set_or_return(
           :path,
           arg,
-          :kind_of => String
+          :kind_of => [ String, Array ]
         )
       end
 


### PR DESCRIPTION
This would make it a bit cleaner to create directories in bulk. My Ruby coding skills are not the best so this may not be the best way to do this but I'd appreciate some feedback on the validity of the idea and perhaps how to code it better. If people are happy with it I'll also submit a PR to [chef/chef-docs](https://github.com/chef/chef-docs) explaining how to use it.