### PR TITLE
Fix for issue #2666

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -228,6 +228,17 @@ module ChefConfig
         joined_paths
       end
     end
+	
+    # On Windows, expands the given path so that it
+    # contains a drive letter at the beginning.
+    # [path] The path to convert
+    def self.get_full_windows_path(path)
+      if ChefConfig.windows?
+        path = cleanpath(File.absolute_path(path))
+      end
+      path
+    end
+	
   end
 end
 

--- a/chef-config/spec/unit/path_helper_spec.rb
+++ b/chef-config/spec/unit/path_helper_spec.rb
@@ -101,6 +101,18 @@ RSpec.describe ChefConfig::PathHelper do
     it "cleanpath does not remove leading double backslash" do
       expect(path_helper.cleanpath('\\\\a/b\\c/d/')).to eq('\\\\a\\b\\c\\d')
     end
+    
+    describe 'get_full_windows_path' do
+      it 'expands path to begin with drive letter' do
+        expect(File).to receive(:absolute_path).with('\\a\\b\\c').and_return('C:\\a\\b\\c')
+        expect(path_helper.get_full_windows_path('\\a\\b\\c')).to eq('C:\\a\\b\\c')
+      end
+      
+      it 'appends relative path to current directory' do
+        expect(File).to receive(:absolute_path).with('a\\b\\c').and_return('C:\\x\\y\\z\\a\\b\\c')
+        expect(path_helper.get_full_windows_path('a\\b\\c')).to eq('C:\\x\\y\\z\\a\\b\\c')
+      end
+    end
 
   end
 

--- a/spec/unit/role_spec.rb
+++ b/spec/unit/role_spec.rb
@@ -308,6 +308,7 @@ EOR
       allow_any_instance_of(Chef::Role).to receive(:from_file).with("#{Chef::Config[:role_path]}/memes/lolcat.rb")
       expect{ @role.class.from_disk("lolcat") }.not_to raise_error
     end
+    
   end
 
   describe "when loading from disk and role_path is an array" do
@@ -358,5 +359,19 @@ EOR
       expect {@role.class.from_disk("lolcat")}.to raise_error(Chef::Exceptions::RoleNotFound)
     end
 
+  end
+  
+  describe 'get_roles_files_in_path' do
+    it 'should search Windows absolute paths instead of Linux-style paths when on Windows' do
+      allow(ChefConfig).to receive(:windows?) { true }
+      expect(Dir).to receive(:glob).with(File.join('C:\\\\path1\\\\path2', '**', '**')).exactly(1).times
+      @role.class.get_roles_files_in_path('/path1/path2')
+    end
+    
+    it 'should search Linux paths on Linux' do
+      allow(ChefConfig).to receive(:windows?) { false }
+      expect(Dir).to receive(:glob).with(File.join('/path1/path2', '**', '**')).exactly(1).times
+      @role.class.get_roles_files_in_path('/path1/path2')
+    end
   end
 end

--- a/spec/unit/role_spec.rb
+++ b/spec/unit/role_spec.rb
@@ -364,6 +364,7 @@ EOR
   describe 'get_roles_files_in_path' do
     it 'should search Windows absolute paths instead of Linux-style paths when on Windows' do
       allow(ChefConfig).to receive(:windows?) { true }
+      expect(File).to receive(:absolute_path).and_return('C:\\path1\\path2')
       expect(Dir).to receive(:glob).with(File.join('C:\\\\path1\\\\path2', '**', '**')).exactly(1).times
       @role.class.get_roles_files_in_path('/path1/path2')
     end


### PR DESCRIPTION
* Added method to path_helper.rb to convert Linux-style absolute paths to Windows-style absolute paths that begin with a drive letter
* Moved methods that finds roles files into a separate method and then added call to new path_helper method to fix Windows issue [#2666](https://github.com/chef/chef/issues/2666)
* Added unit tests
* Tried with Vagrant script against Windows VM (Virtualbox), checking that add_role and add_recipe work