### PR TITLE
Make required name attributes work

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -130,9 +130,9 @@ class Chef
 
           # Get the default value
           else
-            _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
             _pv_default(opts, symbol, default) unless default == NOT_PASSED
             _pv_name_property(opts, symbol, name_property)
+            _pv_required(opts, symbol, required, explicitly_allows_nil?(symbol, validation)) if required
 
             if opts.has_key?(symbol)
               # Handle lazy defaults.
@@ -380,7 +380,7 @@ class Chef
       def _pv_name_property(opts, key, is_name_property=true)
         if is_name_property
           if opts[key].nil?
-            opts[key] = self.instance_variable_get("@name")
+            opts[key] = self.instance_variable_get(:"@name")
           end
         end
       end

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -549,8 +549,8 @@ describe "Chef::Resource.property validation" do
     end
 
     with_property ':x, name_property: true, required: true' do
-      it "if x is not specified, retrieval fails" do
-        expect { resource.x }.to raise_error Chef::Exceptions::ValidationFailed
+      it "if x is not specified, retrieval succeeds" do
+        expect(resource.x).to eq 'blah'
       end
       it "value 1 is valid" do
         expect(resource.x 1).to eq 1
@@ -564,8 +564,8 @@ describe "Chef::Resource.property validation" do
     end
 
     with_property ':x, default: 10, required: true' do
-      it "if x is not specified, retrieval fails" do
-        expect { resource.x }.to raise_error Chef::Exceptions::ValidationFailed
+      it "if x is not specified, the default is returned" do
+        expect(resource.x).to eq 10
       end
       it "value 1 is valid" do
         expect(resource.x 1).to eq 1


### PR DESCRIPTION
Right now we evaluate required before name_attribute, which means we didn't know it had a value.