### PR TITLE
Lazy load MSI provider, add check for MSI support

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -58,6 +58,22 @@ class Chef
         return nano == 1
       end
 
+      def supports_msi?
+        return false unless windows?
+        require 'win32/registry'
+
+        key = "System\\CurrentControlSet\\Services\\msiserver"
+        access = ::Win32::Registry::KEY_QUERY_VALUE
+
+        begin
+          ::Win32::Registry::HKEY_LOCAL_MACHINE.open(key, access) do |reg|
+            true
+          end
+        rescue ::Win32::Registry::Error
+          false
+        end
+      end
+
       def supports_powershell_execution_bypass?(node)
         node[:languages] && node[:languages][:powershell] &&
           node[:languages][:powershell][:version].to_i >= 3

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -18,7 +18,7 @@
 
 # TODO: Allow @new_resource.source to be a Product Code as a GUID for uninstall / network install
 
-require 'chef/win32/api/installer' if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+require 'chef/win32/api/installer' if (RUBY_PLATFORM =~ /mswin|mingw32|windows/) && Chef::Platform.supports_msi?
 require 'chef/mixin/shell_out'
 
 class Chef
@@ -26,7 +26,7 @@ class Chef
     class Package
       class Windows
         class MSI
-          include Chef::ReservedNames::Win32::API::Installer if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+          include Chef::ReservedNames::Win32::API::Installer if (RUBY_PLATFORM =~ /mswin|mingw32|windows/) && Chef::Platform.supports_msi?
           include Chef::Mixin::ShellOut
 
           def initialize(resource)


### PR DESCRIPTION
This change loads the MSI Installer API only if the platform supports it.  This is currently mostly an issue for Windows Nano.  The current check for MSI uses the registry directly - a longer term change will probably use a Ohai plug-in or other mechanism.

cc @chef/client-windows @chef/client-core 