### PR TITLE
Enable policies in local mode by default

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -106,9 +106,6 @@ module ChefConfig
     # that upload or download files (such as knife upload, knife role from file,
     # etc.) work.
     default :chef_repo_path do
-      # TODO: this should also look at the cookbook_artifacts path, for the
-      # case when we have a repo from `chef export` that has cookbook artifacts
-      # and no cookbooks.
       if self.configuration[:cookbook_path]
         if self.configuration[:cookbook_path].kind_of?(String)
           File.expand_path("..", self.configuration[:cookbook_path])
@@ -117,6 +114,8 @@ module ChefConfig
             File.expand_path("..", path)
           end
         end
+      elsif configuration[:cookbook_artifact_path]
+          File.expand_path("..", self.configuration[:cookbook_artifact_path])
       else
         cache_path
       end
@@ -126,7 +125,7 @@ module ChefConfig
       # In local mode, we auto-discover the repo root by looking for a path with "cookbooks" under it.
       # This allows us to run config-free.
       path = cwd
-      until File.directory?(PathHelper.join(path, "cookbooks"))
+      until File.directory?(PathHelper.join(path, "cookbooks")) || File.directory?(PathHelper.join(path, "cookbook_artifacts"))
         new_path = File.expand_path("..", path)
         if new_path == path
           ChefConfig.logger.warn("No cookbooks directory found at or above current directory.  Assuming #{Dir.pwd}.")

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -321,10 +321,8 @@ module ChefConfig
     #   Chef 11 server.
     # * "hosted_everything": ChefFS manages all object types as of the Chef 12
     #   Server, including RBAC objects and Policyfile objects (new to Chef 12).
-    #
-    # TODO: add a test
     default :repo_mode do
-      if local_mode
+      if local_mode && !chef_zero.osc_compat
         "hosted_everything"
       elsif chef_server_url =~ /\/+organizations\/.+/
         "hosted_everything"

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -331,6 +331,51 @@ RSpec.describe ChefConfig::Config do
           end
         end
 
+        describe "ChefConfig::Config[:chef_repo_path]" do
+
+          context "when cookbook_path is set to a single path" do
+
+            before { ChefConfig::Config[:cookbook_path] = "/home/anne/repo/cookbooks" }
+
+            it "is set to a path one directory up from the cookbook_path" do
+              expect(ChefConfig::Config[:chef_repo_path]).to eq("/home/anne/repo")
+            end
+
+          end
+
+          context "when cookbook_path is set to multiple paths" do
+
+            before do
+              ChefConfig::Config[:cookbook_path] = [
+                "/home/anne/repo/cookbooks",
+                "/home/anne/other_repo/cookbooks"
+              ]
+            end
+
+            it "is set to an Array of paths one directory up from the cookbook_paths" do
+              expect(ChefConfig::Config[:chef_repo_path]).to eq([ "/home/anne/repo", "/home/anne/other_repo"])
+            end
+
+          end
+
+          context "when cookbook_path is not set but cookbook_artifact_path is set" do
+
+            it "is set to a path one directory up from the cookbook_artifact_path", :skip
+
+          end
+
+          context "when cookbook_path is not set" do
+
+            before { ChefConfig::Config[:cookbook_path] = nil }
+
+            it "is set to the cache_path" do
+              expect(ChefConfig::Config[:chef_repo_path]).to eq(ChefConfig::Config[:cache_path])
+            end
+
+          end
+
+        end
+
         # On Windows, we'll detect an omnibus build and set this to the
         # cacert.pem included in the package, but it's nil if you're on Windows
         # w/o omnibus (e.g., doing development on Windows, custom build, etc.)

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -288,6 +288,49 @@ RSpec.describe ChefConfig::Config do
           expect(ChefConfig::Config[:ssl_ca_path]).to be_nil
         end
 
+        describe "ChefConfig::Config[:repo_mode]" do
+
+          context "when local mode is enabled" do
+
+            before { ChefConfig::Config[:local_mode] = true }
+
+            it "defaults to 'hosted_everything'" do
+              expect(ChefConfig::Config[:repo_mode]).to eq("hosted_everything")
+            end
+
+            context "and osc_compat is enabled" do
+
+              before { ChefConfig::Config.chef_zero.osc_compat = true }
+
+              it "defaults to 'everything'" do
+                expect(ChefConfig::Config[:repo_mode]).to eq("everything")
+              end
+            end
+          end
+
+          context "when local mode is not enabled" do
+
+            context "and the chef_server_url is multi-tenant" do
+
+              before { ChefConfig::Config[:chef_server_url] = "https://chef.example/organizations/example" }
+
+              it "defaults to 'hosted_everything'" do
+                expect(ChefConfig::Config[:repo_mode]).to eq("hosted_everything")
+              end
+
+            end
+
+            context "and the chef_server_url is not multi-tenant" do
+
+              before { ChefConfig::Config[:chef_server_url] = "https://chef.example/" }
+
+              it "defaults to 'everything'" do
+                expect(ChefConfig::Config[:repo_mode]).to eq("everything")
+              end
+            end
+          end
+        end
+
         # On Windows, we'll detect an omnibus build and set this to the
         # cacert.pem included in the package, but it's nil if you're on Windows
         # w/o omnibus (e.g., doing development on Windows, custom build, etc.)

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -338,7 +338,8 @@ RSpec.describe ChefConfig::Config do
             before { ChefConfig::Config[:cookbook_path] = "/home/anne/repo/cookbooks" }
 
             it "is set to a path one directory up from the cookbook_path" do
