### PR TITLE
speed improvement for remote_directory() resource

### DIFF
--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -67,7 +67,7 @@ class Chef
                  ::File::FNM_DOTMATCH)
 
         # Remove current directory and previous directory
-        files.reject! do |name|
+        files = files.reject do |name|
           basename = Pathname.new(name).basename().to_s
           ['.', '..'].include?(basename)
         end


### PR DESCRIPTION
***Problem:***
doing `ls(path)` for a very large directory with > 1.8mil files takes upwards of 10 minutes.

***Solution:***
change filtering stage from `files.reject!` to files.reject
switching to `files.reject` decreases the runtime of that function from 650 seconds down to 6-7 seconds.
`files.reject!` does in place filtering and it looks like it copies the remaining array for each item filtered so it's running time is around o(n^2) vs o(n) for `files.reject`

***Second part of the optimisation:**
`files.map {|f| Chef::Util::PathHelper.cleanpath(f)}` takes almost 2 minutes in the above example when going over 1.5kk rows (after 300k were filtered out).
I've tested multiple samples, it appears that cleanpath() makes no difference to the original paths what so ever. Does it need to be there?
Could someone more knowledgeable about the reasons why it was put here in the first place comment on this?

All in all, after doing these changes, my chef run now takes only 4 minutes, down from 14.

Special thanks to @eam for helping to track this down and suggesting the fix.

Note: I've originally started looking this because that same remote_directory step alone was taking ***42 minutes***. I have since cleaned up about a third of data from that directory and the stats above are from after the cleanup.