### PR TITLE
Use signing protocol 1.1 by default

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -443,19 +443,8 @@ module ChefConfig
 
     # Sets the version of the signed header authentication protocol to use (see
     # the 'mixlib-authorization' project for more detail). Currently, versions
-    # 1.0 and 1.1 are available; however, the chef-server must first be
-    # upgraded to support version 1.1 before clients can begin using it.
-    #
-    # Version 1.1 of the protocol is required when using a `node_name` greater
-    # than ~90 bytes (~90 ascii characters), so chef-client will automatically
-    # switch to using version 1.1 when `node_name` is too large for the 1.0
-    # protocol. If you intend to use large node names, ensure that your server
-    # supports version 1.1. Automatic detection of large node names means that
-    # users will generally not need to manually configure this.
-    #
-    # In the future, this configuration option may be replaced with an
-    # automatic negotiation scheme.
-    default :authentication_protocol_version, "1.0"
+    # 1.0 and 1.1 are available.
+    default :authentication_protocol_version, "1.1"
 
     # This key will be used to sign requests to the Chef server. This location
     # must be writable by Chef during initial setup when generating a client

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -550,14 +550,10 @@ class Chef
     # - ohai[:machinename]
     # - ohai[:hostname]
     #
-    # If we are running against a server with authentication protocol < 1.0, we
-    # *require* authentication protocol version 1.1.
-    #
     # @raise [Chef::Exceptions::CannotDetermineNodeName] If the node name is not
     #   set and cannot be determined via ohai.
     #
     # @see Chef::Config#node_name
-    # @see Chef::Config#authentication_protocol_version
     #
     # @api private
     #
@@ -566,14 +562,6 @@ class Chef
       Chef::Config[:node_name] = name
 
       raise Chef::Exceptions::CannotDetermineNodeName unless name
-
-      # node names > 90 bytes only work with authentication protocol >= 1.1
-      # see discussion in config.rb.
-      # TODO use a computed default in Chef::Config to determine this instead of
-      # setting it.
-      if name.bytesize > 90
-        Chef::Config[:authentication_protocol_version] = "1.1"
-      end
 
       name
     end

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -385,12 +385,6 @@ class Chef
       Mixlib::Log::Formatter.show_time = false
       Chef::Log.init(Chef::Config[:log_location])
       Chef::Log.level(Chef::Config[:log_level] || :error)
-
-      if Chef::Config[:node_name] && Chef::Config[:node_name].bytesize > 90
-        # node names > 90 bytes only work with authentication protocol >= 1.1
-        # see discussion in config.rb.
-        Chef::Config[:authentication_protocol_version] = "1.1"
-      end
     end
 
     def configure_chef

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -45,26 +45,8 @@ describe Chef::Client do
   end
 
   describe "authentication protocol selection" do
-    after do
-      Chef::Config[:authentication_protocol_version] = "1.0"
-    end
-
-    context "when the node name is <= 90 bytes" do
-      it "does not force the authentication protocol to 1.1" do
-        Chef::Config[:node_name] = ("f" * 90)
-        # ugly that this happens as a side effect of a getter :(
-        client.node_name
-        expect(Chef::Config[:authentication_protocol_version]).to eq("1.0")
-      end
-    end
-
-    context "when the node name is > 90 bytes" do
-      it "sets the authentication protocol to version 1.1" do
-        Chef::Config[:node_name] = ("f" * 91)
-        # ugly that this happens as a side effect of a getter :(
-        client.node_name
-        expect(Chef::Config[:authentication_protocol_version]).to eq("1.1")
-      end
+    it "defaults to 1.1" do
+      expect(Chef::Config[:authentication_protocol_version]).to eq("1.1")
     end
   end
 

--- a/spec/unit/rest/auth_credentials_spec.rb
+++ b/spec/unit/rest/auth_credentials_spec.rb
@@ -81,33 +81,32 @@ describe Chef::REST::AuthCredentials do
     before do
       @request_time = Time.at(1270920860)
       @request_params = {:http_method => :POST, :path => "/clients", :body => '{"some":"json"}', :host => "localhost"}
+      allow(Chef::Config).to(
+        receive(:[]).with(:authentication_protocol_version).and_return(protocol_version))
     end
 
