### PR TITLE
lazy the socketless require in Chef::HTTP

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -5,7 +5,7 @@
 # Author:: Christopher Brown (<cb@opscode.com>)
 # Author:: Christopher Walters (<cw@opscode.com>)
 # Author:: Daniel DeLeo (<dan@opscode.com>)
-# Copyright:: Copyright (c) 2009, 2010, 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2009, 2010, 2013-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ require 'tempfile'
 require 'net/https'
 require 'uri'
 require 'chef/http/basic_client'
-require 'chef/http/socketless_chef_zero_client'
 require 'chef/monkey_patches/net_http'
 require 'chef/config'
 require 'chef/platform/query_helpers'
@@ -198,6 +197,9 @@ class Chef
     def http_client(base_url=nil)
       base_url ||= url
       if chef_zero_uri?(base_url)
+        # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up all of
+        # chef-zero and webrick when we mostly never want to or have to
+        require 'chef/http/socketless_chef_zero_client'
         SocketlessChefZeroClient.new(base_url)
       else
         BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -197,8 +197,9 @@ class Chef
     def http_client(base_url=nil)
       base_url ||= url
       if chef_zero_uri?(base_url)
-        # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up all of
-        # chef-zero and webrick when we mostly never want to or have to
+        # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
+        # via chef-zero and that hits DNS (at *require* time) which may timeout,
+        # when for most knife/chef-client work we never need/want this loaded.
         require 'chef/http/socketless_chef_zero_client'
         SocketlessChefZeroClient.new(base_url)
       else

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -200,7 +200,11 @@ class Chef
         # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
         # via chef-zero and that hits DNS (at *require* time) which may timeout,
         # when for most knife/chef-client work we never need/want this loaded.
-        require 'chef/http/socketless_chef_zero_client'
+        Thread.exclusive {
+          unless defined?(SocketlessChefZeroClient)
+            require 'chef/http/socketless_chef_zero_client'
+          end
+        }
         SocketlessChefZeroClient.new(base_url)
       else
         BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)


### PR DESCRIPTION
if this is always required then everything that uses Chef::HTTP will
load up chef-zero which will load up Webrick, which does DNS lookups
of the current host which causes a DNS lookup and possible timeout.

it also likely isn't doing pretty things to chef-client memory usage
and load times there as well.