### PR TITLE
Enabling 'knife ssl check/fetch' commands to respect proxy environment variables and moving proxy environment variables export to Chef::Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,114 +26,27 @@ env:
 
 matrix:
   include:
-  - rvm: 2.1
-    sudo: true
-  - rvm: 2.2
-    sudo: true
   - rvm: rbx
     sudo: true
   - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'chef-zero', github: 'chef/chef-zero'\""
-    script: bundle exec rake chef_zero_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'cheffish', github: 'chef/cheffish'\""
-    script: bundle exec rake cheffish_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'chef-provisioning', github: 'chef/chef-provisioning'\""
-    script: bundle exec rake chef_provisioning_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'chef-provisioning-aws', github: 'chef/chef-provisioning-aws'\""
-    script: bundle exec rake chef_provisioning_aws_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'chefspec'\""
-    script: bundle exec rake chefspec_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'chef-sugar'\""
-    script: bundle exec rake chef_sugar_spec
-  # Requires vagrant
-  # - rvm: 2.2
-  #   cache:
-  #   env: "GEMFILE_MOD=\"gem 'chef-rewind'\""
-  #   script: bundle exec rake chef_rewind_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'foodcritic', github: 'acrmp/foodcritic', branch: 'v5.0.0'\""
-    script: bundle exec rake foodcritic_spec
-  - rvm: 2.2
-    before_install:
-    env: "GEMFILE_MOD=\"gem 'halite', github: 'poise/halite'\""
-    script: bundle exec rake halite_spec
-  - rvm: 2.2
-    env: "GEMFILE_MOD=\"gem 'poise', github: 'poise/poise'\""
-    script: bundle exec rake poise_spec
-  ### START TEST KITCHEN ONLY ###
-  - rvm: 2.2
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-    - echo -n $DO_KEY_CHUNK_{0..30} >> ~/.ssh/id_aws.base64
-    - cat ~/.ssh/id_aws.base64 | tr -d ' ' | base64 --decode > ~/.ssh/id_aws.pem
-    before_script:
-    - cd kitchen-tests
-    script:
-# FIXME: we should fix centos-6 against AWS and then enable it here
-    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen test ubuntu; fi
-    after_failure:
-    - cat .kitchen/logs/kitchen.log
-    after_script:
-    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen destroy ubuntu; fi
-    env:
-    - KITCHEN_YAML=.kitchen.travis.yml
-    - EC2_SSH_KEY_PATH=~/.ssh/id_aws.pem
-    - secure: VAauyVnAMWhqvnhJOJ/tCDn3XAdWqzbWiDVQPNBkqtm2SBIvhmZl2hlrusvw6YLU31Prdf8fSFhOSysVQQs/rJYrmD/1BfV79p6M7cGXYZ0nGWwldF81N296lyFoZLyrqtmG4G0cx3Pw2ojADFgFe+B5eTGlqJFD+z371g4RF/Y=
-    - secure: A+qtUF2LPJGkUAdvt04AwZMt69rzaeTyR0/1XEOAuntBKKXSCzddUzr5ePDc9QQ/57AWywKxhVLpnxk3QzKN7r7zerDxyIJBgklNDpNAKkeQjP3T6FpaKEIN9ROcpPtsM6FJ5Agb+bEQoRJF7s+ampO3wLV3XpTiWNuWkcAhv9A=
-    - secure: J8JIg15trrPgc8X/1DsaUWDQCdDWTvN/AorXzZ/ReudHS6G/KpoynZ5lTmKjlgFiFNE/TGMDv486pStGtIcarTKTuIEmNADdEWlAVH7bxclpayMjtppVuapRCkZWccs5gz5CJyhX7yhQCFTYoqVox9Y4qHGCluF3oqCcPRtCOOw=
-    - secure: NJYn0blTMwIoFxZlsoMWK8hPO/fi45rgWOqEImnjvSRk++5WL+GgjLBgLvEi7wCMkBijhIMWtnva60ojd4MrxeS7evrmGRjJKXnPuSKEsrGbArZPskBjCAcg+3PlnQQUkFf6hvbGD3HZlJtcbs4hrx8tbDT2Ie7bmQfqpsawKY4=
-    - secure: FipoX1VzZkzPUP6Gxd05DEva7cX6xKK2Wdq+Y18nNkyW2afPLXCNl5kCsNrgvbqAzbjKaP2M8+b0zwKjrFzNebqmmx1RRfZUJWUkNRF1EgE+tHytmMZW6tNcQlTlvA0KqXi4Dt6SIQ0l/DhwwNKZ80jmpiyYi/ErxIXzbVgVtYA=
-    - secure: T2MbE9twIkdaor796/lDioCgb2+FP3G8lXq+lIqnjaL22WMP8yKtkjNo8ggSlvQZE7MAQHqi5LISw5MU2MI6ImTU50/pgdWreM5Cx37WWYqntcbJ0Sz7v396KGJzeqbDql1fGolHDlykfi+OJzzbIGC8cjz7iAD2RUZU95wEC5s=
-    - secure: hWEQInvuanQavFCE3m6/q9BjNEFZQmLc94EWnBKTMiwUAdYgQQMLohN7K1Gc8irxYKp86F+P+XWE4lfDZNK3sqmxyk51TtT2EfmKWs+jSLq4+NBYQwXCpRELC5Irpm0GRCYthhsQSuarpVWss/0s0o7iJQaHxrSPcQiwDouIpwU=
-    - secure: OllJUaR/WUu+H0FIjU7vQxU10JT4d+/FZuTqnX6ZTcXN3dXCirnabYp/j+r5OBY3QeOojOyzGfHUWYEUGH/PTxcxYjrohtFTWht9N9x+SxfX2fLqieH/kRKyDmIidsY8qKChf/LD9f+SwpXRXND/PctKhNR4C5BH57fGUEqE9FU=
-    - secure: KgKnGtM4e+cVYfLn78eTWJ1q4ORv128abB72QBc/xiSh0rvxSIojVKZCXmRetQPXIl7NoIzU2IyjR1ABEZ+vA83PayTEsOr2KDRDgolSIgZSSiDFt4U2phQsxl4fX7wFv/jWlbxM2fysKBSIRAF57CwBjGhLjmpUO+5PdoR7N2s=
-    - secure: IgOx4STauKnJWENQGcn2iBp32XcNd2anNR0Fua0ugjudu1+CV+IxcIhI8ohOfZEXyVK4MGTF8uXWrYtoiwyExG4mTXqpRWJCgIkncqiWlfT+8BoAGWxCQhUYub3MaNZANPgebKPJhTPQ8OwNz09gPMNkewRfAqNF05eb8FU2kGA=
-    - secure: CPXP6g3c1FH4Zm4U19XaPvq9nnyNsQCXRkxiPcGqsJZsGG2QMgzPQyjiAuPqnWxxZHit/6NgzUszJC+skSgcTzDTeD6rOA0Wcxtbr/Un4RRxRnTcRc6mSEZqSu9RbAZMYur/mSQ9HDHnjFe1ok85He4s9jM1iFdgjtg1ToelEmA=
-    - secure: fp9pzNe09PIyZ/8NjbMPGW1zdG3Q/KhJ+stUKqA+FRopAMX/Hh24gFIVJhFOmfr4Vhn0J8sF7RsFaR1mdzcPewliOzKxknWhGEGMcG9LFCZcv+vVK0Fxs4nUzCRtaXUt08FpsRofG0iBvfapZ7YBhK7lslqGVI+fxCd3ZXmayG8=
-    - secure: NT/6qcecxmuKYOnw1Atc6hsyJlfB6XI2Z1lg7dE0PhlEVW2EpkckHjAc+5hgg8Zt7TifYm2qDQWJwblwPP0mMj3ra4ZIMaZAiG2kzQoZ5kthqwjAV9fatZvrDXi+jd9wBF2hPyiCokAQiTLmKTYjzY2FBqPO3VDLWdf9qZqRmxw=
-    - secure: MjIWyfquKANh/YeoyHGksdvAUQ4wc2tBCQmq1QcRhKwb7Sy6wcDk1nujDmnGE7HFpZUS6CyoZF7AMzJGFkCzrChpsLQYUP4hc7VjkXOLzi90vJUl+ANq7KPOmxC0MjKpgeHqCysRbTYbUsnJZfbbZbIZjCAjY0YCY2pGniXpvQc=
-    - secure: AsZLOiFrHkGsY6jp2ShI5kYz78V6PEUyizgtPCWTgevTRGWpdCq9csIEoqUBY+vMUxmQPC6IY4fwHkrRCbv/rJyhwRl/Rnwa3aw8bdD+YD17IxnpXKGXXUyXdTZmF7HzAkVgStehL+qWZ3x9TBdExIV37KVgrVw/b+S0QqBUlQo=
-    - secure: jwEnSquLreMM1M6N3gGpgTGHd8VtjBUTLDdkrokhiH1jHLpz7Hmr6xeajhZws+2sLtLiB7hYi6WsZBE5VcymBoObh9MeodO9Ve5/1z06lFmx1DyYV6euyo9WUkU2WpoVfu8k7O+eAvyrXXZVqm8Oz1p7Isb6Bh5+fJH2H8rhed4=
-    - secure: HOAK620U6mlS11XK+JtXTBk26Tt2vWO4shA/6Zit/y0/kAz7JnbXtup7FSysXliBoSv4YsxA6IbgZ8V0tuIXj+q7EcqtHMmQhqzMJG5jRKVhtGiFIhDmwmxJvdfIvwtZOO3mMk0OspLz24sWp8wCciYZMPj0hZJR04R9aWEO3cE=
-    - secure: DfTRP74UWWxA460XfLoJFgRLwoKbHWNIueL6qr982AnuAxeZFofsxCqxSxcSJmu67TxuPc+b201+BmanHKYmSauGS31t0F4QXk7lCTaT/x38mAPsWvMFkY8HEl56JhmzEp2hAKDB/t0/HItwmvxT1vd5WvNRSSojEVzChftV/zE=
-    - secure: JoCWsJzTgj+epgzmgbvV7/bdAPHwUGXZA7Jdvv9vIJ5lCo6h9WwCw6/KCvH+bHtrT/RfZmUmxouCxJCLKwts1ZrMmedTIXpMrQJo/YgWRp7ziFnLyZ8jG8bD7rep3ngq1x/cRGc3cZvYN6IK3GS6C27OviYLFsTw74AUnWTaFSo=
-    - secure: iXfl0WnAnfKurZUrMeV1yOoFiiZ+MKx/Zj6ZVP2++A9EOxxIxb/fS/gIOzSjBQwzrR+fJVHIlX0g42CiBKDQWUvIl5I8kZCVIP6AHa1jyzlmZE9lqSlojz3k5RPS7pW6nIX+z1NHMvtb3e5xeLv8y4J5kwZErqZ+YDJmBRtPxPU=
-    - secure: RhAW5kABDPB3GWKD+NCg05Kcd92F/+kg+0icXXN166DWQYUut3MLrSY80xNzkz5nXTI9EFU4fUqlKLDiF/kelr0Zp/zpCQAB54o4cu5FkZz0Bgs9k7yUdCRyz6Vt2ChV5cYI4JTn9bMaeXEaGlOjP1iE51rYT6KO6kKlwsEnjUc=
-    - secure: jy/3fC+UtrDcE/X6/IxkyT2SrYMKkiEMP1ht4d5mxvNA0Xxn43E16c6FNP0JWPpWRGRIP38vnQRB4yOPU9BXvRmmswVL9Ge4e/6flJvKwD5Rlqb2dfaGaHRYV9v8Nkdzl2FvZ9eBH5KHxgG19gCG6L3RXP/+zYwrr4AQdm0fpfw=
-    - secure: RYEwBWYVXRTEdUWhQxdWXo6tldlVx8pha9zB0rgafcUQxaatAefnRc4X4HXTQnqr2n9TZ2TQGpM8vte/wr6Pjc85VZbimWGzgrvn0kg4MwPR8ZYiEM5qQ/pUpj4+93rpA91PhCGvZoZTqOrXHm4kMPuKro5I6qA4BFUXuANeC/s=
-    - secure: gHSicpqkqcZT04QurSgszrAiI6HOCw1DBlfIIi9KAJj7mG5GijD/4AQ6HCmcRMbCDJ0nUuvm/kckASnRtF5+3xvIJnuoyyEfCZWxt1lhK2UbS87VU+pVdws/VzwpisXuKsh3H0uT8DDVkWPH/ZWDgfVa74eYDEHiQFjo+2xx5ZA=
-    - secure: Q42bco3JXEpyVbL2akiOsaCHnAagAFIb3TF6H5qJfaLLqmGs/XrrgxliNaVMfWVSwPT2wpQvg9UGF9x37No9bZBv33DgYcWExmXb/lvGPpkctX37+FTMzECQHxOuUbYPQA7ZEuJ4AA7bwgpMISUeSyz5XXz44KcXIrZK2GWH+X4=
-    - secure: hugd8NVukJc3redDvlOt6zhaqa63XLNMp/eIIlNllW8VfQ6CJ1P7KJPwgxH24sDyrw7rLzOkBl6R4kaVWsCLCFp+NE6yFFHl9wDkSdLC1OX1DMrJnDsogwUqqe+jX8dxePSy26MSTfG8eo9/NxN9uXr+tKaHoi6G7BRXDHtQ8dQ=
-    - secure: TRkW9pIuIYHXJmPlDYoddxIp2M2W2f7qBGNJKEMB5xrOezES7w9XTg2eQXrD8jBO+fUUmMnAaDAXZuU58nMysPXx3vhtZKncg8w5CyuXJk2P8nkdPh0u5nmRhEpWrLKtLwJrX48xmJhNQvQqDAyL5c9WUzlWJ4WJFgoP5IDWmLc=
-    - secure: QHuMdtFCvttiIOx6iS+lH4bKXZMwsgVQ6FPsUW5zJ7uw6mAEWKEil9xNk4aYV9FywinwUs4fnFlnIW/Gj1gLkUjm4DtxdmRZIlRXIbgsNch6H916TCPg4Q2oPsW2nVdXPjW/2jhkfLUiSnuhL+ylami1NF8Up7vokXknh/jFNZU=
-    - secure: GTfrUVmMQSxho3Ia4Y1ONqKvVMD34GHF2/TJb8UdQV7iH+nVxVXpy3nWaCXa9ri7lRzMefkoVLy0gKK13YoVd7w3d2S3/IfNakC85XfN6VuOzK/FDkA0WoPrgKjcQ64I+3dQ6cgrMWWTieKwRZy+Ve24iRbnN055Hk+VRMu6OGw=
-    - secure: SOMYGVfHLkHsH6koxpw68YQ4ydEo6YXPhHbrYGQbehUbFa6+OZzBcAJRJbKjyhD2AZRvNr2jB8XnjYKvVyDGQRpkWhGYZ7CpHqINpDsqKBsbiMe3/+KmKQqS+UKxNGefquoOvyQ1N8Xy77dkWYokRtGMEuR12RkZLonxiDW8Qyg=
-    - secure: bSsDg+dJnPFdFiC/tbb61HdLh/Q0z2RVVAReT1wvV1BN4fN4NydvkUGbQmyFNyyunLulEs+X0oFma9L0497nUlTnan8UOg9sIleTSybPX6E9xSKKCItH1GgDw8bM9Igez5OOrrePBD3altVrH+FmGx0dlTQgM/KZMN50BJ79cXw=
-    ### END TEST KITCHEN ONLY ###
-  - rvm: 2.2
     sudo: required
     dist: trusty
