### PR TITLE
Add monkey patch for webrick

### DIFF
--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -15,6 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'chef/config'
+if Chef::Platform.windows?
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1')
+    require 'chef/monkey_patches/webrick-utils'
+  end
+end
 
 class Chef
   module LocalMode

--- a/lib/chef/monkey_patches/webrick-utils.rb
+++ b/lib/chef/monkey_patches/webrick-utils.rb
@@ -1,0 +1,51 @@
+require 'webrick/utils'
+
+module WEBrick
+  module Utils
+    ##
+    # Creates TCP server sockets bound to +address+:+port+ and returns them.
+    #
+    # It will create IPV4 and IPV6 sockets on all interfaces.
+    #
+    # NOTE: We need to monkey patch this method because
+    # create_listeners on Windows with Ruby > 2.0.0 does not
+    # raise an error if we're already listening on a port.
+    #
+    def create_listeners(address, port, logger=nil)
+      #
+      # utils.rb -- Miscellaneous utilities
+      #
+      # Author: IPR -- Internet Programming with Ruby -- writers
+      # Copyright (c) 2001 TAKAHASHI Masayoshi, GOTOU Yuuzou
+      # Copyright (c) 2002 Internet Programming with Ruby writers. All rights
+      # reserved.
+      #
+      # $IPR: utils.rb,v 1.10 2003/02/16 22:22:54 gotoyuzo Exp $
+      unless port
+        raise ArgumentError, "must specify port"
+      end
+      res = Socket::getaddrinfo(address, port,
+                                Socket::AF_UNSPEC,   # address family
+                                Socket::SOCK_STREAM, # socket type
+                                0,                   # protocol
+                                Socket::AI_PASSIVE)  # flag
+      last_error = nil
+      sockets = []
+      res.each{|ai|
+        begin
+          logger.debug("TCPServer.new(#{ai[3]}, #{port})") if logger
+          sock = TCPServer.new(ai[3], port)
+          port = sock.addr[1] if port == 0
+          Utils::set_close_on_exec(sock)
+          sockets << sock
+        rescue => ex
+          logger.warn("TCPServer Error: #{ex}") if logger
+          last_error  = ex
+        end
+      }
+      raise last_error if sockets.empty?
+      return sockets
+    end
+    module_function :create_listeners
+  end
+end


### PR DESCRIPTION
Ruby 2.1 introduces a regression on Windows in WEBrick.
create_listeners does not throw an exception when we're
already listening on a port. This seems to only be an
issue on Windows. This patch reverts it back to what it
was in Ruby 2.0

It seems the regression was introduced in
https://github.com/ruby/ruby/commit/b1f493dcd1092fe17cccec998e175516ed5c6e47#diff-4b178393150b2b3a5ec9d77eced1f09e

This should fix the failures in the knife integration tests (see #3894)

cc @chef/client-windows @jkeiser 