### PR TITLE
Don't use routes with action :delete when writing config

### DIFF
--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -176,7 +176,7 @@ class Chef::Provider::Route < Chef::Provider
             conf[dev] = String.new if conf[dev].nil?
             case @action
             when :add
-              conf[dev] << config_file_contents(:add, :target => resource.target, :netmask => resource.netmask, :gateway => resource.gateway)
+              conf[dev] << config_file_contents(:add, :target => resource.target, :netmask => resource.netmask, :gateway => resource.gateway) if resource.action == [:add]
             when :delete
               # need to do this for the case when the last route on an int
               # is removed


### PR DESCRIPTION
When I was writing a cookbook that had both route deletions and additions, I noticed that the route-eth0 file written by chef had **all** the route information from **all** the route resources I had defined no matter the type of action. 

I added an additional check to only include the :add route resources.