### PR TITLE
[ECO-451] Bootstrap node with an environment when set in first-boot.json

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -314,7 +314,7 @@ class Chef
 
         # chef-vault integration must use the new client-side hawtness, otherwise to use the
         # new client-side hawtness, just delete your validation key.
-        if chef_vault_handler.doing_chef_vault? || 
+        if chef_vault_handler.doing_chef_vault? ||
             (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
 
           unless config[:chef_node_name]

--- a/lib/chef/knife/bootstrap/client_builder.rb
+++ b/lib/chef/knife/bootstrap/client_builder.rb
@@ -84,7 +84,7 @@ class Chef
         def environment
           # prefer environment from cli over environment from first-boot attributes
           knife_config[:environment] ||
-            (first_boot_attributes[:environment] if first_boot_attributes) ||
+            (first_boot_attributes[:chef_environment] if first_boot_attributes) ||
             chef_config[:environment]
         end
 
@@ -143,7 +143,7 @@ class Chef
               node.run_list(normalized_run_list)
               if first_boot_attributes
                 scrubbed_first_boot_attributes = first_boot_attributes.dup
-                scrubbed_first_boot_attributes.delete(:environment)
+                scrubbed_first_boot_attributes.delete(:chef_environment)
                 unless scrubbed_first_boot_attributes.empty?
                   node.normal_attrs = scrubbed_first_boot_attributes
                 end

--- a/lib/chef/knife/bootstrap/client_builder.rb
+++ b/lib/chef/knife/bootstrap/client_builder.rb
@@ -84,7 +84,7 @@ class Chef
         def environment
           # prefer environment from cli over environment from first-boot attributes
           knife_config[:environment] ||
-            (first_boot_attributes[:chef_environment] if first_boot_attributes) ||
+            (first_boot_attributes['chef_environment'] if first_boot_attributes) ||
             chef_config[:environment]
         end
 
@@ -143,7 +143,7 @@ class Chef
               node.run_list(normalized_run_list)
               if first_boot_attributes
                 scrubbed_first_boot_attributes = first_boot_attributes.dup
-                scrubbed_first_boot_attributes.delete(:chef_environment)
+                scrubbed_first_boot_attributes.delete('chef_environment')
                 unless scrubbed_first_boot_attributes.empty?
                   node.normal_attrs = scrubbed_first_boot_attributes
                 end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -40,7 +40,16 @@ class Chef
         end
 
         def bootstrap_environment
-          @chef_config[:environment] || '_default'
+          # Check for environment in CLI, first_boot_attributes, then in the
+          # config file. Use '_default' if no environment specified.
+
+          # @chef_config picks up @config's environment setting, even when
+          # environment is set in the config file being used. However,
+          # @config[:environment] is not polluted by @chef_config[:environment].
+          @config[:environment] ||
+            (@config[:first_boot_attributes][:environment] if @config[:first_boot_attributes]) ||
+            @chef_config[:environment] ||
+            '_default'
         end
 
         def validation_key
@@ -167,7 +176,7 @@ CONFIG
         end
 
         private
-       
+
         # Returns a string for copying the trusted certificates on the workstation to the system being bootstrapped
         # This string should contain both the commands necessary to both create the files, as well as their content
         def trusted_certs_content

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -47,7 +47,7 @@ class Chef
           # environment is set in the config file being used. However,
           # @config[:environment] is not polluted by @chef_config[:environment].
           @config[:environment] ||
-            (@config[:first_boot_attributes][:environment] if @config[:first_boot_attributes]) ||
+            (@config[:first_boot_attributes][:chef_environment] if @config[:first_boot_attributes]) ||
             @chef_config[:environment] ||
             '_default'
         end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -47,7 +47,7 @@ class Chef
           # environment is set in the config file being used. However,
           # @config[:environment] is not polluted by @chef_config[:environment].
           @config[:environment] ||
-            (@config[:first_boot_attributes][:chef_environment] if @config[:first_boot_attributes]) ||
+            (@config[:first_boot_attributes]['chef_environment'] if @config[:first_boot_attributes]) ||
             @chef_config[:environment] ||
             '_default'
         end

--- a/spec/unit/knife/bootstrap/client_builder_spec.rb
+++ b/spec/unit/knife/bootstrap/client_builder_spec.rb
@@ -169,7 +169,7 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
     end
 
     shared_examples "first-boot environment" do
-      let(:first_boot_attributes) {{ environment: first_boot_environment }}
+      let(:first_boot_attributes) {{ chef_environment: first_boot_environment }}
 
       let(:first_boot_environment) { "first_boot_environment" }
 
@@ -193,7 +193,7 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
       end
 
       context "when environment is not the only first-boot attribute" do
-        let(:first_boot_attributes) {{ environment: first_boot_environment,
+        let(:first_boot_attributes) {{ chef_environment: first_boot_environment,
                                        baz: :quux }}
 
         it "saves the first-boot attributes, but does not save environment" do

--- a/spec/unit/knife/bootstrap/client_builder_spec.rb
+++ b/spec/unit/knife/bootstrap/client_builder_spec.rb
@@ -162,14 +162,14 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
     end
 
     it "builds a node with first_boot_attributes if they're given" do
-      knife_config[:first_boot_attributes] = {:baz => :quux}
-      expect(node).to receive(:normal_attrs=).with({:baz=>:quux})
+      knife_config[:first_boot_attributes] = { 'baz' => 'quux' }
+      expect(node).to receive(:normal_attrs=).with({ 'baz' => 'quux' })
       expect(node).to receive(:run_list).with([])
       client_builder.run
     end
 
     shared_examples "first-boot environment" do
-      let(:first_boot_attributes) {{ chef_environment: first_boot_environment }}
+      let(:first_boot_attributes) {{ 'chef_environment' => first_boot_environment }}
 
       let(:first_boot_environment) { "first_boot_environment" }
 
@@ -193,11 +193,11 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
       end
 
       context "when environment is not the only first-boot attribute" do
-        let(:first_boot_attributes) {{ chef_environment: first_boot_environment,
-                                       baz: :quux }}
+        let(:first_boot_attributes) {{ 'chef_environment' => first_boot_environment,
+                                       'baz' => 'quux' }}
 
         it "saves the first-boot attributes, but does not save environment" do
-          expect(node).to receive(:normal_attrs=).with({ baz: :quux })
+          expect(node).to receive(:normal_attrs=).with({ 'baz' => 'quux' })
           allow(node).to receive(:environment)
           client_builder.run
         end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -98,9 +98,17 @@ EXPECTED
   end
 
   describe "when JSON attributes are given" do
-    let(:config) { {:first_boot_attributes => {:baz => :quux}} }
+    let(:first_boot_attributes) { {baz: :quux} }
+    let(:config) { {:first_boot_attributes => first_boot_attributes} }
     it "adds the attributes to first_boot" do
       expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json({:baz => :quux, :run_list => run_list}))
+    end
+
+    context "when an environment is specified" do
+      let(:first_boot_attributes) { {environment: "proderption"} }
+      it "starts chef in the configured environment" do
+        expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E proderption')
+      end
     end
   end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -105,7 +105,7 @@ EXPECTED
     end
 
     context "when an environment is specified" do
-      let(:first_boot_attributes) { {environment: "proderption"} }
+      let(:first_boot_attributes) { {chef_environment: "proderption"} }
       it "starts chef in the configured environment" do
         expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E proderption')
       end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -98,14 +98,14 @@ EXPECTED
   end
 
   describe "when JSON attributes are given" do
-    let(:first_boot_attributes) { {baz: :quux} }
+    let(:first_boot_attributes) {{ 'baz' => 'quux' }}
     let(:config) { {:first_boot_attributes => first_boot_attributes} }
     it "adds the attributes to first_boot" do
       expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json({:baz => :quux, :run_list => run_list}))
     end
 
     context "when an environment is specified" do
-      let(:first_boot_attributes) { {chef_environment: "proderption"} }
+      let(:first_boot_attributes) {{ 'chef_environment' => 'proderption' }}
       it "starts chef in the configured environment" do
         expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E proderption')
       end


### PR DESCRIPTION
Adds the ability to bootstrap a node with an environment when one is set in first-boot.json. Order of environment preference: `-E ENV`, `-j JSON`, config file.

@chef/client-core 