### PR TITLE
Add "property" with identity and desired_state

### DIFF
--- a/lib/chef/constants.rb
+++ b/lib/chef/constants.rb
@@ -1,0 +1,20 @@
+#
+# Author:: John Keiser <jkeiser@chef.io>
+# Copyright:: Copyright (c) 2015 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  NOT_PASSED = Object.new
+end

--- a/lib/chef/constants.rb
+++ b/lib/chef/constants.rb
@@ -17,4 +17,11 @@
 
 class Chef
   NOT_PASSED = Object.new
+  def NOT_PASSED.to_s
+    "NOT_PASSED"
+  end
+  def NOT_PASSED.inspect
+    to_s
+  end
+  NOT_PASSED.freeze
 end

--- a/lib/chef/delayed_evaluator.rb
+++ b/lib/chef/delayed_evaluator.rb
@@ -1,0 +1,21 @@
+#
+# Author:: John Keiser <jkeiser@chef.io>
+# Copyright:: Copyright (c) 2015 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  class DelayedEvaluator < Proc
+  end
+end

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -103,6 +103,7 @@ class Chef
     class ProviderNotFound < RuntimeError; end
     NoProviderAvailable = ProviderNotFound
     class VerificationNotFound < RuntimeError; end
+    class MultipleIdentityError < RuntimeError; end
 
     # Can't find a Resource of this type that is valid on this platform.
     class NoSuchResourceType < NameError

--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class Chef
-  NOT_PASSED = Object.new
+require 'chef/constants'
+require 'chef/property'
+require 'chef/delayed_evaluator'
 
-  class DelayedEvaluator < Proc
-  end
+class Chef
   module Mixin
     module ParamsValidate
 
@@ -34,20 +34,55 @@ class Chef
       # Would raise an exception if the value of :one above is not a kind_of? string.  Valid
       # map options are:
       #
-      # :default:: Sets the default value for this parameter.
-      # :callbacks:: Takes a hash of Procs, which should return true if the argument is valid.
-      #              The key will be inserted into the error message if the Proc does not return true:
-      #                 "Option #{key}'s value #{value} #{message}!"
-      # :kind_of:: Ensure that the value is a kind_of?(Whatever).  If passed an array, it will ensure
-      #            that the value is one of those types.
-      # :respond_to:: Ensure that the value has a given method.  Takes one method name or an array of
-      #               method names.
-      # :required:: Raise an exception if this parameter is missing. Valid values are true or false,
-      #             by default, options are not required.
-      # :regex:: Match the value of the parameter against a regular expression.
-      # :equal_to:: Match the value of the parameter with ==.  An array means it can be equal to any
-      #             of the values.
+      # @param opts [Hash<Symbol,Object>] Validation opts.
+      #   @option opts [Object,Array] :is An object, or list of
+      #     objects, that must match the value using Ruby's `===` operator
+      #     (`opts[:is].any? { |v| v === value }`). (See #_pv_is.)
+      #   @option opts [Object,Array] :equal_to An object, or list
+      #     of objects, that must be equal to the value using Ruby's `==`
+      #     operator (`opts[:is].any? { |v| v == value }`)  (See #_pv_equal_to.)
+      #   @option opts [Regexp,Array<Regexp>] :regex An object, or
+      #     list of objects, that must match the value with `regex.match(value)`.
+      #     (See #_pv_regex)
+      #   @option opts [Class,Array<Class>] :kind_of A class, or
+      #     list of classes, that the value must be an instance of.  (See
+      #     #_pv_kind_of.)
+      #   @option opts [Hash<String,Proc>] :callbacks A hash of
+      #     messages -> procs, all of which match the value. The proc must
+      #     return a truthy or falsey value (true means it matches).  (See
+      #     #_pv_callbacks.)
+      #   @option opts [Symbol,Array<Symbol>] :respond_to A method
+      #     name, or list of method names, the value must respond to.  (See
+      #     #_pv_respond_to.)
+      #   @option opts [Symbol,Array<Symbol>] :cannot_be A property,
+      #     or a list of properties, that the value cannot have (such as `:nil` or
+      #     `:empty`). The method with a questionmark at the end is called on the
+      #     value (e.g. `value.empty?`). If the value does not have this method,
+      #     it is considered valid (i.e. if you don't respond to `empty?` we
+      #     assume you are not empty).  (See #_pv_cannot_be.)
+      #   @option opts [Proc] :coerce A proc which will be called to
+      #     transform the user input to canonical form. The value is passed in,
+      #     and the transformed value returned as output. Lazy values will *not*
+      #     be passed to this method until after they are evaluated. Called in the
+      #     context of the resource (meaning you can access other properties).
+      #     (See #_pv_coerce.) (See #_pv_coerce.)
+      #   @option opts [Boolean] :required `true` if this property
+      #     must be present and not `nil`; `false` otherwise. This is checked
+      #     after the resource is fully initialized. (See #_pv_required.)
+      #   @option opts [Boolean] :name_property `true` if this
+      #     property defaults to the same value as `name`. Equivalent to
+      #     `default: lazy { name }`, except that #property_is_set? will
+      #     return `true` if the property is set *or* if `name` is set. (See
+      #     #_pv_name_property.)
+      #   @option opts [Boolean] :name_attribute Same as `name_property`.
+      #   @option opts [Object] :default The value this property
+      #     will return if the user does not set one. If this is `lazy`, it will
+      #     be run in the context of the instance (and able to access other
+      #     properties).  (See #_pv_default.)
+      #
       def validate(opts, map)
+        map = map.validation_options if map.is_a?(Property)
+
         #--
         # validate works by taking the keys in the validation map, assuming it's a hash, and
         # looking for _pv_:symbol as methods.  Assuming it find them, it calls the right
@@ -84,91 +119,8 @@ class Chef
       end
 
       def set_or_return(symbol, value, validation)
-        symbol = symbol.to_sym
-        iv_symbol = :"@#{symbol}"
-
-        # Steal default, coerce, name_property and required from validation
-        # so that we can handle the order in which they are applied
-        validation = validation.dup
-        if validation.has_key?(:default)
-          default = validation.delete(:default)
-        elsif validation.has_key?('default')
-          default = validation.delete('default')
-        else
-          default = NOT_PASSED
-        end
-        coerce    = validation.delete(:coerce)
-        coerce  ||= validation.delete('coerce')
-        name_property   = validation.delete(:name_property)
-        name_property ||= validation.delete('name_property')
-        name_property ||= validation.delete(:name_attribute)
-        name_property ||= validation.delete('name_attribute')
-        required   = validation.delete(:required)
-        required ||= validation.delete('required')
-
-        opts = {}
-        # If the user passed NOT_PASSED, or passed nil, then this is a get.
-        if value == NOT_PASSED || (value.nil? && !explicitly_allows_nil?(symbol, validation))
-
-          # Get the value if there is one
-          if self.instance_variable_defined?(iv_symbol)
-            opts[symbol] = self.instance_variable_get(iv_symbol)
-
-            # Handle lazy values
-            if opts[symbol].is_a?(DelayedEvaluator)
-              if opts[symbol].arity >= 1
-                opts[symbol] = opts[symbol].call(self)
-              else
-                opts[symbol] = opts[symbol].call
-              end
-
-              # Coerce and validate the default value
-              _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
-              _pv_coerce(opts, symbol, coerce) if coerce
-              validate(opts, { symbol => validation })
-            end
-
-          # Get the default value
-          else
-            _pv_default(opts, symbol, default) unless default == NOT_PASSED
-            _pv_name_property(opts, symbol, name_property)
-            _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
-
-            if opts.has_key?(symbol)
-              # Handle lazy defaults.
-              if opts[symbol].is_a?(DelayedEvaluator)
-                if opts[symbol].arity >= 1
-                  opts[symbol] = opts[symbol].call(self)
-                else
-                  opts[symbol] = instance_eval(&opts[symbol])
-                end
-              end
-
-              # Coerce and validate the default value
-              _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
-              _pv_coerce(opts, symbol, coerce) if coerce
-              # We presently do not validate defaults, for backwards compatibility.
-#              validate(opts, { symbol => validation })
-
-              # Defaults are presently "stickily" set on the instance
-              self.instance_variable_set(iv_symbol, opts[symbol])
-            end
-          end
-
-        # Set the value
-        else
-          opts[symbol] = value
-          unless opts[symbol].is_a?(DelayedEvaluator)
-            # Coerce and validate the value
-            _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
-            _pv_coerce(opts, symbol, coerce) if coerce
-            validate(opts, { symbol => validation })
-          end
-
-          self.instance_variable_set(iv_symbol, opts[symbol])
-        end
-
-        opts[symbol]
+        property = Property::NonDeprecatedNilGetter.new(name: symbol, **validation)
+        property.call(self, value)
       end
 
       private
