### PR TITLE
Using master of kitchen-ec2 for travis integration tests

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -5,5 +5,5 @@ group :end_to_end do
   gem 'test-kitchen', '~> 1.4.0'
   gem 'kitchen-appbundle-updater', '~> 0.0.1'
   gem "kitchen-vagrant", '~> 0.17.0'
-  gem 'kitchen-ec2', github: 'test-kitchen/kitchen-ec2', tag: 'v0.9.3'
+  gem 'kitchen-ec2', github: 'test-kitchen/kitchen-ec2'
 end


### PR DESCRIPTION
Because https://github.com/test-kitchen/kitchen-ec2/issues/148 has been fixed, travis should no longer break