### PR TITLE
remove pending reboot check for HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile

### DIFF
--- a/lib/chef/dsl/reboot_pending.rb
+++ b/lib/chef/dsl/reboot_pending.rb
@@ -49,7 +49,8 @@ class Chef
 
           # The mere existence of the UpdateExeVolatile key should indicate a pending restart for certain updates
           # http://support.microsoft.com/kb/832475
-          (registry_key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
+          Chef::Platform.windows_server_2003? &&
+                (registry_key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
                 !registry_get_values('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').select { |v| v[:name] == "Flags" }[0].nil? &&
                 [1,2,3].include?(registry_get_values('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').select { |v| v[:name] == "Flags" }[0][:data]))
         elsif platform?("ubuntu")

--- a/spec/functional/dsl/reboot_pending_spec.rb
+++ b/spec/functional/dsl/reboot_pending_spec.rb
@@ -30,13 +30,6 @@ describe Chef::DSL::RebootPending, :windows_only do
     ohai
   end
 
-  def registry_unsafe?
-    registry.value_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', { :name => 'PendingFileRenameOperations' }) ||
-    registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired')
-    registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired') ||
-    registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile')
-  end
-
   let(:node) { Chef::Node.new }
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let!(:ohai) { run_ohai } # Ensure we have necessary node data
@@ -45,76 +38,73 @@ describe Chef::DSL::RebootPending, :windows_only do
   let(:registry) { Chef::Win32::Registry.new(run_context) }
 
   describe "reboot_pending?" do
+    let(:reg_key) { nil }
+    let(:original_set) { false }
 
-    describe "when there is nothing to indicate a reboot is pending" do
-      it "should return false" do
-        skip "Found existing registry keys" if registry_unsafe?
-        expect(recipe.reboot_pending?).to be_falsey
-      end
-    end
+    before(:all) { @any_flag = Hash.new }
+
+    after { @any_flag[reg_key] = original_set }
 
     describe 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations' do
+      let(:reg_key) { 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager' }
+      let(:original_set) { registry.value_exists?(reg_key, { :name => 'PendingFileRenameOperations' }) }
+
       it "returns true if the registry value exists" do
-        skip "Found existing registry keys" if registry_unsafe?
-        registry.set_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager',
+        skip 'found existing registry key' if original_set
+        registry.set_value(reg_key,
             { :name => 'PendingFileRenameOperations', :type => :multi_string, :data => ['\??\C:\foo.txt|\??\C:\bar.txt'] })
 
         expect(recipe.reboot_pending?).to be_truthy
       end
 
       after do
-        unless registry_unsafe?
-          registry.delete_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', { :name => 'PendingFileRenameOperations' })
-        end
-      end
-    end
-
-    describe 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' do
-      it "returns true if the registry key exists" do
-        skip "Found existing registry keys" if registry_unsafe?
-        registry.create_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired', false)
-
-        expect(recipe.reboot_pending?).to be_truthy
-      end
-
-      after do
-        unless registry_unsafe?
-          registry.delete_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired', false)
+        unless original_set
+          registry.delete_value(reg_key, { :name => 'PendingFileRenameOperations' })
         end
       end
     end
 
     describe 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired' do
+      let(:reg_key) { 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired' }
+      let(:original_set) { registry.key_exists?(reg_key) }
+
       it "returns true if the registry key exists" do
+        skip 'found existing registry key' if original_set
         pending "Permissions are limited to 'TrustedInstaller' by default"
-        skip "Found existing registry keys" if registry_unsafe?
-        registry.create_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired', false)
+        registry.create_key(reg_key, false)
 
         expect(recipe.reboot_pending?).to be_truthy
       end
 
       after do
-        unless registry_unsafe?
-          registry.delete_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired', false)
+        unless original_set
+          registry.delete_key(reg_key, false)
         end
       end
     end
 
-    describe 'HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile\Flags' do
+    describe 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' do
+      let(:reg_key) { 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' }
+      let(:original_set) { registry.key_exists?(reg_key) }
+
       it "returns true if the registry key exists" do
-        skip "Found existing registry keys" if registry_unsafe?
-        registry.create_key('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', true)
-        registry.set_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile',
-                    { :name => 'Flags', :type => :dword, :data => 3 })
+        skip 'found existing registry key' if original_set
+        registry.create_key(reg_key, false)
 
         expect(recipe.reboot_pending?).to be_truthy
       end
 
       after do
-        unless registry_unsafe?
-          registry.delete_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', { :name => 'Flags' })
-          registry.delete_key('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', false)
+        unless original_set
+          registry.delete_key(reg_key, false)
         end
+      end
+    end
+
+    describe "when there is nothing to indicate a reboot is pending" do
+      it "should return false" do
+        skip 'reboot pending' if @any_flag.any? { |_,v| v == true }
+        expect(recipe.reboot_pending?).to be_falsey
       end
     end
   end

--- a/spec/unit/dsl/reboot_pending_spec.rb
+++ b/spec/unit/dsl/reboot_pending_spec.rb
@@ -50,11 +50,17 @@ describe Chef::DSL::RebootPending do
           expect(recipe.reboot_pending?).to be_truthy
         end
   
-        it 'should return true if value "HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile" contains specific data' do
-          allow(recipe).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(true)
-          allow(recipe).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(
-                [{:name => "Flags", :type => :dword, :data => 3}])
-          expect(recipe.reboot_pending?).to be_truthy
+        context "version is server 2003" do
+          before do
+            allow(Chef::Platform).to receive(:windows_server_2003?).and_return(true)
+          end
+
+          it 'should return true if value "HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile" contains specific data on 2k3' do
+            allow(recipe).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(true)
+            allow(recipe).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(
+                  [{:name => "Flags", :type => :dword, :data => 3}])
+            expect(recipe.reboot_pending?).to be_truthy
+          end
         end
       end
   


### PR DESCRIPTION
The pending reboot functional tests fail on checks for HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile with the value of 1-3. A clean 2k8r2 sp1 machine has a 3 which persists after reboots. The only way to remove it is to do so manually.

This key was introduced in the windows package installer on windows server 2003 and windows XP. It indicates that a previously installed update requires a reboot in order to complete. See https://support.microsoft.com/en-us/kb/832475

There are many folks running into issues installing various products and being told that a reboot is required and they get stuck because they receive this message after every reboot. This seems to occur most commonly with older office or sharepoint products. The guidance tends to be to delete this key. Apparently it can be orphaned and even Microsoft includes this tip in their support sites. See https://technet.microsoft.com/en-us/library/Cc164360(v=EXCHG.80).aspx

The more [popular modern reboot detection scripts](http://gallery.technet.microsoft.com/scriptcenter/Get-PendingReboot-Query-bdb79542) do not include this key and I think the fix is going to be removing it from our reboot check expecially since we no longer support server 2003.