### PR TITLE
Fix error message for providers without `provides`

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -200,14 +200,13 @@ class Chef
             class_name = resource_type.class.name ? resource_type.class.name.split('::').last :
               convert_to_class_name(resource_type.resource_name.to_s)
 
-            begin
-              result = Chef::Provider.const_get(class_name)
-              Chef::Log.warn("Class Chef::Provider::#{class_name} does not declare 'resource_name #{convert_to_snake_case(class_name).to_sym.inspect}'.")
-              Chef::Log.warn("This will no longer work in Chef 13: you must use 'resource_name' to provide DSL.")
-            rescue NameError
+            if Chef::Provider.const_defined?(class_name)
+              Chef::Log.warn("Class Chef::Provider::#{class_name} does not declare 'provides #{convert_to_snake_case(class_name).to_sym.inspect}'.")
+              Chef::Log.warn("This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.")
+              return Chef::Provider.const_get(class_name)
             end
           end
-          result
+          nil
         end
 
     end

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -119,7 +119,7 @@ describe "Recipe DSL methods" do
             recipe = converge {
               backcompat_thingy 'blah' do; end
             }
-            expect(recipe.logged_warnings).to match(/Class Chef::Provider::BackcompatThingy does not declare 'resource_name :backcompat_thingy'./)
+            expect(recipe.logged_warnings).to match(/Class Chef::Provider::BackcompatThingy does not declare 'provides :backcompat_thingy'./)
             expect(BaseThingy.created_resource).not_to be_nil
           end
         end


### PR DESCRIPTION
The warning incorrectly said that the provider was missing
`resource_name :resource` when it should have said it was
missing `provides :resource`

I also switched from using `begin`...`rescue` since it isn't needed and
needlessly slow things up.

I think I got the logic right, but would appreciate a careful review.

Fixes #3614