-    os: linux
     cache:
     before_install:
       - sudo apt-get update
       - sudo apt-get -y install squid3 git
     env:
-      - PROXY_TESTS_DIR=/tmp/proxy_tests
-      - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+      global:
+        - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
+        - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
     script:
       - bundle exec chef-client --version
-      - git clone https://github.com/chef/proxy_tests.git
-      - cd proxy_tests
-      - bundle exec chef-client -z -o proxy_tests::render
-      #- sh /tmp/proxy_tests/setup.sh
-      - bundle exec sudo -E bash /tmp/proxy_tests/run_tests.sh chef_client \* \* /tmp/out.txt
-    after_script: cat /tmp/out.txt
+      - git clone -b tball/knife_tests https://github.com/chef/proxy_tests.git
+      - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh chef_client \* \* /tmp/out.txt
+    after_script:
+      - cat /tmp/out.txt
+      - sudo cat /var/log/squid3/cache.log
+      - sudo cat /var/log/squid3/access.log
 
   allow_failures:
     - rvm: rbx

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,108 @@ env:
 
 matrix:
   include:
+  - rvm: 2.1
+    sudo: true
+  - rvm: 2.2
+    sudo: true
   - rvm: rbx
     sudo: true
   - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'chef-zero', github: 'chef/chef-zero'\""
