### PR TITLE
Windows alternate user support for execute resources

### DIFF
--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -18,3 +18,40 @@ To enable the standardized exit code behavior, there is a new setting in client.
 
 If you need to maintain the previous exit code behavior to support your current workflow, you can disable this (and the deprecation warnings) by setting `exit_status` to `:disabled`.
 
+### Windows alternate user identity execute support
+
+The `execute` resource and simliar resources such as `script`, `batch`, and `powershell_script`
+now support the specification of credentials on Windows so that the resulting process
+is created with the security identity that corresponds to those credentials.
+
+#### Properties
+
+The following properties are new or updated for the `execute`, `script`, `batch`, and
+`powershell_script` resources and any resources derived from them:
+
+*   `user`</br>
+    **Ruby types:** String</br>
+    The user name of the user identity with which to launch the new process.
+    Default value: `nil`. The user name may optionally be specifed
+    with a domain, i.e. `domain\user` or `user@my.dns.domain.com` via Universal Principal Name (UPN)
+    format. It can also be specified without a domain simply as `user` if the domain is
+    instead specified using the `domain` attribute. On Windows only, if this property is specified, the `password`
+    property **must** be specified.
+
+*   `password`</br>
+    **Ruby types** String</br>
+    *Windows only:* The password of the user specified by the `user` property.
+    Default value: `nil`. This property is mandatory if `user` is specified on Windows and may only
+    be specified if `user` is specified. The `sensitive` property for this resource will
+    automatically be set to `true` if `password` is specified.
+
+*   `domain`</br>
+    **Ruby types** String</br>
+    *Windows only:* The domain of the user user specified by the `user` property.
+    Default value: `nil`. If not specified, the user name and password specified
+    by the `user` and `password` properties will be used to resolve
+    that user against the domain in which the system running Chef client
+    is joined, or if that system is not joined to a domain it will resolve the user
+    as a local account on that system. An alternative way to specify the domain is to leave
+    this property unspecified and specify the domain as part of the `user` property.
+

--- a/lib/chef/mixin/user_identity.rb
+++ b/lib/chef/mixin/user_identity.rb
@@ -1,0 +1,81 @@
+#
+# Author:: Adam Edwards (<adamed@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  module Mixin
+    module UserIdentity
+
+      def validate_identity(specified_user, password = nil, specified_domain = nil)
+        validate_identity_platform(specified_user, password, specified_domain)
+        validate_identity_syntax(specified_user, password, specified_domain)
+      end
+
+      def validate_identity_platform(specified_user, password = nil, specified_domain = nil)
+        if ! Chef::Platform.windows?
+          if password || specified_domain
+            raise Exceptions::UnsupportedPlatform, "Values for `domain` and `password` are only supported on the Windows platform"
+          end
+        else
+          if specified_user && password.nil?
+            raise ArgumentError, "A value for `password` must be specified when a value for `user` is specified on the Windows platform"
+          end
+        end
+      end
+
+      def validate_identity_syntax(specified_user, password = nil, specified_domain = nil)
+        identity = qualify_user(specified_user, specified_domain)
+
+        if ( password || identity[:domain] ) && identity[:user].nil?
+          raise ArgumentError, "A value for `password` or `domain` was specified without specification of a value for `user`"
+        end
+      end
+
+      def qualify_user(specified_user, specified_domain = nil)
+        domain = specified_domain
+        user = specified_user
+
+        if specified_user.nil? && ! specified_domain.nil?
+          raise ArgumentError, "The domain `#{specified_domain}` was specified, but no user name was given"
+        end
+
+        if ! specified_user.nil? && specified_domain.nil?
+          domain_and_user = user.split('\\')
+
+          if domain_and_user.length == 1
+            domain_and_user = user.split('@')
+          end
+
+          if domain_and_user.length == 2
+            domain = domain_and_user[0]
+            user = domain_and_user[1]
+          elsif domain_and_user.length != 1
+            raise ArgumentError, "The specified user name `#{user}` is not a syntactically valid user name"
+          end
+        end
+
+        { domain: domain, user: user }
+      end
+
+      protected(:validate_identity)
+      protected(:validate_identity_platform)
+      protected(:validate_identity_syntax)
+      protected(:qualify_user)
+
+    end
+  end
+end

--- a/lib/chef/mixin/user_identity.rb
+++ b/lib/chef/mixin/user_identity.rb
@@ -57,7 +57,7 @@ class Chef
           domain_and_user = user.split('\\')
 
           if domain_and_user.length == 1
-            domain_and_user = user.split('@')
+            domain_and_user = user.split("@")
           end
 
           if domain_and_user.length == 2

--- a/lib/chef/mixin/user_identity.rb
+++ b/lib/chef/mixin/user_identity.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,10 +71,10 @@ class Chef
         { domain: domain, user: user }
       end
 
-      protected(:validate_identity)
-      protected(:validate_identity_platform)
-      protected(:validate_identity_syntax)
-      protected(:qualify_user)
+      private(:validate_identity)
+      private(:validate_identity_platform)
+      private(:validate_identity_syntax)
+      private(:qualify_user)
 
     end
   end

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
-require 'chef/log'
-require 'chef/provider'
-require 'forwardable'
-require 'chef/mixin/user_identity'
+require "chef/log"
+require "chef/provider"
+require "forwardable"
+require "chef/mixin/user_identity"
 
 class Chef
   class Provider
@@ -46,7 +46,7 @@ class Chef
       end
 
       def define_resource_requirements