-              expect(ChefConfig::Config[:chef_repo_path]).to eq("/home/anne/repo")
+              expected = File.expand_path("/home/anne/repo")
+              expect(ChefConfig::Config[:chef_repo_path]).to eq(expected)
             end
 
           end
@@ -348,19 +349,28 @@ RSpec.describe ChefConfig::Config do
             before do
               ChefConfig::Config[:cookbook_path] = [
                 "/home/anne/repo/cookbooks",
-                "/home/anne/other_repo/cookbooks"
+                "/home/anne/other_repo/cookbooks",
               ]
             end
 
             it "is set to an Array of paths one directory up from the cookbook_paths" do
-              expect(ChefConfig::Config[:chef_repo_path]).to eq([ "/home/anne/repo", "/home/anne/other_repo"])
+              expected = [ "/home/anne/repo", "/home/anne/other_repo"].map { |p| File.expand_path(p) }
+              expect(ChefConfig::Config[:chef_repo_path]).to eq(expected)
             end
 
           end
 
           context "when cookbook_path is not set but cookbook_artifact_path is set" do
 
-            it "is set to a path one directory up from the cookbook_artifact_path", :skip
+            before do
+              ChefConfig::Config[:cookbook_path] = nil
+              ChefConfig::Config[:cookbook_artifact_path] = "/home/roxie/repo/cookbook_artifacts"
+            end
+
+            it "is set to a path one directory up from the cookbook_artifact_path" do
+              expected = File.expand_path("/home/roxie/repo")
+              expect(ChefConfig::Config[:chef_repo_path]).to eq(expected)
+            end
 
           end
 
@@ -395,6 +405,12 @@ RSpec.describe ChefConfig::Config do
           allow(ChefConfig::Config).to receive(:cache_path).and_return(primary_cache_path)
           environment_path = is_windows ? "#{primary_cache_path}\\environments" : "#{primary_cache_path}/environments"
           expect(ChefConfig::Config[:environment_path]).to eq(environment_path)
+        end
+
+        it "ChefConfig::Config[:cookbook_artifact_path] defaults to /var/chef/cookbook_artifacts" do
+          allow(ChefConfig::Config).to receive(:cache_path).and_return(primary_cache_path)
+          environment_path = is_windows ? "#{primary_cache_path}\\cookbook_artifacts" : "#{primary_cache_path}/cookbook_artifacts"
+          expect(ChefConfig::Config[:cookbook_artifact_path]).to eq(environment_path)
         end
 
         describe "setting the config dir" do

--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -65,6 +65,8 @@ class Chef
         server_options = {}
         server_options[:data_store] = data_store
         server_options[:log_level] = Chef::Log.level
+        server_options[:osc_compat] = Chef::Config.chef_zero.osc_compat
+        server_options[:single_org] = Chef::Config.chef_zero.single_org
 
         server_options[:host] = Chef::Config.chef_zero.host
         server_options[:port] = parse_port(Chef::Config.chef_zero.port)

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -169,7 +169,7 @@ EOM
       it "knife raw -z -i dummynode.json -m PUT /nodes/x" do
         knife("raw -z -i #{path_to('dummynode.json')} -m PUT /nodes/x").should_succeed( /"x"/ )
         knife("list --local /nodes").should_succeed "/nodes/x.json\n"
-        knife("show -z /nodes/x.json --verbose").should_succeed /"bar"/
+        knife("show -z /nodes/x.json --verbose").should_succeed(/"bar"/)
       end
 
       it "knife raw -z -i empty.json -m PUT /roles/x" do
@@ -237,7 +237,7 @@ EOM
       it "knife raw -z -i dummynode.json -m POST /nodes" do
         knife("raw -z -i #{path_to('dummynode.json')} -m POST /nodes").should_succeed( /uri/ )
         knife("list --local /nodes").should_succeed "/nodes/z.json\n"
-        knife("show -z /nodes/z.json").should_succeed /"bar"/
+        knife("show -z /nodes/z.json").should_succeed(/"bar"/)
       end
 
       it "knife raw -z -i empty.json -m POST /roles" do

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -29,20 +29,407 @@ describe "ChefFSDataStore tests", :workstation do
   let(:cookbook_x_100_metadata_rb) { cb_metadata("x", "1.0.0") }
   let(:cookbook_z_100_metadata_rb) { cb_metadata("z", "1.0.0") }
 
-  when_the_repository "has one of each thing" do
+  describe "with repo mode 'hosted_everything' (default)" do
     before do