+    script: bundle exec rake chef_zero_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'cheffish', github: 'chef/cheffish'\""
+    script: bundle exec rake cheffish_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'chef-provisioning', github: 'chef/chef-provisioning'\""
+    script: bundle exec rake chef_provisioning_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'chef-provisioning-aws', github: 'chef/chef-provisioning-aws'\""
+    script: bundle exec rake chef_provisioning_aws_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'chefspec'\""
+    script: bundle exec rake chefspec_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'chef-sugar'\""
+    script: bundle exec rake chef_sugar_spec
+  # Requires vagrant
+  # - rvm: 2.2
+  #   cache:
+  #   env: "GEMFILE_MOD=\"gem 'chef-rewind'\""
+  #   script: bundle exec rake chef_rewind_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'foodcritic', github: 'acrmp/foodcritic', branch: 'v5.0.0'\""
+    script: bundle exec rake foodcritic_spec
+  - rvm: 2.2
+    before_install:
+    env: "GEMFILE_MOD=\"gem 'halite', github: 'poise/halite'\""
+    script: bundle exec rake halite_spec
+  - rvm: 2.2
+    env: "GEMFILE_MOD=\"gem 'poise', github: 'poise/poise'\""
+    script: bundle exec rake poise_spec
+  ### START TEST KITCHEN ONLY ###
+  - rvm: 2.2
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+    - echo -n $DO_KEY_CHUNK_{0..30} >> ~/.ssh/id_aws.base64
+    - cat ~/.ssh/id_aws.base64 | tr -d ' ' | base64 --decode > ~/.ssh/id_aws.pem
+    before_script:
+    - cd kitchen-tests
+    script:
+# FIXME: we should fix centos-6 against AWS and then enable it here
+    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen test ubuntu; fi
+    after_failure:
+    - cat .kitchen/logs/kitchen.log
+    after_script:
+    - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then bundle exec kitchen destroy ubuntu; fi
+    env:
+    - KITCHEN_YAML=.kitchen.travis.yml
+    - EC2_SSH_KEY_PATH=~/.ssh/id_aws.pem
+    - secure: VAauyVnAMWhqvnhJOJ/tCDn3XAdWqzbWiDVQPNBkqtm2SBIvhmZl2hlrusvw6YLU31Prdf8fSFhOSysVQQs/rJYrmD/1BfV79p6M7cGXYZ0nGWwldF81N296lyFoZLyrqtmG4G0cx3Pw2ojADFgFe+B5eTGlqJFD+z371g4RF/Y=
+    - secure: A+qtUF2LPJGkUAdvt04AwZMt69rzaeTyR0/1XEOAuntBKKXSCzddUzr5ePDc9QQ/57AWywKxhVLpnxk3QzKN7r7zerDxyIJBgklNDpNAKkeQjP3T6FpaKEIN9ROcpPtsM6FJ5Agb+bEQoRJF7s+ampO3wLV3XpTiWNuWkcAhv9A=
+    - secure: J8JIg15trrPgc8X/1DsaUWDQCdDWTvN/AorXzZ/ReudHS6G/KpoynZ5lTmKjlgFiFNE/TGMDv486pStGtIcarTKTuIEmNADdEWlAVH7bxclpayMjtppVuapRCkZWccs5gz5CJyhX7yhQCFTYoqVox9Y4qHGCluF3oqCcPRtCOOw=
+    - secure: NJYn0blTMwIoFxZlsoMWK8hPO/fi45rgWOqEImnjvSRk++5WL+GgjLBgLvEi7wCMkBijhIMWtnva60ojd4MrxeS7evrmGRjJKXnPuSKEsrGbArZPskBjCAcg+3PlnQQUkFf6hvbGD3HZlJtcbs4hrx8tbDT2Ie7bmQfqpsawKY4=
+    - secure: FipoX1VzZkzPUP6Gxd05DEva7cX6xKK2Wdq+Y18nNkyW2afPLXCNl5kCsNrgvbqAzbjKaP2M8+b0zwKjrFzNebqmmx1RRfZUJWUkNRF1EgE+tHytmMZW6tNcQlTlvA0KqXi4Dt6SIQ0l/DhwwNKZ80jmpiyYi/ErxIXzbVgVtYA=
+    - secure: T2MbE9twIkdaor796/lDioCgb2+FP3G8lXq+lIqnjaL22WMP8yKtkjNo8ggSlvQZE7MAQHqi5LISw5MU2MI6ImTU50/pgdWreM5Cx37WWYqntcbJ0Sz7v396KGJzeqbDql1fGolHDlykfi+OJzzbIGC8cjz7iAD2RUZU95wEC5s=
+    - secure: hWEQInvuanQavFCE3m6/q9BjNEFZQmLc94EWnBKTMiwUAdYgQQMLohN7K1Gc8irxYKp86F+P+XWE4lfDZNK3sqmxyk51TtT2EfmKWs+jSLq4+NBYQwXCpRELC5Irpm0GRCYthhsQSuarpVWss/0s0o7iJQaHxrSPcQiwDouIpwU=
+    - secure: OllJUaR/WUu+H0FIjU7vQxU10JT4d+/FZuTqnX6ZTcXN3dXCirnabYp/j+r5OBY3QeOojOyzGfHUWYEUGH/PTxcxYjrohtFTWht9N9x+SxfX2fLqieH/kRKyDmIidsY8qKChf/LD9f+SwpXRXND/PctKhNR4C5BH57fGUEqE9FU=
+    - secure: KgKnGtM4e+cVYfLn78eTWJ1q4ORv128abB72QBc/xiSh0rvxSIojVKZCXmRetQPXIl7NoIzU2IyjR1ABEZ+vA83PayTEsOr2KDRDgolSIgZSSiDFt4U2phQsxl4fX7wFv/jWlbxM2fysKBSIRAF57CwBjGhLjmpUO+5PdoR7N2s=
+    - secure: IgOx4STauKnJWENQGcn2iBp32XcNd2anNR0Fua0ugjudu1+CV+IxcIhI8ohOfZEXyVK4MGTF8uXWrYtoiwyExG4mTXqpRWJCgIkncqiWlfT+8BoAGWxCQhUYub3MaNZANPgebKPJhTPQ8OwNz09gPMNkewRfAqNF05eb8FU2kGA=
+    - secure: CPXP6g3c1FH4Zm4U19XaPvq9nnyNsQCXRkxiPcGqsJZsGG2QMgzPQyjiAuPqnWxxZHit/6NgzUszJC+skSgcTzDTeD6rOA0Wcxtbr/Un4RRxRnTcRc6mSEZqSu9RbAZMYur/mSQ9HDHnjFe1ok85He4s9jM1iFdgjtg1ToelEmA=
+    - secure: fp9pzNe09PIyZ/8NjbMPGW1zdG3Q/KhJ+stUKqA+FRopAMX/Hh24gFIVJhFOmfr4Vhn0J8sF7RsFaR1mdzcPewliOzKxknWhGEGMcG9LFCZcv+vVK0Fxs4nUzCRtaXUt08FpsRofG0iBvfapZ7YBhK7lslqGVI+fxCd3ZXmayG8=
+    - secure: NT/6qcecxmuKYOnw1Atc6hsyJlfB6XI2Z1lg7dE0PhlEVW2EpkckHjAc+5hgg8Zt7TifYm2qDQWJwblwPP0mMj3ra4ZIMaZAiG2kzQoZ5kthqwjAV9fatZvrDXi+jd9wBF2hPyiCokAQiTLmKTYjzY2FBqPO3VDLWdf9qZqRmxw=
+    - secure: MjIWyfquKANh/YeoyHGksdvAUQ4wc2tBCQmq1QcRhKwb7Sy6wcDk1nujDmnGE7HFpZUS6CyoZF7AMzJGFkCzrChpsLQYUP4hc7VjkXOLzi90vJUl+ANq7KPOmxC0MjKpgeHqCysRbTYbUsnJZfbbZbIZjCAjY0YCY2pGniXpvQc=
+    - secure: AsZLOiFrHkGsY6jp2ShI5kYz78V6PEUyizgtPCWTgevTRGWpdCq9csIEoqUBY+vMUxmQPC6IY4fwHkrRCbv/rJyhwRl/Rnwa3aw8bdD+YD17IxnpXKGXXUyXdTZmF7HzAkVgStehL+qWZ3x9TBdExIV37KVgrVw/b+S0QqBUlQo=
+    - secure: jwEnSquLreMM1M6N3gGpgTGHd8VtjBUTLDdkrokhiH1jHLpz7Hmr6xeajhZws+2sLtLiB7hYi6WsZBE5VcymBoObh9MeodO9Ve5/1z06lFmx1DyYV6euyo9WUkU2WpoVfu8k7O+eAvyrXXZVqm8Oz1p7Isb6Bh5+fJH2H8rhed4=
+    - secure: HOAK620U6mlS11XK+JtXTBk26Tt2vWO4shA/6Zit/y0/kAz7JnbXtup7FSysXliBoSv4YsxA6IbgZ8V0tuIXj+q7EcqtHMmQhqzMJG5jRKVhtGiFIhDmwmxJvdfIvwtZOO3mMk0OspLz24sWp8wCciYZMPj0hZJR04R9aWEO3cE=
+    - secure: DfTRP74UWWxA460XfLoJFgRLwoKbHWNIueL6qr982AnuAxeZFofsxCqxSxcSJmu67TxuPc+b201+BmanHKYmSauGS31t0F4QXk7lCTaT/x38mAPsWvMFkY8HEl56JhmzEp2hAKDB/t0/HItwmvxT1vd5WvNRSSojEVzChftV/zE=
+    - secure: JoCWsJzTgj+epgzmgbvV7/bdAPHwUGXZA7Jdvv9vIJ5lCo6h9WwCw6/KCvH+bHtrT/RfZmUmxouCxJCLKwts1ZrMmedTIXpMrQJo/YgWRp7ziFnLyZ8jG8bD7rep3ngq1x/cRGc3cZvYN6IK3GS6C27OviYLFsTw74AUnWTaFSo=
+    - secure: iXfl0WnAnfKurZUrMeV1yOoFiiZ+MKx/Zj6ZVP2++A9EOxxIxb/fS/gIOzSjBQwzrR+fJVHIlX0g42CiBKDQWUvIl5I8kZCVIP6AHa1jyzlmZE9lqSlojz3k5RPS7pW6nIX+z1NHMvtb3e5xeLv8y4J5kwZErqZ+YDJmBRtPxPU=
+    - secure: RhAW5kABDPB3GWKD+NCg05Kcd92F/+kg+0icXXN166DWQYUut3MLrSY80xNzkz5nXTI9EFU4fUqlKLDiF/kelr0Zp/zpCQAB54o4cu5FkZz0Bgs9k7yUdCRyz6Vt2ChV5cYI4JTn9bMaeXEaGlOjP1iE51rYT6KO6kKlwsEnjUc=
+    - secure: jy/3fC+UtrDcE/X6/IxkyT2SrYMKkiEMP1ht4d5mxvNA0Xxn43E16c6FNP0JWPpWRGRIP38vnQRB4yOPU9BXvRmmswVL9Ge4e/6flJvKwD5Rlqb2dfaGaHRYV9v8Nkdzl2FvZ9eBH5KHxgG19gCG6L3RXP/+zYwrr4AQdm0fpfw=
+    - secure: RYEwBWYVXRTEdUWhQxdWXo6tldlVx8pha9zB0rgafcUQxaatAefnRc4X4HXTQnqr2n9TZ2TQGpM8vte/wr6Pjc85VZbimWGzgrvn0kg4MwPR8ZYiEM5qQ/pUpj4+93rpA91PhCGvZoZTqOrXHm4kMPuKro5I6qA4BFUXuANeC/s=
+    - secure: gHSicpqkqcZT04QurSgszrAiI6HOCw1DBlfIIi9KAJj7mG5GijD/4AQ6HCmcRMbCDJ0nUuvm/kckASnRtF5+3xvIJnuoyyEfCZWxt1lhK2UbS87VU+pVdws/VzwpisXuKsh3H0uT8DDVkWPH/ZWDgfVa74eYDEHiQFjo+2xx5ZA=
+    - secure: Q42bco3JXEpyVbL2akiOsaCHnAagAFIb3TF6H5qJfaLLqmGs/XrrgxliNaVMfWVSwPT2wpQvg9UGF9x37No9bZBv33DgYcWExmXb/lvGPpkctX37+FTMzECQHxOuUbYPQA7ZEuJ4AA7bwgpMISUeSyz5XXz44KcXIrZK2GWH+X4=
+    - secure: hugd8NVukJc3redDvlOt6zhaqa63XLNMp/eIIlNllW8VfQ6CJ1P7KJPwgxH24sDyrw7rLzOkBl6R4kaVWsCLCFp+NE6yFFHl9wDkSdLC1OX1DMrJnDsogwUqqe+jX8dxePSy26MSTfG8eo9/NxN9uXr+tKaHoi6G7BRXDHtQ8dQ=
+    - secure: TRkW9pIuIYHXJmPlDYoddxIp2M2W2f7qBGNJKEMB5xrOezES7w9XTg2eQXrD8jBO+fUUmMnAaDAXZuU58nMysPXx3vhtZKncg8w5CyuXJk2P8nkdPh0u5nmRhEpWrLKtLwJrX48xmJhNQvQqDAyL5c9WUzlWJ4WJFgoP5IDWmLc=
+    - secure: QHuMdtFCvttiIOx6iS+lH4bKXZMwsgVQ6FPsUW5zJ7uw6mAEWKEil9xNk4aYV9FywinwUs4fnFlnIW/Gj1gLkUjm4DtxdmRZIlRXIbgsNch6H916TCPg4Q2oPsW2nVdXPjW/2jhkfLUiSnuhL+ylami1NF8Up7vokXknh/jFNZU=
+    - secure: GTfrUVmMQSxho3Ia4Y1ONqKvVMD34GHF2/TJb8UdQV7iH+nVxVXpy3nWaCXa9ri7lRzMefkoVLy0gKK13YoVd7w3d2S3/IfNakC85XfN6VuOzK/FDkA0WoPrgKjcQ64I+3dQ6cgrMWWTieKwRZy+Ve24iRbnN055Hk+VRMu6OGw=
+    - secure: SOMYGVfHLkHsH6koxpw68YQ4ydEo6YXPhHbrYGQbehUbFa6+OZzBcAJRJbKjyhD2AZRvNr2jB8XnjYKvVyDGQRpkWhGYZ7CpHqINpDsqKBsbiMe3/+KmKQqS+UKxNGefquoOvyQ1N8Xy77dkWYokRtGMEuR12RkZLonxiDW8Qyg=
+    - secure: bSsDg+dJnPFdFiC/tbb61HdLh/Q0z2RVVAReT1wvV1BN4fN4NydvkUGbQmyFNyyunLulEs+X0oFma9L0497nUlTnan8UOg9sIleTSybPX6E9xSKKCItH1GgDw8bM9Igez5OOrrePBD3altVrH+FmGx0dlTQgM/KZMN50BJ79cXw=
+    ### END TEST KITCHEN ONLY ###
+  - rvm: 2.2
     sudo: required
     dist: trusty
