### PR TITLE
Add bootstrap proxy authentication support.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -99,13 +99,11 @@ class Chef
 
       option :bootstrap_proxy_user,
         :long => "--bootstrap-proxy-user PROXY_USER",
-        :description => "The proxy authentication username for the node being bootstrapped",
-        :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy_user] = p }
+        :description => "The proxy authentication username for the node being bootstrapped"
 
       option :bootstrap_proxy_pass,
         :long => "--bootstrap-proxy-pass PROXY_PASS",
-        :description => "The proxy authentication password for the node being bootstrapped",
-        :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy_pass] = p }
+        :description => "The proxy authentication password for the node being bootstrapped"
 
       option :bootstrap_no_proxy,
         :long => "--bootstrap-no-proxy [NO_PROXY_URL|NO_PROXY_IP]",

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -97,6 +97,16 @@ class Chef
         :description => "The proxy server for the node being bootstrapped",
         :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy] = p }
 
+      option :bootstrap_proxy_user,
+        :long => "--bootstrap-proxy-user PROXY_USER",
+        :description => "The proxy authentication username for the node being bootstrapped",
+        :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy_user] = p }
+
+      option :bootstrap_proxy_pass,
+        :long => "--bootstrap-proxy-pass PROXY_PASS",
+        :description => "The proxy authentication password for the node being bootstrapped",
+        :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy_pass] = p }
+
       option :bootstrap_no_proxy,
         :long => "--bootstrap-no-proxy [NO_PROXY_URL|NO_PROXY_IP]",
         :description => "Do not proxy locations for the node being bootstrapped; this option is used internally by Opscode",

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -108,6 +108,16 @@ CONFIG
             client_rb << %Q{https_proxy       "#{knife_config[:bootstrap_proxy]}"\n}
           end
 
+          if knife_config[:bootstrap_proxy_user]
+            client_rb << %Q{http_proxy_user   "#{knife_config[:bootstrap_proxy_user]}"\n}
+            client_rb << %Q{https_proxy_user  "#{knife_config[:bootstrap_proxy_user]}"\n}
+          end
+
+          if knife_config[:bootstrap_proxy_pass]
+            client_rb << %Q{http_proxy_pass   "#{knife_config[:bootstrap_proxy_pass]}"\n}
+            client_rb << %Q{https_proxy_pass  "#{knife_config[:bootstrap_proxy_pass]}"\n}
+          end
+
           if knife_config[:bootstrap_no_proxy]
             client_rb << %Q{no_proxy       "#{knife_config[:bootstrap_no_proxy]}"\n}
           end


### PR DESCRIPTION
Using `knife bootstrap --bootstrap-proxy` it is not currently possible to provide proxy authentication credentials.  Including credentials in the URL does not seem to work, as apparently Chef requires explicit  `http_proxy_user` and `http_proxy_pass` entries in client.rb.
