### PR TITLE
Allow downloading of root_files in a chef repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 
 * [pr#4034](https://github.com/chef/chef/pull/4034) add optional ruby-profiling with --profile-ruby
 * [pr#3119](https://github.com/chef/chef/pull/3119) allow removing user, even if their GID isn't resolvable
-* [pr#4068](https://github.com/chef/chef/pull/4068) update messaging from LWRP to Custom Resource in logging and spec 
-* [pr#4021](https://github.com/chef/chef/pull/4021) add missing requires for Chef::DSL::Recipe to LWRPBase 
+* [pr#4068](https://github.com/chef/chef/pull/4068) update messaging from LWRP to Custom Resource in logging and spec
+* [pr#4021](https://github.com/chef/chef/pull/4021) add missing requires for Chef::DSL::Recipe to LWRPBase
 * [pr#3597](https://github.com/chef/chef/pull/3597) print STDOUT from the powershell_script
+* [pr#4091](https://github.com/chef/chef/pull/4091) Allow downloading of root_files in a chef repository
 
 ## 12.5.1
 

--- a/lib/chef/chef_fs/file_system/file_system_entry.rb
+++ b/lib/chef/chef_fs/file_system/file_system_entry.rb
@@ -83,7 +83,7 @@ class Chef
         end
 
         def exists?
-          File.exists?(file_path) && parent.can_have_child?(name, dir?)
+          File.exists?(file_path) && (parent.nil? || parent.can_have_child?(name, dir?))
         end
 
         def read

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -1103,6 +1103,15 @@ EOM
     before :each do
       Chef::Config.chef_server_url = URI.join(Chef::Config.chef_server_url, '/organizations/foo')
     end
+    when_the_repository 'has existing top level files' do
+      before do
+        file 'invitations.json', {}
+      end
+
+      it "can still download top level files" do
+        knife('download /invitations.json').should_succeed
+      end
+    end
 
     when_the_repository 'is empty' do
       it 'knife download / downloads everything' do


### PR DESCRIPTION
A FileSystemEntry with a nil parent is a "root directory" and thus
should exists so long as its filesystem path exists. This was preventing
the download of files such as invitation.json whose parent directory is
a root directory.