### PR TITLE
Get external tests running again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,11 @@ matrix:
     cache:
     env: "GEMFILE_MOD=\"gem 'chef-sugar'\""
     script: bundle exec rake chef_sugar_spec
-  - rvm: 2.2
-    cache:
-    env: "GEMFILE_MOD=\"gem 'chef-rewind'\""
-    script: bundle exec rake chef_rewind_spec
+  # Requires vagrant
+  # - rvm: 2.2
+  #   cache:
+  #   env: "GEMFILE_MOD=\"gem 'chef-rewind'\""
+  #   script: bundle exec rake chef_rewind_spec
   - rvm: 2.2
     cache:
     env: "GEMFILE_MOD=\"gem 'foodcritic', github: 'acrmp/foodcritic', branch: 'v5.0.0'\""
@@ -69,9 +70,6 @@ matrix:
     cache:
     env: "GEMFILE_MOD=\"gem 'poise', github: 'poise/poise'\""
     script: bundle exec rake poise_spec
-  # Not working yet: halite
-  # - rvm: 2.2
-  #   script: bundle exec rake poise_spec
   ### START TEST KITCHEN ONLY ###
   - rvm: 2.2
     gemfile: kitchen-tests/Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,30 +34,39 @@ matrix:
     gemfile: pedant.gemfile
     script: bundle exec rake pedant
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'cheffish', github: 'chef/cheffish'\""
     script: bundle exec rake cheffish_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'chef-provisioning', github: 'chef/chef-provisioning'\""
     script: bundle exec rake chef_provisioning_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'chef-provisioning-aws', github: 'chef/chef-provisioning-aws'\""
     script: bundle exec rake chef_provisioning_aws_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'chefspec'\""
     script: bundle exec rake chefspec_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'chef-sugar'\""
     script: bundle exec rake chef_sugar_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'chef-rewind'\""
     script: bundle exec rake chef_rewind_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'foodcritic', github: 'acrmp/foodcritic', branch: 'v5.0.0'\""
     script: bundle exec rake foodcritic_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'halite', github: 'poise/halite'\""
     script: bundle exec rake halite_spec
   - rvm: 2.2
+    cache:
     env: "GEMFILE_MOD=\"gem 'poise', github: 'poise/poise'\""
     script: bundle exec rake poise_spec
   # Not working yet: halite

--- a/tasks/external_tests.rb
+++ b/tasks/external_tests.rb
@@ -1,33 +1,41 @@
 require 'tempfile'
+require 'bundler'
+
+CURRENT_GEM_NAME = 'chef'
+CURRENT_GEM_PATH = File.expand_path('../..', __FILE__)
 
 def bundle_exec_with_chef(test_gem, commands)
   gem_path = Bundler.environment.specs[test_gem].first.full_gem_path
-  gemfile_path = File.join(gem_path, 'Gemfile.chef-external-test')
+  gemfile_path = File.join(gem_path, "Gemfile.#{CURRENT_GEM_NAME}-external-test")
   gemfile = File.open(gemfile_path, "w")
   begin
     IO.read(File.join(gem_path, 'Gemfile')).each_line do |line|
       if line =~ /^\s*gemspec/
         next
-      elsif line =~ /^\s*gem 'chef'|\s*gem "chef"/
+      elsif line =~ /^\s*gem '#{CURRENT_GEM_NAME}'|\s*gem "#{CURRENT_GEM_NAME}"/
         next
       elsif line =~ /^\s*dev_gem\s*['"](.+)['"]\s*$/
         line = "gem '#{$1}', github: 'poise/#{$1}'"
-      elsif line =~ /\s*gem\s*['"]#{test_gem}['"]/ # foodcritic
+      elsif line =~ /\s*gem\s*['"]#{test_gem}['"]/ # foodcritic      end
         next
       end
       gemfile.puts(line)
     end
-    gemfile.puts("gem 'chef', path: #{File.expand_path('../..', __FILE__).inspect}")
+    gemfile.puts("gem #{CURRENT_GEM_NAME.inspect}, path: #{CURRENT_GEM_PATH.inspect}")
     gemfile.puts("gemspec path: #{gem_path.inspect}")
     gemfile.close
     Dir.chdir(gem_path) do
-      system({ 'BUNDLE_GEMFILE' => gemfile.path, 'RUBYOPT' => nil }, "bundle install")
+      unless system({ 'RUBYOPT' => nil, 'GEMFILE_MOD' => nil }, "bundle install --gemfile #{gemfile_path}")
+        raise "Error running bundle install --gemfile #{gemfile_path} in #{gem_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(gemfile_path)}"
+      end
       Array(commands).each do |command|
-        system({ 'BUNDLE_GEMFILE' => gemfile.path, 'RUBYOPT' => nil }, "bundle exec #{command}")
+        unless system({ 'BUNDLE_GEMFILE' => gemfile_path, 'RUBYOPT' => nil, 'GEMFILE_MOD' => nil }, "bundle exec #{command}")
+          raise "Error running bundle exec #{command} in #{gem_path} with BUNDLE_GEMFILE=#{gemfile_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(gemfile_path)}"
+        end
       end
     end
   ensure
-    File.delete(gemfile_path)
+    File.delete(gemfile_path) if File.exist?(gemfile_path)
   end
 end
 


### PR DESCRIPTION
When `cache: bundler` was added, Travis started running `bundle install --path bundle/vendor`, but bundler does not get installed in that directory and therefore the tests can't run `bundle install`. Adding bundler to the `Gemfile` does not change this, either.

The fix is to stop caching for external tests.