### PR TITLE
RFC-037:  add chef_version and ohai_version metadata

### DIFF
--- a/lib/chef/cookbook/cookbook_collection.rb
+++ b/lib/chef/cookbook/cookbook_collection.rb
@@ -45,6 +45,9 @@ class Chef
     #
     # Currently checks chef_version and ohai_version in the cookbook metadata
     # against the running Chef::VERSION and Ohai::VERSION.
+    #
+    # @raises [Chef::Exceptions::CookbookChefVersionMismatch] if the Chef::VERSION fails validation
+    # @raises [Chef::Exceptions::CookbookOhaiVersionMismatch] if the Ohai::VERSION fails validation
     def validate!
       each do |cookbook_name, cookbook_version|
         cookbook_version.metadata.validate_chef_version!

--- a/lib/chef/cookbook/cookbook_collection.rb
+++ b/lib/chef/cookbook/cookbook_collection.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Tim Hinderliter (<tim@opscode.com>)
 # Author:: Christopher Walters (<cw@opscode.com>)
-# Copyright:: Copyright (c) 2010 Opscode, Inc.
+# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,10 @@ class Chef
       cookbook_versions.each{ |cookbook_name, cookbook_version| self[cookbook_name] = cookbook_version }
     end
 
+    # Validates that the cookbook metadata allows it to run on this instance.
+    #
+    # Currently checks chef_version and ohai_version in the cookbook metadata
+    # against the running Chef::VERSION and Ohai::VERSION.
     def validate!
       each do |cookbook_name, cookbook_version|
         cookbook_version.metadata.validate_chef_version!

--- a/lib/chef/cookbook/cookbook_collection.rb
+++ b/lib/chef/cookbook/cookbook_collection.rb
@@ -41,5 +41,11 @@ class Chef
       cookbook_versions.each{ |cookbook_name, cookbook_version| self[cookbook_name] = cookbook_version }
     end
 
+    def validate!
+      each do |cookbook_name, cookbook_version|
+        cookbook_version.metadata.validate_chef_version!
+        cookbook_version.metadata.validate_ohai_version!
+      end
+    end
   end
 end

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -665,11 +665,10 @@ class Chef
     private
 
       def gem_dep_matches?(what, version, *deps)
+        # always match if we have no chef_version at all
         return true unless deps.length > 0
-        deps.each do |dep|
-          return true if dep.match?(what, version)
-        end
-        return false
+        # match if we match any of the chef_version lines
+        deps.any? { |dep| dep.match?(what, version) }
       end
 
       def run_validation

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -650,7 +650,27 @@ class Chef
         )
       end
 
+      def validate_ohai_version!
+        unless gem_dep_matches?("ohai", Gem::Version.new(Ohai::VERSION), *ohai_versions)
+          raise Exceptions::CookbookOhaiVersionMismatch.new(Ohai::VERSION, *ohai_versions)
+        end
+      end
+
+      def validate_chef_version!
+        unless gem_dep_matches?("chef", Gem::Version.new(Chef::VERSION), *chef_versions)
+          raise Exceptions::CookbookChefVersionMismatch.new(Chef::VERSION, *chef_versions)
+        end
+      end
+
     private
+
+      def gem_dep_matches?(what, version, *deps)
+        return true unless deps.length > 0
+        deps.each do |dep|
+          return true if dep.match?(what, version)
+        end
+        return false
+      end
 
       def run_validation
         if name.nil?

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: AJ Christensen (<aj@opscode.com>)
 # Author:: Seth Falcon (<seth@opscode.com>)
-# Copyright:: Copyright 2008-2010 Opscode, Inc.
+# Copyright:: Copyright 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -652,13 +652,13 @@ class Chef
 
       def validate_ohai_version!
         unless gem_dep_matches?("ohai", Gem::Version.new(Ohai::VERSION), *ohai_versions)
-          raise Exceptions::CookbookOhaiVersionMismatch.new(Ohai::VERSION, *ohai_versions)
+          raise Exceptions::CookbookOhaiVersionMismatch.new(Ohai::VERSION, name, version, *ohai_versions)
         end
       end
 
       def validate_chef_version!
         unless gem_dep_matches?("chef", Gem::Version.new(Chef::VERSION), *chef_versions)
