### PR TITLE
Fix for #3992: Add check for custom command in redhat service provider

### DIFF
--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -64,7 +64,7 @@ class Chef
             a.assertion do
               custom_command_for_action?(action) || !@service_missing
             end
-            a.failure_message Chef::Exceptions::Service, "#{new_resource}: unable to locate the init.d script!"
+            a.failure_message Chef::Exceptions::Service, "#{new_resource}: No custom command for #{action} specified and unable to locate the init.d script!"
             a.whyrun "Assuming service would be disabled. The init script is not presently installed."
           end
         end

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -61,7 +61,9 @@ class Chef
           end
 
           requirements.assert(:start, :enable, :reload, :restart) do |a|
-            a.assertion { !@service_missing }
+            a.assertion do
+              custom_command_for_action?(action) || !@service_missing
+            end
             a.failure_message Chef::Exceptions::Service, "#{new_resource}: unable to locate the init.d script!"
             a.whyrun "Assuming service would be disabled. The init script is not presently installed."
           end


### PR DESCRIPTION
Fixing https://github.com/chef/chef/issues/3992 

Instead of just checking for the missing service, check if a custom command was provided for the action as well. If neither is provided throw Chef::Exceptions::Service pointing at a missing init.d script or custom command for action.