### PR TITLE
Raise error when running 32-bit scripts on Windows Nano.

### DIFF
--- a/lib/chef/resource/windows_script.rb
+++ b/lib/chef/resource/windows_script.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef/platform/query_helpers'
 require 'chef/resource/script'
 require 'chef/mixin/windows_architecture_helper'
 
@@ -51,9 +52,12 @@ class Chef
       protected
 
       def assert_architecture_compatible!(desired_architecture)
-        if ! node_supports_windows_architecture?(node, desired_architecture)
+        if desired_architecture == :i386 && Chef::Platform.windows_nano_server?
           raise Chef::Exceptions::Win32ArchitectureIncorrect,
-          "cannot execute script with requested architecture '#{desired_architecture.to_s}' on a system with architecture '#{node_windows_architecture(node)}'"
+            "cannot execute script with requested architecture 'i386' on Windows Nano Server"
+        elsif ! node_supports_windows_architecture?(node, desired_architecture)
+          raise Chef::Exceptions::Win32ArchitectureIncorrect,
+            "cannot execute script with requested architecture '#{desired_architecture.to_s}' on a system with architecture '#{node_windows_architecture(node)}'"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -133,6 +133,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :windows_2008r2_or_later => true unless windows_2008r2_or_later?
   config.filter_run_excluding :windows64_only => true unless windows64?
   config.filter_run_excluding :windows32_only => true unless windows32?
+  config.filter_run_excluding :windows_nano_only => true unless windows_nano_server?
   config.filter_run_excluding :ruby64_only => true unless ruby_64bit?
   config.filter_run_excluding :ruby32_only => true unless ruby_32bit?
   config.filter_run_excluding :windows_powershell_dsc_only => true unless windows_powershell_dsc?

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -103,14 +103,22 @@ shared_context Chef::Resource::WindowsScript do
         end
       end
 
-      context "when the guard's architecture is specified as 32-bit" do
+      context "when the guard's architecture is specified as 32-bit", :not_supported_on_nano do
         let (:guard_architecture) { :i386 }
         it "executes a 32-bit guard" do
-          pending "executing scripts with a 32-bit process should raise an error on nano" if Chef::Platform.windows_nano_server?
-
           resource.only_if resource_guard_command, :architecture => guard_architecture
           resource.run_action(:run)
           expect(get_guard_process_architecture).to eq('x86')
+        end
+      end
+
+      context "when the guard's architecture is specified as 32-bit", :windows_nano_only do
+        let (:guard_architecture) { :i386 }
+        it "raises an error" do
+          resource.only_if resource_guard_command, :architecture => guard_architecture
+          expect{ resource.run_action(:run) }.to raise_error(
+            Chef::Exceptions::Win32ArchitectureIncorrect,
+            /cannot execute script with requested architecture 'i386' on Windows Nano Server/)
         end
       end
     end

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -30,22 +30,26 @@ describe Chef::Resource::PowershellScript do
     run_context = Chef::RunContext.new(node, nil, nil)
 
     @resource = Chef::Resource::PowershellScript.new("powershell_unit_test", run_context)
-
   end
 
-  it "should create a new Chef::Resource::PowershellScript" do
+  it "creates a new Chef::Resource::PowershellScript" do
     expect(@resource).to be_a_kind_of(Chef::Resource::PowershellScript)
   end
 
-  it "should set convert_boolean_return to false by default" do
+  it "sets convert_boolean_return to false by default" do
     expect(@resource.convert_boolean_return).to eq(false)
   end
 
-  it "should return the value for convert_boolean_return that was set" do
+  it "returns the value for convert_boolean_return that was set" do
     @resource.convert_boolean_return true
     expect(@resource.convert_boolean_return).to eq(true)
     @resource.convert_boolean_return false
     expect(@resource.convert_boolean_return).to eq(false)
