### PR TITLE
Update appveyor.yml to correct OS version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Windows Server 2012
+os: Windows Server 2012 R2
 platform:
   - x64
 
@@ -21,6 +21,7 @@ cache:
   - C:\Ruby200\bin
 
 install:
+  - systeminfo
   - winrm quickconfig -q
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%


### PR DESCRIPTION
Appveyor was running on 2012R2 - I guess Windows Server 2012 was just a shorthand for R2.  I've changed it to make this explicit.