### PR TITLE
Fix powershell_script validation 

### DIFF
--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -99,7 +99,10 @@ EOH
           # Therefore, the only return value for a syntactically valid
           # script is 0. If an exception is raised by shellout, this
           # means a non-zero return and thus a syntactically invalid script.
-          shell_out!(validation_command, {returns: [0]})
+
+          with_os_architecture(node, architecture: new_resource.architecture) do
+            shell_out!(validation_command, {returns: [0]})
+          end
         end
       end
 

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -227,6 +227,22 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       expect { resource.should_skip?(:run) }.to raise_error(ArgumentError, /guard_interpreter does not support blocks/)
     end
 
+    context "when dsc is supported", :windows_powershell_dsc_only do
+      it "can execute LCM configuration code" do
+        resource.code <<-EOF
+configuration LCM
+{
+  param ($thumbprint)
+  localconfigurationmanager
+  {
+    RebootNodeIfNeeded = $false
+    ConfigurationMode = 'ApplyOnly'
+  }
+}
+        EOF
+        expect { resource.run_action(:run) }.not_to raise_error
+      end
+    end
   end
 
   context "when running on a 32-bit version of Ruby", :ruby32_only do


### PR DESCRIPTION
Powershell script validation did not use same architecture as
executing the script. This caused configuring the LCM to fail.