### PR TITLE
windows service uses log file location from config if none is given on commandline

### DIFF
--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Copyright:: Copyright (c) 2011 Opscode, Inc.
+# Copyright:: Copyright (c) 2011-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,8 +51,7 @@ class Chef
       option :log_location,
         :short        => "-L LOGLOCATION",
         :long         => "--logfile LOGLOCATION",
-        :description  => "Set the log file location for chef-service",
-        :default => "#{ENV['SYSTEMDRIVE']}/chef/client.log"
+        :description  => "Set the log file location for chef-service"
 
       option :help,
         :short        => "-h",

--- a/spec/unit/windows_service_spec.rb
+++ b/spec/unit/windows_service_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,59 +21,95 @@ if Chef::Platform.windows?
 end
 
 describe "Chef::Application::WindowsService", :windows_only do
-  let (:instance) {Chef::Application::WindowsService.new}
-  let (:shell_out_result) {Object.new}
-  let (:tempfile) {Tempfile.new "log_file"}
-  before do
-    allow(instance).to receive(:parse_options)
-    allow(shell_out_result).to receive(:stdout)
-    allow(shell_out_result).to receive(:stderr)
+  let(:shell_out_result) { double('shellout', stdout: nil, stderr: nil) }
+  let(:config_options) do
+    {
+      config_file: "test_config_file",
+      log_level: :info
+    }
   end
-  it "runs chef-client in new process" do
-    expect(instance).to receive(:configure_chef).twice
-    instance.service_init
-    expect(instance).to receive(:run_chef_client).and_call_original
-    expect(instance).to receive(:shell_out).and_return(shell_out_result)
-    allow(instance).to receive(:running?).and_return(true, false)
-    allow(instance.instance_variable_get(:@service_signal)).to receive(:wait)
-    allow(instance).to receive(:state).and_return(4)
-    instance.service_main
+  let(:timeout) { 7200 }
+  let(:shellout_options) do
+    {
+      :timeout => timeout,
+      :logger => Chef::Log
+    }
   end
 
-  context 'when running chef-client' do
-    it "passes config params to new process with a default timeout of 2 hours (7200 seconds)" do
-      Chef::Config.merge!({:log_location => tempfile.path, :config_file => "test_config_file", :log_level => :info})
-      expect(instance).to receive(:configure_chef).twice
-      instance.service_init
-      allow(instance).to receive(:running?).and_return(true, false)
-      allow(instance.instance_variable_get(:@service_signal)).to receive(:wait)
-      allow(instance).to receive(:state).and_return(4)
-      expect(instance).to receive(:run_chef_client).and_call_original
-      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}",
-        {
-          :timeout => 7200,
-          :logger => Chef::Log
-        }).and_return(shell_out_result)
-      instance.service_main
+  before do
+    Chef::Config.merge!(config_options)
+    allow(subject).to receive(:configure_chef)
+    allow(subject).to receive(:parse_options)
+    allow(MonoLogger).to receive(:new)
+    allow(subject).to receive(:running?).and_return(true, false)
+    allow(subject).to receive(:state).and_return(4)
+    subject.service_init
+  end
+
+  subject { Chef::Application::WindowsService.new }
+
+  it "passes config params to new process with default options" do
+    expect(subject).to receive(:shell_out).with(
+      "chef-client  --no-fork -c test_config_file -L #{Chef::Application::WindowsService::DEFAULT_LOG_LOCATION}",
+      shellout_options
+    ).and_return(shell_out_result)
+    subject.service_main
+  end
+
+  context 'has a log location configured' do
+    let(:tempfile) { Tempfile.new 'log_file' }
+    let(:config_options) do
+      {
+        log_location: tempfile.path,
+        config_file: "test_config_file",
+        log_level: :info
+      }
+    end
+
+    after do
       tempfile.unlink
     end
 
-    it "passes config params to new process with a the timeout specified in the config" do
-      Chef::Config.merge!({:log_location => tempfile.path, :config_file => "test_config_file", :log_level => :info})
-      Chef::Config[:windows_service][:watchdog_timeout] = 10
-      expect(instance).to receive(:configure_chef).twice
-      instance.service_init
-      allow(instance).to receive(:running?).and_return(true, false)
-      allow(instance.instance_variable_get(:@service_signal)).to receive(:wait)
-      allow(instance).to receive(:state).and_return(4)
-      expect(instance).to receive(:run_chef_client).and_call_original
-      expect(instance).to receive(:shell_out).with("chef-client  --no-fork -c test_config_file -L #{tempfile.path}",
+    it "uses the configured log location" do
+      expect(subject).to receive(:shell_out).with(
+        "chef-client  --no-fork -c test_config_file -L #{tempfile.path}",
+        shellout_options
+      ).and_return(shell_out_result)
+      subject.service_main
+    end
+
+    context 'configured to STDOUT' do
+      let(:config_options) do
         {
-          :timeout => 10,
-          :logger => Chef::Log
-        }).and_return(shell_out_result)
-      instance.service_main
-      tempfile.unlink
+          log_location: STDOUT,
+          config_file: "test_config_file",
+          log_level: :info
+        }
+      end
+
+      it "does not pass log location to new process" do
+        expect(subject).to receive(:shell_out).with(
+          "chef-client  --no-fork -c test_config_file",
+          shellout_options
+        ).and_return(shell_out_result)
+        subject.service_main
+      end
+    end
+  end
+
+  context 'configueres a watchdog timeout' do
+    let(:timeout) { 10 }
+
+    before do
+      Chef::Config[:windows_service][:watchdog_timeout] = 10
+    end
+
+    it "passes watchdog timeout to new process" do
+      expect(subject).to receive(:shell_out).with(
+        "chef-client  --no-fork -c test_config_file -L #{Chef::Application::WindowsService::DEFAULT_LOG_LOCATION}",
+        shellout_options
+      ).and_return(shell_out_result)
+      subject.service_main
     end
   end
 end


### PR DESCRIPTION
Currently the windows service manager passes a log_location to the windows service at startup. Once the service is installed, this lof_location cannot be changed and overrides any log_location set in the client.rb. This PR allows a windows service to be installed with no log_location passed to the windows service. In such a case, the service will always use what is in the client.rb or the typical default path if none is configured.