### PR TITLE
bundle install without maintenance and others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,13 @@ matrix:
   include:
   - rvm: 2.1
     sudo: true
+    bundler_args: --without server docgen maintenance
   - rvm: 2.2
     sudo: true
+    bundler_args: --without server docgen maintenance
   - rvm: rbx
     sudo: true
+    bundler_args: --without server docgen maintenance
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chef-zero', github: 'chef/chef-zero'\""
     script: bundle exec rake chef_zero_spec


### PR DESCRIPTION
if we don't test this here, then when the jenkins ci cluster runs it
we may error in the Rakefile when it tries to require a gem which is
not in the bundle that is installed there --without several gems.