### PR TITLE
Don't run dpkg functional tests on Ubuntu 10.04

### DIFF
--- a/spec/functional/resource/dpkg_package_spec.rb
+++ b/spec/functional/resource/dpkg_package_spec.rb
@@ -18,7 +18,8 @@
 require 'spec_helper'
 require 'chef/mixin/shell_out'
 
-describe Chef::Resource::DpkgPackage, :requires_root, :debian_family_only, arch: "x86_64" do
+describe Chef::Resource::DpkgPackage, :requires_root, :debian_family_only,
+  :not_ubuntu_1004, arch: "x86_64" do
   include Chef::Mixin::ShellOut
 
   let(:apt_data) { File.join(CHEF_SPEC_DATA, "apt") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -163,6 +163,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :openssl_lt_101 => true unless openssl_lt_101?
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
   config.filter_run_excluding :broken => true
+  config.filter_run_excluding :not_ubuntu_1004 => false unless ubuntu_1004?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -199,3 +199,8 @@ end
 def aes_256_gcm?
   OpenSSL::Cipher.ciphers.include?("aes-256-gcm")
 end
+
+
+def ubuntu_1004?
+  ohai[:platform] == "ubuntu" && ohai[:platform_version] == "10.04"
+end


### PR DESCRIPTION
The test package does not work on Ubuntu 10.04.

Ubuntu 10.04 is EOL

We agreed Ubuntu 10.04 will not be directly tested in
https://github.com/chef/chef-rfc/commit/78f123c4b3d7dbdcc578c8054607ca793c4538c5#diff-82941490249ae72b9c79656734240eff