### PR TITLE
Only call Chef::Log.init() if needed

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -134,7 +134,9 @@ class Chef
     # that a user has configured a log_location in client.rb, but is running
     # chef-client by hand to troubleshoot a problem.
     def configure_logging
-      Chef::Log.init(MonoLogger.new(Chef::Config[:log_location]))
+      if Chef::Config[:log_location] || Chef::Log.unconfigured?
+        Chef::Log.init(MonoLogger.new(Chef::Config[:log_location]))
+      end
       if want_additional_logger?
         configure_stdout_logger
       end

--- a/lib/chef/log.rb
+++ b/lib/chef/log.rb
@@ -46,5 +46,8 @@ class Chef
       end
     end
 
+    def self.unconfigured?
+      @logger.nil?
+    end
   end
 end


### PR DESCRIPTION
Check if loc_location is set or if Chef::Log is unconfigured
before calling init() on it.

See issue #3735 for reason/use-case.