### PR TITLE
Update knife bootstrap command to honor --no-color flag in chef-client run that is part of the bootstrap process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [pr#4021](https://github.com/chef/chef/pull/4021) add missing requires for Chef::DSL::Recipe to LWRPBase
 * [pr#3597](https://github.com/chef/chef/pull/3597) print STDOUT from the powershell_script
 * [pr#4091](https://github.com/chef/chef/pull/4091) Allow downloading of root_files in a chef repository
+* [pr#4112](https://github.com/chef/chef/pull/4112) Update knife bootstrap command to honor --no-color flag in chef-client run that is part of the bootstrap process.
 
 ## 12.5.1
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -129,6 +129,7 @@ CONFIG
           s = "#{client_path} -j /etc/chef/first-boot.json"
           s << ' -l debug' if @config[:verbosity] and @config[:verbosity] >= 2
           s << " -E #{bootstrap_environment}" unless bootstrap_environment.nil?
+          s << " --no-color" unless @config[:color]
           s
         end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -39,13 +39,20 @@ describe Chef::Knife::Core::BootstrapContext do
   end
 
   it "runs chef with the first-boot.json with no environment specified" do
-    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
+    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json --no-color"
   end
 
   describe "when in verbosity mode" do
     let(:config) { {:verbosity => 2} }
     it "adds '-l debug' when verbosity is >= 2" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug"
+      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug --no-color"
+    end
+  end
+
+  describe "when in color is true" do
+    let(:config) { {:color => true} }
+    it "removes '--no-color' when color is true" do
+      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
     end
   end
 
@@ -70,7 +77,7 @@ EXPECTED
   describe "alternate chef-client path" do
     let(:chef_config){ {:chef_client_path => '/usr/local/bin/chef-client'} }
     it "runs chef-client from another path when specified" do
-      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json"
+      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json --no-color"
     end
   end
 
@@ -93,7 +100,7 @@ EXPECTED
   describe "when bootstrapping into a specific environment" do
     let(:config){ {:environment => "prodtastic"} }
     it "starts chef in the configured environment" do
-      expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E prodtastic')
+      expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E prodtastic --no-color')
     end
   end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 require 'chef/knife/core/bootstrap_context'
 
 describe Chef::Knife::Core::BootstrapContext do
-  let(:config) { {:foo => :bar} }
+  let(:config) { {:foo => :bar, :color => true} }
   let(:run_list) { Chef::RunList.new('recipe[tmux]', 'role[base]') }
   let(:chef_config) do
     {
@@ -39,20 +39,20 @@ describe Chef::Knife::Core::BootstrapContext do
   end
 
   it "runs chef with the first-boot.json with no environment specified" do
-    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json --no-color"
+    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
   end
 
   describe "when in verbosity mode" do
-    let(:config) { {:verbosity => 2} }
+    let(:config) { {:verbosity => 2, :color => true} }
     it "adds '-l debug' when verbosity is >= 2" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug --no-color"
+      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug"
     end
   end
 
-  describe "when in color is true" do
-    let(:config) { {:color => true} }
-    it "removes '--no-color' when color is true" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
+  describe "when no color value has been set in config" do
+    let(:config) { {:color => false } }
+    it "adds '--no-color' when color is false" do
+      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json --no-color"
     end
   end
 
@@ -77,7 +77,7 @@ EXPECTED
   describe "alternate chef-client path" do
     let(:chef_config){ {:chef_client_path => '/usr/local/bin/chef-client'} }
     it "runs chef-client from another path when specified" do
-      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json --no-color"
+      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json"
     end
   end
 
@@ -98,9 +98,9 @@ EXPECTED
   end
 
   describe "when bootstrapping into a specific environment" do
-    let(:config){ {:environment => "prodtastic"} }
+    let(:config){ {:environment => "prodtastic", :color => true} }
     it "starts chef in the configured environment" do
-      expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E prodtastic --no-color')
+      expect(bootstrap_context.start_chef).to eq('chef-client -j /etc/chef/first-boot.json -E prodtastic')
     end
   end
 


### PR DESCRIPTION
A customer noticed this issue when using `knife bootstrap` with vCO and the color bits messing up the logging of the chef-client's output.

@btm suggested the line to add in `bootstrap_context.rb`.  I updated some existing tests to pass and added a new one "when color is true".

Submitting PR for merge.