### PR TITLE
Run the chef service executable from the bin directory

### DIFF
--- a/bin/chef-service-manager
+++ b/bin/chef-service-manager
@@ -28,7 +28,7 @@ if Chef::Platform.windows?
     :service_name => "chef-client",
     :service_display_name => "Chef Client Service",
     :service_description => "Runs Chef Client on regular, configurable intervals.",
-    :service_file_path => File.expand_path(File.join(File.dirname(__FILE__), '../../../../bin/chef-windows-service')),
+    :service_file_path => File.expand_path('../chef-windows-service', $PROGRAM_NAME),
     :delayed_start => true,
     :dependencies => ['Winmgmt']
   }


### PR DESCRIPTION
we are currently running from instead of guessing where it is