### PR TITLE
chefstyle: fix Lint/StringConversionInInterpolation

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -186,12 +186,12 @@ class Chef
 
     # Called prior to starting the application, by the run method
     def setup_application
-      raise Chef::Exceptions::Application, "#{self.to_s}: you must override setup_application"
+      raise Chef::Exceptions::Application, "#{self}: you must override setup_application"
     end
 
     # Actually run the application
     def run_application
-      raise Chef::Exceptions::Application, "#{self.to_s}: you must override run_application"
+      raise Chef::Exceptions::Application, "#{self}: you must override run_application"
     end
 
     # Initializes Chef::Client instance and runs it
@@ -307,7 +307,7 @@ class Chef
     class << self
       def debug_stacktrace(e)
         message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
-        chef_stacktrace_out = "Generated at #{Time.now.to_s}\n"
+        chef_stacktrace_out = "Generated at #{Time.now}\n"
         chef_stacktrace_out += message
 
         Chef::FileCache.store("chef-stacktrace.out", chef_stacktrace_out)

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -106,7 +106,7 @@ class Chef
       if @cookbooks_by_name.has_key?(cookbook.to_sym) or load_cookbook(cookbook.to_sym)
         @cookbooks_by_name[cookbook.to_sym]
       else
-        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook.to_s}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html)"
+        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html)"
       end
     end
 

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -157,7 +157,7 @@ class Chef
           puts "\n"
           puts "resources updated this run:"
           updated_resources.each do |resource|
-            puts "* #{resource.to_s}"
+            puts "* #{resource}"
             updates_by_resource[resource.name].flatten.each do |update|
               puts "  - #{update}"
             end

--- a/lib/chef/guard_interpreter/resource_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/resource_guard_interpreter.rb
@@ -88,7 +88,7 @@ class Chef
         resource_class = Chef::Resource.resource_for_node(parent_resource.guard_interpreter, parent_resource.node)
 
         if resource_class.nil?
-          raise ArgumentError, "Specified guard_interpreter resource #{parent_resource.guard_interpreter.to_s} unknown for this platform"
+          raise ArgumentError, "Specified guard_interpreter resource #{parent_resource.guard_interpreter} unknown for this platform"
         end
 
         if ! resource_class.ancestors.include?(Chef::Resource::Execute)

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -396,7 +396,7 @@ class Chef
       if Chef::Platform.windows?
         tf.binmode # required for binary files on Windows platforms
       end
-      Chef::Log.debug("Streaming download from #{url.to_s} to tempfile #{tf.path}")
+      Chef::Log.debug("Streaming download from #{url} to tempfile #{tf.path}")
       # Stolen from http://www.ruby-forum.com/topic/166423
       # Kudos to _why!
 

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -127,7 +127,7 @@ class Chef
         # http://redmine.ruby-lang.org/issues/show/2758
         if e.to_s =~ /#{Regexp.escape(%q|undefined method `closed?' for nil:NilClass|)}/
           Chef::Log.debug("Rescued error in http connect, re-raising as Errno::ECONNREFUSED to hide bug in net/http")
-          Chef::Log.debug("#{e.class.name}: #{e.to_s}")
+          Chef::Log.debug("#{e.class.name}: #{e}")
           Chef::Log.debug(e.backtrace.join("\n"))
           raise Errno::ECONNREFUSED, "Connection refused attempting to contact #{url.scheme}://#{host}:#{port}"
         else

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -76,7 +76,7 @@ class Chef
           time = Time.now.to_i
           # AND NOT is not valid lucene syntax, so don't use append_to_query
           @query << " " unless @query.empty?
-          @query << "NOT ohai_time:[#{(time - 60*60).to_s} TO #{time.to_s}]"
+          @query << "NOT ohai_time:[#{(time - 60*60)} TO #{time}]"
         end
 
         if config[:hide_by_mins]
@@ -84,7 +84,7 @@ class Chef
           time = Time.now.to_i
           # AND NOT is not valid lucene syntax, so don't use append_to_query
           @query << " " unless @query.empty?
