### PR TITLE
launchd for osx

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -72,7 +72,7 @@ class Chef
       def manage_plist(action)
         if @source
           res = cookbook_file_resource
-        elsif
+        else
           res = file_resource
         end
         res.run_action(action)

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -1,0 +1,205 @@
+#
+# Author:: Mike Dodge (<mikedodge04@gmail.com>)
+# Copyright:: Copyright (c) 2015 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider'
+require 'chef/resource'
+require 'chef/resource/file'
+require 'chef/resource/cookbook_file'
+require 'chef/resource/macosx_service'
+
+class Chef
+  class Provider
+    class Launchd < Chef::Provider
+
+      def load_current_resource
+        @current_resource = Chef::Resource::Launchd.new(@new_resource.name)
+        @name = @new_resource.name
+        @label = @new_resource.label ? @new_resource.label : @name
+        @backup = @new_resource.backup
+        @cookbook = @new_resource.cookbook
+        @group = @new_resource.group
+        @mode = @new_resource.mode
+        @owner = @new_resource.owner
+        @path = @new_resource.path
+        @source = @new_resource.source
+        @content = content?
+      end
+
+      def action_create
+        manage_plist(:create)
+      end
+
+      def action_create_if_missing
+        manage_plist(:create_if_missing)
+      end
+
+      def action_delete
+        # If you delete a service you want to make sure its not loaded or
+        # the service will be in memory and you wont be able to stop it.
+        if ::File.exists?(@path)
+          manage_service(:disable)
+        end
+        manage_plist(:delete)
+      end
+
+      def action_enable
+        if manage_plist(:create)
+          manage_service(:restart)
+        else
+          manage_service(:enable)
+        end
+      end
+
+      def action_disable
+        manage_service(:disable)
+      end
+
+      def manage_plist(action)
+        if @source
+          res = cookbook_file_resource
+        elsif
+          res = file_resource
+        end
+        res.run_action(action)
+        new_resource.updated_by_last_action(true) if res.updated?
+        res.updated
+      end
+
+      def manage_service(action)
+        res = service_resource
+        res.run_action(action)
+        new_resource.updated_by_last_action(true) if res.updated?
+      end
+
+      def service_resource
+        res = Chef::Resource::MacosxService.new(@label, run_context)
+        res.name(@label)
+        res.service_name(@label)
+        res.plist(@path)
+        res.session_type(@session_type) if @session_type
+
+        res
+      end
+
+      def file_resource
+        res = Chef::Resource::File.new(@path, run_context)
+        res.name(@path)
+        res.backup(@backup) if @backup
+        res.content(@content) if @content
+        res.group(@group) if @group
+        res.mode(@mode) if @mode
+        res.owner(@owner) if @owner
+        res.source(@source) if @source
+
+        res
+      end
+
+      def cookbook_file_resource
+        res = Chef::Resource::CookbookFile.new(@path, run_context)
+        res.name(@path)
+        res.backup(@backup) if @backup
+        res.content(@content) if @content
+        res.cookbook_name = @cookbook if @cookbook
+        res.group(@group) if @group
+        res.mode(@mode) if @mode
+        res.owner(@owner) if @owner
+        res.source(@source) if @source
+
+        res
+      end
+
+      def define_resource_requirements
+        super
+        requirements.assert(
+          :create, :create_if_missing, :delete, :enable, :disable
+        ) do |a|
+          type = @new_resource.type.to_s
+          a.assertion { !['daemon', 'agent'].include?(type) }
+          a.failure_message(
+            Chef::Exceptions::UnsupportedAction,
+            "service_type must be 'daemon' or 'agent'"
+          )
+        end
+      end
+
+      private
+
+      def content?
+        if @new_resource.hash
+          @new_resource.hash.to_plist
+        elsif @new_resource.program || @new_resource.program_arguments
+          gen_plist
+        end
+      end
+
+      def gen_plist
+        plist_hash = {}
+        {
+          'label' => 'Label',
+          'program' => 'Program',
+          'program_arguments' => 'ProgramArguments',
+          'abandon_process_group' => 'AbandonProcessGroup',
+          'debug' => 'Debug',
+          'disabled' => 'Disabled',
+          'enable_globbing' => 'EnableGlobbing',
+          'enable_transactions' => 'EnableTransactions',
+          'environment_variables' => 'EnvironmentVariables',
+          'exit_timeout' => 'ExitTimeout',
+          'ld_group' => 'GroupName',
+          'hard_resource_limits' => 'HardreSourceLimits',
+          'inetd_compatibility' => 'inetdCompatibility',
+          'init_groups' => 'InitGroups',
+          'keep_alive' => 'KeepAlive',
+          'launch_only_once' => 'LaunchOnlyOnce',
+          'limit_load_from_hosts' => 'LimitLoadFromHosts',
+          'limit_load_to_hosts' => 'LimitLoadToHosts',
+          'limit_load_to_session_type' => 'LimitLoadToSessionType',
+          'low_priority_io' => 'LowPriorityIO',
+          'mach_services' => 'MachServices',
+          'nice' => 'Nice',
+          'on_demand' => 'OnDemand',
+          'process_type' => 'ProcessType',
+          'queue_directories' => 'QueueDirectories',
+          'root_directory' => 'RootDirectory',
+          'run_at_load' => 'RunAtLoad',
+          'sockets' => 'Sockets',
+          'soft_resource_limits' => 'SoftResourceLimits',
+          'standard_error_path' => 'StandardErrorPath',
+          'standard_in_path' => 'StandardInPath',
+          'standard_out_path' => 'StandardOutPath',
+          'start_calendar_interval' => 'StartCalendarInterval',
+          'start_interval' => 'StartInterval',
+          'start_on_mount' => 'StartOnMount',
+          'throttle_interval' => 'ThrottleInterval',
+          'time_out' => 'TimeOut',
+          'umask' => 'Umask',
+          'username' => 'UserName',
+          'wait_for_debugger' => 'WaitForDebugger',
+          'watch_paths' => 'WatchPaths',
+          'working_directory' => 'WorkingDirectory',
+        }.each do |key, val|
+          if @new_resource.send(key)
+            plist_hash[val] = @new_resource.send(key)
+          end
+        end
+        plist_hash.to_plist
+      end
+
+    end
+  end
+end

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -104,17 +104,15 @@ class Chef
         res.group(@group) if @group
         res.mode(@mode) if @mode
         res.owner(@owner) if @owner
-        res.source(@source) if @source
 
         res
       end
 
       def cookbook_file_resource
         res = Chef::Resource::CookbookFile.new(@path, run_context)
+        res.cookbook_name = @cookbook if @cookbook
         res.name(@path)
         res.backup(@backup) if @backup
-        res.content(@content) if @content
-        res.cookbook_name = @cookbook if @cookbook
         res.group(@group) if @group
         res.mode(@mode) if @mode
         res.owner(@owner) if @owner
@@ -124,20 +122,15 @@ class Chef
       end
 
       def define_resource_requirements
-        super
         requirements.assert(
           :create, :create_if_missing, :delete, :enable, :disable
         ) do |a|
           type = @new_resource.type.to_s
