### PR TITLE
Reduce appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200"
     - ruby_version: "200-x64"
     - ruby_version: "21"
 


### PR DESCRIPTION
Our tests are getting backed up. 2 hours is unreasonable.
Removing ruby 2.0 32 bit from the matrix