### PR TITLE
Fix for #3888: Define method_name in Chef::Cookbook::Metadata.validate_json if undefined

### DIFF
--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -641,8 +641,8 @@ class Chef
         VERSION_CONSTRAINTS.each do |dependency_type, hash_key|
           if dependency_group = o[hash_key]
             dependency_group.each do |cb_name, constraints|
-              if metadata.respond_to?(method_name)
-                metadata.public_send(method_name, cb_name, *Array(constraints))
+              if metadata.respond_to?(dependency_type)
+                metadata.public_send(dependency_type, cb_name, *Array(constraints))
               end
             end
           end


### PR DESCRIPTION
It looks like method_name could never be properly scoped here? 

It's inclusion makes any cookbook with a dependency and no metadata.rb in a cookbook fail sharing to both public and private supermarkets.

Line 626 throws an exception if method_name is undefined.

For now I've assigned an empty string if its undefined. Open for input @chef/client-core 

closes #3888 
