### PR TITLE
add maintainers/Lts for tier 1 & 2 support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -102,6 +102,10 @@ The specific components of Chef related to a given platform - including (but not
 
 ## Solaris
 
+### Lieutenant
+
+* [Thom May](https://github.com/thommay)
+
 ### Maintainers
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
@@ -122,6 +126,34 @@ The specific components of Chef related to a given platform - including (but not
 
 * [Tyler Ball](https://github.com/tyler-ball)
 
+## Debian
+
+### Lieutenant
+
+* [Thom May](https://github.com/thommay)
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
+
+## Fedora
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
+
+## openSUSE
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
+
+## SUSE Enterprise Linux Server
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
+
 ## FreeBSD
 
 ### Lieutenant
@@ -138,4 +170,10 @@ The specific components of Chef related to a given platform - including (but not
 ### Lieutenant
 
 * [Joe Miller](https://github.com/joemiller)
+
+## Gentoo
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -112,7 +112,7 @@ The specific components of Chef related to a given platform - including (but not
 
 ## AIX
 
-### Maintainers
+### Lieutenant
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
 
@@ -176,4 +176,10 @@ The specific components of Chef related to a given platform - including (but not
 ### Maintainers
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
+
+## OmniOS
+
+### Maintainers
+
+* [Thom May](https://github.com/thommay)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -183,3 +183,9 @@ The specific components of Chef related to a given platform - including (but not
 
 * [Thom May](https://github.com/thommay)
 
+## ArchLinux
+
+### Maintainers
+
+* [Lamont Granquist](https://github.com/lamont-granquist)
+

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -115,6 +115,8 @@ The specific components of Chef related to a given platform - including (but not
       [Org.Components.Subsystems.Solaris]
         title = "Solaris"
 
+        lieutenant = "thommay"
+
         maintainers = [
           "lamont-granquist"
         ]
@@ -135,6 +137,36 @@ The specific components of Chef related to a given platform - including (but not
           "tyler-ball"
         ]
 
+      [Org.Components.Subsystems.Debian]
+        title = "Debian"
+
+        lieutenant = "thommay"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
+
+    [Org.Components.Subsystems.Fedora]
+        title = "Fedora"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
+
+      [Org.Components.Subsystems.openSUSE]
+        title = "openSUSE"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
+
+      [Org.Components.Subsystems."SUSE Enterprise Linux"]
+        title = "SUSE Enterprise Linux Server"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
+
       [Org.Components.Subsystems.FreeBSD]
         title = "FreeBSD"
 
@@ -149,6 +181,13 @@ The specific components of Chef related to a given platform - including (but not
         title = "OpenBSD"
 
         lieutenant = "joemiller"
+
+    [Org.Components.Subsystems.Gentoo]
+        title = "Gentoo"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
 
 [people]
   [people.adamhjk]

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -194,6 +194,13 @@ The specific components of Chef related to a given platform - including (but not
           "thommay"
         ]
 
+    [Org.Components.Subsystems.ArchLinux]
+        title = "ArchLinux"
+
+        maintainers = [
+          "lamont-granquist"
+        ]
+
 [people]
   [people.adamhjk]
     Name = "Adam Jacob"

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -124,9 +124,7 @@ The specific components of Chef related to a given platform - including (but not
       [Org.Components.Subsystems.AIX]
         title = "AIX"
 
-        maintainers = [
-          "lamont-granquist"
-        ]
+        lieutenant = "lamont-granquist"
 
       [Org.Components.Subsystems."Mac OS X"]
         title = "Mac OS X"
@@ -187,6 +185,13 @@ The specific components of Chef related to a given platform - including (but not
 
         maintainers = [
           "lamont-granquist"
+        ]
+
+    [Org.Components.Subsystems.OmniOS]
+        title = "OmniOS"
+
+        maintainers = [
+          "thommay"
         ]
 
 [people]


### PR DESCRIPTION
Per the RFC submitted in chef-rfc PR 131:

https://github.com/chef/chef-rfc/pull/131

We need lieutenants, maintainers for all the tier 1 and tier 2 platforms. Thom May and Lamont Granquist have volunteered for various platforms.

Lamont volunteered for AIX but only interim until someone else can step up.

Still outstanding:

* [X] Ubuntu
* [x] AIX
* [x] ArchLinux
* [x] OmniOS
* [x] OpenBSD ([PR](https://github.com/chef/chef-rfc/pull/130))