-         # @todo: this should change to raise in some appropriate major version bump.
+        # @todo: this should change to raise in some appropriate major version bump.
         if creates && creates_relative? && !cwd
           Chef::Log.warn "Providing a relative path for the creates attribute without the cwd is deprecated and will be changed to fail in the future (CHEF-3819)"
         end

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -32,10 +32,6 @@ class Chef
 
       def_delegators :@new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates
 
-      def initialize(new_resource, run_context)
-        super
-      end
-
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
         current_resource

--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -149,6 +149,14 @@ EOH
         <<-EOH
 # Chef Client wrapper for powershell_script resources
 
+# In rare cases, such as when PowerShell is executed
+# as an alternate user, the new-variable cmdlet is not
+# available, so import it just in case
+if ( get-module -ListAvailable Microsoft.PowerShell.Utility )
+{
+    Import-Module Microsoft.PowerShell.Utility
+}
+
 # LASTEXITCODE can be uninitialized -- make it explictly 0
 # to avoid incorrect detection of failure (non-zero) codes
 $global:LASTEXITCODE = 0

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -16,9 +16,10 @@
 # limitations under the License.
 #
 
-require "tempfile"
-require "chef/provider/execute"
-require "forwardable"
+require 'tempfile'
+require 'chef/provider/execute'
+require 'chef/win32/security' if Chef::Platform.windows?
+require 'forwardable'
 
 class Chef
   class Provider
@@ -69,7 +70,36 @@ class Chef
         # FileUtils itself implements a no-op if +user+ or +group+ are nil
         # You can prove this by running FileUtils.chown(nil,nil,'/tmp/file')
         # as an unprivileged user.
-        FileUtils.chown(new_resource.user, new_resource.group, script_file.path)
+        if ! Chef::Platform.windows?
+          FileUtils.chown(new_resource.user, new_resource.group, script_file.path)
+        else
+          grant_alternate_user_read_access
+        end
+      end
+
+      def grant_alternate_user_read_access
+        return if new_resource.user.nil?
+
+        # Duplicate the script file's existing DACL
+        # so we can add an ACE later
+        securable_object = Chef::ReservedNames::Win32::Security::SecurableObject.new(script_file.path)
+        aces = securable_object.security_descriptor.dacl.reduce([]) { | result, current | result.push(current) }
+
+        username = new_resource.user
+
+        if new_resource.domain
+          username = new_resource.domain + '\\' + new_resource.user
+        end
+
+        # Create an ACE that allows the alternate user read access to the script
+        # file so it can be read and executed.
+        user_sid = Chef::ReservedNames::Win32::Security::SID.from_account(username)
+        read_ace = Chef::ReservedNames::Win32::Security::ACE.access_allowed(user_sid, Chef::ReservedNames::Win32::API::Security::GENERIC_READ | Chef::ReservedNames::Win32::API::Security::GENERIC_EXECUTE, 0)
+        aces.push(read_ace)
+        acl = Chef::ReservedNames::Win32::Security::ACL.create(aces)
+
+        # This actually applies the modified DACL to the file
+        securable_object.dacl = acl
       end
 
       def script_file

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
-require 'tempfile'
-require 'chef/provider/execute'
-require 'chef/win32/security' if Chef::Platform.windows?
-require 'forwardable'
+require "tempfile"
+require "chef/provider/execute"
+require "chef/win32/security" if Chef::Platform.windows?
+require "forwardable"
 
 class Chef
   class Provider
@@ -83,7 +83,7 @@ class Chef
         # Duplicate the script file's existing DACL
         # so we can add an ACE later
         securable_object = Chef::ReservedNames::Win32::Security::SecurableObject.new(script_file.path)
-        aces = securable_object.security_descriptor.dacl.reduce([]) { | result, current | result.push(current) }
+        aces = securable_object.security_descriptor.dacl.reduce([]) { |result, current| result.push(current) }
 
         username = new_resource.user
 
@@ -99,7 +99,9 @@ class Chef
         acl = Chef::ReservedNames::Win32::Security::ACL.create(aces)
 
         # This actually applies the modified DACL to the file
-        securable_object.dacl = acl
+        # Use parentheses to bypass RuboCop / ChefStyle warning
+        # about useless setter
+        (securable_object.dacl = acl)
       end
 
       def script_file

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -67,17 +67,21 @@ class Chef
       end
 
       def set_owner_and_group
-        # FileUtils itself implements a no-op if +user+ or +group+ are nil
-        # You can prove this by running FileUtils.chown(nil,nil,'/tmp/file')
-        # as an unprivileged user.
         if ! Chef::Platform.windows?
+          # FileUtils itself implements a no-op if +user+ or +group+ are nil
+          # You can prove this by running FileUtils.chown(nil,nil,'/tmp/file')
+          # as an unprivileged user.
           FileUtils.chown(new_resource.user, new_resource.group, script_file.path)
         else
+          # And on Windows also this is a no-op if there is no user specified.
           grant_alternate_user_read_access
         end
       end
 
       def grant_alternate_user_read_access
+        # Do nothing if an alternate user isn't specified -- the file
+        # will already have the correct permissions for the user as part
+        # of the default ACL behavior on Windows.
         return if new_resource.user.nil?
 
         # Duplicate the script file's existing DACL

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -143,6 +143,30 @@ class Chef
         )
       end
 
