### PR TITLE
Fix cookbook installation from supermarket on windows

### DIFF
--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -142,7 +142,11 @@ class Chef
       def extract_cookbook(upstream_file, version)
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
         # FIXME: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
-        shell_out!("tar zxvf \"#{convert_path upstream_file}\" --force-local", :cwd => @install_path)
+        extract_command="tar zxvf \"#{convert_path upstream_file}\"" 
+        if Chef::Platform.windows?
+          extract_command << " --force-local"
+        end
+        shell_out!(extract_command, :cwd => @install_path)
       end
 
       def clear_existing_files(cookbook_path)

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -142,7 +142,7 @@ class Chef
       def extract_cookbook(upstream_file, version)
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
         # FIXME: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
-        shell_out!("tar zxvf #{convert_path upstream_file}", :cwd => @install_path)
+        shell_out!("tar zxvf \"#{convert_path upstream_file}\" --force-local", :cwd => @install_path)
       end
 
       def clear_existing_files(cookbook_path)


### PR DESCRIPTION
- Fixes https://tickets.opscode.com/browse/CHEF-3394 by adding the `--force-local` option to tar
- Might fix #1753 with the added double quotes

Successfully ran the unit tests in spec/unit/knife/cookbook_site_install_spec.rb with the change.

Proof of the fix:
![Proof of the fix](http://imgur.com/MOvHdPD.png)