### PR TITLE
powershell_script move validation into one shell_out!

### DIFF
--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -104,15 +104,20 @@ $global:lastcmdlet = $null
 
 # Create a scriptblock with the user's code
 # This will validate the syntax of the PowerShell provided
-$UserScriptBlock =  $ExecutionContext.InvokeCommand.NewScriptBlock(@'
+function New-UserScriptBlock {
+  try {
+    $ExecutionContext.InvokeCommand.NewScriptBlock(@'
   #{@new_resource.code}
 
   # This assignment doesn't affect the block's return value
   $global:lastcmdlet = $?
 '@)
+  }
+  catch {write-error ($_.Exception.Message);exit 5}
+}
 
 # Execute the user's code in a script block --
-$chefscriptresult = $UserScriptBlock.invokereturnasis()
+$chefscriptresult = (New-UserScriptBlock).invokereturnasis()
 
 # Assume failure status of 1 -- success cases
 # will have to override this


### PR DESCRIPTION
@jaym This reverts your change from https://github.com/chef/chef/pull/3815, but reduces the number of shell_outs to one, where we get validation and execution from one powershell process.  /cc @chef/client-windows 