### PR TITLE
[chef/4294] group: split #members/#excluded_members on commas

### DIFF
--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -55,7 +55,7 @@ class Chef
       end
 
       def members(arg=nil)
-        converted_members = arg.is_a?(String) ? [].push(arg) : arg
+        converted_members = arg.is_a?(String) ? arg.split(',') : arg
         set_or_return(
           :members,
           converted_members,
@@ -66,7 +66,7 @@ class Chef
       alias_method :users, :members
 
       def excluded_members(arg=nil)
-        converted_members = arg.is_a?(String) ? [].push(arg) : arg
+        converted_members = arg.is_a?(String) ? arg.split(',') : arg
         set_or_return(
           :excluded_members,
           converted_members,


### PR DESCRIPTION
Given the following test:
```
stooges = %w(moe larry curly)

stooges.each do |name|
  user name
end

group 'actors' do
  members stooges
end

group 'stooges' do
  members 'moe,larry,curly'
end
```
The groups are created properly. However, subsequent runs will update 'stooges'
```
# getent group stooges
stooges:x:501:larry,moe,curly

# chef-apply /vagrant/bug
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * user[larry] action create (up to date)
  * user[moe] action create (up to date)
  * user[curly] action create (up to date)
  * group[actors] action create (up to date)
  * group[stooges] action create
    - alter group stooges
    - replace group members with new list of members
```

By splitting on commas, it will convert into an array and not update the resource each run.