### PR TITLE
Fixes #2819 - Correcting regex for upstart_state

### DIFF
--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -30,7 +30,7 @@ class Chef
           Chef::Platform::ServiceHelpers.service_resource_providers.include?(:upstart)
         end
 
-        UPSTART_STATE_FORMAT = /\w+ \(?(\w+)\)?[\/ ](\w+)/
+        UPSTART_STATE_FORMAT = /\S+ \(?(start|stop)?\)? ?[\/ ](\w+)/
 
         def self.supports?(resource, action)
           Chef::Platform::ServiceHelpers.config_for_service(resource.service_name).include?(:upstart)
@@ -224,10 +224,10 @@ class Chef
           command = "/sbin/status #{@job}"
           status = popen4(command) do |pid, stdin, stdout, stderr|
             stdout.each_line do |line|
-              # rsyslog stop/waiting
               # service goal/state
               # OR
-              # rsyslog (stop) waiting
+              # service (instance) goal/state
+              # OR
               # service (goal) state
               line =~ UPSTART_STATE_FORMAT
               data = Regexp.last_match

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -123,6 +123,25 @@ describe Chef::Provider::Service::Upstart do
       end
     end
 
+    describe "when the status command uses the new format with an instance" do
+      before do
+      end
+
+      it "should set running to true if the status command returns 0" do
+        @stdout = StringIO.new("rsyslog (test) start/running, process 100")
+        allow(@provider).to receive(:popen4).and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+        @provider.load_current_resource
+        expect(@current_resource.running).to be_truthy
+      end
+
+      it "should set running to false if the status command returns anything except 0" do
+        @stdout = StringIO.new("rsyslog (test) stop/waiting, process 100")
+        allow(@provider).to receive(:popen4).and_yield(@pid, @stdin, @stdout, @stderr).and_return(@status)
+        @provider.load_current_resource
+        expect(@current_resource.running).to be_falsey
+      end
+    end
+
     describe "when the status command uses the old format" do
       it "should set running to true if the status command returns 0" do
         @stdout = StringIO.new("rsyslog (start) running, process 32225")


### PR DESCRIPTION
This is a fix for #2819. The regular expression for the upstart_state function under the upstart service provider. The original regex failed to match the new style format with an [instance](http://upstart.ubuntu.com/cookbook/#instance):

`rsyslog (test) start/running, process 100`

According to Ubuntu best practices, the goal should only ever be start or stop [[source]](http://upstart.ubuntu.com/cookbook/#initctl-status) and the regex can be re-written to the following:

`\S+ \(?(start|stop)?\)? ?[\/ ](\w+)`

Submitting a patch with updated testing.