### PR TITLE
Only warn about potentially duplicate properties during the resource initializer.

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -18,6 +18,8 @@
 
 require 'chef/exceptions'
 require 'chef/delayed_evaluator'
+require 'chef/chef_class'
+require 'chef/log'
 
 class Chef
   #
@@ -314,9 +316,10 @@ class Chef
         #
         # It won't do what they expect. This checks whether you try to *read*
         # `content` while we are compiling the resource.
-        if resource.respond_to?(:enclosing_provider) && resource.enclosing_provider &&
-           !resource.currently_running_action &&
-           !name_property? &&
+        if resource.respond_to?(:resource_initializing) &&
+           resource.resource_initializing &&
+           resource.respond_to?(:enclosing_provider) &&
+           resource.enclosing_provider &&
            resource.enclosing_provider.respond_to?(name)
            Chef::Log.warn("#{Chef::Log.caller_location}: property #{name} is declared in both #{resource} and #{resource.enclosing_provider}. Use new_resource.#{name} instead. At #{Chef::Log.caller_location}")
         end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -569,8 +569,6 @@ class Chef
     #
     def run_action(action, notification_type=nil, notifying_resource=nil)
       # reset state in case of multiple actions on the same resource.
-      old_currently_running_action = @currently_running_action
-      @currently_running_action = action
       @elapsed_time = 0
       start_time = Time.now
       events.resource_action_start(self, action, notification_type, notifying_resource)
@@ -612,7 +610,6 @@ class Chef
         end
       end
     ensure
-      @currently_running_action = old_currently_running_action
       @elapsed_time = Time.now - start_time
       # Reporting endpoint doesn't accept a negative resource duration so set it to 0.
       # A negative value can occur when a resource changes the system time backwards
@@ -621,12 +618,18 @@ class Chef
     end
 
     #
-    # If we are currently running an action, this shows the action we are running.
-    # If the resource is running multiple actions at once, this will show the most recent.
+    # If we are currently initializing the resource, this will be true.
     #
     # Do NOT use this. It may be removed. It is for internal purposes only.
     # @api private
-    attr_reader :currently_running_action
+    attr_reader :resource_initializing
+    def resource_initializing=(value)
+      if value
+        @resource_initializing = true
+      else
+        remove_instance_variable(:@resource_initializing)
+      end
+    end
 
     #
     # Generic Ruby and Data Structure Stuff (for user)

--- a/lib/chef/resource_builder.rb
+++ b/lib/chef/resource_builder.rb
@@ -70,7 +70,14 @@ class Chef
       resource.params = params
 
       # Evaluate resource attribute DSL
-      resource.instance_eval(&block) if block_given?
+      if block_given?
+        resource.resource_initializing = true
+        begin
+          resource.instance_eval(&block)
+        ensure
+          resource.resource_initializing = false
+        end
+      end
 
       # emit a cloned resource warning if it is warranted
       if prior_resource
@@ -130,7 +137,7 @@ class Chef
       @prior_resource ||=
         begin
           key = "#{type}[#{name}]"
-          prior_resource = run_context.resource_collection.lookup(key)
+          run_context.resource_collection.lookup(key)
         rescue Chef::Exceptions::ResourceNotFound
           nil
         end


### PR DESCRIPTION
There are a number of cases where people will construct a resource, initialize it, and then use properties from the resource to calculate other things during compilation. We want to not warn on these; we are really only trying to get rid of ambiguities during the `resource :x do ... end` block.