### PR TITLE
Add ohai configuration context to config.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ gem "activesupport", "< 4.0.0", :group => :compat_testing, :platform => "ruby"
 
 gem 'chef-config', path: "chef-config"
 
-# REMOVEME once there is a release of Ohai with these changes, and the
-# chef.gemspec is updated.
-gem 'ohai', github: 'chef/ohai',
-            ref: '7556a1d55808c459f3a9fad88e2a2371f361f3e0'
-
 group(:docgen) do
   gem "tomlrb"
   gem "yard"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ gem "activesupport", "< 4.0.0", :group => :compat_testing, :platform => "ruby"
 
 gem 'chef-config', path: "chef-config"
 
+# REMOVEME once there is a release of Ohai with these changes, and the
+# chef.gemspec is updated.
+gem 'ohai', github: 'chef/ohai',
+            ref: '7556a1d55808c459f3a9fad88e2a2371f361f3e0'
+
 group(:docgen) do
   gem "tomlrb"
   gem "yard"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-log", "~> 1.3"
   s.add_dependency "mixlib-authentication", "~> 1.3"
   s.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0"
-  s.add_dependency "ohai", "~> 8.0"
+  # s.add_dependency "ohai", "~> 8.0"
 
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", "~> 2.6"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-log", "~> 1.3"
   s.add_dependency "mixlib-authentication", "~> 1.3"
   s.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0"
-  # s.add_dependency "ohai", "~> 8.0"
+  s.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9"
 
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", "~> 2.6"

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -28,8 +28,11 @@ require 'chef-config/logger'
 ChefConfig.logger = Chef::Log
 
 require 'chef-config/config'
-
 require 'chef/platform/query_helpers'
+
+# Load the ohai config into the chef config. We can't have an empty ohai
+# configuration context because `ohai.plugins_path << some_path` won't work.
+require 'ohai/config'
 
 class Chef
   Config = ChefConfig::Config

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,31 @@
+
+require 'spec_helper'
+
+require 'chef/config'
+
+RSpec.describe Chef::Config do
+
+  shared_examples_for "deprecated by ohai but not deprecated" do
+    it "does not emit a deprecation warning when set" do
+      expect(Chef::Log).to_not receive(:warn).
+        with(/Ohai::Config\[:#{option}\] is deprecated/)
+      Chef::Config[option] = value
+      expect(Chef::Config[option]).to eq(value)
+    end
+  end
+
+  describe ":log_level" do
+    include_examples "deprecated by ohai but not deprecated" do
+      let(:option) { :log_level }
+      let(:value) { :debug }
+    end
+  end
+
+  describe ":log_location" do
+    include_examples "deprecated by ohai but not deprecated" do
+      let(:option) { :log_location }
+      let(:value) { "path/to/log" }
+    end
+  end
+
+end


### PR DESCRIPTION
We need a way for `Chef::Config` to pick up `Ohai::Config.ohai` configurables so that Ohai is properly configured at the start of a `chef-client` run.

Adding an empty `ohai` configuration context to `Chef::Config` means append/modify operations (e.g., `ohai.plugin_path << some_path` or `ohai.plugin_path += [ some_path_1, ..., some_path_N ]`) won't work and it's not DRY to copy default values here.

Since the new Ohai configuration uses `ChefConfig::Config`, a `require 'ohai/config'` will make the Ohai configurables available to `Chef::Config`.

Requires a release of Ohai including (at least) [this change](https://github.com/chef/ohai/pull/574).

@chef/client-core 