-          @query << "NOT ohai_time:[#{(time - hidemins*60).to_s} TO #{time.to_s}]"
+          @query << "NOT ohai_time:[#{(time - hidemins*60)} TO #{time}]"
         end
 
         @query = @query.empty? ? "*:*" : @query

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -112,7 +112,7 @@ class Chef
           # equivalent to something like:
           # def rights(permissions=nil, principals=nil, args_hash=nil)
           define_method(name) do |permissions=nil, principals=nil, args_hash=nil|
-            rights = self.instance_variable_get("@#{name.to_s}".to_sym)
+            rights = self.instance_variable_get("@#{name}".to_sym)
             unless permissions.nil?
               input = {
                 :permissions => permissions,

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -390,7 +390,7 @@ class Chef
         if attrs.key?("recipes") || attrs.key?("run_list")
           raise Chef::Exceptions::AmbiguousRunlistSpecification, "please set the node's run list using the 'run_list' attribute only."
         end
-        Chef::Log.info("Setting the run_list to #{new_run_list.to_s} from CLI options")
+        Chef::Log.info("Setting the run_list to #{new_run_list} from CLI options")
         run_list(new_run_list)
       end
       attrs

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -53,7 +53,7 @@ class Chef
             begin
               version_constraint = Chef::VersionConstraint::Platform.new(platform_version)
               if version_constraint.include?(version)
-                Chef::Log.debug("Platform #{name.to_s} version #{version} found")
+                Chef::Log.debug("Platform #{name} version #{version} found")
                 provider_map.merge!(provider)
               end
             rescue Chef::Exceptions::InvalidPlatformVersion

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -94,7 +94,7 @@ class Chef
     end
 
     def load_current_resource
-      raise Chef::Exceptions::Override, "You must override load_current_resource in #{self.to_s}"
+      raise Chef::Exceptions::Override, "You must override load_current_resource in #{self}"
     end
 
     def define_resource_requirements
@@ -104,7 +104,7 @@ class Chef
     end
 
     def action_nothing
-      Chef::Log.debug("Doing nothing for #{@new_resource.to_s}")
+      Chef::Log.debug("Doing nothing for #{@new_resource}")
       true
     end
 
@@ -209,7 +209,7 @@ class Chef
           else
             specified_properties.map { |p| "#{p}=#{new_resource.send(p).inspect}" }.join(", ")
           end
-          Chef::Log.debug("Skipping update of #{new_resource.to_s}: has not changed any of the specified properties #{properties_str}.")
+          Chef::Log.debug("Skipping update of #{new_resource}: has not changed any of the specified properties #{properties_str}.")
           return false
         end
 

--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -365,7 +365,7 @@ class Chef
       end
 
       def release_slug
-        raise Chef::Exceptions::Override, "You must override release_slug in #{self.to_s}"
+        raise Chef::Exceptions::Override, "You must override release_slug in #{self}"
       end
 
       def install_gems

--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -144,7 +144,7 @@ class Chef
 
       def invoke_resource(method, output_format=:object)
         properties = translate_type(@new_resource.properties)
-        switches = "-Method #{method.to_s} -Name #{@new_resource.resource}"\
+        switches = "-Method #{method} -Name #{@new_resource.resource}"\
                    " -Property #{properties} -Verbose"
         if module_name != :none
           switches += " -Module #{module_name}"

--- a/lib/chef/provider/dsc_script.rb
+++ b/lib/chef/provider/dsc_script.rb
@@ -99,7 +99,7 @@ class Chef
           configuration_document = generate_configuration_document(config_directory, configuration_flags)
           @operations[operation].call(config_manager, configuration_document, shellout_flags)
         rescue Exception => e
-          Chef::Log.error("DSC operation failed: #{e.message.to_s}")
+          Chef::Log.error("DSC operation failed: #{e.message}")
           raise e
         ensure
           ::FileUtils.rm_rf(config_directory)

--- a/lib/chef/provider/env.rb
+++ b/lib/chef/provider/env.rb
@@ -48,7 +48,7 @@ class Chef
       end
 
       def env_value(key_name)
-        raise Chef::Exceptions::Env, "#{self.to_s} provider does not implement env_value!"
+        raise Chef::Exceptions::Env, "#{self} provider does not implement env_value!"
       end
 
       def env_key_exists(key_name)
@@ -141,11 +141,11 @@ class Chef
       end
 
       def create_env
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :#{@new_resource.action}"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :#{@new_resource.action}"
       end
 
       def delete_env
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :delete"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :delete"
       end
 
       def modify_env

--- a/lib/chef/provider/group/aix.rb
+++ b/lib/chef/provider/group/aix.rb
@@ -72,7 +72,7 @@ class Chef
           { :gid => "id" }.sort { |a,b| a[0] <=> b[0] }.each do |field, option|
             if @current_resource.send(field) != @new_resource.send(field)
               if @new_resource.send(field)
-                Chef::Log.debug("#{@new_resource} setting #{field.to_s} to #{@new_resource.send(field)}")
+                Chef::Log.debug("#{@new_resource} setting #{field} to #{@new_resource.send(field)}")
                 opts << " '#{option}=#{@new_resource.send(field)}'"
               end
             end

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -96,15 +96,15 @@ class Chef
         end
 
         def add_member(member)
-          raise Chef::Exceptions::Group, "you must override add_member in #{self.to_s}"
+          raise Chef::Exceptions::Group, "you must override add_member in #{self}"
         end
 
         def remove_member(member)
-          raise Chef::Exceptions::Group, "you must override remove_member in #{self.to_s}"
+          raise Chef::Exceptions::Group, "you must override remove_member in #{self}"
         end
 
         def set_members(members)
-          raise Chef::Exceptions::Group, "you must override set_members in #{self.to_s}"
+          raise Chef::Exceptions::Group, "you must override set_members in #{self}"
         end
 
         # Little bit of magic as per Adam's useradd provider to pull the assign the command line flags
@@ -117,7 +117,7 @@ class Chef
             if @current_resource.send(field) != @new_resource.send(field)
               if @new_resource.send(field)
                 opts << " #{option} '#{@new_resource.send(field)}'"
-                Chef::Log.debug("#{@new_resource} set #{field.to_s} to #{@new_resource.send(field)}")
+                Chef::Log.debug("#{@new_resource} set #{field} to #{@new_resource.send(field)}")
               end
             end
           end

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -41,13 +41,13 @@ class Chef
 
           requirements.assert(:modify, :manage) do |a|
             a.assertion { @new_resource.members.empty? || @new_resource.append }
-            a.failure_message Chef::Exceptions::Group, "setting group members directly is not supported by #{self.to_s}, must set append true in group"
+            a.failure_message Chef::Exceptions::Group, "setting group members directly is not supported by #{self}, must set append true in group"
             # No whyrun alternative - this action is simply not supported.
           end
 
           requirements.assert(:all_actions) do |a|
             a.assertion { @new_resource.excluded_members.empty? }
-            a.failure_message Chef::Exceptions::Group, "excluded_members is not supported by #{self.to_s}"
+            a.failure_message Chef::Exceptions::Group, "excluded_members is not supported by #{self}"
             # No whyrun alternative - this action is simply not supported.
           end
         end
@@ -62,7 +62,7 @@ class Chef
               add_member(member)
             end
           else
-            raise Chef::Exceptions::UnsupportedAction, "Setting members directly is not supported by #{self.to_s}"
+            raise Chef::Exceptions::UnsupportedAction, "Setting members directly is not supported by #{self}"
           end
         end
 
@@ -73,7 +73,7 @@ class Chef
         def remove_member(member)
           # This provider only supports adding members with
           # append. This function should never be called.
-          raise Chef::Exceptions::UnsupportedAction, "Removing members members is not supported by #{self.to_s}"
+          raise Chef::Exceptions::UnsupportedAction, "Removing members members is not supported by #{self}"
         end
 
         def append_flags

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -80,7 +80,7 @@ class Chef
               true
             end
           end
-          a.failure_message Chef::Exceptions::Link, "Cannot delete #{@new_resource} at #{@new_resource.target_file}! Not a #{@new_resource.link_type.to_s} link."
+          a.failure_message Chef::Exceptions::Link, "Cannot delete #{@new_resource} at #{@new_resource.target_file}! Not a #{@new_resource.link_type} link."
           a.whyrun("Would assume the link at #{@new_resource.target_file} was previously created")
         end
       end

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -118,12 +118,12 @@ class Chef
 
       # should actually check if the filesystem is mounted (not just return current_resource) and return true/false
       def mounted?
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not implement #mounted?"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not implement #mounted?"
       end
 
       # should check new_resource against current_resource to see if mount options need updating, returns true/false
       def mount_options_unchanged?
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not implement #mount_options_unchanged?"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not implement #mount_options_unchanged?"
       end
 
       #
@@ -134,28 +134,28 @@ class Chef
 
       # should implement mounting of the filesystem, raises if action does not succeed
       def mount_fs
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :mount"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :mount"
       end
 
       # should implement unmounting of the filesystem, raises if action does not succeed
       def umount_fs
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :umount"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :umount"
       end
 
       # should implement remounting of the filesystem (via a -o remount or some other atomic-ish action that isn't
       # simply a umount/mount style remount), raises if action does not succeed
       def remount_fs
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :remount"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :remount"
       end
 
       # should implement enabling of the filesystem (e.g. in /etc/fstab), raises if action does not succeed
       def enable_fs
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :enable"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :enable"
       end
 
       # should implement disabling of the filesystem (e.g. in /etc/fstab), raises if action does not succeed
       def disable_fs
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :disable"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :disable"
       end
 
       private

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -121,7 +121,7 @@ class Chef
         # file must exist in cookbook
         if new_profile.end_with?('.mobileconfig')
           unless cookbook_file_available?(new_profile)
-            error_string = "#{self.to_s}: '#{new_profile}' not found in cookbook"
+            error_string = "#{self}: '#{new_profile}' not found in cookbook"
             raise Chef::Exceptions::FileNotFound, error_string
           end
           cookbook_profile = cache_cookbook_profile(new_profile)

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -228,27 +228,27 @@ class Chef
       end
 
       def install_package(name, version)
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :install"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :install"
       end
 
       def upgrade_package(name, version)
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :upgrade"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :upgrade"
       end
 
       def remove_package(name, version)
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :remove"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :remove"
       end
 
       def purge_package(name, version)
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :purge"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :purge"
       end
 
       def preseed_package(file)
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support pre-seeding package install/upgrade instructions"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support pre-seeding package install/upgrade instructions"
       end
 
       def reconfig_package(name, version)
-        raise( Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reconfig" )
+        raise( Chef::Exceptions::UnsupportedAction, "#{self} does not support :reconfig" )
       end
 
       # used by subclasses.  deprecated.  use #a_to_s instead.

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -137,7 +137,7 @@ class Chef
               spec.version
             else
               # This is probably going to end badly...
-              logger.warn { "#{@new_resource} gem package #{source} does not satisfy the requirements #{gem_dependency.to_s}" }
+              logger.warn { "#{@new_resource} gem package #{source} does not satisfy the requirements #{gem_dependency}" }
               nil
             end
           end
@@ -445,7 +445,7 @@ class Chef
             logger.debug { "#{@new_resource} newest installed version of gem #{gemspec.name} is #{gemspec.version}" }
             gemspec
           else
-            logger.debug { "#{@new_resource} no installed version found for #{gem_dependency.to_s}"}
+            logger.debug { "#{@new_resource} no installed version found for #{gem_dependency}"}
             nil
           end
         end

--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -55,7 +55,7 @@ class Chef
             end
             raw_file = grab_file_from_uri(uri)
           rescue SocketError, Errno::ECONNREFUSED, Errno::ENOENT, Errno::EACCES, Timeout::Error, Net::HTTPServerException, Net::HTTPFatalError, Net::FTPError => e
-            Chef::Log.warn("#{@new_resource} cannot be downloaded from #{source}: #{e.to_s}")
+            Chef::Log.warn("#{@new_resource} cannot be downloaded from #{source}: #{e}")
             if source = sources.shift
               Chef::Log.info("#{@new_resource} trying to download from another mirror")
               retry

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -64,7 +64,7 @@ class Chef
       def define_resource_requirements
        requirements.assert(:reload) do |a|
          a.assertion { supports[:reload] || @new_resource.reload_command }
-         a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
+         a.failure_message Chef::Exceptions::UnsupportedAction, "#{self} does not support :reload"
          # if a service is not declared to support reload, that won't
          # typically change during the course of a run - so no whyrun
          # alternative here.
@@ -143,27 +143,27 @@ class Chef
       end
 
       def enable_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :enable"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :enable"
       end
 
       def disable_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :disable"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :disable"
       end
 
       def start_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :start"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :start"
       end
 
       def stop_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :stop"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :stop"
       end
 
       def restart_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :restart"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :restart"
       end
 
       def reload_service
-        raise Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
+        raise Chef::Exceptions::UnsupportedAction, "#{self} does not support :reload"
       end
 
       protected

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -74,7 +74,7 @@ class Chef
 
         def define_resource_requirements
           requirements.assert(:reload) do |a|
-            a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} does not support :reload"
+            a.failure_message Chef::Exceptions::UnsupportedAction, "#{self} does not support :reload"
           end
 
           requirements.assert(:all_actions) do |a|

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -58,21 +58,21 @@ class Chef
           shared_resource_requirements
           requirements.assert(:start) do |a|
             a.assertion { @new_resource.start_command }
-            a.failure_message Chef::Exceptions::Service, "#{self.to_s} requires that start_command be set"
+            a.failure_message Chef::Exceptions::Service, "#{self} requires that start_command be set"
           end
           requirements.assert(:stop) do |a|
             a.assertion { @new_resource.stop_command }
-            a.failure_message Chef::Exceptions::Service, "#{self.to_s} requires that stop_command be set"
+            a.failure_message Chef::Exceptions::Service, "#{self} requires that stop_command be set"
           end
 
           requirements.assert(:restart) do |a|
             a.assertion { @new_resource.restart_command  || ( @new_resource.start_command && @new_resource.stop_command ) }
-            a.failure_message Chef::Exceptions::Service, "#{self.to_s} requires a restart_command or both start_command and stop_command be set in order to perform a restart"
+            a.failure_message Chef::Exceptions::Service, "#{self} requires a restart_command or both start_command and stop_command be set in order to perform a restart"
           end
 
           requirements.assert(:reload) do |a|
             a.assertion { @new_resource.reload_command }
-            a.failure_message Chef::Exceptions::UnsupportedAction, "#{self.to_s} requires a reload_command be set in order to perform a reload"
+            a.failure_message Chef::Exceptions::UnsupportedAction, "#{self} requires a reload_command be set in order to perform a reload"
           end
 
           requirements.assert(:all_actions) do |a|

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -658,7 +658,7 @@ class Chef
 
     def inspect
       ivars = instance_variables.map { |ivar| ivar.to_sym } - FORBIDDEN_IVARS
-      ivars.inject("<#{to_s}") do |str, ivar|
+      ivars.inject("<#{self}") do |str, ivar|
         str << " #{ivar}: #{instance_variable_get(ivar).inspect}"
       end << ">"
     end
@@ -1332,7 +1332,7 @@ class Chef
       if enclosing_provider && enclosing_provider.respond_to?(method_symbol)
         enclosing_provider.send(method_symbol, *args, &block)
       else
-        raise NoMethodError, "undefined method `#{method_symbol.to_s}' for #{self.class.to_s}"
+        raise NoMethodError, "undefined method `#{method_symbol}' for #{self.class}"
       end
     end
 

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -123,7 +123,7 @@ class Chef
         end
         begin
           error_message = "You provided '#{arg}' as a weekday, acceptable values are "
-          error_message << Provider::Cron::WEEKDAY_SYMBOLS.map {|sym| ":#{sym.to_s}"}.join(', ')
+          error_message << Provider::Cron::WEEKDAY_SYMBOLS.map {|sym| ":#{sym}"}.join(', ')
           error_message << " and a string in crontab format"
           if (arg.is_a?(Symbol) && !Provider::Cron::WEEKDAY_SYMBOLS.include?(arg)) ||
             (!arg.is_a?(Symbol) && integerize(arg) > 7) ||

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -70,7 +70,7 @@ class Chef
 
       def property(property_name, value=nil)
         if not property_name.is_a?(Symbol)
-          raise TypeError, "A property name of type Symbol must be specified, '#{property_name.to_s}' of type #{property_name.class.to_s} was given"
+          raise TypeError, "A property name of type Symbol must be specified, '#{property_name}' of type #{property_name.class} was given"
         end
 
         if value.nil?

--- a/lib/chef/resource/windows_script.rb
+++ b/lib/chef/resource/windows_script.rb
@@ -57,7 +57,7 @@ class Chef
             "cannot execute script with requested architecture 'i386' on Windows Nano Server"
         elsif ! node_supports_windows_architecture?(node, desired_architecture)
           raise Chef::Exceptions::Win32ArchitectureIncorrect,
-            "cannot execute script with requested architecture '#{desired_architecture.to_s}' on a system with architecture '#{node_windows_architecture(node)}'"
+            "cannot execute script with requested architecture '#{desired_architecture}' on a system with architecture '#{node_windows_architecture(node)}'"
         end
       end
     end

--- a/lib/chef/resource_definition.rb
+++ b/lib/chef/resource_definition.rb
@@ -62,7 +62,7 @@ class Chef
     end
 
     def to_s
-      "#{name.to_s}"
+      "#{name}"
     end
   end
 end

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -331,7 +331,7 @@ E
         edited_data = Tempfile.open([filename, ".js"]) do |tempfile|
           tempfile.sync = true
           tempfile.puts Chef::JSONCompat.to_json(object)
-          system("#{Shell.editor.to_s} #{tempfile.path}")
+          system("#{Shell.editor} #{tempfile.path}")
           tempfile.rewind
           tempfile.read
         end

--- a/lib/chef/util/dsc/configuration_generator.rb
+++ b/lib/chef/util/dsc/configuration_generator.rb
@@ -72,7 +72,7 @@ class Chef::Util::DSC
       if configuration_flags
         configuration_flags.map do | switch, value |
           if merged_configuration_flags.key?(switch.to_s.downcase.to_sym)
-            raise ArgumentError, "The `flags` attribute for the dsc_script resource contained a command line switch :#{switch.to_s} that is disallowed."
+            raise ArgumentError, "The `flags` attribute for the dsc_script resource contained a command line switch :#{switch} that is disallowed."
           end
           merged_configuration_flags[switch.to_s.downcase.to_sym] = value
         end

--- a/lib/chef/util/powershell/cmdlet.rb
+++ b/lib/chef/util/powershell/cmdlet.rb
@@ -38,7 +38,7 @@ class Powershell
       when :object
         @json_format = true
       else
-        raise ArgumentError, "Invalid output format #{output_format.to_s} specified"
+        raise ArgumentError, "Invalid output format #{output_format} specified"
       end
 
       @cmdlet = cmdlet
@@ -114,7 +114,7 @@ class Powershell
     def command_switches_string(switches)
       command_switches = switches.map do | switch_name, switch_value |
         if switch_name.class != Symbol
-          raise ArgumentError, "Invalid type `#{switch_name} `for PowerShell switch '#{switch_name.to_s}'. The switch must be specified as a Symbol'"
+          raise ArgumentError, "Invalid type `#{switch_name} `for PowerShell switch '#{switch_name}'. The switch must be specified as a Symbol'"
         end
 
         validate_switch_name!(switch_name)
@@ -133,7 +133,7 @@ class Powershell
         when String
           switch_argument = escape_string_parameter_value(switch_value)
         else
-          raise ArgumentError, "Invalid argument type `#{switch_value.class}` specified for PowerShell switch `:#{switch_name.to_s}`. Arguments to PowerShell must be of type `String`, `Numeric`, `Float`, `FalseClass`, or `TrueClass`"
+          raise ArgumentError, "Invalid argument type `#{switch_value.class}` specified for PowerShell switch `:#{switch_name}`. Arguments to PowerShell must be of type `String`, `Numeric`, `Float`, `FalseClass`, or `TrueClass`"
         end
 
         switch_present ? ["-#{switch_name.to_s.downcase}", switch_argument].join(' ').strip : ''

--- a/lib/chef/version/platform.rb
+++ b/lib/chef/version/platform.rb
@@ -34,7 +34,7 @@ class Chef
           when /^(\d+).(\d+)-[a-z]+\d?(-p(\d+))?$/i   # Match FreeBSD
             [ $1.to_i, $2.to_i, ($4 ? $4.to_i : 0)]
           else
-            msg = "'#{str.to_s}' does not match 'x.y.z', 'x.y' or 'x'"
+            msg = "'#{str}' does not match 'x.y.z', 'x.y' or 'x'"
             raise Chef::Exceptions::InvalidPlatformVersion.new( msg )
           end
       end

--- a/lib/chef/version_class.rb
+++ b/lib/chef/version_class.rb
@@ -61,7 +61,7 @@ class Chef
         when /^(\d+)\.(\d+)$/
           [ $1.to_i, $2.to_i, 0 ]
         else
-          msg = "'#{str.to_s}' does not match 'x.y.z' or 'x.y'"
+          msg = "'#{str}' does not match 'x.y.z' or 'x.y'"
           raise Chef::Exceptions::InvalidCookbookVersion.new( msg )
         end
     end

--- a/lib/chef/version_constraint.rb
+++ b/lib/chef/version_constraint.rb
@@ -50,7 +50,7 @@ class Chef
     end
 
     def inspect
-      "(#{to_s})"
+      "(#{self})"
     end
 
     def to_s

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -81,7 +81,7 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       # PowerShell 4.0 and later versions return a 32-bit signed value.
       file = Tempfile.new(['foo', '.ps1'])
       begin
-        file.write "exit #{negative_exit_status.to_s}"
+        file.write "exit #{negative_exit_status}"
         file.close
         resource.code(". \"#{file.path}\"")
 

--- a/spec/support/shared/unit/file_system_support.rb
+++ b/spec/support/shared/unit/file_system_support.rb
@@ -56,7 +56,7 @@ module FileSystemSupport
   def no_blocking_calls_allowed
     [ Chef::ChefFS::FileSystem::MemoryFile, Chef::ChefFS::FileSystem::MemoryDir ].each do |c|
       [ :children, :exists?, :read ].each do |m|
-        allow_any_instance_of(c).to receive(m).and_raise("#{m.to_s} should not be called")
+        allow_any_instance_of(c).to receive(m).and_raise("#{m} should not be called")
       end
     end
   end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -891,31 +891,31 @@ describe Chef::Cookbook::Metadata do
        :suggestions,
        :conflicting,
        :replacing].each do |to_check|