-          raise Exceptions::CookbookChefVersionMismatch.new(Chef::VERSION, *chef_versions)
+          raise Exceptions::CookbookChefVersionMismatch.new(Chef::VERSION, name, version, *chef_versions)
         end
       end
 

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -404,7 +404,7 @@ class Chef
       # @param version_args [Array<String>] Version constraint in String form
       # @return [Array<Gem::Dependency>] Current chef_versions array
       def chef_version(*version_args)
-        @chef_versions << Gem::Dependency.new('chef', *version_args)
+        @chef_versions << Gem::Dependency.new('chef', *version_args) unless version_args.empty?
         @chef_versions
       end
 
@@ -415,7 +415,7 @@ class Chef
       # @param version_args [Array<String>] Version constraint in String form
       # @return [Array<Gem::Dependency>] Current ohai_versions array
       def ohai_version(*version_args)
-        @ohai_versions << Gem::Dependency.new('ohai', *version_args)
+        @ohai_versions << Gem::Dependency.new('ohai', *version_args) unless version_args.empty?
         @ohai_versions
       end
 

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -482,6 +482,18 @@ class Chef
       end
     end
 
+    class CookbookChefVersionMismatch < RuntimeError
+      def initialize(chef_version, *constraints)
+        super "chef version #{chef_version} is badness"
+      end
+    end
+
+    class CookbookOhaiVersionMismatch < RuntimeError
+      def initialize(ohai_version, *constraints)
+        super "ohai version #{ohai_version} is badness"
+      end
+    end
+
     class MultipleDscResourcesFound < RuntimeError
       attr_reader :resources_found
       def initialize(resources_found)

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Seth Falcon (<seth@opscode.com>)
 # Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
-# Copyright:: Copyright 2008-2010 Opscode, Inc.
+# Copyright:: Copyright 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -483,14 +483,16 @@ class Chef
     end
 
     class CookbookChefVersionMismatch < RuntimeError
-      def initialize(chef_version, *constraints)
-        super "chef version #{chef_version} is badness"
+      def initialize(chef_version, cookbook_name, cookbook_version, *constraints)
+        constraint_str = constraints.map { |c| c.requirement.as_list.to_s }.join(', ')
+        super "Cookbook '#{cookbook_name}' version '#{cookbook_version}' depends on chef version #{constraint_str}, but the running chef version is #{chef_version}"
       end
     end
 
     class CookbookOhaiVersionMismatch < RuntimeError
-      def initialize(ohai_version, *constraints)
-        super "ohai version #{ohai_version} is badness"
+      def initialize(ohai_version, cookbook_name, cookbook_version, *constraints)
+        constraint_str = constraints.map { |c| c.requirement.as_list.to_s }.join(', ')
+        super "Cookbook '#{cookbook_name}' version '#{cookbook_version}' depends on ohai version #{constraint_str}, but the running ohai version is #{ohai_version}"
       end
     end
 

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -74,11 +74,13 @@ class Chef
           cl = Chef::CookbookLoader.new(Chef::Config[:cookbook_path])
           cl.load_cookbooks
           cookbook_collection = Chef::CookbookCollection.new(cl)
+          cookbook_collection.validate!
           run_context = Chef::RunContext.new(node, cookbook_collection, @events)
         else
           Chef::Cookbook::FileVendor.fetch_from_remote(api_service)
           cookbook_hash = sync_cookbooks
           cookbook_collection = Chef::CookbookCollection.new(cookbook_hash)
+          cookbook_collection.validate!
           run_context = Chef::RunContext.new(node, cookbook_collection, @events)
         end
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -153,6 +153,7 @@ class Chef
         Chef::Cookbook::FileVendor.fetch_from_remote(http_api)
         sync_cookbooks
         cookbook_collection = Chef::CookbookCollection.new(cookbooks_to_sync)
+        cookbook_collection.validate!
         run_context = Chef::RunContext.new(node, cookbook_collection, events)
 
         setup_chef_class(run_context)

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -320,6 +320,26 @@ EOM
     end
   end
 
+  when_the_repository "has a cookbook that should fail chef_version checks" do
+    before do
+      file 'cookbooks/x/recipes/default.rb', ''
+      file 'cookbooks/x/metadata.rb', <<EOM
+name 'x'
+version '0.0.1'
+chef_version '~> 999.99'
+EOM
+      file 'config/client.rb', <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+EOM
+    end
+    it "should fail the chef client run" do
+      command = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default' --no-fork", :cwd => chef_dir)
+      expect(command.exitstatus).to eql(1)
+      expect(command.stdout).to match(/Chef::Exceptions::CookbookChefVersionMismatch/)
+    end
+  end
+
   when_the_repository "has a cookbook that generates deprecation warnings" do
     before do
       file 'cookbooks/x/recipes/default.rb', <<-EOM

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -706,7 +706,7 @@ EOH
         end
         it 'knife upload succeeds' do
           knife('upload /cookbooks/x').should_succeed <<EOM
