### PR TITLE
Knife `bootstrap_environment` should use Explicit config before Implicit

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -40,7 +40,7 @@ class Chef
         end
 
         def bootstrap_environment
-          @chef_config[:environment]
+          @config[:environment]
         end
 
         def validation_key

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -91,7 +91,7 @@ EXPECTED
   end
 
   describe "when bootstrapping into a specific environment" do
-    let(:chef_config){ {:environment => "prodtastic"} }
+    let(:config){ {:environment => "prodtastic"} }
     it "starts chef in the configured environment" do
       expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E prodtastic')
     end


### PR DESCRIPTION
When the knife cli utility is run, it invokes a method named `apply_computed_config`, which transposes some of the CLI options onto Chef::Config. Both Chef::Config, as well as the explicitly passed knife options, are given to the Bootstrap Context.

Bootstrap Context is responsible for setting values for the bootstrap template... one of which is the Chef environment. Currently, this logic pulls the value directly from Chef::Config, and if there is none there, it defaults to `_default`. The problem is that this logic relies on `apply_computed_config` having been run previously. Rather than completely ignoring the Explicit config that we have available to us, we should consider it. If Chef Environment has been explicitly set in this knife invocation, we should use that... else, we can look in Chef::Config... else, we can finally fall back to `_default`.

It is worth noting that chef_node_name is also governed by this same pattern, though the Bootstrap Context does not take the value from Chef::Config, and instead looks only to the explicit config that Knife has received. I would like to see the same behavior for Chef Environment... the underlying issue being that if I programmatically call Knife Bootstrap, I cannot simply pass it a configuration and tell it to run... I must first call `apply_computed_config`, otherwise my node will come up with the default environment.