### PR TITLE
Safely clean up Win32 namespace after specs

### DIFF
--- a/spec/support/shared/context/win32.rb
+++ b/spec/support/shared/context/win32.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+RSpec.shared_context "Win32" do
+  before(:all) do
+    @original_win32 = if defined?(Win32)
+      win32 = Object.send(:const_get, 'Win32')
+      Object.send(:remove_const, 'Win32')
+      win32
+    else
+      nil
+    end
+    Win32 = Module.new
+  end
+
+  after(:all) do
+    Object.send(:remove_const, 'Win32') if defined?(Win32)
+    Object.send(:const_set, 'Win32', @original_win32) if @original_win32
+  end
+end

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -32,6 +32,8 @@ describe "Chef::Platform#windows_server_2003?" do
 end
 
 describe "Chef::Platform#windows_nano_server?" do
+  include_context "Win32"
+
   let(:key) { "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Server\\ServerLevels" }
   let(:key_query_value) { 0x0001 }
   let(:access) { key_query_value | 0x0100 }
@@ -39,14 +41,6 @@ describe "Chef::Platform#windows_nano_server?" do
   let(:registry) { double("Win32::Registry") }
 
   before(:all) do
-    @original_win32 = if defined?(Win32)
-      win32 = Object.send(:const_get, 'Win32')
-      Object.send(:remove_const, 'Win32')
-      win32
-    else
-      nil
-    end
-    Win32 = Module.new
     Win32::Registry = Class.new
     Win32::Registry::Error = Class.new(RuntimeError)
 
@@ -60,11 +54,6 @@ describe "Chef::Platform#windows_nano_server?" do
   after do
     Win32::Registry.send(:remove_const, 'HKEY_LOCAL_MACHINE') if defined?(Win32::Registry::HKEY_LOCAL_MACHINE)
     Win32::Registry.send(:remove_const, 'KEY_QUERY_VALUE') if defined?(Win32::Registry::KEY_QUERY_VALUE)
-  end
-
-  after(:all) do
-    Object.send(:remove_const, 'Win32') if defined?(Win32)
-    Object.send(:const_set, 'Win32', @original_win32) if @original_win32
   end
 
   it "returns false early when not on windows" do

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -43,7 +43,6 @@ describe "Chef::Platform#windows_nano_server?" do
   before(:all) do
     Win32::Registry = Class.new
     Win32::Registry::Error = Class.new(RuntimeError)
-
   end
 
   before do

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -23,25 +23,26 @@ require 'mixlib/shellout'
 describe Chef::Provider::Service::Windows, "load_current_resource" do
   include_context "Win32"
 
+  let(:new_resource) { Chef::Resource::WindowsService.new("chef") }
+  let(:provider) do
+    prvdr = Chef::Provider::Service::Windows.new(new_resource,
+      Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new))
+    prvdr.current_resource = Chef::Resource::WindowsService.new("current-chef")
+    prvdr
+  end
+
   before(:all) do
     Win32::Service = Class.new
   end
 
   before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::WindowsService.new("chef")
-    @provider = Chef::Provider::Service::Windows.new(@new_resource, @run_context)
-    @provider.current_resource = Chef::Resource::WindowsService.new("current-chef")
-
     Win32::Service::AUTO_START = 0x00000002
     Win32::Service::DEMAND_START = 0x00000003
     Win32::Service::DISABLED = 0x00000004
 
-    allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+    allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
       double("StatusStruct", :current_state => "running"))
-    allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+    allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
       double("ConfigStruct", :start_type => "auto start"))
     allow(Win32::Service).to receive(:exists?).and_return(true)
     allow(Win32::Service).to receive(:configure).and_return(Win32::Service)
@@ -54,114 +55,114 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
   end
 
   it "should set the current resources service name to the new resources service name" do
-    @provider.load_current_resource
-    expect(@provider.current_resource.service_name).to eq('chef')
+    provider.load_current_resource
+    expect(provider.current_resource.service_name).to eq('chef')
   end
 
   it "should return the current resource" do
-    expect(@provider.load_current_resource).to equal(@provider.current_resource)
+    expect(provider.load_current_resource).to equal(provider.current_resource)
   end
 
   it "should set the current resources status" do
-    @provider.load_current_resource
-    expect(@provider.current_resource.running).to be_truthy
+    provider.load_current_resource
+    expect(provider.current_resource.running).to be_truthy
   end
 
   it "should set the current resources start type" do
-    @provider.load_current_resource
-    expect(@provider.current_resource.enabled).to be_truthy
+    provider.load_current_resource
+    expect(provider.current_resource.enabled).to be_truthy
   end
 
   it "does not set the current resources start type if it is neither AUTO START or DISABLED" do
-    allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+    allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
       double("ConfigStruct", :start_type => "manual"))
-    @provider.load_current_resource
-    expect(@provider.current_resource.enabled).to be_nil
+    provider.load_current_resource
+    expect(provider.current_resource.enabled).to be_nil
   end
 
   describe Chef::Provider::Service::Windows, "start_service" do
     before(:each) do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "running"))
     end
 
     it "should call the start command if one is specified" do
