### PR TITLE
move warning to debug

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -808,10 +808,6 @@ class Chef
         property = property_type(**options)
       end
 
-      if !options[:default].frozen? && (options[:default].is_a?(Array) || options[:default].is_a?(Hash))
-        Chef.log_deprecation("Property #{self}.#{name} has an array or hash default (#{options[:default]}). This means that if one resource modifies or appends to it, all other resources of the same type will also see the changes. Either freeze the constant with `.freeze` to prevent appending, or use lazy { #{options[:default].inspect} }.")
-      end
-
       local_properties = properties(false)
       local_properties[name] = property
 

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -350,8 +350,6 @@ EOM
       expect(run_complete).to be >= 0
 
       # Make sure there is exactly one result for each, and that it occurs *after* the complete message.
-      expect(match_indices(/MyResource.x has an array or hash default/, result.stdout)).to match([ be > run_complete ])
-      expect(match_indices(/MyResource.y has an array or hash default/, result.stdout)).to match([ be > run_complete ])
       expect(match_indices(/nil currently does not overwrite the value of/, result.stdout)).to match([ be > run_complete ])
     end
   end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -480,12 +480,6 @@ describe "Chef::Resource.property" do
         end
       end
 
-      it "when a property is declared with default: {}, a warning is issued" do
-        expect(Chef::Log).to receive(:deprecation).with( /^Property .+\.x has an array or hash default \(\{\}\)\. This means that if one resource modifies or appends to it, all other resources of the same type will also see the changes\. Either freeze the constant with \`\.freeze\` to prevent appending, or use lazy \{ \{\} \}\.$/, /property_spec\.rb/ )
-        resource_class.class_eval("property :x, default: {}", __FILE__, __LINE__)
-        expect(resource.x).to eq({})
-      end
-
       with_property ':x, default: lazy { {} }' do
         it "when x is not set, it returns {}" do
           expect(resource.x).to eq({})


### PR DESCRIPTION
1.  the deploy resource and other internal chef resources trigger this.

2.  this is largely a non-problem since people have been happily using
the deploy resource for years and nobody has showed up in any of our
bugtrackers due to mutating the default hash.  we simply don't need to
annoy people this badly over this.