### PR TITLE
Add make_child_entry in ChefFS CookbookSubdir

### DIFF
--- a/lib/chef/chef_fs/file_system/cookbook_subdir.rb
+++ b/lib/chef/chef_fs/file_system/cookbook_subdir.rb
@@ -45,6 +45,11 @@ class Chef
           true
         end
 
+        def make_child_entry(name)
+          result = @children.select { |child| child.name == name }.first if @children
+          result || NonexistentFSObject.new(name, self)
+        end
+
         def rest
           parent.rest
         end

--- a/spec/unit/chef_fs/file_system/cookbook_subdir_spec.rb
+++ b/spec/unit/chef_fs/file_system/cookbook_subdir_spec.rb
@@ -1,0 +1,34 @@
+#
+# Author:: John Keiser (<jkeiser@opscode.com>)
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef/chef_fs/file_system/cookbook_subdir'
+
+describe Chef::ChefFS::FileSystem::CookbookSubdir do
+  let(:root) do
+    Chef::ChefFS::FileSystem::BaseFSDir.new('', nil)
+  end
+
+  let(:cookbook_subdir) do
+    Chef::ChefFS::FileSystem::CookbookSubdir.new('test', root, false, true)
+  end
+
+  it 'can get child' do
+    cookbook_subdir.child('test')
+  end
+end


### PR DESCRIPTION
Following a517fa8a we can't call `child` on cookbook subdirs.

Fixes #4070