-      @new_resource.start_command "sc start chef"
-      expect(@provider).to receive(:shell_out!).with("#{@new_resource.start_command}").and_return("Starting custom service")
-      @provider.start_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      new_resource.start_command "sc start chef"
+      expect(provider).to receive(:shell_out!).with("#{new_resource.start_command}").and_return("Starting custom service")
+      provider.start_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should use the built-in command if no start command is specified" do
-      expect(Win32::Service).to receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      expect(Win32::Service).to receive(:start).with(new_resource.service_name)
+      provider.start_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should do nothing if the service does not exist" do
-      allow(Win32::Service).to receive(:exists?).with(@new_resource.service_name).and_return(false)
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      provider.start_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should do nothing if the service is running" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      provider.start_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should raise an error if the service is paused" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "paused"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      expect { provider.start_service }.to raise_error( Chef::Exceptions::Service )
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should wait and continue if the service is in start_pending" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "start pending"),
         double("StatusStruct", :current_state => "start pending"),
         double("StatusStruct", :current_state => "running"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      @provider.start_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      provider.start_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should fail if the service is in stop_pending" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stop pending"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      expect { @provider.start_service }.to raise_error( Chef::Exceptions::Service )
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      expect { provider.start_service }.to raise_error( Chef::Exceptions::Service )
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     describe "running as a different account" do
-      let(:old_run_as_user) { @new_resource.run_as_user }
-      let(:old_run_as_password) { @new_resource.run_as_password }
+      let(:old_run_as_user) { new_resource.run_as_user }
+      let(:old_run_as_password) { new_resource.run_as_password }
 
       before {
-        @new_resource.run_as_user(".\\wallace")
-        @new_resource.run_as_password("Wensleydale")
+        new_resource.run_as_user(".\\wallace")
+        new_resource.run_as_password("Wensleydale")
       }
 
       after {
-        @new_resource.run_as_user(old_run_as_user)
-        @new_resource.run_as_password(old_run_as_password)
+        new_resource.run_as_user(old_run_as_user)
+        new_resource.run_as_password(old_run_as_password)
       }
 
       it "should call #grant_service_logon if the :run_as_user and :run_as_password attributes are present" do
         expect(Win32::Service).to receive(:start)
-        expect(@provider).to receive(:grant_service_logon).and_return(true)
-        @provider.start_service
+        expect(provider).to receive(:grant_service_logon).and_return(true)
+        provider.start_service
       end
     end
   end
@@ -170,78 +171,78 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
   describe Chef::Provider::Service::Windows, "stop_service" do
 
     before(:each) do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"),
         double("StatusStruct", :current_state => "stopped"))
     end
 
     it "should call the stop command if one is specified" do
-      @new_resource.stop_command "sc stop chef"
-      expect(@provider).to receive(:shell_out!).with("#{@new_resource.stop_command}").and_return("Stopping custom service")
-      @provider.stop_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      new_resource.stop_command "sc stop chef"
+      expect(provider).to receive(:shell_out!).with("#{new_resource.stop_command}").and_return("Stopping custom service")
+      provider.stop_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should use the built-in command if no stop command is specified" do
-      expect(Win32::Service).to receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      expect(Win32::Service).to receive(:stop).with(new_resource.service_name)
+      provider.stop_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should do nothing if the service does not exist" do
-      allow(Win32::Service).to receive(:exists?).with(@new_resource.service_name).and_return(false)
-      expect(Win32::Service).not_to receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
+      expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
+      provider.stop_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should do nothing if the service is stopped" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stopped"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
+      provider.stop_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should raise an error if the service is paused" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "paused"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      expect { provider.stop_service }.to raise_error( Chef::Exceptions::Service )
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should wait and continue if the service is in stop_pending" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stop pending"),
         double("StatusStruct", :current_state => "stop pending"),
         double("StatusStruct", :current_state => "stopped"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:stop).with(@new_resource.service_name)
-      @provider.stop_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
+      provider.stop_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should fail if the service is in start_pending" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "start pending"))
-      @provider.load_current_resource
-      expect(Win32::Service).not_to receive(:stop).with(@new_resource.service_name)
-      expect { @provider.stop_service }.to raise_error( Chef::Exceptions::Service )
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.load_current_resource
+      expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
+      expect { provider.stop_service }.to raise_error( Chef::Exceptions::Service )
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
     it "should pass custom timeout to the stop command if provided" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"))
-      @new_resource.timeout 1
-      expect(Win32::Service).to receive(:stop).with(@new_resource.service_name)
+      new_resource.timeout 1
+      expect(Win32::Service).to receive(:stop).with(new_resource.service_name)
       Timeout.timeout(2) do
-        expect { @provider.stop_service }.to raise_error(Timeout::Error)
+        expect { provider.stop_service }.to raise_error(Timeout::Error)
       end
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
   end
@@ -249,152 +250,152 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
   describe Chef::Provider::Service::Windows, "restart_service" do
 
     it "should call the restart command if one is specified" do
-      @new_resource.restart_command "sc restart"
-      expect(@provider).to receive(:shell_out!).with("#{@new_resource.restart_command}")
-      @provider.restart_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      new_resource.restart_command "sc restart"
+      expect(provider).to receive(:shell_out!).with("#{new_resource.restart_command}")
+      provider.restart_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should stop then start the service if it is running" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"),
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "running"))
-      expect(Win32::Service).to receive(:stop).with(@new_resource.service_name)
-      expect(Win32::Service).to receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      expect(Win32::Service).to receive(:stop).with(new_resource.service_name)
+      expect(Win32::Service).to receive(:start).with(new_resource.service_name)
+      provider.restart_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should just start the service if it is stopped" do
-      allow(Win32::Service).to receive(:status).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "running"))
-      expect(Win32::Service).to receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      expect(Win32::Service).to receive(:start).with(new_resource.service_name)
+      provider.restart_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should do nothing if the service does not exist" do
-      allow(Win32::Service).to receive(:exists?).with(@new_resource.service_name).and_return(false)
-      expect(Win32::Service).not_to receive(:stop).with(@new_resource.service_name)
-      expect(Win32::Service).not_to receive(:start).with(@new_resource.service_name)
-      @provider.restart_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
+      expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
+      expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
+      provider.restart_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
   end
 
   describe Chef::Provider::Service::Windows, "enable_service" do
     before(:each) do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "disabled"))
     end
 
     it "should enable service" do
