### PR TITLE
Fix chef-apply usage banner

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -29,7 +29,7 @@ require 'chef/resources'
 
 class Chef::Application::Apply < Chef::Application
 
-  banner "Usage: chef-apply [RECIPE_FILE] [-e RECIPE_TEXT] [-s]"
+  banner "Usage: chef-apply [RECIPE_FILE | -e RECIPE_TEXT | -s] [OPTIONS]"
 
   option :execute,
     :short        => "-e RECIPE_TEXT",


### PR DESCRIPTION
The chef-apply option flags should trail the recipe or recipe text
that is being applied.

This updates the chef-apply banner to show the correct usage.

Fixes #2372