### PR TITLE
pass ssh_password and some options provided by Net::SSH.configuration_for to session

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -225,6 +225,8 @@ class Chef
           if config[:identity_file]
             opts[:keys] = File.expand_path(config[:identity_file])
             opts[:keys_only] = true
+          elsif config[:ssh_password]
+            opts[:password] = config[:ssh_password]
           end
           # Don't set the keys to nil if we don't have them.
           forward_agent = config[:forward_agent] || ssh_config[:forward_agent]

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -241,6 +241,9 @@ class Chef
 
           # Don't include send_env from ssh_config.
           opts.delete(:send_env)
+
+          # Ignores ProxyCommand if passed GW
+          opts[:proxy] = nil if config[:ssh_gateway]
         end
       end
 

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -160,7 +160,7 @@ describe Chef::Knife::Ssh do
     end
 
     it "should return default settings" do
-      expect(@knife.session_options("the.b.org", nil)).to eq(ssh_default_config)
+      expect(@knife.session_options("the.b.org", nil)).to a_hash_including(ssh_default_config)
     end
 
     it "should set keys and keys_only" do

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -149,6 +149,71 @@ describe Chef::Knife::Ssh do
     end
   end
 
+  describe "#session_options" do
+    let(:ssh_default_config) do
+      {:compression_level => 9, :timeout => 50, :user => "locutus", :port => 23}
+    end
+
+    before do
+      ssh_config = {:compression_level => 9, :timeout => 50, :user => "locutus", :port => 23}
+      allow(Net::SSH).to receive(:configuration_for).with('the.b.org').and_return(ssh_config)
+    end
+
+    it "should return default settings" do
+      expect(@knife.session_options("the.b.org", nil)).to eq(ssh_default_config)
+    end
+
+    it "should set keys and keys_only" do
+      @knife.config[:identity_file] = "/tmp/mykey"
+      expect(@knife.session_options("the.b.org", nil)).to a_hash_including(
+        :keys => '/tmp/mykey',
+        :keys_only => true
+      )
+    end
+
+    it "should set password" do
+      @knife.config[:ssh_password] = "mysekretpassw0rd"
+      expect(@knife.session_options("the.b.org", nil)).to a_hash_including(:password => "mysekretpassw0rd")
+    end
+
+    it "should placed set identity_file avove password" do
+      @knife.config[:identity_file] = "/tmp/mykey"
+      @knife.config[:ssh_password] = "mysekretpassw0rd"
+      expect(@knife.session_options("the.b.org", nil)).not_to a_hash_including(:password => "mysekretpassw0rd")
+    end
+
+    it "should set paranoid and user_known_hosts_file" do
+      @knife.config[:host_key_verify] = false
+      expect(@knife.session_options("the.b.org", nil)).to a_hash_including(
+        :paranoid => false,
+        :user_known_hosts_file => '/dev/null'
+      )
+    end
+
+    context "override ssh options from config" do
+      it "should override user" do
+        @knife.config[:ssh_user] = "dog"
+        expect(@knife.session_options("the.b.org", nil)).to a_hash_including(:user => "dog")
+      end
+
+      it "should override port" do
+        @knife.config[:ssh_port] = 9022
+        expect(@knife.session_options("the.b.org", nil)).to a_hash_including(:port => 9022)
+      end
+    end
+
+    context "remove few options from ssh_config provides by NET::SSH" do
+      before do
+        ssh_config = {:compression_level => 9, :timeout => 50, :user => "locutus", :port => 23, :send_env=>[/^LANG$/, /^LC_.*$/]}
+        allow(Net::SSH).to receive(:configuration_for).with('the.b.org').and_return(ssh_config)
+      end
+
+      it "should remove send_env" do
+        expect(@knife.session_options("the.b.org", nil)).not_to have_key(:send_env)
+      end
+    end
+  end
+
   describe "#get_ssh_attribute" do
     # Order of precedence for ssh target
     # 1) command line attribute


### PR DESCRIPTION
option `--ssh-password` will be ignored by ssh session.

----

- I'll add spec for session_options
- And, I think that we should not truncate options from ssh_config. 
