### PR TITLE
fixes #4354 and fixes #4372 stop trying to auto detect versions for exe installers

### DIFF
--- a/lib/chef/provider/package/windows/exe.rb
+++ b/lib/chef/provider/package/windows/exe.rb
@@ -48,7 +48,7 @@ class Chef
           end
 
           def package_version
-            new_resource.version || install_file_version
+            new_resource.version
           end
 
           def install_package
@@ -94,18 +94,6 @@ class Chef
           def current_installed_version
             @current_installed_version ||= uninstall_entries.count == 0 ? nil : begin
               uninstall_entries.map { |entry| entry.display_version }.uniq
-            end
-          end
-
-          def install_file_version
-            @install_file_version ||= begin
-              if !new_resource.source.nil? && ::File.exist?(new_resource.source)
-                version_info = Chef::ReservedNames::Win32::File.version_info(new_resource.source)
-                file_version = version_info.FileVersion || version_info.ProductVersion
-                file_version == '' ? nil : file_version
-              else
-                nil
-              end
             end
           end
 

--- a/spec/functional/resource/windows_package_spec.rb
+++ b/spec/functional/resource/windows_package_spec.rb
@@ -37,11 +37,11 @@ describe Chef::Resource::WindowsPackage, :windows_only, :volatile do
     new_resource
   end
 
-  describe "multi package scenario" do
+  describe "install package" do
     let(:pkg_name) { 'Microsoft Visual C++ 2005 Redistributable' }
+    let(:pkg_checksum) { 'd6832398e3bc9156a660745f427dc1c2392ce4e9a872e04f41f62d0c6bae07a8' }
     let(:pkg_path) { 'https://download.microsoft.com/download/6/B/B/6BB661D6-A8AE-4819-B79F-236472F6070C/vcredist_x86.exe' }
     let(:pkg_checksum) { nil }
-    let(:pkg_version) { '8.0.59193' }
     let(:pkg_type) { :custom }
     let(:pkg_options) { "/Q" }
 
@@ -57,6 +57,7 @@ describe Chef::Resource::WindowsPackage, :windows_only, :volatile do
 
     context "installing additional version" do
       let(:pkg_path) { 'https://download.microsoft.com/download/e/1/c/e1c773de-73ba-494a-a5ba-f24906ecf088/vcredist_x86.exe' }
+      let(:pkg_checksum) { 'eb00f891919d4f894ab725b158459db8834470c382dc60cd3c3ee2c6de6da92c' }
       let(:pkg_version) { '8.0.56336' }
 
       it "installs older version" do
@@ -127,11 +128,6 @@ describe Chef::Resource::WindowsPackage, :windows_only, :volatile do
       let(:pkg_path) { 'http://iweb.dl.sourceforge.net/project/ultradefrag/stable-release/6.1.1/ultradefrag-6.1.1.bin.amd64.exe' }
       let(:pkg_checksum) { '11d53ed4c426c8c867ad43f142b7904226ffd9938c02e37086913620d79e3c09' }
       
-      it "finds the correct package version" do
-        subject.run_action(:install)
-        expect(subject.version).to eq('6.1.1')
-      end
-
       it "finds the correct installer type" do
         subject.run_action(:install)
         expect(subject.provider_for_action(:install).installer_type).to eq(:nsis)
@@ -142,11 +138,6 @@ describe Chef::Resource::WindowsPackage, :windows_only, :volatile do
       let(:pkg_name) { 'Mercurial 3.6.1 (64-bit)' }
       let(:pkg_path) { 'http://mercurial.selenic.com/release/windows/Mercurial-3.6.1-x64.exe' }
       let(:pkg_checksum) { 'febd29578cb6736163d232708b834a2ddd119aa40abc536b2c313fc5e1b5831d' }
-
-      it "finds the correct package version" do
-        subject.run_action(:install)
-        expect(subject.version).to eq(nil) # Mercurial does not include versioning
-      end
 
       it "finds the correct installer type" do
         subject.run_action(:install)

--- a/spec/unit/provider/package/windows/exe_spec.rb
+++ b/spec/unit/provider/package/windows/exe_spec.rb
@@ -53,12 +53,8 @@ describe Chef::Provider::Package::Windows::Exe do
     entries
   end
   let(:provider) { Chef::Provider::Package::Windows::Exe.new(new_resource, :nsis, uninstall_entry) }
-  let(:file_version) { nil }
-  let(:product_version) { nil }
-  let(:version_info) { instance_double("Chef::ReservedNames::Win32::File::Version_info", FileVersion: file_version, ProductVersion: product_version) }
 
   before(:each) do
-    allow(Chef::ReservedNames::Win32::File).to receive(:version_info).and_return(version_info)
     allow(::File).to receive(:exist?).with(Chef::Util::PathHelper.canonical_path(resource_source, false)).and_return(true)
   end
 
@@ -103,73 +99,13 @@ describe Chef::Provider::Package::Windows::Exe do
       end
     end
 
-    context "file version is empty" do
-      let(:file_version) { '' }
-
-      it "returns nil" do
-        expect(provider.package_version).to eql(nil)
-      end
-
-      it "returns the version of a package if given" do
-        new_resource.version('v55555')
-        expect(provider.package_version).to eql('v55555')
-      end
+    it "returns the version attribute if given" do
+      new_resource.version('v55555')
+      expect(provider.package_version).to eql('v55555')
     end
 
-    context "both file and product version are in installer" do
-      let(:file_version) { '1.1.1' }
-      let(:product_version) { '1.1' }
-
-      it "returns the file version" do
-        expect(provider.package_version).to eql('1.1.1')
-      end
-
-      it "returns the version of a package if given" do
-        new_resource.version('v55555')
-        expect(provider.package_version).to eql('v55555')
-      end
-    end
-
-    context "only file version is in installer" do
-      let(:file_version) { '1.1.1' }
-
-      it "returns the file version" do
-        expect(provider.package_version).to eql('1.1.1')
-      end
-
-      it "returns the version of a package if given" do
-        new_resource.version('v55555')
-        expect(provider.package_version).to eql('v55555')
-      end
-    end
-
-    context "only product version is in installer" do
-      let(:product_version) { '1.1' }
-
-      it "returns the product version" do
-        expect(provider.package_version).to eql('1.1')
-      end
-
-      it "returns the version of a package if given" do
-        new_resource.version('v55555')
-        expect(provider.package_version).to eql('v55555')
-      end
-    end
-
-    context "no version info is in installer" do
-      let(:file_version) { nil }
-      let(:product_version) { nil }
-
-      it "returns the version of a package" do
-        new_resource.version('v55555')
-        expect(provider.package_version).to eql('v55555')
-      end
-    end
-
-    context "no version info is in installer and none in attribute" do
-      it "returns the version of a package" do
-        expect(provider.package_version).to eql(nil)
-      end
+    it "returns nil if no version given" do
+      expect(provider.package_version).to eql(nil)
     end
   end
 


### PR DESCRIPTION
Currently we attempt to detect installer version of exes by examining their version resource information embedded in the installer file. Unfortunately there is no guarantee that this version will line up with the version information in the installer's uninstall registry data. This uncertainty is not new but I had misunderstood idempotency dynamics when no version is explicitly given as an attribute. I thought such packages would always reconverge when no source was given. That's not the case. Therefore it is better to not autodetect because if no source is given and the version we autodetect is different from that in the installation metadata, the resource will not be idempotent. Removing the autodetection and not specifying source will only cause the resource to converge if no package is installed on the machine regardless of version.