### PR TITLE
Change shell for locked user.

### DIFF
--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -93,13 +93,11 @@ class Chef
         end
 
         def lock_user
-          shell_out!("usermod", "-L", new_resource.username)
-          shell_out!("chsh", "-s", "/bin/false", new_resource.username)
+          shell_out!("usermod", "-L", "-s", "/bin/false", new_resource.username)
         end
 
         def unlock_user
-          shell_out!("usermod", "-U", new_resource.username)
-          shell_out!("chsh", "-s", new_resource.shell, new_resource.username)
+          shell_out!("usermod", "-U", "-s", new_resource.shell, new_resource.username)
         end
 
         def compile_command(base_command)

--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -94,10 +94,12 @@ class Chef
 
         def lock_user
           shell_out!("usermod", "-L", new_resource.username)
+          shell_out!("chsh", "-s", "/bin/false", new_resource.username)
         end
 
         def unlock_user
           shell_out!("usermod", "-U", new_resource.username)
+          shell_out!("chsh", "-s", new_resource.shell, new_resource.username)
         end
 
         def compile_command(base_command)

--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -145,6 +145,7 @@ describe Chef::Provider::User::Useradd, metadata do
   let(:password) { nil }
   let(:system) { false }
   let(:comment) { nil }
+  let(:shell) { nil }
 
   let(:user_resource) do
     r = Chef::Resource::User.new("TEST USER RESOURCE", run_context)
@@ -155,6 +156,7 @@ describe Chef::Provider::User::Useradd, metadata do
     r.manage_home(manage_home)
     r.password(password)
     r.system(system)
+    r.shell(shell)
     r
   end
 
@@ -631,6 +633,7 @@ describe Chef::Provider::User::Useradd, metadata do
     context "when the user exists" do
 
       include_context "user exists for lock/unlock"
+      let(:shell) { "/bin/bash" }
 
       before do
         begin

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -365,15 +365,15 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   end
 
   describe "when locking the user" do
-    it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out!).with("usermod", "-L", @new_resource.username)
+    it "should run usermod -L -s /bin/false with the new resources username" do
+      expect(provider).to receive(:shell_out!).with("usermod", "-L", "-s", "/bin/false", @new_resource.username)
       provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
-    it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out!).with("usermod", "-U", @new_resource.username)
+    it "should run usermod -U -s with the new resources shell and username" do
+      expect(provider).to receive(:shell_out!).with("usermod", "-U", "-s", @new_resource.shell, @new_resource.username)
       provider.unlock_user
     end
   end


### PR DESCRIPTION
Disallow locked user to log in setting /bin/false as a shell value (without it user is still able to log in using ssh key + authorized keys, even with locked password). 
Reset shell for unlocked user.