### PR TITLE
Warn (v. info) when reloading resources

### DIFF
--- a/lib/chef/provider/lwrp_base.rb
+++ b/lib/chef/provider/lwrp_base.rb
@@ -53,7 +53,7 @@ class Chef
 
         def build_from_file(cookbook_name, filename, run_context)
           if LWRPBase.loaded_lwrps[filename]
-            Chef::Log.info("LWRP provider #{filename} from cookbook #{cookbook_name} has already been loaded!  Skipping the reload.")
+            Chef::Log.debug("LWRP provider #{filename} from cookbook #{cookbook_name} has already been loaded!  Skipping the reload.")
             return loaded_lwrps[filename]
           end
 

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -45,7 +45,7 @@ class Chef
 
         def build_from_file(cookbook_name, filename, run_context)
           if LWRPBase.loaded_lwrps[filename]
-            Chef::Log.info("Custom resource #{filename} from cookbook #{cookbook_name} has already been loaded!  Skipping the reload.")
+            Chef::Log.debug("Custom resource #{filename} from cookbook #{cookbook_name} has already been loaded!  Skipping the reload.")
             return loaded_lwrps[filename]
           end
 

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -84,7 +84,7 @@ describe "LWRP" do
       end
 
       Dir[File.expand_path( "lwrp/resources/*", CHEF_SPEC_DATA)].each do |file|
-        expect(Chef::Log).to receive(:info).with(/Skipping/)
+        expect(Chef::Log).to receive(:debug).with(/Skipping/)
         Chef::Resource::LWRPBase.build_from_file("lwrp", file, nil)
       end
     end
@@ -95,7 +95,7 @@ describe "LWRP" do
       end
 
       Dir[File.expand_path( "lwrp/providers/*", CHEF_SPEC_DATA)].each do |file|
-        expect(Chef::Log).to receive(:info).with(/Skipping/)
+        expect(Chef::Log).to receive(:debug).with(/Skipping/)
         Chef::Provider::LWRPBase.build_from_file("lwrp", file, nil)
       end
     end


### PR DESCRIPTION
These tally up pretty fast. I'd prefer they weren't on the default log level:
```
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/chef_handler/providers/default.rb from cookbook chef_handler has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/chef_handler/resources/default.rb from cookbook chef_handler has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/auto_run.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/batch.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/certificate.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/certificate_binding.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/feature_dism.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/feature_powershell.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/feature_servermanagercmd.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/font.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/http_acl.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/pagefile.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/path.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/printer.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/printer_port.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/reboot.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/registry.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/shortcut.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/task.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/providers/zipfile.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/auto_run.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/batch.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/certificate.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/certificate_binding.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/feature.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/font.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/http_acl.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/pagefile.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/path.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/printer.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/printer_port.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/reboot.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/registry.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/shortcut.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/task.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/windows/resources/zipfile.rb from cookbook windows has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/dmg/providers/package.rb from cookbook dmg has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/dmg/resources/package.rb from cookbook dmg has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/yum/providers/globalconfig.rb from cookbook yum has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/yum/providers/repository.rb from cookbook yum has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/yum/resources/globalconfig.rb from cookbook yum has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/yum/resources/repository.rb from cookbook yum has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/git/providers/config.rb from cookbook git has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/git/resources/config.rb from cookbook git has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/homebrew/providers/cask.rb from cookbook homebrew has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: LWRP provider /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/homebrew/providers/tap.rb from cookbook homebrew has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/homebrew/resources/cask.rb from cookbook homebrew has already been loaded!  Skipping the reload.
[2015-12-28T22:34:18-08:00] INFO: Custom resource /var/folders/1k/xm6r9n6d26b63qsh0m6nlz6m0000gn/T/d20151228-11523-mvxs61/cookbooks/homebrew/resources/tap.rb from cookbook homebrew has already been loaded!  Skipping the reload.
```