### PR TITLE
fix log location resolution in windows service

### DIFF
--- a/spec/unit/windows_service_spec.rb
+++ b/spec/unit/windows_service_spec.rb
@@ -24,6 +24,7 @@ describe "Chef::Application::WindowsService", :windows_only do
   let(:shell_out_result) { double('shellout', stdout: nil, stderr: nil) }
   let(:config_options) do
     {
+      log_location: STDOUT,
       config_file: "test_config_file",
       log_level: :info
     }
@@ -48,7 +49,7 @@ describe "Chef::Application::WindowsService", :windows_only do
 
   subject { Chef::Application::WindowsService.new }
 
-  it "passes config params to new process with default options" do
+  it "passes DEFAULT_LOG_LOCATION to chef-client instead of STDOUT" do
     expect(subject).to receive(:shell_out).with(
       "chef-client  --no-fork -c test_config_file -L #{Chef::Application::WindowsService::DEFAULT_LOG_LOCATION}",
       shellout_options
@@ -78,10 +79,10 @@ describe "Chef::Application::WindowsService", :windows_only do
       subject.service_main
     end
 
-    context 'configured to STDOUT' do
+    context 'configured to Event Logger' do
       let(:config_options) do
         {
-          log_location: STDOUT,
+          log_location: Chef::Log::WinEvt.new,
           config_file: "test_config_file",
           log_level: :info
         }


### PR DESCRIPTION
The changes made here in 20728416579f40c30e0a9c08bdfd86ecd7391cbe had an incorrect assumption about the default `Chef::Config[log_location]`. It assumed `nil` when it is actually `STDOUT`. This PR uses the following logic to determine where the windows service tells `chef-client` to send logging:

* If a location is sent on the command line, that is merged with `Chef::Config` and used for logging
* ELSE If a file path is configured in the config file, that is used
* ELSE if `STDOUT` (the default) is configured, then the `DEFAULT_LOG_LOCATION` path is used
* ELSE we have some other logging class configured (not a file path) like an event viewer and no log_location is sent to chef-client