### PR TITLE
Revert "Freeze default constants"

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -317,7 +317,6 @@ class Chef
       def _pv_default(opts, key, default_value)
         value = _pv_opts_lookup(opts, key)
         if value.nil?
-          default_value = default_value.freeze if !default_value.is_a?(DelayedEvaluator)
           opts[key] = default_value
         end
       end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -367,13 +367,9 @@ describe "Chef::Resource.property" do
           expect(resource.x.object_id).to eq(value.object_id)
         end
         it "Multiple instances of x receive the exact same value" do
+          # TODO this isn't really great behavior, but it's noted here so we find out
+          # if it changed.
           expect(resource.x.object_id).to eq(resource_class.new('blah2').x.object_id)
-        end
-        it "The default value is frozen" do
-          expect(resource.x).to be_frozen
-        end
-        it "The default value cannot be written to" do
-          expect { resource.x[:a] = 1 }.to raise_error RuntimeError, /frozen/
         end
       end
 


### PR DESCRIPTION
This reverts commit 705e22b975196baa6decf23f9c3a7e676d6aefc4.

I'd like to revert this change because it breaks the packagecloud
cookbook.

See https://gist.github.com/cwebberOps/ae002be2339ca843cbb3