+      def domain(arg=nil)
+        set_or_return(
+          :domain,
+          arg,
+          :kind_of => [ String ]
+        )
+      end
+
+      def password(arg=nil)
+        set_or_return(
+          :password,
+          arg,
+          :kind_of => [ String ]
+        )
+      end
+
+      def sensitive(args=nil)
+        if ! password.nil?
+          true
+        else
+          super
+        end
+      end
+
       def self.set_guard_inherited_attributes(*inherited_attributes)
         @class_inherited_attributes = inherited_attributes
       end

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -143,7 +143,7 @@ class Chef
         )
       end
 
-      def domain(arg=nil)
+      def domain(arg = nil)
         set_or_return(
           :domain,
           arg,
@@ -151,7 +151,7 @@ class Chef
         )
       end
 
-      def password(arg=nil)
+      def password(arg = nil)
         set_or_return(
           :password,
           arg,
@@ -159,7 +159,7 @@ class Chef
         )
       end
 
-      def sensitive(args=nil)
+      def sensitive(args = nil)
         if ! password.nil?
           true
         else

--- a/spec/functional/resource/batch_spec.rb
+++ b/spec/functional/resource/batch_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Resource::WindowsScript::Batch, :windows_only do
 
   let(:output_command) { " > " }
 
-  let(:architecture_command) { '@echo %PROCESSOR_ARCHITECTURE%' }
+  let(:architecture_command) { "@echo %PROCESSOR_ARCHITECTURE%" }
 
   let(:resource) do
     Chef::Resource::WindowsScript::Batch.new("Batch resource functional test", @run_context)

--- a/spec/functional/resource/batch_spec.rb
+++ b/spec/functional/resource/batch_spec.rb
@@ -23,7 +23,11 @@ describe Chef::Resource::WindowsScript::Batch, :windows_only do
 
   let(:output_command) { " > " }
 
-  let (:architecture_command) { "@echo %PROCESSOR_ARCHITECTURE%" }
+  let(:architecture_command) { '@echo %PROCESSOR_ARCHITECTURE%' }
+
+  let(:resource) do
+    Chef::Resource::WindowsScript::Batch.new("Batch resource functional test", @run_context)
+  end
 
   it_behaves_like "a Windows script running on Windows"
 

--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -137,6 +137,18 @@ describe Chef::Resource::Execute do
     end
   end
 
+  describe "when a guard is specified" do
+    describe "when using the default guard interpreter" do
+      let(:guard_interpreter_resource) { nil }
+      it_behaves_like "a resource with a guard specifying an alternate user identity"
+    end
+
+    describe "when using the execute resource as the guard interpreter" do
+      let(:guard_interpreter_resource) { :execute }
+      it_behaves_like "a resource with a guard specifying an alternate user identity"
+    end
+  end
+
   # Ensure that CommandTimeout is raised, and is caused by resource.timeout really expiring.
   # https://github.com/chef/chef/issues/2985
   #
@@ -150,5 +162,10 @@ describe Chef::Resource::Execute do
       resource.timeout 0.1
       expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::CommandTimeout)
     end
+  end
+
+  describe "when running with an alternate user identity" do
+    let(:resource_command_property) { :command }
+    it_behaves_like "an execute resource that supports alternate user identity"
   end
 end

