### PR TITLE
Allow resource actions to resolve lazy blocks - Issue #3615

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -173,6 +173,7 @@ class Chef
     #
     def action(arg=nil)
       if arg
+        arg = arg.call if arg.respond_to?(:call)
         arg = Array(arg).map(&:to_sym)
         arg.each do |action|
           validate(


### PR DESCRIPTION
Resource actions cannot resolve lazy blocks as they pack the passed
arg into an array and call :to_sym on members. Check to see if
the arg :responds_to?(:call) and resolve the block before Array
instantiation

Fixes #3615 (on the 12.4 codebase)