### PR TITLE
Simplify LWRP Deprecations Proposal 1

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1499,56 +1499,11 @@ class Chef
         Chef::Resource.send(:remove_const, class_name)
       end
 
-      # In order to generate deprecation warnings when you use Chef::Resource::MyLwrp,
-      # we make a special subclass (identical in nearly all respects) of the
-      # actual LWRP.  When you say any of these, a deprecation warning will be
-      # generated:
-      #
-      # - Chef::Resource::MyLwrp.new(...)
-      # - resource.is_a?(Chef::Resource::MyLwrp)
-      # - resource.kind_of?(Chef::Resource::MyLwrp)
-      # - case resource
-      #   when Chef::Resource::MyLwrp
-      #   end
-      #
-      resource_subclass = Class.new(resource_class) do
-        resource_name nil # we do not actually provide anything
-        def initialize(*args, &block)
-          Chef::Log.deprecation("Using an LWRP by its name (#{self.class.name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
-          super
-        end
-        def self.resource_name(*args)
-          if args.empty?
-            @resource_name ||= superclass.resource_name
-          else
-            super
-          end
-        end
-        self
+      if !Chef::Config[:treat_deprecation_warnings_as_errors]
+        Chef::Resource.const_set(class_name, resource_class)
+        deprecated_constants[class_name.to_sym] = resource_class
       end
-      eval("Chef::Resource::#{class_name} = resource_subclass")
-      # Make case, is_a and kind_of work with the new subclass, for backcompat.
-      # Any subclass of Chef::Resource::ResourceClass is already a subclass of resource_class
-      # Any subclass of resource_class is considered a subclass of Chef::Resource::ResourceClass
-      resource_class.class_eval do
-        define_method(:is_a?) do |other|
-          other.is_a?(Module) && other === self
-        end
-        define_method(:kind_of?) do |other|
-          other.is_a?(Module) && other === self
-        end
-      end
-      resource_subclass.class_eval do
-        define_singleton_method(:===) do |other|
-          Chef::Log.deprecation("Using an LWRP by its name (#{class_name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
-          # resource_subclass is a superclass of all resource_class descendants.
-          if self == resource_subclass && other.class <= resource_class
-            return true
-          end
-          super(other)
-        end
-      end
-      deprecated_constants[class_name.to_sym] = resource_subclass
+
     end
 
     def self.deprecated_constants

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1499,9 +1499,56 @@ class Chef
         Chef::Resource.send(:remove_const, class_name)
       end
 
-      Chef::Resource.const_set(class_name, resource_class)
-
-      deprecated_constants[class_name.to_sym] = resource_class
+      # In order to generate deprecation warnings when you use Chef::Resource::MyLwrp,
+      # we make a special subclass (identical in nearly all respects) of the
+      # actual LWRP.  When you say any of these, a deprecation warning will be
+      # generated:
+      #
+      # - Chef::Resource::MyLwrp.new(...)
+      # - resource.is_a?(Chef::Resource::MyLwrp)
+      # - resource.kind_of?(Chef::Resource::MyLwrp)
+      # - case resource
+      #   when Chef::Resource::MyLwrp
+      #   end
+      #
+      resource_subclass = Class.new(resource_class) do
+        resource_name nil # we do not actually provide anything
+        def initialize(*args, &block)
+          Chef::Log.deprecation("Using an LWRP by its name (#{self.class.name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
+          super
+        end
+        def self.resource_name(*args)
+          if args.empty?
+            @resource_name ||= superclass.resource_name
+          else
+            super
+          end
+        end
+        self
+      end
+      eval("Chef::Resource::#{class_name} = resource_subclass")
+      # Make case, is_a and kind_of work with the new subclass, for backcompat.
+      # Any subclass of Chef::Resource::ResourceClass is already a subclass of resource_class
+      # Any subclass of resource_class is considered a subclass of Chef::Resource::ResourceClass
+      resource_class.class_eval do
+        define_method(:is_a?) do |other|
+          other.is_a?(Module) && other === self
+        end
+        define_method(:kind_of?) do |other|
+          other.is_a?(Module) && other === self
+        end
+      end
+      resource_subclass.class_eval do
+        define_singleton_method(:===) do |other|
+          Chef::Log.deprecation("Using an LWRP by its name (#{class_name}) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.")
+          # resource_subclass is a superclass of all resource_class descendants.
+          if self == resource_subclass && other.class <= resource_class
+            return true
+          end
+          super(other)
+        end
+      end
+      deprecated_constants[class_name.to_sym] = resource_subclass
     end
 
     def self.deprecated_constants

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -177,6 +177,16 @@ describe "LWRP" do
       end
     end
 
+    it "allows monkey patching of the lwrp through Chef::Resource" do
+      monkey = Module.new do
+        def issue_3607
+        end
+      end
+      allow(Chef::Config).to receive(:[]).with(:treat_deprecation_warnings_as_errors).and_return(false)
+      Chef::Resource::LwrpFoo.send(:include, monkey)
+      expect { get_lwrp(:lwrp_foo).new("blah").issue_3607 }.not_to raise_error
+    end
+
     it "should load the resource into a properly-named class and emit a warning when it is initialized" do
       expect { Chef::Resource::LwrpFoo.new('hi') }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
     end

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -177,16 +177,6 @@ describe "LWRP" do
       end
     end
 
-    it "allows monkey patching of the lwrp through Chef::Resource" do
-      monkey = Module.new do
-        def issue_3607
-        end
-      end
-      allow(Chef::Config).to receive(:[]).with(:treat_deprecation_warnings_as_errors).and_return(false)
-      Chef::Resource::LwrpFoo.send(:include, monkey)
-      expect { get_lwrp(:lwrp_foo).new("blah").issue_3607 }.not_to raise_error
-    end
-
     it "should load the resource into a properly-named class and emit a warning when it is initialized" do
       expect { Chef::Resource::LwrpFoo.new('hi') }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
     end

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -177,20 +177,6 @@ describe "LWRP" do
       end
     end
 
-    it "allows monkey patching of the lwrp through Chef::Resource" do
-      monkey = Module.new do
-        def issue_3607
-        end
-      end
-      allow(Chef::Config).to receive(:[]).with(:treat_deprecation_warnings_as_errors).and_return(false)
-      Chef::Resource::LwrpFoo.send(:include, monkey)
-      expect { get_lwrp(:lwrp_foo).new("blah").issue_3607 }.not_to raise_error
-    end
-
-    it "should load the resource into a properly-named class and emit a warning when it is initialized" do
-      expect { Chef::Resource::LwrpFoo.new('hi') }.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-    end
-
     it "should be resolvable with Chef::ResourceResolver.resolve(:lwrp_foo)" do
       expect(Chef::ResourceResolver.resolve(:lwrp_foo, node: Chef::Node.new)).to eq(get_lwrp(:lwrp_foo))
     end
@@ -236,127 +222,6 @@ describe "LWRP" do
       expect(cls.node).to be_kind_of(Chef::Node)
       expect(cls.run_context).to be_kind_of(Chef::RunContext)
       expect(cls.node[:penguin_name]).to eql("jackass")
-    end
-
-    context "resource class created" do
-      before do
-        @old_treat_deprecation_warnings_as_errors = Chef::Config[:treat_deprecation_warnings_as_errors]
-        Chef::Config[:treat_deprecation_warnings_as_errors] = false
-      end
-      after do
-        Chef::Config[:treat_deprecation_warnings_as_errors] = @old_treat_deprecation_warnings_as_errors
-      end
-
-      it "should load the resource into a properly-named class" do
-        expect(Chef::Resource::LwrpFoo).to be_kind_of(Class)
-        expect(Chef::Resource::LwrpFoo <= Chef::Resource::LWRPBase).to be_truthy
-      end
-
-      it "get_lwrp(:lwrp_foo).new is a Chef::Resource::LwrpFoo" do
-        lwrp = get_lwrp(:lwrp_foo).new('hi')
-        expect(lwrp.kind_of?(Chef::Resource::LwrpFoo)).to be_truthy
-        expect(lwrp.is_a?(Chef::Resource::LwrpFoo)).to be_truthy
-        expect(get_lwrp(:lwrp_foo) === lwrp).to be_truthy
-        expect(Chef::Resource::LwrpFoo === lwrp).to be_truthy
-      end
-
-      it "Chef::Resource::LwrpFoo.new is a get_lwrp(:lwrp_foo)" do
-        lwrp = Chef::Resource::LwrpFoo.new('hi')
-        expect(lwrp.kind_of?(get_lwrp(:lwrp_foo))).to be_truthy
-        expect(lwrp.is_a?(get_lwrp(:lwrp_foo))).to be_truthy
-        expect(get_lwrp(:lwrp_foo) === lwrp).to be_truthy
-        expect(Chef::Resource::LwrpFoo === lwrp).to be_truthy
-      end
-
-      it "works even if LwrpFoo exists in the top level" do
-        module ::LwrpFoo
-        end
-        expect(Chef::Resource::LwrpFoo).not_to eq(::LwrpFoo)
-      end
-
-      context "with a subclass of get_lwrp(:lwrp_foo)" do
-        let(:subclass) do
-          Class.new(get_lwrp(:lwrp_foo))
-        end
-
-        it "subclass.new is a subclass" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_truthy
-          expect(lwrp.is_a?(subclass)).to be_truthy
-          expect(subclass === lwrp).to be_truthy
-          expect(lwrp.class === subclass)
-        end
-        it "subclass.new is a Chef::Resource::LwrpFoo" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(Chef::Resource::LwrpFoo)).to be_truthy
-          expect(lwrp.is_a?(Chef::Resource::LwrpFoo)).to be_truthy
-          expect(Chef::Resource::LwrpFoo === lwrp).to be_truthy
-          expect(lwrp.class === Chef::Resource::LwrpFoo)
-        end
-        it "subclass.new is a get_lwrp(:lwrp_foo)" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(get_lwrp(:lwrp_foo))).to be_truthy
-          expect(lwrp.is_a?(get_lwrp(:lwrp_foo))).to be_truthy
-          expect(get_lwrp(:lwrp_foo) === lwrp).to be_truthy
-          expect(lwrp.class === get_lwrp(:lwrp_foo))
-        end
-        it "Chef::Resource::LwrpFoo.new is *not* a subclass" do
-          lwrp = Chef::Resource::LwrpFoo.new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_falsey
-          expect(lwrp.is_a?(subclass)).to be_falsey
-          expect(subclass === lwrp.class).to be_falsey
-          expect(subclass === Chef::Resource::LwrpFoo).to be_falsey
-        end
-        it "get_lwrp(:lwrp_foo).new is *not* a subclass" do
-          lwrp = get_lwrp(:lwrp_foo).new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_falsey
-          expect(lwrp.is_a?(subclass)).to be_falsey
-          expect(subclass === lwrp.class).to be_falsey
-          expect(subclass === get_lwrp(:lwrp_foo)).to be_falsey
-        end
-      end
-
-      context "with a subclass of Chef::Resource::LwrpFoo" do
-        let(:subclass) do
-          Class.new(Chef::Resource::LwrpFoo)
-        end
-
-        it "subclass.new is a subclass" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_truthy
-          expect(lwrp.is_a?(subclass)).to be_truthy
-          expect(subclass === lwrp).to be_truthy
-          expect(lwrp.class === subclass)
-        end
-        it "subclass.new is a Chef::Resource::LwrpFoo" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(Chef::Resource::LwrpFoo)).to be_truthy
-          expect(lwrp.is_a?(Chef::Resource::LwrpFoo)).to be_truthy
-          expect(Chef::Resource::LwrpFoo === lwrp).to be_truthy
-          expect(lwrp.class === Chef::Resource::LwrpFoo)
-        end
-        it "subclass.new is a get_lwrp(:lwrp_foo)" do
-          lwrp = subclass.new('hi')
-          expect(lwrp.kind_of?(get_lwrp(:lwrp_foo))).to be_truthy
-          expect(lwrp.is_a?(get_lwrp(:lwrp_foo))).to be_truthy
-          expect(get_lwrp(:lwrp_foo) === lwrp).to be_truthy
-          expect(lwrp.class === get_lwrp(:lwrp_foo))
-        end
-        it "Chef::Resource::LwrpFoo.new is *not* a subclass" do
-          lwrp = Chef::Resource::LwrpFoo.new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_falsey
-          expect(lwrp.is_a?(subclass)).to be_falsey
-          expect(subclass === lwrp.class).to be_falsey
-          expect(subclass === Chef::Resource::LwrpFoo).to be_falsey
-        end
-        it "get_lwrp(:lwrp_foo).new is *not* a subclass" do
-          lwrp = get_lwrp(:lwrp_foo).new('hi')
-          expect(lwrp.kind_of?(subclass)).to be_falsey
-          expect(lwrp.is_a?(subclass)).to be_falsey
-          expect(subclass === lwrp.class).to be_falsey
-          expect(subclass === get_lwrp(:lwrp_foo)).to be_falsey
-        end
-      end
     end
 
     context "resource_name" do