-          a.assertion { !['daemon', 'agent'].include?(type) }
-          a.failure_message(
-            Chef::Exceptions::UnsupportedAction,
-            "service_type must be 'daemon' or 'agent'"
-          )
+          a.assertion { ['daemon', 'agent'].include?(type) }
+          error_msg = 'type must be daemon or agent'
+          a.failure_message Chef::Exceptions::ValidationFailed, error_msg
         end
       end
-
-      private
 
       def content?
         if @new_resource.hash

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -16,12 +16,12 @@
 # limitations under the License.
 #
 
-require 'chef/provider'
-require 'chef/resource/launchd'
-require 'chef/resource/file'
-require 'chef/resource/cookbook_file'
-require 'chef/resource/macosx_service'
-require 'plist'
+require "chef/provider"
+require "chef/resource/launchd"
+require "chef/resource/file"
+require "chef/resource/cookbook_file"
+require "chef/resource/macosx_service"
+require "plist"
 require "forwardable"
 
 class Chef
@@ -50,8 +50,8 @@ class Chef
 
       def gen_path_from_type
         types = {
-          'daemon' => "/Library/LaunchDaemons/#{label}.plist",
-          'agent' => "/Library/LaunchAgents/#{label}.plist"
+          "daemon" => "/Library/LaunchDaemons/#{label}.plist",
+          "agent" => "/Library/LaunchAgents/#{label}.plist"
         }
         types[type]
       end
@@ -139,8 +139,8 @@ class Chef
           :create, :create_if_missing, :delete, :enable, :disable
         ) do |a|
           type = new_resource.type
-          a.assertion { ['daemon', 'agent'].include?(type.to_s) }
-          error_msg = 'type must be daemon or agent.'
+          a.assertion { %w{daemon agent}.include?(type.to_s) }
+          error_msg = "type must be daemon or agent."
           a.failure_message Chef::Exceptions::ValidationFailed, error_msg
         end
       end
@@ -157,48 +157,48 @@ class Chef
       def gen_hash
         return nil unless new_resource.program || new_resource.program_arguments
         {
-          'label' => 'Label',
-          'program' => 'Program',
-          'program_arguments' => 'ProgramArguments',
-          'abandon_process_group' => 'AbandonProcessGroup',
-          'debug' => 'Debug',
-          'disabled' => 'Disabled',
-          'enable_globbing' => 'EnableGlobbing',
-          'enable_transactions' => 'EnableTransactions',
-          'environment_variables' => 'EnvironmentVariables',
-          'exit_timeout' => 'ExitTimeout',
-          'ld_group' => 'GroupName',
-          'hard_resource_limits' => 'HardreSourceLimits',
-          'inetd_compatibility' => 'inetdCompatibility',
-          'init_groups' => 'InitGroups',
-          'keep_alive' => 'KeepAlive',
-          'launch_only_once' => 'LaunchOnlyOnce',
-          'limit_load_from_hosts' => 'LimitLoadFromHosts',
-          'limit_load_to_hosts' => 'LimitLoadToHosts',
-          'limit_load_to_session_type' => 'LimitLoadToSessionType',
-          'low_priority_io' => 'LowPriorityIO',
-          'mach_services' => 'MachServices',
-          'nice' => 'Nice',
-          'on_demand' => 'OnDemand',
-          'process_type' => 'ProcessType',
-          'queue_directories' => 'QueueDirectories',
-          'root_directory' => 'RootDirectory',
-          'run_at_load' => 'RunAtLoad',
-          'sockets' => 'Sockets',
-          'soft_resource_limits' => 'SoftResourceLimits',
-          'standard_error_path' => 'StandardErrorPath',
-          'standard_in_path' => 'StandardInPath',
-          'standard_out_path' => 'StandardOutPath',
-          'start_calendar_interval' => 'StartCalendarInterval',
-          'start_interval' => 'StartInterval',
-          'start_on_mount' => 'StartOnMount',
-          'throttle_interval' => 'ThrottleInterval',
-          'time_out' => 'TimeOut',
-          'umask' => 'Umask',
-          'username' => 'UserName',
-          'wait_for_debugger' => 'WaitForDebugger',
-          'watch_paths' => 'WatchPaths',
-          'working_directory' => 'WorkingDirectory',
+          "label" => "Label",
+          "program" => "Program",
+          "program_arguments" => "ProgramArguments",
+          "abandon_process_group" => "AbandonProcessGroup",
+          "debug" => "Debug",
+          "disabled" => "Disabled",
+          "enable_globbing" => "EnableGlobbing",
+          "enable_transactions" => "EnableTransactions",
+          "environment_variables" => "EnvironmentVariables",
+          "exit_timeout" => "ExitTimeout",
+          "ld_group" => "GroupName",
+          "hard_resource_limits" => "HardreSourceLimits",
+          "inetd_compatibility" => "inetdCompatibility",
+          "init_groups" => "InitGroups",
+          "keep_alive" => "KeepAlive",
+          "launch_only_once" => "LaunchOnlyOnce",
+          "limit_load_from_hosts" => "LimitLoadFromHosts",
+          "limit_load_to_hosts" => "LimitLoadToHosts",
+          "limit_load_to_session_type" => "LimitLoadToSessionType",
+          "low_priority_io" => "LowPriorityIO",
+          "mach_services" => "MachServices",
+          "nice" => "Nice",
+          "on_demand" => "OnDemand",
+          "process_type" => "ProcessType",
+          "queue_directories" => "QueueDirectories",
+          "root_directory" => "RootDirectory",
+          "run_at_load" => "RunAtLoad",
+          "sockets" => "Sockets",
+          "soft_resource_limits" => "SoftResourceLimits",
+          "standard_error_path" => "StandardErrorPath",
+          "standard_in_path" => "StandardInPath",
+          "standard_out_path" => "StandardOutPath",
+          "start_calendar_interval" => "StartCalendarInterval",
+          "start_interval" => "StartInterval",
+          "start_on_mount" => "StartOnMount",
+          "throttle_interval" => "ThrottleInterval",
+          "time_out" => "TimeOut",
+          "umask" => "Umask",
+          "username" => "UserName",
+          "wait_for_debugger" => "WaitForDebugger",
+          "watch_paths" => "WatchPaths",
+          "working_directory" => "WorkingDirectory",
         }.each_with_object({}) do |(key, val), memo|
           memo[val] = new_resource.send(key) if new_resource.send(key)
         end

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -35,7 +35,7 @@ require "chef/provider/git"
 require "chef/provider/group"
 require "chef/provider/http_request"
 require "chef/provider/ifconfig"
-require 'chef/provider/launchd'
+require "chef/provider/launchd"
 require "chef/provider/link"
 require "chef/provider/log"
 require "chef/provider/ohai"

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -35,6 +35,7 @@ require "chef/provider/git"
 require "chef/provider/group"
 require "chef/provider/http_request"
 require "chef/provider/ifconfig"
