### PR TITLE
fix errors when files go away during chown

### DIFF
--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -276,7 +276,7 @@ class Chef
 
       def enforce_ownership
         converge_by("force ownership of #{@new_resource.deploy_to} to #{@new_resource.group}:#{@new_resource.user}") do
-          FileUtils.chown_R(@new_resource.user, @new_resource.group, @new_resource.deploy_to)
+          FileUtils.chown_R(@new_resource.user, @new_resource.group, @new_resource.deploy_to, :force => true)
           Chef::Log.info("#{@new_resource} set user to #{@new_resource.user}") if @new_resource.user
           Chef::Log.info("#{@new_resource} set group to #{@new_resource.group}") if @new_resource.group
         end

--- a/spec/unit/provider/deploy_spec.rb
+++ b/spec/unit/provider/deploy_spec.rb
@@ -356,7 +356,7 @@ describe Chef::Provider::Deploy do
   it "chowns the whole release dir to user and group specified in the resource" do
     @resource.user "foo"
     @resource.group "bar"
-    expect(FileUtils).to receive(:chown_R).with("foo", "bar", "/my/deploy/dir")
+    expect(FileUtils).to receive(:chown_R).with("foo", "bar", "/my/deploy/dir", { :force => true })
     @provider.enforce_ownership
   end
 


### PR DESCRIPTION
The deploy resource attempts to change the owner of all files in the
deploy directory, but it breaks when files are removed during the
process. This is because FileUtils::chown_R gets a list of the files and
then walks through and updates them, and if that takes any time at  all
then files may be deleted during the process. When this happens, the
deploy will fail with Errno::ENOENT. chown_R takes an options hash with
:force as one of the available options, and the only thing it does is
stop errors from being raised under these circumstances.

NOTE: when I originally pushed this I hadn't updated the test, so the build failed, but it should be passing now.