--- a/spec/support/shared/functional/execute_resource.rb
+++ b/spec/support/shared/functional/execute_resource.rb
@@ -1,0 +1,145 @@
+#
+# Author:: Adam Edwards (<adamed@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+shared_context "a non-admin Windows user" do
+  include Chef::Mixin::ShellOut
+
+  let(:windows_nonadmin_user_domain) { ENV['COMPUTERNAME'] }
+  let(:windows_nonadmin_user_qualified) { "#{windows_nonadmin_user_domain}\\#{windows_nonadmin_user}" }
+
+  before do
+    shell_out!("net.exe user /delete #{windows_nonadmin_user}", returns: [0,2])
+    shell_out!("net.exe user /add #{windows_nonadmin_user} \"#{windows_nonadmin_user_password}\"")
+  end
+
+  after do
+    shell_out!("net.exe user /delete #{windows_nonadmin_user}", returns: [0,2])
+  end
+end
+
+shared_context "alternate user identity" do
+  let(:windows_alternate_user) {"chef%02d%02d%02d" %[Time.now.year % 100, Time.now.month, Time.now.day]}
+  let(:windows_alternate_user_password) { 'lj28;fx3T!x,2'}
+  let(:windows_alternate_user_qualified) { "#{ENV['COMPUTERNAME']}\\#{windows_alternate_user}" }
+
+  let(:windows_nonadmin_user) { windows_alternate_user }
+  let(:windows_nonadmin_user_password) { windows_alternate_user_password }
+
+  include_context 'a non-admin Windows user'
+end
+
+shared_context "a command that can be executed as an alternate user" do
+  include_context "alternate user identity"
+
+  let(:script_output_dir) { Dir.mktmpdir }
+  let(:script_output_path) { File.join(script_output_dir, make_tmpname("chef_execute_identity_test")) }
+  let(:script_output) { File.read(script_output_path) }
+
+  include Chef::Mixin::ShellOut
+
+  before do
+    shell_out!("icacls \"#{script_output_dir.gsub(/\//,'\\')}\" /grant \"authenticated users:(F)\"")
+  end
+
+  after do
+    File.delete(script_output_path) if File.exists?(script_output_path)
+    Dir.rmdir(script_output_dir) if Dir.exists?(script_output_dir)
+  end
+end
+
+shared_examples_for "an execute resource that supports alternate user identity" do
+  context "when running on Windows", :windows_only do
+
+    include_context "a command that can be executed as an alternate user"
+
+    let(:windows_current_user) { ENV['USERNAME'] }
+    let(:windows_current_user_qualified) { "#{ENV['USERDOMAIN'] || ENV['COMPUTERNAME']}\\#{windows_current_user}" }
+    let(:resource_identity_command) { "powershell.exe -noprofile -command \"import-module microsoft.powershell.utility;([Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())).identity.name | out-file -encoding ASCII '#{script_output_path}'\"" }
+
+    let(:execute_resource) {
+      resource.user(windows_alternate_user)
+      resource.password(windows_alternate_user_password)
+      resource.send(resource_command_property, resource_identity_command)
+      resource
+    }
+
+    it "executes the process as an alternate user" do
+      expect(windows_current_user.length).to be > 0
+      expect { execute_resource.run_action(:run) }.not_to raise_error
+      expect(script_output.chomp.length).to be > 0
+      expect(script_output.chomp.downcase).to eq(windows_alternate_user_qualified.downcase)
+      expect(script_output.chomp.downcase).not_to eq(windows_current_user.downcase)
+      expect(script_output.chomp.downcase).not_to eq(windows_current_user_qualified.downcase)
+    end
+
+    let(:windows_alternate_user_password_invalid) { "#{windows_alternate_user_password}x" }
+
+    it "raises an exception if the user's password is invalid" do
+      execute_resource.password(windows_alternate_user_password_invalid)
+      expect { execute_resource.run_action(:run) }.to raise_error(SystemCallError)
+    end
+  end
+end
+
+shared_examples_for "a resource with a guard specifying an alternate user identity" do
+  context "when running on Windows", :windows_only do
+    include_context "alternate user identity"
+
+    let(:resource_command_property) { :command }
+
+    let(:powershell_equal_to_alternate_user) { '-eq' }
+    let(:powershell_not_equal_to_alternate_user) { '-ne' }
+    let(:guard_identity_command) { "powershell.exe -noprofile -command \"import-module microsoft.powershell.utility;exit @(392,0)[[int32](([Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())).Identity.Name #{comparison_to_alternate_user} '#{windows_alternate_user_qualified}')]\"" }
+
+    before do
+      resource.guard_interpreter(guard_interpreter_resource)
+    end
+
+    context "when the guard expression is true if the user is alternate and false otherwise" do
+      let(:comparison_to_alternate_user) { powershell_equal_to_alternate_user }
+
+      it "causes the resource to be updated for only_if" do
+        resource.only_if(guard_identity_command, {user: windows_alternate_user, password: windows_alternate_user_password})
+        resource.run_action(:run)
+        expect(resource).to be_updated_by_last_action
+      end
+
+      it "causes the resource to not be updated for not_if" do
+        resource.not_if(guard_identity_command, {user: windows_alternate_user, password: windows_alternate_user_password})
+        resource.run_action(:run)
+        expect(resource).not_to be_updated_by_last_action
+      end
+    end
+
+    context "when the guard expression is false if the user is alternate and true otherwise" do
+      let(:comparison_to_alternate_user) { powershell_not_equal_to_alternate_user }
+
+      it "causes the resource not to be updated for only_if" do
+        resource.only_if(guard_identity_command, {user: windows_alternate_user, password: windows_alternate_user_password})
+        resource.run_action(:run)
+        expect(resource).not_to be_updated_by_last_action
+      end
+
+      it "causes the resource to be updated for not_if" do
+        resource.not_if(guard_identity_command, {user: windows_alternate_user, password: windows_alternate_user_password})
+        resource.run_action(:run)
+        expect(resource).to be_updated_by_last_action
+      end
+    end
+  end
+end

--- a/spec/support/shared/functional/execute_resource.rb
+++ b/spec/support/shared/functional/execute_resource.rb
@@ -21,10 +21,15 @@ shared_context "a non-admin Windows user" do
 
   let(:windows_nonadmin_user_domain) { ENV['COMPUTERNAME'] }
   let(:windows_nonadmin_user_qualified) { "#{windows_nonadmin_user_domain}\\#{windows_nonadmin_user}" }
-
+  let(:temp_profile_path) { "#{ENV['USERPROFILE']}\\..\\cheftesttempuser" }
   before do
     shell_out!("net.exe user /delete #{windows_nonadmin_user}", returns: [0,2])
-    shell_out!("net.exe user /add #{windows_nonadmin_user} \"#{windows_nonadmin_user_password}\"")
+
+    # Supply a profile path when creating a user to avoid an apparent Windows bug where deleting
+    # the user actually creates the profile when it did not immediately exist before executing
+    # net user /delete! For some reason, specifying an explicit path ensures that the path
+    # profile doesn't get created at deletion.
+    shell_out!("net.exe user /add #{windows_nonadmin_user} \"#{windows_nonadmin_user_password}\" /profilepath:#{temp_profile_path}")
   end
 
   after do

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -142,7 +142,7 @@ shared_context Chef::Resource::WindowsScript do
 
       before do
         expect(script_provider).to receive(:unlink_script_file)
-        resource.code('echo hi')
+        resource.code("echo hi")
         script_provider.action_run
       end
 

--- a/spec/support/shared/unit/execute_resource.rb
+++ b/spec/support/shared/unit/execute_resource.rb
@@ -107,13 +107,13 @@ shared_examples_for "an execute resource" do
   end
 
   it "should accept a string for the domain" do
-    @resource.domain 'mothership'
-    expect(@resource.domain).to eql('mothership')
+    @resource.domain "mothership"
+    expect(@resource.domain).to eql("mothership")
   end
 
   it "should accept a string for the password" do
