### PR TITLE
Add timeout attribute to dsc_resource

### DIFF
--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -154,7 +154,7 @@ class Chef
           "Invoke-DscResource #{switches}",
           output_format
         )
-        cmdlet.run!
+        cmdlet.run!({}, {:timeout => new_resource.timeout})
       end
 
       def return_dsc_resource_result(result, property_name)

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -89,7 +89,7 @@ class Chef
 
       # This property takes the action message for the reboot resource
       # If the set method of the DSC resource indicate that a reboot
-      # is necessary, reboot_action provides the mechanism for a reboot to 
+      # is necessary, reboot_action provides the mechanism for a reboot to
       # be requested.
       def reboot_action(value=nil)
         if value
@@ -97,6 +97,14 @@ class Chef
         else
           @reboot_action
         end
+      end
+
+      def timeout(arg=nil)
+        set_or_return(
+          :timeout,
+          arg,
+          :kind_of => [ Integer ]
+        )
       end
       private
 

--- a/spec/unit/resource/dsc_resource_spec.rb
+++ b/spec/unit/resource/dsc_resource_spec.rb
@@ -21,6 +21,7 @@ describe Chef::Resource::DscResource do
   let(:dsc_test_property_name) { :DSCTestProperty }
   let(:dsc_test_property_value) { 'DSCTestValue' }
   let(:dsc_test_reboot_action) { :reboot_now }
+  let(:dsc_test_timeout) { 101 }
 
   context 'when Powershell supports Dsc' do
     let(:dsc_test_run_context) {
@@ -55,6 +56,11 @@ describe Chef::Resource::DscResource do
     it "allows the reboot_action attribute to be set" do
       dsc_test_resource.reboot_action(dsc_test_reboot_action)
       expect(dsc_test_resource.reboot_action).to eq(dsc_test_reboot_action)
+    end
+
+    it "allows the timeout attribute to be set" do
+      dsc_test_resource.timeout(dsc_test_timeout)
+      expect(dsc_test_resource.timeout).to eq(dsc_test_timeout)
     end
 
     context "when setting a dsc property" do


### PR DESCRIPTION
`dsc_resource` was missing a timeout resource. Some resources,
such as `xSQLServerSetup` were taking longer than the default
of 10 minuites set by mixlib-shellout.

Fixes #4232 

cc @chef/client-windows 