### PR TITLE
Use Chef::FileContentManagement::Tempfile to create temp file

### DIFF
--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -49,7 +49,7 @@ class Chef
           end
         end
 
-        raise Chef::Exceptions::FileContentStagingError(errors) if tf.nil?
+        raise Chef::Exceptions::FileContentStagingError, errors if tf.nil?
 
         # We always process the tempfile in binmode so that we
         # preserve the line endings of the content.

--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -29,30 +29,30 @@ class Chef
 
         def template_location
           @template_file_cache_location ||= begin
-            template_finder.find(@new_resource.source, :local => @new_resource.local, :cookbook => @new_resource.cookbook)
+            template_finder.find(new_resource.source, :local => new_resource.local, :cookbook => new_resource.cookbook)
           end
         end
 
         private
 
         def file_for_provider
-          context = TemplateContext.new(@new_resource.variables)
-          context[:node] = @run_context.node
+          context = TemplateContext.new(new_resource.variables)
+          context[:node] = run_context.node
           context[:template_finder] = template_finder
 
           # helper variables
-          context[:cookbook_name] = @new_resource.cookbook_name unless context.keys.include?(:coookbook_name)
-          context[:recipe_name] = @new_resource.recipe_name unless context.keys.include?(:recipe_name)
-          context[:recipe_line_string] = @new_resource.source_line unless context.keys.include?(:recipe_line_string)
-          context[:recipe_path] = @new_resource.source_line_file unless context.keys.include?(:recipe_path)
-          context[:recipe_line] = @new_resource.source_line_number unless context.keys.include?(:recipe_line)
-          context[:template_name] = @new_resource.source unless context.keys.include?(:template_name)
+          context[:cookbook_name] = new_resource.cookbook_name unless context.keys.include?(:coookbook_name)
+          context[:recipe_name] = new_resource.recipe_name unless context.keys.include?(:recipe_name)
+          context[:recipe_line_string] = new_resource.source_line unless context.keys.include?(:recipe_line_string)
+          context[:recipe_path] = new_resource.source_line_file unless context.keys.include?(:recipe_path)
+          context[:recipe_line] = new_resource.source_line_number unless context.keys.include?(:recipe_line)
+          context[:template_name] = new_resource.source unless context.keys.include?(:template_name)
           context[:template_path] = template_location unless context.keys.include?(:template_path)
 
-          context._extend_modules(@new_resource.helper_modules)
+          context._extend_modules(new_resource.helper_modules)
           output = context.render_template(template_location)
 
-          tempfile = Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
+          tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
           tempfile.binmode
           tempfile.write(output)
           tempfile.close
@@ -61,7 +61,7 @@ class Chef
 
         def template_finder
           @template_finder ||= begin
-            TemplateFinder.new(run_context, @new_resource.cookbook_name, @run_context.node)
+            TemplateFinder.new(run_context, new_resource.cookbook_name, run_context.node)
           end
         end
       end

--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -52,7 +52,7 @@ class Chef
           context._extend_modules(@new_resource.helper_modules)
           output = context.render_template(template_location)
 
-          tempfile = Tempfile.open("chef-rendered-template")
+          tempfile = Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
           tempfile.binmode
           tempfile.write(output)
           tempfile.close

--- a/spec/unit/provider/template/content_spec.rb
+++ b/spec/unit/provider/template/content_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 describe Chef::Provider::Template::Content do
 
   let(:enclosing_directory) {
-    Dir.mktmpdir
+    canonicalize_path(Dir.mktmpdir)
   }
 
   let(:resource_path) {

--- a/spec/unit/provider/template/content_spec.rb
+++ b/spec/unit/provider/template/content_spec.rb
@@ -86,14 +86,14 @@ describe Chef::Provider::Template::Content do
 
   it "returns a tempfile in the tempdir when :file_staging_uses_destdir is not set" do
     Chef::Config[:file_staging_uses_destdir] = false
-    expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be_truthy
-    expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be_falsey
+    expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be true
+    expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be false
   end
 
   it "returns a tempfile in the destdir when :file_staging_uses_destdir is set" do
     Chef::Config[:file_staging_uses_destdir] = true
-    expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be_falsey
-    expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be_truthy
+    expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be false
+    expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be true
   end
 
   context "when creating a tempfiles in destdir fails" do
@@ -103,8 +103,8 @@ describe Chef::Provider::Template::Content do
 
     it "returns a tempfile in the tempdir when :file_deployment_uses_destdir is set to :auto" do
       Chef::Config[:file_staging_uses_destdir] = :auto
-      expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be_truthy
-      expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be_falsey
+      expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be true
+      expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be false
     end
 
     it "fails when :file_desployment_uses_destdir is set" do
@@ -113,8 +113,8 @@ describe Chef::Provider::Template::Content do
     end
 
     it "returns a tempfile in the tempdir when :file_desployment_uses_destdir is not set" do
-      expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be_truthy
-      expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be_falsey
+      expect(content.tempfile.path.start_with?(Dir::tmpdir)).to be true
+      expect(canonicalize_path(content.tempfile.path).start_with?(enclosing_directory)).to be false
     end
   end
 


### PR DESCRIPTION
The template resource should honor the file_staging_uses_destdir flag. The current behavior is that the rendered templates are always created in the 'tmp' directory. This change switches over the template provider to have the same behavior as the file provider.

@chef/client-core @adamedx 