### PR TITLE
Windows cookbook dependencies should be updated for Chef 12.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Chef Client Release Notes 12.5.0:
 * OSX 10.11 support (support for SIP and service changes)
+* Windows cookbook <= 1.38.1 contains a library file which does not compile with
+chef-client 12.5.0. This is resolved in version 1.38.2 of the Windows cookbook.
+Cookbooks depending on the Windows cookbook should update the dependency version
+to at least 1.38.2 to be compatible with chef-client 12.5.0.
 
 ## PSCredential support for the `dsc_script` resource
 
@@ -59,7 +63,7 @@ In Fedora 22 yum has been deprecated in favor of DNF.  Unfortunately, while DNF 
 compatible with yum, the yum provider in Chef is not compatible with DNF.  Until a proper `dnf_package`
 resource and associated provider is written and merged into core, 12.5.0 has been patched so that the
 `yum_package` resource takes a property named `yum_binary` which can be set to point at the yum binary
-to run for all its commands.  The `yum_binary` will also default to `yum-deprecated` if the 
+to run for all its commands.  The `yum_binary` will also default to `yum-deprecated` if the
 `/usr/bin/yum-deprecated` command is found on the system.  This means that Fedora 22 users can run
 something like this early in their chef-client run:
 
@@ -73,4 +77,3 @@ end
 
 After which the yum-deprecated binary will exist, and the yum provider will find it and should operate
 normally and successfully.
-


### PR DESCRIPTION
Pending https://github.com/chef-cookbooks/windows/pull/278

@chef/client-windows 