### PR TITLE
configure chef client windows service to the correct chef directory

### DIFF
--- a/omnibus/resources/chef/msi/source.wxs.erb
+++ b/omnibus/resources/chef/msi/source.wxs.erb
@@ -96,7 +96,7 @@
                   <File Id="RubyExecutable" Source="$(var.ProjectSourceDir)\embedded\bin\ruby.exe" KeyPath="yes" />
                   <ServiceInstall Name="chef-client" Type="ownProcess"
                                   Start="auto" Vital="yes" ErrorControl="ignore"
-                                  Arguments="$(var.ProjectSourceDir)\bin\chef-windows-service"
+                                  Arguments="[PROJECTLOCATION]\bin\chef-windows-service"
                                   DisplayName="!(loc.ServiceDisplayName)"
                                   Description="!(loc.ServiceDescription)">
                       <ServiceDependency Id="Winmgmt" />


### PR DESCRIPTION
If a user installs chef to a directory other than c:\opscode\chef via MSI and installs the chef-client service as well., the service will not run because it points to the default location.

I have validated this fix by building a chef client with the changed wix.