### PR TITLE
CHEF-3839 Call osc_user_create from configure_initial

### DIFF
--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -94,7 +94,7 @@ EOH
           Chef::Config[:chef_server_url] = chef_server
           Chef::Config[:node_name] = admin_client_name
           Chef::Config[:client_key] = admin_client_key
-          user_create = Chef::Knife::UserCreate.new
+          user_create = Chef::Knife::OscUserCreate.new
           user_create.name_args = [ new_client_name ]
           user_create.config[:user_password] = config[:user_password] ||
             ui.ask("Please enter a password for the new user: ") {|q| q.echo = false}

--- a/lib/chef/knife/osc_user_create.rb
+++ b/lib/chef/knife/osc_user_create.rb
@@ -17,6 +17,7 @@
 #
 
 require 'chef/knife'
+require 'chef/user'
 
 # DEPRECATION NOTE
 # This code only remains to support users still operating with


### PR DESCRIPTION
This is an obvious fix that keeps configure-initial working until it is updated to work with the new user-create.