-    cache:
     before_install:
       - sudo apt-get update
-      - sudo apt-get -y install squid3 git
+      - sudo apt-get -y install squid3 git curl
     env:
       global:
         - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
         - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
     script:
       - bundle exec chef-client --version
-      - git clone -b tball/knife_tests https://github.com/chef/proxy_tests.git
+      - git clone https://github.com/chef/proxy_tests.git
       - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh chef_client \* \* /tmp/out.txt
     after_script:
       - cat /tmp/out.txt

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -43,6 +43,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "syslog-logger", "~> 1.6"
 
+  s.add_dependency "proxifier", "~> 1.0"
+
   s.add_development_dependency "rack"
   s.add_development_dependency "cheffish", "~> 1.1"
 

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -124,7 +124,7 @@ class Chef::Application::Apply < Chef::Application
     parse_options
     Chef::Config.merge!(config)
     configure_logging
-    configure_proxy_environment_variables
+    Chef::Config.export_proxies
     parse_json
   end
 

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -401,6 +401,7 @@ class Chef
 
       merge_configs
       apply_computed_config
+      Chef::Config.export_proxies
       # This has to be after apply_computed_config so that Mixlib::Log is configured
       Chef::Log.info("Using configuration from #{config[:config_file]}") if config[:config_file]
     end

