### PR TITLE
use platform parser with metadata supports

### DIFF
--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -746,7 +746,7 @@ OBSOLETED
       end
 
       def validate_version_constraint(caller_name, dep_name, constraint_str)
-        Chef::VersionConstraint.new(constraint_str)
+        Chef::VersionConstraint::Platform.new(constraint_str)
       rescue Chef::Exceptions::InvalidVersionConstraint => e
         Log.debug(e)
 

--- a/spec/data/cookbooks/supports-platform-constraints/metadata.rb
+++ b/spec/data/cookbooks/supports-platform-constraints/metadata.rb
@@ -1,0 +1,5 @@
+name 'supports-platform-constraints'
+version '0.1.0'
+
+supports 'centos', '>= 6'
+supports 'freebsd', '> 10.1-fake-p12'


### PR DESCRIPTION
Using the cookbook version parser means that some platforms cannot be properly parsed by the supports method in metadata.

The included test metadata are two cases where it fails to parse because both are invalid cookbook versions but valid platform versions.