### PR TITLE
Allow package version to be nil

### DIFF
--- a/lib/chef/provider/package/easy_install.rb
+++ b/lib/chef/provider/package/easy_install.rb
@@ -93,10 +93,10 @@ class Chef
 
           if package_version == @new_resource.version
             Chef::Log.debug("#{@new_resource} at version #{@new_resource.version}")
-            @current_resource.version(@new_resource.version)
+            @current_resource.version = @new_resource.version
           else
             Chef::Log.debug("#{@new_resource} at version #{package_version}")
-            @current_resource.version(package_version)
+            @current_resource.version = package_version
           end
 
           @current_resource

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -35,7 +35,7 @@ class Chef
 
       property :package_name, [ String, Array ], identity: true
 
-      property :version, [ String, Array ]
+      property :version, [ String, Array, NilClass ]
       property :options, String
       property :response_file, String, desired_state: false
       property :response_file_variables, Hash, default: lazy { {} }, desired_state: false


### PR DESCRIPTION
This feels like the wrong fix. If `default_value` is not specified, a property should probably implicitly allow `kind_of` to contain `nil` as it's going to default to nil.

Fixes failing test:

```
  1) Chef::Provider::Package::EasyInstall easy_install_binary_path should set the current resources package name to the new resources package name
     Failure/Error: @provider.load_current_resource

     Chef::Exceptions::DeprecatedFeatureError:
       version nil currently does not overwrite the value of version. This will change in Chef 13, and the value will be set to nil instead. Please change your code to explicitly accept nil using "property :version, [MyType, nil]", or stop setting this value to nil. at C:/projects/chef/spec/unit/provider/package/easy_install_spec.rb:52:in `block (3 levels) in <top (required)>'
     # ./lib/chef/log.rb:61:in `deprecation'
     # ./lib/chef/chef_class.rb:214:in `log_deprecation'
     # ./lib/chef/property.rb:262:in `call'
     # ./lib/chef/property.rb:484:in `version'
     # ./lib/chef/provider/package/easy_install.rb:99:in `load_current_resource'
     # ./spec/unit/provider/package/easy_install_spec.rb:52:in `block (3 levels) in <top (required)>'

Finished in 24 minutes 22 seconds (files took 10.92 seconds to load)
16178 examples, 1 failure, 104 pending
```