### PR TITLE
Add reboot notification to dsc_resource

### DIFF
--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -56,3 +56,10 @@ Assuming both of those make 12.6, placeholder pages:
 chocolatey_package: https://docs.chef.io/release/12-6/resource_chocolatey_package.html
 
 ksh: https://docs.chef.io/release/12-6/resource_ksh.html
+
+### `dsc_resource` resource
+
+Added allow_reboot attribute to dsc_resource.
+
+If the DSC resource indicates that it requires a reboot, allow_reboot can use the reboot resource to
+either reboot immediately (:reboot_now) or queue a reboot (:request_reboot).

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -59,7 +59,7 @@ ksh: https://docs.chef.io/release/12-6/resource_ksh.html
 
 ### `dsc_resource` resource
 
-Added allow_reboot attribute to dsc_resource.
+Added reboot_action attribute to dsc_resource.
 
-If the DSC resource indicates that it requires a reboot, allow_reboot can use the reboot resource to
-either reboot immediately (:reboot_now) or queue a reboot (:request_reboot).
+If the DSC resource indicates that it requires a reboot, reboot_action can use the reboot resource to
+either reboot immediately (:reboot_now) or queue a reboot (:request_reboot).  The default value of reboot_action is :nothing.

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -31,6 +31,7 @@ class Chef
         super
         @properties = {}
         @resource = nil
+        @reboot_action = :nothing
       end
 
       def resource(value=nil)
@@ -65,6 +66,18 @@ class Chef
         @properties.reduce({}) do |memo, (k, v)|
           memo[k] = value_of(v)
           memo
+        end
+      end
+
+      # This property takes the action message for the reboot resource
+      # If the set method of the DSC resource indicate that a reboot
+      # is necessary, reboot_action provides the mechanism for a reboot to 
+      # be requested.
+      def reboot_action(value=nil)
+        if value
+          @reboot_action = value
+        else
+          @reboot_action
         end
       end
 

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -80,7 +80,6 @@ class Chef
           @reboot_action
         end
       end
-
       private
 
       def value_of(value)

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -72,6 +72,26 @@ describe Chef::Provider::DscResource do
         provider.run_action(:run)
         expect(resource).to be_updated
       end
+      
+      it 'flags the resource as reboot required when required' do
+        expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
+        expect(provider).to receive(:test_resource).and_return(false)
+        expect(provider).to receive(:invoke_resource).
+          and_return(double(:stdout => '', :return_value =>nil))
+        expect(provider).to receive(:return_dsc_resource_result).and_return(true)
+        expect(provider).to receive(:create_reboot_resource)
+        provider.run_action(:run)
+      end
+      
+      it 'does not flag the resource as reboot required when not required' do
+        expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
+        expect(provider).to receive(:test_resource).and_return(false)
+        expect(provider).to receive(:invoke_resource).
+          and_return(double(:stdout => '', :return_value =>nil))
+        expect(provider).to receive(:return_dsc_resource_result).and_return(false)
+        expect(provider).to_not receive(:create_reboot_resource)
+        provider.run_action(:run)
+      end
     end
   end
 end

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require 'chef'
 require 'spec_helper'
 
@@ -34,7 +33,6 @@ describe Chef::Provider::DscResource do
       node.automatic[:languages][:powershell][:version] = '4.0'
       node
     }
-
     it 'raises a ProviderNotFound exception' do
       expect(provider).not_to receive(:meta_configuration)
       expect{provider.run_action(:run)}.to raise_error(
@@ -72,7 +70,7 @@ describe Chef::Provider::DscResource do
         provider.run_action(:run)
         expect(resource).to be_updated
       end
-      
+
       it 'flags the resource as reboot required when required' do
         expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(false)
@@ -82,7 +80,7 @@ describe Chef::Provider::DscResource do
         expect(provider).to receive(:create_reboot_resource)
         provider.run_action(:run)
       end
-      
+
       it 'does not flag the resource as reboot required when not required' do
         expect(provider).to receive(:dsc_refresh_mode_disabled?).and_return(true)
         expect(provider).to receive(:test_resource).and_return(false)

--- a/spec/unit/resource/dsc_resource_spec.rb
+++ b/spec/unit/resource/dsc_resource_spec.rb
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require 'spec_helper'
-
 describe Chef::Resource::DscResource do
   let(:dsc_test_resource_name) { 'DSCTest' }
   let(:dsc_test_property_name) { :DSCTestProperty }
@@ -31,6 +29,7 @@ describe Chef::Resource::DscResource do
       empty_events = Chef::EventDispatch::Dispatcher.new
       Chef::RunContext.new(node, {}, empty_events)
     }
+
     let(:dsc_test_resource) {
       Chef::Resource::DscResource.new(dsc_test_resource_name, dsc_test_run_context)
     }
@@ -39,7 +38,7 @@ describe Chef::Resource::DscResource do
       expect(dsc_test_resource.action).to eq([:run])
     end
 
-    it "has an allowed_actions attribute with only the `:run` and `:nothing` attributes" do
+    it "has an ed_actions attribute with only the `:run` and `:nothing` attributes" do
       expect(dsc_test_resource.allowed_actions.to_set).to eq([:run,:nothing].to_set)
     end
 
@@ -53,7 +52,7 @@ describe Chef::Resource::DscResource do
       expect(dsc_test_resource.module_name).to eq(dsc_test_resource_name)
     end
 
-    it "allows the reboot_action attribute to be set" do 
+    it "allows the reboot_action attribute to be set" do
       dsc_test_resource.reboot_action(dsc_test_reboot_action)
       expect(dsc_test_resource.reboot_action).to eq(dsc_test_reboot_action)
     end

--- a/spec/unit/resource/dsc_resource_spec.rb
+++ b/spec/unit/resource/dsc_resource_spec.rb
@@ -22,6 +22,7 @@ describe Chef::Resource::DscResource do
   let(:dsc_test_resource_name) { 'DSCTest' }
   let(:dsc_test_property_name) { :DSCTestProperty }
   let(:dsc_test_property_value) { 'DSCTestValue' }
+  let(:dsc_test_reboot_action) { :reboot_now }
 
   context 'when Powershell supports Dsc' do
     let(:dsc_test_run_context) {
@@ -50,6 +51,11 @@ describe Chef::Resource::DscResource do
     it "allows the module_name attribute to be set" do
       dsc_test_resource.module_name(dsc_test_resource_name)
       expect(dsc_test_resource.module_name).to eq(dsc_test_resource_name)
+    end
+
+    it "allows the reboot_action attribute to be set" do 
+      dsc_test_resource.reboot_action(dsc_test_reboot_action)
+      expect(dsc_test_resource.reboot_action).to eq(dsc_test_reboot_action)
     end
 
     context "when setting a dsc property" do


### PR DESCRIPTION
Adds an allow_reboot attribute to dsc_resource.

Example:
```
dsc_resource 'Install AD' do
  resource :windowsfeature
  property :name, 'ad-domain-services'
  allow_reboot :reboot_now
end
```

Closes #4156 