@@ -193,8 +145,9 @@ class Chef
         if is_required
           return true if opts.has_key?(key.to_s) && (explicitly_allows_nil || !opts[key.to_s].nil?)
           return true if opts.has_key?(key.to_sym) && (explicitly_allows_nil || !opts[key.to_sym].nil?)
-          raise Exceptions::ValidationFailed, "Required argument #{key} is missing!"
+          raise Exceptions::ValidationFailed, "Required argument #{key.inspect} is missing!"
         end
+        true
       end
 
       #
@@ -425,9 +378,9 @@ class Chef
       #   x 1 #=> invalid
       #   ```
       #
-      # @example PropertyType
+      # @example Property
       #   ```ruby
-      #   type = PropertyType.new(is: String)
+      #   type = Property.new(is: String)
       #   property :x, type
       #   x 'foo' #=> valid
       #   x 1     #=> invalid
@@ -448,8 +401,12 @@ class Chef
         value = _pv_opts_lookup(opts, key)
         to_be = [ to_be ].flatten(1)
         to_be.each do |tb|
-          if tb.is_a?(Proc)
+          case tb
+          when Proc
             return true if instance_exec(value, &tb)
+          when Property
+            validate(opts, { key => tb.validation_options })
+            return true
           else
             return true if tb === value
           end

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -1,0 +1,491 @@
+require 'chef/exceptions'
+require 'chef/delayed_evaluator'
+
+class Chef
+  #
+  # Type and validation information for a property on a resource.
+  #
+  # A property named "x" manipulates the "@x" instance variable on a
+  # resource.  The *presence* of the variable (`instance_variable_defined?(@x)`)
+  # tells whether the variable is defined; it may have any actual value,
+  # constrained only by validation.
+  #
+  # Properties may have validation, defaults, and coercion, and have full
+  # support for lazy values.
+  #
+  # @see Chef::Resource.property
+  # @see Chef::DelayedEvaluator
+  #
+  class Property
+    #
+    # Create a new property.
+    #
+    # @param options [Hash<Symbol,Object>] Property options, including
+    #   control options here, as well as validation options (see
+    #   Chef::Mixin::ParamsValidate#validate for a description of validation
+    #   options).
+    #   @option options [Symbol] :name The name of this property.
+    #   @option options [Class] :declared_in The class this property comes from.
+    #   @option options [Symbol] :instance_variable_name The instance variable
+    #     tied to this property. Must include a leading `@`. Defaults to `@<name>`.
+    #     `nil` means the property is opaque and not tied to a specific instance
+    #     variable.
+    #   @option options [Boolean] :desired_state `true` if this property is part of desired
+    #     state. Defaults to `true`.
+    #   @option options [Boolean] :identity `true` if this property is part of object
+    #     identity. Defaults to `false`.
+    #   @option options [Boolean] :name_property `true` if this
+    #     property defaults to the same value as `name`. Equivalent to
+    #     `default: lazy { name }`, except that #property_is_set? will
+    #     return `true` if the property is set *or* if `name` is set.
+    #   @option options [Object] :default The value this property
+    #     will return if the user does not set one. If this is `lazy`, it will
+    #     be run in the context of the instance (and able to access other
+    #     properties) and cached. If not, the value will be frozen with Object#freeze
+    #     to prevent users from modifying it in an instance.
+    #   @option options [Proc] :computed The value this property will return if
+    #     the user does not set one. If this is `lazy`, it will be run in the
+    #     context of the instance (and able to access other properties).
+    #   @option options [Proc] :coerce A proc which will be called to
+    #     transform the user input to canonical form. The value is passed in,
+    #     and the transformed value returned as output. Lazy values will *not*
+    #     be passed to this method until after they are evaluated. Called in the
+    #     context of the resource (meaning you can access other properties).
+    #   @option options [Boolean] :required `true` if this property
+    #     must be present; `false` otherwise. This is checked after the resource
+    #     is fully initialized.
+    #
+    def initialize(**options)
+      options.each { |k,v| options[k.to_sym] = v if k.is_a?(String) }
+      options[:name_property] = options.delete(:name_attribute) unless options.has_key?(:name_property)
+      @options = options
+
+      if options.has_key?(:default)
+        options[:default] = options[:default].freeze
+      end
+      options[:name] = options[:name].to_sym if options[:name]
+      options[:instance_variable_name] = options[:instance_variable_name].to_sym if options[:instance_variable_name]
+    end
+
+    #
+    # The name of this property.
+    #
+    # @return [String]
+    #
+    def name
+      options[:name]
+    end
+
+    #
+    # The class this property was defined in.
+    #
+    # @return [Class]
+    #
+    def declared_in
+      options[:declared_in]
+    end
+
+    #
+    # The instance variable associated with this property.
+    #
+    # Defaults to `@<name>`
+    #
+    # @return [Symbol]
+    #
+    def instance_variable_name
+      if options.has_key?(:instance_variable_name)
+        options[:instance_variable_name]
+      elsif name
+        :"@#{name}"
+      end
+    end
+
+    #
+    # The raw default value for this resource.
+    #
+    # Does not coerce or validate the default. Does not evaluate lazy values.
+    #
+    # Defaults to `lazy { name }` if name_property is true; otherwise defaults to
+    # `nil`
+    #
+    def default
+      return options[:default] if options.has_key?(:default)
+      return Chef::DelayedEvaluator.new { name } if name_property?
+      nil
+    end
+
+    #
+    # Whether this is part of the resource's natural identity or not.
+    #
+    # @return [Boolean]
+    #
+    def identity?
+      options[:identity]
+    end
+
+    #
+    # Whether this is part of desired state or not.
+    #
+    # Defaults to true.
+    #
+    # @return [Boolean]
+    #
+    def desired_state?
+      return true if !options.has_key?(:desired_state)
+      options[:desired_state]
+    end
+
+    #
+    # Whether this is name_property or not.
+    #
+    # @return [Boolean]
+    #
+    def name_property?
+      options[:name_property]
+    end
+
+    #
+    # Whether this property has a default value.
+    #
+    # @return [Boolean]
+    #
+    def has_default?
+      options.has_key?(:default) || name_property?
+    end
+
+    #
+    # Whether this property has a computed default value.
+    #
+    # @return [Boolean]
+    #
+    def has_computed?
+      options.has_key?(:computed)
+    end
+
+    #
+    # Whether this property is required or not.
+    #
+    # @return [Boolean]
+    #
+    def required?
+      options[:required]
+    end
+
+    #
+    # Validation options.  (See Chef::Mixin::ParamsValidate#validate.)
+    #
+    # @return [Hash<Symbol,Object>]
+    #
+    def validation_options
+      @validation_options ||= options.reject { |k,v|
+        [:declared_in,:name,:instance_variable_name,:desired_state,:identity,:default,:name_property,:coerce,:required].include?(k)
+      }
+    end
+
+    #
+    # Handle the property being called.
+    #
+    # The base implementation does the property get-or-set:
+    #
+    # ```ruby
+    # resource.myprop # get
+    # resource.myprop value # set
+    # ```
+    #
+    # If multiple values or a block are passed, they will be passed to coerce.
+    # If there is no coerce method and multiple values are passed, we will throw
+    # an error.
+    #
+    # @param resource [Chef::Resource] The resource to get the property from.
+    # @param value The value to set the property to. If not passed or set to
+    #   NOT_PASSED, this is treated as a get.
+    #
+    # @return The current value of the property. If it is a `set`, lazy values
+    #   will be returned without running, validating or coercing. If it is a
+    #   `get`, the non-lazy, coerced, validated value will always be returned.
+    #
+    def call(resource, value=NOT_PASSED)
+      # myprop with no args
+      if value == NOT_PASSED
+        return get(resource)
+      end
+
+      # myprop nil is sometimes a get (backcompat)
+      if value.nil? && !explicitly_accepts_nil?(resource)
+        # If you say "my_property nil" and the property explicitly accepts
+        # nil values, we consider this a get.
+        Chef::Log.deprecation("#{name} nil currently does not overwrite the value of #{name}. This will change in Chef 13, and the value will be set to nil instead. Please change your code to explicitly accept nil using \"property :#{name}, [MyType, nil]\", or stop setting this value to nil.")
+        return get(resource)
+      end
+
+      # Anything else (myprop value) is a set
+      set(resource, value)
+    end
+
+    #
+    # Get the property value from the resource, handling lazy values,
+    # defaults, and validation.
+    #
+    # - If the property's value is lazy, it is evaluated, coerced and validated.
+    # - If the property has no value, and is required, raises ValidationFailed.
+    # - If the property has no value, but has a lazy default, it is evaluated,
+    #   coerced and validated. If the evaluated value is frozen, the resulting
+    # - If the property has no value, but has a default, the default value
+    #   will be returned and frozen. If the default value is lazy, it will be
+    #   evaluated, coerced and validated, and the result stored in the property.
+    # - If the property has no value, but is name_property, `resource.name`
+    #   is retrieved, coerced, validated and stored in the property.
+    # - Otherwise, `nil` is returned.
+    #
+    # @param resource [Chef::Resource] The resource to get the property from.
+    #
+    # @return The value of the property.
+    #
+    # @raise Chef::Exceptions::ValidationFailed If the value is invalid for
+    #   this property, or if the value is required and not set.
+    #
+    def get(resource)
+      if is_set?(resource)
+        value = get_value(resource)
+        if value.is_a?(DelayedEvaluator)
+          value = exec_in_resource(resource, value)
+          value = coerce(resource, value)
+          validate(resource, value)
+        end
+        value
+
+      else
+        raise Chef::Exceptions::ValidationFailed, "#{name} is required" if required?
+
+        if has_default?
+          value = default
+          if value.is_a?(DelayedEvaluator)
+            value = exec_in_resource(resource, value)
+            value = coerce(resource, value)
+            # We don't validate defaults
+            set_value(resource, value)
+          else
+            value = coerce(resource, value)
+          end
+        end
+      end
+    end
+
+    #
+    # Set the value of this property in the given resource.
+    #
+    # Non-lazy values are coerced and validated before being set. Coercion
+    # and validation of lazy values is delayed until they are first retrieved.
+    #
+    # @param resource [Chef::Resource] The resource to set this property in.
+    # @param value The value to set.
+    #
+    # @return The value that was set, after coercion (if lazy, still returns
+    #   the lazy value)
+    #
+    # @raise Chef::Exceptions::ValidationFailed If the value is invalid for
+    #   this property.
+    #
+    def set(resource, value)
+      unless value.is_a?(DelayedEvaluator)
+        value = coerce(resource, value)
+        validate(resource, value)
+      end
+      set_value(resource, value)
+    end
+
+    #
+    # Find out whether this property has been set.
+    #
+    # This will be true if:
+    # - The user explicitly set the value
+    # - The property has a default, and the value was retrieved.
+    #
+    # From this point of view, it is worth looking at this as "what does the
+    # user think this value should be." In order words, if the user grabbed
+    # the value, even if it was a default, they probably based calculations on
+    # it. If they based calculations on it and the value changes, the rest of
+    # the world gets inconsistent.
+    #
+    # @param resource [Chef::Resource] The resource to get the property from.
+    #
+    # @return [Boolean]
+    #
+    def is_set?(resource)
+      value_is_set?(resource)
+    end
+
+    #
+    # Reset the value of this property so that is_set? will return false and the
+    # default will be returned in the future.
+    #
+    # @param resource [Chef::Resource] The resource to get the property from.
+    #
+    def reset(resource)
+      reset_value(resource)
+    end
+
+    #
+    # Coerce an input value into canonical form for the property.
+    #
+    # After coercion, the value is suitable for storage in the resource.
+    # You must validate values after coercion, however.
+    #
+    # Does no special handling for lazy values.
+    #
+    # @param resource [Chef::Resource] The resource we're coercing against
+    #   (to provide context for the coerce).
+    # @param value The value to coerce.
+    #
+    # @return The coerced value.
+    #
+    # @raise Chef::Exceptions::ValidationFailed If the value is invalid for
+    #   this property.
+    #
+    def coerce(resource, value)
+      if options.has_key?(:coerce)
+        value = exec_in_resource(resource, options[:coerce], value)
+      end
+      value
+    end
+
+    #
+    # Validate a value.
+    #
+    # Calls Chef::Mixin::ParamsValidate#validate with #validation_options as
+    # options.
+    #
+    # @param resource [Chef::Resource] The resource we're validating against
+    #   (to provide context for the validate).
+    # @param value The value to validate.
+    #
+    # @raise Chef::Exceptions::ValidationFailed If the value is invalid for
+    #   this property.
+    #
+    def validate(resource, value)
+      resource.validate({ name => value }, { name => validation_options })
+    end
+
+    #
+    # Specialize this Property by making a duplicate with some added or
+    # changed options.
+    #
+    # @param options [Hash<Symbol,Object>] List of options that would be passed
+    #   to #initialize.
+    #
+    # @return [Property] The new property type.
+    #
+    def specialize(**modified_options)
+      Property.new(**options, **modified_options)
+    end
+
+    protected
+
+    #
+    # Find out whether this type accepts nil explicitly.
+    #
+    # A type accepts nil explicitly if "is" allows nil, it validates as nil, *and* is not simply
+    # an empty type.
+    #
+    # These examples accept nil explicitly:
+    # ```ruby
+    # property :a, [ String, nil ]
+    # property :a, [ String, NilClass ]
+    # property :a, [ String, proc { |v| v.nil? } ]
+    # ```
+    #
+    # This does not (because the "is" doesn't exist or doesn't have nil):
+    #
+    # ```ruby
+    # property :x, String
+    # ```
+    #
+    # These do not, even though nil would validate fine (because they do not
+    # have "is"):
+    #
+    # ```ruby
+    # property :a
+    # property :a, equal_to: [ 1, 2, 3, nil ]
+    # property :a, kind_of: [ String, NilClass ]
+    # property :a, respond_to: [ ]
+    # property :a, callbacks: { "a" => proc { |v| v.nil? } }
+    # ```
+    #
+    # @param resource [Chef::Resource] The resource we're coercing against
+    #   (to provide context for the coerce).
+    #
+    # @return [Boolean] Whether this value explicitly accepts nil.
+    #
+    # @api private
+    def explicitly_accepts_nil?(resource)
+      options.has_key?(:is) && resource.send(:_pv_is, { name => nil }, name, options[:is], raise_error: false)
+    end
+
+    def get_value(resource)
+      if instance_variable_name
+        resource.send(:instance_variable_get, instance_variable_name)
+      else
+        resource.send(name)
+      end
+    end
+
+    def set_value(resource, value)
+      if instance_variable_name
+        resource.send(:instance_variable_set, instance_variable_name, value)
+      else
+        resource.send(name, value)
+      end
+    end
+
+    def value_is_set?(resource)
+      if instance_variable_name
+        resource.send(:instance_variable_defined?, instance_variable_name)
+      else
+        true
+      end
+    end
+
+    def reset_value(resource)
+      if instance_variable_name
+        if value_is_set?(resource)
+          resource.send(:remove_instance_variable, instance_variable_name)
+        end
+      else
+        raise ArgumentError, "Property #{name} has no instance variable defined and cannot be reset"
+      end
+    end
+
+    def exec_in_resource(resource, proc, *args)
+      if resource
+        if proc.arity > args.size
+          value = proc.call(resource, *args)
+        else
+          value = resource.instance_exec(*args, &proc)
+        end
+      else
+        value = proc.call
+      end
+
+      if value.is_a?(DelayedEvaluator)
+        value = coerce(resource, value)
+        validate(resource, value)
+      end
+      value
+    end
+
+    attr_reader :options
+
+    # Used by #set_or_return to avoid emitting a deprecation warning for
+    # "value nil"
+    # @api private
+    class NonDeprecatedNilGetter < Property
+      def call(resource, value=NOT_PASSED)
+        if value.nil? && !explicitly_accepts_nil?(resource)
+          get(resource)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -500,18 +500,5 @@ class Chef
       end
       value
     end