-        it "should transform deprecated greater than syntax for :#{to_check.to_s}" do
+        it "should transform deprecated greater than syntax for :#{to_check}" do
           @hash[to_check.to_s]["foo::bar"] = ">> 0.2"
           deserial = Chef::Cookbook::Metadata.from_hash(@hash)
           expect(deserial.send(to_check)["foo::bar"]).to eq('> 0.2')
         end
 
-        it "should transform deprecated less than syntax for :#{to_check.to_s}" do
+        it "should transform deprecated less than syntax for :#{to_check}" do
           @hash[to_check.to_s]["foo::bar"] = "<< 0.2"
           deserial = Chef::Cookbook::Metadata.from_hash(@hash)
           expect(deserial.send(to_check)["foo::bar"]).to eq('< 0.2')
         end
 
-        it "should ignore multiple dependency constraints for :#{to_check.to_s}" do
+        it "should ignore multiple dependency constraints for :#{to_check}" do
           @hash[to_check.to_s]["foo::bar"] = [ ">= 1.0", "<= 5.2" ]
           deserial = Chef::Cookbook::Metadata.from_hash(@hash)
           expect(deserial.send(to_check)["foo::bar"]).to eq([])
         end
 
-        it "should accept an empty array of dependency constraints for :#{to_check.to_s}" do
+        it "should accept an empty array of dependency constraints for :#{to_check}" do
           @hash[to_check.to_s]["foo::bar"] = []
           deserial = Chef::Cookbook::Metadata.from_hash(@hash)
           expect(deserial.send(to_check)["foo::bar"]).to eq([])
         end
 
