### PR TITLE
explicitly adding .bat to service install command in installer

### DIFF
--- a/omnibus/resources/chef/msi/source.wxs.erb
+++ b/omnibus/resources/chef/msi/source.wxs.erb
@@ -96,7 +96,7 @@
                   <File Id="RubyExecutable" Source="$(var.ProjectSourceDir)\embedded\bin\ruby.exe" KeyPath="yes" />
                   <ServiceInstall Name="chef-client" Type="ownProcess"
                                   Start="auto" Vital="yes" ErrorControl="ignore"
-                                  Arguments="[PROJECTLOCATION]\bin\chef-windows-service"
+                                  Arguments="[PROJECTLOCATION]\bin\chef-windows-service.bat"
                                   DisplayName="!(loc.ServiceDisplayName)"
                                   Description="!(loc.ServiceDescription)">
                       <ServiceDependency Id="Winmgmt" />


### PR DESCRIPTION
for those who dont have `.bat` in `PATHEXT`