### PR TITLE
Fix dpkg interruption

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -176,20 +176,22 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(command)
-          cmd = shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil }, :returns => [0, 100] )
-          if cmd.stderr == "E: dpkg was interrupted, you must manually run 'dpkg --configure -a' to correct the problem. \n"
+          env = { 'DEBIAN_FRONTEND' => 'noninteractive', 'LC_ALL' => nil }
+          cmd = shell_out_with_timeout!(command, env: env, returns: [0, 100])
+          dpkg_error = 'E: dpkg was interrupted, you must manually ' \
+            "run 'dpkg --configure -a' to correct the problem. \n"
+          if cmd.stderr == dpkg_error
             # If the issue was that dpkg was interrupted,
             # run 'dpkg --configure -a' to fix it.
-            Chef::Log.warn("dpkg was interrupted on the last run; running 'dpkg --configure -a' to correct the problem.")
-            shell_out_with_timeout!('dpkg --configure -a', :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
+            Chef::Log.warn("dpkg interrupted; running 'dpkg --configure -a'")
+            shell_out_with_timeout!('dpkg --configure -a', env: env)
           else
             # Otherwise, we want to preserve the error message, so we either
             # need to run the original command again, or duplicate the error
             # message code. Re-running the command is easier for now.
-            shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
+            shell_out_with_timeout!(command, env: env)
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
If dpkg gets interrupted while installing a package (such as if it gets killed for exceeding the timeout when installing a large package like `texlive-full`), subsequent runs of the `apt_package` resource will fail with an error like the following:
```
Mixlib::ShellOut::ShellCommandFailed: apt_package[mplayer] (workstation::packages line 21) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
---- Begin output of apt-get -q -y install mplayer ----
STDOUT:
STDERR: E: dpkg was interrupted, you must manually run 'dpkg --configure -a' to correct the problem.
---- End output of apt-get -q -y install mplayer ----
Ran apt-get -q -y install mplayer returned 100
```
This PR should cause Chef to detect when this error happens and automatically run `dpkg --configure -a`, rather than continually failing Chef runs until `dpkg --configure -a` is manually run on the node.