### PR TITLE
add windows user to group if one is given

### DIFF
--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -65,8 +65,14 @@ class Chef
             Chef::Log.debug("#{@new_resource} password has changed")
             return true
           end
-          [ :uid, :gid, :comment, :home, :shell ].any? do |user_attrib|
-            !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib) != @current_resource.send(user_attrib)
+          [ :uid, :comment, :home, :shell ].any? do |user_attrib|
+            if !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib) != @current_resource.send(user_attrib)
+              return true
+            end
+          end
+
+          if @new_resource.gid
+            return true if @net_user.get_local_groups.include?(@new_resource.gid)
           end
         end
 

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -72,8 +72,10 @@ class Chef
           end
 
           if @new_resource.gid
-            return true if @net_user.get_local_groups.include?(@new_resource.gid)
+            return true unless @net_user.get_local_groups.include?(@new_resource.gid)
           end
+
+          return false
         end
 
         def create_user

--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -115,6 +115,14 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
     usri3_to_hash(ui3)
   end
 
+  def get_local_groups
+    begin
+      Chef::ReservedNames::Win32::NetUser::net_user_get_local_groups(nil, @username)
+    rescue Chef::Exceptions::Win32NetAPIError => e
+      raise ArgumentError, e.msg
+    end
+  end
+
   def add(args)
     transformed_args = transform_usri3(args)
     group_name = transformed_args.delete(:usri3_primary_group_id)

--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -114,8 +114,10 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
 
   def add(args)
     transformed_args = transform_usri3(args)
+    group_name = transformed_args.delete(:usri3_primary_group_id)
     NetUser::net_user_add_l3(nil, transformed_args)
     NetUser::net_local_group_add_member(nil, "Users", args[:name])
+    NetUser::net_local_group_add_member(nil, group_name, args[:name]) if group_name
   end
 
   def user_modify(&proc)

--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -81,7 +81,7 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
       transformed_args = transform_usri3(args)
       group_name = transformed_args.delete(:usri3_primary_group_id)
       NetUser::net_user_set_info_l3(nil, @username, transformed_args)
-      if group_name && group_name.is_a?(String)
+      if group_name && group_name.is_a?(String) && !get_local_groups.include?(group_name)
         NetUser::net_local_group_add_member(nil, group_name, args[:name])
       end
     rescue Chef::Exceptions::Win32APIError => e

--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -81,7 +81,9 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
       transformed_args = transform_usri3(args)
       group_name = transformed_args.delete(:usri3_primary_group_id)
       NetUser::net_user_set_info_l3(nil, @username, transformed_args)
-      NetUser::net_local_group_add_member(nil, group_name, args[:name]) if group_name
+      if group_name && group_name.is_a?(String)
+        NetUser::net_local_group_add_member(nil, group_name, args[:name])
+      end
     rescue Chef::Exceptions::Win32APIError => e
       raise ArgumentError, e
     end

--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -78,7 +78,10 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
 
   def set_info(args)
     begin
-      rc = NetUser::net_user_set_info_l3(nil, @username, transform_usri3(args))
+      transformed_args = transform_usri3(args)
+      group_name = transformed_args.delete(:usri3_primary_group_id)
+      NetUser::net_user_set_info_l3(nil, @username, transformed_args)
+      NetUser::net_local_group_add_member(nil, group_name, args[:name]) if group_name
     rescue Chef::Exceptions::Win32APIError => e
       raise ArgumentError, e
     end

--- a/lib/chef/win32/api/net.rb
+++ b/lib/chef/win32/api/net.rb
@@ -152,6 +152,7 @@ class Chef
         end
 
         class LOCALGROUP_USERS_INFO_0 < FFI::Struct
+          include StructHelpers
           layout :lgrui0_name, :LPWSTR
         end
 

--- a/lib/chef/win32/api/net.rb
+++ b/lib/chef/win32/api/net.rb
@@ -151,6 +151,10 @@ class Chef
           layout :lgrmi3_domainandname, :LPWSTR
         end
 
+        class LOCALGROUP_USERS_INFO_0 < FFI::Struct
+          layout :lgrui0_name, :LPWSTR
+        end
+
         class LOCALGROUP_INFO_0 < FFI::Struct
           layout :lgrpi0_name, :LPWSTR
         end
@@ -318,6 +322,18 @@ class Chef
   #_Out_ LPDWORD ParmError
 #);
         safe_attach_function :NetUseAdd, [:LMSTR, :DWORD, :LPBYTE, :LPDWORD], :DWORD
+
+#NET_API_STATUS NetUserGetLocalGroups (
+  #_In_  LPCWSTR servername,
+  #_In_  LPCWSTR username,
+  #_In_  DWORD   level,
+  #_In_  DWORD   flags,
+  #_Out_ LPBYTE  *bufptr,
+  #_In_  DWORD   prefmaxlen,
+  #_Out_ LPDWORD entriesread,
+  #_Out_ LPDWORD totalentries
+#);
+        safe_attach_function :NetUserGetLocalGroups , [:LPCWSTR, :LPCWSTR, :DWORD, :DWORD, :LPBYTE, :DWORD, :LPDWORD, :LPDWORD], :DWORD
       end
     end
   end

