### PR TITLE
Deprecation waring by ruby 2.3.0: Thread.exclusive is deprecated, use Mutex.

### DIFF
--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -88,7 +88,7 @@ class Chef
       #
       def build_resource(type, name, created_at=nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
-        Thread.exclusive do
+        Mutex.new.synchronize do
           require 'chef/resource_builder' unless defined?(Chef::ResourceBuilder)
         end
 

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -202,7 +202,7 @@ class Chef
         # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
         # via chef-zero and that hits DNS (at *require* time) which may timeout,
         # when for most knife/chef-client work we never need/want this loaded.
-        Thread.exclusive {
+        Mutex.new.synchronize {
           unless defined?(SocketlessChefZeroClient)
             require 'chef/http/socketless_chef_zero_client'
           end


### PR DESCRIPTION
Hi, Ruby 2.3 told that `Thread.exclusive is deprecated, use Mutex`.

It works also 1.9.3.