### PR TITLE
Per RFC 64, do style checking of the Chef repo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+    - "spec/data/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 AllCops:
   Exclude:
     - "spec/data/**/*"
+    - "vendor/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
 
 # do not run expensive spec tests on PRs, only on branches
 script: "
+bundle exec rake style;
 echo '--color\n-fp' > .rspec;
 sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers;
 sudo -E $(which bundle) exec rake spec;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ branches:
 
 # do not run expensive spec tests on PRs, only on branches
 script: "
+set -e;
 bundle exec rake style;
 echo '--color\n-fp' > .rspec;
 sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers;

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ group(:development, :test) do
   gem "simplecov"
   gem 'rack', "~> 1.5.1"
 
+  # for testing new chefstyle rules
+  # gem 'chefstyle', github: 'chef/chefstyle'
+  gem 'chefstyle', '= 0.1.0'
 
   gem 'ruby-shadow', :platforms => :ruby unless RUBY_PLATFORM.downcase.match(/(aix|cygwin)/)
 

--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,13 @@ task :register_eventlog do
   end
 end
 
+
+require "chefstyle"
+require "rubocop/rake_task"
+RuboCop::RakeTask.new(:style) do |task|
+  task.options += ["--display-cop-names", "--no-color"]
+end
+
 begin
   require 'yard'
   DOC_FILES = [ "README.rdoc", "LICENSE", "spec/tiny_server.rb", "lib/**/*.rb" ]


### PR DESCRIPTION
This commit enables ChefStyle, but with no active cops. Cops will be
added per the RFC (one at a time, with a supporting PR to this repo) as
we go on.

cc @chef/client-maintainers