### PR TITLE
Seeing a useradd failure in Nexus7 functional tests

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -245,7 +245,7 @@ describe Chef::Provider::User::Useradd, metadata do
           expect(pw_entry.home).to eq(home)
         end
 
-        if %w{rhel fedora}.include?(OHAI_SYSTEM["platform_family"])
+        if %w{rhel fedora wrlinux}.include?(OHAI_SYSTEM["platform_family"])
           # Inconsistent behavior. See: CHEF-2205
           it "creates the home dir when not explicitly asked to on RHEL (XXX)" do
             expect(File).to exist(home)


### PR DESCRIPTION
This fixes the test failure we were seeing on Nexus7 bots.  Already went through Manhattan.  Because Nexus7 is a derivative of RHEL then this behavior is correct.

\cc @chef/maintainers 