### PR TITLE
Restore rspec 3.4 by setting project_source_dirs

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'plist', '~> 3.1.0'
 
   # Audit mode requires these, so they are non-developmental dependencies now
-  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.3.0" }
+  %w(rspec-core rspec-expectations rspec-mocks).each { |gem| s.add_dependency gem, "~> 3.4" }
   s.add_dependency "rspec_junit_formatter", "~> 0.2.0"
   s.add_dependency "serverspec", "~> 2.7"
   s.add_dependency "specinfra", "~> 2.10"

--- a/lib/chef/audit/runner.rb
+++ b/lib/chef/audit/runner.rb
@@ -106,6 +106,7 @@ class Chef
         RSpec.configure do |c|
           c.color = Chef::Config[:color]
           c.expose_dsl_globally = false
+          c.project_source_dirs = Array(Chef::Config[:cookbook_path])
           c.backtrace_exclusion_patterns << exclusion_pattern
         end
       end

--- a/spec/functional/audit/runner_spec.rb
+++ b/spec/functional/audit/runner_spec.rb
@@ -52,6 +52,10 @@ describe Chef::Audit::Runner do
     let(:run_context) { instance_double(Chef::RunContext, :events => events, :audits => audits) }
     let(:control_group_name) { "control_group_name" }
 
+    # Set cookbook path to include our parent, so that it will recognize this
+    # rspec file as one that should show up in the backtrace.
+    before(:each) { Chef::Config[:cookbook_path] = File.dirname(__FILE__) }
+
     shared_context "passing audit" do
       let(:audits) do
         should_pass = lambda do


### PR DESCRIPTION
to be the cookbooks (see http://rspec.info/blog/2015/11/rspec-3-4-has-been-released/, Better Failure Source Detection, for more info)