### PR TITLE
Don't modify members of new_resource in pw group implmentation

### DIFF
--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -109,7 +109,7 @@ class Chef
           else
             # Append is not set so we're resetting the membership of
             # the group to the given members.
-            members_to_be_added = @new_resource.members
+            members_to_be_added = @new_resource.members.dup
             @current_resource.members.each do |member|
               # No need to re-add a member if it's present in the new
               # list of members


### PR DESCRIPTION
This was causing the

```
Chef::Resource::Group
  group modify action
    when there is a group
      behaves like correct group management
        when the users exist
          when append is not set
            when group already contains some users
              should remove all existing users and only add the new users to the group
```
spec to fail. The test passes an array which gets modified which breaks the test.