### PR TITLE
Fix ability to monkey match LWRP through Chef::Resource::MyLwrp

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1499,7 +1499,7 @@ class Chef
         Chef::Resource.send(:remove_const, class_name)
       end
 
-      eval("Chef::Resource::#{class_name} = resource_class")
+      Chef::Resource.const_set(class_name, resource_class)
 
       deprecated_constants[class_name.to_sym] = resource_class
     end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1499,56 +1499,9 @@ class Chef
         Chef::Resource.send(:remove_const, class_name)
       end
 
-      # In order to generate deprecation warnings when you use Chef::Resource::MyLwrp,
-      # we make a special subclass (identical in nearly all respects) of the
-      # actual LWRP.  When you say any of these, a deprecation warning will be
-      # generated:
-      #
-      # - Chef::Resource::MyLwrp.new(...)
-      # - resource.is_a?(Chef::Resource::MyLwrp)
-      # - resource.kind_of?(Chef::Resource::MyLwrp)
-      # - case resource
-      #   when Chef::Resource::MyLwrp
-      #   end
-      #
-      resource_subclass = Class.new(resource_class) do
-        resource_name nil # we do not actually provide anything
-        def initialize(*args, &block)
-          Chef::Log.deprecation("Using an LWRP by its name (#{self.class.name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
-          super
-        end
-        def self.resource_name(*args)
-          if args.empty?
-            @resource_name ||= superclass.resource_name
-          else
-            super
-          end
-        end
-        self
-      end
-      eval("Chef::Resource::#{class_name} = resource_subclass")
-      # Make case, is_a and kind_of work with the new subclass, for backcompat.
-      # Any subclass of Chef::Resource::ResourceClass is already a subclass of resource_class
-      # Any subclass of resource_class is considered a subclass of Chef::Resource::ResourceClass
-      resource_class.class_eval do
-        define_method(:is_a?) do |other|
-          other.is_a?(Module) && other === self
-        end
-        define_method(:kind_of?) do |other|
-          other.is_a?(Module) && other === self
-        end
-      end
-      resource_subclass.class_eval do
-        define_singleton_method(:===) do |other|
-          Chef::Log.deprecation("Using an LWRP by its name (#{class_name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
-          # resource_subclass is a superclass of all resource_class descendants.
-          if self == resource_subclass && other.class <= resource_class
-            return true
-          end
-          super(other)
-        end
-      end
-      deprecated_constants[class_name.to_sym] = resource_subclass
+      eval("Chef::Resource::#{class_name} = resource_class")
+
+      deprecated_constants[class_name.to_sym] = resource_class
     end
 
     def self.deprecated_constants

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -78,10 +78,25 @@ class Chef
 
           resource_class = Class.new(deprecated_resource_class).tap do |resource_class|
             resource_class.resource_name(resource_name.to_sym)
+            resource_class.run_context = run_context
             resource_class.instance_eval do
               define_method(:chef_deprecated_access) do
                 false
               end
+            end
+            resource_class.class_eval do
+              define_singleton_method(:===) do |instance|
+                super(instance) || instance.class <= deprecated_resource_class
+              end
+            end
+          end
+
+          deprecated_resource_class.class_eval do
+            define_method(:kind_of?) do |klass|
+              super(klass) || klass == resource_class
+            end
+            define_method(:is_a?) do |klass|
+              super(klass) || klass == resource_class
             end
           end
 

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -177,6 +177,16 @@ describe "LWRP" do
       end
     end
 
+    it "allows monkey patching of the lwrp through Chef::Resource" do
+      monkey = Module.new do
+        def issue_3607
+        end
+      end
+      allow(Chef::Config).to receive(:[]).with(:treat_deprecation_warnings_as_errors).and_return(false)
+      Chef::Resource::LwrpFoo.send(:include, monkey)
+      expect { get_lwrp(:lwrp_foo).new("blah").issue_3607 }.not_to raise_error
+    end
+
     it "should load the resource into a properly-named class and emit a warning when it is initialized" do
       expect { Chef::Resource::LwrpFoo.new('hi') }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
     end


### PR DESCRIPTION
Repro
=====
The following cookbook would repro the issue

cookbooks/lwrptest/resources/my_lwrp.rb
---------------------------------------
```ruby
```

cookbooks/lwrptest/providers/my_lwrp.rb
---------------------------------------
```ruby
```

cookbooks/lwrptest/recipes/default.rb
-------------------------------------
```ruby
module Something
  def something
    puts 'something here'
  end
end

::Chef::Resource::LwrptestMyLwrp.send(:include, Something)

lwrptest_my_lwrp 'blah' do
  something
end
```

Why it does not work
====================
Running this in 12.4.0 produces the error
```
NoMethodError
-------------
undefined method `something' for LWRP resource lwrptest_my_lwrp from cookbook lwrptest
```

The problem is that LWRP usage through `Chef::Resource::MyLwrp` and
`Chef::Provider::MyLwrp` is depreacted. In order to participate in
the deprecation, `Chef::Resource::MyLwrp` is a subclass of the actual
`MyLwrp` class with `initialize` overriden to do a Chef::Log.deprecation.

In the example above, the intention is to add a method to the resource
so that it can be used from the dsl. The reason this does not work is
because including the method on `Chef::Resource::MyLwrp` adds the method
to the subclass, and the resource that is looked up when running the
recipe is the actual resource.