-        it "should accept single-element arrays of dependency constraints for :#{to_check.to_s}" do
+        it "should accept single-element arrays of dependency constraints for :#{to_check}" do
           @hash[to_check.to_s]["foo::bar"] = [ ">= 2.0" ]
           deserial = Chef::Cookbook::Metadata.from_hash(@hash)
           expect(deserial.send(to_check)["foo::bar"]).to eq(">= 2.0")

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -42,7 +42,7 @@ describe Chef::Provider::Group::Groupadd, "set_options" do
   }
 
   field_list.each do |attribute, option|
-    it "should check for differences in #{attribute.to_s} between the current and new resources" do
+    it "should check for differences in #{attribute} between the current and new resources" do
         expect(@new_resource).to receive(attribute)
         expect(@current_resource).to receive(attribute)
         @provider.set_options
@@ -145,7 +145,7 @@ describe Chef::Provider::Group::Groupadd do
 
   [:add_member, :remove_member, :set_members].each do |m|
     it "should raise an error when calling #{m}" do
-      expect { @provider.send(m, [ ]) }.to raise_error(Chef::Exceptions::Group, "you must override #{m} in #{@provider.to_s}")
+      expect { @provider.send(m, [ ]) }.to raise_error(Chef::Exceptions::Group, "you must override #{m} in #{@provider}")
     end
   end
 

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Provider::Group::Usermod do
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
         @provider.action = :modify
