### PR TITLE
tags always an array; fix set_unless

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -1,4 +1,3 @@
-#
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Christopher Brown (<cb@opscode.com>)
 # Author:: Christopher Walters (<cw@opscode.com>)
@@ -372,7 +371,7 @@ class Chef
 
     # Lazy initializer for tags attribute
     def tags
-      normal_unless[:tags] = []
+      normal[:tags] = Array(normal[:tags])
       normal[:tags]
     end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -3,7 +3,7 @@
 # Author:: Christopher Brown (<cb@opscode.com>)
 # Author:: Christopher Walters (<cw@opscode.com>)
 # Author:: Tim Hinderliter (<tim@opscode.com>)
-# Copyright:: Copyright (c) 2008-2011 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -372,7 +372,7 @@ class Chef
 
     # Lazy initializer for tags attribute
     def tags
-      normal[:tags] = [] unless attribute?(:tags)
+      normal_unless[:tags] = []
       normal[:tags]
     end
 

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: AJ Christensen (<aj@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -1,6 +1,6 @@
 #--
 # Author:: Daniel DeLeo (<dan@opscode.com>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +148,7 @@ class Chef
 
       def []=(key, value)
         root.top_level_breadcrumb ||= key
-        if set_unless? && key?(key)
+        if set_unless? && key?(key) && !self[key].nil?
           self[key]
         else
           root.reset_cache(root.top_level_breadcrumb)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -810,6 +810,18 @@ describe Chef::Node do
       expect(node.tags).to eql([])
     end
 
+    it "should return an array if it is fed a string" do
+      node.normal[:tags] = "string"
+      node.consume_external_attrs(@ohai_data, {})
+      expect(node.tags).to eql(["string"])
+    end
+
+    it "should return an array if it is fed a hash" do
+      node.normal[:tags] = {}
+      node.consume_external_attrs(@ohai_data, {})
+      expect(node.tags).to eql([])
+    end
+
     it "deep merges attributes instead of overwriting them" do
       node.consume_external_attrs(@ohai_data, "one" => {"two" => {"three" => "four"}})
       expect(node.one.to_hash).to eq({"two" => {"three" => "four"}})

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2008 Opscode, Inc.
+# Copyright:: Copyright (c) 2008-2015 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,6 +262,12 @@ describe Chef::Node do
         node.set[:snoopy][:is_a_puppy] = true
         node.set_unless[:snoopy][:is_a_puppy] = false
         expect(node[:snoopy][:is_a_puppy]).to eq(true)
+      end
+
+      it "should allow you to set an attribute with set_unless if is a nil value" do
+        node.attributes.normal = { snoopy: { is_a_puppy: nil } }
+        node.set_unless[:snoopy][:is_a_puppy] = false
+        expect(node[:snoopy][:is_a_puppy]).to eq(false)
       end
 
       it "should allow you to set a value after a set_unless" do
@@ -796,6 +802,12 @@ describe Chef::Node do
       node.tag("radiohead")
       node.consume_external_attrs(@ohai_data, {})
       expect(node.tags).to eql([ "radiohead" ])
+    end
+
+    it "should set the tags attribute to an empty array if it is nil" do
+      node.attributes.normal = { 'tags' => nil }
+      node.consume_external_attrs(@ohai_data, {})
+      expect(node.tags).to eql([])
     end
 
     it "deep merges attributes instead of overwriting them" do


### PR DESCRIPTION
previously if the node had a { normal: { tags: nil } } that we read
since the key existed (but was nil) we would not initialize with an
array.  replacing the code with a call to node.set_unless revealed that
set_unless was similarly buggy.  fixed both issues by fixing set_unless.