### PR TITLE
Add policyfile support to `knife bootstrap`

### DIFF
--- a/lib/chef/knife/bootstrap/client_builder.rb
+++ b/lib/chef/knife/bootstrap/client_builder.rb
@@ -91,6 +91,16 @@ class Chef
           knife_config[:run_list]
         end
 
+        # @return [String] policy_name from the knife_config
+        def policy_name
+          knife_config[:policy_name]
+        end
+
+        # @return [String] policy_group from the knife_config
+        def policy_group
+          knife_config[:policy_group]
+        end
+
         # @return [Hash,Array] Object representation of json first-boot attributes from the knife_config
         def first_boot_attributes
           knife_config[:first_boot_attributes]
@@ -141,6 +151,8 @@ class Chef
               node.run_list(normalized_run_list)
               node.normal_attrs = first_boot_attributes if first_boot_attributes
               node.environment(environment) if environment
+              node.policy_name = policy_name if policy_name
+              node.policy_group = policy_group if policy_group
               (knife_config[:tags] || []).each do |tag|
                 node.tags << tag
               end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -164,7 +164,12 @@ CONFIG
 
         def first_boot
           (@config[:first_boot_attributes] || {}).tap do |attributes|
-            attributes.merge!(:run_list => @run_list)
+            if @config[:policy_name] && @config[:policy_group]
+              attributes.merge!(:policy_name => @config[:policy_name], :policy_group => @config[:policy_group])
+            else
+              attributes.merge!(:run_list => @run_list)
+            end
+
             attributes.merge!(:tags => @config[:tags]) if @config[:tags] && !@config[:tags].empty?
           end
         end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -40,7 +40,7 @@ class Chef
         end
 
         def bootstrap_environment
-          @chef_config[:environment] || '_default'
+          @chef_config[:environment]
         end
 
         def validation_key
@@ -128,7 +128,7 @@ CONFIG
           client_path = @chef_config[:chef_client_path] || 'chef-client'
           s = "#{client_path} -j /etc/chef/first-boot.json"
           s << ' -l debug' if @config[:verbosity] and @config[:verbosity] >= 2
-          s << " -E #{bootstrap_environment}"
+          s << " -E #{bootstrap_environment}" unless bootstrap_environment.nil?
           s
         end
 

--- a/spec/unit/knife/bootstrap/client_builder_spec.rb
+++ b/spec/unit/knife/bootstrap/client_builder_spec.rb
@@ -190,5 +190,16 @@ describe Chef::Knife::Bootstrap::ClientBuilder do
       expect(node).to receive(:run_list).with([])
       client_builder.run
     end
+
+    it "builds a node with policy_name and policy_group when given" do
+      knife_config[:policy_name] = "my-app"
+      knife_config[:policy_group] = "staging"
+
+      expect(node).to receive(:run_list).with([])
+      expect(node).to receive(:policy_name=).with("my-app")
+      expect(node).to receive(:policy_group=).with("staging")
+
+      client_builder.run
+    end
   end
 end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -38,14 +38,14 @@ describe Chef::Knife::Core::BootstrapContext do
     expect{described_class.new(config, run_list, chef_config)}.not_to raise_error
   end
 
-  it "runs chef with the first-boot.json in the _default environment" do
-    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -E _default"
+  it "runs chef with the first-boot.json with no environment specified" do
+    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
   end
 
   describe "when in verbosity mode" do
     let(:config) { {:verbosity => 2} }
     it "adds '-l debug' when verbosity is >= 2" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug -E _default"
+      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug"
     end
   end
 
@@ -70,7 +70,7 @@ EXPECTED
   describe "alternate chef-client path" do
     let(:chef_config){ {:chef_client_path => '/usr/local/bin/chef-client'} }
     it "runs chef-client from another path when specified" do
-      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json -E _default"
+      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json"
     end
   end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -117,6 +117,16 @@ EXPECTED
     end
   end
 
+  describe "when policy_name and policy_group are present in config" do
+
+    let(:config) { { policy_name: "my_app_server", policy_group: "staging" } }
+
+    it "includes them in the first_boot data and excludes run_list" do
+      expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json(config))
+    end
+
+  end
+
   describe "when an encrypted_data_bag_secret is provided" do
     let(:secret) { "supersekret" }
     it "reads the encrypted_data_bag_secret" do


### PR DESCRIPTION
Adds `--policy-name` and `--policy-group` options to knife bootstrap, which will be passed on to the node via the first-boot JSON file.

Note that this changes the bootstrap behavior for non-policyfile usage when the user does _not_ specify an environment. Before this patch, knife would pass `-E _default` to the node, whereas now it does not give a `-E` option in the default case. The node should still default to an environment of `_default`. Looking in the git history, I didn't find a specific reason for the existing behavior.
