### PR TITLE
fix supports hash issues in service providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   [pr#3704](https://github.com/chef/chef/pull/3704): Add SIP (OS X 10.11) support
 * [**Phil Dibowitz**](https://github.com/jaymzh):
 
+* [pr#3799](https://github.com/chef/chef/pull/3799) fix supports hash issues in service providers
 * [pr#3817](https://github.com/chef/chef/pull/3817) Remove now-useless forcing of ruby Garbage Collector run
 * [pr#3805](https://github.com/chef/chef/pull/3805) LWRP parameter validators should use truthiness
 * [pr#3774](https://github.com/chef/chef/pull/3774) Add support for yum-deprecated in yum provider

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,10 @@ class Chef
 
       include Chef::Mixin::Command
 
+      def supports
+        @supports ||= new_resource.supports.dup
+      end
+
       def initialize(new_resource, run_context)
         super
         @enabled = nil
@@ -32,6 +36,12 @@ class Chef
 
       def whyrun_supported?
         true
+      end
+
+      def load_current_resource
+        supports[:status] = false if supports[:status].nil?
+        supports[:reload] = false if supports[:reload].nil?
+        supports[:restart] = false if supports[:restart].nil?
       end
 
      def load_new_resource_state
@@ -50,7 +60,7 @@ class Chef
 
       def define_resource_requirements
        requirements.assert(:reload) do |a|
-         a.assertion { @new_resource.supports[:reload] || @new_resource.reload_command }
+         a.assertion { supports[:reload] || @new_resource.reload_command }
          a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
          # if a service is not declared to support reload, that won't
          # typically change during the course of a run - so no whyrun

--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -99,7 +99,7 @@ class Chef
         def restart_service
           if new_resource.restart_command
             super
-          elsif new_resource.supports[:restart]
+          elsif supports[:restart]
             shell_out_with_systems_locale!("#{init_command} fastrestart")
           else
             stop_service

--- a/lib/chef/provider/service/gentoo.rb
+++ b/lib/chef/provider/service/gentoo.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Lee Jensen (<ljensen@engineyard.com>)
 # Author:: AJ Christensen (<aj@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,9 +26,9 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
   provides :service, platform_family: "gentoo"
 
   def load_current_resource
+    supports[:status] = true if supports[:status].nil?
+    supports[:restart] = true if supports[:restart].nil?
 
-    @new_resource.supports[:status] = true
-    @new_resource.supports[:restart] = true
     @found_script = false
     super
 

--- a/lib/chef/provider/service/init.rb
+++ b/lib/chef/provider/service/init.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ class Chef
         def restart_service
           if @new_resource.restart_command
             super
-          elsif @new_resource.supports[:restart]
+          elsif supports[:restart]
             shell_out_with_systems_locale!("#{default_init_command} restart")
           else
             stop_service
@@ -84,7 +84,7 @@ class Chef
         def reload_service
           if @new_resource.reload_command
             super
-          elsif @new_resource.supports[:reload]
+          elsif supports[:reload]
             shell_out_with_systems_locale!("#{default_init_command} reload")
           end
         end

--- a/lib/chef/provider/service/openbsd.rb
+++ b/lib/chef/provider/service/openbsd.rb
@@ -40,11 +40,12 @@ class Chef
           @rc_conf = ::File.read(RC_CONF_PATH) rescue ''
           @rc_conf_local = ::File.read(RC_CONF_LOCAL_PATH) rescue ''
           @init_command = ::File.exist?(rcd_script_path) ? rcd_script_path : nil
-          new_resource.supports[:status] = true
           new_resource.status_command("#{default_init_command} check")
         end
 
         def load_current_resource
+          supports[:status] = true if supports[:status].nil?
+
           @current_resource = Chef::Resource::Service.new(new_resource.name)
           current_resource.service_name(new_resource.service_name)
 

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -42,7 +42,6 @@ class Chef
         def initialize(new_resource, run_context)
           super
           @init_command = "/sbin/service #{new_resource.service_name}"
-          new_resource.supports[:status] = true
           @service_missing = false
           @current_run_levels = []
         end
@@ -69,6 +68,8 @@ class Chef
         end
 
         def load_current_resource
+          supports[:status] = true if supports[:status].nil?
+
           super
 
           if ::File.exists?("/sbin/chkconfig")

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -76,7 +76,7 @@ class Chef
           end
 
           requirements.assert(:all_actions) do |a|
-            a.assertion { @new_resource.status_command or @new_resource.supports[:status] or
+            a.assertion { @new_resource.status_command or supports[:status] or
               (!ps_cmd.nil? and !ps_cmd.empty?) }
             a.failure_message Chef::Exceptions::Service, "#{@new_resource} could not determine how to inspect the process table, please set this node's 'command.ps' attribute"
           end
@@ -127,7 +127,7 @@ class Chef
               nil
             end
 
-          elsif @new_resource.supports[:status]
+          elsif supports[:status]
             Chef::Log.debug("#{@new_resource} supports status, running")
             begin
               if shell_out("#{default_init_command} status").exitstatus == 0

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -45,7 +45,7 @@ class Chef
         @priority = nil
         @timeout = nil
         @run_levels = nil
-        @supports = { :restart => false, :reload => false, :status => false }
+        @supports = { :restart => nil, :reload => nil, :status => nil }
       end
 
       def service_name(arg=nil)

--- a/spec/unit/provider/service/gentoo_service_spec.rb
+++ b/spec/unit/provider/service/gentoo_service_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Lee Jensen (<ljensen@engineyard.com>)
 # Author:: AJ Christensen (<aj@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,17 +108,17 @@ describe Chef::Provider::Service::Gentoo do
 
     it "should support the status command automatically" do
       @provider.load_current_resource
-      expect(@new_resource.supports[:status]).to be_truthy
+      expect(@provider.supports[:status]).to be true
     end
 
     it "should support the restart command automatically" do
       @provider.load_current_resource
-      expect(@new_resource.supports[:restart]).to be_truthy
+      expect(@provider.supports[:restart]).to be true
     end
 
     it "should not support the reload command automatically" do
       @provider.load_current_resource
-      expect(@new_resource.supports[:reload]).not_to be_truthy
+      expect(@provider.supports[:reload]).to be_falsey
     end
 
   end

--- a/spec/unit/provider/service/openbsd_service_spec.rb
+++ b/spec/unit/provider/service/openbsd_service_spec.rb
@@ -35,10 +35,12 @@ describe Chef::Provider::Service::Openbsd do
     node
   end
 
+  let(:supports) { {:status => false} }
+
   let(:new_resource) do
     new_resource = Chef::Resource::Service.new("sndiod")
     new_resource.pattern("sndiod")
-    new_resource.supports({:status => false})
+    new_resource.supports(supports)
     new_resource
   end
 
@@ -106,9 +108,7 @@ describe Chef::Provider::Service::Openbsd do
     context "when the service supports status" do
       let(:status) { double(:stdout => "", :exitstatus => 0) }
 
-      before do
-        new_resource.supports({:status => true})
-      end
+      let(:supports) { { :status => true } }
 
       it "should run '/etc/rc.d/service_name status'" do
         expect(provider).to receive(:shell_out).with("/etc/rc.d/#{new_resource.service_name} check").and_return(status)
@@ -305,10 +305,12 @@ describe Chef::Provider::Service::Openbsd do
     end
 
     describe Chef::Provider::Service::Openbsd, "restart_service" do
-      it "should call 'restart' on the service_name if the resource supports it" do
-        new_resource.supports({:restart => true})
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{new_resource.service_name} restart")
-        provider.restart_service()
+      context "when the new_resource supports restart" do
+        let(:supports) { { restart: true } }
+        it "should call 'restart' on the service_name if the resource supports it" do
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{new_resource.service_name} restart")
+          provider.restart_service()
+        end
       end
 
       it "should call the restart_command if one has been specified" do

--- a/spec/unit/resource/service_spec.rb
+++ b/spec/unit/resource/service_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
 # Author:: Tyler Cloke (<tyler@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,14 +139,14 @@ describe Chef::Resource::Service do
       expect { @resource.send(attrib, "poop") }.to raise_error(ArgumentError)
     end
 
-    it "should default all the feature support to false" do
-      support_hash = { :status => false, :restart => false, :reload=> false }
+    it "should default all the feature support to nil" do
+      support_hash = { :status => nil, :restart => nil, :reload=> nil }
       expect(@resource.supports).to eq(support_hash)
     end
 
     it "should allow you to set what features this resource supports as a array" do
       support_array = [ :status, :restart ]
-      support_hash = { :status => true, :restart => true, :reload => false }
+      support_hash = { :status => true, :restart => true, :reload => nil }
       @resource.supports(support_array)
       expect(@resource.supports).to eq(support_hash)
     end


### PR DESCRIPTION
- redhat provider now allows the user to override :status
- gentoo provider now allows the user to override :status and :restart
- service providers now dup the status hash and mutate their private
  copy instead of mutating the new_resource

closes #2168