### PR TITLE
Fix to allow LW resources to be used with HW providers

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -197,7 +197,8 @@ class Chef
 
         def resource_matching_provider(platform, version, resource_type)
           if resource_type.kind_of?(Chef::Resource)
-            class_name = resource_type.class.to_s.split('::').last
+            class_name = resource_type.class.name ? resource_type.class.name.split('::').last : 
+              convert_to_class_name(resource_type.resource_name.to_s)
 
             begin
               result = Chef::Provider.const_get(class_name)

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -969,4 +969,29 @@ describe "Recipe DSL methods" do
       end
     end
   end
+
+  context "with a dynamically defined resource and regular provider" do
+    before(:context) do
+      Class.new(Chef::Resource) do
+        resource_name :lw_resource_with_hw_provider_test_case
+        default_action :create
+        attr_accessor :created_provider
+      end
+      class Chef::Provider::LwResourceWithHwProviderTestCase < Chef::Provider
+        def load_current_resource
+        end
+        def action_create
+          new_resource.created_provider = self.class
+        end
+      end
+    end
+
+    it "looks up the provider in Chef::Provider converting the resource name from snake case to camel case" do
+      resource = nil
+      recipe = converge {
+        resource = lw_resource_with_hw_provider_test_case 'blah' do; end
+      }
+      expect(resource.created_provider).to eq(Chef::Provider::LwResourceWithHwProviderTestCase)
+    end
+  end
 end


### PR DESCRIPTION
This should fix sethvargo-cookbooks/swap#22

Here's what was happening:
The cookbooks creates a Resource using the LWRP base. This dynamically
creates a class. We used to create this class with the name
Chef::Resource::SomeResourceName. In 12.4, this change to something like
"LWRP resource some_resource_name from cookbook CookbookName". When
searching for a provider, it couldn't be found because it wasn't explicitly
set, as it would have been if it was a LW provider, and it wasn't found
in Chef::Provider, because Chef::Provider had a provider SomeResourceName
instead of "LWRP resource some_resource_name from cookbook CookbookName".

cc @jkeiser @sethvargo @chef/client-maintainers 