### PR TITLE
Use fixed vagrant-wrapper, kitchen-ec2 and test-kitchen gems

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -2,9 +2,9 @@ source "https://rubygems.org"
 
 group :end_to_end do
   gem 'berkshelf'
-  gem 'test-kitchen', '~> 1.4.0'
+  gem 'test-kitchen', '~> 1.4.0', github: 'test-kitchen/test-kitchen'
   gem 'kitchen-appbundle-updater', '~> 0.0.1'
   gem "kitchen-vagrant", '~> 0.17.0'
   gem 'kitchen-ec2', github: 'test-kitchen/kitchen-ec2'
-  gem 'vagrant-wrapper'
+  gem 'vagrant-wrapper', github: 'jkeiser/gem-vagrant-wrapper', branch: 'jk/binread'
 end


### PR DESCRIPTION
@tball this incorporates kitchen-ec2 and test-kitchen master branch, as well as an as-yet-merged-or-released change to vagrant-wrapper that fixes kitchen-tests on OS/X.