### PR TITLE
ignore gid in the user resource on windows

### DIFF
--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -63,7 +63,7 @@ class Chef
         # === Returns
         # <true>:: If a change is required
         # <false>:: If the users are identical
-        def compare_user       
+        def compare_user
           unless @net_user.validate_credentials(@new_resource.password)
             Chef::Log.debug("#{@new_resource} password has changed")
             return true

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -36,7 +36,7 @@ class Chef
 
         def load_current_resource
           if @new_resource.gid
-            Chef::Log.warn("The 'gid' attribute is not implemented by the Windows platform. Please use the 'group' resource to assign a user th a group.")
+            Chef::Log.warn("The 'gid' attribute is not implemented by the Windows platform. Please use the 'group' resource to assign a user to a group.")
           end          
 
           @current_resource = Chef::Resource::User.new(@new_resource.name)

--- a/spec/functional/resource/user/windows_spec.rb
+++ b/spec/functional/resource/user/windows_spec.rb
@@ -66,6 +66,14 @@ describe Chef::Provider::User::Windows, :windows_only do
       new_resource.run_action(:create)
       expect(new_resource).to be_updated_by_last_action
     end
+
+    context 'with a gid specified' do
+      it 'warns unsupported' do
+        expect(Chef::Log).to receive(:warn).with(/not implemented/)
+        new_resource.gid('agroup')
+        new_resource.run_action(:create)
+      end
+    end
   end
 
   describe 'action :remove' do

--- a/spec/unit/provider/user/windows_spec.rb
+++ b/spec/unit/provider/user/windows_spec.rb
@@ -107,8 +107,8 @@ describe Chef::Provider::User::Windows do
         expect(@provider.set_options[:home_dir]).to eq('/home/adam')
       end
 
-      it "marks the primary_group_id attribute to be updated" do
-        expect(@provider.set_options[:primary_group_id]).to eq(1000)
+      it "ignores the primary_group_id attribute" do
+        expect(@provider.set_options[:primary_group_id]).to eq(nil)
       end
 
       it "marks the user_id attribute to be updated" do


### PR DESCRIPTION
This fixes #4024 and ignores the `gid` attribute on the windows platform. This also emits a warning if the gid is used on windows and suggests that the user use the `group` resource.

I had originally addressed this fix by implementing the gid/user association and adding the user to the group. However, I have switched to this approach for the following reasons:

1. The `gid` in linux refers to a user's "primary" group. Technicaly there is such a term in the windows API but it is conceptually different from linux and has no mapping to a specific local windows group.
2. Treating the gid as a local windows group is awkward because the gid/uid relationship in linux is 1 user to 1 group while windows users can be assigned to many local groups.
3. The implementation in windows is fairly verbose do to the need to pull in more win32 api bindings and adds complexity to the code.
4. The required functionality of maintaining local user/group relationships is present already in chef using the `group` resource.