--- a/lib/chef/knife/ssl_check.rb
+++ b/lib/chef/knife/ssl_check.rb
@@ -29,6 +29,8 @@ class Chef
         require 'uri'
         require 'chef/http/ssl_policies'
         require 'openssl'
+        require 'chef/mixin/proxified_socket'
+        include Chef::Mixin::ProxifiedSocket
       end
 
       banner "knife ssl check [URL] (options)"
@@ -75,7 +77,7 @@ class Chef
 
       def verify_peer_socket
         @verify_peer_socket ||= begin
-          tcp_connection = TCPSocket.new(host, port)
+          tcp_connection = proxified_socket(host, port)
           ssl_client = OpenSSL::SSL::SSLSocket.new(tcp_connection, verify_peer_ssl_context)
           ssl_client.hostname = host
           ssl_client
@@ -93,7 +95,7 @@ class Chef
 
       def noverify_socket
         @noverify_socket ||= begin
-          tcp_connection = TCPSocket.new(host, port)
+          tcp_connection = proxified_socket(host, port)
           OpenSSL::SSL::SSLSocket.new(tcp_connection, noverify_peer_ssl_context)
         end
       end
@@ -125,7 +127,9 @@ class Chef
 
       def verify_cert
         ui.msg("Connecting to host #{host}:#{port}")
