### PR TITLE
Use Mixlib::Shellout instead of Chef::Mixin::Command

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -214,8 +214,8 @@ class Chef::Application::Solo < Chef::Application
       FileUtils.mkdir_p(recipes_path)
       tarball_path = File.join(recipes_path, 'recipes.tgz')
       fetch_recipe_tarball(Chef::Config[:recipe_url], tarball_path)
-      tarcommand = Mixlib::ShellOut.new("tar zxvf #{tarball_path} -C #{recipes_path}")
-	    tarcommand.run_command  
+      Mixlib::ShellOut.new("tar zxvf #{tarball_path} -C #{recipes_path}").run_command
+	    #tarcommand.run_command  
     end
 
     # json_attribs shuld be fetched after recipe_url tarball is unpacked.

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -214,7 +214,8 @@ class Chef::Application::Solo < Chef::Application
       FileUtils.mkdir_p(recipes_path)
       tarball_path = File.join(recipes_path, 'recipes.tgz')
       fetch_recipe_tarball(Chef::Config[:recipe_url], tarball_path)
-      Chef::Mixin::Command.run_command(:command => "tar zxvf #{tarball_path} -C #{recipes_path}")
+      tarcommand = Mixlib::ShellOut.new("tar zxvf #{tarball_path} -C #{recipes_path}")
+	    tarcommand.run_command  
     end
 
     # json_attribs shuld be fetched after recipe_url tarball is unpacked.

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -215,7 +215,6 @@ class Chef::Application::Solo < Chef::Application
       tarball_path = File.join(recipes_path, 'recipes.tgz')
       fetch_recipe_tarball(Chef::Config[:recipe_url], tarball_path)
       Mixlib::ShellOut.new("tar zxvf #{tarball_path} -C #{recipes_path}").run_command
-	    #tarcommand.run_command  
     end
 
     # json_attribs shuld be fetched after recipe_url tarball is unpacked.

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -108,7 +108,6 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       let(:target_file) { StringIO.new }
       let(:shellout) { double(run_command: nil, error!: nil, stdout: '') }
      
-
       before do
         Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
         Chef::Config[:recipe_url] = "http://junglist.gen.nz/recipes.tgz"

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -106,6 +106,8 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
     describe "when the recipe_url configuration option is specified" do
       let(:tarfile) { StringIO.new("remote_tarball_content") }
       let(:target_file) { StringIO.new }
+      let(:shellout) { double(run_command: nil, error!: nil, stdout: '') }
+     
 
       before do
         Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
@@ -117,7 +119,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
         allow(app).to receive(:open).with("http://junglist.gen.nz/recipes.tgz").and_yield(tarfile)
         allow(File).to receive(:open).with("#{Dir.tmpdir}/chef-solo/recipes.tgz", "wb").and_yield(target_file)
 
-        allow(Chef::Mixin::Command).to receive(:run_command).and_return(true)
+        allow(Mixlib::ShellOut).to receive(:new).and_return(shellout)
       end
 
       it "should create the recipes path based on the parent of the cookbook path" do
@@ -136,7 +138,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       end
 
       it "should untar the target file to the parent of the cookbook path" do
-        expect(Chef::Mixin::Command).to receive(:run_command).with({:command => "tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo"}).and_return(true)
+        expect(Mixlib::ShellOut).to receive(:new).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo")  
         app.reconfigure
       end
     end


### PR DESCRIPTION
Using C:\Users\Administrator>chef-solo -i 30 -s 5 -c C:/monsoon/solo.rb -j http://foo-bar/get-run -r http://foo-bar.com/cookbooks.tar.gz
failled with error : 
[2015-06-25T15:01:52+02:00] DEBUG: ---- End output of tar zxvf C:/chef/recipes.t
gz -C C:/chef ----
C:/opscode/chef/embedded/apps/chef/lib/chef/mixin/command.rb:140:in `block in ou
tput_of_command': undefined method `exitstatus' for nil:NilClass (NoMethodError)

        from C:/opscode/chef/embedded/apps/chef/lib/chef/mixin/command.rb:122:in
 `chdir'
        from C:/opscode/chef/embedded/apps/chef/lib/chef/mixin/command.rb:122:in
 `output_of_command'
        from C:/opscode/chef/embedded/apps/chef/lib/chef/mixin/command.rb:101:in
 `run_command_and_return_stdout_stderr'
        from C:/opscode/chef/embedded/apps/chef/lib/chef/mixin/command.rb:79:in
`run_command'
        from C:/opscode/chef/embedded/apps/chef/lib/chef/application/solo.rb:217
:in `reconfigure'
        from C:/opscode/chef/embedded/apps/chef/lib/chef/application.rb:58:in `r
un'
        from C:/opscode/chef/embedded/apps/chef/bin/chef-solo:25:in `<top (requi
red)>'
        from C:/opscode/chef/bin/chef-solo:63:in `load'
        from C:/opscode/chef/bin/chef-solo:63:in `<main>'

using Mixlib::ShellOut instead of Chef::Mixin::Command solved the issue