### PR TITLE
Try fix for failing config test

### DIFF
--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -236,12 +236,17 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
 
       let(:config_content) { "" }
 
+      # We need to keep a reference to the tempfile because while #close does
+      # not unlink the file, the object being GC'd will.
+      let(:tempfile) do
+        Tempfile.new("Chef-WorkstationConfigLoader-rspec-test").tap do |t|
+          t.print(config_content)
+          t.close
+        end
+      end
+
       let(:explicit_config_location) do
-        # could use described_class, but remove all ':' from the path if so.
-        t = Tempfile.new("Chef-WorkstationConfigLoader-rspec-test")
-        t.print(config_content)
-        t.close
-        t.path
+        tempfile.path
       end
 
       after { File.unlink(explicit_config_location) if File.exist?(explicit_config_location) }


### PR DESCRIPTION
We keep seeing this randomly
```
1) Chef::WorkstationConfigLoader loading the config file when the config file exists and raises a ruby exception during evaluation raises a ConfigurationError
   Failure/Error: expect { config_loader.load }.to raise_error(Chef::Exceptions::ConfigurationError)
     expected Chef::Exceptions::ConfigurationError, got #<Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/Chef-WorkstationConfigLoader-rspec-test20150707-35300-f9yfb6> with backtrace:
       # ./lib/chef/workstation_config_loader.rb:164:in `readlines'
       # ./lib/chef/workstation_config_loader.rb:164:in `highlight_config_error'
       # ./lib/chef/workstation_config_loader.rb:156:in `rescue in read_config'
       # ./lib/chef/workstation_config_loader.rb:137:in `read_config'
       # ./lib/chef/workstation_config_loader.rb:72:in `load'
       # ./spec/unit/workstation_config_loader_spec.rb:275:in `block (6 levels) in <top (required)>'
       # ./spec/unit/workstation_config_loader_spec.rb:275:in `block (5 levels) in <top (required)>'
   # ./spec/unit/workstation_config_loader_spec.rb:275:in `block (5 levels) in <top (required)>'
```

I think the issue is that the tempfile gets GC'd, and when it gets GC'd, it deletes the file.
If it is cleaned up before it is used, then the test fails.