### PR TITLE
Set chef_environment in attributes JSON

### DIFF
--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -6,3 +6,19 @@ Example Doc Change:
 Description of the required change.
 -->
 
+### chef-client -j JSON
+Add to the [description of chef-client options](https://docs.chef.io/ctl_chef_client.html#options):
+
+> This option can also be used to set a node's `chef_environment`. For example,
+running `chef-client -j /path/to/file.json` where `/path/to/file.json` is
+similar to:
+```
+{
+  "chef_environment": "pre-production"
+}
+```
+will set the node's environment to `"pre-production"`.
+
+> *Note that the environment specified by `chef_environment` in your JSON will
+take precedence over an environment specified by `-E ENVIROMENT` when both options
+are provided.*

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -672,6 +672,13 @@ describe Chef::Node do
       expect(node.run_list).to eq([ "role[base]", "recipe[chef::server]" ])
     end
 
+    it "sets the node chef_environment" do
+      attrs = { "chef_environment" => "foo_environment", "bar" => "baz" }
+      expect(node.consume_chef_environment(attrs)).to eq({ "bar" => "baz" })
+      expect(node.chef_environment).to eq("foo_environment")
+      expect(node['chef_environment']).to be nil
+    end
+
     it "should overwrites the run list with the run list it consumes" do
       node.consume_run_list "recipes" => [ "one", "two" ]
       node.consume_run_list "recipes" => [ "three" ]


### PR DESCRIPTION
Allows users to have `"chef_environment": "some_environment"` in their JSON attributes file (e.g., `/etc/chef/first_boot.json`). Setting `"chef_environment"` in the attributes JSON has the same effect as running `chef-client -E some_environment`.

Note [this comment on CLI option precedence](https://github.com/chef/chef/blob/64e0a1da0826f5befababb5693d8bb5b8de913e9/lib/chef/node.rb#L351-L360). I've struggled to come up with a reasonable workaround which doesn't involve completely reworking the interaction between`Chef::Config` and CLI `config`.

\cc @chef/client-core @charlesjohnson @alexpop 