### PR TITLE
Improve rubygems provider for gems without version

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -494,7 +494,7 @@ class Chef
 
         def target_version_already_installed?(current_version, new_version)
           return false unless current_version
-          return false if new_version.nil?
+          return false if new_version.nil? && action == :upgrade
 
           Gem::Requirement.new(new_version).satisfied_by?(Gem::Version.new(current_version))
         end

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -345,10 +345,16 @@ describe Chef::Provider::Package::Rubygems do
   describe "when new_resource version is nil" do
     let(:target_version) { nil }
 
-    it "target_version_already_installed? should return false so that we can search for candidates" do
+    it "target_version_already_installed? should return false so that we can search for candidates if action is :upgrade" do
+      @provider.action = :upgrade
       @provider.load_current_resource
       expect(@provider.target_version_already_installed?(@provider.current_resource.version, @new_resource.version)).to be_falsey
     end
+  end
+
+  it "target_version_already_installed? should return true so we avoid searching for other candidates" do
+    @provider.load_current_resource
+    expect(@provider.target_version_already_installed?(@provider.current_resource.version, @new_resource.version)).to be_truthy
   end
 
   describe "when new_resource version is current rspec version" do


### PR DESCRIPTION
When a resource has no target version and a version is already
installed, we should only download metadata from rubygems when action is
:upgrade.

Fixes #3983