### PR TITLE
Policyfile node integration

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -339,10 +339,27 @@ module ChefConfig
     # most of our testing scenarios)
     default :minimal_ohai, false
 
+    ###
+    # Policyfile Settings
+    #
     # Policyfile is a feature where a node gets its run list and cookbook
     # version set from a single document on the server instead of expanding the
     # run list and having the server compute the cookbook version set based on
     # environment constraints.
+    #
+    # Policyfiles are auto-versioned. The user groups nodes by `policy_name`,
+    # which generally describes a hosts's functional role, and `policy_group`,
+    # which generally groups nodes by deployment phase (a.k.a., "environment").
+    # The Chef Server maps a given set of `policy_name` plus `policy_group` to
+    # a particular revision of a policy.
+
+    default :policy_name, nil
+    default :policy_group, nil
+
+    # During initial development, users were required to set `use_policyfile true`
+    # in `client.rb` to opt-in to policyfile use. Chef Client now examines
+    # configuration, node json, and the stored node to determine if policyfile
+    # usage is desired. This flag is still honored if set, but is unnecessary.
     default :use_policyfile, false
 
     # Policyfiles can be used in a native mode (default) or compatibility mode.
@@ -355,6 +372,16 @@ module ChefConfig
     # compatibility mode. Compatibility mode remains available so you can use
     # policyfiles with servers that don't yet support the native endpoints.
     default :policy_document_native_api, true
+
+    # When policyfiles are used in compatibility mode, `policy_name` and
+    # `policy_group` are instead specified using a combined configuration
+    # setting, `deployment_group`. For example, if policy_name should be
+    # "webserver" and policy_group should be "staging", then `deployment_group`
+    # should be set to "webserver-staging", which is the name of the data bag
+    # item that the policy will be stored as. NOTE: this setting only has an
+    # effect if `policy_document_native_api` is set to `false`.
+    default :deployment_group, nil
+
 
     # Set these to enable SSL authentication / mutual-authentication
     # with the server

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -496,7 +496,7 @@ class Chef
     # @api private
     #
     def policy_builder
-      @policy_builder ||= Chef::PolicyBuilder.strategy.new(node_name, ohai.data, json_attribs, override_runlist, events)
+      @policy_builder ||= Chef::PolicyBuilder::Dynamic.new(node_name, ohai.data, json_attribs, override_runlist, events)
     end
 
     #

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -116,6 +116,8 @@ class Chef
       end
     end
 
+    class InvalidPolicybuilderCall < ArgumentError; end
+
     class InvalidResourceSpecification < ArgumentError; end
     class SolrConnectionError < RuntimeError; end
     class IllegalChecksumRevert < RuntimeError; end

--- a/lib/chef/knife/core/node_presenter.rb
+++ b/lib/chef/knife/core/node_presenter.rb
@@ -67,7 +67,12 @@ class Chef
             result = {}
 
             result["name"] = node.name
-            result["chef_environment"] = node.chef_environment
+            if node.policy_name.nil? && node.policy_group.nil?
+              result["chef_environment"] = node.chef_environment
+            else
+              result["policy_name"] = node.policy_name
+              result["policy_group"] = node.policy_group
+            end
             result["run_list"] = node.run_list
             result["normal"] = node.normal_attrs
 
@@ -95,11 +100,29 @@ class Chef
 
             summarized=<<-SUMMARY
 #{ui.color('Node Name:', :bold)}   #{ui.color(node.name, :bold)}
+SUMMARY
+            show_policy = !(node.policy_name.nil? && node.policy_group.nil?)
+            if show_policy
+              summarized << <<-POLICY
+#{key('Policy Name:')}  #{node.policy_name}
+#{key('Policy Group:')} #{node.policy_group}
+POLICY
+            else
+              summarized << <<-ENV
 #{key('Environment:')} #{node.chef_environment}
+ENV
+            end
+            summarized << <<-SUMMARY
 #{key('FQDN:')}        #{node[:fqdn]}
 #{key('IP:')}          #{ip}
 #{key('Run List:')}    #{node.run_list}
+SUMMARY
+            unless show_policy
+              summarized << <<-ROLES
 #{key('Roles:')}       #{Array(node[:roles]).join(', ')}
+ROLES
+            end
+            summarized << <<-SUMMARY
 #{key('Recipes:')}     #{Array(node[:recipes]).join(', ')}
 #{key('Platform:')}    #{node[:platform]} #{node[:platform_version]}
 #{key('Tags:')}        #{Array(node[:tags]).join(', ')}

--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -160,7 +160,7 @@ class Chef
 
       def fuzzify_query
         if @query !~ /:/
