### PR TITLE
Improve detection of ChefFS-based commands in `knife rehash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [pr#3597](https://github.com/chef/chef/pull/3597) print STDOUT from the powershell_script
 * [pr#4091](https://github.com/chef/chef/pull/4091) Allow downloading of root_files in a chef repository
 * [pr#4112](https://github.com/chef/chef/pull/4112) Update knife bootstrap command to honor --no-color flag in chef-client run that is part of the bootstrap process.
+* [pr#4090](https://github.com/chef/chef/pull/4090) Improve detection of ChefFS-based commands in `knife rehash`
 
 ## 12.5.1
 

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -117,6 +117,14 @@ describe Chef::Knife do
       expect(Chef::Knife.subcommands["super_awesome_command"]).to eq(SuperAwesomeCommand)
     end
 
+    it "records the location of ChefFS-based commands correctly" do
+      class AwesomeCheffsCommand < Chef::ChefFS::Knife
+      end
+
+      Chef::Knife.load_commands
+      expect(Chef::Knife.subcommand_files["awesome_cheffs_command"]).to eq([__FILE__])
+    end
+
     it "guesses a category from a given ARGV" do
       Chef::Knife.subcommands_by_category["cookbook"] << :cookbook
       Chef::Knife.subcommands_by_category["cookbook site"] << :cookbook_site


### PR DESCRIPTION
ChefFS-based commands have a superclass (Chef::ChefFS::Knife) which
defines its own inherited method that calls super. This breaks our
detection of where the subcommand is defined since the file with
the definition is no longer at the top of the call stack.

This commit special-cases subclasses with a superclass of
Chef::ChefFS::Knife to account for this.

Fixes #4089