### PR TITLE
non msi packages must explicitly provide a source attribute on install

### DIFF
--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -88,11 +88,19 @@ to better align with other ssh related options.
 
 `windows_package` now supports more than just `MSI`. Most common windows installer types are supported including Inno Setup, Nullsoft, Wise and InstallShield. The new allowed `installer_type` values are: `inno`, `nsis`, `wise`, `installshield`, `custom`, and `msi`.
 
+**Non `:msi` package installation**
+When installing non `:msi` packages, the `package_name` should match the display name used for the installed package in the "Add/Remove Programs" settings application. This value can also be found in the following registry locations:
+* HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall
+* HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall
+* HKEY_LOCAL_MACHINE\Software\Wow6464Node\Microsoft\Windows\CurrentVersion\Uninstall
+
+ Further, non `:msi` packages must explicitly include a package `source` attribute when using the `:install` action. Unlike `:msi` packages, they will not default to the package name if missing. Without the name matching the software's display name, non `:msi` packages will always reconverge on `:install`.
+
 Also, while being able to download remote installers from a `HTTP` resource is not new, it looks as though the top of the docs page is incorrect stating that only local installers can be used as a source.
 
 Example Nullsoft (`nsis`) package resource:
 ```
-windows_package 'Mercurial 3.6.1 (64-bit)' do
+package 'Mercurial 3.6.1 (64-bit)' do
   source 'http://mercurial.selenic.com/release/windows/Mercurial-3.6.1-x64.exe'
   checksum 'febd29578cb6736163d232708b834a2ddd119aa40abc536b2c313fc5e1b5831d'
 end
@@ -100,7 +108,7 @@ end
 
 Example Custom `windows_package` resource:
 ```
-windows_package 'Microsoft Visual C++ 2005 Redistributable' do
+package 'Microsoft Visual C++ 2005 Redistributable' do
   source 'https://download.microsoft.com/download/6/B/B/6BB661D6-A8AE-4819-B79F-236472F6070C/vcredist_x86.exe'
   installer_type :custom
   options '/Q'
@@ -108,15 +116,18 @@ end
 ```
 Using a `:custom` package is one way to install a non `.msi` file that embeds an `msi` based installer.
 
+**`windows_package` removal**
 Packages can now be removed without the need to include the package `source`. The relevent uninstall metadata will now be discovered from the registry.
 ```
