### PR TITLE
Allow loading bootstrap ssh-user from ssh_config

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -47,8 +47,7 @@ class Chef
       option :ssh_user,
         :short => "-x USERNAME",
         :long => "--ssh-user USERNAME",
-        :description => "The ssh username",
-        :default => "root"
+        :description => "The ssh username"
 
       option :ssh_password,
         :short => "-P PASSWORD",


### PR DESCRIPTION
At present, `knife ssh` can load ssh-user from ssh-comfng.
But `knife bootstrap` sets root by default, it takes precedence over ssh-comfig.

This PR it is related lightly to #4038.