### PR TITLE
Make handling of proxies more consistent

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -856,14 +856,14 @@ module ChefConfig
       # proxy before parsing. The regex /^.*:\/\// matches, for example, http://. Reusing proxy
       # here since we are really just trying to get the string built correctly.
       proxy = if !proxy_env_var.empty?
-        if proxy_env_var.match(/^.*:\/\//)
-          URI.parse(proxy_env_var)
-        else
-          URI.parse("#{scheme}://#{proxy_env_var}")
-        end
-      end
+                if proxy_env_var =~ /^.*:\/\//
+                  URI.parse(proxy_env_var)
+                else
+                  URI.parse("#{scheme}://#{proxy_env_var}")
+                end
+              end
 
-      excludes = ENV['no_proxy'].to_s.split(/\s*,\s*/).compact
+      excludes = ENV["no_proxy"].to_s.split(/\s*,\s*/).compact
       excludes = excludes.map { |exclude| exclude =~ /:\d+$/ ? exclude : "#{exclude}:*" }
       return proxy unless excludes.any? { |exclude| File.fnmatch(exclude, "#{host}:#{port}") }
     end

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -846,6 +846,28 @@ module ChefConfig
       ENV["NO_PROXY"] = value unless ENV["NO_PROXY"]
     end
 
+    # Given a scheme, host, and port, return the correct proxy URI based on the
+    # set environment variables, unless exluded by no_proxy, in which case nil
+    # is returned
+    def self.proxy_uri(scheme, host, port)
+      proxy_env_var = ENV["#{scheme}_proxy"].to_s.strip
+
+      # Check if the proxy string contains a scheme. If not, add the url's scheme to the
+      # proxy before parsing. The regex /^.*:\/\// matches, for example, http://. Reusing proxy
+      # here since we are really just trying to get the string built correctly.
+      proxy = if !proxy_env_var.empty?
+        if proxy_env_var.match(/^.*:\/\//)
+          URI.parse(proxy_env_var)
+        else
+          URI.parse("#{scheme}://#{proxy_env_var}")
+        end
+      end
+
+      excludes = ENV['no_proxy'].to_s.split(/\s*,\s*/).compact
+      excludes = excludes.map { |exclude| exclude =~ /:\d+$/ ? exclude : "#{exclude}:*" }
+      return proxy unless excludes.any? { |exclude| File.fnmatch(exclude, "#{host}:#{port}") }
+    end
+
     # Chef requires an English-language UTF-8 locale to function properly.  We attempt
     # to use the 'locale -a' command and search through a list of preferences until we
     # find one that we can use.  On Ubuntu systems we should find 'C.UTF-8' and be

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -802,6 +802,116 @@ RSpec.describe ChefConfig::Config do
     end
   end
 
+  describe "proxy_uri" do
+    subject(:proxy_uri) { described_class.proxy_uri(scheme, host, port) }
+    let(:env) { {} }
+    let(:scheme) { "http" }
+    let(:host) { "test.example.com" }
+    let(:port) { 8080 }
+    let(:proxy) { "#{proxy_prefix}#{proxy_host}:#{proxy_port}" }
+    let(:proxy_prefix) { "http://" }
+    let(:proxy_host) { "proxy.mycorp.com" }
+    let(:proxy_port) { 8080 }
+
+    before do
+      stub_const("ENV", env)
+    end
+
+    shared_examples_for "a proxy uri" do
+      it "contains the host" do
+        expect(proxy_uri.host).to eq(proxy_host)
+      end
+
+      it "contains the port" do
+        expect(proxy_uri.port).to eq(proxy_port)
+      end
+    end
+
+    context "when the config setting is normalized (does not contain the scheme)" do
+      include_examples "a proxy uri" do
+
+        let(:proxy_prefix) { "" }
+
+        let(:env) do
+          {
+            "#{scheme}_proxy" => proxy,
+            "no_proxy" => nil,
+          }
+        end
+      end
+    end
+
+    context "when the proxy is set by the environment" do
+      include_examples "a proxy uri" do
+        let(:scheme) { "https" }
+        let(:env) do
+          {
+            "https_proxy" => "https://jane_username:opensesame@proxy.mycorp.com:8080",
+          }
+        end
+      end
+    end
+
+    context "when an empty proxy is set by the environment" do
+      let(:env) do
+        {
+          "https_proxy" => ""
+        }
+      end
+
+      it "does not fail with URI parse exception" do
+        expect { proxy_uri }.to_not raise_error
+      end
+    end
+
+    context "when no_proxy is set" do
+      context "when no_proxy is the exact host" do
+        let(:env) do
+          {
+            "http_proxy" => proxy,
+            "no_proxy" => host,
+          }
+        end
+
+        it { is_expected.to eq nil }
+      end
+
+      context "when no_proxy includes the same domain with a wildcard" do
+        let(:env) do
+          {
+            "http_proxy" => proxy,
+            "no_proxy" => "*.example.com",
+          }
+        end
+
+        it { is_expected.to eq nil }
+      end
+
+
+      context "when no_proxy is included on a list" do
+        let(:env) do
+          {
+            "http_proxy" => proxy,
+            "no_proxy" => "chef.io,getchef.com,opscode.com,test.example.com",
+          }
+        end
+
+        it { is_expected.to eq nil }
+      end
+
+      context "when no_proxy is included on a list with wildcards" do
+        let(:env) do
+          {
+            "http_proxy" => proxy,
+            "no_proxy" => "10.*,*.example.com",
+          }
+        end
+
+        it { is_expected.to eq nil }
+      end
+    end
+  end
+
   describe "allowing chefdk configuration outside of chefdk" do
 
     it "allows arbitrary settings in the chefdk config context" do

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -855,7 +855,7 @@ RSpec.describe ChefConfig::Config do
     context "when an empty proxy is set by the environment" do
       let(:env) do
         {
-          "https_proxy" => ""
+          "https_proxy" => "",
         }
       end
 
@@ -886,7 +886,6 @@ RSpec.describe ChefConfig::Config do
 
         it { is_expected.to eq nil }
       end
-
 
       context "when no_proxy is included on a list" do
         let(:env) do

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -96,7 +96,7 @@ class Chef
       end
 
       def proxy_uri
-        @proxy_uri ||= ChefConfig::Config.proxy_uri(url.scheme, host, port)
+        @proxy_uri ||= Chef::Config.proxy_uri(url.scheme, host, port)
       end
 
       def build_http_client
@@ -120,9 +120,17 @@ class Chef
           Net::HTTP
         else
           Chef::Log.debug("Using #{proxy_uri.host}:#{proxy_uri.port} for proxy")
-          Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user,
-                          proxy_uri.password)
+          Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port, http_proxy_user(proxy_uri),
+                          http_proxy_pass(proxy_uri))
         end
