### PR TITLE
fix rspecs-ctrl-c

### DIFF
--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@opscode.com>)
-# Copyright:: Copyright (c) 2010 Opscode, Inc.
+# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,9 +66,11 @@ module TinyServer
         @server = Server.setup(@options) do
           run API.instance
         end
+        @old_handler = trap(:INT, "EXIT")
         @server.start
       end
       block_until_started
+      trap(:INT, @old_handler)
     end
 
     def url

--- a/spec/unit/knife/ssl_check_spec.rb
+++ b/spec/unit/knife/ssl_check_spec.rb
@@ -181,7 +181,7 @@ E
       let(:self_signed_crt) { OpenSSL::X509::Certificate.new(File.read(self_signed_crt_path)) }
 
       before do
-        trap(:INT, "DEFAULT")
+        @old_signal = trap(:INT, "DEFAULT")
 
         expect(TCPSocket).to receive(:new).
           with("foo.example.com", 8443).
@@ -189,6 +189,10 @@ E
         expect(OpenSSL::SSL::SSLSocket).to receive(:new).
           with(tcp_socket_for_debug, ssl_check.noverify_peer_ssl_context).
           and_return(ssl_socket_for_debug)
+      end
+
+      after do
+        trap(:INT, @old_signal)
       end
 
       context "when the certificate's CN does not match the hostname" do


### PR DESCRIPTION
we can't fork off tinyserver without a lot of work in the test
codebase, so instead save a copy of the old rspec signal handler and then
after tinyserver has started (and we're sure that rack has scribbled
over the signal handler), restore the rspec signal handler.

there's an obvious race if someone hits ctrl-c after tinyserver has
scribbled over the sigint handler but before we restore it, but this is
99.9% better of a solution than nothing.

closes #2520 