### PR TITLE
Modify registry specs to adhere to spec naming conventions

### DIFF
--- a/spec/functional/win32/registry_spec.rb
+++ b/spec/functional/win32/registry_spec.rb
@@ -20,25 +20,6 @@
 require 'spec_helper'
 require 'chef/win32/registry'
 
-describe Chef::Resource::RegistryKey, :unix_only do
-  before(:all) do
-    events = Chef::EventDispatch::Dispatcher.new
-    node = Chef::Node.new
-    ohai = Ohai::System.new
-    ohai.all_plugins
-    node.consume_external_attrs(ohai.data,{})
-    run_context = Chef::RunContext.new(node, {}, events)
-    @resource = Chef::Resource::RegistryKey.new("HKCU\\Software", run_context)
-  end
-  context "when load_current_resource is run on a non-windows node" do
-    it "throws an exception because you don't have a windows registry (derp)" do
-      @resource.key("HKCU\\Software\\Opscode")
-      @resource.values([{:name=>"Color", :type=>:string, :data=>"Orange"}])
-      expect{@resource.run_action(:create)}.to raise_error(Chef::Exceptions::Win32NotWindows)
-    end
-  end
-end
-
 describe 'Chef::Win32::Registry', :windows_only do
 
   before(:all) do

--- a/spec/unit/win32/registry_spec.rb
+++ b/spec/unit/win32/registry_spec.rb
@@ -18,7 +18,7 @@
 
 require 'spec_helper'
 
-describe Chef::Provider::RegistryKey do
+describe Chef::Win32::Registry do
 
   let(:value1) { { :name => "one", :type => :string, :data => "1" } }
   let(:value1_upcase_name) { {:name => "ONE", :type => :string, :data => "1"} }


### PR DESCRIPTION
Two files are testing `Chef::Win32::Registry`. Their spec paths should be `spec/*/win32/registry_spec.rb`.