-Updated /cookbooks/x
+Created /cookbooks/x
 EOM
           knife('diff --name-status /cookbooks').should_succeed ''
         end
@@ -1239,8 +1239,8 @@ EOM
           file 'cookbooks/x-1.0.0/metadata.rb', cb_metadata('x', '1.0.0', "\nchef_version '~> 999.0'")
         end
         it 'knife upload succeeds' do
-          knife('upload /cookbooks/x').should_succeed <<EOM
-Updated /cookbooks/x
+          knife('upload /cookbooks/x-1.0.0').should_succeed <<EOM
+Created /cookbooks/x-1.0.0
 EOM
           knife('diff --name-status /cookbooks').should_succeed ''
         end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@opscode.com>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -699,6 +699,19 @@ EOH
         end
       end
     end
+    when_the_chef_server "is empty" do
+      when_the_repository 'has a cookbook with an invalid chef_version constraint in it' do
+        before do
+          file 'cookbooks/x/metadata.rb', cb_metadata('x', '1.0.0', "\nchef_version '~> 999.0'")
+        end
+        it 'knife upload succeeds' do
+          knife('upload /cookbooks/x').should_succeed <<EOM
+Updated /cookbooks/x
+EOM
+          knife('diff --name-status /cookbooks').should_succeed ''
+        end
+      end
+    end
   end # without versioned cookbooks
 
   with_versioned_cookbooks do
@@ -1216,6 +1229,20 @@ EOM
         it 'knife upload succeeds' do
           knife('upload /data_bags/bag/x.json').should_succeed "Created /data_bags/bag\nCreated /data_bags/bag/x.json\n"
           knife('diff --name-status /data_bags/bag/x.json').should_succeed ''
+        end
+      end
+    end
+
+    when_the_chef_server "is empty" do
+      when_the_repository 'has a cookbook with an invalid chef_version constraint in it' do
+        before do
+          file 'cookbooks/x-1.0.0/metadata.rb', cb_metadata('x', '1.0.0', "\nchef_version '~> 999.0'")
+        end
+        it 'knife upload succeeds' do
+          knife('upload /cookbooks/x').should_succeed <<EOM
+Updated /cookbooks/x
+EOM
+          knife('diff --name-status /cookbooks').should_succeed ''
         end
       end
     end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -838,7 +838,7 @@ describe Chef::Cookbook::Metadata do
         chef_versions
       }.each do |t|
         it "should include '#{t}'" do
-          expect(deserialized_metadata[t]).to eq(metadata.gem_requirements_to_hash(*metadata.send(t.to_sym)))
+          expect(deserialized_metadata[t]).to eq(metadata.gem_requirements_to_array(*metadata.send(t.to_sym)))
         end
       end
     end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Seth Falcon (<seth@opscode.com>)
-# Copyright:: Copyright 2008-2010 Opscode, Inc.
+# Copyright:: Copyright 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -351,6 +351,31 @@ describe Chef::Cookbook::Metadata do
     it "should work with multiple complex constraints" do
       expect_chef_version_works([">= 11.14.2", "< 11.18.10"],[">= 12.2.1", "< 12.5.1"])
     end
+
+    it "should fail validation on a simple pessimistic constraint" do
+      expect_chef_version_works(["~> 999.0"])
+      expect { metadata.validate_chef_version! }.not_to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
+    end
+
+    it "should fail validation when that valid chef versions are too big" do
+      expect_chef_version_works([">= 999.0", "< 999.9"])
+      expect { metadata.validate_chef_version! }.to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
+    end
+
+    it "should fail validation when that valid chef versions are too small" do
+      expect_chef_version_works([">= 0.0.1", "< 0.0.9"])
+      expect { metadata.validate_chef_version! }.to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
+    end
+
+    it "should fail validation when all ranges fail" do
+      expect_chef_version_works([">= 999.0", "< 999.9"],[">= 0.0.1", "< 0.0.9"])
+      expect { metadata.validate_chef_version! }.to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
+    end
+
+    it "should pass validation when one constraint passes" do
+      expect_chef_version_works([">= 999.0", "< 999.9"],["= #{Chef::VERSION}"])
+      expect { metadata.validate_chef_version! }.not_to raise_error
+    end
   end
 
   describe "ohai_version" do
