### PR TITLE
Add APIv1 support to the update method of Chef::ApiClient::Registration

### DIFF
--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -97,12 +97,21 @@ class Chef
       end
 
       def update
+        # Try with the v0 API
         response = http_api.put("clients/#{name}", put_data)
         if response.respond_to?(:private_key) # Chef 11
           @server_generated_private_key = response.private_key
         else # Chef 10
           @server_generated_private_key = response["private_key"]
         end
+        # If it fails and we receive a 400 stating to use the keys endpoint
+        # then, let's use it.
+        rescue Net::HTTPServerException => e
+          if e.response.code == '400' && e.response.body == '{"error":["Since Server API v1, all keys must be updated via the keys endpoint. "]}'
+                response = http_api.put("clients/#{name}/keys/default", { :name => 'default', :admin => false, :public_key => generated_public_key })
+          else
+                raise
+          end
         response
       end
 

--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -108,9 +108,9 @@ class Chef
         # then, let's use it.
         rescue Net::HTTPServerException => e
           if e.response.code == '400' && e.response.body == '{"error":["Since Server API v1, all keys must be updated via the keys endpoint. "]}'
-                response = http_api.put("clients/#{name}/keys/default", { :name => 'default', :admin => false, :public_key => generated_public_key })
+            response = http_api.put("clients/#{name}/keys/default", { :name => 'default', :admin => false, :public_key => generated_public_key })
           else
-                raise
+            raise
           end
         response
       end

--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -104,6 +104,7 @@ class Chef
         else # Chef 10
           @server_generated_private_key = response["private_key"]
         end
+        response
         # If it fails and we receive a 400 stating to use the keys endpoint
         # then, let's use it.
         rescue Net::HTTPServerException => e
@@ -112,7 +113,6 @@ class Chef
           else
             raise
           end
-        response
       end
 
       def put_data


### PR DESCRIPTION
Fixing issue #4139 

This fix will work; However, at some point we should likely rewrite the Registration class to check for API version first, then fork required logic based on API version instead of the less efficient practice of throwing extra requests at chef-server to determine the version. 

Whether we want to action that now or merge this to fix the immediate issue and revisit later is a point for discussion.