### PR TITLE
Add formatter and force-logger/formatter options to chef-apply

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -49,6 +49,24 @@ class Chef::Application::Apply < Chef::Application
     :description => "Load attributes from a JSON file or URL",
     :proc => nil
 
+  option :force_logger,
+    :long         => "--force-logger",
+    :description  => "Use logger output instead of formatter output",
+    :boolean      => true,
+    :default      => false
+
+  option :force_formatter,
+    :long         => "--force-formatter",
+    :description  => "Use formatter output instead of logger output",
+    :boolean      => true,
+    :default      => false
+
+  option :formatter,
+    :short        => "-F FORMATTER",
+    :long         => "--format FORMATTER",
+    :description  => "output format to use",
+    :proc         => lambda { |format| Chef::Config.add_formatter(format) }
+
   option :log_level,
     :short        => "-l LEVEL",
     :long         => "--log_level LEVEL",


### PR DESCRIPTION
This change simply copies the formatter, force-logger and force-formatter
options across from chef-client/chef-solo to chef-apply. The options are
honored without further changes, and this allows you to force doc formatting
output with chef-apply when the output isn't a terminal.

To test:

```
$ chef-apply -F doc -e "log 'hello world'" | cat # Should use doc formatter instead of logging
$ chef-apply --force-formatter -e "log 'hello world'" | cat # Should use doc formatter instead of logging
$ chef-apply --force-logger -e "log 'hello world'" # This prints double entries in my tests, but the behavior is the same on chef solo
```