### PR TITLE
Fix no_proxy setting in chef-config

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -720,7 +720,7 @@ module ChefConfig
       export_proxy("http", http_proxy, http_proxy_user, http_proxy_pass) if http_proxy
       export_proxy("https", https_proxy, https_proxy_user, https_proxy_pass) if https_proxy
       export_proxy("ftp", ftp_proxy, ftp_proxy_user, ftp_proxy_pass) if ftp_proxy
-      export_no_proxy("no_proxy", no_proxy) if no_proxy
+      export_no_proxy(no_proxy) if no_proxy
     end
 
     # Builds a proxy uri and exports it to the appropriate environment variables. Examples:

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -677,6 +677,17 @@ RSpec.describe ChefConfig::Config do
       end
       include_examples "no export"
     end
+
+    context "no_proxy is set" do
+      before do
+        ChefConfig::Config.no_proxy = "localhost"
+      end
+      it "exports ENV['no_proxy']" do
+        expect(ENV).to receive(:[]=).with('no_proxy', "localhost")
+        expect(ENV).to receive(:[]=).with('NO_PROXY', "localhost")
+        ChefConfig::Config.export_proxies
+      end
+    end
   end
 
   describe "allowing chefdk configuration outside of chefdk" do


### PR DESCRIPTION
Setting a value for `no_proxy` caused ruby to crash.