### PR TITLE
allow reboot by reboot resource with chef-apply

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -190,6 +190,7 @@ class Chef::Application::Apply < Chef::Application
     ensure
       @recipe_fh.close
     end
+    Chef::Platform::Rebooter.reboot_if_needed!(runner)
   end
 
   def run_application


### PR DESCRIPTION
The Chef-Apply ignores reboot resource currently.
This PR turns on rebooting by Chef-Apply.