### PR TITLE
Always allow nil set; only warn if not using "is"

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -457,7 +457,7 @@ class Chef
 
         def call(resource, value=NOT_PASSED)
           # setting to nil does a get
-          if value.nil? && !explicitly_accepts_nil?(resource)
+          if value.nil?
             get(resource)
           else
             super

--- a/spec/unit/property/validation_spec.rb
+++ b/spec/unit/property/validation_spec.rb
@@ -99,6 +99,14 @@ describe "Chef::Resource.property validation" do
           expect(resource.x).to eq 'default'
         end
       end
+      if tags.include?(:nil_is_reset)
+        it "setting value to nil resets the value" do
+          resource.instance_eval { @x = 'default' }
+          expect(resource.property_is_set?(:x)).to be_truthy
+          expect(resource.x(nil)).not_to eq('default')
+          expect(resource.property_is_set?(:x)).to be_falsey
+        end
+      end
     end
   end
 
@@ -186,32 +194,38 @@ describe "Chef::Resource.property validation" do
     validation_test 'String',
       [ 'hi' ],
       [ 10 ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test ':a',
       [ :a ],
       [ :b ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test ':a, is: :b',
       [ :a, :b ],
       [ :c ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test ':a, is: [ :b, :c ]',
       [ :a, :b, :c ],
       [ :d ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test '[ :a, :b ], is: :c',
       [ :a, :b, :c ],
       [ :d ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test '[ :a, :b ], is: [ :c, :d ]',
       [ :a, :b, :c, :d ],
       [ :e ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test 'nil',
       [ nil ],
@@ -224,7 +238,8 @@ describe "Chef::Resource.property validation" do
     validation_test '[]',
       [],
       [ :a ],
-      [ nil ]
+      [],
+      :nil_is_reset
   end
 
   # is
@@ -233,34 +248,41 @@ describe "Chef::Resource.property validation" do
     validation_test 'is: String',
       [ 'a', '' ],
       [ :a, 1 ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     # Value
     validation_test 'is: :a',
       [ :a ],
       [ :b ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test 'is: [ :a, :b ]',
       [ :a, :b ],
       [ [ :a, :b ] ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test 'is: [ [ :a, :b ] ]',
       [ [ :a, :b ] ],
       [ :a, :b ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     # Regex
     validation_test 'is: /abc/',
       [ 'abc', 'wowabcwow' ],
       [ '', 'abac' ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     # Property
     validation_test 'is: Chef::Property.new(is: :a)',
       [ :a ],
-      [ :b, nil ]
+      [ :b ],
+      [],
+      :nil_is_reset
 
     # RSpec Matcher
     class Globalses
@@ -270,13 +292,15 @@ describe "Chef::Resource.property validation" do
     validation_test "is: Globalses.eq(10)",
       [ 10 ],
       [ 1 ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     # Proc
     validation_test 'is: proc { |x| x }',
       [ true, 1 ],
       [ false ],
-      [ nil ]
+      [],
+      :nil_is_reset
 
     validation_test 'is: proc { |x| x > blah }',
       [ 10 ],
@@ -293,7 +317,8 @@ describe "Chef::Resource.property validation" do
     validation_test 'is: []',
       [],
       [ :a ],
-      [ nil ]
+      [],
+      :nil_is_reset
   end
 
   # Combination

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -79,12 +79,18 @@ describe "Chef::Resource.property" do
       expect(resource.bare_property 10).to eq 10
       expect(resource.bare_property).to eq 10
     end
-    it "emits a deprecation warning and does a get, if set to nil" do
-      expect(resource.bare_property 10).to eq 10
-      expect { resource.bare_property nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
-      Chef::Config[:treat_deprecation_warnings_as_errors] = false
-      expect(resource.bare_property nil).to eq 10
-      expect(resource.bare_property).to eq 10
+    context "when it already has a value" do
+      before { resource.bare_property 10 }
+      it "emits a deprecation warning and does a get, if set to nil" do
+        expect { resource.bare_property nil }.to raise_error Chef::Exceptions::DeprecatedFeatureError
+        Chef::Config[:treat_deprecation_warnings_as_errors] = false
+        expect(resource.bare_property nil).to eq 10
+        expect(resource.bare_property).to eq 10
+      end
+    end
+    it "does a get, if set to nil" do
+      expect(resource.bare_property nil).to be_nil
+      expect(resource.property_is_set?(:bare_property)).to be_falsey
     end
     it "can be updated" do
       expect(resource.bare_property 10).to eq 10
@@ -922,7 +928,7 @@ describe "Chef::Resource.property" do
         expect(Namer.current_index).to eq 1
       end
       it "does not emit a deprecation warning if set to nil" do
-        expect(resource.x nil).to eq "1"
+        expect(resource.x nil).to eq nil
       end
       it "coercion sets the value (and coercion does not run on get)" do
         expect(resource.x 10).to eq "101"


### PR DESCRIPTION
- Aways allow nil to be set.
- If "is" is not specified, treat setting to nil as a get and warn if it would change the value.
- If nil fails validation on set, treat it as a reset.