-
-    # Used by #set_or_return to avoid emitting a deprecation warning for
-    # "value nil"
-    # @api private
-    class NonDeprecatedNilGetter < Property
-      def call(resource, value=NOT_PASSED)
-        if value.nil? && !explicitly_accepts_nil?(resource)
-          get(resource)
-        else
-          super
-        end
-      end
-    end
   end
 end

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -279,12 +279,20 @@ class Chef
           value = default
           if value.is_a?(DelayedEvaluator)
             value = exec_in_resource(resource, value)
-            value = coerce(resource, value)
-            # We don't validate defaults
-            set_value(resource, value)
-          else
-            value = coerce(resource, value)
           end
+
+          value = coerce(resource, value)
+
+          # We don't validate defaults
+
+          # If the value is mutable (non-frozen), we set it on the instance
+          # so that people can mutate it.  (All constant default values are
+          # frozen.)
+          if !value.frozen?
+            set_value(resource, value)
+          end
+
+          value
         end
       end
     end

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -1,3 +1,21 @@
+#
+# Author:: John Keiser <jkeiser@chef.io>
+# Copyright:: Copyright (c) 2015 John Keiser.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require 'chef/exceptions'
 require 'chef/delayed_evaluator'
 
@@ -381,6 +399,8 @@ class Chef
 
     protected
 
