### PR TITLE
Fix failing directory unit tests on rhel

### DIFF
--- a/spec/unit/provider/directory_spec.rb
+++ b/spec/unit/provider/directory_spec.rb
@@ -203,6 +203,7 @@ describe Chef::Provider::Directory do
         allow(node).to receive(:[]).with("platform").and_return('mac_os_x')
         new_resource.path "/usr/bin/chef_test"
         new_resource.recursive false
+        allow_any_instance_of(Chef::Provider::File).to receive(:do_selinux)
       end
 
       it "os x 10.10 can write to sip locations" do


### PR DESCRIPTION
do_selinux needs to be mocked out so it does not actually do anything.
Otherwise, it will be available on rhel and the tests are no longer
unit and will fail