### PR TITLE
Ensuring running Help returns an exit code of 0

### DIFF
--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -162,7 +162,7 @@ class Chef::Application::Knife < Chef::Application
       print_help_and_exit(1, NO_COMMAND_GIVEN)
     elsif no_subcommand_given?
       if (want_help? || want_version?)
-        print_help_and_exit
+        print_help_and_exit(0)
       else
         print_help_and_exit(2, NO_COMMAND_GIVEN)
       end

--- a/spec/functional/knife/smoke_test.rb
+++ b/spec/functional/knife/smoke_test.rb
@@ -31,4 +31,12 @@ describe "knife smoke tests" do
     knife_cmd.error!
     expect(knife_cmd.stdout).to include(Chef::VERSION)
   end
+  
+  it "can run and show help" do
+    knife_path = File.expand_path("../../bin/knife", CHEF_SPEC_DATA)
+    knife_cmd = Mixlib::ShellOut.new("#{knife_path} --help")
+    knife_cmd.run_command
+    knife_cmd.error!
+    expect(knife_cmd.stdout).to include("Usage")
+  end
 end


### PR DESCRIPTION
Request to have Help command return zero when executed
https://github.com/chef/chef/issues/4268
