### PR TITLE
Fix recipe short names with version constraints

### DIFF
--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -50,17 +50,24 @@ class Chef
     #   "aws::elastic_ip" returns [:aws, "elastic_ip"]
     #   "aws" returns [:aws, "default"]
     #   "::elastic_ip" returns [ current_cookbook, "elastic_ip" ]
+    #   "aws::elastic_ip@1.2.3" returns [:aws, "elastic_ip"]
+    #   "aws@1.2.3" returns [:aws, "default"]
+    #   "::elastic_ip@1.2.3" returns [:aws, "default"]
+    #
+    # Fails with RecipeNotFound if current_cookbook is nil.
     #--
     # TODO: Duplicates functionality of RunListItem
     def self.parse_recipe_name(recipe_name, current_cookbook: nil)
-      case recipe_name
+      recipe = recipe_name.sub /@(\d\.){0,2}(\d){1}$/i, ''
+      case recipe
       when /(.+?)::(.+)/
-        [ $1.to_sym, $2 ]
+        [$1.to_sym, $2]
       when /^::(.+)/
-        raise "current_cookbook is nil, cannot resolve #{recipe_name}" if current_cookbook.nil?
-        [ current_cookbook.to_sym, $1 ]
+        raise Chef::Exceptions::RecipeNotFound, 'current_cookbook is nil, ' \
+          "cannot resolve #{recipe_name}" if current_cookbook.nil?
+        [current_cookbook.to_sym, $1]
       else
-        [ recipe_name.to_sym, "default" ]
+        [recipe.to_sym, 'default']
       end
     end
 

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -63,8 +63,7 @@ class Chef
       when /(.+?)::(.+)/
         [$1.to_sym, $2]
       when /^::(.+)/
-        raise Chef::Exceptions::RecipeNotFound, 'current_cookbook is nil, ' \
-          "cannot resolve #{recipe_name}" if current_cookbook.nil?
+        raise Chef::Exceptions::RecipeNotFound, "current_cookbook is nil, cannot resolve #{recipe_name}" if current_cookbook.nil?
         [current_cookbook.to_sym, $1]
       else
         [recipe.to_sym, 'default']

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -63,7 +63,8 @@ class Chef
       when /(.+?)::(.+)/
         [$1.to_sym, $2]
       when /^::(.+)/
-        raise Chef::Exceptions::RecipeNotFound, "current_cookbook is nil, cannot resolve #{recipe_name}" if current_cookbook.nil?
+        raise Chef::Exceptions::RecipeNotFound, "current_cookbook is nil, " \
+          "cannot resolve #{recipe_name}" if current_cookbook.nil?
         [current_cookbook.to_sym, $1]
       else
         [recipe.to_sym, 'default']

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -50,6 +50,21 @@ describe "chef-client" do
 
   let(:critical_env_vars) { %w(PATH RUBYOPT BUNDLE_GEMFILE GEM_PATH).map {|o| "#{o}=#{ENV[o]}"} .join(' ') }
 
+  context 'with fully-qualified recipes' do
+    before(:all) { start_tiny_server }
+    after(:all) { stop_tiny_server }
+
+    it 'should load the recipes' do
+      file 'config/client.rb', <<-EOM
+        local_mode true
+        cookbook_path "#{path_to('cookbooks')}"
+        EOM
+      result = shell_out "#{chef_client} -c '#{path_to 'config/client.rb'}' " \
+         "--recipe-url=http://localhost:9000/recipes.tgz -o 'x::default@0.0.1'"
+      result.error!
+    end
+  end
+
   when_the_repository "has a cookbook with a no-op recipe" do
     before { file 'cookbooks/x/recipes/default.rb', '' }
 

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -23,6 +23,40 @@ require 'spec_helper'
 require 'chef/platform/resource_priority_map'
 
 describe Chef::Recipe do
+  describe 'parses recipe names' do
+    it "parses 'a::b'" do
+      expect(Chef::Recipe.parse_recipe_name 'a::b').to eql [:a, 'b']
+    end
+
+    it "parses 'a'" do
+      expect(Chef::Recipe.parse_recipe_name 'a').to eql [:a, 'default']
+    end
+
+    it "parses '::b'" do
+      expect(Chef::Recipe.parse_recipe_name '::b', current_cookbook: 'a').to eql [:a, 'b']
+    end
+
+    it "parses '::b' with nil current_cookbook" do
+      expect { Chef::Recipe.parse_recipe_name '::b', current_cookbook: nil }.to raise_exception Chef::Exceptions::RecipeNotFound
+    end
+
+    it "parses 'a::b@1.2.3'" do
+      expect(Chef::Recipe.parse_recipe_name 'a::b@1.2.3').to eql [:a, 'b']
+    end
+
+    it "parses 'a@1.2.3'" do
+      expect(Chef::Recipe.parse_recipe_name 'a@1.2.3').to eql [:a, 'default']
+    end
+
+    it "parses '::b@1.2.3'" do
+      expect(Chef::Recipe.parse_recipe_name '::b@1.2.3', current_cookbook: 'a').to eql [:a, 'b']
+    end
+
+    it "parses '::b@1.2.3' with nil current_cookbook" do
+      # FIXME: This fails for some reason
+      expect { Chef::Recipe.parse_recipe_name '::b@1.2.3', current_cookbook: nil }.to raise_exception Chef::Exceptions::RecipeNotFound
+    end
+  end
 
   let(:cookbook_repo) { File.expand_path(File.join(File.dirname(__FILE__), "..", "data", "cookbooks")) }
 

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -23,38 +23,44 @@ require 'spec_helper'
 require 'chef/platform/resource_priority_map'
 
 describe Chef::Recipe do
