### PR TITLE
Add support for OS X 10.11 SIP paths

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -228,6 +228,37 @@ module ChefConfig
         joined_paths
       end
     end
+
+    # Determine if the given path is protected by OS X System Integrity Protection.
+    def self.is_sip_path?(path, node)
+      if node['platform'] == 'mac_os_x' and Gem::Version.new(node['platform_version']) >= Gem::Version.new('10.11')
+          # todo: parse rootless.conf for this?
+          sip_paths= [
+            '/System', '/bin', '/sbin', '/usr',
+          ]
+          sip_paths.each do |sip_path|
+            ChefConfig.logger.info("This is a SIP path, checking if it in exceptions list.")
+            return true if path.start_with?(sip_path)
+          end
+          false
+      else
+        false
+      end
+    end
+    # Determine if the given path is on the exception list for OS X System Integrity Protection.
+    def self.writable_sip_path?(path)
+      # todo: parse rootless.conf for this?
+      sip_exceptions = [
+        '/System/Library/Caches', '/System/Library/Extensions',
+        '/System/Library/Speech', '/System/Library/User Template',
+        '/usr/libexec/cups', '/usr/local', '/usr/share/man'
+      ]
+      sip_exceptions.each do |exception_path|
+        return true if path.start_with?(exception_path)
+      end
+      ChefConfig.logger.error("Cannot write to a SIP Path on OS X 10.11+")
+      false
+    end
   end
 end
 

--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -64,7 +64,13 @@ class Chef
               is_parent_writable = lambda do |base_dir|
                 base_dir = ::File.dirname(base_dir)
                 if ::File.exists?(base_dir)
-                  Chef::FileAccessControl.writable?(base_dir)
+                  if Chef::FileAccessControl.writable?(base_dir)
+                    true
+                  elsif Chef::Util::PathHelper.is_sip_path?(base_dir, node)
+                    Chef::Util::PathHelper.writable_sip_path?(base_dir)
+                  else
+                    false
+                  end
                 else
                   is_parent_writable.call(base_dir)
                 end
@@ -74,7 +80,13 @@ class Chef
               # in why run mode & parent directory does not exist no permissions check is required
               # If not in why run, permissions must be valid and we rely on prior assertion that dir exists
               if !whyrun_mode? || ::File.exists?(parent_directory)
-                Chef::FileAccessControl.writable?(parent_directory)
+                if Chef::FileAccessControl.writable?(parent_directory)
+                  true
+                elsif Chef::Util::PathHelper.is_sip_path?(parent_directory, node)
+                  Chef::Util::PathHelper.writable_sip_path?(@new_resource.path)
+                else
+                  false
+                end
               else
                 true
               end


### PR DESCRIPTION
Currently, Chef will fail to create /usr/local as /usr is no longer writable on OS X 10.11.

To work around this, If a path cannot be written, we do the following:

* Check to see if the path is writable. If is, continue as we normally would.
* Check to see if we are on 10.11 and if it is a SIP path.
* If it is 10.11 and it is a SIP path, check to see if it is on the exception list. If so, return true.
* If it is not 10.11 or a SIP path, return false as you normally would.

I'm sure this could use some tweaking, but I wanted to get the PR up so we could start discussions on it. Without this functionality, Chef will simply break on 10.11 while trying to write /usr/local and any other folder that is an exception path for SIP.

I am with Facebook, so as soon as we are happy with this PR, @jaymzh will have to do the merge as I am not on the CLA.