-        expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "setting group members directly is not supported by #{@provider.to_s}, must set append true in group")
+        expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "setting group members directly is not supported by #{@provider}, must set append true in group")
       end
 
       it "should raise an error when excluded_members are set" do
@@ -75,7 +75,7 @@ describe Chef::Provider::Group::Usermod do
         @provider.action = :modify
         allow(@new_resource).to receive(:append).and_return(true)
         allow(@new_resource).to receive(:excluded_members).and_return(["someone"])
-        expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "excluded_members is not supported by #{@provider.to_s}")
+        expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "excluded_members is not supported by #{@provider}")
       end
 
       platforms.each do |platform, flags|

--- a/spec/unit/resource/deploy_spec.rb
+++ b/spec/unit/resource/deploy_spec.rb
@@ -31,7 +31,7 @@ describe Chef::Resource::Deploy do
 
   class << self
     def resource_has_a_string_attribute(attr_name)
-      it "has a String attribute for #{attr_name.to_s}" do
+      it "has a String attribute for #{attr_name}" do
         @resource.send(attr_name, "this is a string")
         expect(@resource.send(attr_name)).to eql("this is a string")
         expect {@resource.send(attr_name, 8675309)}.to raise_error(ArgumentError)
@@ -39,7 +39,7 @@ describe Chef::Resource::Deploy do
     end
 
     def resource_has_a_boolean_attribute(attr_name, opts={:defaults_to=>false})