-      expect(Win32::Service).to receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::AUTO_START)
-      @provider.enable_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      expect(Win32::Service).to receive(:configure).with(:service_name => new_resource.service_name, :start_type => Win32::Service::AUTO_START)
+      provider.enable_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should do nothing if the service does not exist" do
-      allow(Win32::Service).to receive(:exists?).with(@new_resource.service_name).and_return(false)
+      allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:configure)
-      @provider.enable_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.enable_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
   end
 
   describe Chef::Provider::Service::Windows, "action_enable" do
     it "does nothing if the service is enabled" do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "auto start"))
-      expect(@provider).not_to receive(:enable_service)
-      @provider.action_enable
+      expect(provider).not_to receive(:enable_service)
+      provider.action_enable
     end
 
     it "enables the service if it is not set to automatic start" do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "disabled"))
-      expect(@provider).to receive(:enable_service)
-      @provider.action_enable
+      expect(provider).to receive(:enable_service)
+      provider.action_enable
     end
   end
 
   describe Chef::Provider::Service::Windows, "action_disable" do
     it "does nothing if the service is disabled" do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "disabled"))
-      expect(@provider).not_to receive(:disable_service)
-      @provider.action_disable
+      expect(provider).not_to receive(:disable_service)
+      provider.action_disable
     end
 
     it "disables the service if it is not set to disabled" do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "auto start"))
-      expect(@provider).to receive(:disable_service)
-      @provider.action_disable
+      expect(provider).to receive(:disable_service)
+      provider.action_disable
     end
   end
 
   describe Chef::Provider::Service::Windows, "disable_service" do
     before(:each) do
-      allow(Win32::Service).to receive(:config_info).with(@new_resource.service_name).and_return(
+      allow(Win32::Service).to receive(:config_info).with(new_resource.service_name).and_return(
         double("ConfigStruct", :start_type => "auto start"))
     end
 
     it "should disable service" do
       expect(Win32::Service).to receive(:configure)
-      @provider.disable_service
-      expect(@new_resource.updated_by_last_action?).to be_truthy
+      provider.disable_service
+      expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
     it "should do nothing if the service does not exist" do
-      allow(Win32::Service).to receive(:exists?).with(@new_resource.service_name).and_return(false)
+      allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:configure)
-      @provider.disable_service
-      expect(@new_resource.updated_by_last_action?).to be_falsey
+      provider.disable_service
+      expect(new_resource.updated_by_last_action?).to be_falsey
     end
   end
 
   describe Chef::Provider::Service::Windows, "action_configure_startup" do
     { :automatic => "auto start", :manual => "demand start", :disabled => "disabled" }.each do |type,win32|
       it "sets the startup type to #{type} if it is something else" do
-        @new_resource.startup_type(type)
-        allow(@provider).to receive(:current_start_type).and_return("fire")
-        expect(@provider).to receive(:set_startup_type).with(type)
-        @provider.action_configure_startup
+        new_resource.startup_type(type)
+        allow(provider).to receive(:current_start_type).and_return("fire")
+        expect(provider).to receive(:set_startup_type).with(type)
+        provider.action_configure_startup
       end
 
       it "leaves the startup type as #{type} if it is already set" do
-        @new_resource.startup_type(type)
-        allow(@provider).to receive(:current_start_type).and_return(win32)
-        expect(@provider).not_to receive(:set_startup_type).with(type)
-        @provider.action_configure_startup
+        new_resource.startup_type(type)
+        allow(provider).to receive(:current_start_type).and_return(win32)
+        expect(provider).not_to receive(:set_startup_type).with(type)
+        provider.action_configure_startup
       end
     end
   end
 
   describe Chef::Provider::Service::Windows, "set_start_type" do
     it "when called with :automatic it calls Win32::Service#configure with Win32::Service::AUTO_START" do
-      expect(Win32::Service).to receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::AUTO_START)
-      @provider.send(:set_startup_type, :automatic)
+      expect(Win32::Service).to receive(:configure).with(:service_name => new_resource.service_name, :start_type => Win32::Service::AUTO_START)
+      provider.send(:set_startup_type, :automatic)
     end
 
     it "when called with :manual it calls Win32::Service#configure with Win32::Service::DEMAND_START" do
-      expect(Win32::Service).to receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::DEMAND_START)
-      @provider.send(:set_startup_type, :manual)
+      expect(Win32::Service).to receive(:configure).with(:service_name => new_resource.service_name, :start_type => Win32::Service::DEMAND_START)
+      provider.send(:set_startup_type, :manual)
     end
 
     it "when called with :disabled it calls Win32::Service#configure with Win32::Service::DISABLED" do
-      expect(Win32::Service).to receive(:configure).with(:service_name => @new_resource.service_name, :start_type => Win32::Service::DISABLED)
-      @provider.send(:set_startup_type, :disabled)
+      expect(Win32::Service).to receive(:configure).with(:service_name => new_resource.service_name, :start_type => Win32::Service::DISABLED)
+      provider.send(:set_startup_type, :disabled)
     end
 
     it "raises an exception when given an unknown start type" do
