### PR TITLE
systemd service provider should be restricted to its own area of responsibility

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -74,7 +74,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       if new_resource.start_command
         super
       else
-        shell_out_with_systems_locale!("#{systemctl_path} start #{new_resource.service_name}")
+        shell_out_with_systems_locale!("#{systemctl_path} start #{new_resource.service_name}.service")
       end
     end
   end
@@ -86,7 +86,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       if new_resource.stop_command
         super
       else
-        shell_out_with_systems_locale!("#{systemctl_path} stop #{new_resource.service_name}")
+        shell_out_with_systems_locale!("#{systemctl_path} stop #{new_resource.service_name}.service")
       end
     end
   end
@@ -95,7 +95,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     if new_resource.restart_command
       super
     else
-      shell_out_with_systems_locale!("#{systemctl_path} restart #{new_resource.service_name}")
+      shell_out_with_systems_locale!("#{systemctl_path} restart #{new_resource.service_name}.service")
     end
   end
 
@@ -104,7 +104,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       super
     else
       if current_resource.running
-        shell_out_with_systems_locale!("#{systemctl_path} reload #{new_resource.service_name}")
+        shell_out_with_systems_locale!("#{systemctl_path} reload #{new_resource.service_name}.service")
       else
         start_service
       end
@@ -112,19 +112,19 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
   end
 
   def enable_service
-    shell_out!("#{systemctl_path} enable #{new_resource.service_name}")
+    shell_out!("#{systemctl_path} enable #{new_resource.service_name}.service")
   end
 
   def disable_service
-    shell_out!("#{systemctl_path} disable #{new_resource.service_name}")
+    shell_out!("#{systemctl_path} disable #{new_resource.service_name}.service")
   end
 
   def is_active?
-    shell_out("#{systemctl_path} is-active #{new_resource.service_name} --quiet").exitstatus == 0
+    shell_out("#{systemctl_path} is-active #{new_resource.service_name}.service --quiet").exitstatus == 0
   end
 
   def is_enabled?
-    shell_out("#{systemctl_path} is-enabled #{new_resource.service_name} --quiet").exitstatus == 0
+    shell_out("#{systemctl_path} is-enabled #{new_resource.service_name}.service --quiet").exitstatus == 0
   end
 
   private

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -153,13 +153,13 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} start service_name' if no start command is specified" do
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}.service").and_return(shell_out_success)
           provider.start_service
         end
 
         it "should not call '#{systemctl_path} start service_name' if it is already running" do
           current_resource.running(true)
-          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}")
+          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}.service")
           provider.start_service
         end
 
@@ -172,7 +172,7 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} restart service_name' if no restart command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} restart #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} restart #{service_name}.service").and_return(shell_out_success)
           provider.restart_service
         end
 
@@ -189,7 +189,7 @@ describe Chef::Provider::Service::Systemd do
           context "when a reload command is not specified" do
             it "should call '#{systemctl_path} reload service_name' if the service is running" do
               current_resource.running(true)
-              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} reload #{service_name}").and_return(shell_out_success)
+              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} reload #{service_name}.service").and_return(shell_out_success)
               provider.reload_service
             end
 
@@ -210,13 +210,13 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} stop service_name' if no stop command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}.service").and_return(shell_out_success)
           provider.stop_service
         end
 
         it "should not call '#{systemctl_path} stop service_name' if it is already stopped" do
           current_resource.running(false)
-          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}")
+          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}.service")
           provider.stop_service
         end
       end
@@ -229,12 +229,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} enable service_name' to enable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} enable #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} enable #{service_name}.service").and_return(shell_out_success)
           provider.enable_service
         end
 
         it "should call '#{systemctl_path} disable service_name' to disable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} disable #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} disable #{service_name}.service").and_return(shell_out_success)
           provider.disable_service
         end
       end
@@ -247,12 +247,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} is-active service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name} --quiet").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name}.service --quiet").and_return(shell_out_success)
           expect(provider.is_active?).to be true
         end
 
         it "should return false if '#{systemctl_path} is-active service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name} --quiet").and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name}.service --quiet").and_return(shell_out_failure)
           expect(provider.is_active?).to be false
         end
       end
@@ -265,12 +265,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name} --quiet").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}.service --quiet").and_return(shell_out_success)
           expect(provider.is_enabled?).to be true
         end
 
         it "should return false if '#{systemctl_path} is-enabled service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name} --quiet").and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}.service --quiet").and_return(shell_out_failure)
           expect(provider.is_enabled?).to be false
         end
       end


### PR DESCRIPTION
specify the unit type to prevent inappropriate overloading of the systemd service provider to manage non-service units.