### PR TITLE
more rubocop fixes

### DIFF
--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@opscode.com>)
 # Author:: Nuo Yan (<nuo@opscode.com>)
 # Author:: Christopher Brown (<cb@opscode.com>)
-# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# Copyright:: Copyright (c) 2009-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +163,7 @@ class Chef
       end
     end
 
-    def destroy(data_bag=data_bag(), databag_item=name)
+    def destroy(data_bag=self.data_bag(), databag_item=name)
       chef_server_rest.delete("data/#{data_bag}/#{databag_item}")
     end
 

--- a/lib/chef/mixin/why_run.rb
+++ b/lib/chef/mixin/why_run.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Dan DeLeo ( <dan@opscode.com> )
 # Author:: Marc Paradise ( <marc@opscode.com> )
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -322,7 +322,7 @@ class Chef
             a.run(action, events, @resource)
             if a.assertion_failed? and a.block_action?
               @blocked_actions << action
-              return
+              break
             end
           end
         end

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -160,7 +160,7 @@ class Chef
           end
         end
 
-       def load_service
+        def load_service
           session = @session_type ? "-S #{@session_type} " : ''
           cmd = 'launchctl load -w ' + session + @plist
           shell_out_as_user(cmd)

--- a/spec/data/invalid-metadata-chef-repo/invalid-metadata/metadata.rb
+++ b/spec/data/invalid-metadata-chef-repo/invalid-metadata/metadata.rb
@@ -1,5 +1,3 @@
-raise "THIS METADATA HAS A BUG"
-
 name             'invalid-metadata'
 maintainer       ''
 maintainer_email ''
@@ -8,3 +6,4 @@ description      'Installs/Configures invalid-metadata'
 long_description 'Installs/Configures invalid-metadata'
 version          '0.1.0'
 
+raise "THIS METADATA HAS A BUG"

--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@opscode.com>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -321,7 +321,7 @@ describe Chef::RunLock do
     attr_reader :pid
 
     def last_event
-      while true
+      loop do
         line = readline_nonblock(read_from_process)
         break if line.nil?
         event, time = line.split("@")

--- a/spec/unit/chef_fs/parallelizer.rb
+++ b/spec/unit/chef_fs/parallelizer.rb
@@ -205,14 +205,11 @@ describe Chef::ChefFS::Parallelizer do
         started = false
         @occupying_job_finished = occupying_job_finished = [ false ]
         @thread = Thread.new do
-          begin
-            parallelizer.parallelize([0], :main_thread_processing => false) do |x|
-              started = true
-              sleep(0.3)
-              occupying_job_finished[0] = true
-            end.wait
-          ensure
-          end
+          parallelizer.parallelize([0], :main_thread_processing => false) do |x|
+            started = true
+            sleep(0.3)
+            occupying_job_finished[0] = true
+          end.wait
         end
         while !started
           sleep(0.01)


### PR DESCRIPTION
fixes:

Lint/UnreachableCode
Lint/NonLocalExitFromIterator
Lint/LiteralInCondition
Lint/EmptyEnsure
Lint/DefEndAlignment
Lint/CircularArgumentReference