-      expect { @provider.send(:set_startup_type, :fire_truck) }.to raise_error(Chef::Exceptions::ConfigurationError)
+      expect { provider.send(:set_startup_type, :fire_truck) }.to raise_error(Chef::Exceptions::ConfigurationError)
     end
   end
 
@@ -420,9 +421,9 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     let(:success_string) { "The task has completed successfully.\r\nSee logfile etc." }
     let(:failure_string) { "Look on my works, ye Mighty, and despair!" }
     let(:command) {
-      dbfile = @provider.grant_dbfile_name(username)
-      policyfile = @provider.grant_policyfile_name(username)
-      logfile = @provider.grant_logfile_name(username)
+      dbfile = provider.grant_dbfile_name(username)
+      policyfile = provider.grant_policyfile_name(username)
+      logfile = provider.grant_logfile_name(username)
 
       %Q{secedit.exe /configure /db "#{dbfile}" /cfg "#{policyfile}" /areas USER_RIGHTS SECURITYPOLICY SERVICES /log "#{logfile}"}
     }
@@ -435,20 +436,20 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
 
     after {
       # only needed for the second test.
-      ::File.delete(@provider.grant_policyfile_name(username)) rescue nil
-      ::File.delete(@provider.grant_logfile_name(username)) rescue nil
-      ::File.delete(@provider.grant_dbfile_name(username)) rescue nil
+      ::File.delete(provider.grant_policyfile_name(username)) rescue nil
+      ::File.delete(provider.grant_logfile_name(username)) rescue nil
+      ::File.delete(provider.grant_dbfile_name(username)) rescue nil
     }
 
     it "calls Mixlib::Shellout with the correct command string" do
       expect_any_instance_of(Mixlib::ShellOut).to receive(:exitstatus).and_return(0)
-      expect(@provider.grant_service_logon(username)).to equal true
+      expect(provider.grant_service_logon(username)).to equal true
     end
 
     it "raises an exception when the grant command fails" do
       expect_any_instance_of(Mixlib::ShellOut).to receive(:exitstatus).and_return(1)
       expect_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return(failure_string)
-      expect { @provider.grant_service_logon(username) }.to raise_error(Chef::Exceptions::Service)
+      expect { provider.grant_service_logon(username) }.to raise_error(Chef::Exceptions::Service)
     end
   end
 
@@ -456,17 +457,17 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     include_context "testing private methods"
 
     it "correctly reformats usernames to create valid filenames" do
-      expect(@provider.clean_username_for_path("\\\\problem username/oink.txt")).to eq("_problem_username_oink_txt")
-      expect(@provider.clean_username_for_path("boring_username")).to eq("boring_username")
+      expect(provider.clean_username_for_path("\\\\problem username/oink.txt")).to eq("_problem_username_oink_txt")
+      expect(provider.clean_username_for_path("boring_username")).to eq("boring_username")
     end
 
     it "correctly reformats usernames for the policy file" do
-      expect(@provider.canonicalize_username(".\\maryann")).to eq("maryann")
-      expect(@provider.canonicalize_username("maryann")).to eq("maryann")
+      expect(provider.canonicalize_username(".\\maryann")).to eq("maryann")
+      expect(provider.canonicalize_username("maryann")).to eq("maryann")
 
-      expect(@provider.canonicalize_username("\\\\maryann")).to eq("maryann")
-      expect(@provider.canonicalize_username("mydomain\\\\maryann")).to eq("mydomain\\\\maryann")
-      expect(@provider.canonicalize_username("\\\\mydomain\\\\maryann")).to eq("mydomain\\\\maryann")
+      expect(provider.canonicalize_username("\\\\maryann")).to eq("maryann")
+      expect(provider.canonicalize_username("mydomain\\\\maryann")).to eq("mydomain\\\\maryann")
+      expect(provider.canonicalize_username("\\\\mydomain\\\\maryann")).to eq("mydomain\\\\maryann")
     end
   end
 end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -167,7 +167,6 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     end
   end
 
-
   describe Chef::Provider::Service::Windows, "stop_service" do
 
     before(:each) do

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -54,21 +54,21 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
     Win32::Service.send(:remove_const, 'DISABLED') if defined?(Win32::Service::DISABLED)
   end
 
-  it "should set the current resources service name to the new resources service name" do
+  it "sets the current resources service name to the new resources service name" do
     provider.load_current_resource
     expect(provider.current_resource.service_name).to eq('chef')
   end
 
-  it "should return the current resource" do
+  it "returns the current resource" do
     expect(provider.load_current_resource).to equal(provider.current_resource)
   end
 
-  it "should set the current resources status" do
+  it "sets the current resources status" do
     provider.load_current_resource
     expect(provider.current_resource.running).to be_truthy
   end
 
-  it "should set the current resources start type" do
+  it "sets the current resources start type" do
     provider.load_current_resource
     expect(provider.current_resource.enabled).to be_truthy
   end
@@ -87,27 +87,27 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
         double("StatusStruct", :current_state => "running"))
     end
 
-    it "should call the start command if one is specified" do
+    it "calls the start command if one is specified" do
       new_resource.start_command "sc start chef"
       expect(provider).to receive(:shell_out!).with("#{new_resource.start_command}").and_return("Starting custom service")
       provider.start_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should use the built-in command if no start command is specified" do
+    it "uses the built-in command if no start command is specified" do
       expect(Win32::Service).to receive(:start).with(new_resource.service_name)
       provider.start_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should do nothing if the service does not exist" do
