### PR TITLE
Updates the template to use omnitruck-direct.chef.io

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -165,7 +165,7 @@ do_download() {
 <% if knife_config[:bootstrap_install_command] %>
   <%= knife_config[:bootstrap_install_command] %>
 <% else %>
-  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://www.opscode.com/chef/install.sh" %>"
+  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://omnitruck-direct.chef.io/chef/install.sh" %>"
   if test -f /usr/bin/chef-client; then
     echo "-----> Existing Chef installation detected"
   else


### PR DESCRIPTION
In the past we have had issues with SAN and SNI certificates on RHEL 5.
As a result, the fix was to keep pointing at www.opcode.com which used a
cert that matched what we needed. With recent changes to the
infrastructure omnitruck.chef.io and omnitruck-direct.chef.io are now
available. omnitruck.chef.io is fronted by Fastly and as a result has
the same certificate issues that have kept us using www.opscode.com.
omnitruck-direct.chef.io is what Fastly (and now www.opscode.com) hits
to serve traffic. While we don't get the benefit of the CDN and caching
goodness, this will still do a bit to clean up the codebase.

Bootstrapping was verified on the following platforms:

```
opscode-centos-6.4        running (virtualbox)
opscode-centos-7.1        running (virtualbox)
debian-6.0.10             running (virtualbox)
debian-7.9                running (virtualbox)
debian-8.2                running (virtualbox)
fedora-21                 running (virtualbox)
fedora-22                 running (virtualbox)
freebsd-9.3               running (virtualbox)
freebsd-10.2              running (virtualbox)
opensuse-13.2             running (virtualbox)
opscode-ubuntu-12.04      running (virtualbox)
opscode-ubuntu-14.04      running (virtualbox)
centos-5.11               running (virtualbox)
```