+    attr_reader :options
+
     #
     # Find out whether this type accepts nil explicitly.
     #
@@ -423,7 +443,7 @@ class Chef
 
     def get_value(resource)
       if instance_variable_name
-        resource.send(:instance_variable_get, instance_variable_name)
+        resource.instance_variable_get(instance_variable_name)
       else
         resource.send(name)
       end
@@ -431,7 +451,7 @@ class Chef
 
     def set_value(resource, value)
       if instance_variable_name
-        resource.send(:instance_variable_set, instance_variable_name, value)
+        resource.instance_variable_set(instance_variable_name, value)
       else
         resource.send(name, value)
       end
@@ -439,7 +459,7 @@ class Chef
 
     def value_is_set?(resource)
       if instance_variable_name
-        resource.send(:instance_variable_defined?, instance_variable_name)
+        resource.instance_variable_defined?(instance_variable_name)
       else
         true
       end
@@ -448,7 +468,7 @@ class Chef
     def reset_value(resource)
       if instance_variable_name
         if value_is_set?(resource)
-          resource.send(:remove_instance_variable, instance_variable_name)
+          resource.remove_instance_variable(instance_variable_name)
         end
       else
         raise ArgumentError, "Property #{name} has no instance variable defined and cannot be reset"
@@ -472,8 +492,6 @@ class Chef
       end
       value
     end
-
-    attr_reader :options
 
     # Used by #set_or_return to avoid emitting a deprecation warning for
     # "value nil"

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -39,41 +39,14 @@ class Chef
     # Create a reusable property type that can be used in multiple properties
     # in different resources.
     #
-    # @param type [Object,Array<Object>] The type(s) of this property.
-    #   If present, this is prepended to the `is` validation option.
-    #   If this is a Chef::Property, `specialize` is called on it to create the
-    #   new property instead of prepending to `is`.
-    # @param options [Hash<Symbol,Object>] Validation options. see #property for
+    # @param options [Hash<Symbol,Object>] Validation options. See Chef::Resource.property for
     #   the list of options.
     #
-    # @example Bare property_type
-    #   property_type()
+    # @example
+    #   Property.derive(default: 'hi')
     #
-    # @example With just a type
-    #   property_type(String)
-    #
-    # @example With just options
-    #   property_type(default: 'hi')
-    #
-    # @example With type and options
-    #   property_type(String, default: 'hi')
-    #
-    def self.create(type=NOT_PASSED, **options)
-      # Inherit from the property type, if one is passed
-      if type.is_a?(self)
-        type.specialize(**options)
-
-      else
-        if type != NOT_PASSED
-          # If a type was passed, combine it with "is" (if a type was passed)
-          if options[:is]
-            options[:is] = ([ type ] + [ options[:is] ]).flatten(1)
-          else
-            options[:is] = type
-          end
-        end
-        new(**options)
-      end
+    def self.derive(**options)
+      new(**options)
     end
 
     #
@@ -102,9 +75,6 @@ class Chef
     #     be run in the context of the instance (and able to access other
     #     properties) and cached. If not, the value will be frozen with Object#freeze
     #     to prevent users from modifying it in an instance.
-    #   @option options [Proc] :computed The value this property will return if
-    #     the user does not set one. If this is `lazy`, it will be run in the
-    #     context of the instance (and able to access other properties).
     #   @option options [Proc] :coerce A proc which will be called to
     #     transform the user input to canonical form. The value is passed in,
     #     and the transformed value returned as output. Lazy values will *not*
@@ -210,15 +180,6 @@ class Chef
     #
     def has_default?
       options.has_key?(:default) || name_property?
-    end
-
-    #
-    # Whether this property has a computed default value.
-    #
-    # @return [Boolean]
-    #
-    def has_computed?
-      options.has_key?(:computed)
     end
 
     #
@@ -432,7 +393,7 @@ class Chef
     end
 
     #
-    # Specialize this Property by making a duplicate with some added or
+    # Derive a new Property that is just like this one, except with some added or
     # changed options.
     #
     # @param options [Hash<Symbol,Object>] List of options that would be passed
@@ -440,7 +401,7 @@ class Chef
     #
     # @return [Property] The new property type.
     #
-    def specialize(**modified_options)
+    def derive(**modified_options)
       Property.new(**options.merge(**modified_options))
     end
 

--- a/spec/unit/mixin/params_validate_spec.rb
+++ b/spec/unit/mixin/params_validate_spec.rb
@@ -21,6 +21,8 @@ require 'spec_helper'
 class TinyClass
   include Chef::Mixin::ParamsValidate
 
+  attr_reader :name
+
   def music(is_good=true)
     is_good
   end

--- a/spec/unit/mixin/params_validate_spec.rb
+++ b/spec/unit/mixin/params_validate_spec.rb
@@ -333,11 +333,11 @@ describe Chef::Mixin::ParamsValidate do
   it "asserts that a value returns false from a predicate method" do
     expect do
       @vo.validate({:not_blank => "should pass"},
-                   {:not_blank => {:cannot_be => :nil, :cannot_be => :empty}})
+                   {:not_blank => {:cannot_be => [ :nil, :empty ]}})
     end.not_to raise_error
     expect do
       @vo.validate({:not_blank => ""},
-                   {:not_blank => {:cannot_be => :nil, :cannot_be => :empty}})
+                   {:not_blank => {:cannot_be => [ :nil, :empty ]}})
     end.to raise_error(Chef::Exceptions::ValidationFailed)
   end
 

--- a/spec/unit/property/state_spec.rb
+++ b/spec/unit/property/state_spec.rb
@@ -50,20 +50,20 @@ describe "Chef::Resource#identity and #state" do
   end
 
   # identity
-  context "Chef::Resource#identity_attr" do
+  context "Chef::Resource#identity_properties" do
     with_property ":x" do
-      # it "name is the default identity" do
-      #   expect(resource_class.identity_attr).to eq :name
-      #   expect(resource_class.properties[:name].identity?).to be_falsey
-      #   expect(resource.name).to eq 'blah'
-      #   expect(resource.identity).to eq 'blah'
-      # end
+      it "name is the default identity" do
+        expect(resource_class.identity_properties).to eq [ Chef::Resource.properties[:name] ]
+        expect(Chef::Resource.properties[:name].identity?).to be_falsey
+        expect(resource.name).to eq 'blah'
+        expect(resource.identity).to eq 'blah'
+      end
 