-      it "has a Boolean attribute for #{attr_name.to_s}" do
+      it "has a Boolean attribute for #{attr_name}" do
         expect(@resource.send(attr_name)).to eql(opts[:defaults_to])
         @resource.send(attr_name, !opts[:defaults_to])
         expect(@resource.send(attr_name)).to eql( !opts[:defaults_to] )

--- a/spec/unit/resource/env_spec.rb
+++ b/spec/unit/resource/env_spec.rb
@@ -39,7 +39,7 @@ describe Chef::Resource::Env do
   end
 
   { :create => false, :delete => false, :modify => false, :flibber => true }.each do |action,bad_value|
-    it "should #{bad_value ? 'not' : ''} accept #{action.to_s}" do
+    it "should #{bad_value ? 'not' : ''} accept #{action}" do
       if bad_value
         expect { @resource.action action }.to raise_error(ArgumentError)
       else

--- a/spec/unit/resource/link_spec.rb
+++ b/spec/unit/resource/link_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Resource::Link do
   end
 
   { :create => false, :delete => false, :blues => true }.each do |action,bad_value|
-    it "should #{bad_value ? 'not' : ''} accept #{action.to_s}" do
+    it "should #{bad_value ? 'not' : ''} accept #{action}" do
       if bad_value
         expect { @resource.action action }.to raise_error(ArgumentError)
       else


### PR DESCRIPTION
useless use of `"#{foo.to_s}"`