### PR TITLE
fix package timeout attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,18 @@
 
 * [Issue #2247](https://github.com/chef/chef/issues/2247): powershell_script returns 0 for scripts with syntax errors
 * [pr#3080](https://github.com/chef/chef/pull/3080): Issue 2247: powershell_script exit status should be nonzero for syntax errors
-* [pr#3441](https://github.com/chef/chef/pull/3441): Add powershell_out mixin to core chef
-* [pr#3448](https://github.com/chef/chef/pull/3448): Fix dsc_resource to work with wmf5 april preview
-* [pr#3392](https://github.com/chef/chef/pull/3392): Comment up Chef::Client and privatize/deprecate unused things
-* [pr#3419](https://github.com/chef/chef/pull/3419): Fix cli issue with chef_repo_path when ENV variable is unset
+* [pr#3441](https://github.com/chef/chef/pull/3441): Add `powershell_out` mixin to core chef
+* [pr#3448](https://github.com/chef/chef/pull/3448): Fix `dsc_resource` to work with wmf5 april preview
+* [pr#3392](https://github.com/chef/chef/pull/3392): Comment up `Chef::Client` and privatize/deprecate unused things
+* [pr#3419](https://github.com/chef/chef/pull/3419): Fix cli issue with `chef_repo_path` when ENV variable is unset
 * [pr#3358](https://github.com/chef/chef/pull/3358): Separate audit and converge failures
 * [pr#3431](https://github.com/chef/chef/pull/3431): Fix backups on windows for the file resource
 * [pr#3397](https://github.com/chef/chef/pull/3397): Validate owner exists in directory resources
 * [pr#3418](https://github.com/chef/chef/pull/3418): Add `shell_out` mixin to Chef::Resource class for use in `not_if`/`only_if` conditionals, etc.
 * [pr#3406](https://github.com/chef/chef/pull/3406): Add wide-char 'Environment' to `broadcast_env_change` mixin for setting windows environment variables
-* [pr#3442](https://github.com/chef/chef/pull/3442): Add resource_name to top-level Resource class to make defining resources easier.  `use_automatic_resource_name` also added, to support convention-based resource naming.
-* [pr#3447](https://github.com/chef/chef/pull/3447): Add allowed_actions and default_action to top-level Resource class.
+* [pr#3442](https://github.com/chef/chef/pull/3442): Add `resource_name` to top-level Resource class to make defining resources easier.  `use_automatic_resource_name` also added, to support convention-based resource naming.
+* [pr#3447](https://github.com/chef/chef/pull/3447): Add `allowed_actions` and `default_action` to top-level Resource class.
+* [pr#3475](https://github.com/chef/chef/pull/3475): Fix `shell_out` timeouts in all package providers to respect timeout property on the resource.
 
 ## 12.4.0
 

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -521,6 +521,30 @@ class Chef
       Chef.set_provider_priority_array :package,  SmartOS,  platform: "smartos"
       Chef.set_provider_priority_array :package,  Aix,      platform: "aix"
       Chef.set_provider_priority_array :package,  Paludis,  platform: "exherbo"
+
+      private
+
+      def shell_out_with_timeout(*command_args)
+        shell_out(*add_timeout_option(command_args))
+      end
+
+      def shell_out_with_timeout!(*command_args)
+        shell_out!(*add_timeout_option(command_args))
+      end
+
+      def add_timeout_option(command_args)
+        args = command_args.dup
+        if args.last.is_a?(Hash)
+          options = args.pop.dup
+          options[:timeout] = new_resource.timeout if new_resource.timeout
+          options[:timeout] = 900 unless options.has_key?(:timeout)
+          args << options
+        else
+          args << { :timeout => new_resource.timeout ? new_resource.timeout : 900 }
+        end
+        args
+      end
+
     end
   end
 end

--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -52,7 +52,7 @@ class Chef
             @package_source_found = ::File.exists?(@new_resource.source)
             if @package_source_found
               Chef::Log.debug("#{@new_resource} checking pkg status")
-              ret = shell_out("installp -L -d #{@new_resource.source}")
+              ret = shell_out_with_timeout("installp -L -d #{@new_resource.source}")
               ret.stdout.each_line do | line |
                 case line
                 when /#{@new_resource.package_name}:/
@@ -65,7 +65,7 @@ class Chef
           end
 
           Chef::Log.debug("#{@new_resource} checking install state")
-          ret = shell_out("lslpp -lcq #{@current_resource.package_name}")
+          ret = shell_out_with_timeout("lslpp -lcq #{@current_resource.package_name}")
           ret.stdout.each_line do | line |
             case line
             when /#{@current_resource.package_name}/
@@ -84,7 +84,7 @@ class Chef
 
         def candidate_version
           return @candidate_version if @candidate_version
-          ret = shell_out("installp -L -d #{@new_resource.source}")
+          ret = shell_out_with_timeout("installp -L -d #{@new_resource.source}")
           ret.stdout.each_line do | line |
             case line
             when /\w:#{Regexp.escape(@new_resource.package_name)}:(.*)/
@@ -110,10 +110,10 @@ class Chef
         def install_package(name, version)
           Chef::Log.debug("#{@new_resource} package install options: #{@new_resource.options}")
           if @new_resource.options.nil?
-            shell_out!( "installp -aYF -d #{@new_resource.source} #{@new_resource.package_name}" )
+            shell_out_with_timeout!( "installp -aYF -d #{@new_resource.source} #{@new_resource.package_name}" )
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           else
-            shell_out!( "installp -aYF #{expand_options(@new_resource.options)} -d #{@new_resource.source} #{@new_resource.package_name}" )
+            shell_out_with_timeout!( "installp -aYF #{expand_options(@new_resource.options)} -d #{@new_resource.source} #{@new_resource.package_name}" )
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           end
         end
@@ -122,10 +122,10 @@ class Chef
 
         def remove_package(name, version)
           if @new_resource.options.nil?
-            shell_out!( "installp -u #{name}" )
+            shell_out_with_timeout!( "installp -u #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
           else
-            shell_out!( "installp -u #{expand_options(@new_resource.options)} #{name}" )
+            shell_out_with_timeout!( "installp -u #{expand_options(@new_resource.options)} #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -62,7 +62,7 @@ class Chef
           installed_version  = nil
           candidate_version  = nil
 
-          shell_out!("apt-cache#{expand_options(default_release_options)} policy #{pkg}", {:timeout=>900}).stdout.each_line do |line|
+          shell_out_with_timeout!("apt-cache#{expand_options(default_release_options)} policy #{pkg}").stdout.each_line do |line|
             case line
             when /^\s{2}Installed: (.+)$/
               installed_version = $1
@@ -78,7 +78,7 @@ class Chef
               if candidate_version == '(none)'
                 # This may not be an appropriate assumption, but it shouldn't break anything that already worked -- btm
                 is_virtual_package = true
-                showpkg = shell_out!("apt-cache showpkg #{pkg}", {:timeout => 900}).stdout
+                showpkg = shell_out_with_timeout!("apt-cache showpkg #{pkg}").stdout
                 providers = Hash.new
                 showpkg.rpartition(/Reverse Provides: ?#{$/}/)[2].each_line do |line|
                   provider, version = line.split
@@ -175,7 +175,7 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(command)
-          shell_out!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil }, :timeout => @new_resource.timeout)
+          shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
         end
 
       end

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -62,7 +62,7 @@ class Chef
               # Get information from the package if supplied
               Chef::Log.debug("#{@new_resource} checking dpkg status")
 
-              shell_out("dpkg-deb -W #{@new_resource.source}").stdout.each_line do |line|
+              shell_out_with_timeout("dpkg-deb -W #{@new_resource.source}").stdout.each_line do |line|
                 if pkginfo = DPKG_INFO.match(line)
                   @current_resource.package_name(pkginfo[1])
                   @new_resource.version(pkginfo[2])
@@ -79,7 +79,7 @@ class Chef
           # Check to see if it is installed
           package_installed = nil
           Chef::Log.debug("#{@new_resource} checking install state")
-          status = shell_out("dpkg -s #{@current_resource.package_name}")
+          status = shell_out_with_timeout("dpkg -s #{@current_resource.package_name}")
           status.stdout.each_line do |line|
             case line
             when DPKG_INSTALLED
@@ -134,13 +134,13 @@ class Chef
           run_noninteractive("dpkg-reconfigure #{name}")
         end
 
-        # Runs command via shell_out with magic environment to disable
+        # Runs command via shell_out_with_timeout with magic environment to disable
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         #
         # FIXME: This should be "LC_ALL" => "en_US.UTF-8" in order to stabilize the output and get UTF-8
         def run_noninteractive(command)
-          shell_out!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
+          shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
         end
 
       end

--- a/lib/chef/provider/package/easy_install.rb
+++ b/lib/chef/provider/package/easy_install.rb
@@ -32,10 +32,10 @@ class Chef
 
           begin
             # first check to see if we can import it
-            output = shell_out!("#{python_binary_path} -c \"import #{name}\"", :returns=>[0,1]).stderr
+            output = shell_out_with_timeout!("#{python_binary_path} -c \"import #{name}\"", :returns=>[0,1]).stderr
             if output.include? "ImportError"
               # then check to see if its on the path
-              output = shell_out!("#{python_binary_path} -c \"import sys; print sys.path\"", :returns=>[0,1]).stdout
+              output = shell_out_with_timeout!("#{python_binary_path} -c \"import sys; print sys.path\"", :returns=>[0,1]).stdout
               if output.downcase.include? "#{name.downcase}"
                 check = true
               end
@@ -73,10 +73,10 @@ class Chef
           package_version = nil
           if install_check(module_name)
             begin
-              output = shell_out!("#{python_binary_path} -c \"import #{module_name}; print #{module_name}.__version__\"").stdout
+              output = shell_out_with_timeout!("#{python_binary_path} -c \"import #{module_name}; print #{module_name}.__version__\"").stdout
               package_version = output.strip
             rescue
-              output = shell_out!("#{python_binary_path} -c \"import sys; print sys.path\"", :returns=>[0,1]).stdout
+              output = shell_out_with_timeout!("#{python_binary_path} -c \"import sys; print sys.path\"", :returns=>[0,1]).stdout
 
               output_array = output.gsub(/[\[\]]/,'').split(/\s*,\s*/)
               package_path = ""
@@ -107,7 +107,7 @@ class Chef
            return @candidate_version if @candidate_version
 
            # do a dry run to get the latest version
-           result = shell_out!("#{easy_install_binary_path} -n #{@new_resource.package_name}", :returns=>[0,1])
+           result = shell_out_with_timeout!("#{easy_install_binary_path} -n #{@new_resource.package_name}", :returns=>[0,1])
            @candidate_version = result.stdout[/(.*)Best match: (.*) (.*)$/, 3]
            @candidate_version
         end

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -47,7 +47,7 @@ class Chef
 
             # Otherwise look up the path to the ports directory using 'whereis'
             else
-              whereis = shell_out!("whereis -s #{port}", :env => nil)
+              whereis = shell_out_with_timeout!("whereis -s #{port}", :env => nil)
               unless path = whereis.stdout[/^#{Regexp.escape(port)}:\s+(.+)$/, 1]
                 raise Chef::Exceptions::Package, "Could not find port with the name #{port}"
               end
@@ -57,7 +57,7 @@ class Chef
 
           def makefile_variable_value(variable, dir = nil)
             options = dir ? { :cwd => dir } : {}
-            make_v = shell_out!("make -V #{variable}", options.merge!(:env => nil, :returns => [0,1]))
+            make_v = shell_out_with_timeout!("make -V #{variable}", options.merge!(:env => nil, :returns => [0,1]))
             make_v.exitstatus.zero? ? make_v.stdout.strip.split($\).first : nil   # $\ is the line separator, i.e. newline.
           end
         end

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -34,24 +34,24 @@ class Chef
               case @new_resource.source
               when /^http/, /^ftp/
                 if @new_resource.source =~ /\/$/
-                  shell_out!("pkg_add -r #{package_name}", :env => { "PACKAGESITE" => @new_resource.source, 'LC_ALL' => nil }).status
+                  shell_out_with_timeout!("pkg_add -r #{package_name}", :env => { "PACKAGESITE" => @new_resource.source, 'LC_ALL' => nil }).status
                 else
-                  shell_out!("pkg_add -r #{package_name}", :env => { "PACKAGEROOT" => @new_resource.source, 'LC_ALL' => nil }).status
+                  shell_out_with_timeout!("pkg_add -r #{package_name}", :env => { "PACKAGEROOT" => @new_resource.source, 'LC_ALL' => nil }).status
                 end
                 Chef::Log.debug("#{@new_resource} installed from: #{@new_resource.source}")
 
               when /^\//
-                shell_out!("pkg_add #{file_candidate_version_path}", :env => { "PKG_PATH" => @new_resource.source , 'LC_ALL'=>nil}).status
+                shell_out_with_timeout!("pkg_add #{file_candidate_version_path}", :env => { "PKG_PATH" => @new_resource.source , 'LC_ALL'=>nil}).status
                 Chef::Log.debug("#{@new_resource} installed from: #{@new_resource.source}")
 
               else
-                shell_out!("pkg_add -r #{latest_link_name}", :env => nil).status
+                shell_out_with_timeout!("pkg_add -r #{latest_link_name}", :env => nil).status
               end
             end
           end
 
           def remove_package(name, version)
-            shell_out!("pkg_delete #{package_name}-#{version || @current_resource.version}", :env => nil).status
+            shell_out_with_timeout!("pkg_delete #{package_name}-#{version || @current_resource.version}", :env => nil).status
           end
 
           # The name of the package (without the version number) as understood by pkg_add and pkg_info.
@@ -72,7 +72,7 @@ class Chef
           end
 
           def current_installed_version
-            pkg_info = shell_out!("pkg_info -E \"#{package_name}*\"", :env => nil, :returns => [0,1])
+            pkg_info = shell_out_with_timeout!("pkg_info -E \"#{package_name}*\"", :env => nil, :returns => [0,1])
             pkg_info.stdout[/^#{Regexp.escape(package_name)}-(.+)/, 1]
           end
 

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -28,11 +28,11 @@ class Chef
             unless @current_resource.version
               case @new_resource.source
               when /^(http|ftp|\/)/
-                shell_out!("pkg add#{expand_options(@new_resource.options)} #{@new_resource.source}", :env => { 'LC_ALL' => nil }).status
+                shell_out_with_timeout!("pkg add#{expand_options(@new_resource.options)} #{@new_resource.source}", :env => { 'LC_ALL' => nil }).status
                 Chef::Log.debug("#{@new_resource} installed from: #{@new_resource.source}")
 
               else
-                shell_out!("pkg install -y#{expand_options(@new_resource.options)} #{name}", :env => { 'LC_ALL' => nil }).status
+                shell_out_with_timeout!("pkg install -y#{expand_options(@new_resource.options)} #{name}", :env => { 'LC_ALL' => nil }).status
               end
             end
           end
@@ -40,11 +40,11 @@ class Chef
           def remove_package(name, version)
             options = @new_resource.options && @new_resource.options.sub(repo_regex, '')
             options && !options.empty? || options = nil
-            shell_out!("pkg delete -y#{expand_options(options)} #{name}#{version ? '-' + version : ''}", :env => nil).status
+            shell_out_with_timeout!("pkg delete -y#{expand_options(options)} #{name}#{version ? '-' + version : ''}", :env => nil).status
           end
 
           def current_installed_version
-            pkg_info = shell_out!("pkg info \"#{@new_resource.package_name}\"", :env => nil, :returns => [0,70])
+            pkg_info = shell_out_with_timeout!("pkg info \"#{@new_resource.package_name}\"", :env => nil, :returns => [0,70])
             pkg_info.stdout[/^Version +: (.+)$/, 1]
           end
 
@@ -63,7 +63,7 @@ class Chef
               options = $1
             end
 
-            pkg_query = shell_out!("pkg rquery#{expand_options(options)} '%v' #{@new_resource.package_name}", :env => nil)
+            pkg_query = shell_out_with_timeout!("pkg rquery#{expand_options(options)} '%v' #{@new_resource.package_name}", :env => nil)
             pkg_query.exitstatus.zero? ? pkg_query.stdout.strip.split(/\n/).last : nil
           end
 

--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -26,18 +26,18 @@ class Chef
           include PortsHelper
 
           def install_package(name, version)
-            shell_out!("make -DBATCH install clean", :timeout => 1800, :env => nil, :cwd => port_dir).status
+            shell_out_with_timeout!("make -DBATCH install clean", :timeout => 1800, :env => nil, :cwd => port_dir).status
           end
 
           def remove_package(name, version)
-            shell_out!("make deinstall", :timeout => 300, :env => nil, :cwd => port_dir).status
+            shell_out_with_timeout!("make deinstall", :timeout => 300, :env => nil, :cwd => port_dir).status
           end
 
           def current_installed_version
             pkg_info = if @new_resource.supports_pkgng?
-                         shell_out!("pkg info \"#{@new_resource.package_name}\"", :env => nil, :returns => [0,70])
+                         shell_out_with_timeout!("pkg info \"#{@new_resource.package_name}\"", :env => nil, :returns => [0,70])
                        else
-                         shell_out!("pkg_info -E \"#{@new_resource.package_name}*\"", :env => nil, :returns => [0,1])
+                         shell_out_with_timeout!("pkg_info -E \"#{@new_resource.package_name}*\"", :env => nil, :returns => [0,1])
                        end
             pkg_info.stdout[/^#{Regexp.escape(@new_resource.package_name)}-(.+)/, 1]
           end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -125,7 +125,8 @@ class Chef
           homebrew_user = Etc.getpwuid(homebrew_uid)
 
           Chef::Log.debug "Executing '#{command}' as user '#{homebrew_user.name}'"
-          output = shell_out!(command, :timeout => 1800, :user => homebrew_uid, :environment => { 'HOME' => homebrew_user.dir, 'RUBYOPT' => nil })
+          # FIXME: this 1800 second default timeout should be deprecated
+          output = shell_out_with_timeout!(command, :timeout => 1800, :user => homebrew_uid, :environment => { 'HOME' => homebrew_user.dir, 'RUBYOPT' => nil })
           output.stdout.chomp
         end
 

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -42,14 +42,14 @@ class Chef
         end
 
         def get_current_version
-          shell_out("pkg info #{@new_resource.package_name}").stdout.each_line do |line|
+          shell_out_with_timeout("pkg info #{@new_resource.package_name}").stdout.each_line do |line|
             return $1.split[0] if line =~ /^\s+Version: (.*)/
           end
           return nil
         end
 
         def get_candidate_version
-          shell_out!("pkg info -r #{new_resource.package_name}").stdout.each_line do |line|
+          shell_out_with_timeout!("pkg info -r #{new_resource.package_name}").stdout.each_line do |line|
             return $1.split[0] if line =~ /Version: (.*)/
           end
           return nil
@@ -73,7 +73,7 @@ class Chef
             else
               normal_command
             end
-          shell_out(command)
+          shell_out_with_timeout(command)
         end
 
         def upgrade_package(name, version)
@@ -82,7 +82,7 @@ class Chef
 
         def remove_package(name, version)
           package_name = "#{name}@#{version}"
-          shell_out!( "pkg#{expand_options(@new_resource.options)} uninstall -q #{package_name}" )
+          shell_out_with_timeout!( "pkg#{expand_options(@new_resource.options)} uninstall -q #{package_name}" )
         end
       end
     end

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -48,21 +48,21 @@ class Chef
           unless @current_resource.version == version
             command = "port#{expand_options(@new_resource.options)} install #{name}"
             command << " @#{version}" if version and !version.empty?
-            shell_out!(command)
+            shell_out_with_timeout!(command)
           end
         end
 
         def purge_package(name, version)
           command = "port#{expand_options(@new_resource.options)} uninstall #{name}"
           command << " @#{version}" if version and !version.empty?
-          shell_out!(command)
+          shell_out_with_timeout!(command)
         end
 
         def remove_package(name, version)
           command = "port#{expand_options(@new_resource.options)} deactivate #{name}"
           command << " @#{version}" if version and !version.empty?
 
-          shell_out!(command)
+          shell_out_with_timeout!(command)
         end
 
         def upgrade_package(name, version)
@@ -75,14 +75,14 @@ class Chef
             # that hasn't been installed.
             install_package(name, version)
           elsif current_version != version
-            shell_out!( "port#{expand_options(@new_resource.options)} upgrade #{name} @#{version}" )
+            shell_out_with_timeout!( "port#{expand_options(@new_resource.options)} upgrade #{name} @#{version}" )
           end
         end
 
         private
         def get_response_from_command(command)
           output = nil
-          status = shell_out(command)
+          status = shell_out_with_timeout(command)
           begin
             output = status.stdout
           rescue Exception

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -22,7 +22,6 @@
 
 require 'chef/resource/package'
 require 'chef/provider/package'
-require 'chef/mixin/shell_out'
 require 'chef/mixin/get_source_from_package'
 require 'chef/exceptions'
 
@@ -72,7 +71,7 @@ class Chef
             if parts = name.match(/^(.+?)--(.+)/) # use double-dash for stems with flavors, see man page for pkg_add
               name = parts[1]
             end
-            shell_out!("pkg_add -r #{name}#{version_string}", :env => {"PKG_PATH" => pkg_path}).status
+            shell_out_with_timeout!("pkg_add -r #{name}#{version_string}", :env => {"PKG_PATH" => pkg_path}).status
             Chef::Log.debug("#{new_resource.package_name} installed")
           end
         end
@@ -83,7 +82,7 @@ class Chef
           if parts = name.match(/^(.+?)--(.+)/)
             name = parts[1]
           end
-          shell_out!("pkg_delete #{name}#{version_string}", :env => nil).status
+          shell_out_with_timeout!("pkg_delete #{name}#{version_string}", :env => nil).status
         end
 
         private
@@ -94,7 +93,7 @@ class Chef
           else
             name = new_resource.package_name
           end
-          pkg_info = shell_out!("pkg_info -e \"#{name}->0\"", :env => nil, :returns => [0,1])
+          pkg_info = shell_out_with_timeout!("pkg_info -e \"#{name}->0\"", :env => nil, :returns => [0,1])
           result = pkg_info.stdout[/^inst:#{Regexp.escape(name)}-(.+?)\s/, 1]
           Chef::Log.debug("installed_version of '#{new_resource.package_name}' is '#{result}'")
           result
@@ -103,7 +102,7 @@ class Chef
         def candidate_version
           @candidate_version ||= begin
             results = []
-            shell_out!("pkg_info -I \"#{new_resource.package_name}#{version_string}\"", :env => nil, :returns => [0,1]).stdout.each_line do |line|
+            shell_out_with_timeout!("pkg_info -I \"#{new_resource.package_name}#{version_string}\"", :env => nil, :returns => [0,1]).stdout.each_line do |line|
               if parts = new_resource.package_name.match(/^(.+?)--(.+)/)
                 results << line[/^#{Regexp.escape(parts[1])}-(.+?)\s/, 1]
               else

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -34,7 +34,7 @@ class Chef
           @current_resource.version(nil)
 
           Chef::Log.debug("#{@new_resource} checking pacman for #{@new_resource.package_name}")
-          status = shell_out("pacman -Qi #{@new_resource.package_name}")
+          status = shell_out_with_timeout("pacman -Qi #{@new_resource.package_name}")
           status.stdout.each_line do |line|
             case line
             when /^Version(\s?)*: (.+)$/
@@ -62,7 +62,7 @@ class Chef
 
           package_repos = repos.map {|r| Regexp.escape(r) }.join('|')
 
-          status = shell_out("pacman -Sl")
+          status = shell_out_with_timeout("pacman -Sl")
           status.stdout.each_line do |line|
             case line
               when /^(#{package_repos}) #{Regexp.escape(@new_resource.package_name)} (.+)$/
@@ -85,7 +85,7 @@ class Chef
         end
 
         def install_package(name, version)
-          shell_out!( "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
+          shell_out_with_timeout!( "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
         end
 
         def upgrade_package(name, version)
@@ -93,7 +93,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          shell_out!( "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
+          shell_out_with_timeout!( "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}" )
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -17,7 +17,6 @@
 #
 require 'chef/provider/package'
 require 'chef/mixin/command'
-require 'chef/mixin/shell_out'
 require 'chef/resource/package'
 require 'chef/mixin/get_source_from_package'
 
@@ -60,7 +59,7 @@ class Chef
             end
 
             Chef::Log.debug("#{@new_resource} checking rpm status")
-            shell_out!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}").stdout.each_line do |line|
+            shell_out_with_timeout!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}").stdout.each_line do |line|
               case line
               when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
                 @current_resource.package_name($1)
@@ -76,7 +75,7 @@ class Chef
           end
 
           Chef::Log.debug("#{@new_resource} checking install state")
-          @rpm_status = shell_out("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
+          @rpm_status = shell_out_with_timeout("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@current_resource.package_name}")
           @rpm_status.stdout.each_line do |line|
             case line
             when /^([\w\d+_.-]+)\s([\w\d_.-]+)$/
@@ -90,12 +89,12 @@ class Chef
 
         def install_package(name, version)
           unless @current_resource.version
-            shell_out!( "rpm #{@new_resource.options} -i #{@new_resource.source}" )
+            shell_out_with_timeout!( "rpm #{@new_resource.options} -i #{@new_resource.source}" )
           else
             if allow_downgrade
-              shell_out!( "rpm #{@new_resource.options} -U --oldpackage #{@new_resource.source}" )
+              shell_out_with_timeout!( "rpm #{@new_resource.options} -U --oldpackage #{@new_resource.source}" )
             else
-              shell_out!( "rpm #{@new_resource.options} -U #{@new_resource.source}" )
+              shell_out_with_timeout!( "rpm #{@new_resource.options} -U #{@new_resource.source}" )
             end
           end
         end
@@ -104,9 +103,9 @@ class Chef
 
         def remove_package(name, version)
           if version
-            shell_out!( "rpm #{@new_resource.options} -e #{name}-#{version}" )
+            shell_out_with_timeout!( "rpm #{@new_resource.options} -e #{name}-#{version}" )
           else
-            shell_out!( "rpm #{@new_resource.options} -e #{name}" )
+            shell_out_with_timeout!( "rpm #{@new_resource.options} -e #{name}" )
           end
         end
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -538,9 +538,9 @@ class Chef
             src = @new_resource.source && " --source=#{@new_resource.source} --source=https://rubygems.org"
           end
           if !version.nil? && version.length > 0
-            shell_out!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)
+            shell_out_with_timeout!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", :env=>nil)
           else
-            shell_out!("#{gem_binary_path} install \"#{name}\" -q --no-rdoc --no-ri #{src}#{opts}", :env=>nil)
+            shell_out_with_timeout!("#{gem_binary_path} install \"#{name}\" -q --no-rdoc --no-ri #{src}#{opts}", :env=>nil)
           end
         end
 
@@ -564,9 +564,9 @@ class Chef
 
         def uninstall_via_gem_command(name, version)
           if version
-            shell_out!("#{gem_binary_path} uninstall #{name} -q -x -I -v \"#{version}\"#{opts}", :env=>nil)
+            shell_out_with_timeout!("#{gem_binary_path} uninstall #{name} -q -x -I -v \"#{version}\"#{opts}", :env=>nil)
           else
-            shell_out!("#{gem_binary_path} uninstall #{name} -q -x -I -a#{opts}", :env=>nil)
+            shell_out_with_timeout!("#{gem_binary_path} uninstall #{name} -q -x -I -a#{opts}", :env=>nil)
           end
         end
 

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -43,7 +43,7 @@ class Chef
         def check_package_state(name)
           Chef::Log.debug("#{@new_resource} checking package #{name}")
           version = nil
-          info = shell_out!("/opt/local/sbin/pkg_info", "-E", "#{name}*", :env => nil, :returns => [0,1])
+          info = shell_out_with_timeout!("/opt/local/sbin/pkg_info", "-E", "#{name}*", :env => nil, :returns => [0,1])
 
           if info.stdout
             version = info.stdout[/^#{@new_resource.package_name}-(.+)/, 1]
@@ -60,7 +60,7 @@ class Chef
           return @candidate_version if @candidate_version
           name = nil
           version = nil
-          pkg = shell_out!("/opt/local/bin/pkgin", "se", new_resource.package_name, :env => nil, :returns => [0,1])
+          pkg = shell_out_with_timeout!("/opt/local/bin/pkgin", "se", new_resource.package_name, :env => nil, :returns => [0,1])
           pkg.stdout.each_line do |line|
             case line
             when /^#{new_resource.package_name}/
@@ -74,7 +74,7 @@ class Chef
         def install_package(name, version)
           Chef::Log.debug("#{@new_resource} installing package #{name} version #{version}")
           package = "#{name}-#{version}"
-          out = shell_out!("/opt/local/bin/pkgin", "-y", "install", package, :env => nil)
+          out = shell_out_with_timeout!("/opt/local/bin/pkgin", "-y", "install", package, :env => nil)
         end
 
         def upgrade_package(name, version)
@@ -85,7 +85,7 @@ class Chef
         def remove_package(name, version)
           Chef::Log.debug("#{@new_resource} removing package #{name} version #{version}")
           package = "#{name}"
-          out = shell_out!("/opt/local/bin/pkgin", "-y", "remove", package, :env => nil)
+          out = shell_out_with_timeout!("/opt/local/bin/pkgin", "-y", "remove", package, :env => nil)
         end
 
       end

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -55,7 +55,7 @@ class Chef
             @package_source_found = ::File.exists?(@new_resource.source)
             if @package_source_found
               Chef::Log.debug("#{@new_resource} checking pkg status")
-              shell_out("pkginfo -l -d #{@new_resource.source} #{@new_resource.package_name}").stdout.each_line do |line|
+              shell_out_with_timeout("pkginfo -l -d #{@new_resource.source} #{@new_resource.package_name}").stdout.each_line do |line|
                 case line
                 when /VERSION:\s+(.+)/
                   @new_resource.version($1)
@@ -65,7 +65,7 @@ class Chef
           end
 
           Chef::Log.debug("#{@new_resource} checking install state")
-          status = shell_out("pkginfo -l #{@current_resource.package_name}")
+          status = shell_out_with_timeout("pkginfo -l #{@current_resource.package_name}")
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -87,7 +87,7 @@ class Chef
 
         def candidate_version
           return @candidate_version if @candidate_version
-          status = shell_out("pkginfo -l -d #{@new_resource.source} #{new_resource.package_name}")
+          status = shell_out_with_timeout("pkginfo -l -d #{@new_resource.source} #{new_resource.package_name}")
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -110,7 +110,7 @@ class Chef
             else
               command = "pkgadd -n -d #{@new_resource.source} all"
             end
-            shell_out!(command)
+            shell_out_with_timeout!(command)
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           else
             if ::File.directory?(@new_resource.source) # CHEF-4469
@@ -118,17 +118,17 @@ class Chef
             else
               command = "pkgadd -n#{expand_options(@new_resource.options)} -d #{@new_resource.source} all"
             end
-            shell_out!(command)
+            shell_out_with_timeout!(command)
             Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
           end
         end
 
         def remove_package(name, version)
           if @new_resource.options.nil?
-            shell_out!( "pkgrm -n #{name}" )
+            shell_out_with_timeout!( "pkgrm -n #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
           else
-            shell_out!( "pkgrm -n#{expand_options(@new_resource.options)} #{name}" )
+            shell_out_with_timeout!( "pkgrm -n#{expand_options(@new_resource.options)} #{name}" )
             Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -56,7 +56,7 @@ class Chef
             Chef::Log.debug("#{@new_resource} installing MSI package '#{@new_resource.source}'")
             shell_out!("msiexec /qn /i \"#{@new_resource.source}\" #{expand_options(@new_resource.options)}", {:timeout => @new_resource.timeout, :returns => @new_resource.returns})
           end
-  
+
           def remove_package(name, version)
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             Chef::Log.debug("#{@new_resource} removing MSI package '#{@new_resource.source}'")

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -1,4 +1,4 @@
-#
+
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Copyright:: Copyright (c) 2008 Opscode, Inc.
 # License:: Apache License, Version 2.0
@@ -18,7 +18,6 @@
 
 require 'chef/config'
 require 'chef/provider/package'
-require 'chef/mixin/shell_out'
 require 'chef/mixin/which'
 require 'chef/resource/package'
 require 'singleton'
@@ -647,7 +646,6 @@ class Chef
 
         # Cache for our installed and available packages, pulled in from yum-dump.py
         class YumCache
-          include Chef::Mixin::Command
           include Chef::Mixin::Which
           include Chef::Mixin::ShellOut
           include Singleton
@@ -1028,7 +1026,7 @@ class Chef
 
         def yum_command(command)
           Chef::Log.debug("#{@new_resource}: yum command: \"#{command}\"")
-          status = shell_out(command, {:timeout => Chef::Config[:yum_timeout]})
+          status = shell_out_with_timeout(command, {:timeout => Chef::Config[:yum_timeout]})
 
           # This is fun: rpm can encounter errors in the %post/%postun scripts which aren't
           # considered fatal - meaning the rpm is still successfully installed. These issue
@@ -1045,7 +1043,7 @@ class Chef
               if l =~ %r{^error: %(post|postun)\(.*\) scriptlet failed, exit status \d+$}
                 Chef::Log.warn("#{@new_resource} caught non-fatal scriptlet issue: \"#{l}\". Can't trust yum exit status " +
                                "so running install again to verify.")
-                status = shell_out(command, {:timeout => Chef::Config[:yum_timeout]})
+                status = shell_out_with_timeout(command, {:timeout => Chef::Config[:yum_timeout]})
                 break
               end
             end
@@ -1118,7 +1116,7 @@ class Chef
             end
 
             Chef::Log.debug("#{@new_resource} checking rpm status")
-            shell_out!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}", :timeout => Chef::Config[:yum_timeout]).stdout.each_line do |line|
+            shell_out_with_timeout!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}", :timeout => Chef::Config[:yum_timeout]).stdout.each_line do |line|
               case line
               when /([\w\d_.-]+)\s([\w\d_.-]+)/
                 @current_resource.package_name($1)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -30,6 +30,7 @@ class Chef
       class Zypper < Chef::Provider::Package
 
         def load_current_resource
+          # FIXME: zypper needs a Chef::Resource::ZypperPackage wired up to :zypper_package
           @current_resource = Chef::Resource::Package.new(@new_resource.name)
           @current_resource.package_name(@new_resource.package_name)
 
@@ -38,7 +39,7 @@ class Chef
           version=''
           oud_version=''
           Chef::Log.debug("#{@new_resource} checking zypper")
-          status = shell_out("zypper --non-interactive info #{@new_resource.package_name}")
+          status = shell_out_with_timeout("zypper --non-interactive info #{@new_resource.package_name}")
           status.stdout.each_line do |line|
             case line
             when /^Version: (.+)$/
@@ -104,9 +105,9 @@ class Chef
         def zypper_package(command, pkgname, version)
           version = "=#{version}" unless version.nil? || version.empty?
           if zypper_version < 1.0
-            shell_out!("zypper#{gpg_checks} #{command} -y #{pkgname}")
+            shell_out_with_timeout!("zypper#{gpg_checks} #{command} -y #{pkgname}")
           else
-            shell_out!("zypper --non-interactive#{gpg_checks} "+
+            shell_out_with_timeout!("zypper --non-interactive#{gpg_checks} "+
                       "#{command} #{pkgname}#{version}")
           end
         end

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -40,7 +40,7 @@ class Chef
         @response_file_variables = Hash.new
         @source = nil
         @version = nil
-        @timeout = 900
+        @timeout = nil
       end
 
       def package_name(arg=nil)

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -41,16 +41,16 @@ describe Chef::Provider::Package::Aix do
 
     it "should create a current resource with the name of new_resource" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("samba.base")
     end
 
     it "should set the current resource bff package name to the new resource bff package name" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("samba.base")
     end
@@ -65,8 +65,8 @@ describe Chef::Provider::Package::Aix do
 
     it "should get the source package version from lslpp if provided" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("samba.base")
@@ -77,8 +77,8 @@ describe Chef::Provider::Package::Aix do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       @stdout = StringIO.new(@bffinfo)
       @stdin, @stderr = StringIO.new, StringIO.new
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("3.3.12.0")
     end
@@ -99,8 +99,8 @@ describe Chef::Provider::Package::Aix do
 
     it "should return a current resource with a nil version if the package is not found" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base").and_return(@empty_status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
     end
@@ -109,7 +109,7 @@ describe Chef::Provider::Package::Aix do
       wrongbffinfo = "/usr/lib/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:
 /etc/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:"
       status = double("Status", :stdout => wrongbffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base").and_return(status)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
       expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
   end
@@ -137,7 +137,7 @@ describe Chef::Provider::Package::Aix do
 
   describe "install and upgrade" do
     it "should run installp -aYF -d with the package source to install" do
-      expect(@provider).to receive(:shell_out!).with("installp -aYF -d /tmp/samba.base samba.base")
+      expect(@provider).to receive(:shell_out!).with("installp -aYF -d /tmp/samba.base samba.base", timeout: 900)
       @provider.install_package("samba.base", "3.3.12.0")
     end
 
@@ -145,26 +145,26 @@ describe Chef::Provider::Package::Aix do
       @new_resource = Chef::Resource::Package.new("/tmp/samba.base")
       @provider = Chef::Provider::Package::Aix.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/samba.base")
-      expect(@provider).to receive(:shell_out!).with("installp -aYF -d /tmp/samba.base /tmp/samba.base")
+      expect(@provider).to receive(:shell_out!).with("installp -aYF -d /tmp/samba.base /tmp/samba.base", timeout: 900)
       @provider.install_package("/tmp/samba.base", "3.3.12.0")
     end
 
     it "should run installp with -eLogfile option." do
       allow(@new_resource).to receive(:options).and_return("-e/tmp/installp.log")
-      expect(@provider).to receive(:shell_out!).with("installp -aYF  -e/tmp/installp.log -d /tmp/samba.base samba.base")
+      expect(@provider).to receive(:shell_out!).with("installp -aYF  -e/tmp/installp.log -d /tmp/samba.base samba.base", timeout: 900)
       @provider.install_package("samba.base", "3.3.12.0")
     end
   end
 
   describe "remove" do
     it "should run installp -u samba.base to remove the package" do
-      expect(@provider).to receive(:shell_out!).with("installp -u samba.base")
+      expect(@provider).to receive(:shell_out!).with("installp -u samba.base", timeout: 900)
       @provider.remove_package("samba.base", "3.3.12.0")
     end
 
     it "should run installp -u -e/tmp/installp.log  with options -e/tmp/installp.log" do
       allow(@new_resource).to receive(:options).and_return("-e/tmp/installp.log")
-      expect(@provider).to receive(:shell_out!).with("installp -u  -e/tmp/installp.log samba.base")
+      expect(@provider).to receive(:shell_out!).with("installp -u  -e/tmp/installp.log samba.base", timeout: 900)
       @provider.remove_package("samba.base", "3.3.12.0")
     end
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Provider::Package::Dpkg do
     describe 'gets the source package version from dpkg-deb' do
       def check_version(version)
         @status = double(:stdout => "wget\t#{version}", :exitstatus => 0)
-        allow(@provider).to receive(:shell_out).with("dpkg-deb -W #{@new_resource.source}").and_return(@status)
+        allow(@provider).to receive(:shell_out).with("dpkg-deb -W #{@new_resource.source}", timeout: 900).and_return(@status)
         @provider.load_current_resource
         expect(@provider.current_resource.package_name).to eq("wget")
         expect(@new_resource.version).to eq(version)
@@ -106,7 +106,7 @@ Depends: libc6 (>= 2.8~20080505), libssl0.9.8 (>= 0.9.8f-5)
 Conflicts: wget-ssl
 DPKG_S
       status = double(:stdout => stdout, :exitstatus => 1)
-      allow(@provider).to receive(:shell_out).with("dpkg -s wget").and_return(status)
+      allow(@provider).to receive(:shell_out).with("dpkg -s wget", timeout: 900).and_return(status)
 
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("1.11.4-1ubuntu1")

--- a/spec/unit/provider/package/freebsd/pkg_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkg_spec.rb
@@ -77,7 +77,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should return the version number when it is installed" do
       pkg_info = OpenStruct.new(:stdout => "zsh-4.3.6_7")
-      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', :env => nil, :returns => [0,1]).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', env: nil, returns: [0,1], timeout: 900).and_return(pkg_info)
       #@provider.should_receive(:popen4).with('pkg_info -E "zsh*"').and_yield(@pid, @stdin, ["zsh-4.3.6_7"], @stderr).and_return(@status)
       allow(@provider).to receive(:package_name).and_return("zsh")
       expect(@provider.current_installed_version).to eq("4.3.6_7")
@@ -85,14 +85,14 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "does not set the current version number when the package is not installed" do
       pkg_info = OpenStruct.new(:stdout => "")
-      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', :env => nil, :returns => [0,1]).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', env: nil, returns: [0,1], timeout: 900).and_return(pkg_info)
       allow(@provider).to receive(:package_name).and_return("zsh")
       expect(@provider.current_installed_version).to be_nil
     end
 
     it "should return the port path for a valid port name" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", :env => nil).and_return(whereis)
+      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", env: nil, timeout: 900).and_return(whereis)
       #@provider.should_receive(:popen4).with("whereis -s zsh").and_yield(@pid, @stdin, ["zsh: /usr/ports/shells/zsh"], @stderr).and_return(@status)
       allow(@provider).to receive(:port_name).and_return("zsh")
       expect(@provider.port_path).to eq("/usr/ports/shells/zsh")
@@ -102,7 +102,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     it "should return the ports candidate version when given a valid port path" do
       allow(@provider).to receive(:port_path).and_return("/usr/ports/shells/zsh")
       make_v = OpenStruct.new(:stdout => "4.3.6\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("make -V PORTVERSION", {:cwd=>"/usr/ports/shells/zsh", :returns=>[0, 1], :env=>nil}).and_return(make_v)
+      expect(@provider).to receive(:shell_out!).with("make -V PORTVERSION", {cwd: "/usr/ports/shells/zsh", returns: [0, 1], env: nil, timeout: 900}).and_return(make_v)
       expect(@provider.ports_candidate_version).to eq("4.3.6")
     end
 
@@ -110,7 +110,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(::File).to receive(:exist?).with('/usr/ports/Makefile').and_return(true)
       allow(@provider).to receive(:port_path).and_return("/usr/ports/shells/zsh")
       make_v = OpenStruct.new(:stdout => "zsh-4.3.6_7\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("make -V PKGNAME", {:cwd=>"/usr/ports/shells/zsh", :env=>nil, :returns=>[0, 1]}).and_return(make_v)
+      expect(@provider).to receive(:shell_out!).with("make -V PKGNAME", {cwd: "/usr/ports/shells/zsh", env: nil, returns: [0, 1], timeout: 900}).and_return(make_v)
       #@provider.should_receive(:ports_makefile_variable_value).with("PKGNAME").and_return("zsh-4.3.6_7")
       expect(@provider.package_name).to eq("zsh")
     end
@@ -127,7 +127,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_add -r with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pkg_add -r zsh", :env => nil).and_return(@cmd_result)
+      expect(@provider).to receive(:shell_out!).with("pkg_add -r zsh", env: nil, timeout: 900).and_return(@cmd_result)
       @provider.install_package("zsh", "4.3.6_7")
     end
   end
@@ -142,7 +142,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should figure out the port path from the package_name using whereis" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", :env=>nil).and_return(whereis)
+      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", env: nil, timeout: 900).and_return(whereis)
       expect(@provider.port_path).to eq("/usr/ports/shells/zsh")
     end
 
@@ -178,7 +178,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_add -r with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pkg_add -r ruby18-iconv", :env => nil).and_return(@install_result)
+      expect(@provider).to receive(:shell_out!).with("pkg_add -r ruby18-iconv", env: nil, timeout: 900).and_return(@install_result)
       @provider.install_package("ruby-iconv", "1.0")
     end
   end
@@ -193,7 +193,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_delete with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pkg_delete zsh-4.3.6_7", :env => nil).and_return(@pkg_delete)
+      expect(@provider).to receive(:shell_out!).with("pkg_delete zsh-4.3.6_7", env: nil, timeout: 900).and_return(@pkg_delete)
       @provider.remove_package("zsh", "4.3.6_7")
     end
   end
@@ -213,14 +213,14 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should return the port path for a valid port name" do
       whereis = OpenStruct.new(:stdout => "bonnie++: /usr/ports/benchmarks/bonnie++")
-      expect(@provider).to receive(:shell_out!).with("whereis -s bonnie++", :env => nil).and_return(whereis)
+      expect(@provider).to receive(:shell_out!).with("whereis -s bonnie++", env: nil, timeout: 900).and_return(whereis)
       allow(@provider).to receive(:port_name).and_return("bonnie++")
       expect(@provider.port_path).to eq("/usr/ports/benchmarks/bonnie++")
     end
 
     it "should return the version number when it is installed" do
       pkg_info = OpenStruct.new(:stdout => "bonnie++-1.96")
-      expect(@provider).to receive(:shell_out!).with('pkg_info -E "bonnie++*"', :env => nil, :returns => [0,1]).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg_info -E "bonnie++*"', env: nil, returns: [0,1], timeout: 900).and_return(pkg_info)
       allow(@provider).to receive(:package_name).and_return("bonnie++")
       expect(@provider.current_installed_version).to eq("1.96")
     end
@@ -253,7 +253,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(@provider).to receive(:latest_link_name).and_return("perl")
 
       cmd = OpenStruct.new(:status => true)
-      expect(@provider).to receive(:shell_out!).with("pkg_add -r perl", :env => nil).and_return(cmd)
+      expect(@provider).to receive(:shell_out!).with("pkg_add -r perl", env: nil, timeout: 900).and_return(cmd)
       @provider.install_package("perl5.8", "5.8.8_1")
     end
 
@@ -267,7 +267,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(@provider).to receive(:latest_link_name).and_return("mysql50-server")
 
       cmd = OpenStruct.new(:status => true)
-      expect(@provider).to receive(:shell_out!).with("pkg_add -r mysql50-server", :env=>nil).and_return(cmd)
+      expect(@provider).to receive(:shell_out!).with("pkg_add -r mysql50-server", env: nil, timeout: 900).and_return(cmd)
       @provider.install_package("mysql50-server", "5.0.45_1")
     end
   end

--- a/spec/unit/provider/package/freebsd/pkgng_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkgng_spec.rb
@@ -71,7 +71,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     end
 
     it "should query pkg database" do
-      expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', env: nil, returns: [0,70], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
   end
@@ -80,14 +80,14 @@ describe Chef::Provider::Package::Freebsd::Port do
   describe "determining candidate version" do
     it "should query repository" do
       pkg_query = OpenStruct.new(:stdout => "5.0.5\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("pkg rquery '%v' zsh", :env => nil).and_return(pkg_query)
+      expect(@provider).to receive(:shell_out!).with("pkg rquery '%v' zsh", env: nil, timeout: 900).and_return(pkg_query)
       expect(@provider.candidate_version).to eq("5.0.5")
     end
 
     it "should query specified repository when given option" do
       @provider.new_resource.options('-r LocalMirror') # This requires LocalMirror repo configuration.
       pkg_query = OpenStruct.new(:stdout => "5.0.3\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("pkg rquery -r LocalMirror '%v' zsh", :env => nil).and_return(pkg_query)
+      expect(@provider).to receive(:shell_out!).with("pkg rquery -r LocalMirror '%v' zsh", env: nil, timeout: 900).and_return(pkg_query)
       expect(@provider.candidate_version).to eq("5.0.3")
     end
 
@@ -106,7 +106,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should handle package source from file" do
       @provider.new_resource.source("/nas/pkg/repo/zsh-5.0.1.txz")
       expect(@provider).to receive(:shell_out!).
-        with("pkg add /nas/pkg/repo/zsh-5.0.1.txz", :env => { 'LC_ALL' => nil }).
+        with("pkg add /nas/pkg/repo/zsh-5.0.1.txz", env: { 'LC_ALL' => nil }, timeout: 900).
         and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
@@ -114,21 +114,21 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should handle package source over ftp or http" do
       @provider.new_resource.source("http://repo.example.com/zsh-5.0.1.txz")
       expect(@provider).to receive(:shell_out!).
-        with("pkg add http://repo.example.com/zsh-5.0.1.txz", :env => { 'LC_ALL' => nil }).
+        with("pkg add http://repo.example.com/zsh-5.0.1.txz", env: { 'LC_ALL' => nil }, timeout: 900).
         and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
 
     it "should handle a package name" do
       expect(@provider).to receive(:shell_out!).
-        with("pkg install -y zsh", :env => { 'LC_ALL' => nil }).and_return(@install_result)
+        with("pkg install -y zsh", env: { 'LC_ALL' => nil }, timeout: 900).and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
 
     it "should handle a package name with a specified repo" do
       @provider.new_resource.options('-r LocalMirror') # This requires LocalMirror repo configuration.
       expect(@provider).to receive(:shell_out!).
-        with("pkg install -y -r LocalMirror zsh", :env => { 'LC_ALL' => nil }).and_return(@install_result)
+        with("pkg install -y -r LocalMirror zsh", env: { 'LC_ALL' => nil }, timeout: 900).and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
   end
@@ -141,14 +141,14 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should call pkg delete" do
       expect(@provider).to receive(:shell_out!).
-        with("pkg delete -y zsh-5.0.1", :env => nil).and_return(@install_result)
+        with("pkg delete -y zsh-5.0.1", env: nil, timeout: 900).and_return(@install_result)
       @provider.remove_package("zsh", "5.0.1")
     end
 
     it "should not include repo option in pkg delete" do
       @provider.new_resource.options('-r LocalMirror') # This requires LocalMirror repo configuration.
       expect(@provider).to receive(:shell_out!).
-        with("pkg delete -y zsh-5.0.1", :env => nil).and_return(@install_result)
+        with("pkg delete -y zsh-5.0.1", env: nil, timeout: 900).and_return(@install_result)
       @provider.remove_package("zsh", "5.0.1")
     end
   end

--- a/spec/unit/provider/package/freebsd/port_spec.rb
+++ b/spec/unit/provider/package/freebsd/port_spec.rb
@@ -72,7 +72,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should check 'pkg_info' if system uses pkg_* tools" do
       allow(@new_resource).to receive(:supports_pkgng?)
       expect(@new_resource).to receive(:supports_pkgng?).and_return(false)
-      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', :env => nil, :returns => [0,1]).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg_info -E "zsh*"', env: nil, returns: [0,1], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
 
@@ -80,8 +80,8 @@ describe Chef::Provider::Package::Freebsd::Port do
       pkg_enabled = OpenStruct.new(:stdout => "yes\n")
       [1000016, 1000000, 901503, 902506, 802511].each do |__freebsd_version|
         @node.automatic_attrs[:os_version] = __freebsd_version
-        expect(@new_resource).to receive(:shell_out!).with('make -V WITH_PKGNG', :env => nil).and_return(pkg_enabled)
-        expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
+        expect(@new_resource).to receive(:shell_out!).with('make -V WITH_PKGNG', env: nil).and_return(pkg_enabled)
+        expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', env: nil, returns: [0,70], timeout: 900).and_return(@pkg_info)
         expect(@provider.current_installed_version).to eq("3.1.7")
       end
     end
@@ -89,7 +89,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should check 'pkg info' if the freebsd version is greater than or equal to 1000017" do
       __freebsd_version = 1000017
       @node.automatic_attrs[:os_version] = __freebsd_version
-      expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', :env => nil, :returns => [0,70]).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out!).with('pkg info "zsh"', env: nil, returns: [0,70], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
   end
@@ -102,7 +102,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should return candidate version if port exists" do
       allow(::File).to receive(:exist?).with('/usr/ports/Makefile').and_return(true)
       allow(@provider).to receive(:port_dir).and_return('/usr/ports/shells/zsh')
-      expect(@provider).to receive(:shell_out!).with("make -V PORTVERSION", :cwd => "/usr/ports/shells/zsh", :env => nil, :returns => [0,1]).
+      expect(@provider).to receive(:shell_out!).with("make -V PORTVERSION", cwd: "/usr/ports/shells/zsh", env: nil, returns: [0,1], timeout: 900).
         and_return(@port_version)
       expect(@provider.candidate_version).to eq("5.0.5")
     end
@@ -127,13 +127,13 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should query system for path given just a name" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh\n")
-      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", :env => nil).and_return(whereis)
+      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", env: nil, timeout: 900).and_return(whereis)
       expect(@provider.port_dir).to eq("/usr/ports/shells/zsh")
     end
 
     it "should raise exception if not found" do
       whereis = OpenStruct.new(:stdout => "zsh:\n")
-      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", :env => nil).and_return(whereis)
+      expect(@provider).to receive(:shell_out!).with("whereis -s zsh", env: nil, timeout: 900).and_return(whereis)
       expect { @provider.port_dir }.to raise_error(Chef::Exceptions::Package, "Could not find port with the name zsh")
     end
   end

--- a/spec/unit/provider/package/ips_spec.rb
+++ b/spec/unit/provider/package/ips_spec.rb
@@ -65,28 +65,28 @@ PKG_STATUS
 
   context "when loading current resource" do
     it "should create a current resource with the name of the new_resource" do
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
       @provider.load_current_resource
     end
 
     it "should set the current resources package name to the new resources package name" do
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.package_name).to eq(@new_resource.package_name)
     end
 
     it "should run pkg info with the package name" do
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       @provider.load_current_resource
     end
 
     it "should set the installed version to nil on the current resource if package state is not installed" do
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.version).to be_nil
     end
@@ -108,27 +108,27 @@ Packaging Date: October 19, 2011 09:14:50 AM
           Size: 8.07 MB
           FMRI: pkg://solaris/crypto/gnupg@2.0.17,5.11-0.175.0.0.0.2.537:20111019T091450Z
 INSTALLED
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.version).to eq("2.0.17")
     end
 
     it "should return the current resource" do
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote_output)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote_output)
       expect(@provider.load_current_resource).to eql(@current_resource)
     end
   end
 
   context "when installing a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out).with("pkg install -q crypto/gnupg@2.0.17")
+      expect(@provider).to receive(:shell_out).with("pkg install -q crypto/gnupg@2.0.17", timeout: 900)
       @provider.install_package("crypto/gnupg", "2.0.17")
     end
 
     it "should run pkg install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out).with("pkg --no-refresh install -q crypto/gnupg@2.0.17")
+      expect(@provider).to receive(:shell_out).with("pkg --no-refresh install -q crypto/gnupg@2.0.17", timeout: 900)
       allow(@new_resource).to receive(:options).and_return("--no-refresh")
       @provider.install_package("crypto/gnupg", "2.0.17")
     end
@@ -147,8 +147,8 @@ Packaging Date: April  1, 2012 05:55:52 PM
           Size: 2.57 MB
           FMRI: pkg://omnios/security/sudo@1.8.4.1,5.11-0.151002:20120401T175552Z
 PKG_STATUS
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote)
       @provider.load_current_resource
       expect(@current_resource.version).to be_nil
       expect(@provider.candidate_version).to eql("1.8.4.1")
@@ -188,8 +188,8 @@ Packaging Date: October 19, 2011 09:14:50 AM
           FMRI: pkg://solaris/crypto/gnupg@2.0.18,5.11-0.175.0.0.0.2.537:20111019T091450Z
 REMOTE
 
-      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}").and_return(local)
-      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}").and_return(remote)
+      expect(@provider).to receive(:shell_out).with("pkg info #{@new_resource.package_name}", timeout: 900).and_return(local)
+      expect(@provider).to receive(:shell_out!).with("pkg info -r #{@new_resource.package_name}", timeout: 900).and_return(remote)
       expect(@provider).to receive(:install_package).exactly(0).times
       @provider.run_action(:install)
     end
@@ -200,7 +200,7 @@ REMOTE
       end
 
       it "should run pkg install with the --accept flag" do
-        expect(@provider).to receive(:shell_out).with("pkg install -q --accept crypto/gnupg@2.0.17")
+        expect(@provider).to receive(:shell_out).with("pkg install -q --accept crypto/gnupg@2.0.17", timeout: 900)
         @provider.install_package("crypto/gnupg", "2.0.17")
       end
     end
@@ -208,19 +208,19 @@ REMOTE
 
   context "when upgrading a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out).with("pkg install -q crypto/gnupg@2.0.17")
+      expect(@provider).to receive(:shell_out).with("pkg install -q crypto/gnupg@2.0.17", timeout: 900)
       @provider.upgrade_package("crypto/gnupg", "2.0.17")
     end
   end
 
   context "when uninstalling a package" do
     it "should run pkg uninstall with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pkg uninstall -q crypto/gnupg@2.0.17")
+      expect(@provider).to receive(:shell_out!).with("pkg uninstall -q crypto/gnupg@2.0.17", timeout: 900)
       @provider.remove_package("crypto/gnupg", "2.0.17")
     end
 
     it "should run pkg uninstall with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pkg --no-refresh uninstall -q crypto/gnupg@2.0.17")
+      expect(@provider).to receive(:shell_out!).with("pkg --no-refresh uninstall -q crypto/gnupg@2.0.17", timeout: 900)
       allow(@new_resource).to receive(:options).and_return("--no-refresh")
       @provider.remove_package("crypto/gnupg", "2.0.17")
     end

--- a/spec/unit/provider/package/macports_spec.rb
+++ b/spec/unit/provider/package/macports_spec.rb
@@ -105,7 +105,7 @@ EOF
     it "should run the port install command with the correct version" do
       expect(@current_resource).to receive(:version).and_return("4.1.6")
       @provider.current_resource = @current_resource
-      expect(@provider).to receive(:shell_out!).with("port install zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port install zsh @4.2.7", timeout: 900)
 
       @provider.install_package("zsh", "4.2.7")
     end
@@ -122,7 +122,7 @@ EOF
       expect(@current_resource).to receive(:version).and_return("4.1.6")
       @provider.current_resource = @current_resource
       allow(@new_resource).to receive(:options).and_return("-f")
-      expect(@provider).to receive(:shell_out!).with("port -f install zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port -f install zsh @4.2.7", timeout: 900)
 
       @provider.install_package("zsh", "4.2.7")
     end
@@ -130,36 +130,36 @@ EOF
 
   describe "purge_package" do
     it "should run the port uninstall command with the correct version" do
-      expect(@provider).to receive(:shell_out!).with("port uninstall zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port uninstall zsh @4.2.7", timeout: 900)
       @provider.purge_package("zsh", "4.2.7")
     end
 
     it "should purge the currently active version if no explicit version is passed in" do
-      expect(@provider).to receive(:shell_out!).with("port uninstall zsh")
+      expect(@provider).to receive(:shell_out!).with("port uninstall zsh", timeout: 900)
       @provider.purge_package("zsh", nil)
     end
 
     it "should add options to the port command when specified" do
       allow(@new_resource).to receive(:options).and_return("-f")
-      expect(@provider).to receive(:shell_out!).with("port -f uninstall zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port -f uninstall zsh @4.2.7", timeout: 900)
       @provider.purge_package("zsh", "4.2.7")
     end
   end
 
   describe "remove_package" do
     it "should run the port deactivate command with the correct version" do
-      expect(@provider).to receive(:shell_out!).with("port deactivate zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port deactivate zsh @4.2.7", timeout: 900)
       @provider.remove_package("zsh", "4.2.7")
     end
 
     it "should remove the currently active version if no explicit version is passed in" do
-      expect(@provider).to receive(:shell_out!).with("port deactivate zsh")
+      expect(@provider).to receive(:shell_out!).with("port deactivate zsh", timeout: 900)
       @provider.remove_package("zsh", nil)
     end
 
     it "should add options to the port command when specified" do
       allow(@new_resource).to receive(:options).and_return("-f")
-      expect(@provider).to receive(:shell_out!).with("port -f deactivate zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port -f deactivate zsh @4.2.7", timeout: 900)
       @provider.remove_package("zsh", "4.2.7")
     end
   end
@@ -169,7 +169,7 @@ EOF
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.1.6")
       @provider.current_resource = @current_resource
 
-      expect(@provider).to receive(:shell_out!).with("port upgrade zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port upgrade zsh @4.2.7", timeout: 900)
 
       @provider.upgrade_package("zsh", "4.2.7")
     end
@@ -195,7 +195,7 @@ EOF
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.1.6")
       @provider.current_resource = @current_resource
 
-      expect(@provider).to receive(:shell_out!).with("port -f upgrade zsh @4.2.7")
+      expect(@provider).to receive(:shell_out!).with("port -f upgrade zsh @4.2.7", timeout: 900)
 
       @provider.upgrade_package("zsh", "4.2.7")
     end

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -56,7 +56,7 @@ describe Chef::Provider::Package::Openbsd do
               instance_double('shellout', :stdout => "#{name}-#{version}\n"))
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}",
-              {:env => {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}}
+              {:env => {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}, timeout: 900}
             ) {OpenStruct.new :status => true}
             provider.run_action(:install)
           end
@@ -88,7 +88,7 @@ describe Chef::Provider::Package::Openbsd do
                 instance_double('shellout', :stdout => "#{name}-#{version}-#{flavor}\n"))
               expect(provider).to receive(:shell_out!).with(
                 "pkg_add -r #{name}-#{version}-#{flavor}",
-                {:env => {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}}
+                {env: {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}, timeout: 900}
               ) {OpenStruct.new :status => true}
               provider.run_action(:install)
             end
@@ -104,7 +104,7 @@ describe Chef::Provider::Package::Openbsd do
             new_resource.version("#{version}-#{flavor_b}")
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}-#{flavor_b}",
-              {:env => {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}}
+              {env: {"PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/"}, timeout: 900}
             ) {OpenStruct.new :status => true}
             provider.run_action(:install)
           end
@@ -123,11 +123,10 @@ describe Chef::Provider::Package::Openbsd do
     end
     it "should run the command to delete the installed package" do
       expect(@provider).to receive(:shell_out!).with(
-        "pkg_delete #{@name}", :env=>nil
+        "pkg_delete #{@name}", env: nil, timeout: 900
       ) {OpenStruct.new :status => true}
       @provider.remove_package(@name, nil)
     end
   end
 
 end
-

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -51,7 +51,7 @@ ERR
     end
 
     it "should run pacman query with the package name" do
-      expect(@provider).to receive(:shell_out).with("pacman -Qi #{@new_resource.package_name}").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("pacman -Qi #{@new_resource.package_name}", {timeout: 900}).and_return(@status)
       @provider.load_current_resource
     end
 
@@ -152,12 +152,12 @@ PACMAN_CONF
 
   describe Chef::Provider::Package::Pacman, "install_package" do
     it "should run pacman install with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pacman --sync --noconfirm --noprogressbar nano")
+      expect(@provider).to receive(:shell_out!).with("pacman --sync --noconfirm --noprogressbar nano", {timeout: 900})
       @provider.install_package("nano", "1.0")
     end
 
     it "should run pacman install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pacman --sync --noconfirm --noprogressbar --debug nano")
+      expect(@provider).to receive(:shell_out!).with("pacman --sync --noconfirm --noprogressbar --debug nano", {timeout: 900})
       allow(@new_resource).to receive(:options).and_return("--debug")
 
       @provider.install_package("nano", "1.0")
@@ -173,12 +173,12 @@ PACMAN_CONF
 
   describe Chef::Provider::Package::Pacman, "remove_package" do
     it "should run pacman remove with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pacman --remove --noconfirm --noprogressbar nano")
+      expect(@provider).to receive(:shell_out!).with("pacman --remove --noconfirm --noprogressbar nano", {timeout: 900})
       @provider.remove_package("nano", "1.0")
     end
 
     it "should run pacman remove with the package name and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pacman --remove --noconfirm --noprogressbar --debug nano")
+      expect(@provider).to receive(:shell_out!).with("pacman --remove --noconfirm --noprogressbar --debug nano", {timeout: 900})
       allow(@new_resource).to receive(:options).and_return("--debug")
 
       @provider.remove_package("nano", "1.0")

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -57,16 +57,16 @@ describe Chef::Provider::Package::Rpm do
       let(:stdout) { "ImageMagick-c++ 6.5.4.7-7.el6_5" }
 
       it "should get the source package version from rpm if provided" do
-        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900).and_return(status)
+        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++", timeout: 900).and_return(status)
         provider.load_current_resource
         expect(provider.current_resource.package_name).to eq("ImageMagick-c++")
         expect(provider.new_resource.version).to eq("6.5.4.7-7.el6_5")
       end
 
       it "should return the current version installed if found by rpm" do
-        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm").and_return(status)
-        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900).and_return(status)
+        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' ImageMagick-c++", timeout: 900).and_return(status)
         provider.load_current_resource
         expect(provider.current_resource.version).to eq("6.5.4.7-7.el6_5")
       end
@@ -121,8 +121,8 @@ describe Chef::Provider::Package::Rpm do
       end
 
       it "should not detect the package name as version when not installed" do
-        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
-        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass").and_return(status)
+        expect(provider).to receive(:shell_out!).with("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass", timeout: 900).and_return(status)
+        expect(provider).to receive(:shell_out).with("rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' openssh-askpass", timeout: 900).and_return(status)
         provider.load_current_resource
         expect(provider.current_resource.version).to be_nil
       end
@@ -139,19 +139,19 @@ describe Chef::Provider::Package::Rpm do
 
     describe "when installing or upgrading" do
       it "should run rpm -i with the package source to install" do
-        expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
         provider.install_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
       it "should run rpm -U with the package source to upgrade" do
         current_resource.version("21.4-19.el5")
-        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
         provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
       it "should install package if missing and set to upgrade" do
         current_resource.version("ImageMagick-c++")
-        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
         provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
 
@@ -162,7 +162,7 @@ describe Chef::Provider::Package::Rpm do
         it "should run rpm -U --oldpackage with the package source to downgrade" do
           new_resource.allow_downgrade(true)
           current_resource.version("21.4-19.el5")
-          expect(provider).to receive(:shell_out!).with("rpm  -U --oldpackage /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          expect(provider).to receive(:shell_out!).with("rpm  -U --oldpackage /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
           provider.upgrade_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
         end
       end
@@ -174,7 +174,7 @@ describe Chef::Provider::Package::Rpm do
         it "should install from a path when the package is a path and the source is nil" do
           expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
           provider.current_resource = current_resource
-          expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          expect(provider).to receive(:shell_out!).with("rpm  -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
           provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
         end
 
@@ -182,7 +182,7 @@ describe Chef::Provider::Package::Rpm do
           expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
           current_resource.version("21.4-19.el5")
           provider.current_resource = current_resource
-          expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+          expect(provider).to receive(:shell_out!).with("rpm  -U /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
           provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
         end
       end
@@ -190,14 +190,14 @@ describe Chef::Provider::Package::Rpm do
       it "installs with custom options specified in the resource" do
         provider.candidate_version = '11'
         new_resource.options("--dbpath /var/lib/rpm")
-        expect(provider).to receive(:shell_out!).with("rpm --dbpath /var/lib/rpm -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
+        expect(provider).to receive(:shell_out!).with("rpm --dbpath /var/lib/rpm -i /tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
         provider.install_package(new_resource.name, provider.candidate_version)
       end
     end
 
     describe "when removing the package" do
       it "should run rpm -e to remove the package" do
-        expect(provider).to receive(:shell_out!).with("rpm  -e ImageMagick-c++-6.5.4.7-7.el6_5")
+        expect(provider).to receive(:shell_out!).with("rpm  -e ImageMagick-c++-6.5.4.7-7.el6_5", timeout: 900)
         provider.remove_package("ImageMagick-c++", "6.5.4.7-7.el6_5")
       end
     end

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -508,7 +508,7 @@ describe Chef::Provider::Package::Rubygems do
         it "installs the gem by shelling out when options are provided as a String" do
           @new_resource.options('-i /alt/install/location')
           expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" -i /alt/install/location"
-          expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+          expect(@provider).to receive(:shell_out!).with(expected, env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -517,7 +517,7 @@ describe Chef::Provider::Package::Rubygems do
           @new_resource.gem_binary('/foo/bar')
           @new_resource.source('http://mirror.ops.rhcloud.com/mirror/ruby')
           expected ="/foo/bar install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" --source=#{@new_resource.source} --source=https://rubygems.org"
-          expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+          expect(@provider).to receive(:shell_out!).with(expected, env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -527,7 +527,7 @@ describe Chef::Provider::Package::Rubygems do
           @new_resource.source('http://mirror.ops.rhcloud.com/mirror/ruby')
           @new_resource.clear_sources(true)
           expected ="/foo/bar install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\" --clear-sources --source=#{@new_resource.source}"
-          expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+          expect(@provider).to receive(:shell_out!).with(expected, env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -538,7 +538,7 @@ describe Chef::Provider::Package::Rubygems do
           it "installs the gem by shelling out when options are provided but no version is given" do
             @new_resource.options('-i /alt/install/location')
             expected ="gem install rspec-core -q --no-rdoc --no-ri -v \"#{@provider.candidate_version}\" -i /alt/install/location"
-            expect(@provider).to receive(:shell_out!).with(expected, :env => nil)
+            expect(@provider).to receive(:shell_out!).with(expected, env: nil, timeout: 900)
             @provider.run_action(:install)
             expect(@new_resource).to be_updated_by_last_action
           end
@@ -584,7 +584,7 @@ describe Chef::Provider::Package::Rubygems do
       describe "in an alternate gem environment" do
         it "installs the gem by shelling out to gem install" do
           @new_resource.gem_binary('/usr/weird/bin/gem')
-          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\"", :env=>nil)
+          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install rspec-core -q --no-rdoc --no-ri -v \"#{@spec_version}\"", env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -593,7 +593,7 @@ describe Chef::Provider::Package::Rubygems do
           @new_resource.gem_binary('/usr/weird/bin/gem')
           @new_resource.source(CHEF_SPEC_DATA + '/gems/chef-integration-test-0.1.0.gem')
           @new_resource.version('>= 0')
-          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install #{CHEF_SPEC_DATA}/gems/chef-integration-test-0.1.0.gem -q --no-rdoc --no-ri -v \">= 0\"", :env=>nil)
+          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install #{CHEF_SPEC_DATA}/gems/chef-integration-test-0.1.0.gem -q --no-rdoc --no-ri -v \">= 0\"", env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -605,7 +605,7 @@ describe Chef::Provider::Package::Rubygems do
           @new_resource.gem_binary('/usr/weird/bin/gem')
           @new_resource.version('>= 0')
           expect(@new_resource.source).to eq(CHEF_SPEC_DATA + '/gems/chef-integration-test-0.1.0.gem')
-          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install #{CHEF_SPEC_DATA}/gems/chef-integration-test-0.1.0.gem -q --no-rdoc --no-ri -v \">= 0\"", :env=>nil)
+          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem install #{CHEF_SPEC_DATA}/gems/chef-integration-test-0.1.0.gem -q --no-rdoc --no-ri -v \">= 0\"", env: nil, timeout: 900)
           @provider.run_action(:install)
           expect(@new_resource).to be_updated_by_last_action
         end
@@ -644,7 +644,7 @@ describe Chef::Provider::Package::Rubygems do
 
         it "uninstalls via the gem command when options are given as a String" do
           @new_resource.options('-i /alt/install/location')
-          expect(@provider).to receive(:shell_out!).with("gem uninstall rspec -q -x -I -a -i /alt/install/location", :env=>nil)
+          expect(@provider).to receive(:shell_out!).with("gem uninstall rspec -q -x -I -a -i /alt/install/location", env: nil, timeout: 900)
           @provider.action_remove
         end
 
@@ -658,7 +658,7 @@ describe Chef::Provider::Package::Rubygems do
       describe "in an alternate gem environment" do
         it "uninstalls via the gem command" do
           @new_resource.gem_binary('/usr/weird/bin/gem')
-          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem uninstall rspec -q -x -I -a", :env=>nil)
+          expect(@provider).to receive(:shell_out!).with("/usr/weird/bin/gem uninstall rspec -q -x -I -a", env: nil, timeout: 900)
           @provider.action_remove
         end
       end

--- a/spec/unit/provider/package/smartos_spec.rb
+++ b/spec/unit/provider/package/smartos_spec.rb
@@ -82,7 +82,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
         and_yield("something-varnish-1.1.1   something varnish like\n").
         and_yield("varnish-2.3.4             actual varnish\n")
       @shell_out = double('shell_out!', :stdout => search)
-      expect(@provider).to receive(:shell_out!).with('/opt/local/bin/pkgin', 'se', 'varnish', :env => nil, :returns => [0,1]).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out!).with('/opt/local/bin/pkgin', 'se', 'varnish', :env => nil, :returns => [0,1], :timeout=>900).and_return(@shell_out)
       expect(@provider.candidate_version).to eq("2.3.4")
     end
 
@@ -92,7 +92,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
         and_yield("something-varnish-1.1.1;;something varnish like\n").
         and_yield("varnish-2.3.4;;actual varnish\n")
       @shell_out = double('shell_out!', :stdout => search)
-      expect(@provider).to receive(:shell_out!).with('/opt/local/bin/pkgin', 'se', 'varnish', :env => nil, :returns => [0,1]).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out!).with('/opt/local/bin/pkgin', 'se', 'varnish', :env => nil, :returns => [0,1], :timeout=>900).and_return(@shell_out)
       expect(@provider.candidate_version).to eq("2.3.4")
     end
   end
@@ -101,8 +101,8 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
 
     it "run pkgin and install the package" do
       out = OpenStruct.new(:stdout => nil)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/sbin/pkg_info", "-E", "varnish*", {:env => nil, :returns=>[0,1]}).and_return(@shell_out)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/bin/pkgin", "-y", "install", "varnish-2.1.5nb2", {:env=>nil}).and_return(out)
+      expect(@provider).to receive(:shell_out!).with("/opt/local/sbin/pkg_info", "-E", "varnish*", {:env => nil, :returns=>[0,1], :timeout=>900}).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out!).with("/opt/local/bin/pkgin", "-y", "install", "varnish-2.1.5nb2", {:env=>nil, :timeout=>900}).and_return(out)
       @provider.load_current_resource
       @provider.install_package("varnish", "2.1.5nb2")
     end

--- a/spec/unit/provider/package/solaris_spec.rb
+++ b/spec/unit/provider/package/solaris_spec.rb
@@ -71,8 +71,8 @@ PKGINFO
 
     it "should get the source package version from pkginfo if provided" do
       status = double(:stdout => @pkginfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash").and_return(status)
-      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash", { timeout: 900 }).and_return(status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash", { timeout: 900 }).and_return(@status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("SUNWbash")
@@ -81,8 +81,8 @@ PKGINFO
 
     it "should return the current version installed if found by pkginfo" do
       status = double(:stdout => @pkginfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash").and_return(@status)
-      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash").and_return(status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash", { timeout: 900 }).and_return(status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("11.10.0,REV=2005.01.08.05.16")
     end
@@ -101,8 +101,8 @@ PKGINFO
     end
 
     it "should return a current resource with a nil version if the package is not found" do
-      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash").and_return(@status)
-      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash").and_return(@status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l -d /tmp/bash.pkg SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out).with("pkginfo -l SUNWbash", { timeout: 900 }).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
     end
@@ -132,7 +132,7 @@ PKGINFO
 
   describe "install and upgrade" do
     it "should run pkgadd -n -d with the package source to install" do
-      expect(@provider).to receive(:shell_out!).with("pkgadd -n -d /tmp/bash.pkg all")
+      expect(@provider).to receive(:shell_out!).with("pkgadd -n -d /tmp/bash.pkg all", { timeout: 900 })
       @provider.install_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 
@@ -140,26 +140,26 @@ PKGINFO
       @new_resource = Chef::Resource::Package.new("/tmp/bash.pkg")
       @provider = Chef::Provider::Package::Solaris.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/bash.pkg")
-      expect(@provider).to receive(:shell_out!).with("pkgadd -n -d /tmp/bash.pkg all")
+      expect(@provider).to receive(:shell_out!).with("pkgadd -n -d /tmp/bash.pkg all", { timeout: 900 })
       @provider.install_package("/tmp/bash.pkg", "11.10.0,REV=2005.01.08.05.16")
     end
 
     it "should run pkgadd -n -a /tmp/myadmin -d with the package options -a /tmp/myadmin" do
       allow(@new_resource).to receive(:options).and_return("-a /tmp/myadmin")
-      expect(@provider).to receive(:shell_out!).with("pkgadd -n -a /tmp/myadmin -d /tmp/bash.pkg all")
+      expect(@provider).to receive(:shell_out!).with("pkgadd -n -a /tmp/myadmin -d /tmp/bash.pkg all", { timeout: 900 })
       @provider.install_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
   end
 
   describe "remove" do
     it "should run pkgrm -n to remove the package" do
-      expect(@provider).to receive(:shell_out!).with("pkgrm -n SUNWbash")
+      expect(@provider).to receive(:shell_out!).with("pkgrm -n SUNWbash", { timeout: 900 })
       @provider.remove_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 
     it "should run pkgrm -n -a /tmp/myadmin with options -a /tmp/myadmin" do
       allow(@new_resource).to receive(:options).and_return("-a /tmp/myadmin")
-      expect(@provider).to receive(:shell_out!).with("pkgrm -n -a /tmp/myadmin SUNWbash")
+      expect(@provider).to receive(:shell_out!).with("pkgrm -n -a /tmp/myadmin SUNWbash", { timeout: 900 })
       @provider.remove_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -19,126 +19,150 @@
 require 'spec_helper'
 
 describe Chef::Provider::Package::Zypper do
+  let!(:new_resource) { Chef::Resource::Package.new("cups") }
+
+  let!(:current_resource) { Chef::Resource::Package.new("cups") }
+
+  let(:provider) do
+    node = Chef::Node.new
+    events = Chef::EventDispatch::Dispatcher.new
+    run_context = Chef::RunContext.new(node, {}, events)
+    Chef::Provider::Package::Zypper.new(new_resource, run_context)
+  end
+
+  let(:status) { double(:stdout => "\n", :exitstatus => 0) }
+
   before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::Package.new("cups")
+    allow(Chef::Resource::Package).to receive(:new).and_return(current_resource)
+    allow(provider).to receive(:shell_out).and_return(status)
+    allow(provider).to receive(:`).and_return("2.0")
+  end
 
-    @current_resource = Chef::Resource::Package.new("cups")
+  def shell_out_expectation(command, options=nil)
+    options ||= { timeout: 900 }
+    expect(provider).to receive(:shell_out).with(command, options)
+  end
 
-    @provider = Chef::Provider::Package::Zypper.new(@new_resource, @run_context)
-    allow(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
-    @status = double(:stdout => "\n", :exitstatus => 0)
-    allow(@provider).to receive(:shell_out).and_return(@status)
-    allow(@provider).to receive(:`).and_return("2.0")
+  def shell_out_expectation!(command, options=nil)
+    options ||= { timeout: 900 }
+    expect(provider).to receive(:shell_out!).with(command, options)
   end
 
   describe "when loading the current package state" do
     it "should create a current resource with the name of the new_resource" do
-      expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
-      @provider.load_current_resource
+      expect(Chef::Resource::Package).to receive(:new).with(new_resource.name).and_return(current_resource)
+      provider.load_current_resource
     end
 
     it "should set the current resources package name to the new resources package name" do
-      expect(@current_resource).to receive(:package_name).with(@new_resource.package_name)
-      @provider.load_current_resource
+      expect(current_resource).to receive(:package_name).with(new_resource.package_name)
+      provider.load_current_resource
     end
 
     it "should run zypper info with the package name" do
-      expect(@provider).to receive(:shell_out).with("zypper --non-interactive info #{@new_resource.package_name}").and_return(@status)
-      @provider.load_current_resource
+      shell_out_expectation(
+        "zypper --non-interactive info #{new_resource.package_name}"
+      ).and_return(status)
+      provider.load_current_resource
     end
 
     it "should set the installed version to nil on the current resource if zypper info installed version is (none)" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
-      expect(@current_resource).to receive(:version).with(nil).and_return(true)
-      @provider.load_current_resource
+      allow(provider).to receive(:shell_out).and_return(status)
+      expect(current_resource).to receive(:version).with(nil).and_return(true)
+      provider.load_current_resource
     end
 
     it "should set the installed version if zypper info has one" do
       status = double(:stdout => "Version: 1.0\nInstalled: Yes\n", :exitstatus => 0)
 
-      allow(@provider).to receive(:shell_out).and_return(status)
-      expect(@current_resource).to receive(:version).with("1.0").and_return(true)
-      @provider.load_current_resource
+      allow(provider).to receive(:shell_out).and_return(status)
+      expect(current_resource).to receive(:version).with("1.0").and_return(true)
+      provider.load_current_resource
     end
 
     it "should set the candidate version if zypper info has one" do
       status = double(:stdout => "Version: 1.0\nInstalled: No\nStatus: out-of-date (version 0.9 installed)", :exitstatus => 0)
 
-      allow(@provider).to receive(:shell_out).and_return(status)
-      @provider.load_current_resource
-      expect(@provider.candidate_version).to eql("1.0")
+      allow(provider).to receive(:shell_out).and_return(status)
+      provider.load_current_resource
+      expect(provider.candidate_version).to eql("1.0")
     end
 
     it "should raise an exception if zypper info fails" do
-      expect(@status).to receive(:exitstatus).and_return(1)
-      expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
+      expect(status).to receive(:exitstatus).and_return(1)
+      expect { provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should not raise an exception if zypper info succeeds" do
-      expect(@status).to receive(:exitstatus).and_return(0)
-      expect { @provider.load_current_resource }.not_to raise_error
+      expect(status).to receive(:exitstatus).and_return(0)
+      expect { provider.load_current_resource }.not_to raise_error
     end
 
     it "should return the current resouce" do
-      expect(@provider.load_current_resource).to eql(@current_resource)
+      expect(provider.load_current_resource).to eql(current_resource)
     end
   end
 
   describe "install_package" do
     it "should run zypper install with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
-      expect(@provider).to receive(:shell_out!).with(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0")
-      @provider.install_package("emacs", "1.0")
+      shell_out_expectation!(
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
+      )
+      provider.install_package("emacs", "1.0")
     end
     it "should run zypper install without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
-      expect(@provider).to receive(:shell_out!).with(
+      shell_out_expectation!(
         "zypper --non-interactive --no-gpg-checks install "+
-        "--auto-agree-with-licenses emacs=1.0")
-      @provider.install_package("emacs", "1.0")
+        "--auto-agree-with-licenses emacs=1.0"
+      )
+      provider.install_package("emacs", "1.0")
     end
     it "should warn about gpg checks on zypper install" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/)
-      expect(@provider).to receive(:shell_out!).with(
+        /All packages will be installed without gpg signature checks/
+      )
+      shell_out_expectation!(
         "zypper --non-interactive --no-gpg-checks install "+
-        "--auto-agree-with-licenses emacs=1.0")
-      @provider.install_package("emacs", "1.0")
+        "--auto-agree-with-licenses emacs=1.0"
+      )
+      provider.install_package("emacs", "1.0")
     end
   end
 
   describe "upgrade_package" do
     it "should run zypper update with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
-      expect(@provider).to receive(:shell_out!).with(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0")
-      @provider.upgrade_package("emacs", "1.0")
+      shell_out_expectation!(
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
+      )
+      provider.upgrade_package("emacs", "1.0")
     end
     it "should run zypper update without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
-      expect(@provider).to receive(:shell_out!).with(
+      shell_out_expectation!(
         "zypper --non-interactive --no-gpg-checks install "+
-        "--auto-agree-with-licenses emacs=1.0")
-      @provider.upgrade_package("emacs", "1.0")
+        "--auto-agree-with-licenses emacs=1.0"
+      )
+      provider.upgrade_package("emacs", "1.0")
     end
     it "should warn about gpg checks on zypper upgrade" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/)
-      expect(@provider).to receive(:shell_out!).with(
+        /All packages will be installed without gpg signature checks/
+      )
+      shell_out_expectation!(
         "zypper --non-interactive --no-gpg-checks install "+
-        "--auto-agree-with-licenses emacs=1.0")
-      @provider.upgrade_package("emacs", "1.0")
+        "--auto-agree-with-licenses emacs=1.0"
+      )
+      provider.upgrade_package("emacs", "1.0")
     end
     it "should run zypper upgrade without gpg checks" do
-      expect(@provider).to receive(:shell_out!).with(
+      shell_out_expectation!(
         "zypper --non-interactive --no-gpg-checks install "+
-        "--auto-agree-with-licenses emacs=1.0")
-
-      @provider.upgrade_package("emacs", "1.0")
+        "--auto-agree-with-licenses emacs=1.0"
+      )
+      provider.upgrade_package("emacs", "1.0")
     end
   end
 
@@ -147,83 +171,94 @@ describe Chef::Provider::Package::Zypper do
     context "when package version is not explicitly specified" do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
-        expect(@provider).to receive(:shell_out!).with(
-            "zypper --non-interactive remove emacs")
-        @provider.remove_package("emacs", nil)
+        shell_out_expectation!(
+            "zypper --non-interactive remove emacs"
+        )
+        provider.remove_package("emacs", nil)
       end
     end
 
     context "when package version is explicitly specified" do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
-        expect(@provider).to receive(:shell_out!).with(
-          "zypper --non-interactive remove emacs=1.0")
-        @provider.remove_package("emacs", "1.0")
+        shell_out_expectation!(
+          "zypper --non-interactive remove emacs=1.0"
+        )
+        provider.remove_package("emacs", "1.0")
       end
       it "should run zypper remove without gpg checks" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
-        expect(@provider).to receive(:shell_out!).with(
-            "zypper --non-interactive --no-gpg-checks remove emacs=1.0")
-        @provider.remove_package("emacs", "1.0")
+        shell_out_expectation!(
+            "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
+        )
+        provider.remove_package("emacs", "1.0")
       end
       it "should warn about gpg checks on zypper remove" do
         expect(Chef::Log).to receive(:warn).with(
-          /All packages will be installed without gpg signature checks/)
-        expect(@provider).to receive(:shell_out!).with(
-          "zypper --non-interactive --no-gpg-checks remove emacs=1.0")
-
-        @provider.remove_package("emacs", "1.0")
+          /All packages will be installed without gpg signature checks/
+        )
+        shell_out_expectation!(
+          "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
+        )
+        provider.remove_package("emacs", "1.0")
       end
     end
   end
 
   describe "purge_package" do
     it "should run remove_package with the name and version" do
-      expect(@provider).to receive(:shell_out!).with(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0")
-      @provider.purge_package("emacs", "1.0")
+      shell_out_expectation!(
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+      )
+      provider.purge_package("emacs", "1.0")
     end
     it "should run zypper purge without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
-      expect(@provider).to receive(:shell_out!).with(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0")
-      @provider.purge_package("emacs", "1.0")
+      shell_out_expectation!(
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+      )
+      provider.purge_package("emacs", "1.0")
     end
     it "should warn about gpg checks on zypper purge" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/)
-      expect(@provider).to receive(:shell_out!).with(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0")
-      @provider.purge_package("emacs", "1.0")
+        /All packages will be installed without gpg signature checks/
+      )
+      shell_out_expectation!(
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+      )
+      provider.purge_package("emacs", "1.0")
     end
   end
 
   describe "on an older zypper" do
     before(:each) do
-      allow(@provider).to receive(:`).and_return("0.11.6")
+      allow(provider).to receive(:`).and_return("0.11.6")
     end
 
     describe "install_package" do
       it "should run zypper install with the package name and version" do
-        expect(@provider).to receive(:shell_out!).with(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs")
-        @provider.install_package("emacs", "1.0")
+        shell_out_expectation!(
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
+        )
+        provider.install_package("emacs", "1.0")
       end
     end
 
     describe "upgrade_package" do
       it "should run zypper update with the package name and version" do
-        expect(@provider).to receive(:shell_out!).with(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs")
-        @provider.upgrade_package("emacs", "1.0")
+        shell_out_expectation!(
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
+        )
+        provider.upgrade_package("emacs", "1.0")
       end
     end
 
     describe "remove_package" do
       it "should run zypper remove with the package name" do
-        expect(@provider).to receive(:shell_out!).with(
-           "zypper --no-gpg-checks remove -y emacs")
-        @provider.remove_package("emacs", "1.0")
+        shell_out_expectation!(
+           "zypper --no-gpg-checks remove -y emacs"
+        )
+        provider.remove_package("emacs", "1.0")
       end
     end
   end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -704,4 +704,38 @@ describe "Chef::Provider::Package - Multi" do
       expect(@new_resource).not_to be_updated_by_last_action
     end
   end
+
+  describe "shell_out helpers" do
+    [ :shell_out_with_timeout, :shell_out_with_timeout! ].each do |method|
+      stubbed_method = method == :shell_out_with_timeout! ? :shell_out! : :shell_out
+      [ %w{command arg1 arg2}, "command arg1 arg2" ].each do |command|
+        it "#{method} defaults to 900 seconds" do
+          expect(@provider).to receive(stubbed_method).with(*command, timeout: 900)
+          @provider.send(method, *command)
+        end
+        it "#{method} overrides the default timeout with its options" do
+          expect(@provider).to receive(stubbed_method).with(*command, timeout: 1)
+          @provider.send(method, *command, timeout: 1)
+        end
+        it "#{method} overrides both timeouts with the new_resource.timeout" do
+          @new_resource.timeout(99)
+          expect(@provider).to receive(stubbed_method).with(*command, timeout: 99)
+          @provider.send(method, *command, timeout: 1)
+        end
+        it "#{method} defaults to 900 seconds and preserves options" do
+          expect(@provider).to receive(stubbed_method).with(*command, env: nil, timeout: 900)
+          @provider.send(method, *command, env: nil)
+        end
+        it "#{method} overrides the default timeout with its options and preserves options" do
+          expect(@provider).to receive(stubbed_method).with(*command, timeout: 1, env: nil)
+          @provider.send(method, *command, timeout: 1, env: nil)
+        end
+        it "#{method} overrides both timeouts with the new_resource.timeout and preseves options" do
+          @new_resource.timeout(99)
+          expect(@provider).to receive(stubbed_method).with(*command, timeout: 99, env: nil)
+          @provider.send(method, *command, timeout: 1, env: nil)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
updates all the shell_out calls to respect the timeout which is passed
on the new_resource.

the old `Chef::Config` yum timeout values are still respected and will
override the default.

the default of 900 seconds is preserved.

closes #2943 
closes #2944 
closes #2441 
closes #2444 