+        ui.msg("TYLER DEBUGGING INFO1")
         verify_peer_socket.connect
+        ui.msg("TYLER DEBUGGING INFO2")
         true
       rescue OpenSSL::SSL::SSLError => e
         ui.error "The SSL certificate of #{host} could not be verified"

--- a/lib/chef/knife/ssl_check.rb
+++ b/lib/chef/knife/ssl_check.rb
@@ -127,9 +127,7 @@ class Chef
 
       def verify_cert
         ui.msg("Connecting to host #{host}:#{port}")
-        ui.msg("TYLER DEBUGGING INFO1")
         verify_peer_socket.connect
-        ui.msg("TYLER DEBUGGING INFO2")
         true
       rescue OpenSSL::SSL::SSLError => e
         ui.error "The SSL certificate of #{host} could not be verified"

--- a/lib/chef/knife/ssl_fetch.rb
+++ b/lib/chef/knife/ssl_fetch.rb
@@ -28,6 +28,8 @@ class Chef
         require 'socket'
         require 'uri'
         require 'openssl'
+        require 'chef/mixin/proxified_socket'
+        include Chef::Mixin::ProxifiedSocket
       end
 
       banner "knife ssl fetch [URL] (options)"
@@ -71,7 +73,7 @@ class Chef
       end
 
       def remote_cert_chain
