### PR TITLE
We shouldn't be subclassing Struct.new - if the file is loaded twice we get a superclass mismatch error

### DIFF
--- a/lib/chef/resource/resource_notification.rb
+++ b/lib/chef/resource/resource_notification.rb
@@ -20,7 +20,15 @@ require 'chef/resource'
 
 class Chef
   class Resource
-    class Notification < Struct.new(:resource, :action, :notifying_resource)
+    class Notification
+
+      attr_accessor :resource, :action, :notifying_resource
+
+      def initialize(resource, action, notifying_resource)
+        @resource = resource
+        @action = action
+        @notifying_resource = notifying_resource
+      end
 
       def duplicates?(other_notification)
         unless other_notification.respond_to?(:resource) && other_notification.respond_to?(:action)
@@ -102,6 +110,11 @@ is defined near #{resource.source_line}
         F
         err.set_backtrace(e.backtrace)
         raise err
+      end
+
+      def ==(other)
+        return false unless other.is_a?(self.class)
+        other.resource == resource && other.action == action && other.notifying_resource == notifying_resource
       end
 
     end

--- a/spec/unit/resource/resource_notification_spec.rb
+++ b/spec/unit/resource/resource_notification_spec.rb
@@ -19,149 +19,148 @@ require 'spec_helper'
 require 'chef/resource/resource_notification'
 
 describe Chef::Resource::Notification do
-  before do
-    @notification = Chef::Resource::Notification.new(:service_apache, :restart, :template_httpd_conf)
-  end
+
+  let(:notification) { Chef::Resource::Notification.new(:service_apache, :restart, :template_httpd_conf) }
 
   it "has a resource to be notified" do
-    expect(@notification.resource).to eq(:service_apache)
+    expect(notification.resource).to eq(:service_apache)
   end
 
   it "has an action to take on the service" do
-    expect(@notification.action).to eq(:restart)
+    expect(notification.action).to eq(:restart)
   end
 
   it "has a notifying resource" do
-    expect(@notification.notifying_resource).to eq(:template_httpd_conf)
+    expect(notification.notifying_resource).to eq(:template_httpd_conf)
   end
 
   it "is a duplicate of another notification with the same target resource and action" do
     other = Chef::Resource::Notification.new(:service_apache, :restart, :sync_web_app_code)
-    expect(@notification.duplicates?(other)).to be_truthy
+    expect(notification.duplicates?(other)).to be_truthy
   end
 
   it "is not a duplicate of another notification if the actions differ" do
     other = Chef::Resource::Notification.new(:service_apache, :enable, :install_apache)
-    expect(@notification.duplicates?(other)).to be_falsey
+    expect(notification.duplicates?(other)).to be_falsey
   end
 
   it "is not a duplicate of another notification if the target resources differ" do
     other = Chef::Resource::Notification.new(:service_sshd, :restart, :template_httpd_conf)
-    expect(@notification.duplicates?(other)).to be_falsey
+    expect(notification.duplicates?(other)).to be_falsey
   end
 
   it "raises an ArgumentError if you try to check a non-ducktype object for duplication" do
-    expect {@notification.duplicates?(:not_a_notification)}.to raise_error(ArgumentError)
+    expect {notification.duplicates?(:not_a_notification)}.to raise_error(ArgumentError)
   end
 
   it "takes no action to resolve a resource reference that doesn't need to be resolved" do
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
-    @notification.resource = @keyboard_cat
+    notification.resource = @keyboard_cat
     @long_cat = Chef::Resource::Cat.new("long_cat")
-    @notification.notifying_resource = @long_cat
+    notification.notifying_resource = @long_cat
     @resource_collection = Chef::ResourceCollection.new
     # would raise an error since the resource is not in the collection
-    @notification.resolve_resource_reference(@resource_collection)
-    expect(@notification.resource).to eq(@keyboard_cat)
+    notification.resolve_resource_reference(@resource_collection)
+    expect(notification.resource).to eq(@keyboard_cat)
   end
 
   it "resolves a lazy reference to a resource" do
-    @notification.resource = {:cat => "keyboard_cat"}
+    notification.resource = {:cat => "keyboard_cat"}
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @keyboard_cat
     @long_cat = Chef::Resource::Cat.new("long_cat")
