### PR TITLE
Skip tests unless RefreshMode is Disabled

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -52,6 +52,13 @@ class Chef
           Gem::Version.new(node[:languages][:powershell][:version]) >=
             Gem::Version.new("5.0.10018.0")
       end
+      
+      def refresh_mode_disabled?(node)
+        require 'chef/util/powershell/cmdlet'
+        cmdlet = Chef::Util::Powershell::Cmdlet.new(node, "Get-DscLocalConfigurationManager", :object)
+        metadata = cmdlet.run!.return_value
+        metadata['RefreshMode'] == 'Disabled'
+      end
     end
   end
 end

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -53,7 +53,7 @@ class Chef
             Gem::Version.new("5.0.10018.0")
       end
       
-      def refresh_mode_disabled?(node)
+      def dsc_refresh_mode_disabled?(node)
         require 'chef/util/powershell/cmdlet'
         cmdlet = Chef::Util::Powershell::Cmdlet.new(node, "Get-DscLocalConfigurationManager", :object)
         metadata = cmdlet.run!.return_value

--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -59,9 +59,7 @@ class Chef
           a.block_action!
         end
         requirements.assert(:run) do |a|
-          a.assertion {
-            meta_configuration['RefreshMode'] == 'Disabled'
-          }
+          a.assertion { refresh_mode_disabled? }
           err = ["The LCM must have its RefreshMode set to Disabled. "]
           a.failure_message Chef::Exceptions::ProviderNotFound, err.join(' ')
           a.whyrun err + ["Assuming a previous resource sets the RefreshMode."]
@@ -84,6 +82,10 @@ class Chef
 
       def supports_dsc_invoke_resource?
         run_context && Chef::Platform.supports_dsc_invoke_resource?(node)
+      end
+      
+      def refresh_mode_disabled?
+        Chef::Platform.refresh_mode_disabled?(node)
       end
 
       def generate_description
@@ -151,12 +153,6 @@ class Chef
           output_format
         )
         cmdlet.run!
-      end
-
-      def meta_configuration
-        cmdlet = Chef::Util::Powershell::Cmdlet.new(node, "Get-DscLocalConfigurationManager", :object)
-        result = cmdlet.run!
-        result.return_value
       end
 
     end

--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -59,7 +59,7 @@ class Chef
           a.block_action!
         end
         requirements.assert(:run) do |a|
-          a.assertion { refresh_mode_disabled? }
+          a.assertion { dsc_refresh_mode_disabled? }
           err = ["The LCM must have its RefreshMode set to Disabled. "]
           a.failure_message Chef::Exceptions::ProviderNotFound, err.join(' ')
           a.whyrun err + ["Assuming a previous resource sets the RefreshMode."]
@@ -84,8 +84,8 @@ class Chef
         run_context && Chef::Platform.supports_dsc_invoke_resource?(node)
       end
       
-      def refresh_mode_disabled?
-        Chef::Platform.refresh_mode_disabled?(node)
+      def dsc_refresh_mode_disabled?
+        Chef::Platform.dsc_refresh_mode_disabled?(node)
       end
 
       def generate_description

--- a/spec/functional/resource/dsc_resource_spec.rb
+++ b/spec/functional/resource/dsc_resource_spec.rb
@@ -43,6 +43,8 @@ describe Chef::Resource::DscResource, :windows_powershell_dsc_only do
     before do
       if !Chef::Platform.supports_dsc_invoke_resource?(node)
         skip 'Requires Powershell >= 5.0.10018.0'
+      elsif !Chef::Platform.refresh_mode_disabled?(node)
+        skip 'Requires LCM RefreshMode is Disabled'
       end
     end
     context 'with an invalid dsc resource' do

--- a/spec/functional/resource/dsc_resource_spec.rb
+++ b/spec/functional/resource/dsc_resource_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Resource::DscResource, :windows_powershell_dsc_only do
     before do
       if !Chef::Platform.supports_dsc_invoke_resource?(node)
         skip 'Requires Powershell >= 5.0.10018.0'
-      elsif !Chef::Platform.refresh_mode_disabled?(node)
+      elsif !Chef::Platform.dsc_refresh_mode_disabled?(node)
         skip 'Requires LCM RefreshMode is Disabled'
       end
     end

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -75,7 +75,7 @@ describe 'Chef::Platform#supports_dsc_invoke_resource?' do
   end
 end
 
-describe 'Chef::Platform#refresh_mode_disabled?' do
+describe 'Chef::Platform#dsc_refresh_mode_disabled?' do
   let(:node) { instance_double('Chef::Node') }
   let(:cmdlet) { instance_double('Chef::Util::Powershell::Cmdlet') }
   let(:cmdlet_result) { instance_double('Chef::Util::Powershell::CmdletResult')}
