### PR TITLE
Allow all Chef Zero 4.x after 4.4

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", "~> 4.4.0", ">= 4.2.2"
+  s.add_dependency "chef-zero", "~> 4.4"
   s.add_dependency "pry", "~> 0.9"
 
   s.add_dependency "plist", "~> 3.1.0"


### PR DESCRIPTION
We require 4.4+ to support policyfile APIs with ChefFS and local mode,
but we don't want to be pessimistic about minor versions, only major.

It looks like the minor version pessimism was accidentally introduced
here:
https://github.com/chef/chef/commit/6e4d70826d8ee6977348bd071d0ce543686b89f6

Now that Chef Zero 4.5 is released, this is breaking stuff where we load chef and chef zero from master.

@chef/client-core 