### PR TITLE
Require Chef::VersionConstraint::Platform b/c it's used here

### DIFF
--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -25,6 +25,7 @@ require "chef/mixin/params_validate"
 require "chef/log"
 require "chef/version_class"
 require "chef/version_constraint"
+require "chef/version_constraint/platform"
 require "chef/json_compat"
 
 class Chef


### PR DESCRIPTION
The metadata class is now referencing this constant, but the code isn't loaded if you're selectively requiring it (this occurs in the code that loads cookbooks for policyfiles), so ChefDK bails with:

```
(NameError) uninitialized constant Chef::VersionConstraint::Platform


/Users/ddeleo/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/chef-c53d73f77c8c/lib/chef/cookbook/metadata.rb:749:in `validate_version_constraint'
/Users/ddeleo/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/chef-c53d73f77c8c/lib/chef/cookbook/metadata.rb:379:in `provides'
/Users/ddeleo/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/chef-c53d73f77c8c/lib/chef/cookbook/metadata.rb:454:in `block in recipes_from_cookbook_version'
```

@chef/client-core 