### PR TITLE
Issue#3485: Fix corruption of run_context when guard interpreters are executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* [pr#3497](https://github.com/chef/chef/pull/3497): Issue 3485: Corruption of node's run\_context when non-default guard\_interpreter is evaluated
 * [**Yukihiko SAWANOBORI**](https://github.com/sawanoboly): Pass name by
   knife cil attribute [pr#3195](https://github.com/chef/chef/pull/3195)
 * [**Torben Knerr**](https://github.com/tknerr):

--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -92,8 +92,11 @@ class Chef
           raise ArgumentError, "Specified guard interpreter class #{resource_class} must be a kind of Chef::Resource::Execute resource"
         end
 
+        # Duplicate the node below because the new RunContext
+        # overwrites the state of Node instances passed to it.
+        # See https://github.com/chef/chef/issues/3485.
         empty_events = Chef::EventDispatch::Dispatcher.new
-        anonymous_run_context = Chef::RunContext.new(parent_resource.node, {}, empty_events)
+        anonymous_run_context = Chef::RunContext.new(parent_resource.node.dup, {}, empty_events)
         interpreter_resource = resource_class.new('Guard resource', anonymous_run_context)
         interpreter_resource.is_guard_interpreter = true
 

--- a/spec/unit/guard_interpreter/resource_guard_interpreter_spec.rb
+++ b/spec/unit/guard_interpreter/resource_guard_interpreter_spec.rb
@@ -84,6 +84,14 @@ describe Chef::GuardInterpreter::ResourceGuardInterpreter do
       expect(guard_interpreter.evaluate).to eq(true)
     end
 
+    it "does not corrupt the run_context of the node" do
+      node_run_context_before_guard_execution = parent_resource.run_context
+      expect(node_run_context_before_guard_execution.object_id).to eq(parent_resource.node.run_context.object_id)
+      guard_interpreter.evaluate
+      node_run_context_after_guard_execution = parent_resource.run_context
+      expect(node_run_context_after_guard_execution.object_id).to eq(parent_resource.node.run_context.object_id)
+    end
+
     describe "script command opts switch" do
       let(:command_opts) { {} }
       let(:guard_interpreter) { Chef::GuardInterpreter::ResourceGuardInterpreter.new(parent_resource, "exit 0", command_opts) }


### PR DESCRIPTION
Addresses #3485 -- the `RunContext` alters the private state of the node passed to the `RunContext#initialize`. The node passed in this case is the actual `Node` instance being tracked by the Chef Client run, so unpredictable side-effects may occur, though so far we have only one known issue related to this problem. The limited observations are possibly due to the internals of Chef using the `RunContext` instance referenced from sources other than the corrupt `Node` instance.

Passing a duplicate of the `Node` instance to the `initialize` method of `RunContext` avoids this problem while still meeting the requirements of `guard_interpreter` resource execution.