### PR TITLE
Policyfile named run list support

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -356,6 +356,12 @@ module ChefConfig
     default :policy_name, nil
     default :policy_group, nil
 
+    # Policyfiles can have multiple run lists, via the named run list feature.
+    # Generally this will be set by a CLI option via Chef::Application::Client,
+    # but it could be set in client.rb if desired.
+
+    default :named_run_list, nil
+
     # During initial development, users were required to set `use_policyfile true`
     # in `client.rb` to opt-in to policyfile use. Chef Client now examines
     # configuration, node json, and the stored node to determine if policyfile

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -160,6 +160,12 @@ class Chef::Application::Client < Chef::Application
     :description  => "Set the client key file location",
     :proc         => nil
 
+  option :named_run_list,
+    :short        => "-n NAMED_RUN_LIST",
+    :long         => "--named-run-list NAMED_RUN_LIST",
+    :description  => "Use a policyfile's named run list instead of the default run list",
+    :default      => nil
+
   option :environment,
     :short        => '-E ENVIRONMENT',
     :long         => '--environment ENVIRONMENT',

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -250,7 +250,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
     end
 
     it "should throw an exception" do
-      expect { @app.reconfigure }.to raise_error
+      expect { app.reconfigure }.to raise_error(Chef::Exceptions::PIDFileLockfileMatch)
     end
   end
 end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -47,6 +47,19 @@ describe Chef::Application::Client, "reconfigure" do
       expect(app).to receive(:set_specific_recipes).and_return(true)
       app.reconfigure
     end
+
+    context "when given a named_run_list" do
+
+      before do
+        ARGV.replace( %w[ --named-run-list arglebargle-example ] )
+        app.reconfigure
+      end
+
+      it "sets named_run_list in Chef::Config" do
+        expect(Chef::Config[:named_run_list]).to eq("arglebargle-example")
+      end
+
+    end
   end
 
   describe "when configured to not fork the client process" do


### PR DESCRIPTION
Named run list support has existed for quite a while in ChefDK, this allows the user to actually select a named run list. I need to do an end-to-end test, but the code is ready for review.

@chef/client-core @kisoku