-    @resource.password 'we.funk!'
-    expect(@resource.password).to eql('we.funk!')
+    @resource.password "we.funk!"
+    expect(@resource.password).to eql("we.funk!")
   end
 
   it "should accept a string for creates" do
@@ -139,13 +139,13 @@ shared_examples_for "an execute resource" do
 
     it "should be true if the password is non-nil" do
       expect(@resource.sensitive).to eq(false)
-      @resource.password('we.funk!')
+      @resource.password("we.funk!")
       expect(@resource.sensitive).to eq(true)
     end
 
     it "should be true if the password is non-nil but the value is explicitly set to false" do
       expect(@resource.sensitive).to eq(false)
-      @resource.password('we.funk!')
+      @resource.password("we.funk!")
       expect(@resource.sensitive).to eq(true)
       @resource.sensitive false
       expect(@resource.sensitive).to eq(true)
@@ -153,7 +153,7 @@ shared_examples_for "an execute resource" do
 
   end
 
-  describe "when it has cwd, environment, group, path, return value, and a user" do 
+  describe "when it has cwd, environment, group, path, return value, and a user" do
     before do
       @resource.command("grep")
       @resource.cwd("/tmp/")

--- a/spec/support/shared/unit/execute_resource.rb
+++ b/spec/support/shared/unit/execute_resource.rb
@@ -106,6 +106,16 @@ shared_examples_for "an execute resource" do
     expect(@resource.user).to eql(1)
   end
 
+  it "should accept a string for the domain" do
+    @resource.domain 'mothership'
+    expect(@resource.domain).to eql('mothership')
+  end
+
+  it "should accept a string for the password" do
+    @resource.password 'we.funk!'
+    expect(@resource.password).to eql('we.funk!')
+  end
+
   it "should accept a string for creates" do
     @resource.creates "something"
     expect(@resource.creates).to eql("something")
@@ -116,7 +126,34 @@ shared_examples_for "an execute resource" do
     expect(@resource.live_stream).to be true
   end
 
-  describe "when it has cwd, environment, group, path, return value, and a user" do
+  describe "the resource's sensitive attribute" do
+    it "should be false by default" do
+      expect(@resource.sensitive).to eq(false)
+    end
+
+    it "should be true if set to true" do
+      expect(@resource.sensitive).to eq(false)
+      @resource.sensitive true
+      expect(@resource.sensitive).to eq(true)
+    end
+
+    it "should be true if the password is non-nil" do
+      expect(@resource.sensitive).to eq(false)
+      @resource.password('we.funk!')
+      expect(@resource.sensitive).to eq(true)
+    end
+
+    it "should be true if the password is non-nil but the value is explicitly set to false" do
+      expect(@resource.sensitive).to eq(false)
+      @resource.password('we.funk!')
+      expect(@resource.sensitive).to eq(true)
+      @resource.sensitive false
+      expect(@resource.sensitive).to eq(true)
+    end
+
+  end
+
+  describe "when it has cwd, environment, group, path, return value, and a user" do 
     before do
       @resource.command("grep")
       @resource.cwd("/tmp/")

