### PR TITLE
Fix inverted filter logic for not_fips rspec filter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,7 +169,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
   config.filter_run_excluding :broken => true
   config.filter_run_excluding :not_wpar => true unless wpar?
-  config.filter_run_excluding :not_fips => true if fips?
+  config.filter_run_excluding :not_supported_under_fips => true if fips?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,7 +169,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :aes_256_gcm_only => true unless aes_256_gcm?
   config.filter_run_excluding :broken => true
   config.filter_run_excluding :not_wpar => true unless wpar?
-  config.filter_run_excluding :not_fips => true unless fips?
+  config.filter_run_excluding :not_fips => true if fips?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -290,7 +290,7 @@ describe Chef::EncryptedDataBagItem::Decryptor do
 
   end
 
-  context "when decrypting a version 0 (YAML+aes-256-cbc+no iv) encrypted value", :not_fips do
+  context "when decrypting a version 0 (YAML+aes-256-cbc+no iv) encrypted value", :not_supported_under_fips  do
     let(:encrypted_value) do
       Version0Encryptor.encrypt_value(plaintext_data, encryption_key)
     end


### PR DESCRIPTION
The logic here is inverted, and I think the `not_wpar` one is as well. We'll fix that in a different PR.