+    it "does nothing if the service does not exist" do
       allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
       provider.start_service
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should do nothing if the service is running" do
+    it "does nothing if the service is running" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"))
       provider.load_current_resource
@@ -116,7 +116,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should raise an error if the service is paused" do
+    it "raises an error if the service is paused" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "paused"))
       provider.load_current_resource
@@ -125,7 +125,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should wait and continue if the service is in start_pending" do
+    it "waits and continues if the service is in start_pending" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "start pending"),
         double("StatusStruct", :current_state => "start pending"),
@@ -136,7 +136,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should fail if the service is in stop_pending" do
+    it "fails if the service is in stop_pending" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stop pending"))
       provider.load_current_resource
@@ -159,7 +159,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
         new_resource.run_as_password(old_run_as_password)
       }
 
-      it "should call #grant_service_logon if the :run_as_user and :run_as_password attributes are present" do
+      it "calls #grant_service_logon if the :run_as_user and :run_as_password attributes are present" do
         expect(Win32::Service).to receive(:start)
         expect(provider).to receive(:grant_service_logon).and_return(true)
         provider.start_service
@@ -176,27 +176,27 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
         double("StatusStruct", :current_state => "stopped"))
     end
 
-    it "should call the stop command if one is specified" do
+    it "calls the stop command if one is specified" do
       new_resource.stop_command "sc stop chef"
       expect(provider).to receive(:shell_out!).with("#{new_resource.stop_command}").and_return("Stopping custom service")
       provider.stop_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should use the built-in command if no stop command is specified" do
+    it "uses the built-in command if no stop command is specified" do
       expect(Win32::Service).to receive(:stop).with(new_resource.service_name)
       provider.stop_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should do nothing if the service does not exist" do
+    it "does nothing if the service does not exist" do
       allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
       provider.stop_service
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should do nothing if the service is stopped" do
+    it "does nothing if the service is stopped" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stopped"))
       provider.load_current_resource
@@ -205,7 +205,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should raise an error if the service is paused" do
+    it "raises an error if the service is paused" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "paused"))
       provider.load_current_resource
@@ -214,7 +214,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should wait and continue if the service is in stop_pending" do
+    it "waits and continue if the service is in stop_pending" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stop pending"),
         double("StatusStruct", :current_state => "stop pending"),
@@ -225,7 +225,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should fail if the service is in start_pending" do
+    it "fails if the service is in start_pending" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "start pending"))
       provider.load_current_resource
@@ -234,7 +234,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_falsey
     end
 
-    it "should pass custom timeout to the stop command if provided" do
+    it "passes custom timeout to the stop command if provided" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"))
       new_resource.timeout 1
@@ -249,14 +249,14 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
 
   describe Chef::Provider::Service::Windows, "restart_service" do
 
-    it "should call the restart command if one is specified" do
+    it "calls the restart command if one is specified" do
       new_resource.restart_command "sc restart"
       expect(provider).to receive(:shell_out!).with("#{new_resource.restart_command}")
       provider.restart_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should stop then start the service if it is running" do
+    it "stops then starts the service if it is running" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "running"),
         double("StatusStruct", :current_state => "stopped"),
@@ -268,7 +268,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should just start the service if it is stopped" do
+    it "just starts the service if it is stopped" do
       allow(Win32::Service).to receive(:status).with(new_resource.service_name).and_return(
         double("StatusStruct", :current_state => "stopped"),
         double("StatusStruct", :current_state => "stopped"),
@@ -278,7 +278,7 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should do nothing if the service does not exist" do
+    it "does nothing if the service does not exist" do
       allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:stop).with(new_resource.service_name)
       expect(Win32::Service).not_to receive(:start).with(new_resource.service_name)
@@ -294,13 +294,13 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
         double("ConfigStruct", :start_type => "disabled"))
     end
 
-    it "should enable service" do
+    it "enables service" do
       expect(Win32::Service).to receive(:configure).with(:service_name => new_resource.service_name, :start_type => Win32::Service::AUTO_START)
       provider.enable_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should do nothing if the service does not exist" do
+    it "does nothing if the service does not exist" do
       allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:configure)
       provider.enable_service
@@ -346,13 +346,13 @@ describe Chef::Provider::Service::Windows, "load_current_resource" do
         double("ConfigStruct", :start_type => "auto start"))
     end
 
-    it "should disable service" do
+    it "disables service" do
       expect(Win32::Service).to receive(:configure)
       provider.disable_service
       expect(new_resource.updated_by_last_action?).to be_truthy
     end
 
-    it "should do nothing if the service does not exist" do
+    it "does nothing if the service does not exist" do
       allow(Win32::Service).to receive(:exists?).with(new_resource.service_name).and_return(false)
       expect(Win32::Service).not_to receive(:configure)
       provider.disable_service

--- a/spec/unit/win32/registry_spec.rb
+++ b/spec/unit/win32/registry_spec.rb
@@ -29,6 +29,9 @@ describe Chef::Win32::Registry do
   let(:key_to_delete) { 'OpscodeNumbers' }
   let(:sub_key) {'OpscodePrimes'}
   let(:missing_key_path) {'HKCU\Software'}
+  let(:registry) { Chef::Win32::Registry.new() }
+  let(:hive_mock) { double("::Win32::Registry::KHKEY_CURRENT_USER") }
+  let(:reg_mock) { double("reg") }
 
   before(:all) do
     Win32::Registry = Class.new
