### PR TITLE
Honor the ordering of whichever `name_attribute` or `default` comes first

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -86,6 +86,21 @@ class Chef
     #
     def initialize(**options)
       options.each { |k,v| options[k.to_sym] = v if k.is_a?(String) }
+      # Only pick the first of :default, :name_property and :name_attribute if
+      # more than one is specified.
+      found_default = false
+      options.reject! do |k,v|
+        if [ :name_property, :name_attribute, :default ].include?(k)
+          if found_default
+            true
+          else
+            found_default = true
+            false
+          end
+        else
+          false
+        end
+      end
       options[:name_property] = options.delete(:name_attribute) if options.has_key?(:name_attribute) && !options.has_key?(:name_property)
       @options = options
 

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -86,22 +86,24 @@ class Chef
     #
     def initialize(**options)
       options.each { |k,v| options[k.to_sym] = v if k.is_a?(String) }
+
       # Only pick the first of :default, :name_property and :name_attribute if
       # more than one is specified.
-      found_default = false
+      found_defaults = []
       options.reject! do |k,v|
         if [ :name_property, :name_attribute, :default ].include?(k)
-          if found_default
-            true
-          else
-            found_default = true
-            false
-          end
+          found_defaults << k
+          # Reject all but the first default key you find
+          found_defaults.size > 1
         else
           false
         end
       end
+      if found_defaults.size > 1
+        Chef::Log.deprecation("Cannot specify keys #{found_defaults.join(", ")} together on property #{options[:name]}--only the first one (#{found_defaults[0]}) will be obeyed. Please pick one.", caller(5..5)[0])
+      end
       options[:name_property] = options.delete(:name_attribute) if options.has_key?(:name_attribute) && !options.has_key?(:name_property)
+
       @options = options
 
       options[:name] = options[:name].to_sym if options[:name]

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -782,6 +782,8 @@ class Chef
     def self.property(name, type=NOT_PASSED, **options)
       name = name.to_sym
 
+      options.each { |k,v| options[k.to_sym] = v if k.is_a?(String) }
+
       options[:instance_variable_name] = :"@#{name}" if !options.has_key?(:instance_variable_name)
       options.merge!(name: name, declared_in: self)
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -952,8 +952,8 @@ describe "Chef::Resource.property" do
         end
       end
       with_property ":x, #{name}: true, default: 10" do
-        it "chooses default over #{name}" do
-          expect(resource.x).to eq 10
+        it "chooses #{name} over default" do
+          expect(resource.x).to eq 'blah'
         end
       end
       with_property ":x, #{name}: true, required: true" do


### PR DESCRIPTION
Fixes #3950 . The issue is that in 12.4.1, if you specify both `default` and `name_attribute` in an attribute, it will pick whichever comes first. In 12.5, it always picks `default`. This restores the old (weird) behavior for backwards compatibility's sake.