### PR TITLE
Use the initializer to avoid NoMethodError on nil.include?

### DIFF
--- a/lib/chef/knife/core/node_presenter.rb
+++ b/lib/chef/knife/core/node_presenter.rb
@@ -125,7 +125,7 @@ ROLES
             summarized << <<-SUMMARY
 #{key('Recipes:')}     #{Array(node[:recipes]).join(', ')}
 #{key('Platform:')}    #{node[:platform]} #{node[:platform_version]}
-#{key('Tags:')}        #{Array(node[:tags]).join(', ')}
+#{key('Tags:')}        #{node.tags.join(', ')}
 SUMMARY
             if config[:medium_output] || config[:long_output]
               summarized +=<<-MORE

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -376,12 +376,12 @@ class Chef
       normal[:tags]
     end
 
-    def tag(*tags)
-      tags.each do |tag|
-        self.normal[:tags].push(tag.to_s) unless self[:tags].include? tag.to_s
+    def tag(*args)
+      args.each do |tag|
+        tags.push(tag.to_s) unless tags.include? tag.to_s
       end
 
-      self[:tags]
+      tags
     end
 
     # Extracts the run list from +attrs+ and applies it. Returns the remaining attributes

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -97,8 +97,6 @@ class Chef
     # true<TrueClass>:: If all the parameters are present
     # false<FalseClass>:: If any of the parameters are missing
     def tagged?(*tags)
-      return false if run_context.node[:tags].nil?
-
       tags.each do |tag|
         return false unless run_context.node[:tags].include?(tag)
       end

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -98,7 +98,7 @@ class Chef
     # false<FalseClass>:: If any of the parameters are missing
     def tagged?(*tags)
       tags.each do |tag|
-        return false unless run_context.node[:tags].include?(tag)
+        return false unless run_context.node.tags.include?(tag)
       end
       true
     end
@@ -109,10 +109,10 @@ class Chef
     # tags<Array>:: A list of tags
     #
     # === Returns
-    # tags<Array>:: The current list of run_context.node[:tags]
+    # tags<Array>:: The current list of run_context.node.tags
     def untag(*tags)
       tags.each do |tag|
-        run_context.node.normal[:tags].delete(tag)
+        run_context.node.tags.delete(tag)
       end
     end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -785,7 +785,7 @@ describe Chef::Node do
     end
 
     it "should not set the tags attribute to an empty array if it is already defined" do
-      node.normal[:tags] = [ "radiohead" ]
+      node.tag("radiohead")
       node.consume_external_attrs(@ohai_data, {})
       expect(node.tags).to eql([ "radiohead" ])
     end

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -621,19 +621,19 @@ describe Chef::Recipe do
 
     it "should set tags via tag" do
       recipe.tag "foo"
-      expect(node[:tags]).to include("foo")
+      expect(node.tags).to include("foo")
     end
 
     it "should set multiple tags via tag" do
       recipe.tag "foo", "bar"
-      expect(node[:tags]).to include("foo")
-      expect(node[:tags]).to include("bar")
+      expect(node.tags).to include("foo")
+      expect(node.tags).to include("bar")
     end
 
     it "should not set the same tag twice via tag" do
       recipe.tag "foo"
       recipe.tag "foo"
-      expect(node[:tags]).to eql([ "foo" ])
+      expect(node.tags).to eql([ "foo" ])
     end
 
     it "should return the current list of tags from tag with no arguments" do
@@ -657,13 +657,13 @@ describe Chef::Recipe do
     it "should remove a tag from the tag list via untag" do
       recipe.tag "foo"
       recipe.untag "foo"
-      expect(node[:tags]).to eql([])
+      expect(node.tags).to eql([])
     end
 
     it "should remove multiple tags from the tag list via untag" do
       recipe.tag "foo", "bar"
       recipe.untag "bar", "foo"
-      expect(node[:tags]).to eql([])
+      expect(node.tags).to eql([])
     end
   end
 

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -35,7 +35,7 @@ describe Chef::Recipe do
   let(:cookbook_collection) { Chef::CookbookCollection.new(cookbook_loader) }
 
   let(:node) do
-    Chef::Node.new.tap {|n| n.normal[:tags] = [] }
+    Chef::Node.new
   end
 
   let(:events) do

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -615,6 +615,10 @@ describe Chef::Recipe do
       end
     end
 
+    it "should initialize tags to an empty Array" do
+      expect(node.tags).to eql([])
+    end
+
     it "should set tags via tag" do
       recipe.tag "foo"
       expect(node[:tags]).to include("foo")

--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Resource::ChefGem, "gem_binary" do
 
   context "when building the resource" do
     let(:node) do
-      Chef::Node.new.tap {|n| n.normal[:tags] = [] }
+      Chef::Node.new
     end
 
     let(:run_context) do


### PR DESCRIPTION
Fixes ``` undefined method `include?' for nil:NilClass``` when using tag() in the recipe DSL.