-      file "clients/x.json", {}
-      file "cookbooks/x/metadata.rb", cookbook_x_100_metadata_rb
-      file "data_bags/x/y.json", {}
-      file "environments/x.json", {}
-      file "nodes/x.json", {}
-      file "roles/x.json", {}
-      file "users/x.json", {}
+      Chef::Config.chef_zero.osc_compat = false
     end
 
-    context "GET /TYPE" do
-      it "knife list -z -R returns everything" do
+    when_the_repository "has one of each thing" do
+      before do
+        file "clients/x.json", {}
+        file "cookbooks/x/metadata.rb", cookbook_x_100_metadata_rb
+        file "data_bags/x/y.json", {}
+        file "environments/x.json", {}
+        file "nodes/x.json", {}
+        file "roles/x.json", {}
+        # file "users/x.json", {}
+        file "containers/x.json", {}
+        file "groups/x.json", {}
+        file "containers/x.json", {}
+        file "groups/x.json", {}
+        file "policies/x.json", {}
+        file "policy_groups/x.json", {}
+      end
+
+      context "GET /TYPE" do
+        it "knife list -z -R returns everything" do
+          knife("list -z -Rfp /").should_succeed <<EOM
+/acls/
+/acls/clients/
+/acls/clients/x.json
+/acls/containers/
+/acls/containers/x.json
+/acls/cookbooks/
+/acls/cookbooks/x.json
+/acls/data_bags/
+/acls/data_bags/x.json
+/acls/environments/
+/acls/environments/x.json
+/acls/groups/
+/acls/groups/x.json
+/acls/nodes/
+/acls/nodes/x.json
+/acls/organization.json
+/acls/roles/
+/acls/roles/x.json
+/clients/
+/clients/x.json
+/containers/
+/containers/x.json
+/cookbook_artifacts/
+/cookbooks/
+/cookbooks/x/
+/cookbooks/x/metadata.rb
+/data_bags/
+/data_bags/x/
+/data_bags/x/y.json
+/environments/
+/environments/x.json
+/groups/
+/groups/x.json
+/invitations.json
+/members.json
+/nodes/
+/nodes/x.json
+/org.json
+/policies/
+/policy_groups/
+/policy_groups/x.json
+/roles/
+/roles/x.json
+EOM
+        end
+      end
+
+      context "DELETE /TYPE/NAME" do
+        it "knife delete -z /clients/x.json works" do
+          knife("delete -z /clients/x.json").should_succeed "Deleted /clients/x.json\n"
+          knife("list -z -Rfp /clients").should_succeed ""
+        end
+
+        it "knife delete -z -r /cookbooks/x works" do
+          knife("delete -z -r /cookbooks/x").should_succeed "Deleted /cookbooks/x\n"
+          knife("list -z -Rfp /cookbooks").should_succeed ""
+        end
+
+        it "knife delete -z -r /data_bags/x works" do
+          knife("delete -z -r /data_bags/x").should_succeed "Deleted /data_bags/x\n"
+          knife("list -z -Rfp /data_bags").should_succeed ""
+        end
+
+        it "knife delete -z /data_bags/x/y.json works" do
+          knife("delete -z /data_bags/x/y.json").should_succeed "Deleted /data_bags/x/y.json\n"
+          knife("list -z -Rfp /data_bags").should_succeed "/data_bags/x/\n"
+        end
+
+        it "knife delete -z /environments/x.json works" do
+          knife("delete -z /environments/x.json").should_succeed "Deleted /environments/x.json\n"
+          knife("list -z -Rfp /environments").should_succeed ""
+        end
+
+        it "knife delete -z /nodes/x.json works" do
+          knife("delete -z /nodes/x.json").should_succeed "Deleted /nodes/x.json\n"
+          knife("list -z -Rfp /nodes").should_succeed ""
+        end
+
+        it "knife delete -z /roles/x.json works" do
+          knife("delete -z /roles/x.json").should_succeed "Deleted /roles/x.json\n"
+          knife("list -z -Rfp /roles").should_succeed ""
+        end
+
+      end
+
+      context "GET /TYPE/NAME" do
+        it "knife show -z /clients/x.json works" do
+          knife("show -z /clients/x.json").should_succeed( /"x"/ )
+        end
+
+        it "knife show -z /cookbooks/x/metadata.rb works" do
+          knife("show -z /cookbooks/x/metadata.rb").should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
+        end
+
+        it "knife show -z /data_bags/x/y.json works" do
+          knife("show -z /data_bags/x/y.json").should_succeed( /"y"/ )
+        end
+
+        it "knife show -z /environments/x.json works" do
+          knife("show -z /environments/x.json").should_succeed( /"x"/ )
+        end
+
+        it "knife show -z /nodes/x.json works" do
+          knife("show -z /nodes/x.json").should_succeed( /"x"/ )
+        end
+
+        it "knife show -z /roles/x.json works" do
+          knife("show -z /roles/x.json").should_succeed( /"x"/ )
+        end
+
+      end
+
+      context "PUT /TYPE/NAME" do
+        before do
+          file "empty.json", {}
+          file "dummynode.json", { "name" => "x", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
+          file "rolestuff.json", '{"description":"hi there","name":"x"}'
+          file "cookbooks_to_upload/x/metadata.rb", cookbook_x_100_metadata_rb
+        end
+
+        it "knife raw -z -i empty.json -m PUT /clients/x" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_succeed( /"x"/ )
+          knife("list --local /clients").should_succeed "/clients/x.json\n"
+        end
+
+        it "knife cookbook upload works" do
+          knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} x").should_succeed :stderr => <<EOM
+Uploading x              [1.0.0]
+Uploaded 1 cookbook.
+EOM
+          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
+        end
+
+        it "knife raw -z -i empty.json -m PUT /data/x/y" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_succeed( /"y"/ )
+          knife("list --local -Rfp /data_bags").should_succeed "/data_bags/x/\n/data_bags/x/y.json\n"
+        end
+
+        it "knife raw -z -i empty.json -m PUT /environments/x" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_succeed( /"x"/ )
+          knife("list --local /environments").should_succeed "/environments/x.json\n"
+        end
+
+        it "knife raw -z -i dummynode.json -m PUT /nodes/x" do
+          knife("raw -z -i #{path_to('dummynode.json')} -m PUT /nodes/x").should_succeed( /"x"/ )
+          knife("list --local /nodes").should_succeed "/nodes/x.json\n"
+          knife("show -z /nodes/x.json --verbose").should_succeed(/"bar"/)
+        end
+
+        it "knife raw -z -i empty.json -m PUT /roles/x" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_succeed( /"x"/ )
+          knife("list --local /roles").should_succeed "/roles/x.json\n"
+        end
+
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+          knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
+          expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
+{
+  "name": "x",
+  "description": "hi there"
+}
+EOM
+        end
+      end
+    end
+
+    when_the_repository "is empty" do
+      context "POST /TYPE/NAME" do
+        before do
+          file "empty.json", { "name" => "z" }
+          file "dummynode.json", { "name" => "z", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
+          file "empty_x.json", { "name" => "x" }
+          file "empty_id.json", { "id" => "z" }
+          file "rolestuff.json", '{"description":"hi there","name":"x"}'
+          file "cookbooks_to_upload/z/metadata.rb", cookbook_z_100_metadata_rb
+        end
+
+        it "knife raw -z -i empty.json -m POST /clients" do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /clients").should_succeed( /uri/ )
+          knife("list --local /clients").should_succeed "/clients/z.json\n"
+        end
+
+        it "knife cookbook upload works" do
+          knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} z").should_succeed :stderr => <<EOM
+Uploading z            [1.0.0]
+Uploaded 1 cookbook.
+EOM
+          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
+        end
+
+        it "knife raw -z -i empty.json -m POST /data" do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /data").should_succeed( /uri/ )
+          knife("list --local -Rfp /data_bags").should_succeed "/data_bags/z/\n"
+        end
+
+        it "knife raw -z -i empty.json -m POST /data/x" do
+          knife("raw -z -i #{path_to('empty_x.json')} -m POST /data").should_succeed( /uri/ )
+          knife("raw -z -i #{path_to('empty_id.json')} -m POST /data/x").should_succeed( /"z"/ )
+          knife("list --local -Rfp /data_bags").should_succeed "/data_bags/x/\n/data_bags/x/z.json\n"
+        end
+
+        it "knife raw -z -i empty.json -m POST /environments" do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /environments").should_succeed( /uri/ )
+          knife("list --local /environments").should_succeed "/environments/z.json\n"
+        end
+
+        it "knife raw -z -i dummynode.json -m POST /nodes" do
+          knife("raw -z -i #{path_to('dummynode.json')} -m POST /nodes").should_succeed( /uri/ )
+          knife("list --local /nodes").should_succeed "/nodes/z.json\n"
+          knife("show -z /nodes/z.json").should_succeed(/"bar"/)
+        end
+
+        it "knife raw -z -i empty.json -m POST /roles" do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /roles").should_succeed( /uri/ )
+          knife("list --local /roles").should_succeed "/roles/z.json\n"
+        end
+
+        it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+          knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
+          expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
+{
+  "name": "x",
+  "description": "hi there"
+}
+EOM
+        end
+      end
+
+      it "knife list -z -R returns nothing" do
         knife("list -z -Rfp /").should_succeed <<EOM
