### PR TITLE
Warn when user sets a property of an inline resource to itself.

### DIFF
--- a/lib/chef/chef_class.rb
+++ b/lib/chef/chef_class.rb
@@ -205,17 +205,7 @@ class Chef
     # @api private this will likely be removed in favor of an as-yet unwritten
     #      `Chef.log`
     def log_deprecation(message, location=nil)
-      if !location
-        # Pick the first caller that is *not* part of the Chef gem, that's the
-        # thing the user wrote.
-        chef_gem_path = File.expand_path("../..", __FILE__)
-        caller(0..10).each do |c|
-          if !c.start_with?(chef_gem_path)
-            location = c
-            break
-          end
-        end
-      end
+      location ||= Chef::Log.caller_location
       # `run_context.events` is the primary deprecation target if we're in a
       # run. If we are not yet in a run, print to `Chef::Log`.
       if run_context && run_context.events

--- a/lib/chef/log.rb
+++ b/lib/chef/log.rb
@@ -37,6 +37,20 @@ class Chef
       end
     end
 
+    #
+    # Get the location of the caller (from the recipe). Grabs the first caller
+    # that is *not* in the chef gem proper (allowing us to weed out internal
+    # calls and give the user a more useful perspective).
+    #
+    # @return [String] The location of the caller (file:line#) from caller(0..20), or nil if no non-chef caller is found.
+    #
+    def self.caller_location
+      # Pick the first caller that is *not* part of the Chef gem, that's the
+      # thing the user wrote.
+      chef_gem_path = File.expand_path("../..", __FILE__)
+      caller(0..20).select { |c| !c.start_with?(chef_gem_path) }.first
+    end
+
     def self.deprecation(msg=nil, location=caller(2..2)[0], &block)
       if msg
         msg << " at #{Array(location).join("\n")}"

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -292,9 +292,21 @@ class Chef
         value
 
       else
-        # If we are still compiling this resource (rather than running an action
-        # on it), reading this property before it's been set is likely the wrong
-        # thing. Warn if it's a duplicate of the enclosing provider.
+        # If the user does something like this:
+        #
+        # ```
+        # class MyResource < Chef::Resource
+        #   property :content
+        #   action :create do
+        #     file '/x.txt' do
+        #       content content
+        #     end
+        #   end
+        # end
+        # ```
+        #
+        # It won't do what they expect. This checks whether you try to *read*
+        # `content` while we are compiling the resource.
         if resource.respond_to?(:enclosing_provider) && resource.enclosing_provider &&
            !resource.currently_running_action &&
            !name_property? &&

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -292,6 +292,16 @@ class Chef
         value
 
       else
+        # If we are still compiling this resource (rather than running an action
+        # on it), reading this property before it's been set is likely the wrong
+        # thing. Warn if it's a duplicate of the enclosing provider.
+        if resource.respond_to?(:enclosing_provider) && resource.enclosing_provider &&
+           !resource.currently_running_action &&
+           !name_property? &&
+           resource.enclosing_provider.respond_to?(name)
+           Chef::Log.warn("#{Chef::Log.caller_location}: property #{name} is declared in both #{resource} and #{resource.enclosing_provider}. Use new_resource.#{name} instead. At #{Chef::Log.caller_location}")
+        end
+
         if has_default?
           value = default
           if value.is_a?(DelayedEvaluator)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -569,6 +569,8 @@ class Chef
     #
     def run_action(action, notification_type=nil, notifying_resource=nil)
       # reset state in case of multiple actions on the same resource.
+      old_currently_running_action = @currently_running_action
+      @currently_running_action = action
       @elapsed_time = 0
       start_time = Time.now
       events.resource_action_start(self, action, notification_type, notifying_resource)
@@ -608,14 +610,21 @@ class Chef
           events.resource_failed(self, action, e)
           raise customize_exception(e)
         end
-      ensure
-        @elapsed_time = Time.now - start_time
-        # Reporting endpoint doesn't accept a negative resource duration so set it to 0.
-        # A negative value can occur when a resource changes the system time backwards
-        @elapsed_time = 0 if @elapsed_time < 0
-        events.resource_completed(self)
       end
+    ensure
+      @currently_running_action = old_currently_running_action
+      @elapsed_time = Time.now - start_time
+      # Reporting endpoint doesn't accept a negative resource duration so set it to 0.
+      # A negative value can occur when a resource changes the system time backwards
+      @elapsed_time = 0 if @elapsed_time < 0
+      events.resource_completed(self)
     end
+
+    #
+    # If we are currently running an action, this shows the action we are running.
+    # If the resource is running multiple actions at once, this will show the most recent.
+    #
+    attr_reader :currently_running_action
 
     #
     # Generic Ruby and Data Structure Stuff (for user)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -624,6 +624,8 @@ class Chef
     # If we are currently running an action, this shows the action we are running.
     # If the resource is running multiple actions at once, this will show the most recent.
     #
+    # Do NOT use this. It may be removed. It is for internal purposes only.
+    # @api private
     attr_reader :currently_running_action
 
     #

--- a/lib/chef/resource/action_class.rb
+++ b/lib/chef/resource/action_class.rb
@@ -21,6 +21,10 @@ require 'chef/exceptions'
 class Chef
   class Resource
     module ActionClass
+      def to_s
+        "#{new_resource || "<no resource>"} action #{action ? action.inspect : "<no action>"}"
+      end
+
       #
       # If load_current_value! is defined on the resource, use that.
       #


### PR DESCRIPTION
(User will expect "x x" to grab the parent property.)