### PR TITLE
Minor tree cleanup I noticed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ tags
 
 # you should check in your Gemfile.lock in applications, and not in gems
 external_tests/*.lock
-Gemfile.lock
+*.lock
 Gemfile.local
 
 # Do not check in the .bundle directory, or any of the files inside it. Those files are specific to each particular machine, and are used to persist installation options between runs of the bundle install command.

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -102,10 +102,6 @@ class Chef
           run_context ? run_context.node : nil
         end
 
-        def lazy(&block)
-          DelayedEvaluator.new(&block)
-        end
-
         protected
 
         def loaded_lwrps


### PR DESCRIPTION
- add pedant.gemfile.lock to .gitignore
- remove redundant `def lazy` from LWRPBase now that Chef::Resource implements it