@@ -714,7 +579,144 @@ describe "LWRP" do
       end
 
     end
-
   end
 
+  context "resource class created" do
+    before(:context) do
+      @tmpdir = Dir.mktmpdir("lwrp_test")
+      resource_path = File.join(@tmpdir, "once.rb")
+      IO.write(resource_path, "default_action :create")
+
+      @old_treat_deprecation_warnings_as_errors = Chef::Config[:treat_deprecation_warnings_as_errors]
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+      Chef::Resource::LWRPBase.build_from_file("lwrp", resource_path, nil)
+    end
+
+    after(:context) do
+      FileUtils.remove_entry @tmpdir
+      Chef::Config[:treat_deprecation_warnings_as_errors] = @old_treat_deprecation_warnings_as_errors
+    end
+
+    it "should load the resource into a properly-named class" do
+      expect(Chef::Resource::LwrpOnce).to be_kind_of(Class)
+      expect(Chef::Resource::LwrpOnce <= Chef::Resource::LWRPBase).to be_truthy
+    end
+
+    it "get_lwrp(:lwrp_once).new is a Chef::Resource::LwrpOnce" do
+      lwrp = get_lwrp(:lwrp_once).new('hi')
+      expect(lwrp.kind_of?(Chef::Resource::LwrpOnce)).to be_truthy
+      expect(lwrp.is_a?(Chef::Resource::LwrpOnce)).to be_truthy
+      expect(get_lwrp(:lwrp_once) === lwrp).to be_truthy
+      expect(Chef::Resource::LwrpOnce === lwrp).to be_truthy
+    end
+
+    it "Chef::Resource::LwrpOnce.new is a get_lwrp(:lwrp_once)" do
+      lwrp = Chef::Resource::LwrpOnce.new('hi')
+      expect(lwrp.kind_of?(get_lwrp(:lwrp_once))).to be_truthy
+      expect(lwrp.is_a?(get_lwrp(:lwrp_once))).to be_truthy
+      expect(get_lwrp(:lwrp_once) === lwrp).to be_truthy
+      expect(Chef::Resource::LwrpOnce === lwrp).to be_truthy
+    end
+
+    it "works even if LwrpOnce exists in the top level" do
+      module ::LwrpOnce
+      end
+      expect(Chef::Resource::LwrpOnce).not_to eq(::LwrpOnce)
+    end
+
+    it "allows monkey patching of the lwrp through Chef::Resource" do
+      monkey = Module.new do
+        def issue_3607
+        end
+      end
+      Chef::Resource::LwrpOnce.send(:include, monkey)
+      expect { get_lwrp(:lwrp_once).new("blah").issue_3607 }.not_to raise_error
+    end
+
+    context "with a subclass of get_lwrp(:lwrp_once)" do
+      let(:subclass) do
+        Class.new(get_lwrp(:lwrp_once))
+      end
+
+      it "subclass.new is a subclass" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_truthy
+        expect(lwrp.is_a?(subclass)).to be_truthy
+        expect(subclass === lwrp).to be_truthy
+        expect(lwrp.class === subclass)
+      end
+      it "subclass.new is a Chef::Resource::LwrpOnce" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(Chef::Resource::LwrpOnce)).to be_truthy
+        expect(lwrp.is_a?(Chef::Resource::LwrpOnce)).to be_truthy
+        expect(Chef::Resource::LwrpOnce === lwrp).to be_truthy
+        expect(lwrp.class === Chef::Resource::LwrpOnce)
+      end
+      it "subclass.new is a get_lwrp(:lwrp_once)" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(get_lwrp(:lwrp_once))).to be_truthy
+        expect(lwrp.is_a?(get_lwrp(:lwrp_once))).to be_truthy
+        expect(get_lwrp(:lwrp_once) === lwrp).to be_truthy
+        expect(lwrp.class === get_lwrp(:lwrp_once))
+      end
+      it "Chef::Resource::LwrpOnce.new is *not* a subclass" do
+        lwrp = Chef::Resource::LwrpOnce.new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_falsey
+        expect(lwrp.is_a?(subclass)).to be_falsey
+        expect(subclass === lwrp.class).to be_falsey
+        expect(subclass === Chef::Resource::LwrpOnce).to be_falsey
+      end
+      it "get_lwrp(:lwrp_once).new is *not* a subclass" do
+        lwrp = get_lwrp(:lwrp_once).new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_falsey
+        expect(lwrp.is_a?(subclass)).to be_falsey
+        expect(subclass === lwrp.class).to be_falsey
+        expect(subclass === get_lwrp(:lwrp_once)).to be_falsey
+      end
+    end
+
+    context "with a subclass of Chef::Resource::LwrpOnce" do
+      let(:subclass) do
+        Class.new(Chef::Resource::LwrpOnce)
+      end
+
+      it "subclass.new is a subclass" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_truthy
+        expect(lwrp.is_a?(subclass)).to be_truthy
+        expect(subclass === lwrp).to be_truthy
+        expect(lwrp.class === subclass)
+      end
+      it "subclass.new is a Chef::Resource::LwrpOnce" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(Chef::Resource::LwrpOnce)).to be_truthy
+        expect(lwrp.is_a?(Chef::Resource::LwrpOnce)).to be_truthy
+        expect(Chef::Resource::LwrpOnce === lwrp).to be_truthy
+        expect(lwrp.class === Chef::Resource::LwrpOnce)
+      end
+      it "subclass.new is a get_lwrp(:lwrp_once)" do
+        lwrp = subclass.new('hi')
+        expect(lwrp.kind_of?(get_lwrp(:lwrp_once))).to be_truthy
+        expect(lwrp.is_a?(get_lwrp(:lwrp_once))).to be_truthy
+        expect(get_lwrp(:lwrp_once) === lwrp).to be_truthy
+        expect(lwrp.class === get_lwrp(:lwrp_once))
+      end
+      it "Chef::Resource::LwrpOnce.new is *not* a subclass" do
+        lwrp = Chef::Resource::LwrpOnce.new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_falsey
+        expect(lwrp.is_a?(subclass)).to be_falsey
+        expect(subclass === lwrp.class).to be_falsey
+        expect(subclass === Chef::Resource::LwrpOnce).to be_falsey
+      end
+      it "get_lwrp(:lwrp_once).new is *not* a subclass" do
+        lwrp = get_lwrp(:lwrp_once).new('hi')
+        expect(lwrp.kind_of?(subclass)).to be_falsey
+        expect(lwrp.is_a?(subclass)).to be_falsey
+        expect(subclass === lwrp.class).to be_falsey
+        expect(subclass === get_lwrp(:lwrp_once)).to be_falsey
+      end
+    end
+  end
 end
+
+


### PR DESCRIPTION
Our logic for creating the deprecation class was too complicated and had
a lot of edge cases. Simplifying here to only deprecate when
`:treat_deprecation_warnings_as_errors` is set. This means that warnings
will no longer be printed, however this is a lot less risky.

Loading the lwrp multiple times causes problems when comparing classes
due to the their dynamic nature. It worked fine when we were overriding
the things that checked.

I've left the tests mostly as is, other than the fact that the test
lwrp is loaded only once. The tests should still hold true, even
with the new implementation.