-      it "identity_attr :x changes the identity" do
-        expect(resource_class.identity_attr :x).to eq :x
-        expect(resource_class.identity_attr).to eq :x
-        # expect(resource_class.properties[:name].identity?).to be_falsey
-        # expect(resource_class.properties[:x].identity?).to be_truthy
+      it "identity_properties :x changes the identity" do
+        expect(resource_class.identity_properties :x).to eq [ resource_class.properties[:x] ]
+        expect(resource_class.identity_properties).to eq [ resource_class.properties[:x] ]
+        expect(Chef::Resource.properties[:name].identity?).to be_falsey
+        expect(resource_class.properties[:x].identity?).to be_truthy
 
         expect(resource.x 'woo').to eq 'woo'
         expect(resource.x).to eq 'woo'
@@ -72,28 +72,31 @@ describe "Chef::Resource#identity and #state" do
         expect(resource.identity).to eq 'woo'
       end
 
-      # with_property ":y, identity: true" do
-      #   context "and identity_attr :x" do
-      #     before do
-      #       resource_class.class_eval do
-      #         identity_attr :x
-      #       end
-      #     end
-      #
-      #     it "only returns :x as identity" do
-      #       resource.x 'foo'
-      #       resource.y 'bar'
-      #       expect(resource_class.identity_attr).to eq :x
-      #       expect(resource.identity).to eq 'foo'
-      #     end
-      #     it "does not flip y.desired_state off" do
-      #       resource.x 'foo'
-      #       resource.y 'bar'
-      #       expect(resource_class.state_attrs).to eq [ :x, :y ]
-      #       expect(resource.state).to eq({ x: 'foo', y: 'bar' })
-      #     end
-      #   end
-      # end
+      with_property ":y, identity: true" do
+        context "and identity_properties :x" do
+          before do
+            resource_class.class_eval do
+              identity_properties :x
+            end
+          end
+
+          it "only returns :x as identity" do
+            resource.x 'foo'
+            resource.y 'bar'
+            expect(resource_class.identity_properties).to eq [ resource_class.properties[:x] ]
+            expect(resource.identity).to eq 'foo'
+          end
+          it "does not flip y.desired_state off" do
+            resource.x 'foo'
+            resource.y 'bar'
+            expect(resource_class.state_properties).to eq [
+              resource_class.properties[:x],
+              resource_class.properties[:y]
+            ]
+            expect(resource.state_for_resource_reporter).to eq(x: 'foo', y: 'bar')
+          end
+        end
+      end
 
       context "With a subclass" do
         let(:subresource_class) do
@@ -107,57 +110,63 @@ describe "Chef::Resource#identity and #state" do
         end
 
         it "name is the default identity on the subclass" do
-          # expect(subresource_class.identity_attr).to eq :name
-          # expect(subresource_class.properties[:name].identity?).to be_falsey
+          expect(subresource_class.identity_properties).to eq [ Chef::Resource.properties[:name] ]
+          expect(Chef::Resource.properties[:name].identity?).to be_falsey
           expect(subresource.name).to eq 'sub'
           expect(subresource.identity).to eq 'sub'
         end
 
-        context "With identity_attr :x on the superclass" do
+        context "With identity_properties :x on the superclass" do
           before do
             resource_class.class_eval do
-              identity_attr :x
+              identity_properties :x
             end
           end
 
           it "The subclass inherits :x as identity" do
-            expect(subresource_class.identity_attr).to eq :x
-            # expect(subresource_class.properties[:name].identity?).to be_falsey
-            # expect(subresource_class.properties[:x].identity?).to be_truthy
+            expect(subresource_class.identity_properties).to eq [ subresource_class.properties[:x] ]
+            expect(Chef::Resource.properties[:name].identity?).to be_falsey
+            expect(subresource_class.properties[:x].identity?).to be_truthy
 
             subresource.x 'foo'
             expect(subresource.identity).to eq 'foo'
           end
 
-          # context "With property :y, identity: true on the subclass" do
-          #   before do
-          #     subresource_class.class_eval do
-          #       property :y, identity: true
-          #     end
-          #   end
-          #   it "The subclass's identity includes both x and y" do
-          #     expect(subresource_class.identity_attr).to eq :x
-          #     subresource.x 'foo'
-          #     subresource.y 'bar'
-          #     expect(subresource.identity).to eq({ x: 'foo', y: 'bar' })
-          #   end
-          # end
+          context "With property :y, identity: true on the subclass" do
+            before do
+              subresource_class.class_eval do
+                property :y, identity: true
+              end
+            end
+            it "The subclass's identity includes both x and y" do
+              expect(subresource_class.identity_properties).to eq [
+                subresource_class.properties[:x],
+                subresource_class.properties[:y]
+              ]
+              subresource.x 'foo'
+              subresource.y 'bar'
+              expect(subresource.identity).to eq(x: 'foo', y: 'bar')
+            end
+          end
 
           with_property ":y, String" do
-            context "With identity_attr :y on the subclass" do
+            context "With identity_properties :y on the subclass" do
               before do
                 subresource_class.class_eval do
-                  identity_attr :y
+                  identity_properties :y
                 end
               end
-              # it "y is part of state" do
-              #   subresource.x 'foo'
-              #   subresource.y 'bar'
-              #   expect(subresource.state).to eq({ x: 'foo', y: 'bar' })
-              #   expect(subresource_class.state_attrs).to eq [ :x, :y ]
-              # end
+              it "y is part of state" do
+                subresource.x 'foo'
+                subresource.y 'bar'
+                expect(subresource.state_for_resource_reporter).to eq(x: 'foo', y: 'bar')
+                expect(subresource_class.state_properties).to eq [
+                  subresource_class.properties[:x],
+                  subresource_class.properties[:y]
+                ]
+              end
               it "y is the identity" do
-                expect(subresource_class.identity_attr).to eq :y
+                expect(subresource_class.identity_properties).to eq [ subresource_class.properties[:y] ]
                 subresource.x 'foo'
                 subresource.y 'bar'
                 expect(subresource.identity).to eq 'bar'
@@ -171,24 +180,24 @@ describe "Chef::Resource#identity and #state" do
       end
     end
 
-    # with_property ":string_only, String, identity: true", ":string_only2, String" do
-    #   it "identity_attr does not change validation" do
-    #     resource_class.identity_attr :string_only
-    #     expect { resource.string_only 12 }.to raise_error Chef::Exceptions::ValidationFailed
-    #     expect { resource.string_only2 12 }.to raise_error Chef::Exceptions::ValidationFailed
-    #   end
-    # end
-    #
-    # with_property ":x, desired_state: false" do
-    #   it "identity_attr does not flip on desired_state" do
-    #     resource_class.identity_attr :x
-    #     resource.x 'hi'
-    #     expect(resource.identity).to eq 'hi'
-    #     # expect(resource_class.properties[:x].desired_state?).to be_falsey
-    #     expect(resource_class.state_attrs).to eq []
-    #     expect(resource.state).to eq({})
-    #   end
-    # end
+    with_property ":string_only, String, identity: true", ":string_only2, String" do
+      it "identity_properties does not change validation" do
+        resource_class.identity_properties :string_only
+        expect { resource.string_only 12 }.to raise_error Chef::Exceptions::ValidationFailed
+        expect { resource.string_only2 12 }.to raise_error Chef::Exceptions::ValidationFailed
+      end
+    end
+
+    with_property ":x, desired_state: false" do
+      it "identity_properties does not change desired_state" do
+        resource_class.identity_properties :x
+        resource.x 'hi'
+        expect(resource.identity).to eq 'hi'
+        expect(resource_class.properties[:x].desired_state?).to be_falsey
+        expect(resource_class.state_properties).to eq []
+        expect(resource.state_for_resource_reporter).to eq({})
+      end
+    end
 
     context "With custom property custom_property defined only as methods, using different variables for storage" do
       before do
@@ -202,24 +211,26 @@ describe "Chef::Resource#identity and #state" do
         end
       end
 
-      context "And identity_attr :custom_property" do
+      context "And identity_properties :custom_property" do
         before do
           resource_class.class_eval do
-            identity_attr :custom_property
+            identity_properties :custom_property
           end
         end
 
-        it "identity_attr comes back as :custom_property" do
-          # expect(resource_class.properties[:custom_property].identity?).to be_truthy
-          expect(resource_class.identity_attr).to eq :custom_property
+        it "identity_properties comes back as :custom_property" do
+          expect(resource_class.properties[:custom_property].identity?).to be_truthy
+          expect(resource_class.identity_properties).to eq [ resource_class.properties[:custom_property] ]
         end
