### PR TITLE
make chefstyle optional in the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ begin
   RuboCop::RakeTask.new(:style) do |task|
     task.options += ["--display-cop-names", "--no-color"]
   end
-rescue
+rescue LoadError
   puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -46,10 +46,14 @@ task :register_eventlog do
 end
 
 
-require "chefstyle"
-require "rubocop/rake_task"
-RuboCop::RakeTask.new(:style) do |task|
-  task.options += ["--display-cop-names", "--no-color"]
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options += ["--display-cop-names", "--no-color"]
+  end
+rescue
+  puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
 end
 
 begin


### PR DESCRIPTION
if you 'bundle install --without development test' then the Rakefile
will be broken without this.

breaks appbundle-updater, so not sure how our kitchen tests are
passing...