-  describe 'parses recipe names' do
-    it "parses 'a::b'" do
-      expect(Chef::Recipe.parse_recipe_name 'a::b').to eql [:a, 'b']
-    end
+  describe '#parse_recipe_name' do
+    context 'with full naming and version constraints' do
+      it "parses 'a::b'" do
+        expect(Chef::Recipe.parse_recipe_name 'a::b').to eql [:a, 'b']
+      end
 
-    it "parses 'a'" do
-      expect(Chef::Recipe.parse_recipe_name 'a').to eql [:a, 'default']
-    end
+      it "parses 'a'" do
+        expect(Chef::Recipe.parse_recipe_name 'a').to eql [:a, 'default']
+      end
 
-    it "parses '::b'" do
-      expect(Chef::Recipe.parse_recipe_name '::b', current_cookbook: 'a').to eql [:a, 'b']
-    end
+      it "parses '::b'" do
+        expect(Chef::Recipe.parse_recipe_name '::b', current_cookbook: 'a')
+          .to eql [:a, 'b']
+      end
 
-    it "parses '::b' with nil current_cookbook" do
-      expect { Chef::Recipe.parse_recipe_name '::b', current_cookbook: nil }.to raise_exception Chef::Exceptions::RecipeNotFound
-    end
+      it "parses '::b' with nil current_cookbook" do
+        expect { Chef::Recipe.parse_recipe_name '::b', current_cookbook: nil }
+          .to raise_exception Chef::Exceptions::RecipeNotFound
+      end
 
-    it "parses 'a::b@1.2.3'" do
-      expect(Chef::Recipe.parse_recipe_name 'a::b@1.2.3').to eql [:a, 'b']
-    end
+      it "parses 'a::b@1.2.3'" do
+        expect(Chef::Recipe.parse_recipe_name 'a::b@1.2.3').to eql [:a, 'b']
+      end
 
-    it "parses 'a@1.2.3'" do
-      expect(Chef::Recipe.parse_recipe_name 'a@1.2.3').to eql [:a, 'default']
-    end
+      it "parses 'a@1.2.3'" do
+        expect(Chef::Recipe.parse_recipe_name 'a@1.2.3').to eql [:a, 'default']
+      end
 
-    it "parses '::b@1.2.3'" do
-      expect(Chef::Recipe.parse_recipe_name '::b@1.2.3', current_cookbook: 'a').to eql [:a, 'b']
-    end
+      it "parses '::b@1.2.3'" do
+        expect(Chef::Recipe.parse_recipe_name '::b@1.2.3',
+          current_cookbook: 'a').to eql [:a, 'b']
+      end
 
-    it "parses '::b@1.2.3' with nil current_cookbook" do
-      # FIXME: This fails for some reason
-      expect { Chef::Recipe.parse_recipe_name '::b@1.2.3', current_cookbook: nil }.to raise_exception Chef::Exceptions::RecipeNotFound
+      it "parses '::b@1.2.3' with nil current_cookbook" do
+        expect { Chef::Recipe.parse_recipe_name '::b@1.2.3',
+          current_cookbook: nil }
+            .to raise_exception Chef::Exceptions::RecipeNotFound
+      end
     end
   end
 


### PR DESCRIPTION
[See my original comment for background details](https://github.com/chef/chef/commit/db62393671925bd778193c3ed8b2af49ccbb63a4#diff-24f6d563d14f4c6af13813c23ab046a5R375).

Essentially, `Chef::Recipe#parse_recipe_name` is a problematic method that does not account for version constraints. This results in recipes being "not found" because it's looking for, like, "recipe@1.2.3" instead of "recipe", and `Chef::Exceptions::RecipeNotFound` errors are raised under certain circumstances.

I'm not sure if this is the right approach, or if it deserves more consideration for the `Node` accessor methods mentioned in my comments (link above).

I also am not sure what chef/chef branch I should put this PR against.

@justinredd @double-z @danielsdeleo @lamont-granquist 