### PR TITLE
Allow resource action to call block if passed - Issues #3615

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1367,7 +1367,7 @@ class Chef
     # @return The Action class implementing the action
     #
     def self.action(action, &recipe_block)
-      action = action.to_sym
+      action = action.respond_to?(:call) ? action.call.to_sym : action.to_sym
       new_action_provider_class.action(action, &recipe_block)
       self.allowed_actions += [ action ]
       default_action action if Array(default_action) == [:nothing]


### PR DESCRIPTION
Fixes #3615

Addressed by checking the action param of self.action for Resource
for a response to :call. If found, action.call.to_sym is used
instead of the original action.to_sym which doesn't work on a proc.