### PR TITLE
Undeprecate RunContext#resource_collection=

### DIFF
--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -92,7 +92,7 @@ class Chef
     #
     # @see CookbookCompiler
     #
-    attr_reader :resource_collection
+    attr_accessor :resource_collection
 
     #
     # The list of control groups to execute during the audit phase
@@ -532,11 +532,6 @@ ERROR_MESSAGE
       ###
       # These need to be settable so deploy can run a resource_collection
       # independent of any cookbooks via +recipe_eval+
-      def resource_collection=(value)
-        Chef.log_deprecation("Setting run_context.resource_collection will be removed in a future Chef.  Use run_context.create_child to create a new RunContext instead.")
-        @resource_collection = value
-      end
-
       def audits=(value)
         Chef.log_deprecation("Setting run_context.audits will be removed in a future Chef.  Use run_context.create_child to create a new RunContext instead.")
         @audits = value


### PR DESCRIPTION
I use this in Poise and would like to make sure it continues to be a supported API. This is required because I use subcontexts with different semantics from Chef's isolated ones. The alternative to un-deprecating this would be to allow passing in an alternate factory other than `Chef::ResourceCollection.new()`.

Ping @jkeiser and @chef/client-core for review.