--- a/lib/chef/win32/api/net.rb
+++ b/lib/chef/win32/api/net.rb
@@ -46,6 +46,7 @@ class Chef
         USE_LOTS_OF_FORCE = 2 #every windows API should support this flag
 
         NERR_Success = 0
+        NERR_MEMBER_IN_ALIAS = 1378
         NERR_InvalidComputer = 2351
         NERR_NotPrimary = 2226
         NERR_SpeGroupOp = 2234

--- a/lib/chef/win32/net.rb
+++ b/lib/chef/win32/net.rb
@@ -71,6 +71,8 @@ class Chef
 
       def self.net_api_error!(code)
         msg = case code
+        when NERR_MEMBER_IN_ALIAS
+          "The specified account name is already a member of the group."
         when NERR_InvalidComputer
           "The user does not have access to the requested information."
         when NERR_NotPrimary

--- a/lib/chef/win32/net.rb
+++ b/lib/chef/win32/net.rb
@@ -159,6 +159,39 @@ END
         group_members
       end
 
+      def self.net_user_get_local_groups(server_name, user_name)
+        server_name = wstring(server_name)
+        user_name = wstring(user_name)
+
+        buf = FFI::MemoryPointer.new(:pointer)
+        entries_read_ptr = FFI::MemoryPointer.new(:long)
+        total_read_ptr = FFI::MemoryPointer.new(:long)
+        resume_handle_ptr = FFI::MemoryPointer.new(:pointer)
+
+        rc = ERROR_MORE_DATA
+        local_groups = []
+        while rc == ERROR_MORE_DATA
+          rc = NetUserGetLocalGroups(
+            server_name, user_name, 0, 0, buf, -1,
+            entries_read_ptr, total_read_ptr
+          )
+
+          nread = entries_read_ptr.read_long
+          nread.times do |i|
+            group = LOCALGROUP_USERS_INFO_0.new(buf.read_pointer +
+                       (i * LOCALGROUP_USERS_INFO_0.size))
+            local_groups << group[:lgrui0_name]
+          end
+          NetApiBufferFree(buf.read_pointer)
+        end
+
+        if rc != NERR_Success
+          net_api_error!(rc)
+        end
+
+        local_groups
+      end
+
       def self.net_user_add_l3(server_name, args)
         buf = default_user_info_3
 

--- a/lib/chef/win32/net.rb
+++ b/lib/chef/win32/net.rb
@@ -179,7 +179,7 @@ END
           nread = entries_read_ptr.read_long
           nread.times do |i|
             group = LOCALGROUP_USERS_INFO_0.new(buf.read_pointer +
-                       (i * LOCALGROUP_USERS_INFO_0.size))
+                       (i * LOCALGROUP_USERS_INFO_0.size)).as_ruby
             local_groups << group[:lgrui0_name]
           end
           NetApiBufferFree(buf.read_pointer)

--- a/spec/functional/resource/user/windows_spec.rb
+++ b/spec/functional/resource/user/windows_spec.rb
@@ -23,6 +23,7 @@ describe Chef::Provider::User::Windows, :windows_only do
 
   let(:username) { 'ChefFunctionalTest' }
   let(:password) { SecureRandom.uuid }
+  let(:group) {'Guests'}
 
   let(:node) do
     n = Chef::Node.new
@@ -35,6 +36,7 @@ describe Chef::Provider::User::Windows, :windows_only do
   let(:new_resource) do
     Chef::Resource::User.new(username, run_context).tap do |r|
       r.provider(Chef::Provider::User::Windows)
+      r.gid(group)
       r.password(password)
     end
   end
@@ -52,6 +54,7 @@ describe Chef::Provider::User::Windows, :windows_only do
       new_resource.run_action(:create)
       expect(new_resource).to be_updated_by_last_action
       expect(shell_out("net user #{username}").exitstatus).to eq(0)
+      expect(shell_out("net localgroup \"#{group}\"").stdout).to match(/^#{username}\r$/)
     end
 
     it 'reports no changes if there are no changes needed' do
@@ -60,11 +63,18 @@ describe Chef::Provider::User::Windows, :windows_only do
       expect(new_resource).not_to be_updated_by_last_action
     end
 
-    it 'allows chaning the password' do
+    it 'allows changing the password' do
       new_resource.run_action(:create)
       new_resource.password(SecureRandom.uuid)
       new_resource.run_action(:create)
       expect(new_resource).to be_updated_by_last_action
+    end
+
+    it 'allows changing the group' do
+      new_resource.run_action(:create)
+      new_resource.gid('Power Users')
+      new_resource.run_action(:create)
+      expect(shell_out("net localgroup \"Power Users\"").stdout).to match(/^#{username}\r$/)
     end
   end
 


### PR DESCRIPTION
This fixes #4024 and allows user to be set with a group on windows. I checked as far back as 12.0.0 and it appears that at least until then, specifying a `gid` for a `user` resource on windows raises an error. The error message did change recently to an obscure FFI data type related error. Prior to the FFI error, the error was that the group was missing.

This PR includes functional tests for group add, change and ensures idempotency.

Currently this only applies to local groups. This seems reasonable since the group resource is also limited to local groups, but it seems a propper windows implementation for both `user` and `group` resources should include AD groups as well.