### PR TITLE
highline is used by core Chef; therefore remove this misleading comment

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", "~> 2.6"
   s.add_dependency "net-ssh-multi", "~> 1.1"
-  # CHEF-3027: The knife-cloud plugins require newer features from highline, core chef should not.
   s.add_dependency "highline", "~> 1.6", ">= 1.6.9"
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"


### PR DESCRIPTION
I see a few uses of `highline` inside core Chef:

```
lib/chef/formatters/indentable_output_stream.rb:          require 'highline'
lib/chef/knife/bootstrap.rb:        require 'highline'
lib/chef/knife/core/ui.rb:          require 'highline'
lib/chef/knife/list.rb:        require 'highline'
```