### PR TITLE
SSL and Connection Reset Error Retries

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -330,7 +330,7 @@ class Chef
         end
         raise Timeout::Error, "Timeout connecting to #{url}, giving up"
       rescue OpenSSL::SSL::SSLError => e
-        if http_retry_count - http_attempts + 1 > 0
+        if (http_retry_count - http_attempts + 1 > 0) && !e.message.include?("certificate verify failed")
           Chef::Log.error("SSL Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -329,13 +329,13 @@ class Chef
           retry
         end
         raise Timeout::Error, "Timeout connecting to #{url}, giving up"
-      rescue OpenSSL::SSL::SSLError
+      rescue OpenSSL::SSL::SSLError => e
         if http_retry_count - http_attempts + 1 > 0
           Chef::Log.error("SSL Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)
           retry
         end
-        raise Timeout::Error, "SSL Error connecting to #{url}, giving up"
+        raise OpenSSL::SSL::SSLError, "SSL Error connecting to #{url} - #{e.message}"
       end
     end
 

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -329,6 +329,13 @@ class Chef
           retry
         end
         raise Timeout::Error, "Timeout connecting to #{url}, giving up"
+      rescue OpenSSL::SSL::SSLError
+        if http_retry_count - http_attempts + 1 > 0
+          Chef::Log.error("SSL Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
+          sleep(http_retry_delay)
+          retry
+        end
+        raise Timeout::Error, "SSL Error connecting to #{url}, giving up"
       end
     end
 

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -307,7 +307,7 @@ class Chef
           end
           return [response, request, return_value]
         end
-      rescue SocketError, Errno::ETIMEDOUT => e
+      rescue SocketError, Errno::ETIMEDOUT, Errno::ECONNRESET => e
         if http_retry_count - http_attempts + 1 > 0
           Chef::Log.error("Error connecting to #{url}, retry #{http_attempts}/#{http_retry_count}")
           sleep(http_retry_delay)


### PR DESCRIPTION
Includes https://github.com/chef/chef/pull/3444 and fixes pull request comments, adds retries for connection resets, and adds tests for retries for the Chef::HTTP base class.

@chef/client-core 