### PR TITLE
Allow windows_service_spec to only run in appveyor

### DIFF
--- a/spec/functional/resource/windows_service_spec.rb
+++ b/spec/functional/resource/windows_service_spec.rb
@@ -18,7 +18,7 @@
 
 require 'spec_helper'
 
-describe Chef::Resource::WindowsService, :windows_only, :system_windows_service_gem_only do
+describe Chef::Resource::WindowsService, :windows_only, :system_windows_service_gem_only, :appveyor_only do
 
   include_context "using Win32::Service"
 


### PR DESCRIPTION
We thing that these tests may be causing instability on our
jenkins slaves.

cc @sersut @chef/client-windows 