@@ -37,16 +40,12 @@ describe Chef::Win32::Registry do
 
   before(:each) do
     allow_any_instance_of(Chef::Win32::Registry).to receive(:machine_architecture).and_return(:x86_64)
-    @registry = Chef::Win32::Registry.new()
-
+    
     #Making the values for registry constants available on unix
     Win32::Registry::KEY_SET_VALUE = 0x0002
     Win32::Registry::KEY_QUERY_VALUE = 0x0001
     Win32::Registry::KEY_WRITE = 0x00020000 | 0x0002 | 0x0004
     Win32::Registry::KEY_READ = 0x00020000 | 0x0001 | 0x0008 | 0x0010
-
-    @hive_mock = double("::Win32::Registry::HKEY_CURRENT_USER")
-    @reg_mock = double("reg")
   end
 
   after(:each) do
@@ -58,338 +57,338 @@ describe Chef::Win32::Registry do
 
   describe "get_values" do
     it "gets all values for a key if the key exists" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:map)
-      @registry.get_values(key_path)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:map)
+      registry.get_values(key_path)
     end
 
     it "throws an exception if key does not exist" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      expect{@registry.get_values(key_path)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      expect{registry.get_values(key_path)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
   end
 
   describe "set_value" do
     it "does nothing if key and hive and value exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:data_exists?).with(key_path, value1).and_return(true)
-      @registry.set_value(key_path, value1)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:data_exists?).with(key_path, value1).and_return(true)
+      registry.set_value(key_path, value1)
     end
     it "does nothing if case insensitive key and hive and value exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([@hive_mock, key])
-      expect(@registry).to receive(:value_exists?).with(key_path.downcase, value1).and_return(true)
-      expect(@registry).to receive(:data_exists?).with(key_path.downcase, value1).and_return(true)
-      @registry.set_value(key_path.downcase, value1)
+      expect(registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([hive_mock, key])
+      expect(registry).to receive(:value_exists?).with(key_path.downcase, value1).and_return(true)
+      expect(registry).to receive(:data_exists?).with(key_path.downcase, value1).and_return(true)
+      registry.set_value(key_path.downcase, value1)
     end
     it "does nothing if key and hive and value with a case insensitive name exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([@hive_mock, key])
-      expect(@registry).to receive(:value_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
-      expect(@registry).to receive(:data_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
-      @registry.set_value(key_path.downcase, value1_upcase_name)
+      expect(registry).to receive(:key_exists!).with(key_path.downcase).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path.downcase).and_return([hive_mock, key])
+      expect(registry).to receive(:value_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
+      expect(registry).to receive(:data_exists?).with(key_path.downcase, value1_upcase_name).and_return(true)
+      registry.set_value(key_path.downcase, value1_upcase_name)
     end
     it "updates value if key and hive and value exist, but data is different" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:data_exists?).with(key_path, value1).and_return(false)
-      expect(@hive_mock).to receive(:open).with(key, Win32::Registry::KEY_SET_VALUE | ::Win32::Registry::KEY_QUERY_VALUE | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(@reg_mock).to receive(:write).with("one", 1, "1")
-      @registry.set_value(key_path, value1)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:data_exists?).with(key_path, value1).and_return(false)
+      expect(hive_mock).to receive(:open).with(key, Win32::Registry::KEY_SET_VALUE | ::Win32::Registry::KEY_QUERY_VALUE | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
+      expect(reg_mock).to receive(:write).with("one", 1, "1")
+      registry.set_value(key_path, value1)
     end
 
     it "creates value if the key exists and the value does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_SET_VALUE | ::Win32::Registry::KEY_QUERY_VALUE | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(@reg_mock).to receive(:write).with("one", 1, "1")
-      @registry.set_value(key_path, value1)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_SET_VALUE | ::Win32::Registry::KEY_QUERY_VALUE | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
+      expect(reg_mock).to receive(:write).with("one", 1, "1")
+      registry.set_value(key_path, value1)
     end
 
     it "should raise an exception if the key does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      expect {@registry.set_value(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      expect {registry.set_value(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
   end
 
   describe "delete_value" do
     it "deletes value if value exists" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_SET_VALUE | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:delete_value).with("one").and_return(true)
-      @registry.delete_value(key_path, value1)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_SET_VALUE | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:delete_value).with("one").and_return(true)
+      registry.delete_value(key_path, value1)
     end
 
     it "raises an exception if the key does not exist" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      @registry.delete_value(key_path, value1)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      registry.delete_value(key_path, value1)
     end
 
     it "does nothing if the value does not exist" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
-      @registry.delete_value(key_path, value1)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
+      registry.delete_value(key_path, value1)
     end
   end
 
   describe "create_key" do
     it "creates key if intermediate keys are missing and recursive is set to true" do
-      expect(@registry).to receive(:keys_missing?).with(key_path).and_return(true)
-      expect(@registry).to receive(:create_missing).with(key_path)
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(false)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | @registry.registry_system_architecture)
-      @registry.create_key(key_path, true)
+      expect(registry).to receive(:keys_missing?).with(key_path).and_return(true)
+      expect(registry).to receive(:create_missing).with(key_path)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(false)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | registry.registry_system_architecture)
+      registry.create_key(key_path, true)
     end
 
     it "raises an exception if intermediate keys are missing and recursive is set to false" do
-      expect(@registry).to receive(:keys_missing?).with(key_path).and_return(true)
-      expect{@registry.create_key(key_path, false)}.to raise_error(Chef::Exceptions::Win32RegNoRecursive)
+      expect(registry).to receive(:keys_missing?).with(key_path).and_return(true)
+      expect{registry.create_key(key_path, false)}.to raise_error(Chef::Exceptions::Win32RegNoRecursive)
     end
 
     it "does nothing if the key exists" do
