### PR TITLE
Default Chef with FIPS OpenSSL to use sign v1.3

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -452,7 +452,7 @@ module ChefConfig
     default :recipe_url, nil
 
     # Set to true if Chef is to set OpenSSL to run in FIPS mode
-    default :fips, false
+    default(:fips) { ENV['CHEF_FIPS'] == '1' }
 
     # Initialize openssl
     def self.init_openssl

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -27,7 +27,7 @@ require "chef-config/windows"
 require "chef-config/path_helper"
 require "mixlib/shellout"
 require "uri"
-require 'openssl'
+require "openssl"
 
 module ChefConfig
 
@@ -452,18 +452,18 @@ module ChefConfig
     default :recipe_url, nil
 
     # Set to true if Chef is to set OpenSSL to run in FIPS mode
-    default(:fips) { ENV['CHEF_FIPS'] == '1' }
+    default(:fips) { ENV["CHEF_FIPS"] == "1" }
 
     # Initialize openssl
     def self.init_openssl
       if fips
         ChefConfig.logger.warn "The `fips` feature is still a work in progress. This feature is incomplete."
         OpenSSL.fips_mode = true
-        require 'digest'
-        require 'digest/sha1'
-        require 'digest/md5'
-        Digest.const_set('SHA1', OpenSSL::Digest::SHA1)
-        OpenSSL::Digest.const_set('MD5', Digest::MD5)
+        require "digest"
+        require "digest/sha1"
+        require "digest/md5"
+        Digest.const_set("SHA1", OpenSSL::Digest::SHA1)
+        OpenSSL::Digest.const_set("MD5", Digest::MD5)
       end
     end
 

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -27,6 +27,7 @@ require "chef-config/windows"
 require "chef-config/path_helper"
 require "mixlib/shellout"
 require "uri"
+require 'openssl'
 
 module ChefConfig
 
@@ -452,6 +453,19 @@ module ChefConfig
 
     # Set to true if Chef is to set OpenSSL to run in FIPS mode
     default :openssl_fips, false
+
+    # Initialize openssl
+    def self.init_openssl
+      if openssl_fips
+        ChefConfig.logger.warn "The `openssl_fips` is still a work in progress. This feature is incomplete."
+        OpenSSL.fips_mode = true
+        require 'digest'
+        require 'digest/sha1'
+        require 'digest/md5'
+        Digest.const_set('SHA1', OpenSSL::Digest::SHA1)
+        OpenSSL::Digest.const_set('MD5', Digest::MD5)
+      end
+    end
 
     # Sets the version of the signed header authentication protocol to use (see
     # the 'mixlib-authorization' project for more detail). Currently, versions

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -452,12 +452,12 @@ module ChefConfig
     default :recipe_url, nil
 
     # Set to true if Chef is to set OpenSSL to run in FIPS mode
-    default :openssl_fips, false
+    default :fips, false
 
     # Initialize openssl
     def self.init_openssl
-      if openssl_fips
-        ChefConfig.logger.warn "The `openssl_fips` is still a work in progress. This feature is incomplete."
+      if fips
+        ChefConfig.logger.warn "The `fips` feature is still a work in progress. This feature is incomplete."
         OpenSSL.fips_mode = true
         require 'digest'
         require 'digest/sha1'
@@ -471,7 +471,7 @@ module ChefConfig
     # the 'mixlib-authorization' project for more detail). Currently, versions
     # 1.0, 1.1, and 1.3 are available.
     default :authentication_protocol_version do
-      if openssl_fips
+      if fips
         "1.3"
       else
         "1.1"

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -450,10 +450,19 @@ module ChefConfig
     # Where should chef-solo download recipes from?
     default :recipe_url, nil
 
+    # Set to true if Chef is to set OpenSSL to run in FIPS mode
+    default :openssl_fips, false
+
     # Sets the version of the signed header authentication protocol to use (see
     # the 'mixlib-authorization' project for more detail). Currently, versions
