### PR TITLE
We don't need to run ruby 2.0 in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
 
 matrix:
   include:
-  - rvm: 2.0
   - rvm: 2.1
   - rvm: 2.2
   - rvm: 2.1


### PR DESCRIPTION
It only matters on Windows and so it gets run in
appveyor