### PR TITLE
use require_paths and not path so bundler grabs all paths from a git reference

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -54,6 +54,6 @@ Gem::Specification.new do |s|
   s.bindir       = "bin"
   s.executables  = %w{ chef-client chef-solo knife chef-shell chef-apply }
 
-  s.require_path = %w{ lib lib-backcompat }
+  s.require_paths = %w{ lib lib-backcompat }
   s.files = %w{Gemfile Rakefile LICENSE README.md CONTRIBUTING.md} + Dir.glob("{distro,lib,lib-backcompat,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) } + Dir.glob("*.gemspec")
 end


### PR DESCRIPTION
Using bundler to install from git via `gem 'chef', github: 'chef/chef'` only the last path is added to `$LOAD_PATH` when using `require_path` in gemspec. `require_paths` fixes this. This fixes knife-windows builds.