-          @query = "tags:*#{@query}* OR roles:*#{@query}* OR fqdn:*#{@query}* OR addresses:*#{@query}*"
+          @query = "tags:*#{@query}* OR roles:*#{@query}* OR fqdn:*#{@query}* OR addresses:*#{@query}* OR policy_name:*#{@query}* OR policy_group:*#{@query}*"
         end
       end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -510,6 +510,14 @@ class Chef
         #Render correctly for run_list items so malformed json does not result
         "run_list" => @primary_runlist.run_list.map { |item| item.to_s }
       }
+      # Chef Server rejects node JSON with extra keys; prior to 12.3,
+      # "policy_name" and "policy_group" are unknown; after 12.3 they are
+      # optional, therefore only including them in the JSON if present
+      # maximizes compatibility for most people.
+      unless policy_group.nil? && policy_name.nil?
+        result["policy_name"] = policy_name
+        result["policy_group"] = policy_group
+      end
       result
     end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -63,6 +63,8 @@ class Chef
 
     include Chef::Mixin::ParamsValidate
 
+    NULL_ARG = Object.new
+
     # Create a new Chef::Node object.
     def initialize(chef_server_rest: nil)
       @chef_server_rest = chef_server_rest
@@ -71,6 +73,9 @@ class Chef
       @chef_environment = '_default'
       @primary_runlist = Chef::RunList.new
       @override_runlist = Chef::RunList.new
+
+      @policy_name = nil
+      @policy_group = nil
 
       @attributes = Chef::Node::Attribute.new({}, {}, {}, {})
 
@@ -131,6 +136,50 @@ class Chef
     end
 
     alias :environment :chef_environment
+
+    # The `policy_name` for this node. Setting this to a non-nil value will
+    # enable policyfile mode when `chef-client` is run. If set in the config
+    # file or in node json, running `chef-client` will update this value.
+    #
+    # @see Chef::PolicyBuilder::Dynamic
+    # @see Chef::PolicyBuilder::Policyfile
+    #
+    # @param arg [String] the new policy_name value
+    # @return [String] the current policy_name, or the one you just set
+    def policy_name(arg=NULL_ARG)
+      return @policy_name if arg.equal?(NULL_ARG)
+      validate({policy_name: arg}, { policy_name: { kind_of: [ String, NilClass ], regex: /^[\-:.[:alnum:]_]+$/ } })
+      @policy_name = arg
+    end
+
+    # A "non-DSL-style" setter for `policy_name`
+    #
+    # @see #policy_name
+    def policy_name=(policy_name)
+      policy_name(policy_name)
+    end
+
+    # The `policy_group` for this node. Setting this to a non-nil value will
+    # enable policyfile mode when `chef-client` is run. If set in the config
+    # file or in node json, running `chef-client` will update this value.
+    #
+    # @see Chef::PolicyBuilder::Dynamic
+    # @see Chef::PolicyBuilder::Policyfile
+    #
+    # @param arg [String] the new policy_group value
+    # @return [String] the current policy_group, or the one you just set
+    def policy_group(arg=NULL_ARG)
+      return @policy_group if arg.equal?(NULL_ARG)
+      validate({policy_group: arg}, { policy_group: { kind_of: [ String, NilClass ], regex: /^[\-:.[:alnum:]_]+$/ } })
+      @policy_group = arg
+    end
+
+    # A "non-DSL-style" setter for `policy_group`
+    #
+    # @see #policy_group
+    def policy_group=(policy_group)
+      policy_group(policy_group)
+    end
 
     def attributes
       @attributes

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -549,6 +549,10 @@ class Chef
       else
         o["recipes"].each { |r| node.recipes << r }
       end
+
+      node.policy_name = o["policy_name"] if o.has_key?("policy_name")
+      node.policy_group = o["policy_group"] if o.has_key?("policy_group")
+
       node
     end
 

--- a/lib/chef/policy_builder.rb
+++ b/lib/chef/policy_builder.rb
@@ -38,13 +38,5 @@ class Chef
   # * cookbook_hash is stored in run_context
   module PolicyBuilder
 
-    def self.strategy
-      if Chef::Config[:use_policyfile]
-        Policyfile
-      else
-        ExpandNodeObject
-      end
-    end
-
   end
 end

--- a/lib/chef/policy_builder.rb
+++ b/lib/chef/policy_builder.rb
@@ -18,6 +18,7 @@
 
 require 'chef/policy_builder/expand_node_object'
 require 'chef/policy_builder/policyfile'