+require 'chef/provider/launchd'
 require "chef/provider/link"
 require "chef/provider/log"
 require "chef/provider/ohai"

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -31,376 +31,74 @@ class Chef
 
       def initialize(name, run_context = nil)
         super
-        @provider = Chef::Provider::Launchd
-        @resource_name = :launchd
-        @label = name
-        @disabled = false
-        @type = 'daemon'
-        @path = "/Library/LaunchDaemons/#{name}.plist"
+        provider = Chef::Provider::Launchd
+        resource_name = :launchd
       end
 
-      def label(arg = nil)
-        set_or_return(
-          :label, arg,
-          :kind_of => String
-        )
-      end
+      property :label, String, default: lazy { name }, identity: true
+      property :backup, [Integer, FalseClass]
+      property :cookbook, String
+      property :group, [String, Integer]
+      property :hash, Hash
+      property :mode, [String, Integer]
+      property :owner, [String, Integer]
+      property :path, String
+      property :source, String
+      property :session_type, String
 
-      def source(arg = nil)
-        set_or_return(
-          :source, arg,
-          :kind_of => [String, Array]
-        )
-      end
-
-      def cookbook(arg = nil)
-        set_or_return(
-          :cookbook, arg,
-          :kind_of => String
-        )
-      end
-
-      def path(arg = nil)
-        set_or_return(
-          :path, arg,
-          :kind_of => String
-        )
-      end
-
-      def hash(arg = nil)
-        set_or_return(
-          :hash, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def backup(arg=nil)
-        set_or_return(
-          :backup, arg,
-          :kind_of => [Integer, FalseClass]
-        )
-      end
-
-      def group(arg = nil)
-        set_or_return(
-          :group, arg,
-          :kind_of => [String, Integer]
-        )
-      end
-
-      def mode(arg = nil)
-        set_or_return(
-          :mode, arg,
-          :kind_of => [String, Integer]
-        )
-      end
-
-      def owner(arg = nil)
-        set_or_return(
-          :owner, arg,
-          :kind_of => [String, Integer]
-        )
-      end
-
-      def type(type = nil)
+      property :type, String, default: 'daemon', coerce: proc { |type|
         type = type ? type.downcase : 'daemon'
-        if type == 'daemon'
-          @path = "/Library/LaunchDaemons/#{name}.plist"
-        elsif type == 'agent'
-          @path = "/Library/LaunchAgents/#{name}.plist"
-        else
+        types = [ 'daemon', 'agent' ]
+
+        unless types.include?(type)
           error_msg = 'type must be daemon or agent'
           raise Chef::Exceptions::ValidationFailed, error_msg
         end
         type
-      end
+      }
 
-      def abandon_process_group(arg = nil)
-        set_or_return(
-          :abandon_process_group, arg,
-          :kind_of => String
-        )
-      end
-
-      def debug(arg = nil)
-        set_or_return(
-          :debug, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def disabled(arg = nil)
-        set_or_return(
-          :disabled, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def enable_globbing(arg = nil)
-        set_or_return(
-          :enable_globbing, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def enable_transactions(arg = nil)
-        set_or_return(
-          :enable_transactions, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def environment_variables(arg = nil)
-        set_or_return(
-          :environment_variables, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def exit_timeout(arg = nil)
-        set_or_return(
-          :exit_timeout, arg,
-          :kind_of => Integer
-        )
-      end
-
-      def hard_resource_limits(arg = nil)
-        set_or_return(
-          :hardre_source_limits, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def keep_alive(arg = nil)
-        set_or_return(
-          :keep_alive, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def launch_only_once(arg = nil)
-        set_or_return(
-          :launch_only_once, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def limit_load_from_hosts(arg = nil)
-        set_or_return(
-          :limit_load_from_hosts, arg,
-          :kind_of => Array
-        )
-      end
-
-      def limit_load_to_hosts(arg = nil)
-        set_or_return(
-          :limit_load_to_hosts, arg,
-          :kind_of => Array
-        )
-      end
-
-      def limit_load_to_session_type(arg = nil)
-        set_or_return(
-          :limit_load_to_session_type, arg,
-          :kind_of => String
-        )
-      end
-
-      def low_priority_io(arg = nil)
-        set_or_return(
-          :low_priority_io, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def mach_services(arg = nil)
-        set_or_return(
-          :mach_services, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def nice(arg = nil)
-        set_or_return(
-          :nice, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def on_demand(arg = nil)
-        set_or_return(
-          :on_demand, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def username(arg = nil)
-        set_or_return(
-          :username, arg,
-          :kind_of => String
-        )
-      end
-
-      def ld_group(arg = nil)
-        set_or_return(
-          :ld_group, arg,
-          :kind_of => String
-        )
-      end
-
-      def inetd_compatibility(arg = nil)
-        set_or_return(
-          :inetd_compatibility, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def init_groups(arg = nil)
-        set_or_return(
-          :init_groups, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def process_type(arg = nil)
-        set_or_return(
-          :process_type, arg,
-          :kind_of => String
-        )
-      end
-
-      def program(arg = nil)
-        set_or_return(
-          :program, arg,
-          :kind_of => String
-        )
-      end
-
-      def program_arguments(arg = nil)
-        set_or_return(
-          :program_arguments, arg,
-          :kind_of => Array
-        )
-      end
-
-      def queue_directories(arg = nil)
-        set_or_return(
-          :queue_directories, arg,
-          :kind_of => Array
-        )
-      end
-
-      def root_directory(arg = nil)
-        set_or_return(
-          :root_directory, arg,
-          :kind_of => String
-        )
-      end
-
-      def run_at_load(arg = nil)
-        set_or_return(
-          :run_at_load, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def sockets(arg = nil)
-        set_or_return(
-          :sockets, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def soft_resource_limits(arg = nil)
-        set_or_return(
-          :soft_resource_limits, arg,
-          :kind_of => Array
-        )
-      end
-
-      def standard_error_path(arg = nil)
-        set_or_return(
-          :standard_error_path, arg,
-          :kind_of => String
-        )
-      end
-
-      def standard_in_path(arg = nil)
-        set_or_return(
-          :standard_in_path, arg,
-          :kind_of => String
-        )
-      end
-
-      def standard_out_path(arg = nil)
-        set_or_return(
-          :standard_out_path, arg,
-          :kind_of => String
-        )
-      end
-
-      def start_calendar_interval(arg = nil)
-        set_or_return(
-          :start_calendar_interval, arg,
-          :kind_of => Hash
-        )
-      end
-
-      def start_interval(arg = nil)
-        set_or_return(
-          :start_interval, arg,
-          :kind_of => Integer
-        )
-      end
-
-      def start_on_mount(arg = nil)
-        set_or_return(
-          :start_on_mount, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def throttle_interval(arg = nil)
-        set_or_return(
-          :throttle_interval, arg,
-          :kind_of => Integer
-        )
-      end
-
-      def time_out(arg = nil)
-        set_or_return(
-          :time_out, arg,
-          :kind_of => Integer
-        )
-      end
-
-      def umask(arg = nil)
-        set_or_return(
-          :umask, arg,
-          :kind_of => Integer
-        )
-      end
-
-      def wait_for_debugger(arg = nil)
-        set_or_return(
-          :wait_for_debugger, arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def watch_paths(arg = nil)
-        set_or_return(
-          :watch_paths, arg,
-          :kind_of => Array
-        )
-      end
-
-      def working_directory(arg = nil)
-        set_or_return(
-          :working_directory, arg,
-          :kind_of => String
-        )
-      end
+      # Apple LaunchD Keys
+      property :abandon_process_group, [ TrueClass, FalseClass ]
+      property :debug, [ TrueClass, FalseClass ]
+      property :disabled, [ TrueClass, FalseClass ], default: false
+      property :enable_globbing, [ TrueClass, FalseClass ]
+      property :enable_transactions, [ TrueClass, FalseClass ]
+      property :environment_variables, Hash
+      property :exit_timeout, Integer
+      property :hard_resource_limits, Hash
+      property :inetd_compatibility, Hash
+      property :init_groups, [ TrueClass, FalseClass ]
+      property :keep_alive, [ TrueClass, FalseClass ]
+      property :launch_only_once, [ TrueClass, FalseClass ]
+      property :ld_group, String
+      property :limit_load_from_hosts, Array
+      property :limit_load_to_hosts, Array
+      property :limit_load_to_session_type, String
+      property :low_priority_io, [ TrueClass, FalseClass ]
+      property :mach_services, Hash
+      property :nice, Integer
+      property :on_demand, [ TrueClass, FalseClass ]
+      property :process_type, String
+      property :program, String
+      property :program_arguments, Array
+      property :queue_directories, Array
+      property :root_directory, String
+      property :run_at_load, [ TrueClass, FalseClass ]
+      property :sockets, Hash
+      property :soft_resource_limits, Array
+      property :standard_error_path, String
+      property :standard_in_path, String
+      property :standard_out_path, String
+      property :start_calendar_interval, Hash
+      property :start_interval, Integer
+      property :start_on_mount, [ TrueClass, FalseClass ]
+      property :throttle_interval, Integer
+      property :time_out, Integer
+      property :umask, Integer
+      property :username, String
+      property :wait_for_debugger, [ TrueClass, FalseClass ]
+      property :watch_paths, Array
+      property :working_directory, String
     end
   end
 end

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require 'chef/resource'
-require 'chef/provider/launchd'
+require "chef/resource"
+require "chef/provider/launchd"
 
 class Chef
   class Resource
@@ -46,12 +46,12 @@ class Chef
       property :source, String
       property :session_type, String
 
-      property :type, String, default: 'daemon', coerce: proc { |type|
-        type = type ? type.downcase : 'daemon'
-        types = [ 'daemon', 'agent' ]
+      property :type, String, default: "daemon", coerce: proc { |type|
+        type = type ? type.downcase : "daemon"
+        types = %w{daemon agent}
 
         unless types.include?(type)
-          error_msg = 'type must be daemon or agent'
+          error_msg = "type must be daemon or agent"
           raise Chef::Exceptions::ValidationFailed, error_msg
         end
         type

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -230,7 +230,7 @@ class Chef
       def on_demand(arg = nil)
         set_or_return(
           :on_demand, arg,
-          :kind_of => String
+          :kind_of => [TrueClass, FalseClass]
         )
       end
 

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -49,7 +49,7 @@ class Chef
       def source(arg = nil)
         set_or_return(
           :source, arg,
-          :kind_of => [ String, Array ]
+          :kind_of => [String, Array]
         )
       end
 
@@ -77,38 +77,42 @@ class Chef
       def backup(arg=nil)
         set_or_return(
           :backup, arg,
-          :kind_of => [ Integer, FalseClass ]
+          :kind_of => [Integer, FalseClass]
         )
       end
 
       def group(arg = nil)
         set_or_return(
           :group, arg,
-          :kind_of => [ String, Integer ]
+          :kind_of => [String, Integer]
         )
       end
 
       def mode(arg = nil)
         set_or_return(
           :mode, arg,
-          :kind_of => [ String, Integer ]
+          :kind_of => [String, Integer]
         )
       end
 
       def owner(arg = nil)
         set_or_return(
           :owner, arg,
-          :kind_of => [ String, Integer ]
+          :kind_of => [String, Integer]
         )
       end
 
       def type(type = nil)
-        type = type ? type.downcase : nil
+        type = type ? type.downcase : 'daemon'
         if type == 'daemon'
           @path = "/Library/LaunchDaemons/#{name}.plist"
         elsif type == 'agent'
           @path = "/Library/LaunchAgents/#{name}.plist"
+        else
+          error_msg = 'type must be daemon or agent'
+          raise Chef::Exceptions::ValidationFailed, error_msg
         end
+        type
       end
 
       def abandon_process_group(arg = nil)

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -1,0 +1,402 @@
+#
+# Author:: Mike Dodge (<mikedodge04@gmail.com>)
+# Copyright:: Copyright (c) 2015 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider/launchd'
+
+class Chef
+  class Resource
+    class Launchd < Chef::Resource
+      provides :launchd, os: "darwin"
+
+      identity_attr :label
+
+      default_action :create
+      allowed_actions :create, :create_if_missing, :delete, :enable, :disable
+
+      def initialize(name, run_context = nil)
+        super
+        @provider = Chef::Provider::Launchd
+        @resource_name = :launchd
+        @label = name
+        @disabled = false
+        @type = 'daemon'
+        @path = "/Library/LaunchDaemons/#{name}.plist"
+      end
+
+      def label(arg = nil)
+        set_or_return(
+          :label, arg,
+          :kind_of => String
+        )
+      end
+
+      def source(arg = nil)
+        set_or_return(
+          :source, arg,
+          :kind_of => [ String, Array ]
+        )
+      end
+
+      def cookbook(arg = nil)
+        set_or_return(
+          :cookbook, arg,
+          :kind_of => String
+        )
+      end
+
+      def path(arg = nil)
+        set_or_return(
+          :path, arg,
+          :kind_of => String
+        )
+      end
+
+      def hash(arg = nil)
+        set_or_return(
+          :hash, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def backup(arg=nil)
+        set_or_return(
+          :backup, arg,
+          :kind_of => [ Integer, FalseClass ]
+        )
+      end
+
+      def group(arg = nil)
+        set_or_return(
+          :group, arg,
+          :kind_of => [ String, Integer ]
+        )
+      end
+
+      def mode(arg = nil)
+        set_or_return(
+          :mode, arg,
+          :kind_of => [ String, Integer ]
+        )
+      end
+
+      def owner(arg = nil)
+        set_or_return(
+          :owner, arg,
+          :kind_of => [ String, Integer ]
+        )
+      end
+
+      def type(type = nil)
+        type = type ? type.downcase : nil
+        if type == 'daemon'
+          @path = "/Library/LaunchDaemons/#{name}.plist"
+        elsif type == 'agent'
+          @path = "/Library/LaunchAgents/#{name}.plist"
+        end
+      end
+
+      def abandon_process_group(arg = nil)
+        set_or_return(
+          :abandon_process_group, arg,
+          :kind_of => String
+        )
+      end
+
+      def debug(arg = nil)
+        set_or_return(
+          :debug, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def disabled(arg = nil)
+        set_or_return(
+          :disabled, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def enable_globbing(arg = nil)
+        set_or_return(
+          :enable_globbing, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def enable_transactions(arg = nil)
+        set_or_return(
+          :enable_transactions, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def environment_variables(arg = nil)
+        set_or_return(
+          :environment_variables, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def exit_timeout(arg = nil)
+        set_or_return(
+          :exit_timeout, arg,
+          :kind_of => Integer
+        )
+      end
+
+      def hard_resource_limits(arg = nil)
+        set_or_return(
+          :hardre_source_limits, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def keep_alive(arg = nil)
+        set_or_return(
+          :keep_alive, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def launch_only_once(arg = nil)
+        set_or_return(
+          :launch_only_once, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def limit_load_from_hosts(arg = nil)
+        set_or_return(
+          :limit_load_from_hosts, arg,
+          :kind_of => Array
+        )
+      end
+
+      def limit_load_to_hosts(arg = nil)
+        set_or_return(
+          :limit_load_to_hosts, arg,
+          :kind_of => Array
+        )
+      end
+
+      def limit_load_to_session_type(arg = nil)
+        set_or_return(
+          :limit_load_to_session_type, arg,
+          :kind_of => String
+        )
+      end
+
+      def low_priority_io(arg = nil)
+        set_or_return(
+          :low_priority_io, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def mach_services(arg = nil)
+        set_or_return(
+          :mach_services, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def nice(arg = nil)
+        set_or_return(
+          :nice, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def on_demand(arg = nil)
+        set_or_return(
+          :on_demand, arg,
+          :kind_of => String
+        )
+      end
+
+      def username(arg = nil)
+        set_or_return(
+          :username, arg,
+          :kind_of => String
+        )
+      end
+
+      def ld_group(arg = nil)
+        set_or_return(
+          :ld_group, arg,
+          :kind_of => String
+        )
+      end
+
+      def inetd_compatibility(arg = nil)
+        set_or_return(
+          :inetd_compatibility, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def init_groups(arg = nil)
+        set_or_return(
+          :init_groups, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def process_type(arg = nil)
+        set_or_return(
+          :process_type, arg,
+          :kind_of => String
+        )
+      end
+
+      def program(arg = nil)
+        set_or_return(
+          :program, arg,
+          :kind_of => String
+        )
+      end
+
+      def program_arguments(arg = nil)
+        set_or_return(
+          :program_arguments, arg,
+          :kind_of => Array
+        )
+      end
+
+      def queue_directories(arg = nil)
+        set_or_return(
+          :queue_directories, arg,
+          :kind_of => Array
+        )
+      end
+
+      def root_directory(arg = nil)
+        set_or_return(
+          :root_directory, arg,
+          :kind_of => String
+        )
+      end
+
+      def run_at_load(arg = nil)
+        set_or_return(
+          :run_at_load, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def sockets(arg = nil)
+        set_or_return(
+          :sockets, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def soft_resource_limits(arg = nil)
+        set_or_return(
+          :soft_resource_limits, arg,
+          :kind_of => Array
+        )
+      end
+
+      def standard_error_path(arg = nil)
+        set_or_return(
+          :standard_error_path, arg,
+          :kind_of => String
+        )
+      end
+
+      def standard_in_path(arg = nil)
+        set_or_return(
+          :standard_in_path, arg,
+          :kind_of => String
+        )
+      end
+
+      def standard_out_path(arg = nil)
+        set_or_return(
+          :standard_out_path, arg,
+          :kind_of => String
+        )
+      end
+
+      def start_calendar_interval(arg = nil)
+        set_or_return(
+          :start_calendar_interval, arg,
+          :kind_of => Hash
+        )
+      end
+
+      def start_interval(arg = nil)
+        set_or_return(
+          :start_interval, arg,
+          :kind_of => Integer
+        )
+      end
+
+      def start_on_mount(arg = nil)
+        set_or_return(
+          :start_on_mount, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def throttle_interval(arg = nil)
+        set_or_return(
+          :throttle_interval, arg,
+          :kind_of => Integer
+        )
+      end
+
+      def time_out(arg = nil)
+        set_or_return(
+          :time_out, arg,
+          :kind_of => Integer
+        )
+      end
+
+      def umask(arg = nil)
+        set_or_return(
+          :umask, arg,
+          :kind_of => Integer
+        )
+      end
+
+      def wait_for_debugger(arg = nil)
+        set_or_return(
+          :wait_for_debugger, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def watch_paths(arg = nil)
+        set_or_return(
+          :watch_paths, arg,
+          :kind_of => Array
+        )
+      end
+
+      def working_directory(arg = nil)
+        set_or_return(
+          :working_directory, arg,
+          :kind_of => String
+        )
+      end
+    end
+  end
+end

--- a/lib/chef/resources.rb
+++ b/lib/chef/resources.rb
@@ -46,7 +46,7 @@ require "chef/resource/http_request"
 require "chef/resource/homebrew_package"
 require "chef/resource/ifconfig"
 require "chef/resource/ksh"
-require 'chef/resource/launchd'
+require "chef/resource/launchd"
 require "chef/resource/link"
 require "chef/resource/log"
 require "chef/resource/macports_package"

--- a/lib/chef/resources.rb
+++ b/lib/chef/resources.rb
@@ -46,6 +46,7 @@ require "chef/resource/http_request"
 require "chef/resource/homebrew_package"
 require "chef/resource/ifconfig"
 require "chef/resource/ksh"
+require 'chef/resource/launchd'
 require "chef/resource/link"
 require "chef/resource/log"
 require "chef/resource/macports_package"
@@ -85,3 +86,10 @@ require "chef/resource/yum_package"
 require "chef/resource/lwrp_base"
 require "chef/resource/bff_package"
 require "chef/resource/zypper_package"
+
+begin
+  # Optional resources chef_node, chef_client, machine, machine_image, etc.
+  require 'cheffish'
+  require 'chef/provisioning'
+rescue LoadError
+end

--- a/lib/chef/resources.rb
+++ b/lib/chef/resources.rb
@@ -86,10 +86,3 @@ require "chef/resource/yum_package"
 require "chef/resource/lwrp_base"
 require "chef/resource/bff_package"
 require "chef/resource/zypper_package"
-
-begin
-  # Optional resources chef_node, chef_client, machine, machine_image, etc.
-  require 'cheffish'
-  require 'chef/provisioning'
-rescue LoadError
-end

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Chef::Provider::Launchd do
 
@@ -26,9 +26,9 @@ describe Chef::Provider::Launchd do
     let(:run_context) { Chef::RunContext.new(node, {}, events) }
     let(:provider) { Chef::Provider::Launchd.new(new_resource, run_context) }
 
-    let(:label) {'call.mom.weekly'}
-    let(:new_resource) { Chef::Resource::Launchd.new(label)}
-    let!(:current_resource) { Chef::Resource::Launchd.new(label)}
+    let(:label) { "call.mom.weekly" }
+    let(:new_resource) { Chef::Resource::Launchd.new(label) }
+    let!(:current_resource) { Chef::Resource::Launchd.new(label) }
     let(:test_plist) { String.new <<-XML }
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -52,20 +52,20 @@ describe Chef::Provider::Launchd do
 XML
 
     let(:test_hash) do {
-      'Label' => 'call.mom.weekly',
-      'Program' => '/Library/scripts/call_mom.sh',
-      'StartCalendarInterval' => {
-        'Hourly' => 10,
-        'Weekday' => 7,
+      "Label" => "call.mom.weekly",
+      "Program" => "/Library/scripts/call_mom.sh",
+      "StartCalendarInterval" => {
+        "Hourly" => 10,
+        "Weekday" => 7,
       },
-      'TimeOut' => 300
+      "TimeOut" => 300
     } end
 
     before(:each) do
       provider.load_current_resource
     end
 
-    it 'resource name and label should be call.mom.weekly' do
+    it "resource name and label should be call.mom.weekly" do
       expect(new_resource.name).to eql(label)
       expect(new_resource.label).to eql(label)
     end
@@ -78,35 +78,35 @@ XML
       provider.process_resource_requirements
     end
 
-    describe 'with type is set to' do
-      describe 'agent' do
-        it 'path should be /Library/LaunchAgents/call.mom.weekly.plist' do
-          new_resource.type 'agent'
+    describe "with type is set to" do
+      describe "agent" do
+        it "path should be /Library/LaunchAgents/call.mom.weekly.plist" do
+          new_resource.type "agent"
           expect(provider.gen_path_from_type).
-            to eq('/Library/LaunchAgents/call.mom.weekly.plist')
+            to eq("/Library/LaunchAgents/call.mom.weekly.plist")
         end
       end
-      describe 'daemon' do
-        it 'path should be /Library/LaunchDaemons/call.mom.weekly.plist' do
+      describe "daemon" do
+        it "path should be /Library/LaunchDaemons/call.mom.weekly.plist" do
           expect(provider.gen_path_from_type).
-            to eq('/Library/LaunchDaemons/call.mom.weekly.plist')
+            to eq("/Library/LaunchDaemons/call.mom.weekly.plist")
         end
       end
     end
 
-    describe 'with a :create action and' do
-      describe 'program is passed' do
-        it 'should produce the test_plist from properties' do
-          new_resource.program '/Library/scripts/call_mom.sh'
+    describe "with a :create action and" do
+      describe "program is passed" do
+        it "should produce the test_plist from properties" do
+          new_resource.program "/Library/scripts/call_mom.sh"
           new_resource.time_out 300
-          new_resource.start_calendar_interval 'Hourly' => 10, 'Weekday' => 7
+          new_resource.start_calendar_interval "Hourly" => 10, "Weekday" => 7
           expect(provider.content?).to be_truthy
           expect(provider.content).to eql(test_plist)
         end
       end
 
-      describe 'hash is passed' do
-        it 'should produce the test_plist from the hash' do
+      describe "hash is passed" do
+        it "should produce the test_plist from the hash" do
           new_resource.hash test_hash
           expect(provider.content?).to be_truthy
           expect(provider.content).to eql(test_plist)
@@ -114,8 +114,8 @@ XML
       end
     end
 
-    describe 'with an :enable action' do
-      describe 'and the file has been updated' do
+    describe "with an :enable action" do
+      describe "and the file has been updated" do
         before(:each) do
           allow(provider).to receive(
             :manage_plist).with(:create).and_return(true)
@@ -123,17 +123,17 @@ XML
             :manage_service).with(:restart).and_return(true)
         end
 
-        it 'should call manage_service with a :restart action' do
+        it "should call manage_service with a :restart action" do
           expect(provider.manage_service(:restart)).to be_truthy
         end
 
-        it 'works with action enable' do
+        it "works with action enable" do
           expect(run_resource_setup_for_action(:enable)).to be_truthy
           provider.action_enable
         end
       end
 
-      describe 'and the file has not been updated' do
+      describe "and the file has not been updated" do
         before(:each) do
           allow(provider).to receive(
             :manage_plist).with(:create).and_return(nil)
@@ -141,45 +141,45 @@ XML
             :manage_service).with(:enable).and_return(true)
         end
 
-        it 'should call manage_service with a :enable action' do
-         expect(provider.manage_service(:enable)).to be_truthy
+        it "should call manage_service with a :enable action" do
+          expect(provider.manage_service(:enable)).to be_truthy
         end
 
-        it 'works with action enable' do
+        it "works with action enable" do
           expect(run_resource_setup_for_action(:enable)).to be_truthy
           provider.action_enable
         end
       end
     end
 
-    describe 'with an :delete action' do
-      describe 'and the ld file is present' do
+    describe "with an :delete action" do
+      describe "and the ld file is present" do
         before(:each) do
           allow(File).to receive(:exists?).and_return(true)
           allow(provider).to receive(
             :manage_service).with(:disable).and_return(true)
           allow(provider).to receive(
             :manage_plist).with(:delete).and_return(true)
-         end
-
-        it 'should call manage_service with a :disable action' do
-         expect(provider.manage_service(:disable)).to be_truthy
         end
 
-        it 'works with action :delete' do
+        it "should call manage_service with a :disable action" do
+          expect(provider.manage_service(:disable)).to be_truthy
+        end
+
+        it "works with action :delete" do
           expect(run_resource_setup_for_action(:delete)).to be_truthy
           provider.action_delete
         end
       end
 
-      describe 'and the ld file is not present' do
+      describe "and the ld file is not present" do
         before(:each) do
           allow(File).to receive(:exists?).and_return(false)
           allow(provider).to receive(
             :manage_plist).with(:delete).and_return(true)
-         end
+        end
 
-        it 'works with action :delete' do
+        it "works with action :delete" do
           expect(run_resource_setup_for_action(:delete)).to be_truthy
           provider.action_delete
         end

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -70,11 +70,6 @@ XML
       expect(new_resource.label).to eql(label)
     end
 
-    it 'path should be /Library/LaunchDaemons/call.mom.weekly.plist' do
-      expect(new_resource.path).
-        to eq('/Library/LaunchDaemons/call.mom.weekly.plist')
-    end
-
     def run_resource_setup_for_action(action)
       new_resource.action(action)
       provider.action = action
@@ -87,8 +82,14 @@ XML
       describe 'agent' do
         it 'path should be /Library/LaunchAgents/call.mom.weekly.plist' do
           new_resource.type 'agent'
-          expect(new_resource.path).
+          expect(provider.gen_path_from_type).
             to eq('/Library/LaunchAgents/call.mom.weekly.plist')
+        end
+      end
+      describe 'daemon' do
+        it 'path should be /Library/LaunchDaemons/call.mom.weekly.plist' do
+          expect(provider.gen_path_from_type).
+            to eq('/Library/LaunchDaemons/call.mom.weekly.plist')
         end
       end
     end
@@ -99,14 +100,16 @@ XML
           new_resource.program '/Library/scripts/call_mom.sh'
           new_resource.time_out 300
           new_resource.start_calendar_interval 'Hourly' => 10, 'Weekday' => 7
-          expect(provider.content?).to eql(test_plist)
+          expect(provider.content?).to be_truthy
+          expect(provider.content).to eql(test_plist)
         end
       end
 
       describe 'hash is passed' do
         it 'should produce the test_plist from the hash' do
           new_resource.hash test_hash
-          expect(provider.content?).to eql(test_plist)
+          expect(provider.content?).to be_truthy
+          expect(provider.content).to eql(test_plist)
         end
       end
     end

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -1,0 +1,186 @@
+#
+# Author:: Mike Dodge (<mikedodge04@gmail.com>)
+# Copyright:: Copyright (c) 2015 Facebook, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Provider::Launchd do
+
+  context "When launchd manages call.mom.weekly" do
+    let(:node) { Chef::Node.new }
+    let(:events) { Chef::EventDispatch::Dispatcher.new }
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:provider) { Chef::Provider::Launchd.new(new_resource, run_context) }
+
+    let(:label) {'call.mom.weekly'}
+    let(:new_resource) { Chef::Resource::Launchd.new(label)}
+    let!(:current_resource) { Chef::Resource::Launchd.new(label)}
+    let(:test_plist) { String.new <<-XML }
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>Label</key>
+\t<string>call.mom.weekly</string>
+\t<key>Program</key>
+\t<string>/Library/scripts/call_mom.sh</string>
+\t<key>StartCalendarInterval</key>
+\t<dict>
+\t\t<key>Hourly</key>
+\t\t<integer>10</integer>
+\t\t<key>Weekday</key>
+\t\t<integer>7</integer>
+\t</dict>
+\t<key>TimeOut</key>
+\t<integer>300</integer>
+</dict>
+</plist>
+XML
+
+    let(:test_hash) do {
+      'Label' => 'call.mom.weekly',
+      'Program' => '/Library/scripts/call_mom.sh',
+      'StartCalendarInterval' => {
+        'Hourly' => 10,
+        'Weekday' => 7,
+      },
+      'TimeOut' => 300
+    } end
+
+    before(:each) do
+      provider.load_current_resource
+    end
+
+    it 'resource name and label should be call.mom.weekly' do
+      expect(new_resource.name).to eql(label)
+      expect(new_resource.label).to eql(label)
+    end
+
+    it 'path should be /Library/LaunchDaemons/call.mom.weekly.plist' do
+      expect(new_resource.path).
+        to eq('/Library/LaunchDaemons/call.mom.weekly.plist')
+    end
+
+    def run_resource_setup_for_action(action)
+      new_resource.action(action)
+      provider.action = action
+      provider.load_current_resource
+      provider.define_resource_requirements
+      provider.process_resource_requirements
+    end
+
+    describe 'with type is set to' do
+      describe 'agent' do
+        it 'path should be /Library/LaunchAgents/call.mom.weekly.plist' do
+          new_resource.type 'agent'
+          expect(new_resource.path).
+            to eq('/Library/LaunchAgents/call.mom.weekly.plist')
+        end
+      end
+    end
+
+    describe 'with a :create action and' do
+      describe 'program is passed' do
+        it 'should produce the test_plist from properties' do
+          new_resource.program '/Library/scripts/call_mom.sh'
+          new_resource.time_out 300
+          new_resource.start_calendar_interval 'Hourly' => 10, 'Weekday' => 7
+          expect(provider.content?).to eql(test_plist)
+        end
+      end
+
+      describe 'hash is passed' do
+        it 'should produce the test_plist from the hash' do
+          new_resource.hash test_hash
+          expect(provider.content?).to eql(test_plist)
+        end
+      end
+    end
+
+    describe 'with an :enable action' do
+      describe 'and the file has been updated' do
+        before(:each) do
+          allow(provider).to receive(
+            :manage_plist).with(:create).and_return(true)
+          allow(provider).to receive(
+            :manage_service).with(:restart).and_return(true)
+        end
+
+        it 'should call manage_service with a :restart action' do
+          expect(provider.manage_service(:restart)).to be_truthy
+        end
+
+        it 'works with action enable' do
+          expect(run_resource_setup_for_action(:enable)).to be_truthy
+          provider.action_enable
+        end
+      end
+
+      describe 'and the file has not been updated' do
+        before(:each) do
+          allow(provider).to receive(
+            :manage_plist).with(:create).and_return(nil)
+          allow(provider).to receive(
+            :manage_service).with(:enable).and_return(true)
+        end
+
+        it 'should call manage_service with a :enable action' do
+         expect(provider.manage_service(:enable)).to be_truthy
+        end
+
+        it 'works with action enable' do
+          expect(run_resource_setup_for_action(:enable)).to be_truthy
+          provider.action_enable
+        end
+      end
+    end
+
+    describe 'with an :delete action' do
+      describe 'and the ld file is present' do
+        before(:each) do
+          allow(File).to receive(:exists?).and_return(true)
+          allow(provider).to receive(
+            :manage_service).with(:disable).and_return(true)
+          allow(provider).to receive(
+            :manage_plist).with(:delete).and_return(true)
+         end
+
+        it 'should call manage_service with a :disable action' do
+         expect(provider.manage_service(:disable)).to be_truthy
+        end
+
+        it 'works with action :delete' do
+          expect(run_resource_setup_for_action(:delete)).to be_truthy
+          provider.action_delete
+        end
+      end
+
+      describe 'and the ld file is not present' do
+        before(:each) do
+          allow(File).to receive(:exists?).and_return(false)
+          allow(provider).to receive(
+            :manage_plist).with(:delete).and_return(true)
+         end
+
+        it 'works with action :delete' do
+          expect(run_resource_setup_for_action(:delete)).to be_truthy
+          provider.action_delete
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -1,11 +1,11 @@
 #
 
-require 'spec_helper'
+require "spec_helper"
 
 describe Chef::Resource::Launchd do
-  @launchd = Chef::Resource::Launchd.new('io.chef.chef-client')
+  @launchd = Chef::Resource::Launchd.new("io.chef.chef-client")
   let(:resource) { Chef::Resource::Launchd.new(
-    'io.chef.chef-client',
+    "io.chef.chef-client",
     run_context
   )}
 
@@ -23,10 +23,9 @@ describe Chef::Resource::Launchd do
   end
 
   it "should accept enable, disable, create, and delete as actions" do
-    expect { resource.action :enable}.not_to raise_error
-    expect { resource.action :disable}.not_to raise_error
-    expect { resource.action :create}.not_to raise_error
-    expect { resource.action :delete}.not_to raise_error
+    expect { resource.action :enable }.not_to raise_error
+    expect { resource.action :disable }.not_to raise_error
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
   end
 end
-

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -1,0 +1,32 @@
+#
+
+require 'spec_helper'
+
+describe Chef::Resource::Launchd do
+  @launchd = Chef::Resource::Launchd.new('io.chef.chef-client')
+  let(:resource) { Chef::Resource::Launchd.new(
+    'io.chef.chef-client',
+    run_context
+  )}
+
+  it "should create a new Chef::Resource::Launchd" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Launchd)
+  end
+
+  it "should have a resource name of Launchd" do
+    expect(resource.resource_name).to eql(:launchd)
+  end
+
+  it "should have a default action of create" do
+    expect(resource.action).to eql([:create])
+  end
+
+  it "should accept enable, disable, create, and delete as actions" do
+    expect { resource.action :enable}.not_to raise_error
+    expect { resource.action :disable}.not_to raise_error
+    expect { resource.action :create}.not_to raise_error
+    expect { resource.action :delete}.not_to raise_error
+  end
+end
+


### PR DESCRIPTION
@jaymzh will merge under his CCLA once it's passed review by @chef / @client-core

### launchd
This resource installs/removes Launch Daemons and Agents

#### Actions
- :create
- :create_if_missing
- :delete

#### Parameter attributes:
- `label` - This required key uniquely identifies the job to launchd.
- `path` - This is used as an override. By default the provider will generate a
path for you based on service_type. Default: /Library/LaunchDaemons/#{label}
- `hash` - key, value pairs to create launchd plist.
- `source` - Source path to launchd plist.
- `cookbook` - Cookbook which source file exists. Default: current cookbook
- `service_type` - is the type of launchd plist you would like to create.
Options are [system, user], System with create LaunchDaemon, and User will
create a LaunchAgent. Default: system

##### Apple Params
These parameters are Apples keys/values that you can add to a launch daemon or
agent. For more details see:

https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/launchd.plist.5.html#//apple_ref/doc/man/5/launchd.plist

- `program` - This key maps to the first argument of execvp(3). If this key is
missing, then the first element of the array of strings provided to the
ProgramArguments will be used instead. This key is required in the absence of
the ProgramArguments key.
- `program_arguments` - This key maps to the second argument of execvp. This key
is required in the absence of the Program key. Please note: many people are
confused by this key. Please read execvp very carefully!
- `abandon_process_group` - When a job dies, launchd kills any remaining
processes with the same process group ID as the job. Set-ting Setting ting
this key to true disables that behavior.
- `debug` - This optional key specifies that launchd should adjust its log mask
temporarily to LOG_DEBUG while dealing with this job.
- `disabled` - This optional key is used as a hint to launchctl(1) that it
should not submit this job to launchd when loading a job or jobs.
- `enable_globbing` - This flag causes launchd to use the glob(3) mechanism to
update the program arguments before invocation.
- `enable_transactions` - This flag instructs launchd that the job promises to
use vproc_transaction_begin(3) and vproc_transaction_end(3) to track
outstanding transactions that need to be reconciled before the process can
safely terminate. If no outstanding transactions are in progress, then launchd
is free to send the SIGKILL signal.
- `environment_variables` - This optional key is used to specify additional
environmental variables to be set before running the job.
- `exit_timeout` - The amount of time launchd waits before sending a SIGKILL
signal. The default value is 20 seconds. The value zero is interpreted as
infinity.
- `group` - This optional key specifies the group to run the job as. This key is
only applicable when launchd is running as root. If UserName is set and
GroupName is not, the the group will be set to the default group of the user.
- `hard_resource_limits` - Resource limits to be imposed on the job. These
adjust variables set with setrlimit(2).
- `inetd_compatibility` - The presence of this key specifies that the daemon
expects to be run as if it were launched from inetd.
- `init_groups` - This optional key specifies whether initgroups(3) should be
called before running the job. The default is true in 10.5 and false in 10.4.
- `keep_alive` - This optional key is used to control whether your job is to be
kept continuously running or to let demand and conditions control the
invocation.
- `launch_only_once` - This optional key specifies whether the job can only be
run once and only once. In other words, if the job cannot be safely respawned
without a full machine reboot, then set this key to be true.
- `limit_load_from_hosts` - This configuration file only applies to hosts NOT
listed with this key
- `limit_load_to_hosts` - This configuration file only applies to the hosts
listed with this key
- `limit_load_to_session_type` - This configuration file only applies to
sessions of the type specified
- `low_priority_io` - This optional key specifies whether the kernel should
consider this daemon to be low priority when doing file system I/O.
- `mach_services` - This optional key is used to specify Mach services to be
registered with the Mach bootstrap sub-system.
- `nice` - This optional key specifies what nice(3) value should be applied to
the daemon.
- `on_demand` - This key was used in Mac OS X 10.4 to control whether a job was
kept alive or not.
- `process_type` - This optional key describes, at a high level, the intended
purpose of the job. The system will apply resource limits based on what kind
of job it is. [Background, Standard, Adaptive, Interactive]
- `queue_directories` - Much like the WatchPaths option, this key will watch the
paths for modifications. The difference being that the job will only be
started if the path is a directory and the directory is not empty.
- `root_directory` - This optional key is used to specify a directory to
chroot(2) to before running the job.
- `run_at_load` - This optional key is used to control whether your job is
launched once at the time the job is loaded. The default is false.
- `sockets` - This optional key is used to specify launch on demand sockets that
can be used to let launchd know when to run the job.
- `soft_resource_limits` - Resource limits to be imposed on the job. These
adjust variables set with setrlimit(2).
- `standard_error_path` - This optional key specifies what file should be used
for data being sent to stderr when using stdio(3).
- `standard_in_path` - This optional key specifies what file should be used for
data being supplied to stdin when using stdio(3).
- `standard_out_path` - This optional key specifies what file should be used for
data being sent to stdout when using stdio(3).
- `start_calendar_interval` - This optional key causes the job to be started
every calendar interval as specified.
- `start_interval` - This optional key causes the job to be started every N
seconds.
- `start_on_mount` - This optional key causes the job to be started every time a
filesystem is mounted.
- `throttle_interval` - This key lets one override the default throttling policy
imposed on jobs by launchd. The value is in seconds, and by default, jobs will
not be spawned more than once every 10 seconds.
- `time_out` - The recommended idle time out (in seconds) to pass to the job. If
no value is specified, a default time out will be supplied by launchd for use
by the job at check in time.
- `umask` - This optional key specifies what value should be passed to umask(2)
before running the job.
- `username` - This optional key specifies the user to run the job as. This key
is only applicable when launchd is running as root.
- `wait_for_debugger` - This optional key specifies that launchd should instruct
the kernel to have the job wait for a debugger to attach before any code in
the job is executed.
- `watch_paths` - This optional key causes the job to be started if any one of
the listed paths are modified.
- `working_directory` - This optional key is used to specify a directory to
chdir(2) to before running the job.

#### Examples
Create a LaunchDaemon from cookbook file
```
launchd 'com.chef.every15' do
  source 'com.chef.every15.plist'
end
```

Create a LaunchDaemon using keys
```
launchd 'call.mom.weekly' do
  program '/Library/scripts/call_mom.sh'
  start_calendar_interval 'Weekday' => 7, 'Hourly' => 10
  time_out 300
end
```

Remove LaunchDaemon
```
launchd 'com.chef.every15' do
  action :delete
end

```