### PR TITLE
Windows cli tools should have color true by default

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -100,7 +100,7 @@ class Chef::Application::Apply < Chef::Application
   option :color,
     :long         => '--[no-]color',
     :boolean      => true,
-    :default      => !Chef::Platform.windows?,
+    :default      => true,
     :description  => "Use colored output, defaults to enabled"
 
   option :minimal_ohai,

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -58,8 +58,8 @@ class Chef::Application::Client < Chef::Application
   option :color,
     :long         => '--[no-]color',
     :boolean      => true,
-    :default      => !Chef::Platform.windows?,
-    :description  => "Use colored output, defaults to false on Windows, true otherwise"
+    :default      => true,
+    :description  => "Use colored output, defaults to enabled"
 
   option :log_level,
     :short        => "-l LEVEL",

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -44,8 +44,8 @@ class Chef::Application::Knife < Chef::Application
   option :color,
     :long         => '--[no-]color',
     :boolean      => true,
-    :default      => !Chef::Platform.windows?,
-    :description  => "Use colored output, defaults to false on Windows, true otherwise"
+    :default      => true,
+    :description  => "Use colored output, defaults to enabled"
 
   option :environment,
     :short        => "-E ENVIRONMENT",

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -288,9 +288,9 @@ describe Chef::Application::Client, "configure_chef" do
     ARGV.replace(@original_argv)
   end
 
-  it "should set the colored output to false by default on windows and true otherwise" do
+  it "should set the colored output to true by default on windows and true on all other platforms as well" do
     if windows?
-      expect(Chef::Config[:color]).to be_falsey
+      expect(Chef::Config[:color]).to be_truthy
     else
       expect(Chef::Config[:color]).to be_truthy
     end

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -70,13 +70,13 @@ describe Chef::Application::Knife do
     end
   end
 
-  it "should set the colored output to false by default on windows and true otherwise" do
+  it "should set the colored output to true by default on windows and true on all other platforms as well" do
     with_argv(*%w{noop knife command}) do
       expect(@knife).to receive(:exit).with(0)
       @knife.run
     end
     if windows?
-      expect(Chef::Config[:color]).to be_falsey
+      expect(Chef::Config[:color]).to be_truthy
     else
       expect(Chef::Config[:color]).to be_truthy
     end


### PR DESCRIPTION
Older terminal applications on Windows displayed garbage characters instead of altering the color of text in the terminal as a response to color escape sequences. In Win2k12 and newer, the default Windows terminal displays colored text correctly. To reflect this, the defaults on chef-cient, chef-apply, and knife are being changed to be like all other operating systems and use color by default. cc @jaym, @mwrock, @chefsalim, @ksubrama, @McQuin.