### PR TITLE
package/solaris: Adds alias method for upgrade_package.

### DIFF
--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -125,6 +125,8 @@ class Chef
           end
         end
 
+        alias_method :upgrade_package, :install_package
+
         def remove_package(name, version)
           if @new_resource.options.nil?
             shell_out_with_timeout!( "pkgrm -n #{name}" )


### PR DESCRIPTION
This follows the same convention that the [AIX package provider](https://github.com/johnbellone/chef/blob/master/lib/chef/provider/package/aix.rb#L122) has done and adds an alias_method.

/cc @pburkholder @acaiafa