### PR TITLE
Fix issue where DSL is not emitted if state_properties happens before property

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -779,6 +779,7 @@ class Chef
     def self.property(name, type=NOT_PASSED, **options)
       name = name.to_sym
 
+      options[:instance_variable_name] = :"@#{name}" if !options.has_key?(:instance_variable_name)
       options.merge!(name: name, declared_in: self)
 
       if type == NOT_PASSED
@@ -1002,8 +1003,8 @@ class Chef
           end
         end
 
-        # If state_attrs *excludes* something which is currently part of the
-        # identity, mark it as identity: false.
+        # If identity_properties *excludes* something which is currently part of
+        # the identity, mark it as identity: false.
         properties.each do |name,property|
           if property.identity? && !names.include?(name)
             self.property name, identity: false

--- a/spec/unit/property/state_spec.rb
+++ b/spec/unit/property/state_spec.rb
@@ -369,6 +369,21 @@ describe "Chef::Resource#identity and #state" do
       end
     end
 
+    context "When state_properties happens before properties are declared" do
+      before do
+        resource_class.class_eval do
+          state_properties :x
+          property :x
+        end
+      end
+      it "the property works and is in state_properties" do
+        expect(resource_class.state_properties).to include(resource_class.properties[:x])
+        resource.x = 1
+        expect(resource.x).to eq 1
+        expect(resource.state_for_resource_reporter).to eq(x: 1)
+      end
+    end
+
     with_property ":x, Integer, identity: true" do
       it "state_properties(:x) leaves the property in desired_state" do
         resource_class.state_properties(:x)


### PR DESCRIPTION
If you call state_properties :x, and there is no
property :x yet, it assumes you are working with a custom
getter/setter like "def x". This is fine, but when you say
"property :x", it won't override that (and will treat the
property as if the getter/setter were already defined instead
of creating a new one).