### PR TITLE
Make Property.derive create derived properties of the same type

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -431,7 +431,7 @@ class Chef
          modified_options.has_key?(:default)
         options = options.reject { |k,v| k == :name_attribute || k == :name_property || k == :default }
       end
-      Property.new(options.merge(modified_options))
+      self.class.new(options.merge(modified_options))
     end
 
     #


### PR DESCRIPTION
The scenario: I'd like to use a custom property type so I can override `emit_dsl` and make the property's method a little different. But Property.derive doesn't retain the class by default--it just creates a Property, losing the class information.