### PR TITLE
Remove freeze of defaults, add warning for array/hash constant defaults

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -89,9 +89,6 @@ class Chef
       options[:name_property] = options.delete(:name_attribute) if options.has_key?(:name_attribute) && !options.has_key?(:name_property)
       @options = options
 
-      if options.has_key?(:default)
-        options[:default] = options[:default].freeze
-      end
       options[:name] = options[:name].to_sym if options[:name]
       options[:instance_variable_name] = options[:instance_variable_name].to_sym if options[:instance_variable_name]
     end
@@ -285,7 +282,7 @@ class Chef
           # If the value is mutable (non-frozen), we set it on the instance
           # so that people can mutate it.  (All constant default values are
           # frozen.)
-          if !value.frozen?
+          if !value.frozen? && !value.nil?
             set_value(resource, value)
           end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -808,6 +808,10 @@ class Chef
         property = property_type(**options)
       end
 
+      if !options[:default].frozen? && (options[:default].is_a?(Array) || options[:default].is_a?(Hash))
+        Chef::Log.warn("Property #{self}.#{name} has an array or hash default (#{options[:default]}). This means that if one resource modifies or appends to it, all other resources of the same type will also see the changes. Either freeze the constant with `.freeze` to prevent appending, or use lazy { #{options[:default].inspect} }.")
+      end
+
       local_properties = properties(false)
       local_properties[name] = property
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -474,12 +474,12 @@ describe "Chef::Resource.property" do
         it "Multiple instances of x receive the exact same value" do
           expect(resource.x.object_id).to eq(resource_class.new('blah2').x.object_id)
         end
-        it "The default value is frozen" do
-          expect(resource.x).to be_frozen
-        end
-        it "The default value cannot be written to" do
-          expect { resource.x[:a] = 1 }.to raise_error RuntimeError, /frozen/
-        end
+      end
+
+      it "when a property is declared with default: {}, a warning is issued" do
+        expect(Chef::Log).to receive(:warn).with(match(/^Property .+\.x has an array or hash default \(\{\}\)\. This means that if one resource modifies or appends to it, all other resources of the same type will also see the changes\. Either freeze the constant with \`\.freeze\` to prevent appending, or use lazy \{ \{\} \}\.$/))
+        resource_class.class_eval("property :x, default: {}", __FILE__, __LINE__)
+        expect(resource.x).to eq({})
       end
 
       with_property ':x, default: lazy { {} }' do


### PR DESCRIPTION
Relies on https://github.com/chef/mixlib-log/pull/10