--- a/spec/unit/mixin/user_identity_spec.rb
+++ b/spec/unit/mixin/user_identity_spec.rb
@@ -1,0 +1,201 @@
+#
+# Author:: Adam Edwards (<adamed@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef/mixin/user_identity'
+
+shared_examples_for "it received valid credentials" do
+  describe "the validation method" do
+    it "should not raise an error" do
+      expect {instance_with_identity.validate(username, password, domain)}.not_to raise_error
+    end
+  end
+
+  describe "the name qualification method" do
+    it "should correctly translate the user and domain" do
+      identity = nil
+      expect { identity = instance_with_identity.qualify_name(username, domain) }.not_to raise_error
+      expect(identity[:domain]).to eq(domain)
+      expect(identity[:user]).to eq(username)
+    end
+  end
+end
+
+shared_examples_for "it received invalid credentials" do
+  describe "the validation method" do
+    it "should raise an error" do
+      expect { instance_with_identity.validate(username, password, domain)}.to raise_error(ArgumentError)
+    end
+  end
+end
+
+shared_examples_for "it received credentials that are not valid on the platform" do
+  describe "the validation method" do
+    it "should raise an error" do
+      expect { instance_with_identity.validate(username, password, domain)}.to raise_error(Chef::Exceptions::UnsupportedPlatform)
+    end
+  end
+end
+
+shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
+  context "when running on Windows" do
+    before do
+      allow(::Chef::Platform).to receive(:windows?).and_return(true)
+    end
+
+    context "when no user, domain, or password is specified" do
+      let(:username) { nil }
+      let(:domain) { nil }
+      let(:password) { nil }
+      it_behaves_like "it received valid credentials"
+    end
+
+    context "when a valid username is specified" do
+      let(:username) { 'starchild' }
+      context "when a valid domain is specified" do
+        let(:domain) { 'mothership' }
+
+        context "when the password is not specified" do
+          let(:password) { nil }
+          it_behaves_like "it received invalid credentials"
+        end
+
+        context "when the password is specified" do
+          let(:password) { 'we.funk!' }
+          it_behaves_like "it received valid credentials"
+        end
+      end
+
+      context "when the domain is not specified" do
+        let(:domain) { nil }
+
+        context "when the password is not specified" do
+          let(:password) { nil }
+          it_behaves_like "it received invalid credentials"
+        end
+
+        context "when the password is specified" do
+          let(:password) { 'we.funk!' }
+          it_behaves_like "it received valid credentials"
+        end
+      end
+    end
+
+    context "when the username is not specified" do
+      let(:username) { nil }
+
+      context "when the password is specified and the domain is not" do
+        let(:password) { 'we.funk!' }
+        let(:domain) { nil }
+        it_behaves_like "it received invalid credentials"
+      end
+
+      context "when the domain is specified and the password is not" do
+        let(:domain) { 'mothership' }
+        let(:password) { nil }
+        it_behaves_like "it received invalid credentials"
+      end
+
+      context "when the domain and password are specified" do
+        let(:domain) { 'mothership' }
+        let(:password) { 'we.funk!' }
+        it_behaves_like "it received invalid credentials"
+      end
+    end
+  end
+
+  context "when not running on Windows" do
+    before do
+      allow(::Chef::Platform).to receive(:windows?).and_return(false)
+    end
+
+    context "when no user, domain, or password is specified" do
+      let(:username) { nil }
+      let(:domain) { nil }
+      let(:password) { nil }
+      it_behaves_like "it received valid credentials"
+    end
+
+    context "when the user is specified and the domain and password are not" do
+      let(:username) { 'starchild' }
+      let(:domain) { nil }
+      let(:password) { nil }
+      it_behaves_like "it received valid credentials"
+
+      context "when the password is specified and the domain is not" do
+        let(:password) { 'we.funk!' }
+        let(:domain) { nil }
+        it_behaves_like "it received credentials that are not valid on the platform"
+      end
+
+      context "when the domain is specified and the password is not" do
+        let(:domain) { 'mothership' }
+        let(:password) { nil }
+        it_behaves_like "it received credentials that are not valid on the platform"
+      end
+
+      context "when the domain and password are specified" do
+        let(:domain) { 'mothership' }
+        let(:password) { 'we.funk!' }
+        it_behaves_like "it received credentials that are not valid on the platform"
+      end
+    end
+
+    context "when the user is not specified" do
+      let(:username) { nil }
+      context "when the domain is specified" do
+        let(:domain) { 'mothership' }
+        context "when the password is specified" do
+          let(:password) { 'we.funk!' }
+          it_behaves_like "it received credentials that are not valid on the platform"
+        end
+
+        context "when password is not specified" do
+          let(:password) { nil }
+          it_behaves_like "it received credentials that are not valid on the platform"
+        end
+      end
+
+      context "when the domain is not specified" do
+        let(:domain) { nil }
+        context "when the password is specified" do
+          let(:password) { 'we.funk!' }
+          it_behaves_like "it received credentials that are not valid on the platform"
+        end
+      end
+    end
+  end
+end
+
+describe "a class that mixes in user_identity" do
+  let(:instance_with_identity) do
+    class IdentityClass
+      include ::Chef::Mixin::UserIdentity
+      def validate(*args)
+        validate_identity(*args)
+      end
+
+      def qualify_name(*args)
+        qualify_user(*args)
+      end
+    end
+    IdentityClass.new
+  end
+
+  it_behaves_like "a consumer of the ::Chef::Mixin::UserIdentity mixin"
+end

--- a/spec/unit/mixin/user_identity_spec.rb
+++ b/spec/unit/mixin/user_identity_spec.rb
@@ -16,13 +16,13 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
-require 'chef/mixin/user_identity'
+require "spec_helper"
+require "chef/mixin/user_identity"
 
 shared_examples_for "it received valid credentials" do
   describe "the validation method" do
     it "should not raise an error" do
-      expect {instance_with_identity.validate(username, password, domain)}.not_to raise_error
+      expect { instance_with_identity.validate(username, password, domain) }.not_to raise_error
     end
   end
 
@@ -39,7 +39,7 @@ end
 shared_examples_for "it received invalid credentials" do
   describe "the validation method" do
     it "should raise an error" do
-      expect { instance_with_identity.validate(username, password, domain)}.to raise_error(ArgumentError)
+      expect { instance_with_identity.validate(username, password, domain) }.to raise_error(ArgumentError)
     end
   end
 end
@@ -47,7 +47,7 @@ end
 shared_examples_for "it received credentials that are not valid on the platform" do
   describe "the validation method" do
     it "should raise an error" do
-      expect { instance_with_identity.validate(username, password, domain)}.to raise_error(Chef::Exceptions::UnsupportedPlatform)
+      expect { instance_with_identity.validate(username, password, domain) }.to raise_error(Chef::Exceptions::UnsupportedPlatform)
     end
   end
 end
@@ -66,9 +66,9 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
     end
 
     context "when a valid username is specified" do
-      let(:username) { 'starchild' }
+      let(:username) { "starchild" }
       context "when a valid domain is specified" do
-        let(:domain) { 'mothership' }
+        let(:domain) { "mothership" }
 
         context "when the password is not specified" do
           let(:password) { nil }
@@ -76,7 +76,7 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
         end
 
         context "when the password is specified" do
-          let(:password) { 'we.funk!' }
+          let(:password) { "we.funk!" }
           it_behaves_like "it received valid credentials"
         end
       end
@@ -90,7 +90,7 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
         end
 
         context "when the password is specified" do
-          let(:password) { 'we.funk!' }
+          let(:password) { "we.funk!" }
           it_behaves_like "it received valid credentials"
         end
       end
@@ -100,20 +100,20 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
       let(:username) { nil }
 
       context "when the password is specified and the domain is not" do
