### PR TITLE
Prevent inspect on PsCredential from printing out plain text password

### DIFF
--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -20,8 +20,26 @@ require 'chef/dsl/powershell'
 class Chef
   class Resource
     class DscResource < Chef::Resource
-
       provides :dsc_resource, os: "windows"
+
+      # This class will check if the object responds to
+      # to_text. If it does, it will call that as opposed
+      # to inspect. This is useful for properties that hold
+      # objects such as PsCredential, where we do not want
+      # to dump the actual ivars
+      class ToTextHash < Hash
+        def to_text
+          descriptions = self.map do |(property, obj)|
+            obj_text = if obj.respond_to?(:to_text)
+                         obj.to_text
+                       else
+                         obj.inspect
+                       end
+            "#{property}=>#{obj_text}"
+          end
+          "{#{descriptions.join(', ')}}"
+        end
+      end
 
       include Chef::DSL::Powershell
 
@@ -29,7 +47,7 @@ class Chef
 
       def initialize(name, run_context)
         super
-        @properties = {}
+        @properties = ToTextHash.new
         @resource = nil
         @reboot_action = :nothing
       end

--- a/lib/chef/util/powershell/ps_credential.rb
+++ b/lib/chef/util/powershell/ps_credential.rb
@@ -29,9 +29,8 @@ class Chef::Util::Powershell
       "New-Object System.Management.Automation.PSCredential('#{@username}',('#{encrypt(@password)}' | ConvertTo-SecureString))"
     end
 
-    def to_s
-      to_psobject
-    end
+    alias to_s to_psobject
+    alias to_text to_psobject
 
     private
 

--- a/spec/unit/util/powershell/ps_credential_spec.rb
+++ b/spec/unit/util/powershell/ps_credential_spec.rb
@@ -21,7 +21,7 @@ require 'chef/util/powershell/ps_credential'
 
 describe Chef::Util::Powershell::PSCredential do
   let (:username) { 'foo' }
-  let (:password) { 'password' }
+  let (:password) { 'ThIsIsThEpAsSwOrD' }
 
   context 'when username and password are provided' do
     let(:ps_credential) { Chef::Util::Powershell::PSCredential.new(username, password)}
@@ -31,6 +31,13 @@ describe Chef::Util::Powershell::PSCredential do
         expect(ps_credential.to_psobject).to eq(
         "New-Object System.Management.Automation.PSCredential("\
             "'#{username}',('encrypted' | ConvertTo-SecureString))")
+      end
+    end
+
+    context 'when to_text is called' do
+      it 'should not contain the password' do
+        allow(ps_credential).to receive(:encrypt).with(password).and_return('encrypted')
+        expect(ps_credential.to_text).not_to match(/#{password}/)
       end
     end
   end


### PR DESCRIPTION
See the following use of a DSC resource -- note that it dumps out the password (which itself was not obvious in the code because an environment variable was used to obtain it). On failure (failure was expected in this case), the password, in this case '\\sea-adamed1', is displayed on the screen.

```
    Resource Declaration:
    ---------------------
    # In C:\test\chefdsc\ps5dscuser.rb

      4: dsc_resource 'Create Test User' do
      5:   resource :user
      6:   #  property :username, 'testuserps5'
      7:   property :username, 'testuserps5__\\'
      8:   property :password, ps_credential(ENV['COMPUTERNAME'])
      9:   property :ensure, 'Present'
     10: end
     11:

    Compiled Resource:
    ------------------
    # Declared in C:\test\chefdsc\ps5dscuser.rb:4:in `run_chef_recipe'

    dsc_resource("Create Test User") do
      action [:run]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      properties {:username=>"testuserps5__\\", :password=>#<Chef::Util::Powershell::PSCredential:0x75c5088 @username="placeholder", @password="SEA-ADAMED1">, :ensure=>"Present"}
      resource :user
      declared_type :dsc_resource
      cookbook_name "(chef-apply cookbook)"
      recipe_name "(chef-apply recipe)"
    end
```

With this change:
```
    Resource Declaration:
    ---------------------
    # In .\foo.rb

      1: dsc_resource 'Create Test User' do
      2:   resource :user
      3:   property :username, 'testuserps5__\\'
      4:   property :password, ps_credential(ENV['COMPUTERNAME'])
      5:   property :ensure, 'Present'
      6: end

    Compiled Resource:
    ------------------
    # Declared in .\foo.rb:1:in `run_chef_recipe'

    dsc_resource("Create Test User") do
      action [:run]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      properties {:username=>"testuserps5__\\", :password=>New-Object System.Management.Automation.PSCredential('placeholder',('01000000d08c9ddf0115d1118c7a00c04fc297eb010000006083790c2fc2a24c946799335d38282b0400000002000000000010660000000100002000000086b05f5a3d8ba25dcf328f5cce1bab8343b4ebc981947f186ebb0f215bba0e1b000000000e800000000200002000000060624c80a246a5e8374fb5e9d9aa87129d16a5afd65eab7ca10942a68a4d8b9f3000000082ae38decc68a5f8ee03914b5a4b7cb72683c7ab31be65443e932646b99f82639ae112d90b81cdeaa11edc81cccc73e84000000025cc0420658c4c9e72a355a0262a2b1e9dbac9ccbaedfd2e1d87e9ab27e73950261ffc4d2dd350d27b51e14adc2afc9e8a78935ec4d83c12112916f8353840b7' | ConvertTo-SecureString)), :ensure=>"Present"}
      resource :user
      reboot_action :nothing
      declared_type :dsc_resource
      cookbook_name "(chef-apply cookbook)"
      recipe_name "(chef-apply recipe)"
    end
```
cc @adamedx @chef/client-windows 