### PR TITLE
Make sure name_attribute works on derived properties

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -422,7 +422,13 @@ class Chef
     # @return [Property] The new property type.
     #
     def derive(**modified_options)
-      Property.new(**options.merge(**modified_options))
+      # Since name_property and name_attribute are aliases, if you specify either
+      # one in modified_options it overrides anything in original options.
+      options = self.options
+      if modified_options.has_key?(:name_property) || modified_options.has_key?(:name_attribute)
+        options = options.reject { |k,v| k == :name_attribute || k == :name_property }
+      end
+      Property.new(options.merge(modified_options))
     end
 
     #


### PR DESCRIPTION
Currently this will fail:

```
class X < Chef::Resource
  property :x, name_property: true
end

class Y < X
  property :x, name_attribute: true
end
```

Because when `name_property` is inherited to `name_attribute`, the properties conflict.