-windows_package 'Mercurial 3.6.1 (64-bit)' do
+package 'Mercurial 3.6.1 (64-bit)' do
   action :remove
 end
 ```
-It is important that the package name used when not including the `source` is EXACTLY the same as the display name found in "Add/Remove programs" or the `DisplayName` property in the appropriate registry key:
+For non `:msi` packages, it is important that the package name used is EXACTLY the same as the display name found in "Add/Remove programs" or the `DisplayName` property in the appropriate registry key:
 * HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall
 * HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall
 * HKEY_LOCAL_MACHINE\Software\Wow6464Node\Microsoft\Windows\CurrentVersion\Uninstall
+
+When removing `:msi` packages, this same package naming rule applies if the `source` is omitted.
 
 Note that if there are multiple versions of a package installed with the same display name, all packages will be removed unless a version is provided in the `version` attribute or can be discovered in the `source` installer file.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,7 +59,7 @@ This is the first release where we are rolling out a MSI package for Windows tha
 
 ## `windows_package` now supports non-`MSI` based Windows installers
 
-Today you can install `MSI`s using the `windows_package` resource. However, you have had to use the windows cookbook in order to install non `MSI` based installer packages such as Nullsoft, Inno Setup, Installshield and other `EXE` based installers. We have moved and slightly improved the windows cookbook resource into the core chef client. This means you can now run most windows installer types without taking on external cookbook dependencies.
+Today you can install `MSI`s using the `windows_package` resource. However, you have had to use the windows cookbook in order to install non `MSI` based installer packages such as Nullsoft, Inno Setup, Installshield and other `EXE` based installers. We have moved and slightly improved the windows cookbook resource into the core chef client. This means you can now run most windows installer types without taking on external cookbook dependencies. Note that the `source` attribute of non `:msi` windows packages is required since the `package_name` is expected to match the same name displayed in "Add/Remove Programs."
 
 ## Better handling of log_location with chef client service (Windows)
 

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -170,6 +170,7 @@ class Chef
 
     class CannotDetermineHomebrewOwner < Package; end
     class CannotDetermineWindowsInstallerType < Package; end
+    class NoWindowsPackageSource < Package; end
 
     # Can not create staging file during file deployment
     class FileContentStagingError < RuntimeError

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -49,7 +49,7 @@ class Chef
             current_resource.version(:unknown.to_s)
           else
             current_resource.version(package_provider.installed_version)
-            new_resource.version(package_provider.package_version)
+            new_resource.version(package_provider.package_version) if package_provider.package_version
           end
 
           current_resource

--- a/lib/chef/provider/package/windows/exe.rb
+++ b/lib/chef/provider/package/windows/exe.rb
@@ -99,7 +99,7 @@ class Chef
 
           def install_file_version
             @install_file_version ||= begin
-              if ::File.exist?(@new_resource.source)
+              if !new_resource.source.nil? && ::File.exist?(new_resource.source)
                 version_info = Chef::ReservedNames::Win32::File.version_info(new_resource.source)
                 file_version = version_info.FileVersion || version_info.ProductVersion
                 file_version == '' ? nil : file_version

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -44,7 +44,7 @@ class Chef
 
           # Returns a version if the package is installed or nil if it is not.
           def installed_version
-            if ::File.exist?(new_resource.source)
+            if !new_resource.source.nil? && ::File.exist?(new_resource.source)
               Chef::Log.debug("#{new_resource} getting product code for package at #{new_resource.source}")
               product_code = get_product_property(new_resource.source, "ProductCode")
               Chef::Log.debug("#{new_resource} checking package status and version for #{product_code}")
@@ -58,7 +58,7 @@ class Chef
 
           def package_version
             return new_resource.version if new_resource.version
-            if ::File.exist?(new_resource.source)
+            if !new_resource.source.nil? && ::File.exist?(new_resource.source)
               Chef::Log.debug("#{new_resource} getting product version for package at #{new_resource.source}")
               get_product_property(new_resource.source, "ProductVersion")
             end
@@ -72,7 +72,7 @@ class Chef
 
           def remove_package
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
-            if ::File.exist?(new_resource.source)
+            if !new_resource.source.nil? && ::File.exist?(new_resource.source)
               Chef::Log.debug("#{new_resource} removing MSI package '#{new_resource.source}'")
               shell_out!("msiexec /qn /x \"#{new_resource.source}\" #{expand_options(new_resource.options)}", {:timeout => new_resource.timeout, :returns => new_resource.returns})
             else

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -32,16 +32,20 @@ class Chef
 
       allowed_actions :install, :remove
 
+      def initialize(name, run_context=nil)
+        super
+        @source ||= source(@package_name) if @package_name.downcase.end_with?('.msi')
+      end
+
       # Unique to this resource
       property :installer_type, Symbol
       property :timeout, [ String, Integer ], default: 600
       # In the past we accepted return code 127 for an unknown reason and 42 because of a bug
       property :returns, [ String, Integer, Array ], default: [ 0 ], desired_state: false
-      property :source, String, name_property: true,
+      property :source, String,
                 coerce: proc { |s| uri_scheme?(s) ? s : Chef::Util::PathHelper.canonical_path(s, false) }
       property :checksum, String, desired_state: false
       property :remote_file_attributes, Hash, desired_state: false
-
     end
   end
 end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -43,7 +43,11 @@ class Chef
       # In the past we accepted return code 127 for an unknown reason and 42 because of a bug
       property :returns, [ String, Integer, Array ], default: [ 0 ], desired_state: false
       property :source, String,
-                coerce: proc { |s| uri_scheme?(s) ? s : Chef::Util::PathHelper.canonical_path(s, false) }
+                coerce: (proc do |s|
+                  unless s.nil?
+                    uri_scheme?(s) ? s : Chef::Util::PathHelper.canonical_path(s, false)
+                  end
+                end)
       property :checksum, String, desired_state: false
       property :remote_file_attributes, Hash, desired_state: false
     end

--- a/spec/functional/resource/windows_package_spec.rb
+++ b/spec/functional/resource/windows_package_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Resource::WindowsPackage, :windows_only, :volatile do
 
   subject do
     new_resource = Chef::Resource::WindowsPackage.new(pkg_name, run_context)
-    new_resource.source pkg_path
+    new_resource.source pkg_path if pkg_path
     new_resource.version pkg_version
     new_resource.installer_type pkg_type
     new_resource.options pkg_options

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -280,15 +280,25 @@ describe Chef::Provider::Package::Windows, :windows_only do
   end
 
   describe "action_install" do
-    let(:new_resource) { Chef::Resource::WindowsPackage.new("blah.exe") }
+    let(:resource_name) { "blah" }
+    let(:resource_source) { "blah.exe" }
+
     before do
       new_resource.installer_type(:inno)
       allow_any_instance_of(Chef::Provider::Package::Windows::Exe).to receive(:package_version).and_return(new_resource.version)
     end
 
+    context "no source given" do
+      let(:resource_source) { nil }
+
+      it "raises a NoWindowsPackageSource error" do
+        expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::NoWindowsPackageSource)
+      end
+    end
+
     context "no version given, discovered or installed" do
       it "installs latest" do
-        expect(provider).to receive(:install_package).with("blah.exe", "latest")
+        expect(provider).to receive(:install_package).with("blah", "latest")
         provider.run_action(:install)
       end
     end
@@ -306,7 +316,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
       before { new_resource.version('5.5.5') }
 
       it "installs given version" do
-        expect(provider).to receive(:install_package).with("blah.exe", "5.5.5")
+        expect(provider).to receive(:install_package).with("blah", "5.5.5")
         provider.run_action(:install)
       end
     end
@@ -331,7 +341,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
         end
         
         it "installs given version" do
-          expect(provider).to receive(:install_package).with("blah.exe", "5.5.5")
+          expect(provider).to receive(:install_package).with("blah", "5.5.5")
           provider.run_action(:install)
         end
       end
@@ -357,7 +367,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
         end
         
         it "installs given version" do
-          expect(provider).to receive(:install_package).with("blah.exe", "5.5.5")
+          expect(provider).to receive(:install_package).with("blah", "5.5.5")
           provider.run_action(:install)
         end
       end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
   let(:resource_name) { 'calculator' }
   let(:new_resource) do
     new_resource = Chef::Resource::WindowsPackage.new(resource_name)
-    new_resource.source(resource_source)
+    new_resource.source(resource_source) if resource_source
     new_resource
   end
   let(:provider) { Chef::Provider::Package::Windows.new(new_resource, run_context) }
@@ -98,7 +98,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
     shared_examples "a local file" do
 
       it "checks that the source path is valid" do
-        expect(Chef::Util::PathHelper).to receive(:validate_path)
+        expect(Chef::Util::PathHelper).to receive(:validate_path).and_call_original
         provider.package_provider
       end
 


### PR DESCRIPTION
Currently one can use a package `source` location as a package name:
```
package 'http://mercurial.selenic.com/release/windows/Mercurial-3.6.1-x64.exe' do
  checksum 'febd29578cb6736163d232708b834a2ddd119aa40abc536b2c313fc5e1b5831d'
end
```

In the case of non-`:msi` `installer_type`s, this will result in package resources reconverging an `:install` action even though the package has been previously installed.

The reason is that when the `windows_package` scans the registry for all current software installations, it cannot search by install path or url. So it searches by the `DisplayName` property in the registry keys mentioned above. If you use a source path as the name of a non `:msi` `windows_package` it will not find any currently installed package and will therefore attempt to reinstall the package. `:msi` packages get around this because there is a well known API for extracting the id of the installed MSI package from a `.msi` file.

Requiring an explicit `source` for non `:msi` packages will reduce confusion here around idempotency.