-        # it "custom_property becomes part of desired_state" do
-        #   resource.custom_property = 1
-        #   expect(resource.state).to eq({ custom_property: 6 })
-        #   expect(resource_class.properties[:custom_property].desired_state?).to be_truthy
-        #   expect(resource_class.state_attrs).to eq [ :custom_property ]
-        # end
-        it "identity_attr does not change custom_property's getter or setter" do
+        it "custom_property becomes part of desired_state" do
+          resource.custom_property = 1
+          expect(resource.state_for_resource_reporter).to eq(custom_property: 6)
+          expect(resource_class.properties[:custom_property].desired_state?).to be_truthy
+          expect(resource_class.state_properties).to eq [
+            resource_class.properties[:custom_property]
+          ]
+        end
+        it "identity_properties does not change custom_property's getter or setter" do
           resource.custom_property = 1
           expect(resource.custom_property).to eq 6
         end
@@ -232,111 +243,111 @@ describe "Chef::Resource#identity and #state" do
     end
   end
 
-  # context "PropertyType#identity" do
-  #   with_property ":x, identity: true" do
-  #     it "name is only part of the identity if an identity attribute is defined" do
-  #       expect(resource_class.identity_attr).to eq :x
-  #       resource.x 'woo'
-  #       expect(resource.identity).to eq 'woo'
-  #     end
-  #   end
-  #
-  #   with_property ":x, identity: true, default: 'xxx'",
-  #                 ":y, identity: true, default: 'yyy'",
-  #                 ":z, identity: true, default: 'zzz'" do
-  #     it "identity_attr returns the first identity attribute if multiple are defined" do
-  #       expect(resource_class.identity_attr).to eq :x
-  #     end
-  #     it "identity returns all identity values in a hash if multiple are defined" do
-  #       resource.x 'foo'
-  #       resource.y 'bar'
-  #       resource.z 'baz'
-  #       expect(resource.identity).to eq({ x: 'foo', y: 'bar', z: 'baz' })
-  #     end
-  #     it "identity returns only identity values that are set, and does not include defaults" do
-  #       resource.x 'foo'
-  #       resource.z 'baz'
-  #       expect(resource.identity).to eq({ x: 'foo', z: 'baz' })
-  #     end
-  #     it "identity returns only set identity values in a hash, if there is only one set identity value" do
-  #       resource.x 'foo'
-  #       expect(resource.identity).to eq({ x: 'foo' })
-  #     end
-  #     it "identity returns an empty hash if no identity values are set" do
-  #       expect(resource.identity).to eq({})
-  #     end
-  #     it "identity_attr wipes out any other identity attributes if multiple are defined" do
-  #       resource_class.identity_attr :y
-  #       resource.x 'foo'
-  #       resource.y 'bar'
-  #       resource.z 'baz'
-  #       expect(resource.identity).to eq 'bar'
-  #     end
-  #   end
-  #
-  #   with_property ":x, identity: true, name_property: true" do
-  #     it "identity when x is not defined returns the value of x" do
-  #       expect(resource.identity).to eq 'blah'
-  #     end
-  #     it "state when x is not defined returns the value of x" do
-  #       expect(resource.state).to eq({ x: 'blah' })
-  #     end
-  #   end
-  # end
-
-  # state_attrs
-  context "Chef::Resource#state_attrs" do
-    it "name is not part of state_attrs" do
-      expect(Chef::Resource.state_attrs).to eq []
-      expect(resource_class.state_attrs).to eq []
-      expect(resource.state).to eq({})
+  context "Property#identity" do
+    with_property ":x, identity: true" do
+      it "name is only part of the identity if an identity attribute is defined" do
+        expect(resource_class.identity_properties).to eq [ resource_class.properties[:x] ]
+        resource.x 'woo'
+        expect(resource.identity).to eq 'woo'
+      end
     end
 
-    # with_property ":x", ":y", ":z" do
-    #   it "x, y and z are state attributes" do
-    #     resource.x 1
-    #     resource.y 2
-    #     resource.z 3
-    #     expect(resource_class.state_attrs).to eq [ :x, :y, :z ]
-    #     expect(resource.state).to eq(x: 1, y: 2, z: 3)
-    #   end
-    #   it "values that are not set are not included in state" do
-    #     resource.x 1
-    #     expect(resource.state).to eq(x: 1)
-    #   end
-    #   it "when no values are set, nothing is included in state" do
-    #   end
-    # end
-    #
-    # with_property ":x", ":y, desired_state: false", ":z, desired_state: true" do
-    #   it "x and z are state attributes, and y is not" do
-    #     resource.x 1
-    #     resource.y 2
-    #     resource.z 3
-    #     expect(resource_class.state_attrs).to eq [ :x, :z ]
-    #     expect(resource.state).to eq(x: 1, z: 3)
-    #   end
-    # end
+    with_property ":x, identity: true, default: 'xxx'",
+                  ":y, identity: true, default: 'yyy'",
+                  ":z, identity: true, default: 'zzz'" do
+      it "identity_property raises an error if multiple identity values are defined" do
+        expect { resource_class.identity_property }.to raise_error Chef::Exceptions::MultipleIdentityError
+      end
+      it "identity_attr raises an error if multiple identity values are defined" do
+        expect { resource_class.identity_attr }.to raise_error Chef::Exceptions::MultipleIdentityError
+      end
+      it "identity returns all identity values in a hash if multiple are defined" do
+        resource.x 'foo'
+        resource.y 'bar'
+        resource.z 'baz'
+        expect(resource.identity).to eq(x: 'foo', y: 'bar', z: 'baz')
+      end
+      it "identity returns all values whether any value is set or not" do
+        expect(resource.identity).to eq(x: 'xxx', y: 'yyy', z: 'zzz')
+      end
+      it "identity_properties wipes out any other identity attributes if multiple are defined" do
+        resource_class.identity_properties :y
+        resource.x 'foo'
+        resource.y 'bar'
+        resource.z 'baz'
+        expect(resource.identity).to eq 'bar'
+      end
+    end
 
-    # with_property ":x, name_property: true" do
-    #   it "Unset values with name_property are included in state" do
-    #     expect(resource.state).to eq(x: 'blah')
-    #   end
-    #   it "Set values with name_property are included in state" do
-    #     resource.x 1
-    #     expect(resource.state).to eq(x: 1)
-    #   end
-    # end
+    with_property ":x, identity: true, name_property: true" do
+      it "identity when x is not defined returns the value of x" do
+        expect(resource.identity).to eq 'blah'
+      end
+      it "state when x is not defined returns the value of x" do
+        expect(resource.state_for_resource_reporter).to eq(x: 'blah')
+      end
+    end
+  end
 
-    # with_property ":x, default: 1" do
-    #   it "Unset values with defaults are not included in state" do
-    #     expect(resource.state).to eq({})
-    #   end
-    #   it "Set values with defaults are included in state" do
-    #     resource.x 1
-    #     expect(resource.state).to eq(x: 1)
-    #   end
-    # end
+  # state_properties
+  context "Chef::Resource#state_properties" do
+    it "state_properties is empty by default" do
+      expect(Chef::Resource.state_properties).to eq []
+      expect(resource.state_for_resource_reporter).to eq({})
+    end
+
+    with_property ":x", ":y", ":z" do
+      it "x, y and z are state attributes" do
+        resource.x 1
+        resource.y 2
+        resource.z 3
+        expect(resource_class.state_properties).to eq [
+          resource_class.properties[:x],
+          resource_class.properties[:y],
+          resource_class.properties[:z]
+        ]
+        expect(resource.state_for_resource_reporter).to eq(x: 1, y: 2, z: 3)
+      end
+      it "values that are not set are not included in state" do
+        resource.x 1
+        expect(resource.state_for_resource_reporter).to eq(x: 1)
+      end
+      it "when no values are set, nothing is included in state" do
+      end
+    end
+
+    with_property ":x", ":y, desired_state: false", ":z, desired_state: true" do
+      it "x and z are state attributes, and y is not" do
+        resource.x 1
+        resource.y 2
+        resource.z 3
+        expect(resource_class.state_properties).to eq [
+          resource_class.properties[:x],
+          resource_class.properties[:z]
+        ]
+        expect(resource.state_for_resource_reporter).to eq(x: 1, z: 3)
+      end
+    end
+
+    with_property ":x, name_property: true" do
+      # it "Unset values with name_property are included in state" do
+      #   expect(resource.state_for_resource_reporter).to eq({ x: 'blah' })
+      # end
+      it "Set values with name_property are included in state" do
+        resource.x 1
+        expect(resource.state_for_resource_reporter).to eq(x: 1)
+      end
+    end
+
+    with_property ":x, default: 1" do
+      it "Unset values with defaults are not included in state" do
+        expect(resource.state_for_resource_reporter).to eq({})
+      end
+      it "Set values with defaults are included in state" do
+        resource.x 1
+        expect(resource.state_for_resource_reporter).to eq(x: 1)
+      end
+    end
 
     context "With a class with a normal getter and setter" do
       before do