+require 'chef/policy_builder/dynamic'
 
 class Chef
 

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -1,0 +1,136 @@
+#
+# Author:: Daniel DeLeo (<dan@chef.io>)
+# Copyright:: Copyright 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/log'
+require 'chef/rest'
+require 'chef/run_context'
+require 'chef/config'
+require 'chef/node'
+
+class Chef
+  module PolicyBuilder
+
+    # PolicyBuilder that selects either a Policyfile or non-Policyfile
+    # implementation based on the content of the node object.
+    class Dynamic
+
+      attr_reader :node
+      attr_reader :node_name
+      attr_reader :ohai_data
+      attr_reader :json_attribs
+      attr_reader :override_runlist
+      attr_reader :events
+
+      def initialize(node_name, ohai_data, json_attribs, override_runlist, events)
+        @implementation = nil
+
+        @node_name = node_name
+        @ohai_data = ohai_data
+        @json_attribs = json_attribs
+        @override_runlist = override_runlist
+        @events = events
+
+        @node = nil
+      end
+
+      ## PolicyBuilder API ##
+
+      # Loads the node state from the server, then picks the correct
+      # implementation class based on the node and json_attribs.
+      def load_node
+        events.node_load_start(node_name, config)
+        Chef::Log.debug("Building node object for #{node_name}")
+
+        node = Chef::Node.find_or_create(node_name)
+        select_implementation(node)
+        implementation.finish_load_node(node)
+        node
+      rescue Exception => e
+        events.node_load_failed(node_name, e, config)
+        raise
+      end
+
+      ## Delegated Methods ##
+
+      def original_runlist
+        implementation.original_runlist
+      end
+
+      def run_context
+        implementation.run_context
+      end
+
+      def run_list_expansion
+        implementation.run_list_expansion
+      end
+
+      def build_node
+        implementation.build_node
+      end
+
+      def setup_run_context(specific_recipes=nil)
+        implementation.setup_run_context(specific_recipes)
+      end
+
+      def expand_run_list
+        implementation.expand_run_list
+      end
+
+      def sync_cookbooks
+        implementation.sync_cookbooks
+      end
+
+      def temporary_policy?
+        implementation.temporary_policy?
+      end
+
+      ## Internal Public API ##
+
+      def implementation
+        @implementation
+      end
+
+      def select_implementation(node)
+        if policyfile_set_in_config? || policyfile_attribs_in_node_json? || node_has_policyfile_attrs?(node)
+          @implementation = Policyfile.new(node_name, ohai_data, json_attribs, override_runlist, events)
+        else
+          @implementation = ExpandNodeObject.new(node_name, ohai_data, json_attribs, override_runlist, events)
+        end
+      end
+
+      def config
+        Chef::Config
+      end
+
+      private
+
+      def node_has_policyfile_attrs?(node)
+        node.policy_name || node.policy_group
+      end
+
+      def policyfile_attribs_in_node_json?
+        json_attribs.key?("policy_name") || json_attribs.key?("policy_group")
+      end
+
+      def policyfile_set_in_config?
+        config[:use_policyfile] || config[:policy_name] || config[:policy_group]
+      end
+
+    end
+  end
+end

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -112,7 +112,10 @@ class Chef
       end
 
       def select_implementation(node)
-        if policyfile_set_in_config? || policyfile_attribs_in_node_json? || node_has_policyfile_attrs?(node)
+        if policyfile_set_in_config? ||
+            policyfile_attribs_in_node_json? ||
+            node_has_policyfile_attrs?(node) ||
+            policyfile_compat_mode_config?
           @implementation = Policyfile.new(node_name, ohai_data, json_attribs, override_runlist, events)
         else
           @implementation = ExpandNodeObject.new(node_name, ohai_data, json_attribs, override_runlist, events)
@@ -135,6 +138,10 @@ class Chef
 
       def policyfile_set_in_config?
         config[:use_policyfile] || config[:policy_name] || config[:policy_group]
+      end
+
+      def policyfile_compat_mode_config?
+        config[:deployment_group] && !config[:policy_document_native_api]
       end
 
     end

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+require 'forwardable'
+
 require 'chef/log'
 require 'chef/rest'
 require 'chef/run_context'
@@ -29,6 +31,8 @@ class Chef
     # PolicyBuilder that selects either a Policyfile or non-Policyfile
     # implementation based on the content of the node object.
     class Dynamic
+
+      extend Forwardable
 
       attr_reader :node
       attr_reader :node_name
@@ -71,39 +75,16 @@ class Chef
         raise
       end
 
-      ## Delegated Methods ##
+      ## Delegated Public API Methods ##
 
