### PR TITLE
Don't rerun ohai for unit/regsitry_helper_spec

### DIFF
--- a/spec/unit/dsl/regsitry_helper_spec.rb
+++ b/spec/unit/dsl/regsitry_helper_spec.rb
@@ -24,9 +24,7 @@ describe Chef::Resource::RegistryKey do
   before (:all) do
     events = Chef::EventDispatch::Dispatcher.new
     node = Chef::Node.new
-    ohai = Ohai::System.new
-    ohai.all_plugins
-    node.consume_external_attrs(ohai.data,{})
+    node.consume_external_attrs(OHAI_SYSTEM.data,{})
     run_context = Chef::RunContext.new(node, {}, events)
     @resource = Chef::Resource::new("foo", run_context)
   end


### PR DESCRIPTION
Ohai is slow. We don't need to rerun this, it's
already run in our spec_helper.