### PR TITLE
Add new option json attributes file to bootstraping

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -74,7 +74,11 @@ class Chef
     class InvalidPrivateKey < ArgumentError; end
     class MissingKeyAttribute < ArgumentError; end
     class KeyCommandInputError < ArgumentError; end
-    class BootstrapCommandInputError < ArgumentError; end
+    class BootstrapCommandInputError < ArgumentError
+      def initialize
+        super "You cannot pass both --json-attributes and --json-attribute-file. Please pass one or none."
+      end
+    end
     class InvalidKeyArgument < ArgumentError; end
     class InvalidKeyAttribute < ArgumentError; end
     class InvalidUserAttribute < ArgumentError; end

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -74,6 +74,7 @@ class Chef
     class InvalidPrivateKey < ArgumentError; end
     class MissingKeyAttribute < ArgumentError; end
     class KeyCommandInputError < ArgumentError; end
+    class BootstrapCommandInputError < ArgumentError; end
     class InvalidKeyArgument < ArgumentError; end
     class InvalidKeyAttribute < ArgumentError; end
     class InvalidUserAttribute < ArgumentError; end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -321,6 +321,7 @@ EOS
       end
 
       def render_template
+        @config[:first_boot_attributes].merge!(@config[:first_boot_attributes_from_file]) if @config[:first_boot_attributes_from_file]
         template_file = find_template
         template = IO.read(template_file).chomp
         Erubis::Eruby.new(template).evaluate(bootstrap_context)
@@ -330,7 +331,6 @@ EOS
         if @config[:first_boot_attributes].any? && @config[:first_boot_attributes_from_file]
           raise Chef::Exceptions::BootstrapCommandInputError, jsonstring_and_jsonfile_msg
         end
-        @config[:first_boot_attributes].merge!(@config[:first_boot_attributes_from_file]) if @config[:first_boot_attributes_from_file]
 
         validate_name_args!
 

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -154,7 +154,7 @@ class Chef
         :long => "--json-attributes",
         :description => "A JSON string to be added to the first run of chef-client",
         :proc => lambda { |o| Chef::JSONCompat.parse(o) },
-        :default => {}
+        :default => nil
 
       option :first_boot_attributes_from_file,
         :long => "--json-attribute-file FILE",
@@ -244,13 +244,6 @@ class Chef
         )
       end
 
-      def jsonstring_and_jsonfile_msg
-<<EOS
-You cannot pass both --json-attributes and --json-attribute-file.
-Please pass one or none.
-EOS
-      end
-
       # The default bootstrap template to use to bootstrap a server This is a public API hook
       # which knife plugins use or inherit and override.
       #
@@ -320,16 +313,20 @@ EOS
         )
       end
 
+      def first_boot_attributes
+        @config[:first_boot_attributes] || @config[:first_boot_attributes_from_file] || {}
+      end
+
       def render_template
-        @config[:first_boot_attributes].merge!(@config[:first_boot_attributes_from_file]) if @config[:first_boot_attributes_from_file]
+        @config[:first_boot_attributes] = first_boot_attributes
         template_file = find_template
         template = IO.read(template_file).chomp
         Erubis::Eruby.new(template).evaluate(bootstrap_context)
       end
 
       def run
-        if @config[:first_boot_attributes].any? && @config[:first_boot_attributes_from_file]
-          raise Chef::Exceptions::BootstrapCommandInputError, jsonstring_and_jsonfile_msg
+        if @config[:first_boot_attributes] && @config[:first_boot_attributes_from_file]
+          raise Chef::Exceptions::BootstrapCommandInputError
         end
 
         validate_name_args!


### PR DESCRIPTION
replace of #3459

- We can pass jsonfile to bootstrap via --json-attribute-file option.
- raise an exception if both set  json-attributes and json-attribute-file.
