### PR TITLE
fix Lint/DuplicatedKey

### DIFF
--- a/spec/unit/provider/service/aixinit_service_spec.rb
+++ b/spec/unit/provider/service/aixinit_service_spec.rb
@@ -208,7 +208,9 @@ describe Chef::Provider::Service::AixInit do
     context "when rc2.d contains both start and stop scripts" do
       before do
         @files = ["/etc/rc.d/rc2.d/S20apache", "/etc/rc.d/rc2.d/K80apache"]
-        @priority = {2 => [:start, 20], 2 => [:stop, 80]}
+        # FIXME: this is clearly buggy the duplicated keys do not work
+        #@priority = {2 => [:start, 20], 2 => [:stop, 80]}
+        @priority = {2 => [:stop, 80]}
 
         allow(Dir).to receive(:glob).with(["/etc/rc.d/rc2.d/[SK][0-9][0-9]#{@new_resource.service_name}", "/etc/rc.d/rc2.d/[SK]chef"]).and_return(@files)
       end
@@ -253,7 +255,9 @@ describe Chef::Provider::Service::AixInit do
     context "when rc2.d contains both start and stop scripts" do
       before do
         files = ["/etc/rc.d/rc2.d/Sapache", "/etc/rc.d/rc2.d/Kapache"]
-        @priority = {2 => [:start, ''], 2 => [:stop, '']}
+        # FIXME: this is clearly buggy the duplicated keys do not work
+        #@priority = {2 => [:start, ''], 2 => [:stop, '']}
+        @priority = {2 => [:stop, '']}
 
         allow(Dir).to receive(:glob).with(["/etc/rc.d/rc2.d/[SK][0-9][0-9]#{@new_resource.service_name}", "/etc/rc.d/rc2.d/[SK]#{@new_resource.service_name}"]).and_return(files)
       end
@@ -266,4 +270,3 @@ describe Chef::Provider::Service::AixInit do
     end
   end
 end
-


### PR DESCRIPTION
so, this is a bit special...

the API for "priority" is clearly broken.  but this broken API comes
from the service resource itself which appears to have been broken
by design since at least 2010.

just fixing the code for how it behaves and dropping in FIXMEs
for now, since this uncovered a fairly massive API-breaking yak.