### PR TITLE
Lcg/bundle cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 sudo: false
 # Early warning system to catch if Rubygems breaks something


### PR DESCRIPTION
cuts the end-to-end tests down to 9 mins from 17 mins due to being able to reuse libgecode from a previous bundle install.

this should operate the same way as caching bundles across app deployments with shared directories in the deploy provider.  if we bump libgecode then without a Gemfile.lock we'll still need a new version so we'll build it once and add the new version to the cache -- we shouldn't wind up accidentally version pinned.