-      def original_runlist
-        implementation.original_runlist
-      end
-
-      def run_context
-        implementation.run_context
-      end
-
-      def run_list_expansion
-        implementation.run_list_expansion
-      end
-
-      def build_node
-        implementation.build_node
-      end
-
-      def setup_run_context(specific_recipes=nil)
-        implementation.setup_run_context(specific_recipes)
-      end
-
-      def expand_run_list
-        implementation.expand_run_list
-      end
-
-      def sync_cookbooks
-        implementation.sync_cookbooks
-      end
-
-      def temporary_policy?
-        implementation.temporary_policy?
-      end
+      def_delegator :implementation, :original_runlist
+      def_delegator :implementation, :run_context
+      def_delegator :implementation, :run_list_expansion
+      def_delegator :implementation, :build_node
+      def_delegator :implementation, :setup_run_context
+      def_delegator :implementation, :expand_run_list
+      def_delegator :implementation, :sync_cookbooks
+      def_delegator :implementation, :temporary_policy?
 
       ## Internal Public API ##
 

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -93,25 +93,9 @@ class Chef
         run_context
       end
 
-
-      # In client-server operation, loads the node state from the server. In
-      # chef-solo operation, builds a new node object.
-      def load_node
-        events.node_load_start(node_name, Chef::Config)
-        Chef::Log.debug("Building node object for #{node_name}")
-
-        if Chef::Config[:solo]
-          @node = Chef::Node.build(node_name)
-        else
-          @node = Chef::Node.find_or_create(node_name)
-        end
-      rescue Exception => e
-        # TODO: wrap this exception so useful error info can be given to the
-        # user.
-        events.node_load_failed(node_name, e, Chef::Config)
-        raise
+      def finish_load_node(node)
+        @node = node
       end
-
 
       # Applies environment, external JSON attributes, and override run list to
       # the node, Then expands the run_list.

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -57,6 +57,9 @@ class Chef
 
       # This method injects the run_context and into the Chef class.
       #
+      # NOTE: This is duplicated with the Policyfile implementation. If
+      # it gets any more complicated, it needs to be moved elsewhere.
+      #
       # @param run_context [Chef::RunContext] the run_context to inject
       def setup_chef_class(run_context)
         Chef.set_run_context(run_context)

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -55,9 +55,7 @@ class Chef
         @run_list_expansion = nil
       end
 
-      # This method injects the run_context and provider and resource priority
-      # maps into the Chef class.  The run_context has to be injected here, the provider and
-      # resource maps could be moved if a better place can be found to do this work.
+      # This method injects the run_context and into the Chef class.
       #
       # @param run_context [Chef::RunContext] the run_context to inject
       def setup_chef_class(run_context)

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -112,18 +112,10 @@ class Chef
 
       ## PolicyBuilder API ##
 
-      # Loads the node state from the server.
-      def load_node
-        events.node_load_start(node_name, Chef::Config)
-        Chef::Log.debug("Building node object for #{node_name}")
-
-        @node = Chef::Node.find_or_create(node_name)
+      def finish_load_node(node)
+        @node = node
         validate_policyfile
         events.policyfile_loaded(policy)
-        node
-      rescue Exception => e
-        events.node_load_failed(node_name, e, Chef::Config)
-        raise
       end
 
       # Applies environment, external JSON attributes, and override run list to

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -114,6 +114,7 @@ class Chef
 
       def finish_load_node(node)
         @node = node
+        select_policy_name_and_group
         validate_policyfile
         events.policyfile_loaded(policy)
       end
@@ -293,6 +294,48 @@ class Chef
 
       def policy_name
         Chef::Config[:policy_name]
+      end
+
+      def select_policy_name_and_group
+        policy_name_to_set =
+          policy_name_from_json_attribs ||
+          policy_name_from_config ||
+          policy_name_from_node
+
+        policy_group_to_set =
+          policy_group_from_json_attribs ||
+          policy_group_from_config ||
+          policy_group_from_node
+
+        node.policy_name = policy_name_to_set
+        node.policy_group = policy_group_to_set
+
+        Chef::Config[:policy_name] = policy_name_to_set
+        Chef::Config[:policy_group] = policy_group_to_set
+      end
+
+      def policy_group_from_json_attribs
+        json_attribs["policy_group"]
+      end
+
+      def policy_name_from_json_attribs
+        json_attribs["policy_name"]
+      end
+
+      def policy_group_from_config
+        Chef::Config[:policy_group]
+      end
+
+      def policy_name_from_config
+        Chef::Config[:policy_name]
+      end
+
+      def policy_group_from_node
+        node.policy_group
+      end
+
+      def policy_name_from_node
+        node.policy_name
       end
 
       # Builds a 'cookbook_hash' map of the form

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -147,17 +147,28 @@ class Chef
         raise
       end
 
+      # Synchronizes cookbooks and initializes the run context object for the
+      # run.
+      #
+      # @return [Chef::RunContext]
       def setup_run_context(specific_recipes=nil)
         Chef::Cookbook::FileVendor.fetch_from_remote(http_api)
         sync_cookbooks
         cookbook_collection = Chef::CookbookCollection.new(cookbooks_to_sync)
         run_context = Chef::RunContext.new(node, cookbook_collection, events)
 
