### PR TITLE
Switch notifications from Hipchat to Slack (#open-source channel)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,5 @@ notifications:
     urls:
     # Gitter IM
     - secure: HmMKr/ysKVyKUJ24PRCHcA8QCmlFoukrYumY0GRLzvaFWO8PknHO1t/0RbrKRb2ed/hgkFd+RKNCYvSvcE8Ahr2vlMrBeGHGfVeOGkWtbhLgNqo1b50Ll9CqvTM8X2ZIq6hIWraanwoYRQu/8uGL29yH4lBi7DhpTkFwBMLulhQ=
-  hipchat:
-    rooms:
-    # Build Statuses
-    - secure: G8MNo94L8bmWWwkH2/ViB2QaZnZHZscYM/mEjDbOGd15sqrruwckeARyBoUcRI7P1C6AFmS4IKCNVXa6KzX4Pbh51gQWM92zRpRTZpplwtXz53/1l8ajLFLLMLvEMTlBFAANUKEUFAQPY4dMa14V3Qc5oijfIncN61k4nZNTKpY=
-    # Open Source
-    - secure: hmcex4PpG5dn8WvjndONO4xCUKOC5kPU/bUEGRrfVbe2YKJE7t0XXbNDC96W/xBgzgnJzvf1Er0zJKDrNf4qEDEWFoozdN00WLcqREgaLLS3Seto2FjR/BpBk5q+sCV0rwwEMms2P4Qk+VSnDCnm9EaeM55hOabqNuOrRzoZLBQ=
+  slack:
+    secure: K1R0u9K9RDczKu7byFXbrG7wLcJlWUVlkXWU5ULviMxTZgPf1/NuYnIPhrgHBBcFWDV4iURlFtGfu9Iyepdv/n3y1UoC+sACGmfGsY8y/BSCz6gb5o+e5YCPlAyQXeJd7TaKTfjH20n1xwGcwg3+I7QgVyg430U5m1jtcfIskWU=


### PR DESCRIPTION
I'm assuming the token is global to our org, so it's not tied to me... but if someone finds out otherwise please let me know.