+  end
+
+  it "raises an error when architecture is i386 on Windows Nano Server" do
+    allow(Chef::Platform).to receive(:windows_nano_server?).and_return(true)
+    expect{@resource.architecture(:i386)}.to raise_error(Chef::Exceptions::Win32ArchitectureIncorrect, "cannot execute script with requested architecture 'i386' on Windows Nano Server")
   end
 
   context "when using guards" do
@@ -62,32 +66,32 @@ describe Chef::Resource::PowershellScript do
       expect(inherited_difference).to eq([])
     end
 
-    it "should allow guard interpreter to be set to Chef::Resource::Script" do
+    it "allows guard interpreter to be set to Chef::Resource::Script" do
       resource.guard_interpreter(:script)
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
       resource.only_if("echo hi")
     end
 
-    it "should allow guard interpreter to be set to Chef::Resource::Bash derived from Chef::Resource::Script" do
+    it "allows guard interpreter to be set to Chef::Resource::Bash derived from Chef::Resource::Script" do
       resource.guard_interpreter(:bash)
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
       resource.only_if("echo hi")
     end
 
-    it "should allow guard interpreter to be set to Chef::Resource::PowershellScript derived indirectly from Chef::Resource::Script" do
+    it "allows guard interpreter to be set to Chef::Resource::PowershellScript derived indirectly from Chef::Resource::Script" do
       resource.guard_interpreter(:powershell_script)
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(false)
       resource.only_if("echo hi")
     end
 
-    it "should enable convert_boolean_return by default for guards in the context of powershell_script when no guard params are specified" do
+    it "enables convert_boolean_return by default for guards in the context of powershell_script when no guard params are specified" do
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
         {:convert_boolean_return => true, :code => "$true"}).and_return(Proc.new {})
       resource.only_if("$true")
     end
 
-    it "should enable convert_boolean_return by default for guards in non-Chef::Resource::Script derived resources when no guard params are specified" do
+    it "enables convert_boolean_return by default for guards in non-Chef::Resource::Script derived resources when no guard params are specified" do
       node = Chef::Node.new
       run_context = Chef::RunContext.new(node, nil, nil)
       file_resource = Chef::Resource::File.new('idontexist', run_context)
@@ -98,21 +102,21 @@ describe Chef::Resource::PowershellScript do
       resource.only_if("$true")
     end
 
-    it "should enable convert_boolean_return by default for guards in the context of powershell_script when guard params are specified" do
+    it "enables convert_boolean_return by default for guards in the context of powershell_script when guard params are specified" do
       guard_parameters = {:cwd => '/etc/chef', :architecture => :x86_64}
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
         {:convert_boolean_return => true, :code => "$true"}.merge(guard_parameters)).and_return(Proc.new {})
       resource.only_if("$true", guard_parameters)
     end
 
-    it "should pass convert_boolean_return as true if it was specified as true in a guard parameter" do
+    it "passes convert_boolean_return as true if it was specified as true in a guard parameter" do
       guard_parameters = {:cwd => '/etc/chef', :convert_boolean_return => true, :architecture => :x86_64}
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
         {:convert_boolean_return => true, :code => "$true"}.merge(guard_parameters)).and_return(Proc.new {})
       resource.only_if("$true", guard_parameters)
     end
 
-    it "should pass convert_boolean_return as false if it was specified as true in a guard parameter" do
+    it "passes convert_boolean_return as false if it was specified as true in a guard parameter" do
       other_guard_parameters = {:cwd => '/etc/chef', :architecture => :x86_64}
       parameters_with_boolean_disabled = other_guard_parameters.merge({:convert_boolean_return => false, :code => "$true"})
       allow_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:block_from_attributes).with(
@@ -127,6 +131,6 @@ describe Chef::Resource::PowershellScript do
     let(:resource_name) { :powershell_script }
     let(:interpreter_file_name) { 'powershell.exe' }
 
-    it_should_behave_like "a Windows script resource"
+    it_behaves_like "a Windows script resource"
   end
 end


### PR DESCRIPTION
Raise an error when specifying `architecture :i386` for the `powershell_script` resource or guard on Windows Nano Server.