### PR TITLE
Use SHA256 instead of MD5 for registry_key when data is not displayable

### DIFF
--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -38,7 +38,11 @@ class Chef
     end
 
     def generate_checksum(file)
-      checksum_file(file, OpenSSL::Digest::SHA256.new)
+      if file.is_a?(StringIO)
+        checksum_io(file, OpenSSL::Digest::SHA256.new)
+      else
+        checksum_file(file, OpenSSL::Digest::SHA256.new)
+      end
     end
 
     def self.generate_md5_checksum_for_file(*args)

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -125,7 +125,7 @@ class Chef
           scrubbed_value = value.dup
           if needs_checksum?(scrubbed_value)
             data_io = StringIO.new(scrubbed_value[:data].to_s)
-            scrubbed_value[:data] = Chef::Digester.instance.generate_md5_checksum(data_io)
+            scrubbed_value[:data] = Chef::Digester.instance.generate_checksum(data_io)
           end
           scrubbed << scrubbed_value
         end

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -91,7 +91,7 @@ describe Chef::Resource::RegistryKey, "values" do
 
   it "should return checksummed data if the type is unsafe" do
     @resource.values( { :name => 'poosh', :type => :binary, :data => 255.chr * 1 })
-    expect(@resource.values).to eql([ { :name => 'poosh', :type => :binary, :data => "00594fd4f42ba43fc1ca0427a0576295" } ])
+    expect(@resource.values).to eql([ { :name => 'poosh', :type => :binary, :data => 'a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89' } ])
   end
 
   it "should throw an exception if the name field is missing" do
@@ -194,6 +194,6 @@ describe Chef::Resource::RegistryKey, "state" do
 
   it "should return scrubbed values" do
     @resource.values([ { :name => 'poosh', :type => :binary, :data => 255.chr * 1 } ])
-    expect(@resource.state).to eql( { :values => [{ :name => 'poosh', :type => :binary, :data => "00594fd4f42ba43fc1ca0427a0576295" }] } )
+    expect(@resource.state).to eql( { :values => [{ :name => 'poosh', :type => :binary, :data => 'a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89'}] } )
   end
 end


### PR DESCRIPTION
Getting rid of md5 where we dont need it. See #3945 for more info