### PR TITLE
prepending chef to tempfile name

### DIFF
--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -65,6 +65,7 @@ class Chef
       def tempfile_basename
         basename = ::File.basename(@new_resource.name)
         basename.insert 0, "." unless Chef::Platform.windows?  # dotfile if we're not on windows
+        basename << '-chef-'
         basename
       end
 

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -64,8 +64,8 @@ class Chef
       #
       def tempfile_basename
         basename = ::File.basename(@new_resource.name)
+        basename.insert 0, "chef-"
         basename.insert 0, "." unless Chef::Platform.windows?  # dotfile if we're not on windows
-        basename << '-chef-'
         basename
       end
 


### PR DESCRIPTION
prepending chef to tempfile name because we monitor file modifications in specific directories.