+        setup_chef_class(run_context)
+
         run_context.load(run_list_expansion_ish)
 
+        setup_chef_class(run_context)
         run_context
       end
 
+      # Sets `run_list` on the node from the policy, sets `roles` and `recipes`
+      # attributes on the node accordingly.
+      #
+      # @return [RunListExpansionIsh] A RunListExpansion duck-type.
       def expand_run_list
         node.run_list(run_list)
         node.automatic_attrs[:roles] = []
@@ -165,7 +176,11 @@ class Chef
         run_list_expansion_ish
       end
 
-
+      # Synchronizes cookbooks. In a normal chef-client run, this is handled by
+      # #setup_run_context, but may be called directly in some circumstances.
+      #
+      # @return [Hash{String => Chef::CookbookManifest}] A map of
+      #   CookbookManifest objects by cookbook name.
       def sync_cookbooks
         Chef::Log.debug("Synchronizing cookbooks")
         synchronizer = Chef::CookbookSynchronizer.new(cookbooks_to_sync, events)
@@ -179,12 +194,18 @@ class Chef
 
       # Whether or not this is a temporary policy. Since PolicyBuilder doesn't
       # support override_runlist, this is always false.
+      #
+      # @return [false]
       def temporary_policy?
         false
       end
 
       ## Internal Public API ##
 
+      # @api private
+      #
+      # Generates an array of strings with recipe names including version and
+      # identifier info.
       def run_list_with_versions_for_display
         run_list.map do |recipe_spec|
           cookbook, recipe = parse_recipe_spec(recipe_spec)
@@ -194,6 +215,11 @@ class Chef
         end
       end
 
+      # @api private
+      #
+      # Sets up a RunListExpansionIsh object so that it can be used in place of
+      # a RunListExpansion object, to satisfy the API contract of
+      # #expand_run_list
       def run_list_expansion_ish
         recipes = run_list.map do |recipe_spec|
           cookbook, recipe = parse_recipe_spec(recipe_spec)
@@ -202,11 +228,15 @@ class Chef
         RunListExpansionIsh.new(recipes, [])
       end
 
+      # @api private
+      #
+      # Sets attributes from the policyfile on the node, using the role priority.
       def apply_policyfile_attributes
         node.attributes.role_default = policy["default_attributes"]
         node.attributes.role_override = policy["override_attributes"]
       end
 
+      # @api private
       def parse_recipe_spec(recipe_spec)
         rmatch = recipe_spec.match(/recipe\[([^:]+)::([^:]+)\]/)
         if rmatch.nil?
@@ -216,20 +246,24 @@ class Chef
         end
       end
 
+      # @api private
       def cookbook_lock_for(cookbook_name)
         cookbook_locks[cookbook_name]
       end
 
+      # @api private
       def run_list
         policy["run_list"]
       end
 
+      # @api private
       def policy
         @policy ||= http_api.get(policyfile_location)
       rescue Net::HTTPServerException => e
         raise ConfigurationError, "Error loading policyfile from `#{policyfile_location}': #{e.class} - #{e.message}"
       end
 
+      # @api private
       def policyfile_location
         if Chef::Config[:policy_document_native_api]
           validate_policy_config!
@@ -266,6 +300,7 @@ class Chef
         end
       end
 
+      # @api private
       def validate_recipe_spec(recipe_spec)
         parse_recipe_spec(recipe_spec)
         nil
@@ -275,11 +310,13 @@ class Chef
 
       class ConfigurationError < StandardError; end
 
+      # @api private
       def deployment_group
         Chef::Config[:deployment_group] or
           raise ConfigurationError, "Setting `deployment_group` is not configured."
       end
 
+      # @api private
       def validate_policy_config!
         policy_group or
           raise ConfigurationError, "Setting `policy_group` is not configured."
@@ -288,14 +325,26 @@ class Chef
           raise ConfigurationError, "Setting `policy_name` is not configured."
       end
 
+      # @api private
       def policy_group
         Chef::Config[:policy_group]
       end
 
+      # @api private
       def policy_name
         Chef::Config[:policy_name]
       end
 
+      # @api private
+      #
+      # Selects the `policy_name` and `policy_group` from the following sources
+      # in priority order:
+      #
+      # 1. JSON attribs (i.e., `-j JSON_FILE`)
+      # 2. `Chef::Config`
+      # 3. The node object
+      #
+      # The selected values are then copied to `Chef::Config` and the node.
       def select_policy_name_and_group
         policy_name_to_set =
           policy_name_from_json_attribs ||
@@ -314,30 +363,37 @@ class Chef
         Chef::Config[:policy_group] = policy_group_to_set
       end
 