-        let(:password) { 'we.funk!' }
+        let(:password) { "we.funk!" }
         let(:domain) { nil }
         it_behaves_like "it received invalid credentials"
       end
 
       context "when the domain is specified and the password is not" do
-        let(:domain) { 'mothership' }
+        let(:domain) { "mothership" }
         let(:password) { nil }
         it_behaves_like "it received invalid credentials"
       end
 
       context "when the domain and password are specified" do
-        let(:domain) { 'mothership' }
-        let(:password) { 'we.funk!' }
+        let(:domain) { "mothership" }
+        let(:password) { "we.funk!" }
         it_behaves_like "it received invalid credentials"
       end
     end
@@ -132,26 +132,26 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
     end
 
     context "when the user is specified and the domain and password are not" do
-      let(:username) { 'starchild' }
+      let(:username) { "starchild" }
       let(:domain) { nil }
       let(:password) { nil }
       it_behaves_like "it received valid credentials"
 
       context "when the password is specified and the domain is not" do
-        let(:password) { 'we.funk!' }
+        let(:password) { "we.funk!" }
         let(:domain) { nil }
         it_behaves_like "it received credentials that are not valid on the platform"
       end
 
       context "when the domain is specified and the password is not" do
-        let(:domain) { 'mothership' }
+        let(:domain) { "mothership" }
         let(:password) { nil }
         it_behaves_like "it received credentials that are not valid on the platform"
       end
 
       context "when the domain and password are specified" do
-        let(:domain) { 'mothership' }
-        let(:password) { 'we.funk!' }
+        let(:domain) { "mothership" }
+        let(:password) { "we.funk!" }
         it_behaves_like "it received credentials that are not valid on the platform"
       end
     end
@@ -159,9 +159,9 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
     context "when the user is not specified" do
       let(:username) { nil }
       context "when the domain is specified" do
-        let(:domain) { 'mothership' }
+        let(:domain) { "mothership" }
         context "when the password is specified" do
-          let(:password) { 'we.funk!' }
+          let(:password) { "we.funk!" }
           it_behaves_like "it received credentials that are not valid on the platform"
         end
 
@@ -174,7 +174,7 @@ shared_examples_for "a consumer of the ::Chef::Mixin::UserIdentity mixin" do
       context "when the domain is not specified" do
         let(:domain) { nil }
         context "when the password is specified" do
-          let(:password) { 'we.funk!' }
+          let(:password) { "we.funk!" }
           it_behaves_like "it received credentials that are not valid on the platform"
         end
       end

--- a/spec/unit/provider/execute_spec.rb
+++ b/spec/unit/provider/execute_spec.rb
@@ -251,12 +251,12 @@ describe Chef::Provider::Execute do
 
         context "when the username is specified" do
           before do
-            new_resource.user('starchild')
+            new_resource.user("starchild")
           end
 
           context "when the domain is specified" do
             before do
-              new_resource.domain('mydomain')
+              new_resource.domain("mydomain")
             end
 
             it "should raise an error if the password is not specified" do
@@ -265,7 +265,7 @@ describe Chef::Provider::Execute do
             end
 
             it "should not raise an error if the password is specified" do
-              expect(new_resource).to receive(:password).at_least(1).times.and_return('we.funk!')
+              expect(new_resource).to receive(:password).at_least(1).times.and_return("we.funk!")
               expect { provider.run_action(:run) }.not_to raise_error
             end
           end
@@ -281,7 +281,7 @@ describe Chef::Provider::Execute do
             end
 
             it "should not raise an error if the password is specified" do
-              expect(new_resource).to receive(:password).at_least(1).times.and_return('we.funk!')
+              expect(new_resource).to receive(:password).at_least(1).times.and_return("we.funk!")
               expect { provider.run_action(:run) }.not_to raise_error
 
             end
@@ -294,18 +294,18 @@ describe Chef::Provider::Execute do
           end
 
           it "should raise an error if the password is specified" do
-            expect(new_resource).to receive(:password).at_least(1).times.and_return('we.funk!')
+            expect(new_resource).to receive(:password).at_least(1).times.and_return("we.funk!")
             expect { provider.run_action(:run) }.to raise_error(ArgumentError)
           end
 
           it "should raise an error if the domain is specified" do
-            expect(new_resource).to receive(:domain).at_least(1).times.and_return('mothership')
+            expect(new_resource).to receive(:domain).at_least(1).times.and_return("mothership")
             expect { provider.run_action(:run) }.to raise_error(ArgumentError)
           end
 
           it "should raise an error if the domain and password are specified" do
-            expect(new_resource).to receive(:password).at_least(1).times.and_return('we.funk!')
-            expect(new_resource).to receive(:domain).at_least(1).times.and_return('mothership')
+            expect(new_resource).to receive(:password).at_least(1).times.and_return("we.funk!")
+            expect(new_resource).to receive(:domain).at_least(1).times.and_return("mothership")
             expect { provider.run_action(:run) }.to raise_error(ArgumentError)
           end
         end
@@ -317,16 +317,16 @@ describe Chef::Provider::Execute do
         end
 
         it "should not raise an error if the user is specified" do
-          new_resource.user('starchild')
+          new_resource.user("starchild")
         end
 
         it "should raise an error if the password is specified" do
-          expect(new_resource).to receive(:password).and_return('we.funk!')
+          expect(new_resource).to receive(:password).and_return("we.funk!")
           expect { provider.run_action(:run) }.to raise_error(Chef::Exceptions::UnsupportedPlatform)
         end
 
         it "should raise an error if the domain is specified" do
