### PR TITLE
Bug#3531

### DIFF
--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -64,7 +64,7 @@ class Chef
 
       def values_to_hash(values)
         if values
-          @name_hash = Hash[values.map { |val| [val[:name], val] }]
+          @name_hash = Hash[values.map { |val| [val[:name].downcase, val] }]
         else
           @name_hash = {}
         end
@@ -100,8 +100,8 @@ class Chef
           end
         end
         @new_resource.unscrubbed_values.each do |value|
-          if @name_hash.has_key?(value[:name])
-            current_value = @name_hash[value[:name]]
+          if @name_hash.has_key?(value[:name].downcase)
+            current_value = @name_hash[value[:name].downcase]
             unless current_value[:type] == value[:type] && current_value[:data] == value[:data]
               converge_by("set value #{value}") do
                 registry.set_value(@new_resource.key, value)
@@ -122,7 +122,7 @@ class Chef
           end
         end
         @new_resource.unscrubbed_values.each do |value|
-          unless @name_hash.has_key?(value[:name])
+          unless @name_hash.has_key?(value[:name].downcase)
             converge_by("create value #{value}") do
               registry.set_value(@new_resource.key, value)
             end
@@ -133,7 +133,7 @@ class Chef
       def action_delete
         if registry.key_exists?(@new_resource.key)
           @new_resource.unscrubbed_values.each do |value|
-            if @name_hash.has_key?(value[:name])
+            if @name_hash.has_key?(value[:name].downcase)
               converge_by("delete value #{value}") do
                 registry.delete_value(@new_resource.key, value)
               end

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -200,7 +200,11 @@ class Chef
       end
 
       def SafelyDowncase(val)
-        (val == nil ? nil : val.downcase)
+        begin
+          return (val == nil ? nil : val.downcase)
+        rescue NoMethodError
+          return val
+        end
       end
 
       def value_exists?(key_path, value)

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -203,7 +203,7 @@ class Chef
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
-          return true if reg.any? {|val| val.downcase == value[:name].downcase }
+          return true if reg.any? {|val| val.casecmp(value[:name]) == 0 }
         end
         return false
       end
@@ -213,7 +213,7 @@ class Chef
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
           reg.each do |val_name, val_type, val_data|
-            if val_name == value[:name] &&
+            if val_name.casecmp(value[:name]) == 0 &&
               val_type == get_type_from_name(value[:type]) &&
               val_data == value[:data]
               return true

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -203,7 +203,7 @@ class Chef
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
-          return true if reg.any? {|val| val == value[:name] }
+          return true if reg.any? {|val| val.downcase == value[:name].downcase }
         end
         return false
       end

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -199,19 +199,18 @@ class Chef
         ( applied_arch == :x86_64 ) ? 0x0100 : 0x0200
       end
 
-      def SafelyDowncase(val)
-        begin
-          return (val == nil ? nil : val.downcase)
-        rescue NoMethodError
-          return val
+      def safely_downcase(val)
+        if val.is_a? String
+          return val.downcase
         end
+        return val
       end
 
       def value_exists?(key_path, value)
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
-          return true if reg.any? {|val| SafelyDowncase(val) == SafelyDowncase(value[:name]) }
+          return true if reg.any? {|val| safely_downcase(val) == safely_downcase(value[:name]) }
         end
         return false
       end
@@ -221,7 +220,7 @@ class Chef
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
           reg.each do |val_name, val_type, val_data|
-            if SafelyDowncase(val_name) == SafelyDowncase(value[:name]) &&
+            if safely_downcase(val_name) == safely_downcase(value[:name]) &&
               val_type == get_type_from_name(value[:type]) &&
               val_data == value[:data]
               return true

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -199,11 +199,15 @@ class Chef
         ( applied_arch == :x86_64 ) ? 0x0100 : 0x0200
       end
 
+      def SafelyDowncase(val)
+        (val == nil ? nil : val.downcase)
+      end
+
       def value_exists?(key_path, value)
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
-          return true if reg.any? {|val| val.casecmp(value[:name]) == 0 }
+          return true if reg.any? {|val| SafelyDowncase(val) == SafelyDowncase(value[:name]) }
         end
         return false
       end
