### PR TITLE
Allow use of command line fips switch for knife

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -496,13 +496,7 @@ module ChefConfig
     # Initialize openssl
     def self.init_openssl
       if fips
-        ChefConfig.logger.warn "The `fips` feature is still a work in progress. This feature is incomplete."
-        OpenSSL.fips_mode = true
-        require "digest"
-        require "digest/sha1"
-        require "digest/md5"
-        Digest.const_set("SHA1", OpenSSL::Digest::SHA1)
-        OpenSSL::Digest.const_set("MD5", Digest::MD5)
+        self.enable_fips_mode
       end
     end
 
@@ -909,6 +903,19 @@ module ChefConfig
     # Path to this file in the current install.
     def self._this_file
       File.expand_path(__FILE__)
+    end
+
+    # Set fips mode in openssl. Do any patching necessary to make
+    # sure Chef runs do not crash.
+    # @api private
+    def self.enable_fips_mode
+      ChefConfig.logger.warn "The `fips` feature is still a work in progress. This feature is incomplete."
+      OpenSSL.fips_mode = true
+      require "digest"
+      require "digest/sha1"
+      require "digest/md5"
+      Digest.const_set("SHA1", OpenSSL::Digest::SHA1)
+      OpenSSL::Digest.const_set("MD5", Digest::MD5)
     end
   end
 end

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -134,6 +134,12 @@ class Chef::Application::Knife < Chef::Application
     :proc         => lambda {|v| puts "Chef: #{::Chef::VERSION}"},
     :exit         => 0
 
+  option :fips,
+    :long         => "--[no-]fips",
+    :description  => "Enable fips mode",
+    :boolean      => true,
+    :default      => nil
+
   # Run knife
   def run
     Mixlib::Log::Formatter.show_time = false

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -398,7 +398,6 @@ class Chef
       merge_configs
       apply_computed_config
       Chef::Config.export_proxies
-      Chef::Config.init_openssl
       # This has to be after apply_computed_config so that Mixlib::Log is configured
       Chef::Log.info("Using configuration from #{config[:config_file]}") if config[:config_file]
     end
@@ -412,6 +411,7 @@ class Chef
         ui.error "You need to add a #run method to your knife command before you can use it"
       end
       enforce_path_sanity
+      maybe_setup_fips
       Chef::LocalMode.with_server_connectivity do
         run
       end
@@ -570,5 +570,11 @@ class Chef
       Chef::Config[:chef_server_url]
     end
 
+    def maybe_setup_fips
+      if !config[:fips].nil?
+        Chef::Config[:fips] = config[:fips]
+      end
+      Chef::Config.init_openssl
+    end
   end
 end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -250,11 +250,6 @@ class Chef
           Chef::Config[:knife][:bootstrap_vault_item]
         }
 
