### PR TITLE
Add myself as an Archlinux maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,6 +29,7 @@ another component.
 ### Maintainers
 
 * [Bryan McLellan](https://github.com/btm)
+* [Noah Kantrowitz](https://github.com/coderanger)
 * [Daniel DeLeo](https://github.com/danielsdeleo)
 * [AJ Christensen](https://github.com/fujin)
 * [Phil Dibowitz](https://github.com/jaymzh)
@@ -189,4 +190,5 @@ The specific components of Chef related to a given platform - including (but not
 ### Maintainers
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
+* [Ryan Cragun](https://github.com/ryancragun)
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -200,7 +200,8 @@ The specific components of Chef related to a given platform - including (but not
         title = "ArchLinux"
 
         maintainers = [
-          "lamont-granquist"
+          "lamont-granquist",
+          "ryancragun"
         ]
 
 [people]
@@ -296,3 +297,6 @@ The specific components of Chef related to a given platform - including (but not
     Name = "Noah Kantrowitz"
     GitHub = "coderanger"
 
+  [people.ryancragun]
+    Name = "Ryan Cragun"
+    GitHub = "ryancragun"


### PR DESCRIPTION
This PR piggybacks on top of https://github.com/chef/chef/pull/3525 and adds myself as an Archlinux maintainer