@@ -213,7 +217,7 @@ class Chef
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
           reg.each do |val_name, val_type, val_data|
-            if val_name.casecmp(value[:name]) == 0 &&
+            if SafelyDowncase(val_name) == SafelyDowncase(value[:name]) &&
               val_type == get_type_from_name(value[:type]) &&
               val_data == value[:data]
               return true

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -199,13 +199,6 @@ class Chef
         ( applied_arch == :x86_64 ) ? 0x0100 : 0x0200
       end
 
-      def safely_downcase(val)
-        if val.is_a? String
-          return val.downcase
-        end
-        return val
-      end
-
       def value_exists?(key_path, value)
         key_exists!(key_path)
         hive, key = get_hive_and_key(key_path)
@@ -295,6 +288,14 @@ class Chef
       end
 
       private
+
+
+      def safely_downcase(val)
+        if val.is_a? String
+          return val.downcase
+        end
+        return val
+      end
 
       def node
         run_context && run_context.node

--- a/spec/functional/win32/registry_helper_spec.rb
+++ b/spec/functional/win32/registry_helper_spec.rb
@@ -148,6 +148,9 @@ describe 'Chef::Win32::Registry', :windows_only do
     it "returns true if the value exists" do
       expect(@registry.value_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"Petals"})).to eq(true)
     end
+    it "returns true if the value exists with a case mismatch on the value name" do
+      expect(@registry.value_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"petals"})).to eq(true)
+    end
     it "throws an exception if the value does not exist" do
       expect {@registry.value_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"FOOBAR"})}.to raise_error(Chef::Exceptions::Win32RegValueMissing)
     end
@@ -162,6 +165,9 @@ describe 'Chef::Win32::Registry', :windows_only do
     end
     it "returns true if all the data matches" do
       expect(@registry.data_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"Petals", :type=>:multi_string, :data=>["Pink", "Delicate"]})).to eq(true)
+    end
+    it "returns true if all the data matches with a case mismatch on the data name" do
+      expect(@registry.data_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"petals", :type=>:multi_string, :data=>["Pink", "Delicate"]})).to eq(true)
     end
     it "returns false if the name does not exist" do
       expect(@registry.data_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"slateP", :type=>:multi_string, :data=>["Pink", "Delicate"]})).to eq(false)
@@ -183,6 +189,9 @@ describe 'Chef::Win32::Registry', :windows_only do
     end
     it "returns true if all the data matches" do
       expect(@registry.data_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"Petals", :type=>:multi_string, :data=>["Pink", "Delicate"]})).to eq(true)
+    end
+    it "returns true if all the data matches with a case mismatch on the data name" do
+      expect(@registry.data_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"petals", :type=>:multi_string, :data=>["Pink", "Delicate"]})).to eq(true)
     end
     it "throws an exception if the name does not exist" do
       expect {@registry.data_exists!("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"slateP", :type=>:multi_string, :data=>["Pink", "Delicate"]})}.to raise_error(Chef::Exceptions::Win32RegDataMissing)

--- a/spec/functional/win32/registry_helper_spec.rb
+++ b/spec/functional/win32/registry_helper_spec.rb
@@ -111,10 +111,6 @@ describe 'Chef::Win32::Registry', :windows_only do
       expect(@registry.key_exists!("HKCU\\Software\\Root\\Branch\\Flower")).to eq(true)
     end
 
-    it "returns true if the key path exists with a case insensitive path" do
-      expect(@registry.key_exists!("HKCU\\Software\\Root\\Branch\\flower")).to eq(true)
-    end
-
     it "throws an exception if the key path does not exist" do
       expect {@registry.key_exists!("HKCU\\Software\\Branch\\Flower")}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
@@ -133,6 +129,9 @@ describe 'Chef::Win32::Registry', :windows_only do
     end
     it "returns true if the value exists" do
       expect(@registry.value_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"Petals"})).to eq(true)