-      option :fips,
-        :long => "--fips",
-        :description => "Set openssl to run in fips mode",
-        :boolean => true
-
       def initialize(argv=[])
         super
         @client_builder = Chef::Knife::Bootstrap::ClientBuilder.new(

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -120,7 +120,7 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
             client_rb << %Q{trusted_certs_dir "/etc/chef/trusted_certs"\n}
           end
 
-          if @config[:fips]
+          if Chef::Config[:fips]
             client_rb << %Q{fips true\n}
           end
 

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -93,7 +93,7 @@ describe Chef::Application::Knife do
       it "does not initialize fips mode when no flags are passed" do
         with_argv(*%w{noop knife command}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(OpenSSL).not_to receive(:'fips_mode=')
+          expect(Chef::Config).not_to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(false)
         end
@@ -102,7 +102,7 @@ describe Chef::Application::Knife do
       it "overwrites the Chef::Config value when passed --fips" do
         with_argv(*%w{noop knife command --fips}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(OpenSSL).to receive(:'fips_mode=').with(true)
+          expect(Chef::Config).to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(true)
         end
@@ -117,7 +117,7 @@ describe Chef::Application::Knife do
       it "initializes fips mode when passed --fips" do
         with_argv(*%w{noop knife command --fips}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(OpenSSL).to receive(:'fips_mode=').with(true)
+          expect(Chef::Config).to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(true)
         end
@@ -126,7 +126,7 @@ describe Chef::Application::Knife do
       it "overwrites the Chef::Config value when passed --no-fips" do
         with_argv(*%w{noop knife command --no-fips}) do
           expect(@knife).to receive(:exit).with(0)
-          expect(OpenSSL).not_to receive(:'fips_mode=')
+          expect(Chef::Config).not_to receive(:enable_fips_mode)
           @knife.run
           expect(Chef::Config[:fips]).to eq(false)
         end

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -82,6 +82,58 @@ describe Chef::Application::Knife do
     end
   end
 
+  context "when given fips flags" do
+    context "when Chef::Config[:fips]=false" do
+      before do
+        # This is required because the chef-fips pipeline does
+        # has a default value of true for fips
+        Chef::Config[:fips] = false
+      end
+
+      it "does not initialize fips mode when no flags are passed" do
+        with_argv(*%w{noop knife command}) do
+          expect(@knife).to receive(:exit).with(0)
+          expect(OpenSSL).not_to receive(:'fips_mode=')
+          @knife.run
+          expect(Chef::Config[:fips]).to eq(false)
+        end
+      end
+
+      it "overwrites the Chef::Config value when passed --fips" do
+        with_argv(*%w{noop knife command --fips}) do
+          expect(@knife).to receive(:exit).with(0)
+          expect(OpenSSL).to receive(:'fips_mode=').with(true)
+          @knife.run
+          expect(Chef::Config[:fips]).to eq(true)
+        end
+      end
+    end
+
+    context "when Chef::Config[:fips]=true" do
+      before do
+        Chef::Config[:fips] = true
+      end
+
+      it "initializes fips mode when passed --fips" do
+        with_argv(*%w{noop knife command --fips}) do
+          expect(@knife).to receive(:exit).with(0)
+          expect(OpenSSL).to receive(:'fips_mode=').with(true)
+          @knife.run
+          expect(Chef::Config[:fips]).to eq(true)
+        end
+      end
+
+      it "overwrites the Chef::Config value when passed --no-fips" do
+        with_argv(*%w{noop knife command --no-fips}) do
+          expect(@knife).to receive(:exit).with(0)
+          expect(OpenSSL).not_to receive(:'fips_mode=')
+          @knife.run
+          expect(Chef::Config[:fips]).to eq(false)
+        end
+      end
+    end
+  end
+
   describe "when given a path to the client key" do
     it "expands a relative path relative to the CWD" do
       relative_path = ".chef/client.pem"

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -148,7 +148,7 @@ describe Chef::Application do
           end
 
           it "sets openssl in fips mode" do
-            expect(OpenSSL).to receive(:'fips_mode=').with(true)
+            expect(Chef::Config).to receive(:enable_fips_mode)
             @app.configure_chef
           end
         end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -422,6 +422,42 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
+  context "when doing fips things" do
+    let(:template_file) { File.expand_path(File.join(CHEF_SPEC_DATA, "bootstrap", "no_proxy.erb")) }
+    let(:trusted_certs_dir) { Chef::Util::PathHelper.cleanpath(File.join(File.dirname(__FILE__), "../../data/trusted_certs")) }
+
+    before do
+      Chef::Config[:knife][:bootstrap_template] = template_file
+    end
+
+    let(:rendered_template) do
+      knife.render_template
+    end
+
+    context "when knife is in fips mode" do
+      before do
+        Chef::Config[:fips] = true
+      end
+
+      it "renders 'fips true'" do
+        Chef::Config[:fips] = true
+        expect(rendered_template).to match("fips")
+      end
+    end
+
+    context "when knife is not in fips mode" do
+      before do
+        # This is required because the chef-fips pipeline does
+        # has a default value of true for fips
+        Chef::Config[:fips] = false
+      end
+
+      it "does not render anything about fips" do
+        expect(rendered_template).not_to match("fips")
+      end
+    end
+  end
+
   describe "handling policyfile options" do
 
     context "when only policy_name is given" do
@@ -735,5 +771,4 @@ describe Chef::Knife::Bootstrap do
   describe "specifying ssl verification" do
 
   end
-
 end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -20,6 +20,12 @@ require "spec_helper"
 require "chef/knife/core/bootstrap_context"
 
 describe Chef::Knife::Core::BootstrapContext do
+  before do
+    # This is required because the chef-fips pipeline does
+    # has a default value of true for fips
+    Chef::Config[:fips] = false
+  end
+
   let(:config) { {:foo => :bar, :color => true} }
   let(:run_list) { Chef::RunList.new("recipe[tmux]", "role[base]") }
   let(:chef_config) do


### PR DESCRIPTION
This somewhat worked before. However, it was just for knife bootstrap.
It also didn't support --no-fips in the case where it was in your
knife.rb and you decided that you didn't want to use fips for
that one call.

The assumption here is fips mode you run knife with is the fips
mode the node will get. This has the nice property that validatorless
bootstraps will talk to the chef server in fips mode if the node
is requested to be in fips mode.