### PR TITLE
Hyphenated LWRP

### DIFF
--- a/lib/chef/mixin/convert_to_class_name.rb
+++ b/lib/chef/mixin/convert_to_class_name.rb
@@ -23,9 +23,7 @@ class Chef
       extend self
 
       def convert_to_class_name(str)
-        str = str.dup
-        str.gsub!(/[^A-Za-z0-9_]/,'_')
-        str.gsub!(/^(_+)?/,'')
+        str = normalize_snake_case_name(str)
         rname = nil
         regexp = %r{^(.+?)(_(.+))?$}
 
@@ -51,6 +49,13 @@ class Chef
         str
       end
 
+      def normalize_snake_case_name(str)
+        str = str.dup
+        str.gsub!(/[^A-Za-z0-9_]/,'_')
+        str.gsub!(/^(_+)?/,'')
+        str
+      end
+
       def snake_case_basename(str)
         with_namespace = convert_to_snake_case(str)
         with_namespace.split("::").last.sub(/^_/, '')
@@ -58,7 +63,8 @@ class Chef
 
       def filename_to_qualified_string(base, filename)
         file_base = File.basename(filename, ".rb")
-        base.to_s + (file_base == 'default' ? '' : "_#{file_base}")
+        str = base.to_s + (file_base == 'default' ? '' : "_#{file_base}")
+        normalize_snake_case_name(str)
       end
 
       # Copied from rails activesupport.  In ruby >= 2.0 const_get will just do this, so this can

--- a/spec/integration/recipes/lwrp_spec.rb
+++ b/spec/integration/recipes/lwrp_spec.rb
@@ -1,0 +1,57 @@
+require 'support/shared/integration/integration_helper'
+require 'chef/mixin/shell_out'
+
+describe "LWRPs" do
+  include IntegrationSupport
+  include Chef::Mixin::ShellOut
+
+  let(:chef_dir) { File.expand_path("../../../../bin", __FILE__) }
+
+  # Invoke `chef-client` as `ruby PATH/TO/chef-client`. This ensures the
+  # following constraints are satisfied:
+  # * Windows: windows can only run batch scripts as bare executables. Rubygems
+  # creates batch wrappers for installed gems, but we don't have batch wrappers
+  # in the source tree.
+  # * Other `chef-client` in PATH: A common case is running the tests on a
+  # machine that has omnibus chef installed. In that case we need to ensure
+  # we're running `chef-client` from the source tree and not the external one.
+  # cf. CHEF-4914
+  let(:chef_client) { "ruby '#{chef_dir}/chef-client' --minimal-ohai" }
+
+  when_the_repository "has a cookbook named l-w-r-p" do
+    before do
+      directory 'cookbooks/l-w-r-p' do
+
+        file 'resources/foo.rb', <<EOM
+default_action :create
+EOM
+        file 'providers/foo.rb', <<EOM
+action :create do
+end
+EOM
+
+        file 'recipes/default.rb', <<EOM
+l_w_r_p_foo "me"
+EOM
+
+      end # directory 'cookbooks/x'
+    end
+
+    it "should complete with success" do
+      file 'config/client.rb', <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+log_level :warn
+EOM
+
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" --no-color -F doc -o 'l-w-r-p::default'", :cwd => chef_dir)
+      actual = result.stdout.lines.map { |l| l.chomp }.join("\n")
+      expected = <<EOM
+  * l_w_r_p_foo[me] action create (up to date)
+EOM
+      expected = expected.lines.map { |l| l.chomp }.join("\n")
+      expect(actual).to include(expected)
+      result.error!
+    end
+  end
+end

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -122,6 +122,23 @@ describe "LWRP" do
 
   end
 
+  context "When an LWRP resource in cookbook l-w-r-p is loaded" do
+    before do
+      @tmpdir = Dir.mktmpdir("lwrp_test")
+      resource_path = File.join(@tmpdir, "foo.rb")
+      IO.write(resource_path, "default_action :create")
+      provider_path = File.join(@tmpdir, "foo.rb")
+      IO.write(provider_path, <<-EOM)
+        action :create do
+          raise "hi"
+        end
+      EOM
+    end
+
+    it "Can find the resource at l_w_r_p_foo" do
+    end
+  end
+
   context "When an LWRP resource lwrp_foo is loaded" do
     before do
       @tmpdir = Dir.mktmpdir("lwrp_test")
@@ -531,8 +548,6 @@ describe "LWRP" do
         let(:lwrp_cookbok_name) { "l-w-r-p" }
 
         it "sets itself as a provider for a resource of the same name" do
-          pp Chef::Platform::ProviderPriorityMap.instance.send(:priority_map)
-
           incorrect_providers = Chef::Platform::ProviderPriorityMap.instance.list_handlers(node, :'l-w-r-p_buck_passer')
           expect(incorrect_providers).to eq([])
 


### PR DESCRIPTION
has a regression test for provider priority map setting with cookbooks with hyphens in the name. Currently doesn't have the fix. I did some refactoring in the first commit, so you might want to focus on the second commit.

@sdelano @jkeiser 