### PR TITLE
Add delayed start for chef client service manager

### DIFF
--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -123,6 +123,7 @@ class Chef
                                  :binary_path_name => cmd,
                                  :service_start_name => @service_start_name,
                                  :password => @password,
+                                 :delayed_start => true,
                                  )
             puts "Service '#{@service_name}' has successfully been installed."
           end


### PR DESCRIPTION
This enables delayed start for the service that the client manager creates.  It duplicates the behavior in omnibus-chef windows installer for chef-client service.  I did not add any tests as I was unsure where to add these, but the only change would be the existence of a registry key on the system under ` HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\<service-name>` should have the key value `DelayedAutoStart: 1`