### PR TITLE
Changes --hide-healthy to --hide-by-mins MINS

### DIFF
--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -41,8 +41,12 @@ class Chef
         :long => "--sort-reverse",
         :description => "Sort the status list by last run time descending"
 
+      option :hide_healthy,
+        :short => "-H",
+        :long => "--hide-healthy",
+        :description => "Hide nodes that have run chef in the last hour. [DEPRECATED] Use --hide-by-mins MINS instead"
+
       option :hide_by_mins,
-        :short => "-H MINS",
         :long => "--hide-by-mins MINS",
         :description => "Hide nodes that have run chef in the last MINS minutes"
 
@@ -66,6 +70,14 @@ class Chef
         @query ||= ""
         append_to_query(@name_args[0]) if @name_args[0]
         append_to_query("chef_environment:#{config[:environment]}") if config[:environment]
+
+        if config[:hide_healthy]
+          ui.warn("-H / --hide-healthy is deprecated. Use --hide-by-mins MINS instead")
+          time = Time.now.to_i
+          # AND NOT is not valid lucene syntax, so don't use append_to_query
+          @query << " " unless @query.empty?
+          @query << "NOT ohai_time:[#{(time - 60*60).to_s} TO #{time.to_s}]"
+        end
 
         if config[:hide_by_mins]
           hidemins = config[:hide_by_mins].to_i

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -41,10 +41,10 @@ class Chef
         :long => "--sort-reverse",
         :description => "Sort the status list by last run time descending"
 
-      option :hide_healthy,
-        :short => "-H",
-        :long => "--hide-healthy",
-        :description => "Hide nodes that have run chef in the last hour"
+      option :hide_by_mins,
+        :short => "-H MINS",
+        :long => "--hide-by-mins MINS",
+        :description => "Hide nodes that have run chef in the last MINS minutes"
 
       def append_to_query(term)
         @query << " AND " unless @query.empty?
@@ -67,11 +67,12 @@ class Chef
         append_to_query(@name_args[0]) if @name_args[0]
         append_to_query("chef_environment:#{config[:environment]}") if config[:environment]
 
-        if config[:hide_healthy]
+        if config[:hide_by_mins]
+          hidemins = config[:hide_by_mins].to_i
           time = Time.now.to_i
           # AND NOT is not valid lucene syntax, so don't use append_to_query
           @query << " " unless @query.empty?
-          @query << "NOT ohai_time:[#{(time - 60*60).to_s} TO #{time.to_s}]"
+          @query << "NOT ohai_time:[#{(time - hidemins*60).to_s} TO #{time.to_s}]"
         end
 
         @query = @query.empty? ? "*:*" : @query

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -44,8 +44,8 @@ describe Chef::Knife::Status do
       @knife.run
     end
 
-    it "should filter healthy nodes" do
-      @knife.config[:hide_healthy] = true
+    it "should filter by nodes older than some mins" do
+      @knife.config[:hide_by_mins] = 60
       expect(@query).to receive(:search).with(:node, "NOT ohai_time:[1428569820 TO 1428573420]", opts)
       @knife.run
     end
@@ -56,9 +56,9 @@ describe Chef::Knife::Status do
       @knife.run
     end
 
-    it "should filter by environment and health" do
+    it "should filter by environment and nodes older than some mins" do
       @knife.config[:environment] = "production"
-      @knife.config[:hide_healthy] = true
+      @knife.config[:hide_by_mins] = 60
       expect(@query).to receive(:search).with(:node, "chef_environment:production NOT ohai_time:[1428569820 TO 1428573420]", opts)
       @knife.run
     end
@@ -79,21 +79,21 @@ describe Chef::Knife::Status do
         @knife.run
       end
 
-      it "should filter healthy nodes" do
-        @knife.config[:hide_healthy] = true
+      it "should filter by nodes older than some mins with nodename specified" do
+        @knife.config[:hide_by_mins] = 60
         expect(@query).to receive(:search).with(:node, "name:my_custom_name NOT ohai_time:[1428569820 TO 1428573420]", opts)
         @knife.run
       end
 
-      it "should filter by environment" do
+      it "should filter by environment with nodename specified" do
         @knife.config[:environment] = "production"
         expect(@query).to receive(:search).with(:node, "name:my_custom_name AND chef_environment:production", opts)
         @knife.run
       end
 
-      it "should filter by environment and health" do
+      it "should filter by environment and nodes older than some mins with nodename specified" do
         @knife.config[:environment] = "production"
-        @knife.config[:hide_healthy] = true
+        @knife.config[:hide_by_mins] = 60
         expect(@query).to receive(:search).with(:node, "name:my_custom_name AND chef_environment:production NOT ohai_time:[1428569820 TO 1428573420]", opts)
         @knife.run
       end

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -45,8 +45,8 @@ describe Chef::Knife::Status do
     end
 
     it "should filter by nodes older than some mins" do
-      @knife.config[:hide_by_mins] = 60
-      expect(@query).to receive(:search).with(:node, "NOT ohai_time:[1428569820 TO 1428573420]", opts)
+      @knife.config[:hide_by_mins] = 59
+      expect(@query).to receive(:search).with(:node, "NOT ohai_time:[1428569880 TO 1428573420]", opts)
       @knife.run
     end
 
@@ -58,8 +58,8 @@ describe Chef::Knife::Status do
 
     it "should filter by environment and nodes older than some mins" do
       @knife.config[:environment] = "production"
-      @knife.config[:hide_by_mins] = 60
-      expect(@query).to receive(:search).with(:node, "chef_environment:production NOT ohai_time:[1428569820 TO 1428573420]", opts)
+      @knife.config[:hide_by_mins] = 59
+      expect(@query).to receive(:search).with(:node, "chef_environment:production NOT ohai_time:[1428569880 TO 1428573420]", opts)
       @knife.run
     end
 
@@ -80,8 +80,8 @@ describe Chef::Knife::Status do
       end
 
       it "should filter by nodes older than some mins with nodename specified" do
-        @knife.config[:hide_by_mins] = 60
-        expect(@query).to receive(:search).with(:node, "name:my_custom_name NOT ohai_time:[1428569820 TO 1428573420]", opts)
+        @knife.config[:hide_by_mins] = 59
+        expect(@query).to receive(:search).with(:node, "name:my_custom_name NOT ohai_time:[1428569880 TO 1428573420]", opts)
         @knife.run
       end
 
@@ -93,8 +93,8 @@ describe Chef::Knife::Status do
 
       it "should filter by environment and nodes older than some mins with nodename specified" do
         @knife.config[:environment] = "production"
-        @knife.config[:hide_by_mins] = 60
-        expect(@query).to receive(:search).with(:node, "name:my_custom_name AND chef_environment:production NOT ohai_time:[1428569820 TO 1428573420]", opts)
+        @knife.config[:hide_by_mins] = 59
+        expect(@query).to receive(:search).with(:node, "name:my_custom_name AND chef_environment:production NOT ohai_time:[1428569880 TO 1428573420]", opts)
         @knife.run
       end
     end


### PR DESCRIPTION
Fixes #3679

Reasoning:

The definition of "healthy" is overloaded in the old form
(--hide-healthy) to be "a host that has run chef". The code
makes no check to determine if the chef run was successful,
so it has the capability to provide false positives for
"health". Just because a node object was saved with ohai_time
set doesn't mean the Chef run was successful. There are
exception handlers like lastrun that intentionally save the node
object on exception.

The previous 1 hour hardcoded time was totally arbitrary. Perhaps
"healthy" to others means "nodes that have run chef in the last
4 hours" (or 30 minutes, or 3 days...).