+      # @api private
       def policy_group_from_json_attribs
         json_attribs["policy_group"]
       end
 
+      # @api private
       def policy_name_from_json_attribs
         json_attribs["policy_name"]
       end
 
+      # @api private
       def policy_group_from_config
         Chef::Config[:policy_group]
       end
 
+      # @api private
       def policy_name_from_config
         Chef::Config[:policy_name]
       end
 
+      # @api private
       def policy_group_from_node
         node.policy_group
       end
 
+      # @api private
       def policy_name_from_node
         node.policy_name
       end
 
+      # @api private
       # Builds a 'cookbook_hash' map of the form
       #   "COOKBOOK_NAME" => "IDENTIFIER"
       #
@@ -365,6 +421,7 @@ class Chef
         raise
       end
 
+      # @api private
       # Fetches the CookbookVersion object for the given name and identifer
       # specified in the lock_data.
       # TODO: This only implements Chef 11 compatibility mode, which means that
@@ -378,19 +435,32 @@ class Chef
         end
       end
 
+      # @api private
       def cookbook_locks
         policy["cookbook_locks"]
       end
 
+      # @api private
       def http_api
         @api_service ||= Chef::REST.new(config[:chef_server_url])
       end
 
+      # @api private
       def config
         Chef::Config
       end
 
       private
+
+      # This method injects the run_context and into the Chef class.
+      #
+      # NOTE: This is duplicated with the ExpandNodeObject implementation. If
+      # it gets any more complicated, it needs to be moved elsewhere.
+      #
+      # @param run_context [Chef::RunContext] the run_context to inject
+      def setup_chef_class(run_context)
+        Chef.set_run_context(run_context)
+      end
 
       def compat_mode_manifest_for(cookbook_name, lock_data)
         xyz_version = lock_data["dotted_decimal_identifier"]

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -364,6 +364,8 @@ describe Chef::Client do
       expect(node[:expanded_run_list]).to be_nil
 
       allow(client.policy_builder).to receive(:node).and_return(node)
+      client.policy_builder.select_implementation(node)
+      allow(client.policy_builder.implementation).to receive(:node).and_return(node)
 
       # chefspec and possibly others use the return value of this method
       expect(client.build_node).to eq(node)
@@ -391,6 +393,8 @@ describe Chef::Client do
       expect(mock_chef_rest).to receive(:get_rest).with("environments/A").and_return(test_env)
       expect(Chef::REST).to receive(:new).and_return(mock_chef_rest)
       allow(client.policy_builder).to receive(:node).and_return(node)
+      client.policy_builder.select_implementation(node)
+      allow(client.policy_builder.implementation).to receive(:node).and_return(node)
       expect(client.build_node).to eq(node)
 
       expect(node.chef_environment).to eq("A")

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -127,6 +127,78 @@ describe Chef::Node do
     end
   end
 
