### PR TITLE
Allow named_run_list to be loaded from config

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -169,8 +169,7 @@ class Chef::Application::Client < Chef::Application
   option :named_run_list,
     :short        => "-n NAMED_RUN_LIST",
     :long         => "--named-run-list NAMED_RUN_LIST",
-    :description  => "Use a policyfile's named run list instead of the default run list",
-    :default      => nil
+    :description  => "Use a policyfile's named run list instead of the default run list"
 
   option :environment,
     :short        => '-E ENVIRONMENT',


### PR DESCRIPTION
nil default in application/client.rb shadowed any value from config when executing chef-client (but not chef-shell -z)

default in config is set to nil at https://github.com/chef/chef/blob/b0dbe243d469cc36477ba8102b74a8456b6f276d/chef-config/lib/chef-config/config.rb#L363, so otherwise this change is a no-op