### PR TITLE
Replace output_of_command with shell_out! in subversion provider

### DIFF
--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -130,8 +130,8 @@ class Chef
             @new_resource.revision
           else
             command = scm(:info, @new_resource.repository, @new_resource.svn_info_args, authentication, "-r#{@new_resource.revision}")
-            status, svn_info, error_message = output_of_command(command, run_options)
-            handle_command_failures(status, "STDOUT: #{svn_info}\nSTDERR: #{error_message}")
+            svn_info = shell_out!(command, run_options(:cwd => cwd, :returns => [0,1])).stdout
+
             extract_revision_info(svn_info)
           end
         end
@@ -142,11 +142,8 @@ class Chef
       def find_current_revision
         return nil unless ::File.exist?(::File.join(@new_resource.destination, ".svn"))
         command = scm(:info)
-        status, svn_info, error_message = output_of_command(command, run_options(:cwd => cwd))
+        svn_info = shell_out!(command, run_options(:cwd => cwd, :returns => [0,1])).stdout
 
-        unless [0,1].include?(status.exitstatus)
-          handle_command_failures(status, "STDOUT: #{svn_info}\nSTDERR: #{error_message}")
-        end
         extract_revision_info(svn_info)
       end
 
@@ -180,6 +177,7 @@ class Chef
           attrs
         end
         rev = (repo_attrs['Last Changed Rev'] || repo_attrs['Revision'])
+        rev.strip! if rev
         raise "Could not parse `svn info` data: #{svn_info}" if repo_attrs.empty?
         Chef::Log.debug "#{@new_resource} resolved revision #{@new_resource.revision} to #{rev}"
         rev
@@ -197,12 +195,20 @@ class Chef
       end
 
       def scm(*args)
-        ['svn', *args].compact.join(" ")
+        binary = svn_binary
+        binary = "\"#{binary}\"" if binary =~ /\s/
+        [binary, *args].compact.join(" ")
       end
 
       def target_dir_non_existent_or_empty?
         !::File.exist?(@new_resource.destination) || Dir.entries(@new_resource.destination).sort == ['.','..']
       end
+
+      def svn_binary
+        @new_resource.svn_binary ||
+          (Chef::Platform.windows? ? 'svn.exe' : 'svn')
+      end
+
       def assert_target_directory_valid!
         target_parent_directory = ::File.dirname(@new_resource.destination)
         unless ::File.directory?(target_parent_directory)

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -28,11 +28,16 @@ class Chef
         super
         @svn_arguments = '--no-auth-cache'
         @svn_info_args = '--no-auth-cache'
+        @svn_binary = nil
       end
 
       # Override exception to strip password if any, so it won't appear in logs and different Chef notifications
       def custom_exception_message(e)
         "#{self} (#{defined_at}) had an error: #{e.class.name}: #{svn_password ? e.message.gsub(svn_password, "[hidden_password]") : e.message}"
+      end
+
+      def svn_binary(arg=nil)
+        set_or_return(:svn_binary, arg, :kind_of => [String])
       end
     end
   end

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -54,6 +54,10 @@ describe Chef::Resource::Subversion do
     expect(@svn.svn_arguments).to eq('--no-auth-cache')
   end
 
+  it "sets svn binary to nil by default" do
+    expect(@svn.svn_binary).to be_nil
+  end
+
   it "resets svn arguments to nil when given false in the setter" do
     @svn.svn_arguments(false)
     expect(@svn.svn_arguments).to be_nil


### PR DESCRIPTION
output_of_command doesn't work properly on Windows (see chef/chef#1533)