### PR TITLE
Fix dsc_script spec failure on 64-bit Ruby

### DIFF
--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -67,8 +67,7 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only do
     node = Chef::Node.new
     node.automatic['platform'] = 'windows'
     node.automatic['platform_version'] = '6.1'
-    node.automatic['kernel'][:machine] =
-      is_i386_process_on_x86_64_windows? ? :x86_64 : :i386
+    node.automatic['kernel'][:machine] = :x86_64  # Only 64-bit architecture is supported
     node.automatic[:languages][:powershell][:version] = '4.0'
     empty_events = Chef::EventDispatch::Dispatcher.new
     Chef::RunContext.new(node, {}, empty_events)


### PR DESCRIPTION
dsc_script_spec.rb currently fails under 64-bit Ruby. The fix here is to make sure we ensure that the node architecture for the test is always set to 64-bit (since dsc is not supported on 32-bit Windows).  

@adamedx @jaym 