@@ -349,143 +360,132 @@ describe "Chef::Resource#identity and #state" do
           end
         end
       end
-      it "state_attrs(:x) causes the value to be included in properties" do
-        resource_class.state_attrs(:x)
+      it "state_properties(:x) causes the value to be included in properties" do
+        resource_class.state_properties(:x)
         resource.x = 1
 
         expect(resource.x).to eq 6
-        expect(resource.state).to eq(x: 6)
+        expect(resource.state_for_resource_reporter).to eq(x: 6)
       end
     end
 
-    # with_property ":x, Integer, identity: true" do
-    #   it "state_attrs(:x) leaves the property in desired_state" do
-    #     resource_class.state_attrs(:x)
-    #     resource.x 10
-    #
-    #     # expect(resource_class.properties[:x].desired_state?).to be_truthy
-    #     expect(resource_class.state_attrs).to eq [ :x ]
-    #     expect(resource.state).to eq(x: 10)
-    #   end
-    #   it "state_attrs(:x) does not turn off validation" do
-    #     resource_class.state_attrs(:x)
-    #     expect { resource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
-    #   end
-    #   it "state_attrs(:x) does not turn off identity" do
-    #     resource_class.state_attrs(:x)
-    #     resource.x 10
-    #
-    #     expect(resource_class.identity_attr).to eq :x
-    #     # expect(resource_class.properties[:x].identity?).to be_truthy
-    #     expect(resource.identity).to eq 10
-    #   end
-    # end
+    with_property ":x, Integer, identity: true" do
+      it "state_properties(:x) leaves the property in desired_state" do
+        resource_class.state_properties(:x)
+        resource.x 10
 
-    # with_property ":x, Integer, identity: true, desired_state: false" do
-    #   before do
-    #     resource_class.class_eval do
-    #       def y
-    #         20
-    #       end
-    #     end
-    #   end
-    #   it "state_attrs(:x) sets the property in desired_state" do
-    #     resource_class.state_attrs(:x)
-    #     resource.x 10
-    #
-    #     # expect(resource_class.properties[:x].desired_state?).to be_truthy
-    #     expect(resource_class.state_attrs).to eq [ :x ]
-    #     expect(resource.state).to eq(x: 10)
-    #   end
-    #   it "state_attrs(:x) does not turn off validation" do
-    #     resource_class.state_attrs(:x)
-    #     expect { resource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
-    #   end
-    #   it "state_attrs(:x) does not turn off identity" do
-    #     resource_class.state_attrs(:x)
-    #     resource.x 10
-    #
-    #     expect(resource_class.identity_attr).to eq :x
-    #     # expect(resource_class.properties[:x].identity?).to be_truthy
-    #     expect(resource.identity).to eq 10
-    #   end
-    #   it "state_attrs(:y) adds y and removes x from desired state" do
-    #     resource_class.state_attrs(:y)
-    #     resource.x 10
-    #
-    #     # expect(resource_class.properties[:x].desired_state?).to be_falsey
-    #     # expect(resource_class.properties[:y].desired_state?).to be_truthy
-    #     expect(resource_class.state_attrs).to eq [ :y ]
-    #     expect(resource.state).to eq(y: 20)
-    #   end
-    #   it "state_attrs(:y) does not turn off validation" do
-    #     resource_class.state_attrs(:y)
-    #
-    #     expect { resource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
-    #   end
-    #   it "state_attrs(:y) does not turn off identity" do
-    #     resource_class.state_attrs(:y)
-    #     resource.x 10
-    #
-    #     expect(resource_class.identity_attr).to eq :x
-    #     # expect(resource_class.properties[:x].identity?).to be_truthy
-    #     expect(resource.identity).to eq 10
-    #   end
-    #
-    #   context "With a subclassed resource" do
-    #     let(:resource_subclass) do
-    #       new_resource_name = self.class.new_resource_name
-    #       Class.new(resource_class) do
-    #         resource_name new_resource_name
-    #       end
-    #     end
-    #     let(:subresource) do
-    #       resource_subclass.new('blah')
-    #     end
-    #     it "state_attrs(:x) sets the property in desired_state" do
-    #       resource_subclass.state_attrs(:x)
-    #       subresource.x 10
-    #
-    #       # expect(resource_subclass.properties[:x].desired_state?).to be_truthy
-    #       expect(resource_subclass.state_attrs).to eq [ :x ]
-    #       expect(subresource.state).to eq(x: 10)
-    #     end
-    #     it "state_attrs(:x) does not turn off validation" do
-    #       resource_subclass.state_attrs(:x)
-    #       expect { subresource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
-    #     end
-    #     it "state_attrs(:x) does not turn off identity" do
-    #       resource_subclass.state_attrs(:x)
-    #       subresource.x 10
-    #
-    #       expect(resource_subclass.identity_attr).to eq :x
-    #       # expect(resource_subclass.properties[:x].identity?).to be_truthy
-    #       expect(subresource.identity).to eq 10
-    #     end
-    #     it "state_attrs(:y) adds y and removes x from desired state" do
-    #       resource_subclass.state_attrs(:y)
-    #       subresource.x 10
-    #
-    #       # expect(resource_subclass.properties[:x].desired_state?).to be_falsey
-    #       # expect(resource_subclass.properties[:y].desired_state?).to be_truthy
-    #       expect(resource_subclass.state_attrs).to eq [ :y ]
-    #       expect(subresource.state).to eq(y: 20)
-    #     end
-    #     it "state_attrs(:y) does not turn off validation" do
-    #       resource_subclass.state_attrs(:y)
-    #
-    #       expect { subresource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
-    #     end
-    #     it "state_attrs(:y) does not turn off identity" do
-    #       resource_subclass.state_attrs(:y)
-    #       subresource.x 10
-    #
-    #       expect(resource_subclass.identity_attr).to eq :x
-    #       # expect(resource_subclass.properties[:x].identity?).to be_truthy
-    #       expect(subresource.identity).to eq 10
-    #     end
-    #   end
-    # end
+        expect(resource_class.properties[:x].desired_state?).to be_truthy
+        expect(resource_class.state_properties).to eq [
+          resource_class.properties[:x]
+        ]
+        expect(resource.state_for_resource_reporter).to eq(x: 10)
+      end
+      it "state_properties(:x) does not turn off validation" do
+        resource_class.state_properties(:x)
+        expect { resource.x 'ouch' }.to raise_error Chef::Exceptions::ValidationFailed
+      end
+      it "state_properties(:x) does not turn off identity" do
+        resource_class.state_properties(:x)
+        resource.x 10
+
+        expect(resource_class.identity_properties).to eq [ resource_class.properties[:x] ]
+        expect(resource_class.properties[:x].identity?).to be_truthy
+        expect(resource.identity).to eq 10
+      end
+    end
+
+    with_property ":x, Integer, identity: true, desired_state: false" do
+      before do
+        resource_class.class_eval do
+          def y
+            20
+          end
+        end
+      end
+
+      it "state_properties(:x) leaves x identical" do
+        old_value = resource_class.properties[:y]
+        resource_class.state_properties(:x)
+        resource.x 10
+
+        expect(resource_class.properties[:y].object_id).to eq old_value.object_id
+
+        expect(resource_class.properties[:x].desired_state?).to be_truthy
+        expect(resource_class.properties[:x].identity?).to be_truthy
+        expect(resource_class.identity_properties).to eq [
+          resource_class.properties[:x]
+        ]
+        expect(resource.identity).to eq(10)
+        expect(resource_class.state_properties).to eq [
+          resource_class.properties[:x]
+        ]
+        expect(resource.state_for_resource_reporter).to eq(x: 10)
+      end
+
+      it "state_properties(:y) adds y to desired state" do
+        old_value = resource_class.properties[:x]
+        resource_class.state_properties(:y)
+        resource.x 10
+
+        expect(resource_class.properties[:x].object_id).to eq old_value.object_id
+        expect(resource_class.properties[:x].desired_state?).to be_falsey
+        expect(resource_class.properties[:y].desired_state?).to be_truthy
+        expect(resource_class.state_properties).to eq [
+          resource_class.properties[:y]
+        ]
+        expect(resource.state_for_resource_reporter).to eq(y: 20)
+      end
+
+      context "With a subclassed resource" do
+        let(:subresource_class) do
+          new_resource_name = self.class.new_resource_name
+          Class.new(resource_class) do
+            resource_name new_resource_name
+          end
+        end
+        let(:subresource) do
+          subresource_class.new('blah')
+        end
+
+        it "state_properties(:x) adds x to desired state" do
+          old_value = resource_class.properties[:y]
+          subresource_class.state_properties(:x)
+          subresource.x 10
+
+          expect(subresource_class.properties[:y].object_id).to eq old_value.object_id
+
+          expect(subresource_class.properties[:x].desired_state?).to be_truthy
+          expect(subresource_class.properties[:x].identity?).to be_truthy
+          expect(subresource_class.identity_properties).to eq [
+            subresource_class.properties[:x]
+          ]
+          expect(subresource.identity).to eq(10)
+          expect(subresource_class.state_properties).to eq [
+            subresource_class.properties[:x]
+          ]
+          expect(subresource.state_for_resource_reporter).to eq(x: 10)
+        end
+
+        it "state_properties(:y) adds y to desired state" do
+          old_value = resource_class.properties[:x]
+          subresource_class.state_properties(:y)
+          subresource.x 10
+
+          expect(subresource_class.properties[:x].object_id).to eq old_value.object_id
+          expect(subresource_class.properties[:y].desired_state?).to be_truthy
+          expect(subresource_class.state_properties).to eq [
+            subresource_class.properties[:y]
+          ]
+          expect(subresource.state_for_resource_reporter).to eq(y: 20)
+
+          expect(subresource_class.properties[:x].identity?).to be_truthy
+          expect(subresource_class.identity_properties).to eq [
+            subresource_class.properties[:x]
+          ]
+          expect(subresource.identity).to eq(10)
+        end
+      end
+    end
   end
 
 end

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -111,32 +111,38 @@ describe "Chef::Resource.property validation" do
         it "get succeeds" do
           expect(resource.x).to eq 'default'
         end
