### PR TITLE
Use the proper python interpretor for yum-dump.py on Fedora 21+

### DIFF
--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -1844,6 +1844,12 @@ EOF
       expect(@yc.python_bin).to eq("/usr/bin/python")
     end
 
+    it "should return /usr/bin/python if the interpreter is /bin/bash" do
+      other = StringIO.new("#!/bin/bash\n# The yum executable redirecting to dnf from dnf-yum compatible package.")
+      allow(::File).to receive(:open).with("/usr/bin/yum", "r") { |&b| r = b.call(other); other.rewind; r}
+      expect(@yc.python_bin).to eq("/usr/bin/python")
+    end
+
     it "should return the interpreter for yum" do
       other = StringIO.new("#!/usr/bin/super_python\n\nlasjdfdsaljf\nlasdjfs")
       allow(::File).to receive(:open).with("/usr/bin/yum", "r") { |&b| r = b.call(other); other.rewind; r}


### PR DESCRIPTION
Fedora 21+ use dnf as the primary package manager.  Lamont added code in
12.5 to allow for a yum compat mode. This doesn't entirely work though
as we need yum-dump.py to correctly run.  We were parsing the shabang in
the yum binary to find the path to python.  On a dnf system the yum
binary is a bash script though so we were trying to run yum-dump.py
using bash which obviously fails.  I added a fallback method to use
python if the shebang parsing returns bash. With this in place AND the
yum package installed you can use the package resource on Fedora.


Before this patch:

Before:

          ================================================================================
           Error executing action `install` on resource 'yum_package[java-1.8.0-openjdk]'
           ================================================================================

           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '2'
           ---- Begin output of /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 ----
           STDOUT:
           STDERR: /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 33: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 34: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 35: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 36: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 37: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 38: import: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 40: from: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 41: from: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 42: from: command not found
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 46: syntax error near unexpected token `('
           /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 46: `YUM_VER = version.StrictVersion(yum.__version__)'
           ---- End output of /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 ----
           Ran /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 returned 2

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/java/recipes/openjdk.rb

            46:   package pkg do
            47:     version node['java']['openjdk_version'] if node['java']['openjdk_version']

            49: end

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/java/recipes/openjdk.rb:46:in `block in from_file'

           yum_package("java-1.8.0-openjdk") do
             action [:install]
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             package_name "java-1.8.0-openjdk"
             flush_cache {:before=>false, :after=>false}
             declared_type :package
             cookbook_name "java"
             recipe_name "openjdk"



       Running handlers:
       [2015-11-05T17:38:34+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2015-11-05T17:38:34+00:00] ERROR: Exception handlers complete
       Chef Client failed. 0 resources updated in 01 seconds
       [2015-11-05T17:38:34+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2015-11-05T17:38:34+00:00] ERROR: yum_package[java-1.8.0-openjdk] (java::openjdk line 46) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '2'
       ---- Begin output of /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 ----
       STDOUT:
       STDERR: /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 33: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 34: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 35: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 36: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 37: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 38: import: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 40: from: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 41: from: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 42: from: command not found
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 46: syntax error near unexpected token `('
       /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py: line 46: `YUM_VER = version.StrictVersion(yum.__version__)'
       ---- End output of /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 ----
       Ran /bin/bash  /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib/chef/provider/package/yum-dump.py --options --installed-provides --yum-lock-timeout 30 returned 2
       [2015-11-05T17:38:35+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)



After this patch:

       Recipe: java::openjdk
         * yum_package[java-1.8.0-openjdk] action install
           - install version 1.8.0.65-3.b17.fc22 of package java-1.8.0-openjdk