### PR TITLE
Handle nil run list option in knife bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -455,7 +455,15 @@ class Chef
 
       # True if policy_name and run_list are both given
       def policyfile_and_run_list_given?
-        !config[:run_list].empty? && !!config[:policy_name]
+        run_list_given? && policyfile_options_given?
+      end
+
+      def run_list_given?
+        !config[:run_list].nil? && !config[:run_list].empty?
+      end
+
+      def policyfile_options_given?
+        !!config[:policy_name]
       end
 
       # True if one of policy_name or policy_group was given, but not both

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -472,6 +472,21 @@ describe Chef::Knife::Bootstrap do
 
     end
 
+    # https://github.com/chef/chef/issues/4131
+    # Arguably a bug in the plugin: it shouldn't be setting this to nil, but it
+    # worked before, so make it work now.
+    context "when a plugin sets the run list option to nil" do
+
+      before do
+        knife.config[:run_list] = nil
+      end
+
+      it "passes options validation" do
+        expect { knife.validate_options! }.to_not raise_error
+      end
+
+    end
+
   end
 
   describe "when configuring the underlying knife ssh command" do


### PR DESCRIPTION
IMO it's a bug in knife-ec2 but it worked before and there could be lots of plugins relying on the behavior so it needs to just work.

Fixes https://github.com/chef/chef/issues/4131

@btm 