@@ -86,7 +86,7 @@ describe 'Chef::Platform#refresh_mode_disabled?' do
       and_return(cmdlet)
     expect(cmdlet).to receive(:run!).and_return(cmdlet_result)
     expect(cmdlet_result).to receive(:return_value).and_return({ 'RefreshMode' => 'Disabled' })
-    expect(Chef::Platform.refresh_mode_disabled?(node)).to be true
+    expect(Chef::Platform.dsc_refresh_mode_disabled?(node)).to be true
   end
   
   it "returns false when RefreshMode is not Disabled" do
@@ -95,7 +95,7 @@ describe 'Chef::Platform#refresh_mode_disabled?' do
       and_return(cmdlet)
     expect(cmdlet).to receive(:run!).and_return(cmdlet_result)
     expect(cmdlet_result).to receive(:return_value).and_return({ 'RefreshMode' => 'LaLaLa' })
-    expect(Chef::Platform.refresh_mode_disabled?(node)).to be false    
+    expect(Chef::Platform.dsc_refresh_mode_disabled?(node)).to be false    
   end
 end
 

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -75,3 +75,27 @@ describe 'Chef::Platform#supports_dsc_invoke_resource?' do
   end
 end
 
+describe 'Chef::Platform#refresh_mode_disabled?' do
+  let(:node) { instance_double('Chef::Node') }
+  let(:cmdlet) { instance_double('Chef::Util::Powershell::Cmdlet') }
+  let(:cmdlet_result) { instance_double('Chef::Util::Powershell::CmdletResult')}
+  
+  it "returns true when RefreshMode is Disabled" do
+    expect(Chef::Util::Powershell::Cmdlet).to receive(:new).
+      with(node, "Get-DscLocalConfigurationManager", :object).
+      and_return(cmdlet)
+    expect(cmdlet).to receive(:run!).and_return(cmdlet_result)
+    expect(cmdlet_result).to receive(:return_value).and_return({ 'RefreshMode' => 'Disabled' })
+    expect(Chef::Platform.refresh_mode_disabled?(node)).to be true
+  end
+  
+  it "returns false when RefreshMode is not Disabled" do
+    expect(Chef::Util::Powershell::Cmdlet).to receive(:new).
+      with(node, "Get-DscLocalConfigurationManager", :object).
+      and_return(cmdlet)
+    expect(cmdlet).to receive(:run!).and_return(cmdlet_result)
+    expect(cmdlet_result).to receive(:return_value).and_return({ 'RefreshMode' => 'LaLaLa' })
+    expect(Chef::Platform.refresh_mode_disabled?(node)).to be false    
+  end
+end
+

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -50,30 +50,23 @@ describe Chef::Provider::DscResource do
     }
 
     context 'when RefreshMode is not set to Disabled' do
-      let (:meta_configuration) { {'RefreshMode' => 'AnythingElse'}}
-
       it 'raises an exception' do
-        expect(provider).to receive(:meta_configuration).and_return(
-                                                             meta_configuration)
+        expect(provider).to receive(:refresh_mode_disabled?).and_return(false)
         expect { provider.run_action(:run) }.to raise_error(
           Chef::Exceptions::ProviderNotFound, /Disabled/)
       end
     end
 
     context 'when RefreshMode is set to Disabled' do
-      let (:meta_configuration) { {'RefreshMode' => 'Disabled'}}
-
       it 'does not update the resource if it is up to date' do
-        expect(provider).to receive(:meta_configuration).and_return(
-                                                             meta_configuration)
+        expect(provider).to receive(:refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(true)
         provider.run_action(:run)
         expect(resource).not_to be_updated
       end
 
       it 'converges the resource if it is not up to date' do
-        expect(provider).to receive(:meta_configuration).and_return(
-                                                             meta_configuration)
+        expect(provider).to receive(:refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(false)
         expect(provider).to receive(:set_resource)
         provider.run_action(:run)

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Provider::DscResource do
 
     context 'when RefreshMode is not set to Disabled' do
       it 'raises an exception' do
-        expect(provider).to receive(:refresh_mode_disabled?).and_return(false)
+        expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(false)
         expect { provider.run_action(:run) }.to raise_error(
           Chef::Exceptions::ProviderNotFound, /Disabled/)
       end
@@ -59,14 +59,14 @@ describe Chef::Provider::DscResource do
 
     context 'when RefreshMode is set to Disabled' do
       it 'does not update the resource if it is up to date' do
-        expect(provider).to receive(:refresh_mode_disabled?).and_return(true)
+        expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(true)
         provider.run_action(:run)
         expect(resource).not_to be_updated
       end
 
       it 'converges the resource if it is not up to date' do
-        expect(provider).to receive(:refresh_mode_disabled?).and_return(true)
+        expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(false)
         expect(provider).to receive(:set_resource)
         provider.run_action(:run)


### PR DESCRIPTION
Remove implicit test assumption that the machine is configured so that `'RefreshMode'` is `'Disabled'` for DSC resource.