-        tcp_connection = TCPSocket.new(host, port)
+        tcp_connection = proxified_socket(host, port)
         shady_ssl_connection = OpenSSL::SSL::SSLSocket.new(tcp_connection, noverify_peer_ssl_context)
         shady_ssl_connection.connect
         shady_ssl_connection.peer_cert_chain
@@ -155,4 +157,3 @@ TRUST_TRUST
     end
   end
 end
-

--- a/lib/chef/mixin/proxified_socket.rb
+++ b/lib/chef/mixin/proxified_socket.rb
@@ -1,0 +1,38 @@
+# Author:: Tyler Ball (<tball@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'proxifier'
+
+class Chef
+  module Mixin
+    module ProxifiedSocket
+
+      # This looks at the environment variables and leverages Proxifier to
+      # make the TCPSocket respect ENV['https_proxy'] or ENV['http_proxy'] if
+      # they are present
+      def proxified_socket(host, port)
+        proxy = ENV['https_proxy'] || ENV['http_proxy'] || false
+        if proxy
+          Proxifier.Proxy(proxy, no_proxy: ENV['no_proxy']).open(host, port)
+        else
+          TCPSocket.new(host, port)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -42,7 +42,7 @@ describe Chef::Application do
       Chef::Config[:ftp_proxy] = nil
       Chef::Config[:no_proxy] = nil
 
-      @app.configure_proxy_environment_variables
+      Chef::Config.export_proxies
     end
 
     it "saves built proxy to ENV which shell_out can use" do

--- a/spec/unit/knife/ssl_check_spec.rb
+++ b/spec/unit/knife/ssl_check_spec.rb
@@ -145,7 +145,7 @@ E
     let(:ssl_socket) { double(OpenSSL::SSL::SSLSocket) }
 
     before do
-      expect(TCPSocket).to receive(:new).with("foo.example.com", 8443).and_return(tcp_socket)
+      expect(ssl_check).to receive(:proxified_socket).with("foo.example.com", 8443).and_return(tcp_socket)
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_check.verify_peer_ssl_context).and_return(ssl_socket)
     end
 
@@ -183,7 +183,7 @@ E
       before do
         @old_signal = trap(:INT, "DEFAULT")
 