+      end
+
+      def http_proxy_user(proxy_uri)
+        proxy_uri.user || Chef::Config["#{proxy_uri.scheme}_proxy_user"]
+      end
+
+      def http_proxy_pass(proxy_uri)
+        proxy_uri.password || Chef::Config["#{proxy_uri.scheme}_proxy_pass"]
       end
 
       def configure_ssl(http_client)

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -146,19 +146,8 @@ class Chef
           tempfile
         end
 
-        #adapted from buildr/lib/buildr/core/transports.rb via chef/rest/rest_client.rb
         def proxy_uri(uri)
-          proxy = Chef::Config["ftp_proxy"]
-          proxy = URI.parse(proxy) if String === proxy
-          if Chef::Config["ftp_proxy_user"]
-            proxy.user = Chef::Config["ftp_proxy_user"]
-          end
-          if Chef::Config["ftp_proxy_pass"]
-            proxy.password = Chef::Config["ftp_proxy_pass"]
-          end
-          excludes = Chef::Config[:no_proxy].to_s.split(/\s*,\s*/).compact
-          excludes = excludes.map { |exclude| exclude =~ /:\d+$/ ? exclude : "#{exclude}:*" }
-          return proxy unless excludes.any? { |exclude| File.fnmatch(exclude, "#{host}:#{port}") }
+          ChefConfig::Config.proxy_uri("ftp", hostname, port)
         end
 
         def parse_path

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -147,7 +147,7 @@ class Chef
         end
 
         def proxy_uri(uri)
-          ChefConfig::Config.proxy_uri("ftp", hostname, port)
+          Chef::Config.proxy_uri("ftp", hostname, port)
         end
 
         def parse_path

--- a/spec/unit/provider/remote_file/ftp_spec.rb
+++ b/spec/unit/provider/remote_file/ftp_spec.rb
@@ -200,9 +200,7 @@ describe Chef::Provider::RemoteFile::FTP do
 
     context "and proxying is enabled" do
       before do
-        Chef::Config[:ftp_proxy] = "socks5://socks.example.com:5000"
-        Chef::Config[:ftp_proxy_user] = "bill"
-        Chef::Config[:ftp_proxy_pass] = "ted"
+        stub_const("ENV", "ftp_proxy" => "socks5://bill:ted@socks.example.com:5000")
       end
 
       it "fetches the file via the proxy" do

--- a/spec/unit/rest/auth_credentials_spec.rb
+++ b/spec/unit/rest/auth_credentials_spec.rb
@@ -96,13 +96,13 @@ end
 describe Chef::REST::RESTRequest do
   let(:url) { URI.parse("http://chef.example.com:4000/?q=chef_is_awesome") }
 
-  def new_request(method=nil)
+  def new_request(method = nil)
     method ||= :POST
     Chef::REST::RESTRequest.new(method, url, @req_body, @headers)
   end
 
   before do
-    @auth_credentials = Chef::REST::AuthCredentials.new("client-name", CHEF_SPEC_DATA + '/ssl/private_key.pem')
+    @auth_credentials = Chef::REST::AuthCredentials.new("client-name", CHEF_SPEC_DATA + "/ssl/private_key.pem")
     @req_body = '{"json_data":"as_a_string"}'
     @headers = { "Content-type" => "application/json",
                  "Accept" => "application/json",
@@ -182,7 +182,7 @@ describe Chef::REST::RESTRequest do
                           "http_proxy_pass" => nil,
                           "https_proxy_user" => nil,
                           "https_proxy_pass" => nil,
-                          "no_proxy" => nil,
+                          "no_proxy" => nil
                   )
       end
 
@@ -265,7 +265,7 @@ describe Chef::REST::RESTRequest do
       describe "with :https_proxy_user and :https_proxy_pass set" do
         before do
           stub_const("ENV", "http_proxy" => "http://proxy.example.com:3128",
-                            "https_proxy" => "https://homie:theclown@sproxy.example.com:3129",
+                            "https_proxy" => "https://homie:theclown@sproxy.example.com:3129"
                     )
         end
 


### PR DESCRIPTION
* Always use `*_proxy` environment variables.
* Make a `ChefConfig::Config.proxy_uri` method that gets used by
  `Chef::Provider::RemoteFile::FTP` and `Chef::HTTP::BasicClient`.
* Remove `env` method from `Chef::HTTP::BasicClient` (using
  `stub_const("ENV", ...)` in specs instead.)
* Remove `http_proxy_user` and `http_proxy_pass` methods from
  `Chef::HTTP::BasicClient` (replaced by functionality in `ChefConfig`.)