-    # 1.0 and 1.1 are available.
-    default :authentication_protocol_version, "1.1"
+    # 1.0, 1.1, and 1.3 are available.
+    default :authentication_protocol_version do
+      if openssl_fips
+        "1.3"
+      else
+        "1.1"
+      end
+    end
 
     # This key will be used to sign requests to the Chef server. This location
     # must be writable by Chef during initial setup when generating a client

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "mixlib-cli", "~> 1.4"
   s.add_dependency "mixlib-log", "~> 1.3"
-  s.add_dependency "mixlib-authentication", "~> 1.3"
+  s.add_dependency "mixlib-authentication", "~> 1.4"
   s.add_dependency "mixlib-shellout", "~> 2.0"
   s.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9"
 

--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -52,5 +52,8 @@ IF "%PIPELINE_NAME%" == "chef-13" (
   call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/unit spec/functional
 ) ELSE (
   REM ; Running unit tests
+  IF "%PIPELINE_NAME%" == "chef-fips" (
+    set CHEF_FIPS=1
+  )
   call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/unit spec/functional
 )

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -86,4 +86,9 @@ if [ ! -f "Gemfile.lock" ]; then
   exit 1
 fi
 
-sudo env PATH=$PATH TERM=xterm bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit
+CHEF_FIPS=0
+if [ $PIPELINE_NAME='chef-fips'];
+then
+    CHEF_FIPS=1
+fi
+sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -84,6 +84,7 @@ class Chef
       parse_options
       load_config_file
       Chef::Config.export_proxies
+      Chef::Config.init_openssl
     end
 
     # Parse the config file

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -125,6 +125,7 @@ class Chef::Application::Apply < Chef::Application
     Chef::Config.merge!(config)
     configure_logging
     Chef::Config.export_proxies
+    Chef::Config.init_openssl
     parse_json
   end
 

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -274,6 +274,11 @@ class Chef::Application::Client < Chef::Application
     :description    => "Whether a local mode (-z) server binds to a port",
     :boolean        => true
 
+  option :fips,
+    :long         => "--fips",
+    :description  => "Enable fips mode",
+    :boolean      => true
+
   IMMEDIATE_RUN_SIGNAL = "1".freeze
 
   attr_reader :chef_client_json
@@ -286,6 +291,8 @@ class Chef::Application::Client < Chef::Application
     raise Chef::Exceptions::PIDFileLockfileMatch if Chef::Util::PathHelper.paths_eql? (Chef::Config[:pid_file] || "" ), (Chef::Config[:lockfile] || "")
 
     set_specific_recipes
+
+    Chef::Config[:fips] = config[:fips] if config.has_key? :fips
 
     Chef::Config[:chef_server_url] = config[:chef_server_url] if config.has_key? :chef_server_url
 

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -42,7 +42,8 @@ class Chef
       end
 
       def run_start(version)
-        puts_line "Starting Chef Client, version #{version}"
+        puts_line "Starting Chef Client#{" (FIPS mode)" if Chef::Config[:openssl_fips]}" \
+          ", version #{version}"
       end
 
       def total_resources

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -42,8 +42,8 @@ class Chef
       end
 
       def run_start(version)
-        puts_line "Starting Chef Client#{" (FIPS mode)" if Chef::Config[:openssl_fips]}" \
-          ", version #{version}"
+        puts_line "Starting Chef Client, version #{version}"
+        puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
       end
 
       def total_resources

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -29,7 +29,8 @@ class Chef
 
       # Called at the very start of a Chef Run
       def run_start(version)
-        puts "Starting Chef Client, version #{version}"
+        puts_line "Starting Chef Client#{" (FIPS mode)" if Chef::Config[:openssl_fips]}" \
+            ", version #{version}"
       end
 
       # Called at the end of the Chef run.

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -29,8 +29,8 @@ class Chef
 
       # Called at the very start of a Chef Run
       def run_start(version)
-        puts_line "Starting Chef Client#{" (FIPS mode)" if Chef::Config[:openssl_fips]}" \
-            ", version #{version}"
+        puts_line "Starting Chef Client, version #{version}"
+        puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
       end
 
       # Called at the end of the Chef run.

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -47,8 +47,8 @@ class Chef
       end
 
       def handle_request(method, url, headers={}, data=false)
-        headers.merge!(authentication_headers(method, url, data)) if sign_requests?
         headers.merge!({"X-Ops-Server-API-Version" => @api_version})
