### PR TITLE
Don't use public IP for AWS

### DIFF
--- a/acceptance/cookbook-git/.kitchen.ec2.yml
+++ b/acceptance/cookbook-git/.kitchen.ec2.yml
@@ -18,7 +18,7 @@ driver:
   subnet_id: subnet-19ac017c
   security_group_ids: ["sg-e401eb83", "sg-96274af3"]
   instance_type: m3.large
-  associate_public_ip: true
+#  associate_public_ip: true  # Don't enable public IP, as subnet specified is behind VPN
 
 transport:
   ssh_key: <%= file_if_exists("~/.ssh/#{ENV['AWS_SSH_KEY_ID'] || ENV['USER'] || ENV['USERNAME']}.pem") ||


### PR DESCRIPTION
Minor change to comment out use of public IP for AWS instance.

@chef/client-maintainers @sersut @jkeiser 