### PR TITLE
Fix win32 error code handling in NamedSecurityInfo

### DIFF
--- a/lib/chef/win32/error.rb
+++ b/lib/chef/win32/error.rb
@@ -57,8 +57,8 @@ class Chef
       # nil::: always returns nil when it does not raise
       # === Raises
       # Chef::Exceptions::Win32APIError:::
-      def self.raise!(message = nil)
-        code = get_last_error
+      def self.raise!(message = nil, code = nil)
+        code = get_last_error if code.nil?
         msg = format_message(code).strip
         formatted_message = ""
         formatted_message << message if message

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -201,7 +201,7 @@ class Chef
         security_descriptor = FFI::MemoryPointer.new :pointer
         hr = GetNamedSecurityInfoW(path.to_wstring, type, info, nil, nil, nil, nil, security_descriptor)
         if hr != ERROR_SUCCESS
-          Chef::ReservedNames::Win32::Error.raise!("get_named_security_info(#{path}, #{type}, #{info})")
+          Chef::ReservedNames::Win32::Error.raise!("get_named_security_info(#{path}, #{type}, #{info})", hr)
         end
 
         result_pointer = security_descriptor.read_pointer
@@ -500,7 +500,7 @@ class Chef
 
         hr = SetNamedSecurityInfoW(path.to_wstring, type, security_information, owner, group, dacl, sacl)
         if hr != ERROR_SUCCESS
-          Chef::ReservedNames::Win32::Error.raise!
+          Chef::ReservedNames::Win32::Error.raise! nil, hr
         end
       end
 


### PR DESCRIPTION
Hello,

In certain case, NameSecurityInfo methods can fail and return an HR result diffrent from `ERROR_SUCCESS`; current implementation call `Chef::ReservedNames::Win32::Error.raise!` which tries to get the last error code.
But often the last error code has changed in the meantime... resulting to that kind of error message:
> ---- Begin Win32 API output ----
> System Error Code: 0
> System Error Message: The operation completed successfully.
> ---- End Win32 API output ----

So this PR update the `raise!` method to allow to pass the error code, and use this new feature in some methods that directly get the HR error code.