### PR TITLE
Make the doc formatter actually show what version of a cookbook is being used.

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -131,7 +131,7 @@ class Chef
       files_remaining_by_cookbook[file.cookbook] -= 1
 
       if files_remaining_by_cookbook[file.cookbook] == 0
-        @events.synchronized_cookbook(file.cookbook.name)
+        @events.synchronized_cookbook(file.cookbook)
       end
     end
 

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -131,7 +131,7 @@ class Chef
       files_remaining_by_cookbook[file.cookbook] -= 1
 
       if files_remaining_by_cookbook[file.cookbook] == 0
-        @events.synchronized_cookbook(file.cookbook)
+        @events.synchronized_cookbook(file.cookbook.name, file.cookbook)
       end
     end
 

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -119,7 +119,7 @@ class Chef
       end
 
       # Called when cookbook +cookbook+ has been sync'd
-      def synchronized_cookbook(cookbook)
+      def synchronized_cookbook(cookbook_name, cookbook)
       end
 
       # Called when an individual file in a cookbook has been updated

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -118,8 +118,8 @@ class Chef
       def cookbook_sync_start(cookbook_count)
       end
 
-      # Called when cookbook +cookbook_name+ has been sync'd
-      def synchronized_cookbook(cookbook_name)
+      # Called when cookbook +cookbook+ has been sync'd
+      def synchronized_cookbook(cookbook)
       end
 
       # Called when an individual file in a cookbook has been updated

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -134,7 +134,7 @@ class Chef
       end
 
       # Called when cookbook +cookbook+ has been sync'd
-      def synchronized_cookbook(cookbook)
+      def synchronized_cookbook(cookbook_name, cookbook)
         puts_line "- #{cookbook.name} (#{cookbook.version})"
       end
 

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -133,9 +133,9 @@ class Chef
         indent
       end
 
-      # Called when cookbook +cookbook_name+ has been sync'd
-      def synchronized_cookbook(cookbook_name)
-        puts_line "- #{cookbook_name}"
+      # Called when cookbook +cookbook+ has been sync'd
+      def synchronized_cookbook(cookbook)
+        puts_line "- #{cookbook.name} (#{cookbook.version})"
       end
 
       # Called when an individual file in a cookbook has been updated

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -109,8 +109,8 @@ class Chef
         puts "Synchronizing cookbooks"
       end
 
-      # Called when cookbook +cookbook_name+ has been sync'd
-      def synchronized_cookbook(cookbook_name)
+      # Called when cookbook +cookbook+ has been sync'd
+      def synchronized_cookbook(cookbook)
         print "."
       end
 

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -110,7 +110,7 @@ class Chef
       end
 
       # Called when cookbook +cookbook+ has been sync'd
-      def synchronized_cookbook(cookbook)
+      def synchronized_cookbook(cookbook_name, cookbook)
         print "."
       end
 

--- a/spec/unit/formatters/doc_spec.rb
+++ b/spec/unit/formatters/doc_spec.rb
@@ -43,4 +43,10 @@ describe Chef::Formatters::Base do
     expect(out.string).to include("Using policy 'jenkins' at revision '613f803bdd035d574df7fa6da525b38df45a74ca82b38b79655efed8a189e073'")
   end
 
+  it "prints cookbook name and version" do
+    cookbook_version = double(name: "apache2", version: "1.2.3")
+    formatter.synchronized_cookbook("apache2", cookbook_version)
+    expect(out.string).to include("- apache2 (1.2.3")
+  end
+
 end


### PR DESCRIPTION
This has bugged me forever. It does change the API of the Formatter system in a ~non-back-compat way but I don't think I've actually seen any formatters outside of core Chef so how much do we want to worry about this? We could write a shim in `Chef::EventDispatcher::Dispatcher` to check the arity of the method if needed.

Ping @chef/client-core.