+        headers.merge!(authentication_headers(method, url, data, headers)) if sign_requests?
         [method, url, headers, data]
       end
 
@@ -90,12 +90,17 @@ class Chef
         raise Chef::Exceptions::InvalidPrivateKey, msg
       end
 
-      def authentication_headers(method, url, json_body=nil)
-        request_params = {:http_method => method, :path => url.path, :body => json_body, :host => "#{url.host}:#{url.port}"}
+      def authentication_headers(method, url, json_body=nil, headers=nil)
+        request_params = {
+          :http_method => method,
+          :path => url.path,
+          :body => json_body,
+          :host => "#{url.host}:#{url.port}",
+          :headers => headers,
+        }
         request_params[:body] ||= ""
         auth_credentials.signature_headers(request_params)
       end
-
     end
   end
 end

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -398,6 +398,7 @@ class Chef
       merge_configs
       apply_computed_config
       Chef::Config.export_proxies
+      Chef::Config.init_openssl
       # This has to be after apply_computed_config so that Mixlib::Log is configured
       Chef::Log.info("Using configuration from #{config[:config_file]}") if config[:config_file]
     end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -250,6 +250,11 @@ class Chef
           Chef::Config[:knife][:bootstrap_vault_item]
         }
 
+      option :openssl_fips,
+        :long => "--openssl-fips",
+        :description => "Set openssl to run in fips mode",
+        :boolean => true
+
       def initialize(argv=[])
         super
         @client_builder = Chef::Knife::Bootstrap::ClientBuilder.new(

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -250,8 +250,8 @@ class Chef
           Chef::Config[:knife][:bootstrap_vault_item]
         }
 
-      option :openssl_fips,
-        :long => "--openssl-fips",
+      option :fips,
+        :long => "--fips",
         :description => "Set openssl to run in fips mode",
         :boolean => true
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -120,6 +120,10 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
             client_rb << %Q{trusted_certs_dir "/etc/chef/trusted_certs"\n}
           end
 
+          if @config[:openssl_fips]
+            client_rb << %Q{openssl_fips true\n}
+          end
+
           client_rb
         end
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -120,8 +120,8 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
             client_rb << %Q{trusted_certs_dir "/etc/chef/trusted_certs"\n}
           end
 
-          if @config[:openssl_fips]
-            client_rb << %Q{openssl_fips true\n}
+          if @config[:fips]
+            client_rb << %Q{fips true\n}
           end
 
           client_rb

--- a/omnibus/config/projects/chef-fips.rb
+++ b/omnibus/config/projects/chef-fips.rb
@@ -38,7 +38,7 @@ end
 override :fips, enabled: true
 override :'ruby-windows', version: "2.0.0-p647"
 
-override :chef, version: "jdm/1.3-fips"
+override :chef, version: "local_source"
 override :ohai, version: "master"
 
 msi_upgrade_code = "819F5DB3-B818-4358-BB2B-54B8171D0A26"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,10 @@ require "chef/util/file_edit"
 
 require "chef/config"
 
