### PR TITLE
`@name_args` may contain some duplicated items.

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -183,6 +183,7 @@ class Chef
                 Log.debug(e)
               end
             end
+            @name_args.uniq!
             upload_set
           end
       end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -183,6 +183,7 @@ E
         knife.config[:depends] = true
         allow(knife).to receive(:cookbook_names).and_return(["test_cookbook1", "test_cookbook2", "test_cookbook3"])
         expect(knife).to receive(:upload).exactly(3).times
+        expect(knife.cookbooks_to_upload.keys).to match_array knife.name_args
         expect do
           Timeout::timeout(5) do
             knife.run


### PR DESCRIPTION
It makes `upload_failures` wrongly computed, and prints some weird warning message even though all cookbooks are successfully uploaded, for example:

```
$ knife cookbook upload nodejs --include-dependencies
Uploading nodejs         [2.4.4]
Uploading yum-epel       [0.6.5]
Uploading build-essential [2.2.4]
Uploading ark            [0.9.0]
Uploading apt            [2.9.2]
Uploading homebrew       [2.0.3]
Uploading yum            [3.8.2]
Uploading windows        [1.39.0]
Uploading 7-zip          [1.0.2]
Uploading chef_handler   [1.2.0]
WARNING: Uploaded 10 cookbooks ok but 2 cookbooks upload failed.
```