-    it "generates signature headers for the request" do
-      allow(Time).to receive(:now).and_return(@request_time)
-      actual = @auth_credentials.signature_headers(@request_params)
-      expect(actual["HOST"]).to                    eq("localhost")
-      expect(actual["X-OPS-AUTHORIZATION-1"]).to eq("kBssX1ENEwKtNYFrHElN9vYGWS7OeowepN9EsYc9csWfh8oUovryPKDxytQ/")
-      expect(actual["X-OPS-AUTHORIZATION-2"]).to eq("Wc2/nSSyxdWJjjfHzrE+YrqNQTaArOA7JkAf5p75eTUonCWcvNPjFrZVgKGS")
-      expect(actual["X-OPS-AUTHORIZATION-3"]).to eq("yhzHJQh+lcVA9wwARg5Hu9q+ddS8xBOdm3Vp5atl5NGHiP0loiigMYvAvzPO")
-      expect(actual["X-OPS-AUTHORIZATION-4"]).to eq("r9853eIxwYMhn5hLGhAGFQznJbE8+7F/lLU5Zmk2t2MlPY8q3o1Q61YD8QiJ")
-      expect(actual["X-OPS-AUTHORIZATION-5"]).to eq("M8lIt53ckMyUmSU0DDURoiXLVkE9mag/6Yq2tPNzWq2AdFvBqku9h2w+DY5k")
-      expect(actual["X-OPS-AUTHORIZATION-6"]).to eq("qA5Rnzw5rPpp3nrWA9jKkPw4Wq3+4ufO2Xs6w7GCjA==")
-      expect(actual["X-OPS-CONTENT-HASH"]).to eq("1tuzs5XKztM1ANrkGNPah6rW9GY=")
-      expect(actual["X-OPS-SIGN"]).to         match(%r{(version=1\.0)|(algorithm=sha1;version=1.0;)})
-      expect(actual["X-OPS-TIMESTAMP"]).to    eq("2010-04-10T17:34:20Z")
-      expect(actual["X-OPS-USERID"]).to       eq("client-name")
+    context "when configured for version 1.0 of the authn protocol" do
+      let(:protocol_version) { "1.0" }
 
+      it "generates signature headers for the request" do
+        allow(Time).to receive(:now).and_return(@request_time)
+        actual = @auth_credentials.signature_headers(@request_params)
+        expect(actual["HOST"]).to                    eq("localhost")
+        expect(actual["X-OPS-AUTHORIZATION-1"]).to eq("kBssX1ENEwKtNYFrHElN9vYGWS7OeowepN9EsYc9csWfh8oUovryPKDxytQ/")
+        expect(actual["X-OPS-AUTHORIZATION-2"]).to eq("Wc2/nSSyxdWJjjfHzrE+YrqNQTaArOA7JkAf5p75eTUonCWcvNPjFrZVgKGS")
+        expect(actual["X-OPS-AUTHORIZATION-3"]).to eq("yhzHJQh+lcVA9wwARg5Hu9q+ddS8xBOdm3Vp5atl5NGHiP0loiigMYvAvzPO")
+        expect(actual["X-OPS-AUTHORIZATION-4"]).to eq("r9853eIxwYMhn5hLGhAGFQznJbE8+7F/lLU5Zmk2t2MlPY8q3o1Q61YD8QiJ")
+        expect(actual["X-OPS-AUTHORIZATION-5"]).to eq("M8lIt53ckMyUmSU0DDURoiXLVkE9mag/6Yq2tPNzWq2AdFvBqku9h2w+DY5k")
+        expect(actual["X-OPS-AUTHORIZATION-6"]).to eq("qA5Rnzw5rPpp3nrWA9jKkPw4Wq3+4ufO2Xs6w7GCjA==")
+        expect(actual["X-OPS-CONTENT-HASH"]).to eq("1tuzs5XKztM1ANrkGNPah6rW9GY=")
+        expect(actual["X-OPS-SIGN"]).to         match(%r{(version=1\.0)|(algorithm=sha1;version=1.0;)})
+        expect(actual["X-OPS-TIMESTAMP"]).to    eq("2010-04-10T17:34:20Z")
+        expect(actual["X-OPS-USERID"]).to       eq("client-name")
+      end
     end
 
-    describe "when configured for version 1.1 of the authn protocol" do
-      before do
-        Chef::Config[:authentication_protocol_version] = "1.1"
-      end
-
-      after do
-        Chef::Config[:authentication_protocol_version] = "1.0"
-      end
+    context "when configured for version 1.1 of the authn protocol" do
+      let(:protocol_version) { "1.1" }
 
       it "generates the correct signature for version 1.1" do
         allow(Time).to receive(:now).and_return(@request_time)


### PR DESCRIPTION
All supported Chef servers support the 1.1 signing protocol.
There is no reason to continue using 1.0, and removing it
as the default allows us to remove a bunch of code that tries
to upgrade 1.0 to 1.1 when the node name is too long.

If the user specifies 1.0 as the auth protocol version from
this point on, they will have to guarantee that the node
name is not too long.

cc @chef/client-core 