### PR TITLE
fixes #4354 and does not raise if file has no version resource

### DIFF
--- a/lib/chef/win32/file/version_info.rb
+++ b/lib/chef/win32/file/version_info.rb
@@ -28,7 +28,11 @@ class Chef
 
         def initialize(file_name)
           raise Errno::ENOENT, file_name unless ::File.exist?(file_name)
-          @file_version_info = retrieve_file_version_info(file_name)
+          begin
+            @file_version_info = retrieve_file_version_info(file_name)
+          rescue Chef::Exceptions::Win32APIError
+            # file likely has no embedded version info
+          end
         end
 
         # defining method for each predefined version resource string
@@ -48,6 +52,8 @@ class Chef
           :SpecialBuild
         ].each do |method|
           define_method method do
+            return nil if @file_version_info.nil?
+
             begin
               get_version_info_string(method.to_s)
             rescue Chef::Exceptions::Win32APIError

--- a/spec/functional/win32/version_info_spec.rb
+++ b/spec/functional/win32/version_info_spec.rb
@@ -47,4 +47,12 @@ describe "Chef::ReservedNames::Win32::File::VersionInfo", :windows_only do
   it "file description is command processor" do
     expect(subject.FileDescription).to eq("Windows Command Processor")
   end
+
+  context "file has no version resources" do
+    let(:file_path) { File.join(ENV['windir'], "bootstat.dat") }
+
+    it "returns nil" do
+      expect(subject.FileVersion).to be nil
+    end
+  end
 end


### PR DESCRIPTION
Some .exe's have no version information resources which currently raises an error. We should instead simply pass back `nil`