### PR TITLE
Disabled mount tests on AIX

### DIFF
--- a/spec/functional/resource/aix_service_spec.rb
+++ b/spec/functional/resource/aix_service_spec.rb
@@ -108,8 +108,8 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
     it_behaves_like "src service"
   end
 
-
-  describe "When service is a group" do
+  # Cannot run this test on a WPAR
+  describe "When service is a group", :not_wpar do
     before(:all) do
       script_dir = File.join(File.dirname(__FILE__), "/../assets/")
       shell_out!("mkssys -s ctestsys -p #{script_dir}/testchefsubsys -u #{get_user_id} -S -n 15 -f 9 -R -Q -G ctestgrp")

--- a/spec/functional/resource/mount_spec.rb
+++ b/spec/functional/resource/mount_spec.rb
@@ -21,7 +21,7 @@ require 'chef/mixin/shell_out'
 require 'tmpdir'
 
 # run this test only for following platforms.
-include_flag = !(['ubuntu', 'centos', 'aix', 'solaris2'].include?(ohai[:platform]))
+include_flag = !(['ubuntu', 'centos', 'solaris2'].include?(ohai[:platform]))
 
 describe Chef::Resource::Mount, :requires_root, :skip_travis, :external => include_flag do
   # Disabled in travis because it refuses to let us mount a ramdisk. /dev/ramX does not
@@ -34,6 +34,7 @@ describe Chef::Resource::Mount, :requires_root, :skip_travis, :external => inclu
   def setup_device_for_mount
     # use ramdisk for creating a test device for mount.
     # This can cleaner if we have chef resource/provider for ramdisk.
+    # TODO: These tests only work in LPARs, not WPARs on AIX.
     case ohai[:platform]
     when "aix"
       ramdisk = shell_out!("mkramdisk 16M").stdout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -164,6 +164,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :openssl_lt_101 => true unless openssl_lt_101?
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
   config.filter_run_excluding :broken => true
+  config.filter_run_excluding :not_wpar => true unless wpar?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -151,6 +151,10 @@ def aix?
   !!(RUBY_PLATFORM =~ /aix/)
 end
 
+def wpar?
+  !((ohai[:virtualization] || {})[:wpar_no].nil?)
+end
+
 def supports_cloexec?
   Fcntl.const_defined?('F_SETFD') && Fcntl.const_defined?('FD_CLOEXEC')
 end


### PR DESCRIPTION
One cannot create a ramdisk in a WPAR, since it shares filesystem with the LPAR host. Since we use ramdisk for the test, mount tests only work in LPARs. In the future we should find a way to test this code.

@btm @jaym 