### PR TITLE
uniquify chef_repo_path

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -128,7 +128,7 @@ module ChefConfig
       if chef_repo_path.kind_of?(String)
         PathHelper.join(chef_repo_path, child_path)
       else
-        chef_repo_path.map { |path| PathHelper.join(path, child_path)}
+        chef_repo_path.uniq.map { |path| PathHelper.join(path, child_path)}
       end
     end
 


### PR DESCRIPTION
With `~/.chef/knife.rb` like below,
```ruby
cookbook_path [
  '/home/polamjag/some-chef-repo/cookbooks',
  '/home/polamjag/some-chef-repo/site-cookbooks'
]
```
error like this occurs:
```
% knife vault create secrets somesystem '{"foo_passwd": "p@ssw0rd"}' -V
INFO: Using configuration from /home/polamjag/.chef/knife.rb
ERROR: Errno::ENOENT: No such file or directory @ dir_s_mkdir - /home/polamjag/some-chef-repo/data_bags/home/polamjag/some-chef-repo/data_bags/secrets
```

This PR fixes that.