### PR TITLE
Run acceptance tests in Jenkins

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -1,0 +1,1 @@
+/Gemfile.lock

--- a/acceptance/cookbook-git/.kitchen.ec2.yml
+++ b/acceptance/cookbook-git/.kitchen.ec2.yml
@@ -301,4 +301,4 @@ provisioner:
   name: chef_zero
   product_name: chef
   product_version: latest
-  channel: current
+  channel: unstable

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |s|
   s.executables  = %w{ chef-client chef-solo knife chef-shell chef-apply }
 
   s.require_paths = %w{ lib lib-backcompat }
-  s.files = %w{Gemfile Rakefile LICENSE README.md CONTRIBUTING.md} + Dir.glob("{distro,lib,lib-backcompat,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) } + Dir.glob("*.gemspec")
+  s.files = %w{Gemfile Rakefile LICENSE README.md CONTRIBUTING.md} + Dir.glob("{distro,lib,lib-backcompat,tasks,acceptance,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) } + Dir.glob("*.gemspec")
 end


### PR DESCRIPTION
An acceptance test that works against EC2 on ubuntu and windows and checks that there is a single version of chef and ohai gems in Chef Client packages.

@tyler-ball this is the first task for making these run in EC2. @chefsalim and @patrick-wright has an incoming change which we will need to rebase on top of soon. Wanted to share this for initial review.