### PR TITLE
Don't rerun ohai for ohai_spec when not needed

### DIFF
--- a/spec/functional/resource/ohai_spec.rb
+++ b/spec/functional/resource/ohai_spec.rb
@@ -20,9 +20,7 @@ require "spec_helper"
 
 describe Chef::Resource::Ohai do
   let(:ohai) {
-    o = Ohai::System.new
-    o.all_plugins
-    o
+    OHAI_SYSTEM
   }
 
   let(:node) { Chef::Node.new }


### PR DESCRIPTION
Running ohai is slow.

This is still not as fast as I hoped, but shaves more than 2/3's of the time off.
Still at 26 seconds on my machine