-        expect(TCPSocket).to receive(:new).
+        expect(ssl_check).to receive(:proxified_socket).
           with("foo.example.com", 8443).
           and_return(tcp_socket_for_debug)
         expect(OpenSSL::SSL::SSLSocket).to receive(:new).

--- a/spec/unit/knife/ssl_fetch_spec.rb
+++ b/spec/unit/knife/ssl_fetch_spec.rb
@@ -139,7 +139,7 @@ E
     context "when the TLS connection is successful" do
 
       before do
-        expect(TCPSocket).to receive(:new).with("foo.example.com", 8443).and_return(tcp_socket)
+        expect(ssl_fetch).to receive(:proxified_socket).with("foo.example.com", 8443).and_return(tcp_socket)
         expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_fetch.noverify_peer_ssl_context).and_return(ssl_socket)
         expect(ssl_socket).to receive(:connect)
         expect(ssl_socket).to receive(:peer_cert_chain).and_return([self_signed_crt])
@@ -161,7 +161,7 @@ E
       let(:unknown_protocol_error) { OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: unknown protocol") }
 
       before do
-        expect(TCPSocket).to receive(:new).with("foo.example.com", 80).and_return(tcp_socket)
+        expect(ssl_fetch).to receive(:proxified_socket).with("foo.example.com", 80).and_return(tcp_socket)
         expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_fetch.noverify_peer_ssl_context).and_return(ssl_socket)
         expect(ssl_socket).to receive(:connect).and_raise(unknown_protocol_error)
 

--- a/spec/unit/mixin/proxified_socket_spec.rb
+++ b/spec/unit/mixin/proxified_socket_spec.rb
@@ -61,6 +61,8 @@ describe Chef::Mixin::ProxifiedSocket do
 
   context "when https_proxy is set" do
     before do
+      # I'm purposefully setting both of these because we prefer the https
+      # variable
       ENV['https_proxy'] = https_uri
       ENV['http_proxy'] = http_uri
     end
@@ -69,6 +71,8 @@ describe Chef::Mixin::ProxifiedSocket do
     include_examples "proxified socket"
 
     context "when no_proxy is set" do
+      # This is testing that no_proxy is also provided to Proxified
+      # when it is set
       before do
         ENV['no_proxy'] = no_proxy_spec
       end

--- a/spec/unit/mixin/proxified_socket_spec.rb
+++ b/spec/unit/mixin/proxified_socket_spec.rb
@@ -1,0 +1,90 @@
+#
+# Author:: Tyler Ball (<tball@chef.io>)
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef/mixin/proxified_socket"
+require "proxifier/proxy"
+
+class TestProxifiedSocket
+  include Chef::Mixin::ProxifiedSocket
+end
+
+describe Chef::Mixin::ProxifiedSocket do
+
+  before do
+    @original_env = ENV.to_hash
+  end
+
+  after do
+    ENV.clear
+    ENV.update(@original_env)
+  end
+
+  let(:host) { "host" }
+  let(:port) { 7979 }
+  let(:test_instance) { TestProxifiedSocket.new }
+  let(:socket_double) { instance_double(TCPSocket)}
+  let(:proxifier_double) { instance_double(Proxifier::Proxy) }
+  let(:http_uri) { "http://somehost:1" }
+  let(:https_uri) { "https://somehost:1" }
+  let(:no_proxy_spec) { nil }
+
+  shared_examples "proxified socket" do
+    it "wraps the Socket in a Proxifier::Proxy" do
+      expect(Proxifier).to receive(:Proxy).with(proxy_uri, no_proxy: no_proxy_spec).and_return(proxifier_double)
+      expect(proxifier_double).to receive(:open).with(host, port).and_return(socket_double)
+      expect(test_instance.proxified_socket(host, port)).to eq(socket_double)
+    end
+  end
+
+  context "when no proxy is set" do
+    it "returns a plain TCPSocket" do
+      expect(TCPSocket).to receive(:new).with(host, port).and_return(socket_double)
+      expect(test_instance.proxified_socket(host, port)).to eq(socket_double)
+    end
+  end
+
+  context "when https_proxy is set" do
+    before do
+      ENV['https_proxy'] = https_uri
+      ENV['http_proxy'] = http_uri
+    end
+
+    let(:proxy_uri) { https_uri }
+    include_examples "proxified socket"
+
+    context "when no_proxy is set" do
+      before do
+        ENV['no_proxy'] = no_proxy_spec
+      end
+
+      let(:no_proxy_spec) { "somehost1,somehost2" }
+      include_examples "proxified socket"
+    end
+  end
+
+  context "when http_proxy is set" do
+    before do
+      ENV['http_proxy'] = http_uri
+    end
+
+    let(:proxy_uri) { http_uri }
+    include_examples "proxified socket"
+  end
+
+end


### PR DESCRIPTION
https://github.com/samuelkadolph/ruby-proxifier is a gem which gives the ability to have `TCPSocket` respect the proxy environment variables.  It does this by sending a `CONNECT` request to the proxy - see https://github.com/samuelkadolph/ruby-proxifier/blob/master/lib/proxifier/proxies/http.rb

\cc @jkeiser @chef/client-maintainers

Fixes https://github.com/chef/chef/issues/4215

**EDIT**
To get the tests passing for this I needed to modify Knife to run the logic which exports `Chef::Config[:http_proxy]` to `ENV['http_proxy']`.  I decided to move the exporting logic into `Chef::Config` because that is where we want it to be able to leverage that logic in Test Kitchen and Berkshelf.