### PR TITLE
Don't use shell_out! on "lssrc -g" 

### DIFF
--- a/lib/chef/provider/service/aix.rb
+++ b/lib/chef/provider/service/aix.rb
@@ -116,7 +116,7 @@ class Chef
         end
 
         def is_resource_group?
-          so = shell_out!("lssrc -g #{@new_resource.service_name}")
+          so = shell_out("lssrc -g #{@new_resource.service_name}")
           if so.exitstatus == 0
             Chef::Log.debug("#{@new_resource.service_name} is a group")
             @is_resource_group = true

--- a/spec/unit/provider/service/aix_service_spec.rb
+++ b/spec/unit/provider/service/aix_service_spec.rb
@@ -94,7 +94,7 @@ describe Chef::Provider::Service::Aix do
       end
 
       it "service is a group" do
-        expect(@provider).to receive(:shell_out!).with("lssrc -g chef").and_return(@status)
+        expect(@provider).to receive(:shell_out).with("lssrc -g chef").and_return(@status)
         @provider.load_current_resource
         expect(@provider.instance_eval("@is_resource_group")).to be_truthy
       end
@@ -106,7 +106,7 @@ describe Chef::Provider::Service::Aix do
       end
 
       it "service is a group" do
-        expect(@provider).to receive(:shell_out!).with("lssrc -g chef").and_return(@status)
+        expect(@provider).to receive(:shell_out).with("lssrc -g chef").and_return(@status)
         @provider.load_current_resource
         expect(@provider.instance_eval("@is_resource_group")).to be_truthy
       end
@@ -119,7 +119,7 @@ describe Chef::Provider::Service::Aix do
       end
 
       it "service is a subsystem" do
-        expect(@provider).to receive(:shell_out!).with("lssrc -g chef").and_return(@group_status)
+        expect(@provider).to receive(:shell_out).with("lssrc -g chef").and_return(@group_status)
         expect(@provider).to receive(:shell_out!).with("lssrc -s chef").and_return(@service_status)
         @provider.load_current_resource
         expect(@provider.instance_eval("@is_resource_group")).to be_falsey


### PR DESCRIPTION
It will raise an exception if the service is not a group; instead what we want is to check the return code. If 0, it's a group, otherwise, it is not.

Fixes #3730.