### PR TITLE
Modify enforce_ownership_and_permissions_spec to be more unit-like

### DIFF
--- a/spec/unit/mixin/enforce_ownership_and_permissions_spec.rb
+++ b/spec/unit/mixin/enforce_ownership_and_permissions_spec.rb
@@ -49,12 +49,12 @@ describe Chef::Mixin::EnforceOwnershipAndPermissions do
       allow_any_instance_of(Chef::FileAccessControl).to receive(:uid_from_resource).and_return(0)
       allow_any_instance_of(Chef::FileAccessControl).to receive(:requires_changes?).and_return(false)
       allow_any_instance_of(Chef::FileAccessControl).to receive(:define_resource_requirements)
+      allow_any_instance_of(Chef::FileAccessControl).to receive(:describe_changes)
 
-      passwd_struct = if windows?
-                        Struct::Passwd.new("root", "x", 0, 0, "/root", "/bin/bash")
-                      else
-                        Struct::Passwd.new("root", "x", 0, 0, "root", "/root", "/bin/bash")
-                      end
+      passwd_struct = OpenStruct.new(:name => "root", :passwd => "x",
+                                     :uid => 0, :gid => 0, :dir => '/root',
+                                     :shell => '/bin/bash')
+
       group_struct = OpenStruct.new(:name => "root", :passwd => "x", :gid => 0)
       allow(Etc).to receive(:getpwuid).and_return(passwd_struct)
       allow(Etc).to receive(:getgrgid).and_return(group_struct)
@@ -73,12 +73,12 @@ describe Chef::Mixin::EnforceOwnershipAndPermissions do
     before do
       allow_any_instance_of(Chef::FileAccessControl).to receive(:requires_changes?).and_return(true)
       allow_any_instance_of(Chef::FileAccessControl).to receive(:uid_from_resource).and_return(0)
+      allow_any_instance_of(Chef::FileAccessControl).to receive(:describe_changes)
 
-      passwd_struct = if windows?
-                        Struct::Passwd.new("root", "x", 0, 0, "/root", "/bin/bash")
-                      else
-                        Struct::Passwd.new("root", "x", 0, 0, "root", "/root", "/bin/bash")
-                      end
+      passwd_struct = OpenStruct.new(:name => "root", :passwd => "x",
+                                     :uid => 0, :gid => 0, :dir => '/root',
+                                     :shell => '/bin/bash')
+
       group_struct = OpenStruct.new(:name => "root", :passwd => "x", :gid => 0)
       allow(Etc).to receive(:getpwuid).and_return(passwd_struct)
       allow(Etc).to receive(:getgrgid).and_return(group_struct)


### PR DESCRIPTION
This should fix the remaining failures for ruby 2.1 (#3894). Seems like the passwd struct changed. `describe_changes` also called platform specific things on windows, which started failing.

cc @chef/client-windows 