### PR TITLE
tiny_server should retry Errno::EHOSTUNREACH

### DIFF
--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -96,7 +96,8 @@ module TinyServer
       sleep 0.1
       # If the host has ":::1 localhost" in its hosts file and if IPv6
       # is not enabled we can get NetworkUnreachable exception...
-    rescue Errno::ENETUNREACH, Net::ReadTimeout, IO::EAGAINWaitReadable => e
+    rescue Errno::ENETUNREACH, Net::ReadTimeout, IO::EAGAINWaitReadable,
+        Errno::EHOSTUNREACH => e
       sleep 0.1
       false
     end

--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -94,6 +94,7 @@ module TinyServer
       true
     rescue Errno::ECONNREFUSED, EOFError, Errno::ECONNRESET => e
       sleep 0.1
+      true
       # If the host has ":::1 localhost" in its hosts file and if IPv6
       # is not enabled we can get NetworkUnreachable exception...
     rescue Errno::ENETUNREACH, Net::ReadTimeout, IO::EAGAINWaitReadable,


### PR DESCRIPTION
AIX seems to raise Errno::EHOSTUNREACH when the server
is not ready yet. Our tests on AIX fail with:
```
      Errno::EHOSTUNREACH:
         No route to host - connect(2) for "localhost" port 9000
       Shared Example Group: "a file with the wrong content" called from ./spec/support/shared/functional/file_resource.rb:936
       Shared Example Group: "a configured file resource" called from ./spec/support/shared/functional/file_resource.rb:279
       Shared Example Group: "a file resource" called from ./spec/functional/resource/remote_file_spec.rb:122
       # ./spec/tiny_server.rb:91:in `started?'
       # ./spec/tiny_server.rb:82:in `block in block_until_started'
       # ./spec/tiny_server.rb:81:in `times'
       # ./spec/tiny_server.rb:81:in `block_until_started'
       # ./spec/tiny_server.rb:72:in `start'
       # ./spec/support/shared/functional/http.rb:45:in `start_tiny_server'
       # ./spec/functional/resource/remote_file_spec.rb:111:in `block (3 levels) in <top (required)>'
```