+    end
+    it "returns true if the value exists with a case mismatch on the value name" do
+      expect(@registry.value_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"petals"})).to eq(true)
     end
     it "returns false if the value does not exist" do
       expect(@registry.value_exists?("HKCU\\Software\\Root\\Branch\\Flower", {:name=>"FOOBAR"})).to eq(false)

--- a/spec/functional/win32/registry_helper_spec.rb
+++ b/spec/functional/win32/registry_helper_spec.rb
@@ -111,6 +111,10 @@ describe 'Chef::Win32::Registry', :windows_only do
       expect(@registry.key_exists!("HKCU\\Software\\Root\\Branch\\Flower")).to eq(true)
     end
 
+    it "returns true if the key path exists with a case insensitive path" do
+      expect(@registry.key_exists!("HKCU\\Software\\Root\\Branch\\flower")).to eq(true)
+    end
+
     it "throws an exception if the key path does not exist" do
       expect {@registry.key_exists!("HKCU\\Software\\Branch\\Flower")}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end

--- a/spec/unit/provider/registry_key_spec.rb
+++ b/spec/unit/provider/registry_key_spec.rb
@@ -77,6 +77,18 @@ shared_examples_for "a registry key" do
   end
 
   describe "action_create" do
+    context "when a case insensitive match for the key exists" do
+      before(:each) do
+        expect(@double_registry).to receive(:key_exists?).twice.with(keyname.downcase).and_return(true)
+      end
+      it "should do nothing if the if a case insensitive key and the value both exist" do
+        @provider.new_resource.key(keyname.downcase)
+        expect(@double_registry).to receive(:get_values).with(keyname.downcase).and_return( testval1 )
+        expect(@double_registry).not_to receive(:set_value)
+        @provider.load_current_resource
+        @provider.action_create
+      end
+    end
     context "when the key exists" do
       before(:each) do
         expect(@double_registry).to receive(:key_exists?).twice.with(keyname).and_return(true)

--- a/spec/unit/registry_helper_spec.rb
+++ b/spec/unit/registry_helper_spec.rb
@@ -21,6 +21,7 @@ require 'spec_helper'
 describe Chef::Provider::RegistryKey do
 
   let(:value1) { { :name => "one", :type => :string, :data => "1" } }
+  let(:value1_upcase_name) { {:name => "ONE", :type => :string, :data => "1"} }
   let(:key_path) { 'HKCU\Software\OpscodeNumbers' }
   let(:key) { 'Software\OpscodeNumbers' }
   let(:key_parent) { 'Software' }
@@ -71,7 +72,20 @@ describe Chef::Provider::RegistryKey do
       expect(@registry).to receive(:data_exists?).with(key_path, value1).and_return(true)
       @registry.set_value(key_path, value1)
     end
-
+    it "does nothing if case insensitive key and hive and value exist" do
+      expect(@registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
+      expect(@registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([@hive_mock, key])
+      expect(@registry).to receive(:value_exists?).with(key_path.downcase, value1).and_return(true)
+      expect(@registry).to receive(:data_exists?).with(key_path.downcase, value1).and_return(true)
+      @registry.set_value(key_path.downcase, value1)
+    end
+    it "does nothing if key and hive and value with a case insensitive name exist" do
+      expect(@registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
+      expect(@registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([@hive_mock, key])
+      expect(@registry).to receive(:value_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
+      expect(@registry).to receive(:data_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
+      @registry.set_value(key_path.downcase, value1_upcase_name)
+    end
     it "updates value if key and hive and value exist, but data is different" do
       expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
       expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])


### PR DESCRIPTION
Fix for issue: #3531 registry_key resource is case sensitive in chef but not on windows

* Changed the registry_key provider to hash downcased keys and compare with downcased key names to prevent unnecessary convergence.
* Changed the Win32.Registry class to compare keys and value names with a case insensitive comparison.
* Added functional and unit tests to cover these changes

This was manually tested locally with the recipe described in  #3531