### PR TITLE
Remove incorrect cookbook artifact normalization

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -333,13 +333,7 @@ class Chef
               end
             end
 
-            # Cookbook artifacts act as if certain things aren't set if they are empty
-            # (e.g. "definitions" and "libraries" are not set if they are empty, but
-            # "recipes" is)
             if cookbook_type == "cookbook_artifacts"
-              result.delete_if do |key,value|
-                (value == [] && key != "recipes")
-              end
               result["metadata"] = result["metadata"].to_hash
               result["metadata"].delete_if do |key,value|
                 value == [] ||

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_artifact_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_artifact_dir.rb
@@ -26,7 +26,7 @@ class Chef
           # Override from parent
           def cookbook_version
             loader = Chef::Cookbook::CookbookVersionLoader.new(file_path, parent.chefignore)
-            cookbook_name, dash, identifier = name.rpartition("-")
+            cookbook_name, _dash, identifier = name.rpartition("-")
             # KLUDGE: We shouldn't have to use instance_variable_set
             loader.instance_variable_set(:@cookbook_name, cookbook_name)
             loader.load_cookbooks


### PR DESCRIPTION
Pedant tests were leading us astray, we don't want to remove entries for
empty cookbook segments.

This needs https://github.com/chef/chef-server/pull/714 in order for Chef Zero to pass pedant in CHEF_FS mode.