### PR TITLE
Require ShellOut before Knife::SSH definition

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'chef/mixin/shell_out'
 require 'chef/knife'
 
 class Chef
@@ -29,7 +30,6 @@ class Chef
         require 'readline'
         require 'chef/exceptions'
         require 'chef/search/query'
-        require 'chef/mixin/shell_out'
         require 'chef/mixin/command'
         require 'chef/util/path_helper'
         require 'mixlib/shellout'


### PR DESCRIPTION
I ran into a NameError when trying to run https://github.com/matschaffer/knife-solo/blob/master/test/knife_bootstrap_test.rb#L14 that this fixes.

My suspicion is that under normal operation shell_out gets required via the application or platform. And prior to moving config into its own project it was being required in chef/config.rb

In my tests since I end up loading knife ssh directly without the surrounding application things don't work out.

I'll likely just add a line to my test helper for now but wanted to open this for comment or future improvement.