### PR TITLE
Create empty config context for chefdk

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -690,6 +690,14 @@ module ChefConfig
       default :watchdog_timeout, 2 * (60 * 60) # 2 hours
     end
 
+    # Add an empty and non-strict config_context for chefdk. This lets the user
+    # have code like `chefdk.generator_cookbook "/path/to/cookbook"` in their
+    # config.rb, and it will be ignored by tools like knife and ohai. ChefDK
+    # itself can define the config options it accepts and enable strict mode,
+    # and that will only apply when running `chef` commands.
+    config_context :chefdk do
+    end
+
     # Chef requires an English-language UTF-8 locale to function properly.  We attempt
     # to use the 'locale -a' command and search through a list of preferences until we
     # find one that we can use.  On Ubuntu systems we should find 'C.UTF-8' and be

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -561,6 +561,14 @@ RSpec.describe ChefConfig::Config do
     end
   end
 
+  describe "allowing chefdk configuration outside of chefdk" do
+
+    it "allows arbitrary settings in the chefdk config context" do
+      expect { ChefConfig::Config.chefdk.generator_cookbook("/path") }.to_not raise_error
+    end
+
+  end
+
   describe "Treating deprecation warnings as errors" do
 
     context "when using our default RSpec configuration" do


### PR DESCRIPTION
Allows `knife` and such to parse config files with `chefdk.settting` in
them without error.

I have tested this via manually patching my chefdk, and I am able to set `config_strict_mode true` in chef-dk while allowing the config context to be non-strict when knife evaluates it.