### PR TITLE
Use minimal Ohai for tests

### DIFF
--- a/spec/functional/dsl/reboot_pending_spec.rb
+++ b/spec/functional/dsl/reboot_pending_spec.rb
@@ -24,7 +24,10 @@ describe Chef::DSL::RebootPending, :windows_only do
   def run_ohai
     ohai = Ohai::System.new
     # Would be nice to limit this to platform/kernel/arch etc for Ohai 7
-    ohai.all_plugins
+
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     node.consume_external_attrs(ohai.data,{})
 
     ohai

--- a/spec/functional/dsl/registry_helper_spec.rb
+++ b/spec/functional/dsl/registry_helper_spec.rb
@@ -31,8 +31,11 @@ describe Chef::Resource::RegistryKey, :windows_only do
 
     events = Chef::EventDispatch::Dispatcher.new
     node = Chef::Node.new
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     node.consume_external_attrs(ohai.data,{})
     run_context = Chef::RunContext.new(node, {}, events)
     @resource = Chef::Resource.new("foo", run_context)

--- a/spec/functional/resource/ohai_spec.rb
+++ b/spec/functional/resource/ohai_spec.rb
@@ -19,9 +19,12 @@
 require "spec_helper"
 
 describe Chef::Resource::Ohai do
-  let(:ohai) {
+  let!(:ohai) {
     o = Ohai::System.new
-    o.all_plugins
+
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    o.all_plugins(filter)
+
     o
   }
 

--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -25,8 +25,11 @@ describe Chef::Resource::RegistryKey, :unix_only do
   before(:all) do
     events = Chef::EventDispatch::Dispatcher.new
     node = Chef::Node.new
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     node.consume_external_attrs(ohai.data,{})
     run_context = Chef::RunContext.new(node, {}, events)
     @resource = Chef::Resource::RegistryKey.new("HKCU\\Software", run_context)
@@ -96,8 +99,11 @@ describe Chef::Resource::RegistryKey, :windows_only, :broken => true do
   before(:all) do
     @events = Chef::EventDispatch::Dispatcher.new
     @node = Chef::Node.new
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     @node.consume_external_attrs(ohai.data,{})
     @run_context = Chef::RunContext.new(@node, {}, @events)
 

--- a/spec/functional/win32/registry_spec.rb
+++ b/spec/functional/win32/registry_spec.rb
@@ -41,8 +41,11 @@ describe "Chef::Win32::Registry", :windows_only do
     #Create the node with ohai data
     events = Chef::EventDispatch::Dispatcher.new
     @node = Chef::Node.new
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     @node.consume_external_attrs(ohai.data,{})
     @run_context = Chef::RunContext.new(@node, {}, events)
 

--- a/spec/unit/dsl/regsitry_helper_spec.rb
+++ b/spec/unit/dsl/regsitry_helper_spec.rb
@@ -24,8 +24,11 @@ describe Chef::Resource::RegistryKey do
   before (:all) do
     events = Chef::EventDispatch::Dispatcher.new
     node = Chef::Node.new
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     node.consume_external_attrs(ohai.data,{})
     run_context = Chef::RunContext.new(node, {}, events)
     @resource = Chef::Resource::new("foo", run_context)
@@ -52,4 +55,3 @@ describe Chef::Resource::RegistryKey do
     end
   end
 end
-

--- a/spec/unit/provider/ohai_spec.rb
+++ b/spec/unit/provider/ohai_spec.rb
@@ -54,8 +54,11 @@ describe Chef::Provider::Ohai do
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
     @new_resource = Chef::Resource::Ohai.new("ohai_reload")
+
     ohai = Ohai::System.new
-    ohai.all_plugins
+    filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+    ohai.all_plugins(filter)
+
     @node.consume_external_attrs(ohai.data,{})
 
     @provider = Chef::Provider::Ohai.new(@new_resource, @run_context)


### PR DESCRIPTION
Use minimal Ohai in order to speed up the AppVeyor tests.

@chef/client-maintainers @jkeiser @jaym 