-          expect(new_resource).to receive(:domain).and_return('we.funk!')
+          expect(new_resource).to receive(:domain).and_return("we.funk!")
           expect { provider.run_action(:run) }.to raise_error(Chef::Exceptions::UnsupportedPlatform)
         end
       end

--- a/spec/unit/provider/script_spec.rb
+++ b/spec/unit/provider/script_spec.rb
@@ -57,31 +57,31 @@ describe Chef::Provider::Script, "action_run" do
   end
 
   context "when configuring the script file's security" do
-    context 'when not running on Windows' do
+    context "when not running on Windows" do
       before do
         allow(::Chef::Platform).to receive(:windows?).and_return(false)
       end
       context "#set_owner_and_group" do
         it "sets the owner and group for the script file" do
-          new_resource.user 'toor'
-          new_resource.group 'wheel'
-          expect(FileUtils).to receive(:chown).with('toor', 'wheel', tempfile.path)
+          new_resource.user "toor"
+          new_resource.group "wheel"
+          expect(FileUtils).to receive(:chown).with("toor", "wheel", tempfile.path)
           provider.set_owner_and_group
         end
       end
     end
 
-    context 'when running on Windows' do
+    context "when running on Windows" do
       before do
         allow(::Chef::Platform).to receive(:windows?).and_return(true)
         expect(new_resource.user).to eq(nil)
-        stub_const('Chef::ReservedNames::Win32::API::Security::GENERIC_READ', 1)
-        stub_const('Chef::ReservedNames::Win32::API::Security::GENERIC_EXECUTE', 4)
-        stub_const('Chef::ReservedNames::Win32::Security', Class.new)
-        stub_const('Chef::ReservedNames::Win32::Security::SecurableObject', Class.new)
-        stub_const('Chef::ReservedNames::Win32::Security::SID', Class.new)
-        stub_const('Chef::ReservedNames::Win32::Security::ACE', Class.new)
-        stub_const('Chef::ReservedNames::Win32::Security::ACL', Class.new)
+        stub_const("Chef::ReservedNames::Win32::API::Security::GENERIC_READ", 1)
+        stub_const("Chef::ReservedNames::Win32::API::Security::GENERIC_EXECUTE", 4)
+        stub_const("Chef::ReservedNames::Win32::Security", Class.new)
+        stub_const("Chef::ReservedNames::Win32::Security::SecurableObject", Class.new)
+        stub_const("Chef::ReservedNames::Win32::Security::SID", Class.new)
+        stub_const("Chef::ReservedNames::Win32::Security::ACE", Class.new)
+        stub_const("Chef::ReservedNames::Win32::Security::ACL", Class.new)
       end
 
       context "when an alternate user is not specified" do
@@ -93,10 +93,10 @@ describe Chef::Provider::Script, "action_run" do
       end
 
       context "when an alternate user is specified" do
-        let(:security_descriptor) { instance_double('Chef::ReservedNames::Win32::Security::SecurityDescriptor', :dacl => []) }
-        let(:securable_object) { instance_double('Chef::ReservedNames::Win32::Security::SecurableObject', :security_descriptor => security_descriptor, :dacl= => nil) }
+        let(:security_descriptor) { instance_double("Chef::ReservedNames::Win32::Security::SecurityDescriptor", :dacl => []) }
+        let(:securable_object) { instance_double("Chef::ReservedNames::Win32::Security::SecurableObject", :security_descriptor => security_descriptor, :dacl= => nil) }
         it "sets the script file's security descriptor" do
-          new_resource.user('toor')
+          new_resource.user("toor")
           expect(Chef::ReservedNames::Win32::Security::SecurableObject).to receive(:new).and_return(securable_object)
           expect(Chef::ReservedNames::Win32::Security::SID).to receive(:from_account).and_return(nil)
           expect(Chef::ReservedNames::Win32::Security::ACE).to receive(:access_allowed).and_return(nil)


### PR DESCRIPTION
### Windows alternate user identity execute support

The `execute` resource and simliar resources such as `script`, `batch`, and `powershell_script`
now support the specification of credentials on Windows so that the resulting process
is created with the security identity that corresponds to those credentials. This gives these resources on Windows the same capability they have on *nix systems to run processes as an alternate identity.
#### Properties

The following properties are new or updated for the `execute`, `script`, `batch`, and
`powershell_script` resources and any resources derived from them:
-   `user`</br>
  **Ruby types:** String</br>
  The user name of the user identity with which to launch the new process.
  Default value: `nil`. The user name may optionally be specifed
  with a domain, i.e. `domain\user` or `user@my.dns.domain.com` via Universal Principal Name (UPN)
  format. It can also be specified without a domain simply as `user` if the domain is
  instead specified using the `domain` attribute. On Windows only, if this property is specified, the `password`
  property **must** be specified.
-   `password`</br>
  **Ruby types** String</br>
  _Windows only:_ The password of the user specified by the `user` property.
  Default value: `nil`. This property is mandatory if `user` is specified on Windows and may only
  be specified if `user` is specified. The `sensitive` property for this resource will
  automatically be set to `true` if `password` is specified.
-   `domain`</br>
  **Ruby types** String</br>
  _Windows only:_ The domain of the user user specified by the `user` property.
  Default value: `nil`. If not specified, the user name and password specified
  by the `user` and `password` properties will be used to resolve
  that user against the domain in which the system running Chef client
  is joined, or if that system is not joined to a domain it will resolve the user
  as a local account on that system. An alternative way to specify the domain is to leave
  this property unspecified and specify the domain as part of the `user` property.
