### PR TITLE
Fix english grammar

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -103,7 +103,7 @@ class Chef
 
             hours, minutes, _ = time_difference_in_hms(node["ohai_time"])
             hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
-            minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"
+            minutes_text = "#{minutes} minute#{minutes <= 1 ? ' ' : 's'}"
             run_list = "#{node['run_list']}" if config[:run_list]
             if hours > 24
               color = :red


### PR DESCRIPTION
Cosmetic change for correct english when a run chef happened less than a minute ago:

```
$ knife status
[...]
0 minutes ago, flow01-uk.blah.eu, centos 6.7.
```