### PR TITLE
only apt and yum support Arrays of packages

### DIFF
--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -30,6 +30,24 @@ class Chef
         @default_release = nil
       end
 
+      # override superclass and support arrays
+      def package_name(arg=nil)
+        set_or_return(
+          :package_name,
+          arg,
+          :kind_of => [ String, Array ]
+        )
+      end
+
+      # override superclass and support arrays
+      def version(arg=nil)
+        set_or_return(
+          :version,
+          arg,
+          :kind_of => [ String, Array ]
+        )
+      end
+
       def default_release(arg=nil)
         set_or_return(
           :default_release,

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -41,19 +41,21 @@ class Chef
         @timeout = nil
       end
 
+      # Package Resources that support Arrays should override in the subclass
       def package_name(arg=nil)
         set_or_return(
           :package_name,
           arg,
-          :kind_of => [ String, Array ]
+          :kind_of => [ String ]
         )
       end
 
+      # Package Resources that support Arrays should override in the subclass
       def version(arg=nil)
         set_or_return(
           :version,
           arg,
-          :kind_of => [ String, Array ]
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -31,6 +31,24 @@ class Chef
         @yum_binary = nil
       end
 
+      # override superclass and support arrays
+      def package_name(arg=nil)
+        set_or_return(
+          :package_name,
+          arg,
+          :kind_of => [ String, Array ]
+        )
+      end
+
+      # override superclass and support arrays
+      def version(arg=nil)
+        set_or_return(
+          :version,
+          arg,
+          :kind_of => [ String, Array ]
+        )
+      end
+
       # Install a specific arch
       def arch(arg=nil)
         set_or_return(


### PR DESCRIPTION
Supporting Arrays in the subclass means that it 'looks' like other
providers all support Arrays when they don't.  By correcting this
we make package resources that aren't multipackage-aware to blow up
at compile time, instead of having some random awful exception when
converging the provider.  This both gets the input validation correct
and allows rescuing the exception and falling back to handle it.

(See the multipackage cookbook for how we use this to duck-type chef 11
vs chef 12 yum_package/apt_package)