### PR TITLE
Use same mixlib-shellout version pin in chef, ohai, and chef-config

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", "~> 1.4"
   s.add_dependency "mixlib-log", "~> 1.3"
   s.add_dependency "mixlib-authentication", "~> 1.3"
-  s.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0"
+  s.add_dependency "mixlib-shellout", "~> 2.0"
   s.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9"
 
   s.add_dependency "ffi-yajl", "~> 2.2"


### PR DESCRIPTION
This is causing problems now that i've released mixlib-shellout 2.2.0.rc.0. Omnibus builds are failing with:
```
Error:

    ERROR:  While executing gem ... (Gem::DependencyError)

    Unresolved dependency found during sorting - mixlib-shellout (~> 2.0) (requested by chef-config-12.5.0.current.0)

C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/util.rb:101:in `rescue in shellout!'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/util.rb:97:in `shellout!'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:701:in `shellout!'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:239:in `block in gem'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:888:in `instance_eval'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:888:in `run'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:719:in `block (3 levels) in execute'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:741:in `call'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:741:in `with_retries'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:718:in `block (2 levels) in execute'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/instrumentation.rb:23:in `call'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/instrumentation.rb:23:in `measure'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:717:in `block in execute'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:791:in `call'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:791:in `with_clean_env'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:716:in `execute'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:612:in `block (2 levels) in build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:611:in `each'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:611:in `block in build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/instrumentation.rb:23:in `call'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/instrumentation.rb:23:in `measure'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/builder.rb:610:in `build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/software.rb:904:in `execute_build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/software.rb:779:in `build_me'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/project.rb:1006:in `block in build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/project.rb:1005:in `each'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/project.rb:1005:in `build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/cli.rb:83:in `build'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/cli/base.rb:33:in `dispatch'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/lib/omnibus/cli.rb:41:in `execute!'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/omnibus-bd748305e15c/bin/omnibus:11:in `<top (required)>'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bin/omnibus:23:in `load'
  C:/rubies/2.1.5/lib/ruby/gems/2.1.0/bin/omnibus:23:in `<main>'
```

This is happening when `gem install chef-12.5.0.current.0-universal-mingw32.gem` is run with rubygems 2.4.4/2.4.8. For whatever reason, it fails to solve the dependencies correctly with the newer versions of rubygems. Rubygems 2.2.5 works fine.

Looks like it's been marked for fix in rubygems 2.5: https://github.com/rubygems/rubygems/issues/1062