### PR TITLE
add missing requires for Chef::DSL::Recipe in Chef::Provider::LWRPBase

### DIFF
--- a/lib/chef/provider/lwrp_base.rb
+++ b/lib/chef/provider/lwrp_base.rb
@@ -19,6 +19,7 @@
 #
 
 require 'chef/provider'
+require 'chef/dsl/recipe'
 require 'chef/dsl/include_recipe'
 
 class Chef


### PR DESCRIPTION
fixes missing requires encountered when trying to `require 'chef/provider/lwrp_base'` when writing a custom provider.

```
[nathwill@wyrd ~]$ chef exec irb
irb(main):001:0> require 'chef/provider/lwrp_base'
NameError: uninitialized constant Chef::DSL::Recipe
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.4.3/lib/chef/provider/lwrp_base.rb:73:in `<class:LWRPBase>'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.4.3/lib/chef/provider/lwrp_base.rb:29:in `<class:Provider>'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.4.3/lib/chef/provider/lwrp_base.rb:25:in `<class:Chef>'
	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.4.3/lib/chef/provider/lwrp_base.rb:24:in `<top (required)>'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:128:in `require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
	from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from (irb):1
	from /opt/chefdk/embedded/bin/irb:11:in `<main>'
irb(main):002:0> require 'chef/dsl/recipe'
=> true
irb(main):003:0> require 'chef/provider/lwrp_base'
=> true
irb(main):004:0> Chef::VERSION
=> "12.4.3"
```