### PR TITLE
Added caching of children to avoid traversing the file system on every file request

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_dir.rb
@@ -58,7 +58,7 @@ class Chef
         end
 
         def children
-          begin
+          @children ||= begin
             Dir.entries(file_path).sort.
                 select { |child_name| can_have_child?(child_name, File.directory?(File.join(file_path, child_name))) }.
                 map { |child_name| make_child(child_name) }.

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbook_entry.rb
@@ -34,7 +34,7 @@ class Chef
         attr_reader :recursive
 
         def children
-          begin
+          @children ||= begin
             Dir.entries(file_path).sort.
                 select { |child_name| can_have_child?(child_name, File.directory?(File.join(file_path, child_name))) }.
                 map { |child_name| make_child(child_name) }.

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_cookbooks_dir.rb
@@ -37,7 +37,7 @@ class Chef
         attr_reader :chefignore
 
         def children
-          begin
+          @children ||= begin
             Dir.entries(file_path).sort.
                 select { |child_name| can_have_child?(child_name, File.directory?(File.join(file_path, child_name))) }.
                 map { |child_name| make_child(child_name) }.

--- a/lib/chef/chef_fs/file_system/chef_repository_file_system_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_repository_file_system_entry.rb
@@ -72,7 +72,7 @@ class Chef
 
         def children
           # Except cookbooks and data bag dirs, all things must be json files
-          begin
+          @children ||= begin
             Dir.entries(file_path).sort.
                 select { |child_name| can_have_child?(child_name, File.directory?(File.join(file_path, child_name))) }.
                 map { |child_name| make_child(child_name) }


### PR DESCRIPTION
When using chef-client in local mode the file system access is extremely slow and causes the resolving of the run list cookbooks to take over 30 minutes for my team.  

When digging into why it was taking so long we discovered that every file request was re-iterating all of the files because the way the children get built.  I saw that ```ChefRepositoryFileSystemRootDir``` cached its created children so I took that concept and extended it to the other related objects.  The caching has significantly improved the performance and the entire resolving & synchronization takes under 20 seconds now.

Here are some performance numbers using Ruby Benchmark on some of the file operations before & after:

## Before
```
LIST organizations/chef/cookbooks/ntp:   0.010000   1.320000   1.330000 (  1.325998)
LIST organizations/chef/cookbooks/sudo:   0.010000   1.270000   1.280000 (  1.291669)
LIST organizations/chef/cookbooks/ssh_known_hosts:   0.000000   1.280000   1.280000 (  1.284465)
LIST organizations/chef/cookbooks/chef-timezone:   0.010000   1.330000   1.340000 (  1.344935)
LIST organizations/chef/cookbooks/postfix:   0.010000   1.340000   1.350000 (  1.367667)
GET organizations/chef/cookbooks/ntp/1.1.8:   0.030000   2.700000   2.730000 (  2.743045)
GET organizations/chef/cookbooks/sudo/2.7.1:   0.020000   2.700000   2.720000 (  2.722147)
GET organizations/chef/cookbooks/ssh_known_hosts/2.0.0:   0.020000   2.630000   2.650000 (  2.660303)
GET organizations/chef/cookbooks/chef-timezone/0.0.1:   0.030000   2.670000   2.700000 (  2.711711)
GET organizations/chef/cookbooks/postfix/3.6.2:   0.060000   2.580000   2.640000 (  2.645569)
```

## After
```
LIST organizations/chef/cookbooks/ntp:   0.000000   0.010000   0.010000 (  0.001487)
LIST organizations/chef/cookbooks/sudo:   0.000000   0.000000   0.000000 (  0.001182)
LIST organizations/chef/cookbooks/ssh_known_hosts:   0.000000   0.000000   0.000000 (  0.000966)
LIST organizations/chef/cookbooks/chef-timezone:   0.000000   0.000000   0.000000 (  0.001770)
LIST organizations/chef/cookbooks/postfix:   0.000000   0.000000   0.000000 (  0.001557)
GET organizations/chef/cookbooks/ntp/1.1.8:   0.000000   0.040000   0.040000 (  0.046823)
GET organizations/chef/cookbooks/sudo/2.7.1:   0.010000   0.030000   0.040000 (  0.042465)
GET organizations/chef/cookbooks/ssh_known_hosts/2.0.0:   0.000000   0.010000   0.010000 (  0.018355)
GET organizations/chef/cookbooks/chef-timezone/0.0.1:   0.000000   0.010000   0.010000 (  0.020508)
GET organizations/chef/cookbooks/postfix/3.6.2:   0.030000   0.040000   0.070000 (  0.063699)
```