-        it "set(nil) = get" do
-          expect(resource.x nil).to eq 'default'
-          expect(resource.x).to eq 'default'
-        end
         it "set to valid value succeeds" do
           expect(resource.x 'str').to eq 'str'
           expect(resource.x).to eq 'str'
         end
         it "set to invalid value raises ValidationFailed" do
           expect { resource.x 10 }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+        it "set to nil emits a deprecation warning and does a get" do
+          expect { resource.x nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
+          Chef::Config[:treat_deprecation_warnings_as_errors] = false
+          resource.x 'str'
+          expect(resource.x nil).to eq 'str'
+          expect(resource.x).to eq 'str'
         end
       end
       context "when the variable does not have an initial value" do
         it "get succeeds" do
           expect(resource.x).to be_nil
         end
-        it "set(nil) = get" do
-          expect(resource.x nil).to be_nil
-          expect(resource.x).to be_nil
-        end
         it "set to valid value succeeds" do
           expect(resource.x 'str').to eq 'str'
           expect(resource.x).to eq 'str'
         end
         it "set to invalid value raises ValidationFailed" do
           expect { resource.x 10 }.to raise_error Chef::Exceptions::ValidationFailed
+        end
+        it "set to nil emits a deprecation warning and does a get" do
+          expect { resource.x nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
+          Chef::Config[:treat_deprecation_warnings_as_errors] = false
+          resource.x 'str'
+          expect(resource.x nil).to eq 'str'
+          expect(resource.x).to eq 'str'
         end
       end
     end
@@ -255,10 +261,10 @@ describe "Chef::Resource.property validation" do
       [ '', 'abac' ],
       [ nil ]
 
-    # PropertyType
-    # validation_test 'is: PropertyType.new(is: :a)',
-    #   [ :a ],
-    #   [ :b, nil ]
+    # Property
+    validation_test 'is: Chef::Property.new(is: :a)',
+      [ :a ],
+      [ :b, nil ]
 
     # RSpec Matcher
     class Globalses
@@ -523,10 +529,11 @@ describe "Chef::Resource.property validation" do
         expect(resource.x 1).to eq 1
         expect(resource.x).to eq 1
       end
-      it "value nil does a get" do
+      it "value nil emits a deprecation warning and does a get" do
+        expect { resource.x nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
         Chef::Config[:treat_deprecation_warnings_as_errors] = false
         resource.x 1
-        resource.x nil
+        expect(resource.x nil).to eq 1
         expect(resource.x).to eq 1
       end
     end
@@ -556,9 +563,11 @@ describe "Chef::Resource.property validation" do
         expect(resource.x 1).to eq 1
         expect(resource.x).to eq 1
       end
-      it "value nil does a get" do
+      it "value nil emits a deprecation warning and does a get" do
+        expect { resource.x nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
+        Chef::Config[:treat_deprecation_warnings_as_errors] = false
         resource.x 1
-        resource.x nil
+        expect(resource.x nil).to eq 1
         expect(resource.x).to eq 1
       end
     end
@@ -571,10 +580,9 @@ describe "Chef::Resource.property validation" do
         expect(resource.x 1).to eq 1
         expect(resource.x).to eq 1
       end
-      it "value nil does a get" do
-        resource.x 1
-        resource.x nil
-        expect(resource.x).to eq 1
+      it "value nil is invalid" do
+        Chef::Config[:treat_deprecation_warnings_as_errors] = false
+        expect { resource.x nil }.to raise_error Chef::Exceptions::ValidationFailed
       end
     end
   end
@@ -595,11 +603,6 @@ describe "Chef::Resource.property validation" do
             end
           end
         end
-
-        # it "getting the value causes a deprecation warning" do
-        #   Chef::Config[:treat_deprecation_warnings_as_errors] = true
-        #   expect { resource.x }.to raise_error Chef::Exceptions::DeprecatedFeatureError
-        # end
 
         it "value 1 is valid" do
           expect(resource.x 1).to eq 1

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -556,7 +556,7 @@ describe "Chef::Resource.property validation" do
     end
 
     with_property ':x, name_property: true, required: true' do
-      it "if x is not specified, retrieval succeeds" do
+      it "if x is not specified, the name property is returned" do
         expect(resource.x).to eq 'blah'
       end
       it "value 1 is valid" do

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -581,8 +581,11 @@ describe "Chef::Resource.property validation" do
         expect(resource.x).to eq 1
       end
       it "value nil is invalid" do
+        expect { resource.x nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
         Chef::Config[:treat_deprecation_warnings_as_errors] = false
-        expect { resource.x nil }.to raise_error Chef::Exceptions::ValidationFailed
+        resource.x 1
+        expect(resource.x nil).to eq 1
+        expect(resource.x).to eq 1
       end
     end
   end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -958,6 +958,11 @@ describe "Chef::Resource.property" do
           expect(resource.x).to eq 10
         end
       end
+      with_property ":x, #{name}: true, required: true" do
+        it "defaults x to resource.name" do
+          expect(resource.x).to eq 'blah'
+        end
+      end
     end
   end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -59,8 +59,8 @@ describe Chef::Resource do
   end
 
   describe "when declaring the identity attribute" do
-    it "has no identity attribute by default" do
-      expect(Chef::Resource.identity_attr).to be_nil
+    it "has :name as identity attribute by default" do
+      expect(Chef::Resource.identity_attr).to eq(:name)
     end
 
     it "sets an identity attribute" do


### PR DESCRIPTION
Adds a Property class to encapsulate property behavior with getters, setters, and defaults; stores identity and desired_state on them; drives identity_attr and state_attrs based on that.