### PR TITLE
Update dsc_resource to use verbose stream output

### DIFF
--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -122,10 +122,15 @@ class Chef
 
       def test_resource
         result = invoke_resource(:test)
+        @converge_description = result.stream(:verbose)
+
         # We really want this information from the verbose stream,
-        # however Invoke-DscResource is not correctly writing to that
-        # stream and instead just dumping to stdout
-        @converge_description = result.stdout
+        # however in some versions of WMF, Invoke-DscResource is not correctly
+        # writing to that stream and instead just dumping to stdout
+        if @converge_description.empty?
+          @converge_description = result.stdout
+        end
+
         return_dsc_resource_result(result, "InDesiredState")
       end
 


### PR DESCRIPTION
This fixes a regression in the Nov 2015 update of Windows 10 where we are not putting any output in the converge description.  This is because the Nov 2015 update has started using the verbose stream instead of stdout. This is actually a good thing, as the use of stdout was a hack.  But now we need to check for both conditions.

@btm @adamedx @smurawski @jaym 