### PR TITLE
Correct Windows reboot command to delay in minutes

### DIFF
--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -32,7 +32,7 @@ class Chef
 
           cmd = if Chef::Platform.windows?
             # should this do /f as well? do we then need a minimum delay to let apps quit?
-            "shutdown /r /t #{reboot_info[:delay_mins]} /c \"#{reboot_info[:reason]}\""
+            "shutdown /r /t #{reboot_info[:delay_mins]*60} /c \"#{reboot_info[:reason]}\""
           else
             # probably Linux-only.
             "shutdown -r +#{reboot_info[:delay_mins]} \"#{reboot_info[:reason]}\""

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => 'shutdown /r /t 5 /c "rebooter spec test"',
+      :windows => 'shutdown /r /t 300 /c "rebooter spec test"',
       :linux => 'shutdown -r +5 "rebooter spec test"'
     }
   end


### PR DESCRIPTION
Correct the command used to reboot Windows machines so that it converts
a given delay_mins option to the appropriate number of seconds.

Fixes #3673