### PR TITLE
chef-client: add --[no]skip-cookbook-sync option

### DIFF
--- a/distro/common/markdown/man8/chef-client.mkd
+++ b/distro/common/markdown/man8/chef-client.mkd
@@ -40,6 +40,8 @@ __chef-client__ _(options)_
     Set the PID file location, defaults to /tmp/chef-client.pid
   * `--once`:
     Cancel any interval or splay options, run chef once and exit
+  * `--skip-cookbook-sync`:
+    Skip cookbook synchronization
   * `-v`, `--version`:
     Show chef version
   * `-h`, `--help`:

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -285,6 +285,11 @@ class Chef::Application::Client < Chef::Application
     :description    => "DANGEROUS: does what it says, only useful with --recipe-url",
     :boolean        => true
 
+  option :skip_cookbook_sync,
+    :long           => "--[no-]skip-cookbook-sync",
+    :description    => "Whether to skip cookbook synchronization",
+    :boolean        => false
+
   IMMEDIATE_RUN_SIGNAL = "1".freeze
 
   attr_reader :chef_client_json

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -287,7 +287,7 @@ class Chef::Application::Client < Chef::Application
 
   option :skip_cookbook_sync,
     :long           => "--[no-]skip-cookbook-sync",
-    :description    => "Whether to skip cookbook synchronization",
+    :description    => "Use cached cookbooks without overwriting local differences from the server",
     :boolean        => false
 
   IMMEDIATE_RUN_SIGNAL = "1".freeze

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -263,6 +263,7 @@ class Chef
     end
 
     def cached_copy_up_to_date?(local_path, expected_checksum)
+      return true if Chef::Config[:skip_cookbook_sync]
       if cache.has_key?(local_path)
         current_checksum = CookbookVersion.checksum_cookbook_file(cache.load(local_path, false))
         expected_checksum == current_checksum

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -263,7 +263,10 @@ class Chef
     end
 
     def cached_copy_up_to_date?(local_path, expected_checksum)
-      return true if Chef::Config[:skip_cookbook_sync]
+      if Chef::Config[:skip_cookbook_sync]
+        Chef::Log.warn "skipping cookbook synchronization!  DO NOT LEAVE THIS ENABLED IN PRODUCTION!!!"
+        return true
+      end
       if cache.has_key?(local_path)
         current_checksum = CookbookVersion.checksum_cookbook_file(cache.load(local_path, false))
         expected_checksum == current_checksum

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -265,6 +265,11 @@ FOOTER
       :description  => "Replace current run list with specified items",
       :proc         => lambda { |items| items.split(",").map { |item| Chef::RunList::RunListItem.new(item) } }
 
+    option :skip_cookbook_sync,
+      :long           => "--[no-]skip-cookbook-sync",
+      :description    => "Whether to skip cookbook synchronization",
+      :boolean        => false
+
     def self.print_help
       instance = new
       instance.parse_options([])

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -267,7 +267,7 @@ FOOTER
 
     option :skip_cookbook_sync,
       :long           => "--[no-]skip-cookbook-sync",
-      :description    => "Whether to skip cookbook synchronization",
+      :description    => "Use cached cookbooks without overwriting local differences from the server",
       :boolean        => false
 
     def self.print_help


### PR DESCRIPTION
Use with caution. Useful for patching a set of cookbooks on a machine
when iterating during development.