### PR TITLE
Add support for override depth and adding test in overriding depth

### DIFF
--- a/lib/chef/resource/deploy.rb
+++ b/lib/chef/resource/deploy.rb
@@ -27,6 +27,7 @@
 #   migration_command "rake db:migrate"
 #   environment "RAILS_ENV" => "production", "OTHER_ENV" => "foo"
 #   shallow_clone true
+#   depth 1
 #   action :deploy # or :rollback
 #   restart_command "touch tmp/restart.txt"
 #   git_ssh_wrapper "wrap-ssh4git.sh"
@@ -74,6 +75,7 @@ class Chef
         @remote = "origin"
         @enable_submodules = false
         @shallow_clone = false
+        @depth = nil
         @scm_provider = Chef::Provider::Git
         @svn_force_export = false
         @additional_remotes = Hash[]
@@ -97,8 +99,12 @@ class Chef
         @current_path ||= @deploy_to + "/current"
       end
 
-      def depth
-        @shallow_clone ? "5" : nil
+      def depth(arg=@shallow_clone ? 5 : nil)
+        set_or_return(
+          :depth,
+          arg,
+          :kind_of => [ Integer ]
+        )
       end
 
       # note: deploy_to is your application "meta-root."

--- a/spec/unit/resource/deploy_spec.rb
+++ b/spec/unit/resource/deploy_spec.rb
@@ -148,10 +148,16 @@ describe Chef::Resource::Deploy do
     expect(@resource.current_path).to eql("/my/deploy/dir/current")
   end
 
+  it "allows depth to be set via integer" do
+    expect(@resource.depth).to be_nil
+    @resource.depth 1
+    expect(@resource.depth).to eql(1)
+  end
+
   it "gives #depth as 5 if shallow clone is true, nil otherwise" do
     expect(@resource.depth).to be_nil
     @resource.shallow_clone true
-    expect(@resource.depth).to eql("5")
+    expect(@resource.depth).to eql(5)
   end
 
   it "aliases repo as repository" do


### PR DESCRIPTION
This change would allow to override depth on deploy.

    include_recipe 'deploy'
    r = resources('deploy[/srv/www/simpleapp]')
    r.depth 1

this also would allow to set depth when creating a deploy resource.

    deploy 'test repo with depth' do
      repo 'https://github.com/renanvicente/lab_ecommerce_simple'
      user 'root'
      depth 1
      deploy_to '/tmp/test_with_depth'
      action :deploy
    end

why we need that?
Some times you may have a git repo with a large .git and you do not want to clone everything because it will take to long. We have shallow_clone but it only allow changing it to 5.