### PR TITLE
Make windows event log tests faster

### DIFF
--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -25,16 +25,21 @@ if Chef::Platform.windows? and not Chef::Platform::windows_server_2003?
 end
 
 describe Chef::EventLoggers::WindowsEventLogger, :windows_only, :not_supported_on_win2k3 do
-  let(:run_id)       { SecureRandom.uuid }
-  let(:version)      { SecureRandom.uuid }
-  let(:elapsed_time) { SecureRandom.random_number(100) }
+  def rand
+    random.rand(1<<32).to_s 
+  end
+
+  let(:random)       { Random.new }
+  let(:run_id)       { rand }
+  let(:version)      { rand }
+  let(:elapsed_time) { rand }
   let(:logger)       { Chef::EventLoggers::WindowsEventLogger.new }
   let(:flags)        { nil }
   let(:node)         { nil }
   let(:run_status)   { double("Run Status", {run_id: run_id, elapsed_time: elapsed_time }) }
   let(:event_log)    { EventLog.new("Application") }
   let!(:offset)      { event_log.read_last_event.record_number }
-  let(:mock_exception) { double("Exception", {message: SecureRandom.uuid, backtrace:[SecureRandom.uuid, SecureRandom.uuid]})}
+  let(:mock_exception) { double("Exception", {message: rand, backtrace:[rand, rand]})}
 
   it "is available" do
     expect(Chef::EventLoggers::WindowsEventLogger.available?).to be_truthy


### PR DESCRIPTION
Using SecureRandom is slow if it is not initialized.
Random is good enough for this test.