### PR TITLE
Included the message part to the body of :delete request

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -131,8 +131,8 @@ class Chef
     #
     # === Parameters
     # path:: path part of the request URL
-    def delete(path, headers={})
-      request(:DELETE, path, headers)
+    def delete(path, json, headers={})
+      request(:DELETE, path, headers, json)
     end
 
     # Makes an HTTP request to +path+ with the given +method+, +headers+, and

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -97,6 +97,7 @@ class Chef
       # Send a DELETE request to @new_resource.url
       def action_delete
         converge_by("#{@new_resource} DELETE to #{@new_resource.url}") do
+          message = check_message(@new_resource.message)
           body = @http.delete(
             "#{@new_resource.url}",
             message,

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -99,6 +99,7 @@ class Chef
         converge_by("#{@new_resource} DELETE to #{@new_resource.url}") do
           body = @http.delete(
             "#{@new_resource.url}",
+            message,
             @new_resource.headers
           )
           @new_resource.updated_by_last_action(true)


### PR DESCRIPTION
While RFC does not explicitly suggest that, there are services like CloudFlare that utilize the data part of DELETE request as well. It actually does not execute the requests with out it making Chef http_request unsuitable for executing actions like purge requests. I added the message part to the body of :delete.