### PR TITLE
Ensure that our list of recipes is backwards compat

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -440,7 +440,7 @@ class Chef
 
       self.tags # make sure they're defined
 
-      automatic_attrs[:recipes] = expansion.recipes.with_fully_qualified_names_and_version_constraints
+      automatic_attrs[:recipes] = expansion.recipes.with_duplicate_names
       automatic_attrs[:expanded_run_list] = expansion.recipes.with_fully_qualified_names_and_version_constraints
       automatic_attrs[:roles] = expansion.roles
 

--- a/lib/chef/run_list/versioned_recipe_list.rb
+++ b/lib/chef/run_list/versioned_recipe_list.rb
@@ -82,6 +82,21 @@ class Chef
           qualified_recipe
         end
       end
+
+      # Get an array of strings of both fully-qualified and unexpanded recipe names
+      # in response to chef/chef#3767
+      # Chef-13 will revert to the behaviour of just including the fully-qualified name
+      #
+      # @return [Array] Array of strings with fully-qualified and unexpanded recipe names
+      def with_duplicate_names
+        self.map do |recipe_name|
+          if recipe_name.include?('::')
+            recipe_name
+          else
+            [recipe_name, "#{recipe_name}::default"]
+          end
+        end.flatten
+      end
     end
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -375,7 +375,8 @@ describe Chef::Client do
       expect(node[:roles].length).to eq(1)
       expect(node[:roles]).to include("role_containing_cookbook1")
       expect(node[:recipes]).not_to be_nil
-      expect(node[:recipes].length).to eq(1)
+      expect(node[:recipes].length).to eq(2)
+      expect(node[:recipes]).to include("cookbook1")
       expect(node[:recipes]).to include("cookbook1::default")
       expect(node[:expanded_run_list]).not_to be_nil
       expect(node[:expanded_run_list].length).to eq(1)

--- a/spec/unit/run_list/versioned_recipe_list_spec.rb
+++ b/spec/unit/run_list/versioned_recipe_list_spec.rb
@@ -187,4 +187,9 @@ describe Chef::RunList::VersionedRecipeList do
     end
   end
 
+  context "with duplicated names", :chef_gte_13_only do
+    it "should fail in Chef 13" do
+      expect(list).to_not respond_to(:with_duplicate_names)
+    end
+  end
 end


### PR DESCRIPTION
Prior to chef 12.2 we included unexpanded 'cookbook' names for default
recipes. In 12.2, we moved to expanded ('cookbook::default') names,
which broke some searches.
However, some of our users have now moved to searching for expanded,
so we need to cater for both.
Fixes #3767

cc @lamont-granquist @chef/client-core