### PR TITLE
add the word group to converge_by call for group provider

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -125,7 +125,7 @@ class Chef
       def action_create
         case @group_exists
         when false
-          converge_by("create #{@new_resource.group_name}") do
+          converge_by("create group #{@new_resource.group_name}") do
             create_group
             Chef::Log.info("#{@new_resource} created")
           end


### PR DESCRIPTION
Other `converge_by` calls specify what resource they are acting on, and other calls in the group provider also do so, but for some reason group creation doesn't.