### PR TITLE
Remove warnings about hander overrides.

### DIFF
--- a/lib/chef/platform/handler_map.rb
+++ b/lib/chef/platform/handler_map.rb
@@ -31,11 +31,6 @@ class Chef
           # are exactly equal
           if new_matcher[:value].is_a?(Class) && !new_matcher[:override]
             cmp = compare_matcher_properties(new_matcher, matcher) { |m| m[:value].name }
-            if cmp < 0
-              Chef::Log.warn "You are overriding #{key} on #{new_matcher[:filters].inspect} with #{new_matcher[:value].inspect}: used to be #{matcher[:value].inspect}. Use override: true if this is what you intended."
-            elsif cmp > 0
-              Chef::Log.warn "You declared a new resource #{new_matcher[:value].inspect} for resource #{key}, but it comes alphabetically after #{matcher[:value].inspect} and has the same filters (#{new_matcher[:filters].inspect}), so it will not be used. Use override: true if you want to use it for #{key}."
-            end
           end
         end
         cmp

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -794,21 +794,6 @@ describe "Recipe DSL methods" do
         end
       end
 
-      context "when Thingy9 provides :thingy9" do
-        before(:context) {
-          class RecipeDSLSpecNamespace::Thingy9 < BaseThingy
-            resource_name :thingy9
-          end
-        }
-
-        it "declaring a resource providing the same :thingy9 produces a warning" do
-          expect(Chef::Log).to receive(:warn).with("You declared a new resource RecipeDSLSpecNamespace::Thingy9AlternateProvider for resource thingy9, but it comes alphabetically after RecipeDSLSpecNamespace::Thingy9 and has the same filters ({}), so it will not be used. Use override: true if you want to use it for thingy9.")
-          class RecipeDSLSpecNamespace::Thingy9AlternateProvider < BaseThingy
-            resource_name :thingy9
-          end
-        end
-      end
-
       context "when Thingy10 provides :thingy10" do
         before(:context) {
           class RecipeDSLSpecNamespace::Thingy10 < BaseThingy

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -163,8 +163,6 @@ describe Chef::Recipe do
           end
 
           it "selects the first one alphabetically even if the declaration order is reversed" do
-            expect(Chef::Log).to receive(:warn).with("You are overriding football2 on {:platform=>\"nbc_sports\"} with Sounders: used to be TottenhamHotspur. Use override: true if this is what you intended.")
-
             TottenhamHotspur.provides :football2, platform: "nbc_sports"
             Sounders.provides :football2, platform: "nbc_sports"
 

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -154,8 +154,6 @@ describe Chef::Recipe do
           end
 
           it "selects the first one alphabetically" do
-            expect(Chef::Log).to receive(:warn).with("You declared a new resource TottenhamHotspur for resource football, but it comes alphabetically after Sounders and has the same filters ({:platform=>\"nbc_sports\"}), so it will not be used. Use override: true if you want to use it for football.")
-
             Sounders.provides :football, platform: "nbc_sports"
             TottenhamHotspur.provides :football, platform: "nbc_sports"
 


### PR DESCRIPTION
These are high-volume, difficult to silence, and often not actually an error (in which case they may be impossible to silence forever). Worse, doing what the error says and setting override:true without understanding what that does can have unexpected effects (https://github.com/jssjr/git/issues/70). If we want to keep them, they should be moved to debug, but as they often don't indicate any error, I think they should be removed.

Opening this for discussion. /cc @jkeiser @lamont-granquist @someara 