### PR TITLE
Fix bug in sh script that runs test in jenkins

### DIFF
--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -86,9 +86,10 @@ if [ ! -f "Gemfile.lock" ]; then
   exit 1
 fi
 
-CHEF_FIPS=0
-if [ $PIPELINE_NAME='chef-fips'];
-then
+unset CHEF_FIPS
+if [ $PIPELINE_NAME="chef-fips" ]; then
+    echo "Setting fips mode"
     CHEF_FIPS=1
+    export CHEF_FIPS
 fi
 sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit


### PR DESCRIPTION
Some testers fail with

```
ci/verify-chef.sh: test: ] missing`
```

This regression was introduced by
https://github.com/chef/chef/commit/2bcb7d06dcb49c953b9e666b24c8bd3cb56da2c5

This patch should fix it, though I can't be 100% sure as the pipeline seems to pick up the ci folder from master.