-    @notification.notifying_resource = @long_cat
-    @notification.resolve_resource_reference(@resource_collection)
-    expect(@notification.resource).to eq(@keyboard_cat)
+    notification.notifying_resource = @long_cat
+    notification.resolve_resource_reference(@resource_collection)
+    expect(notification.resource).to eq(@keyboard_cat)
   end
 
   it "resolves a lazy reference to its notifying resource" do
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
-    @notification.resource = @keyboard_cat
-    @notification.notifying_resource = {:cat => "long_cat"}
+    notification.resource = @keyboard_cat
+    notification.notifying_resource = {:cat => "long_cat"}
     @long_cat = Chef::Resource::Cat.new("long_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @long_cat
-    @notification.resolve_resource_reference(@resource_collection)
-    expect(@notification.notifying_resource).to eq(@long_cat)
+    notification.resolve_resource_reference(@resource_collection)
+    expect(notification.notifying_resource).to eq(@long_cat)
   end
 
   it "resolves lazy references to both its resource and its notifying resource" do
-    @notification.resource = {:cat => "keyboard_cat"}
+    notification.resource = {:cat => "keyboard_cat"}
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @keyboard_cat
-    @notification.notifying_resource = {:cat => "long_cat"}
+    notification.notifying_resource = {:cat => "long_cat"}
     @long_cat = Chef::Resource::Cat.new("long_cat")
     @resource_collection << @long_cat
-    @notification.resolve_resource_reference(@resource_collection)
-    expect(@notification.resource).to eq(@keyboard_cat)
-    expect(@notification.notifying_resource).to eq(@long_cat)
+    notification.resolve_resource_reference(@resource_collection)
+    expect(notification.resource).to eq(@keyboard_cat)
+    expect(notification.notifying_resource).to eq(@long_cat)
   end
 
   it "raises a RuntimeError if you try to reference multiple resources" do
-    @notification.resource = {:cat => ["keyboard_cat", "cheez_cat"]}
+    notification.resource = {:cat => ["keyboard_cat", "cheez_cat"]}
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
     @cheez_cat = Chef::Resource::Cat.new("cheez_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @keyboard_cat
     @resource_collection << @cheez_cat
     @long_cat = Chef::Resource::Cat.new("long_cat")
-    @notification.notifying_resource = @long_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
+    notification.notifying_resource = @long_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
   end
 
   it "raises a RuntimeError if you try to reference multiple notifying resources" do
-    @notification.notifying_resource = {:cat => ["long_cat", "cheez_cat"]}
+    notification.notifying_resource = {:cat => ["long_cat", "cheez_cat"]}
     @long_cat = Chef::Resource::Cat.new("long_cat")
     @cheez_cat = Chef::Resource::Cat.new("cheez_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @long_cat
     @resource_collection << @cheez_cat
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
-    @notification.resource = @keyboard_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
+    notification.resource = @keyboard_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
   end
 
   it "raises a RuntimeError if it can't find a resource in the resource collection when resolving a lazy reference" do
-    @notification.resource = {:cat => "keyboard_cat"}
+    notification.resource = {:cat => "keyboard_cat"}
     @cheez_cat = Chef::Resource::Cat.new("cheez_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @cheez_cat
     @long_cat = Chef::Resource::Cat.new("long_cat")
-    @notification.notifying_resource = @long_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
+    notification.notifying_resource = @long_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
   end
 
   it "raises a RuntimeError if it can't find a notifying resource in the resource collection when resolving a lazy reference" do
-    @notification.notifying_resource = {:cat => "long_cat"}
+    notification.notifying_resource = {:cat => "long_cat"}
     @cheez_cat = Chef::Resource::Cat.new("cheez_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @cheez_cat
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
-    @notification.resource = @keyboard_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
+    notification.resource = @keyboard_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(RuntimeError)
   end
 
   it "raises an ArgumentError if improper syntax is used in the lazy reference to its resource" do
-    @notification.resource = "cat => keyboard_cat"
+    notification.resource = "cat => keyboard_cat"
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @keyboard_cat
     @long_cat = Chef::Resource::Cat.new("long_cat")
-    @notification.notifying_resource = @long_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(ArgumentError)
+    notification.notifying_resource = @long_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(ArgumentError)
   end
 
   it "raises an ArgumentError if improper syntax is used in the lazy reference to its notifying resource" do
-    @notification.notifying_resource = "cat => long_cat"
+    notification.notifying_resource = "cat => long_cat"
     @long_cat = Chef::Resource::Cat.new("long_cat")
     @resource_collection = Chef::ResourceCollection.new
     @resource_collection << @long_cat
     @keyboard_cat = Chef::Resource::Cat.new("keyboard_cat")
-    @notification.resource = @keyboard_cat
-    expect {@notification.resolve_resource_reference(@resource_collection)}.to raise_error(ArgumentError)
+    notification.resource = @keyboard_cat
+    expect {notification.resolve_resource_reference(@resource_collection)}.to raise_error(ArgumentError)
   end
 
   # Create test to resolve lazy references to both notifying resource and dest. resource


### PR DESCRIPTION
This caused an incident, so this is a simple cleanup task.

\cc @randomcamel @danielsdeleo @lamont-granquist 