### PR TITLE
Fix failing specs on Windows

### DIFF
--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -465,8 +465,8 @@ shared_examples_for Chef::Provider::File do
         t
       }
 
-      let(:verification) { double("Verification") }
-      let(:verification_fail) { double("Verification Fail") }
+      let(:verification) { instance_double(Chef::Resource::File::Verification) }
+      let(:verification_fail) { instance_double(Chef::Resource::File::Verification) }
 
       context "with user-supplied verifications" do
         it "calls #verify on each verification with tempfile path" do


### PR DESCRIPTION
The verify tests were not correctly mocking things out. This was causing the tests to actually shellout
for verify, it this started breaking because of an implementation detail that was part of the mixlib-shellout 2.2.1 release

