### PR TITLE
restore handling of dpkg -s returns codes (w/tests)

### DIFF
--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -109,7 +109,7 @@ class Chef
 
         def read_current_version_of_package(package_name)
           Chef::Log.debug("#{new_resource} checking install state of #{package_name}")
-          status = shell_out_with_timeout("dpkg -s #{package_name}")
+          status = shell_out_with_timeout!("dpkg -s #{package_name}", returns: [0, 1])
           package_installed = false
           status.stdout.each_line do |line|
             case line


### PR DESCRIPTION
Previously dpkg -s would allow a 0 or 1 exit status and it wasn't
entirely clear why this was so either from the code or the tests.

This restores throwing an exception if we are outside of the [0,1]
range, and then adds tests for both behaviors:

- on old ubuntu/debian we get an exit(0) and output on stdout if the
  file is not installed
- on newer ubuntu/debian we get an exit(1) and output on stderr if
  the file is not installed

Added tests for both those cases, and the case where dpkg -s does
some other kind of exitcode barf and we should raise.