-      expect(@registry).to receive(:keys_missing?).with(key_path).and_return(true)
-      expect(@registry).to receive(:create_missing).with(key_path)
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(true)
-      @registry.create_key(key_path, true)
+      expect(registry).to receive(:keys_missing?).with(key_path).and_return(true)
+      expect(registry).to receive(:create_missing).with(key_path)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(true)
+      registry.create_key(key_path, true)
     end
 
     it "create key if intermediate keys not missing and recursive is set to false" do
-      expect(@registry).to receive(:keys_missing?).with(key_path).and_return(false)
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(false)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | @registry.registry_system_architecture)
-      @registry.create_key(key_path, false)
+      expect(registry).to receive(:keys_missing?).with(key_path).and_return(false)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(false)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | registry.registry_system_architecture)
+      registry.create_key(key_path, false)
     end
 
     it "create key if intermediate keys not missing and recursive is set to true" do
-      expect(@registry).to receive(:keys_missing?).with(key_path).and_return(false)
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(false)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | @registry.registry_system_architecture)
-      @registry.create_key(key_path, true)
+      expect(registry).to receive(:keys_missing?).with(key_path).and_return(false)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(false)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:create).with(key, ::Win32::Registry::KEY_WRITE | registry.registry_system_architecture)
+      registry.create_key(key_path, true)
     end
   end
 
   describe "delete_key", :windows_only do
     it "deletes key if it has subkeys and recursive is set to true" do
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(true)
-      expect(@registry).to receive(:has_subkeys?).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key_parent, ::Win32::Registry::KEY_WRITE | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:delete_key).with(key_to_delete, true).and_return(true)
-      @registry.delete_key(key_path, true)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(true)
+      expect(registry).to receive(:has_subkeys?).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key_parent, ::Win32::Registry::KEY_WRITE | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:delete_key).with(key_to_delete, true).and_return(true)
+      registry.delete_key(key_path, true)
     end
 
     it "raises an exception if it has subkeys but recursive is set to false" do
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(true)
-      expect(@registry).to receive(:has_subkeys?).with(key_path).and_return(true)
-      expect{@registry.delete_key(key_path, false)}.to raise_error(Chef::Exceptions::Win32RegNoRecursive)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(true)
+      expect(registry).to receive(:has_subkeys?).with(key_path).and_return(true)
+      expect{registry.delete_key(key_path, false)}.to raise_error(Chef::Exceptions::Win32RegNoRecursive)
     end
 
     it "deletes key if the key exists and has no subkeys" do
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(true)
-      expect(@registry).to receive(:has_subkeys?).with(key_path).and_return(false)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key_parent, ::Win32::Registry::KEY_WRITE | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:delete_key).with(key_to_delete, true).and_return(true)
-      @registry.delete_key(key_path, true)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(true)
+      expect(registry).to receive(:has_subkeys?).with(key_path).and_return(false)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key_parent, ::Win32::Registry::KEY_WRITE | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:delete_key).with(key_to_delete, true).and_return(true)
+      registry.delete_key(key_path, true)
     end
   end
 
   describe "key_exists?" do
     it "returns true if key_exists" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry.key_exists?(key_path)).to eq(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry.key_exists?(key_path)).to eq(true)
     end
 
     it "returns false if key does not exist" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_raise(::Win32::Registry::Error)
-      expect(@registry.key_exists?(key_path)).to eq(false)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_raise(::Win32::Registry::Error)
+      expect(registry.key_exists?(key_path)).to eq(false)
     end
   end
 
   describe "key_exists!" do
     it "throws an exception if the key_parent does not exist" do
-      expect(@registry).to receive(:key_exists?).with(key_path).and_return(false)
-      expect{@registry.key_exists!(key_path)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:key_exists?).with(key_path).and_return(false)
+      expect{registry.key_exists!(key_path)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
   end
 
   describe "hive_exists?" do
     it "returns true if the hive exists" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      @registry.hive_exists?(key_path) == true
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      registry.hive_exists?(key_path) == true
     end
 
     it "returns false if the hive does not exist" do
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_raise(Chef::Exceptions::Win32RegHiveMissing)
-      @registry.hive_exists?(key_path) == false
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_raise(Chef::Exceptions::Win32RegHiveMissing)
+      registry.hive_exists?(key_path) == false
     end
   end
 
   describe "has_subkeys?" do
     it "returns true if the key has subkeys" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:each_key).and_yield(key)
-      @registry.has_subkeys?(key_path) == true
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:each_key).and_yield(key)
+      registry.has_subkeys?(key_path) == true
     end
 
     it "returns false if the key does not have subkeys" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:each_key).and_return(no_args())
-      expect(@registry.has_subkeys?(key_path)).to eq(false)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:each_key).and_return(no_args())
+      expect(registry.has_subkeys?(key_path)).to eq(false)
     end
 
     it "throws an exception if the key does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      expect {@registry.set_value(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      expect {registry.set_value(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
   end
 
   describe "get_subkeys" do
     it "returns the subkeys if they exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:each_key).and_yield(sub_key)
-      @registry.get_subkeys(key_path)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:each_key).and_yield(sub_key)
+      registry.get_subkeys(key_path)
     end
   end
 
   describe "value_exists?" do
     it "throws an exception if the key does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      expect {@registry.value_exists?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      expect {registry.value_exists?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
 
     it "returns true if the value exists" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:any?).and_yield("one")
