### PR TITLE
Fix osx_profile coverage failure and update spec

### DIFF
--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -54,10 +54,13 @@ class Chef
           @new_resource.profile_name
         end
 
-        current_profile = all_profiles["_computerlevel"].find {
-          |item| item["ProfileIdentifier"] ==
-             @new_profile_identifier
-        }
+        if all_profiles.empty?
+          current_profile = nil
+        else
+          current_profile = all_profiles["_computerlevel"].find do |item|
+            item["ProfileIdentifier"] == @new_profile_identifier
+          end
+        end
         @current_resource.profile(current_profile)
 
       end

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -106,7 +106,7 @@ describe Chef::Provider::OsxProfile do
         }
       end
       let(:no_profiles) do
-        { "_computerlevel"=> [] }
+        { }
       end
 
     before(:each) do


### PR DESCRIPTION
Bad test lead to a provider coverage failure for brand new machines with no profiles installed. This fixes the test and ensures profiles will actually install on machines that currently have no profiles.

@jaymzh must do the merge as he is our designated CLA person. Thanks Phil!