### PR TITLE
add logger to windows service shellout

### DIFF
--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -189,7 +189,11 @@ class Chef
           config_params += " -c #{Chef::Config[:config_file]}" unless  Chef::Config[:config_file].nil?
           config_params += " -L #{Chef::Config[:log_location]}" unless Chef::Config[:log_location] == STDOUT
           # Starts a new process and waits till the process exits
-          result = shell_out("chef-client #{config_params}", :timeout => Chef::Config[:windows_service][:watchdog_timeout])
+          result = shell_out(
+            "chef-client #{config_params}",
+            :timeout => Chef::Config[:windows_service][:watchdog_timeout],
+            :logger => Chef::Log
+          )
           Chef::Log.debug "#{result.stdout}"
           Chef::Log.debug "#{result.stderr}"
         rescue Mixlib::ShellOut::CommandTimeout => e

--- a/spec/unit/windows_service_spec.rb
+++ b/spec/unit/windows_service_spec.rb
@@ -49,7 +49,11 @@ describe "Chef::Application::WindowsService", :windows_only do
       allow(instance.instance_variable_get(:@service_signal)).to receive(:wait)
       allow(instance).to receive(:state).and_return(4)
       expect(instance).to receive(:run_chef_client).and_call_original
-      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}", {:timeout => 7200}).and_return(shell_out_result)
+      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}",
+        {
+          :timeout => 7200,
+          :logger => Chef::Log
+        }).and_return(shell_out_result)
       instance.service_main
       tempfile.unlink
     end
@@ -63,7 +67,11 @@ describe "Chef::Application::WindowsService", :windows_only do
       allow(instance.instance_variable_get(:@service_signal)).to receive(:wait)
       allow(instance).to receive(:state).and_return(4)
       expect(instance).to receive(:run_chef_client).and_call_original
-      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}", {:timeout => 10}).and_return(shell_out_result)
+      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}",
+        {
+          :timeout => 10,
+          :logger => Chef::Log
+        }).and_return(shell_out_result)
       instance.service_main
       tempfile.unlink
     end


### PR DESCRIPTION
This adds a logger to shellout when spawning a client run in the windows service so that any debug logging regarding process creation/destruction can be captured. This accompanies but can be deployed independently of https://github.com/chef/mixlib-shellout/pull/110