-      @registry.value_exists?(key_path, value1) == true
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:any?).and_yield("one")
+      registry.value_exists?(key_path, value1) == true
     end
 
     it "returns false if the value does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:any?).and_yield(no_args())
-      @registry.value_exists?(key_path, value1) == false
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:any?).and_yield(no_args())
+      registry.value_exists?(key_path, value1) == false
     end
   end
 
   describe "data_exists?" do
     it "throws an exception if the key does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
-      expect {@registry.data_exists?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect(registry).to receive(:key_exists!).with(key_path).and_raise(Chef::Exceptions::Win32RegKeyMissing)
+      expect {registry.data_exists?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
     end
 
     it "returns true if the data exists" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(@reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "1")
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry.data_exists?(key_path, value1)).to eq(true)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
+      expect(reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "1")
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry.data_exists?(key_path, value1)).to eq(true)
     end
 
     it "returns false if the data does not exist" do
-      expect(@registry).to receive(:key_exists!).with(key_path).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(@reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "2")
-      expect(@registry.data_exists?(key_path, value1)).to eq(false)
+      expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
+      expect(reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "2")
+      expect(registry.data_exists?(key_path, value1)).to eq(false)
     end
   end
 
   describe "value_exists!" do
     it "does nothing if the value exists" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
-      @registry.value_exists!(key_path, value1)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(true)
+      registry.value_exists!(key_path, value1)
     end
 
     it "throws an exception if the value does not exist" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
-      expect{@registry.value_exists!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegValueMissing)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
+      expect{registry.value_exists!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegValueMissing)
     end
   end
 
   describe "data_exists!" do
     it "does nothing if the data exists" do
-      expect(@registry).to receive(:data_exists?).with(key_path, value1).and_return(true)
-      @registry.data_exists!(key_path, value1)
+      expect(registry).to receive(:data_exists?).with(key_path, value1).and_return(true)
+      registry.data_exists!(key_path, value1)
     end
 
     it "throws an exception if the data does not exist" do
-      expect(@registry).to receive(:data_exists?).with(key_path, value1).and_return(false)
-      expect{@registry.data_exists!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegDataMissing)
+      expect(registry).to receive(:data_exists?).with(key_path, value1).and_return(false)
+      expect{registry.data_exists!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegDataMissing)
     end
   end
 
   describe "type_matches?" do
     it "returns true if type matches" do
-      expect(@registry).to receive(:value_exists!).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(@reg_mock).to receive(:each).and_yield("one", 1)
-      expect(@registry.type_matches?(key_path, value1)).to eq(true)
+      expect(registry).to receive(:value_exists!).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
+      expect(reg_mock).to receive(:each).and_yield("one", 1)
+      expect(registry.type_matches?(key_path, value1)).to eq(true)
     end
 
     it "returns false if type does not match" do
-      expect(@registry).to receive(:value_exists!).with(key_path, value1).and_return(true)
-      expect(@registry).to receive(:get_hive_and_key).with(key_path).and_return([@hive_mock, key])
-      expect(@hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | @registry.registry_system_architecture).and_yield(@reg_mock)
-      expect(@reg_mock).to receive(:each).and_yield("two", 2)
-      expect(@registry.type_matches?(key_path, value1)).to eq(false)
+      expect(registry).to receive(:value_exists!).with(key_path, value1).and_return(true)
+      expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
+      expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
+      expect(reg_mock).to receive(:each).and_yield("two", 2)
+      expect(registry.type_matches?(key_path, value1)).to eq(false)
     end
 
     it "throws an exception if value does not exist" do
-      expect(@registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
-      expect{@registry.type_matches?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegValueMissing)
+      expect(registry).to receive(:value_exists?).with(key_path, value1).and_return(false)
+      expect{registry.type_matches?(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegValueMissing)
     end
   end
 
   describe "type_matches!" do
     it "does nothing if the type_matches" do
-      expect(@registry).to receive(:type_matches?).with(key_path, value1).and_return(true)
-      @registry.type_matches!(key_path, value1)
+      expect(registry).to receive(:type_matches?).with(key_path, value1).and_return(true)
+      registry.type_matches!(key_path, value1)
     end
 
     it "throws an exception if the type does not match" do
-      expect(@registry).to receive(:type_matches?).with(key_path, value1).and_return(false)
-      expect{@registry.type_matches!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegTypesMismatch)
+      expect(registry).to receive(:type_matches?).with(key_path, value1).and_return(false)
+      expect{registry.type_matches!(key_path, value1)}.to raise_error(Chef::Exceptions::Win32RegTypesMismatch)
     end
   end
 
   describe "keys_missing?" do
     it "returns true if the keys are missing" do
-      expect(@registry).to receive(:key_exists?).with(missing_key_path).and_return(false)
-      expect(@registry.keys_missing?(key_path)).to eq(true)
+      expect(registry).to receive(:key_exists?).with(missing_key_path).and_return(false)
+      expect(registry.keys_missing?(key_path)).to eq(true)
     end
 
     it "returns false if no keys in the path are missing" do
-      expect(@registry).to receive(:key_exists?).with(missing_key_path).and_return(true)
-      expect(@registry.keys_missing?(key_path)).to eq(false)
+      expect(registry).to receive(:key_exists?).with(missing_key_path).and_return(true)
+      expect(registry.keys_missing?(key_path)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Calling `Object.send(:remove_const, 'Win32')` in spec after blocks causes failures in specs which include libraries with rely on Win32.