### PR TITLE
Set range of system user/group id to max of 200

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -287,9 +287,9 @@ describe Chef::Provider::User::Useradd, metadata do
         let(:uid_min) do
           case ohai[:platform]
           when "aix"
-            # UIDs and GIDs below 100 are typically reserved for system accounts and services
-            # http://www.ibm.com/developerworks/aix/library/au-satuidgid/
-            100
+            # UIDs and GIDs below 200 are typically reserved for system accounts and services
+            # https://abcofaix.wordpress.com/tag/usermod/
+            200
           else
             # from `man useradd`, login user means uid will be between
             # UID_SYS_MIN and UID_SYS_MAX defined in /etc/login.defs. On my


### PR DESCRIPTION
According to https://abcofaix.wordpress.com/tag/usermod/, the value
can be up to 200. We were seeing tests on our aix testers fail with

```
  1) Chef::Provider::User::Useradd action :create when the user does not exist beforehand when a system user is specified ensures the user has the properties of a system user
     Failure/Error: expect(pw_entry.uid.to_i).to be < uid_min.to_i

       expected: < 100
            got:   101
     # ./spec/functional/resource/user/useradd_spec.rb:306:in `block (5 levels) in <top (required)>'
```

cc @chef/client-aix @chef/client-core 