+/acls/
+/acls/clients/
+/acls/containers/
+/acls/cookbooks/
+/acls/data_bags/
+/acls/environments/
+/acls/groups/
+/acls/nodes/
+/acls/organization.json
+/acls/roles/
+/clients/
+/containers/
+/cookbook_artifacts/
+/cookbooks/
+/data_bags/
+/environments/
+/groups/
+/invitations.json
+/members.json
+/nodes/
+/org.json
+/policies/
+/policy_groups/
+/roles/
+EOM
+      end
+
+      context "DELETE /TYPE/NAME" do
+        it "knife delete -z /clients/x.json fails with an error" do
+          knife("delete -z /clients/x.json").should_fail "ERROR: /clients/x.json: No such file or directory\n"
+        end
+
+        it "knife delete -z -r /cookbooks/x fails with an error" do
+          knife("delete -z -r /cookbooks/x").should_fail "ERROR: /cookbooks/x: No such file or directory\n"
+        end
+
+        it "knife delete -z -r /data_bags/x fails with an error" do
+          knife("delete -z -r /data_bags/x").should_fail "ERROR: /data_bags/x: No such file or directory\n"
+        end
+
+        it "knife delete -z /data_bags/x/y.json fails with an error" do
+          knife("delete -z /data_bags/x/y.json").should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
+        end
+
+        it "knife delete -z /environments/x.json fails with an error" do
+          knife("delete -z /environments/x.json").should_fail "ERROR: /environments/x.json: No such file or directory\n"
+        end
+
+        it "knife delete -z /nodes/x.json fails with an error" do
+          knife("delete -z /nodes/x.json").should_fail "ERROR: /nodes/x.json: No such file or directory\n"
+        end
+
+        it "knife delete -z /roles/x.json fails with an error" do
+          knife("delete -z /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
+        end
+
+      end
+
+      context "GET /TYPE/NAME" do
+        it "knife show -z /clients/x.json fails with an error" do
+          knife("show -z /clients/x.json").should_fail "ERROR: /clients/x.json: No such file or directory\n"
+        end
+
+        it "knife show -z /cookbooks/x/metadata.rb fails with an error" do
+          knife("show -z /cookbooks/x/metadata.rb").should_fail "ERROR: /cookbooks/x/metadata.rb: No such file or directory\n"
+        end
+
+        it "knife show -z /data_bags/x/y.json fails with an error" do
+          knife("show -z /data_bags/x/y.json").should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
+        end
+
+        it "knife show -z /environments/x.json fails with an error" do
+          knife("show -z /environments/x.json").should_fail "ERROR: /environments/x.json: No such file or directory\n"
+        end
+
+        it "knife show -z /nodes/x.json fails with an error" do
+          knife("show -z /nodes/x.json").should_fail "ERROR: /nodes/x.json: No such file or directory\n"
+        end
+
+        it "knife show -z /roles/x.json fails with an error" do
+          knife("show -z /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
+        end
+
+      end
+
+      context "PUT /TYPE/NAME" do
+        before do
+          file "empty.json", {}
+        end
+
+        it "knife raw -z -i empty.json -m PUT /clients/x fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_fail( /404/ )
+        end
+
+        it "knife raw -z -i empty.json -m PUT /data/x/y fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_fail( /404/ )
+        end
+
+        it "knife raw -z -i empty.json -m PUT /environments/x fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_fail( /404/ )
+        end
+
+        it "knife raw -z -i empty.json -m PUT /nodes/x fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_fail( /404/ )
+        end
+
+        it "knife raw -z -i empty.json -m PUT /roles/x fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_fail( /404/ )
+        end
+
+      end
+    end
+  end
+
+  # We have to configure Zero for Chef 11 mode in order to test users because:
+  # 1. local mode overrides your `chef_server_url` to something like "http://localhost:PORT"
+  # 2. single org mode maps requests like "https://localhost:PORT/users" so
+  #   they're functionally equivalent to "https://localhost:PORT/organizations/DEFAULT/users"
+  # 3. Users are global objects in Chef 12, and should be accessed at URLs like
+  #   "https://localhost:PORT/users" (there is an org-specific users endpoint,
+  #   but it's for listing users in an org, not for managing users).
+  # 4. Therefore you can't hit the _real_ users endpoint in local mode when
+  #   configured for Chef Server 12 mode.
+  #
+  # Because of this, we have to configure Zero for Chef 11 OSC mode in order to
+  # test the users part of the data store with local mode.
+  describe "with repo mode 'everything'" do
+    before do
+      Chef::Config.repo_mode = "everything"
+      Chef::Config.chef_zero.osc_compat = true
+    end
+
+    when_the_repository "has one of each thing" do
+      before do
+        file "clients/x.json", {}
+        file "cookbooks/x/metadata.rb", cookbook_x_100_metadata_rb
+        file "data_bags/x/y.json", {}
+        file "environments/x.json", {}
+        file "nodes/x.json", {}
+        file "roles/x.json", {}
+        file "users/x.json", {}
+      end
+
+      context "GET /TYPE" do
+        it "knife list -z -R returns everything" do
+          knife("list -z -Rfp /").should_succeed <<EOM
 /clients/
 /clients/x.json
 /cookbooks/
@@ -60,209 +447,66 @@ describe "ChefFSDataStore tests", :workstation do
 /users/
 /users/x.json
 EOM
-      end
-    end
-
-    context "DELETE /TYPE/NAME" do
-      it "knife delete -z /clients/x.json works" do
-        knife("delete -z /clients/x.json").should_succeed "Deleted /clients/x.json\n"
-        knife("list -z -Rfp /clients").should_succeed ""
+        end
       end
 
-      it "knife delete -z -r /cookbooks/x works" do
-        knife("delete -z -r /cookbooks/x").should_succeed "Deleted /cookbooks/x\n"
-        knife("list -z -Rfp /cookbooks").should_succeed ""
+      context "DELETE /TYPE/NAME" do
+        it "knife delete -z /users/x.json works" do
+          knife("delete -z /users/x.json").should_succeed "Deleted /users/x.json\n"
+          knife("list -z -Rfp /users").should_succeed ""
+        end
       end
 
-      it "knife delete -z -r /data_bags/x works" do
-        knife("delete -z -r /data_bags/x").should_succeed "Deleted /data_bags/x\n"
-        knife("list -z -Rfp /data_bags").should_succeed ""
+      context "GET /TYPE/NAME" do
+        it "knife show -z /users/x.json works" do
+          knife("show -z /users/x.json").should_succeed( /"x"/ )
+        end
       end
 
-      it "knife delete -z /data_bags/x/y.json works" do
-        knife("delete -z /data_bags/x/y.json").should_succeed "Deleted /data_bags/x/y.json\n"
-        knife("list -z -Rfp /data_bags").should_succeed "/data_bags/x/\n"
-      end
+      context "PUT /TYPE/NAME" do
+        before do
+          file "empty.json", {}
+          file "dummynode.json", { "name" => "x", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
+          file "rolestuff.json", '{"description":"hi there","name":"x"}'
+          file "cookbooks_to_upload/x/metadata.rb", cookbook_x_100_metadata_rb
+        end
 
-      it "knife delete -z /environments/x.json works" do
-        knife("delete -z /environments/x.json").should_succeed "Deleted /environments/x.json\n"
-        knife("list -z -Rfp /environments").should_succeed ""
-      end
+        it "knife raw -z -i empty.json -m PUT /users/x" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_succeed( /"x"/ )
+          knife("list --local /users").should_succeed "/users/x.json\n"
+        end
 
-      it "knife delete -z /nodes/x.json works" do
-        knife("delete -z /nodes/x.json").should_succeed "Deleted /nodes/x.json\n"
-        knife("list -z -Rfp /nodes").should_succeed ""
-      end
-
-      it "knife delete -z /roles/x.json works" do
-        knife("delete -z /roles/x.json").should_succeed "Deleted /roles/x.json\n"
-        knife("list -z -Rfp /roles").should_succeed ""
-      end
-
-      it "knife delete -z /users/x.json works" do
-        knife("delete -z /users/x.json").should_succeed "Deleted /users/x.json\n"
-        knife("list -z -Rfp /users").should_succeed ""
-      end
-    end
-
-    context "GET /TYPE/NAME" do
-      it "knife show -z /clients/x.json works" do
-        knife("show -z /clients/x.json").should_succeed( /"x"/ )
-      end
-
-      it "knife show -z /cookbooks/x/metadata.rb works" do
-        knife("show -z /cookbooks/x/metadata.rb").should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
-      end
-
-      it "knife show -z /data_bags/x/y.json works" do
-        knife("show -z /data_bags/x/y.json").should_succeed( /"y"/ )
-      end
-
-      it "knife show -z /environments/x.json works" do
-        knife("show -z /environments/x.json").should_succeed( /"x"/ )
-      end
-
-      it "knife show -z /nodes/x.json works" do
-        knife("show -z /nodes/x.json").should_succeed( /"x"/ )
-      end
-
-      it "knife show -z /roles/x.json works" do
-        knife("show -z /roles/x.json").should_succeed( /"x"/ )
-      end
-
-      it "knife show -z /users/x.json works" do
-        knife("show -z /users/x.json").should_succeed( /"x"/ )
-      end
-    end
-
-    context "PUT /TYPE/NAME" do
-      before do
-        file "empty.json", {}
-        file "dummynode.json", { "name" => "x", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
-        file "rolestuff.json", '{"description":"hi there","name":"x"}'
-        file "cookbooks_to_upload/x/metadata.rb", cookbook_x_100_metadata_rb
-      end
-
-      it "knife raw -z -i empty.json -m PUT /clients/x" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_succeed( /"x"/ )
-        knife("list --local /clients").should_succeed "/clients/x.json\n"
-      end
-
-      it "knife cookbook upload works" do
-        knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} x").should_succeed :stderr => <<EOM
-Uploading x              [1.0.0]
-Uploaded 1 cookbook.
-EOM
-        knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
-      end
-
-      it "knife raw -z -i empty.json -m PUT /data/x/y" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_succeed( /"y"/ )
-        knife("list --local -Rfp /data_bags").should_succeed "/data_bags/x/\n/data_bags/x/y.json\n"
-      end
-
-      it "knife raw -z -i empty.json -m PUT /environments/x" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_succeed( /"x"/ )
-        knife("list --local /environments").should_succeed "/environments/x.json\n"
-      end
-
-      it "knife raw -z -i dummynode.json -m PUT /nodes/x" do
-        knife("raw -z -i #{path_to('dummynode.json')} -m PUT /nodes/x").should_succeed( /"x"/ )
-        knife("list --local /nodes").should_succeed "/nodes/x.json\n"
-        knife("show -z /nodes/x.json --verbose").should_succeed(/"bar"/)
-      end
-
-      it "knife raw -z -i empty.json -m PUT /roles/x" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_succeed( /"x"/ )
-        knife("list --local /roles").should_succeed "/roles/x.json\n"
-      end
-
-      it "knife raw -z -i empty.json -m PUT /users/x" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_succeed( /"x"/ )
-        knife("list --local /users").should_succeed "/users/x.json\n"
-      end
-
-      it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
-        knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
-        expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+          knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
+          expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
 {
   "name": "x",
   "description": "hi there"
 }
 EOM
-      end
-    end
-  end
-
-  when_the_repository "is empty" do
-    context "POST /TYPE/NAME" do
-      before do
-        file "empty.json", { "name" => "z" }
-        file "dummynode.json", { "name" => "z", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
-        file "empty_x.json", { "name" => "x" }
-        file "empty_id.json", { "id" => "z" }
-        file "rolestuff.json", '{"description":"hi there","name":"x"}'
-        file "cookbooks_to_upload/z/metadata.rb", cookbook_z_100_metadata_rb
-      end
-
-      it "knife raw -z -i empty.json -m POST /clients" do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /clients").should_succeed( /uri/ )
-        knife("list --local /clients").should_succeed "/clients/z.json\n"
-      end
-
-      it "knife cookbook upload works" do
-        knife("cookbook upload -z --cookbook-path #{path_to('cookbooks_to_upload')} z").should_succeed :stderr => <<EOM
-Uploading z            [1.0.0]
-Uploaded 1 cookbook.
-EOM
-        knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
-      end
-
-      it "knife raw -z -i empty.json -m POST /data" do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /data").should_succeed( /uri/ )
-        knife("list --local -Rfp /data_bags").should_succeed "/data_bags/z/\n"
-      end
-
-      it "knife raw -z -i empty.json -m POST /data/x" do
-        knife("raw -z -i #{path_to('empty_x.json')} -m POST /data").should_succeed( /uri/ )
-        knife("raw -z -i #{path_to('empty_id.json')} -m POST /data/x").should_succeed( /"z"/ )
-        knife("list --local -Rfp /data_bags").should_succeed "/data_bags/x/\n/data_bags/x/z.json\n"
-      end
-
-      it "knife raw -z -i empty.json -m POST /environments" do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /environments").should_succeed( /uri/ )
-        knife("list --local /environments").should_succeed "/environments/z.json\n"
-      end
-
-      it "knife raw -z -i dummynode.json -m POST /nodes" do
-        knife("raw -z -i #{path_to('dummynode.json')} -m POST /nodes").should_succeed( /uri/ )
-        knife("list --local /nodes").should_succeed "/nodes/z.json\n"
-        knife("show -z /nodes/z.json").should_succeed(/"bar"/)
-      end
-
-      it "knife raw -z -i empty.json -m POST /roles" do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /roles").should_succeed( /uri/ )
-        knife("list --local /roles").should_succeed "/roles/z.json\n"
-      end
-
-      it "knife raw -z -i empty.json -m POST /users" do
-        knife("raw -z -i #{path_to('empty.json')} -m POST /users").should_succeed( /uri/ )
-        knife("list --local /users").should_succeed "/users/z.json\n"
-      end
-
-      it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
-        knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
-        expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
-{
-  "name": "x",
-  "description": "hi there"
-}
-EOM
+        end
       end
     end
 
-    it "knife list -z -R returns nothing" do
-      knife("list -z -Rfp /").should_succeed <<EOM
+    when_the_repository "is empty" do
+      context "POST /TYPE/NAME" do
+        before do
+          file "empty.json", { "name" => "z" }
+          file "dummynode.json", { "name" => "z", "chef_environment" => "rspec" , "json_class" => "Chef::Node", "normal" => {"foo" => "bar"}}
+          file "empty_x.json", { "name" => "x" }
+          file "empty_id.json", { "id" => "z" }
+          file "rolestuff.json", '{"description":"hi there","name":"x"}'
+          file "cookbooks_to_upload/z/metadata.rb", cookbook_z_100_metadata_rb
+        end
+
+        it "knife raw -z -i empty.json -m POST /users" do
+          knife("raw -z -i #{path_to('empty.json')} -m POST /users").should_succeed( /uri/ )
+          knife("list --local /users").should_succeed "/users/z.json\n"
+        end
+      end
+
+      it "knife list -z -R returns nothing" do
+        knife("list -z -Rfp /").should_succeed <<EOM
 /clients/
 /cookbooks/
 /data_bags/
@@ -271,99 +515,28 @@ EOM
 /roles/
 /users/
 EOM
-    end
-
-    context "DELETE /TYPE/NAME" do
-      it "knife delete -z /clients/x.json fails with an error" do
-        knife("delete -z /clients/x.json").should_fail "ERROR: /clients/x.json: No such file or directory\n"
       end
 
-      it "knife delete -z -r /cookbooks/x fails with an error" do
-        knife("delete -z -r /cookbooks/x").should_fail "ERROR: /cookbooks/x: No such file or directory\n"
+      context "DELETE /TYPE/NAME" do
+        it "knife delete -z /users/x.json fails with an error" do
+          knife("delete -z /users/x.json").should_fail "ERROR: /users/x.json: No such file or directory\n"
+        end
       end
 
-      it "knife delete -z -r /data_bags/x fails with an error" do
-        knife("delete -z -r /data_bags/x").should_fail "ERROR: /data_bags/x: No such file or directory\n"
+      context "GET /TYPE/NAME" do
+        it "knife show -z /users/x.json fails with an error" do
+          knife("show -z /users/x.json").should_fail "ERROR: /users/x.json: No such file or directory\n"
+        end
       end
 
-      it "knife delete -z /data_bags/x/y.json fails with an error" do
-        knife("delete -z /data_bags/x/y.json").should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
-      end
+      context "PUT /TYPE/NAME" do
+        before do
+          file "empty.json", {}
+        end
 
-      it "knife delete -z /environments/x.json fails with an error" do
-        knife("delete -z /environments/x.json").should_fail "ERROR: /environments/x.json: No such file or directory\n"
-      end
-
-      it "knife delete -z /nodes/x.json fails with an error" do
-        knife("delete -z /nodes/x.json").should_fail "ERROR: /nodes/x.json: No such file or directory\n"
-      end
-
-      it "knife delete -z /roles/x.json fails with an error" do
-        knife("delete -z /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
-      end
-
-      it "knife delete -z /users/x.json fails with an error" do
-        knife("delete -z /users/x.json").should_fail "ERROR: /users/x.json: No such file or directory\n"
-      end
-    end
-
-    context "GET /TYPE/NAME" do
-      it "knife show -z /clients/x.json fails with an error" do
-        knife("show -z /clients/x.json").should_fail "ERROR: /clients/x.json: No such file or directory\n"
-      end
-
-      it "knife show -z /cookbooks/x/metadata.rb fails with an error" do
-        knife("show -z /cookbooks/x/metadata.rb").should_fail "ERROR: /cookbooks/x/metadata.rb: No such file or directory\n"
-      end
-
-      it "knife show -z /data_bags/x/y.json fails with an error" do
-        knife("show -z /data_bags/x/y.json").should_fail "ERROR: /data_bags/x/y.json: No such file or directory\n"
-      end
-
-      it "knife show -z /environments/x.json fails with an error" do
-        knife("show -z /environments/x.json").should_fail "ERROR: /environments/x.json: No such file or directory\n"
-      end
-
-      it "knife show -z /nodes/x.json fails with an error" do
-        knife("show -z /nodes/x.json").should_fail "ERROR: /nodes/x.json: No such file or directory\n"
-      end
-
-      it "knife show -z /roles/x.json fails with an error" do
-        knife("show -z /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
-      end
-
-      it "knife show -z /users/x.json fails with an error" do
-        knife("show -z /users/x.json").should_fail "ERROR: /users/x.json: No such file or directory\n"
-      end
-    end
-
-    context "PUT /TYPE/NAME" do
-      before do
-        file "empty.json", {}
-      end
-
-      it "knife raw -z -i empty.json -m PUT /clients/x fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /clients/x").should_fail( /404/ )
-      end
-
-      it "knife raw -z -i empty.json -m PUT /data/x/y fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /data/x/y").should_fail( /404/ )
-      end
-
-      it "knife raw -z -i empty.json -m PUT /environments/x fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /environments/x").should_fail( /404/ )
-      end
-
-      it "knife raw -z -i empty.json -m PUT /nodes/x fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /nodes/x").should_fail( /404/ )
-      end
-
-      it "knife raw -z -i empty.json -m PUT /roles/x fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /roles/x").should_fail( /404/ )
-      end
-
-      it "knife raw -z -i empty.json -m PUT /users/x fails with 404" do
-        knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_fail( /404/ )
+        it "knife raw -z -i empty.json -m PUT /users/x fails with 404" do
+          knife("raw -z -i #{path_to('empty.json')} -m PUT /users/x").should_fail( /404/ )
+        end
       end
     end
   end


### PR DESCRIPTION
The primary goal here is to enable use of policyfile endpoints in local mode without requiring additional configuration on the user's part. Due to the various compatibility constraints around ChefFS (because of `knife download` being a backup/migration mechanism for many folks), this means we have to change the default behavior of Chef Zero to Chef 12 mode for Chef Client local mode operation.

We still default to single-org mode, which means that there's no way to serve user data via local mode with the default configuration, because Chef Zero will map a request for `/users` to `/organizations/chef/users`, but that can be fixed with additional config and is a suspect use case (e.g., `knife list users -z` and similar). This limitation is described in more detail in a comment in the tests.

Additionally, this adds `cookbook_artifacts` as a "sentinel directory" that we look for when finding the chef repo path. This makes local mode correctly find the root of a policyfile-based chef repo, which only has cookbook artifacts (without this change, if a parent directory of CWD has a cookbooks directory, that would be selected as the root, which is incorrect).