@@ -377,6 +402,31 @@ describe Chef::Cookbook::Metadata do
 
     it "should work with multiple complex constraints" do
       expect_ohai_version_works([">= 11.14.2", "< 11.18.10"],[">= 12.2.1", "< 12.5.1"])
+    end
+
+    it "should fail validation on a simple pessimistic constraint" do
+      expect_ohai_version_works(["~> 999.0"])
+      expect { metadata.validate_ohai_version! }.to raise_error(Chef::Exceptions::CookbookOhaiVersionMismatch)
+    end
+
+    it "should fail validation when that valid chef versions are too big" do
+      expect_ohai_version_works([">= 999.0", "< 999.9"])
+      expect { metadata.validate_ohai_version! }.to raise_error(Chef::Exceptions::CookbookOhaiVersionMismatch)
+    end
+
+    it "should fail validation when that valid chef versions are too small" do
+      expect_ohai_version_works([">= 0.0.1", "< 0.0.9"])
+      expect { metadata.validate_ohai_version! }.to raise_error(Chef::Exceptions::CookbookOhaiVersionMismatch)
+    end
+
+    it "should fail validation when all ranges fail" do
+      expect_ohai_version_works([">= 999.0", "< 999.9"],[">= 0.0.1", "< 0.0.9"])
+      expect { metadata.validate_ohai_version! }.to raise_error(Chef::Exceptions::CookbookOhaiVersionMismatch)
+    end
+
+    it "should pass validation when one constraint passes" do
+      expect_ohai_version_works([">= 999.0", "< 999.9"],["= #{Ohai::VERSION}"])
+      expect { metadata.validate_ohai_version! }.not_to raise_error
     end
   end
 

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -354,7 +354,7 @@ describe Chef::Cookbook::Metadata do
 
     it "should fail validation on a simple pessimistic constraint" do
       expect_chef_version_works(["~> 999.0"])
-      expect { metadata.validate_chef_version! }.not_to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
+      expect { metadata.validate_chef_version! }.to raise_error(Chef::Exceptions::CookbookChefVersionMismatch)
     end
 
     it "should fail validation when that valid chef versions are too big" do

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -662,6 +662,7 @@ describe Chef::PolicyBuilder::Policyfile do
             it "builds a run context" do
               expect(cookbook_synchronizer).to receive(:sync_cookbooks)
               expect_any_instance_of(Chef::RunContext).to receive(:load).with(policy_builder.run_list_expansion_ish)
+              expect_any_instance_of(Chef::CookbookCollection).to receive(:validate!)
               run_context = policy_builder.setup_run_context
               expect(run_context.node).to eq(node)
               expect(run_context.cookbook_collection.keys).to match_array(["example1", "example2"])
@@ -670,6 +671,7 @@ describe Chef::PolicyBuilder::Policyfile do
             it "makes the run context available via static method on Chef" do
               expect(cookbook_synchronizer).to receive(:sync_cookbooks)
               expect_any_instance_of(Chef::RunContext).to receive(:load).with(policy_builder.run_list_expansion_ish)
+              expect_any_instance_of(Chef::CookbookCollection).to receive(:validate!)
               run_context = policy_builder.setup_run_context
               expect(Chef.run_context).to eq(run_context)
             end


### PR DESCRIPTION
This allows knife to upload cookbooks containing chef_version and ohai_version.  When the chef-client downloads cookbooks with constraints it checks them and throws an exception if the constraints do not match.  The knife command will upload cookbooks which do not match the version constraint (this is deliberate in the case where knife workstation versions differ from chef-client production versions -- injecting the production chef-client version into knife to prevent uploads is out-of-scope).

Also out of scope - including these into /universe, teaching berkshelf and the policyfile depsolver to avoid them, injecting production chef-version values into policyfiles, teaching the cookbook_versions endpoint to filter based on chef_version, etc, etc, etc, etc, etc....  This is only step number one.

This PR does go slightly beyond the RFC and includes the ability to not only pin via a simple constraint like '~> 12.3' but also to allow multiple pins to handle features that were back-ported:

```ruby
chef_version ">= 11.20.0", "< 12.0"
chef_version ">= 12.6.0"
```

That will be satisfied by a chef version that is 11.x >= 11.20.0, or 12.x >= 12.6.0, or >= 13. 