+  describe "policy_name" do
+
+    it "defaults to nil" do
+      expect(node.policy_name).to be_nil
+    end
+
+    it "sets policy_name with a regular setter" do
+      node.policy_name = "example-policy"
+      expect(node.policy_name).to eq("example-policy")
+    end
+
+    it "allows policy_name with every valid character" do
+      expect { node.policy_name = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }.to_not raise_error
+    end
+
+    it "sets policy_name when given an argument" do
+      node.policy_name("example-policy")
+      expect(node.policy_name).to eq("example-policy")
+    end
+
+    it "sets policy_name to nil when given nil" do
+      node.policy_name = "example-policy"
+      node.policy_name = nil
+      expect(node.policy_name).to be_nil
+    end
+
+    it "disallows non-strings" do
+      expect { node.policy_name(Hash.new) }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { node.policy_name(42) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+
+    it "cannot be blank" do
+      expect { node.policy_name("")}.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+  end
+
+  describe "policy_group" do
+
+    it "defaults to nil" do
+      expect(node.policy_group).to be_nil
+    end
+
+    it "sets policy_group with a regular setter" do
+      node.policy_group = "staging"
+      expect(node.policy_group).to eq("staging")
+    end
+
+    it "allows policy_group with every valid character" do
+      expect { node.policy_group = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }.to_not raise_error
+    end
+
+    it "sets an environment with chef_environment(something)" do
+      node.policy_group("staging")
+      expect(node.policy_group).to eq("staging")
+    end
+
+    it "sets policy_group to nil when given nil" do
+      node.policy_group = "staging"
+      node.policy_group = nil
+      expect(node.policy_group).to be_nil
+    end
+
+    it "disallows non-strings" do
+      expect { node.policy_group(Hash.new) }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { node.policy_group(42) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+
+    it "cannot be blank" do
+      expect { node.policy_group("")}.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+  end
+
   describe "attributes" do
     it "should have attributes" do
       expect(node.attribute).to be_a_kind_of(Hash)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1185,6 +1185,35 @@ describe Chef::Node do
       expect(serialized_node.run_list).to eq(node.run_list)
     end
 
+    context "when policyfile attributes are not present" do
+
+      it "does not have a policy_name key in the json" do
+        expect(node.for_json.keys).to_not include("policy_name")
+      end
+
+      it "does not have a policy_group key in the json" do
+        expect(node.for_json.keys).to_not include("policy_name")
+      end
+    end
+
+    context "when policyfile attributes are present" do
+
+      before do
+        node.policy_name = "my-application"
+        node.policy_group = "staging"
+      end
+
+      it "includes policy_name key in the json" do
+        expect(node.for_json).to have_key("policy_name")
+        expect(node.for_json["policy_name"]).to eq("my-application")
+      end
+
+      it "includes a policy_group key in the json" do
+        expect(node.for_json).to have_key("policy_group")
+        expect(node.for_json["policy_group"]).to eq("staging")
+      end
+    end
+
     include_examples "to_json equivalent to Chef::JSONCompat.to_json" do
       let(:jsonable) {
         node.from_file(File.expand_path("nodes/test.example.com.rb", CHEF_SPEC_DATA))
@@ -1380,6 +1409,7 @@ describe Chef::Node do
           node.save
         end
       end
+
     end
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1212,6 +1212,14 @@ describe Chef::Node do
         expect(node.for_json).to have_key("policy_group")
         expect(node.for_json["policy_group"]).to eq("staging")
       end
+
+      it "parses policyfile attributes from JSON" do
+        round_tripped_node = Chef::Node.json_create(node.for_json)
+
+        expect(round_tripped_node.policy_name).to eq("my-application")
+        expect(round_tripped_node.policy_group).to eq("staging")
+      end
+
     end
 
     include_examples "to_json equivalent to Chef::JSONCompat.to_json" do

--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -1,0 +1,211 @@
+#
+# Author:: Daniel DeLeo (<dan@getchef.com>)
+# Copyright:: Copyright 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef/policy_builder'
+
+describe Chef::PolicyBuilder::Dynamic do
+
+  let(:node_name) { "joe_node" }
+  let(:ohai_data) { {"platform" => "ubuntu", "platform_version" => "13.04", "fqdn" => "joenode.example.com"} }
+  let(:json_attribs) { {"custom_attr" => "custom_attr_value"} }
+  let(:override_runlist) { nil }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+
+  let(:err_namespace) { Chef::PolicyBuilder::Policyfile }
+
+  let(:base_node) do
+    node = Chef::Node.new
+    node.name(node_name)
+    node
+  end
+
+  let(:node) { base_node }
+
+  subject(:policy_builder) { Chef::PolicyBuilder::Dynamic.new(node_name, ohai_data, json_attribs, override_runlist, events) }
+
+  describe "loading policy data" do
+
+    describe "delegating PolicyBuilder API to the correct implementation" do
+
+      let(:implementation) { instance_double("Chef::PolicyBuilder::Policyfile") }
+
+      before do
+        allow(policy_builder).to receive(:implementation).and_return(implementation)
+      end
+
+      # Dynamic should load_node, figure out the correct backend, then forward
+      # messages to it after. That behavior is tested below.
+      it "responds to #load_node" do
+        expect(policy_builder).to respond_to(:load_node)
+      end
+
+      it "forwards #original_runlist" do
+        expect(implementation).to receive(:original_runlist)
+        policy_builder.original_runlist
+      end
+
+      it "forwards #run_context" do
+        expect(implementation).to receive(:run_context)
+        policy_builder.run_context
+      end
+
+      it "forwards #run_list_expansion" do
+        expect(implementation).to receive(:run_list_expansion)
+        policy_builder.run_list_expansion
+      end
+
+      it "forwards #build_node to the implementation object" do
+        expect(implementation).to receive(:build_node)
+        policy_builder.build_node
+      end
+
+      it "forwards #setup_run_context to the implementation object" do
+        expect(implementation).to receive(:setup_run_context)
+        policy_builder.setup_run_context
+
+        arg = Object.new
+
+        expect(implementation).to receive(:setup_run_context).with(arg)
+        policy_builder.setup_run_context(arg)
+      end
+
+      it "forwards #expand_run_list to the implementation object" do
+        expect(implementation).to receive(:expand_run_list)
+        policy_builder.expand_run_list
+      end
+
+      it "forwards #sync_cookbooks to the implementation object" do
+        expect(implementation).to receive(:sync_cookbooks)
+        policy_builder.sync_cookbooks
+      end
+
+      it "forwards #temporary_policy? to the implementation object" do
+        expect(implementation).to receive(:temporary_policy?)
+        policy_builder.temporary_policy?
+      end
+
+    end
+
+    describe "selecting a backend implementation" do
+
+      let(:implementation) do
+        policy_builder.select_implementation(node)
+        policy_builder.implementation
+      end
+
+      context "when no policyfile attributes are present on the node" do
+
+        context "and json_attribs are not given" do
+
+          let(:json_attribs) { {} }
+
+          it "uses the ExpandNodeObject implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::ExpandNodeObject)
+          end
+
+        end
+
+        context "and no policyfile attributes are present in json_attribs" do
+
+          let(:json_attribs) { {"foo" => "bar"} }
+
+          it "uses the ExpandNodeObject implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::ExpandNodeObject)
+          end
+
+        end
+
+        context "and :use_policyfile is set in Chef::Config" do
+
+          before do
+            Chef::Config[:use_policyfile] = true
+          end
+
+          it "uses the Policyfile implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
+          end
+
+        end
+
+        context "and policy_name and policy_group are set on Chef::Config" do
+
+          before do
+            Chef::Config[:policy_name] = "example-policy"
+            Chef::Config[:policy_group] = "testing"
+          end
+
+          it "uses the Policyfile implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
+          end
+
+        end
+
+        context "and policyfile attributes are present in json_attribs" do
+
+          let(:json_attribs) { {"policy_name" => "example-policy", "policy_group" => "testing"} }
+
+          it "uses the Policyfile implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
+          end
+
+        end
+
+      end
+
+      context "when policyfile attributes are present on the node" do
+
+        let(:node) do
+          base_node.policy_name = "example-policy"
+          base_node.policy_group = "staging"
+          base_node
+        end
+
+        it "uses the Policyfile implementation" do
+          expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
+        end
+
+      end
+
+    end
+
+    describe "loading a node" do
+
+      let(:implementation) { instance_double("Chef::PolicyBuilder::Policyfile") }
+
+      before do
+        allow(policy_builder).to receive(:implementation).and_return(implementation)
+
+        expect(Chef::Node).to receive(:find_or_create).with(node_name).and_return(node)
+        expect(policy_builder).to receive(:select_implementation).with(node)
+        expect(implementation).to receive(:finish_load_node).with(node)
+      end
+
+      context "when successful" do
+
+        it "selects the backend implementation and continues node loading", :pending do
+          policy_builder.load_node
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -156,6 +156,19 @@ describe Chef::PolicyBuilder::Dynamic do
 
         end
 
+        context "and deployment_group and policy_document_native_api are set on Chef::Config" do
+
+          before do
+            Chef::Config[:deployment_group] = "example-policy-staging"
+            Chef::Config[:policy_document_native_api] = false
+          end
+
+          it "uses the Policyfile implementation" do
+            expect(implementation).to be_a(Chef::PolicyBuilder::Policyfile)
+          end
+
+        end
+
         context "and policyfile attributes are present in json_attribs" do
 
           let(:json_attribs) { {"policy_name" => "example-policy", "policy_group" => "testing"} }


### PR DESCRIPTION
This patch integrates `policy_name` and `policy_group` into the node object, with the following behavior changes:

- Policyfile attributes can be set on `Chef::Node` objects
- Policyfile attributes are included in the serialization format (JSON)
- Policyfile attributes are persisted between runs, when using a Chef Server that supports them
- Policyfile attributes can be set in the JSON file passed to `chef-client -j JSON_FILE`
- Policyfile attributes are shown by `knife search` and `knife node show`, if present
- Policyfile attributes are searched in the `knife search` "fuzzy" query (which is invoked when the given query doesn't match the `key:value` format).
- The `use_policyfile` feature flag in config is effectively a no-op.

See also the related Chef Server change, which will be released in Chef Server 12.3: https://github.com/chef/chef-server/pull/514

#### Tasks:

- [x] Add getters and setters for `policy_name` and `policy_group` to Node
- [x] Add `policy_name` and `policy_group` to node json, with fallback for older chef servers
- [x] dynamically select policyfile mode or not based on presence of policyfile attributes on node, `-j JSON`, etc.
- [x] propagate `policy_name` and `policy_group` to and from `-j JSON`, `Chef::Config` and node
- [x] add policyfile stuff to `knife node show`
- [x] add policyfile stuff to default query in `knife search`
- [x] ensure compatibility mode still works (e.g., test kitchen)

#### Punted:
- warn if `use_policyfile true` is in config (deprecate and remove in 13): I don't think there's an overwhelming case to nag and eventually break users over this.
- support policy_name/policy_group in bootstrap: This will be a separate pull request, as this one is already very large.