+if ENV["CHEF_FIPS"] == "1"
+  Chef::Config.init_openssl
+end
+
 # If you want to load anything into the testing environment
 # without versioning it, add it to spec/support/local_gems.rb
 require "spec/support/local_gems.rb" if File.exists?(File.join(File.dirname(__FILE__), "support", "local_gems.rb"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -165,6 +165,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
   config.filter_run_excluding :broken => true
   config.filter_run_excluding :not_wpar => true unless wpar?
+  config.filter_run_excluding :not_fips => true unless fips?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -27,7 +27,7 @@ Chef::Config.solo(false)
 
 
 def sha256_checksum(path)
-  Digest::SHA256.hexdigest(File.read(path))
+  OpenSSL::Digest::SHA256.hexdigest(File.read(path))
 end
 
 # From Ruby 1.9.2+

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -204,6 +204,10 @@ def aes_256_gcm?
   OpenSSL::Cipher.ciphers.include?("aes-256-gcm")
 end
 
+def fips?
+  ENV["CHEF_FIPS"] == "1"
+end
+
 class GCEDetector
   extend Ohai::Mixin::GCEMetadata
 end

--- a/spec/unit/api_client/registration_spec.rb
+++ b/spec/unit/api_client/registration_spec.rb
@@ -113,7 +113,7 @@ describe Chef::ApiClient::Registration do
         with("clients", expected_post_data).
         and_return(create_with_pkey_response)
       expect(registration.run.public_key).to eq(create_with_pkey_response["chef_key"]["public_key"])
-      expect(registration.private_key).to eq(generated_private_key_pem)
+      expect(OpenSSL::PKey::RSA.new(registration.private_key).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
     end
 
     it "puts a locally generated public key to the server to update a client" do
@@ -124,7 +124,7 @@ describe Chef::ApiClient::Registration do
         with("clients/#{client_name}", expected_put_data).
         and_return(update_with_pkey_response)
       expect(registration.run.public_key).to eq(update_with_pkey_response["public_key"].to_pem)
-      expect(registration.private_key).to eq(generated_private_key_pem)
+      expect(OpenSSL::PKey::RSA.new(registration.private_key).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
     end
 
     it "writes the generated private key to disk" do
@@ -132,7 +132,7 @@ describe Chef::ApiClient::Registration do
         with("clients", expected_post_data).
         and_return(create_with_pkey_response)
       registration.run
-      expect(IO.read(key_location)).to eq(generated_private_key_pem)
+      expect(OpenSSL::PKey::RSA.new(IO.read(key_location)).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
     end
 
     context "and the client already exists on a Chef 11 server" do
@@ -142,7 +142,7 @@ describe Chef::ApiClient::Registration do
           with("clients/#{client_name}", expected_put_data).
           and_return(update_with_pkey_response)
         expect(registration.run.public_key).to eq(update_with_pkey_response["public_key"].to_pem)
-        expect(registration.private_key).to eq(generated_private_key_pem)
+        expect(OpenSSL::PKey::RSA.new(registration.private_key).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
       end
     end
 
@@ -247,7 +247,7 @@ describe Chef::ApiClient::Registration do
     it "creates the client on the server and writes the key" do
       expect(http_mock).to receive(:post).ordered.and_return(server_v10_response)
       registration.run
-      expect(IO.read(key_location)).to eq(generated_private_key_pem)
+      expect(OpenSSL::PKey::RSA.new(IO.read(key_location)).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
     end
 
     it "retries up to 5 times" do
@@ -262,7 +262,7 @@ describe Chef::ApiClient::Registration do
 
       expect(http_mock).to receive(:post).ordered.and_return(server_v10_response)
       registration.run
-      expect(IO.read(key_location)).to eq(generated_private_key_pem)
+      expect(OpenSSL::PKey::RSA.new(IO.read(key_location)).to_s).to eq(OpenSSL::PKey::RSA.new(generated_private_key_pem).to_s)
     end
 
     it "gives up retrying after the max attempts" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -138,7 +138,7 @@ describe Chef::Application do
 
       context "when openssl fips" do
         before do
-          allow(Chef::Config).to receive(:openssl_fips).and_return(true)
+          allow(Chef::Config).to receive(:fips).and_return(true)
         end
 
         it "sets openssl in fips mode" do

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -136,6 +136,16 @@ describe Chef::Application do
         expect(Chef::Config.rspec_ran).to eq("true")
       end
 
+      context "when openssl fips" do
+        before do
+          allow(Chef::Config).to receive(:openssl_fips).and_return(true)
+        end
+
+        it "sets openssl in fips mode" do
+          expect(OpenSSL).to receive(:'fips_mode=').with(true)
+          @app.configure_chef
+        end
+      end
     end
 
     describe "when there is no config_file defined" do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -45,8 +45,23 @@ describe Chef::Client do
   end
 
   describe "authentication protocol selection" do
-    it "defaults to 1.1" do
-      expect(Chef::Config[:authentication_protocol_version]).to eq("1.1")
+    context "when openssl is not compiled with the FIPS module" do
+      it "defaults to 1.1" do
+        expect(Chef::Config[:authentication_protocol_version]).to eq("1.1")
+      end
+    end
+    context "when openssl is compiled with the FIPS module" do
+      before do
+        Chef::Config[:openssl_fips] = true
+      end
+
+      it "defaults to 1.3" do
+        expect(Chef::Config[:authentication_protocol_version]).to eq("1.3")
+      end
+
+      after do
+        Chef::Config[:openssl_fips] = false
+      end
     end
   end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -45,12 +45,16 @@ describe Chef::Client do
   end
 
   describe "authentication protocol selection" do
-    context "when openssl is not compiled with the FIPS module" do
+    context "when FIPS is disabled" do
+      before do
+        Chef::Config[:fips] = false
+      end
+
       it "defaults to 1.1" do
         expect(Chef::Config[:authentication_protocol_version]).to eq("1.1")
       end
     end
-    context "when openssl is compiled with the FIPS module" do
+    context "when FIPS is enabled" do
       before do
         Chef::Config[:fips] = true
       end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Client do
     end
     context "when openssl is compiled with the FIPS module" do
       before do
-        Chef::Config[:openssl_fips] = true
+        Chef::Config[:fips] = true
       end
 
       it "defaults to 1.3" do
@@ -60,7 +60,7 @@ describe Chef::Client do
       end
 
       after do
-        Chef::Config[:openssl_fips] = false
+        Chef::Config[:fips] = false
       end
     end
   end

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -290,7 +290,7 @@ describe Chef::EncryptedDataBagItem::Decryptor do
 
   end
 
-  context "when decrypting a version 0 (YAML+aes-256-cbc+no iv) encrypted value" do
+  context "when decrypting a version 0 (YAML+aes-256-cbc+no iv) encrypted value", :not_fips do
     let(:encrypted_value) do
       Version0Encryptor.encrypt_value(plaintext_data, encryption_key)
     end

--- a/spec/unit/http/authenticator_spec.rb
+++ b/spec/unit/http/authenticator_spec.rb
@@ -70,7 +70,9 @@ describe Chef::HTTP::Authenticator do
       it_behaves_like "merging the server API version into the headers"
 
       it "calls authentication_headers with the proper input" do
-        expect(class_instance).to receive(:authentication_headers).with(method, url, data).and_return({})
+        expect(class_instance).to receive(:authentication_headers).with(
+          method, url, data,
+          {"X-Ops-Server-API-Version" => Chef::HTTP::Authenticator::DEFAULT_SERVER_API_VERSION}).and_return({})
         class_instance.handle_request(method, url, headers, data)
       end
     end

--- a/spec/unit/http/ssl_policies_spec.rb
+++ b/spec/unit/http/ssl_policies_spec.rb
@@ -109,7 +109,7 @@ describe "HTTP SSL Policy" do
         Chef::Config[:ssl_client_cert] = CHEF_SPEC_DATA + "/ssl/chef-rspec.cert"
         Chef::Config[:ssl_client_key]  = CHEF_SPEC_DATA + "/ssl/chef-rspec.key"
         expect(http_client.cert.to_s).to eq(OpenSSL::X509::Certificate.new(IO.read(CHEF_SPEC_DATA + "/ssl/chef-rspec.cert")).to_s)
-        expect(http_client.key.to_s).to  eq(IO.read(CHEF_SPEC_DATA + "/ssl/chef-rspec.key"))
+        expect(http_client.key.to_s).to eq(OpenSSL::PKey::RSA.new(IO.read(CHEF_SPEC_DATA + "/ssl/chef-rspec.key")).to_s)
       end
     end
 

--- a/spec/unit/rest/auth_credentials_spec.rb
+++ b/spec/unit/rest/auth_credentials_spec.rb
@@ -23,37 +23,6 @@ require "spec_helper"
 require "uri"
 require "net/https"
 
-KEY_DOT_PEM=<<-END_RSA_KEY
------BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA49TA0y81ps0zxkOpmf5V4/c4IeR5yVyQFpX3JpxO4TquwnRh
-8VSUhrw8kkTLmB3cS39Db+3HadvhoqCEbqPE6915kXSuk/cWIcNozujLK7tkuPEy
-YVsyTioQAddSdfe+8EhQVf3oHxaKmUd6waXrWqYCnhxgOjxocenREYNhZ/OETIei
-PbOku47vB4nJK/0GhKBytL2XnsRgfKgDxf42BqAi1jglIdeq8lAWZNF9TbNBU21A
-O1iuT7Pm6LyQujhggPznR5FJhXKRUARXBJZawxpGV4dGtdcahwXNE4601aXPra+x
-PcRd2puCNoEDBzgVuTSsLYeKBDMSfs173W1QYwIDAQABAoIBAGF05q7vqOGbMaSD
-2Q7YbuE/JTHKTBZIlBI1QC2x+0P5GDxyEFttNMOVzcs7xmNhkpRw8eX1LrInrpMk
-WsIBKAFFEfWYlf0RWtRChJjNl+szE9jQxB5FJnWtJH/FHa78tR6PsF24aQyzVcJP
-g0FGujBihwgfV0JSCNOBkz8MliQihjQA2i8PGGmo4R4RVzGfxYKTIq9vvRq/+QEa
-Q4lpVLoBqnENpnY/9PTl6JMMjW2b0spbLjOPVwDaIzXJ0dChjNXo15K5SHI5mALJ
-I5gN7ODGb8PKUf4619ez194FXq+eob5YJdilTFKensIUvt3YhP1ilGMM+Chi5Vi/
-/RCTw3ECgYEA9jTw4wv9pCswZ9wbzTaBj9yZS3YXspGg26y6Ohq3ZmvHz4jlT6uR
-xK+DDcUiK4072gci8S4Np0fIVS7q6ivqcOdzXPrTF5/j+MufS32UrBbUTPiM1yoO
-ECcy+1szl/KoLEV09bghPbvC58PFSXV71evkaTETYnA/F6RK12lEepcCgYEA7OSy
-bsMrGDVU/MKJtwqyGP9ubA53BorM4Pp9VVVSCrGGVhb9G/XNsjO5wJC8J30QAo4A
-s59ZzCpyNRy046AB8jwRQuSwEQbejSdeNgQGXhZ7aIVUtuDeFFdaIz/zjVgxsfj4
-DPOuzieMmJ2MLR4F71ocboxNoDI7xruPSE8dDhUCgYA3vx732cQxgtHwAkeNPJUz
-dLiE/JU7CnxIoSB9fYUfPLI+THnXgzp7NV5QJN2qzMzLfigsQcg3oyo6F2h7Yzwv
-GkjlualIRRzCPaCw4Btkp7qkPvbs1QngIHALt8fD1N69P3DPHkTwjG4COjKWgnJq
-qoHKS6Fe/ZlbigikI6KsuwKBgQCTlSLoyGRHr6oj0hqz01EDK9ciMJzMkZp0Kvn8
-OKxlBxYW+jlzut4MQBdgNYtS2qInxUoAnaz2+hauqhSzntK3k955GznpUatCqx0R
-b857vWviwPX2/P6+E3GPdl8IVsKXCvGWOBZWTuNTjQtwbDzsUepWoMgXnlQJSn5I
-YSlLxQKBgQD16Gw9kajpKlzsPa6XoQeGmZALT6aKWJQlrKtUQIrsIWM0Z6eFtX12
-2jjHZ0awuCQ4ldqwl8IfRogWMBkHOXjTPVK0YKWWlxMpD/5+bGPARa5fir8O1Zpo
-Y6S6MeZ69Rp89ma4ttMZ+kwi1+XyHqC/dlcVRW42Zl5Dc7BALRlJjQ==
------END RSA PRIVATE KEY-----
-  END_RSA_KEY
-
-
 describe Chef::REST::AuthCredentials do
   before do
     @key_file_fixture = CHEF_SPEC_DATA + "/ssl/private_key.pem"
@@ -67,7 +36,7 @@ describe Chef::REST::AuthCredentials do
 
   it "loads the private key when initialized with the path to the key" do
     expect(@auth_credentials.key).to respond_to(:private_encrypt)
-    expect(@auth_credentials.key.to_s).to eq(KEY_DOT_PEM)
+    expect(@auth_credentials.key).to eq(@key)
   end
 
   describe "when loading the private key" do


### PR DESCRIPTION
This adds a feature flag to tell openssl to run in fips mode. We will be including the fips object module in our omnibus builds. This shouldn't affect anybody unless they explicitly ask for openssl to be run in fips mode.