### PR TITLE
lazier coupling of Chef::HTTP to Chef::Config

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -332,30 +332,34 @@ class Chef
       end
     end
 
+    attr_writer :http_retry_delay
     def http_retry_delay
       @http_retry_delay ||= config[:http_retry_delay]
     end
-    attr_writer :http_retry_delay
 
+    attr_writer :http_retry_count
     def http_retry_count
       @http_retry_count ||= config[:http_retry_count]
     end
-    attr_writer :http_retry_count
 
+    attr_writer :local_mode
     def local_mode
       @local_mode ||= config[:local_mode]
     end
-    attr_writer :local_mode
 
+    attr_writer :custom_http_headers
     def custom_http_headers
       @custom_http_headers ||= config[:custom_http_headers]
     end
-    attr_writer :custom_http_headers
 
-    def config
-      @config ||= Chef::Config
-    end
     attr_writer :config
+    def config
+      @config ||=
+        begin
+          Thread.exclusive { require 'chef/config' unless defined?(Chef::Config) }
+          Chef::Config
+        end
+    end
 
     def follow_redirect
       raise Chef::Exceptions::RedirectLimitExceeded if @redirects_followed >= redirect_limit
@@ -425,5 +429,3 @@ class Chef
 
   end
 end
-
-require 'chef/config'

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -38,7 +38,7 @@ class Chef
         @sign_request = true
         @signing_key_filename = opts[:signing_key_filename]
         @key = load_signing_key(opts[:signing_key_filename], opts[:raw_key])
-        @auth_credentials = AuthCredentials.new(opts[:client_name], @key)
+        @auth_credentials = AuthCredentials.new(opts[:client_name], @key, opts)
         if opts[:api_version]
           @api_version = opts[:api_version]
         else

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -72,9 +72,10 @@ class Chef
 
       attr_reader :method, :url, :headers, :http_client, :http_request
 
-      def initialize(method, url, req_body, base_headers={})
+      def initialize(method, url, req_body, base_headers={}, opts = {})
         @method, @url = method, url
         @request_body = nil
+        @config = opts[:config] if opts.key?(:config)
         build_headers(base_headers)
         configure_http_request(req_body)
       end
@@ -110,7 +111,11 @@ class Chef
       end
 
       def config
-        Chef::Config
+        @config ||=
+          begin
+            Thread.exclusive { require 'chef/config' unless defined?(Chef::Config) }
+            Chef::Config
+          end
       end
 
       # DEPRECATED. Call request on an HTTP client object instead.

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -31,15 +31,16 @@ class Chef
     # Configures SSL behavior on an HTTP object via visitor pattern.
     class DefaultSSLPolicy
 
-      def self.apply_to(http_client)
-        new(http_client).apply
+      def self.apply_to(http_client, opts = {})
+        new(http_client, opts).apply
         http_client
       end
 
       attr_reader :http_client
 
-      def initialize(http_client)
+      def initialize(http_client, opts = {})
         @http_client = http_client
+        @config = opts[:config] if opts.key?(:config)
       end
 
       def apply
@@ -102,7 +103,11 @@ class Chef
       end
 
       def config
-        Chef::Config
+        @config ||=
+          begin
+            Thread.exclusive { require 'chef/config' unless defined?(Chef::Config) }
+            Chef::Config
+          end
       end
 
       private


### PR DESCRIPTION
- remove Chef::Config symbol outside of `#config` lazy initializer
- allow for dep injecting a different hash completely for Chef::Config
- allow for updating `@config` or any of the config values from attr_writers
- move chef/config dep to the bottom
