### PR TITLE
Making it possible for delayed resources to know if the current chef run has crashed so far

### DIFF
--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -144,6 +144,8 @@ class Chef
       @reboot_info = {}
       @cookbook_compiler = nil
 
+      @has_crashed = false
+
       initialize_child_state
     end
 
@@ -522,6 +524,22 @@ ERROR_MESSAGE
       ChildRunContext.new(self)
     end
 
+    #
+    # Marks the run_context as having crashed
+    #
+    def has_crashed!
+      @has_crashed = true
+    end
+
+    #
+    # Returns true if the current run has crashed
+    #
+    # @return[True/False] The current value
+    #
+    def has_crashed?
+      @has_crashed
+    end
+
     protected
 
     attr_reader :cookbook_compiler
@@ -589,6 +607,8 @@ ERROR_MESSAGE
         request_reboot
         resolve_attribute
         unreachable_cookbook?
+        has_crashed!
+        has_crashed?
       )
 
       def initialize(parent_run_context)

--- a/lib/chef/runner.rb
+++ b/lib/chef/runner.rb
@@ -94,10 +94,14 @@ class Chef
     # Run all our :delayed actions
     def run_delayed_notifications(error=nil)
       collected_failures = Exceptions::MultipleFailures.new
-      collected_failures.client_run_failure(error) unless error.nil?
+      unless error.nil?
+        run_context.has_crashed!
+        collected_failures.client_run_failure(error)
+      end
       delayed_actions.each do |notification|
         result = run_delayed_notification(notification)
         if result.kind_of?(Exception)
+          run_context.has_crashed!
           collected_failures.notification_failure(result)
         end
       end

--- a/spec/support/lib/chef/provider/snakeoil.rb
+++ b/spec/support/lib/chef/provider/snakeoil.rb
@@ -25,7 +25,7 @@ class Chef
       end
 
       def action_purr
-        @new_resource.updated_by_last_action(true)
+        new_resource.updated_by_last_action(true)
         true
       end
 
@@ -34,6 +34,12 @@ class Chef
       end
 
       def action_buy
+        true
+      end
+
+      def action_check_has_crashed
+        new_resource.updated_by_last_action(true)
+        new_resource.run_context_has_crashed = node.run_context.has_crashed?
         true
       end
     end

--- a/spec/support/lib/chef/resource/cat.rb
+++ b/spec/support/lib/chef/resource/cat.rb
@@ -21,6 +21,7 @@ class Chef
     class Cat < Chef::Resource
 
       attr_accessor :action
+      attr_accessor :run_context_has_crashed
 
       def initialize(name, run_context=nil)
         super


### PR DESCRIPTION
It sometimes happens that some delayed resources get notifications from several other resources,
and that sadness can ensue if some of these notifying resources have run but not others.

This patch makes it possible, in such cases, to test if a delayed resource is running after
another resource has crashed or not, with
```
node.run_context.has_crashed?
```

Updated unit tests.

Note that Travis builds will fail until https://github.com/chef/cheffish/pull/53 is merged.