### PR TITLE
auto-fixing some easy cops

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -78,7 +78,7 @@ module ChefConfig
 
     default :formatters, []
 
-    def self.is_valid_url? uri
+    def self.is_valid_url?(uri)
       url = uri.to_s.strip
       /^http:\/\// =~ url || /^https:\/\// =~ url || /^chefzero:/ =~ url
     end

--- a/lib/chef/chef_fs/file_pattern.rb
+++ b/lib/chef/chef_fs/file_pattern.rb
@@ -258,7 +258,7 @@ class Chef
         has_double_star = false
         pattern.split(pattern_special_characters).each_with_index do |part, index|
           # Odd indexes from the split are symbols.  Even are normal bits.
-          if index % 2 == 0
+          if index.even?
             exact << part if !exact.nil?
             regexp << part
           else

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -205,7 +205,7 @@ class Chef
     class ImmutableAttributeModification < NoMethodError
       def initialize
         super "Node attributes are read-only when you do not specify which precedence level to set. " +
-          %Q{To set an attribute use code like `node.default["key"] = "value"'}
+          %q{To set an attribute use code like `node.default["key"] = "value"'}
       end
     end
 

--- a/lib/chef/formatters/error_inspectors/cookbook_resolve_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/cookbook_resolve_error_inspector.rb
@@ -37,10 +37,10 @@ class Chef
           case exception
           when Net::HTTPServerException, Net::HTTPFatalError
             humanize_http_exception(error_description)
-          when *NETWORK_ERROR_CLASSES
-            describe_network_errors(error_description)
           when EOFError
             describe_eof_error(error_description)
+          when *NETWORK_ERROR_CLASSES
+            describe_network_errors(error_description)
           else
             error_description.section("Unexpected Error:","#{exception.class.name}: #{exception.message}")
           end

--- a/lib/chef/formatters/error_inspectors/cookbook_sync_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/cookbook_sync_error_inspector.rb
@@ -41,12 +41,12 @@ class Chef
 
         def add_explanation(error_description)
           case exception
-          when *NETWORK_ERROR_CLASSES
-            describe_network_errors(error_description)
           when Net::HTTPServerException, Net::HTTPFatalError
             humanize_http_exception(error_description)
           when EOFError
             describe_eof_error(error_description)
+          when *NETWORK_ERROR_CLASSES
+            describe_network_errors(error_description)
           else
             error_description.section("Unexpected Error:","#{exception.class.name}: #{exception.message}")
           end

--- a/lib/chef/formatters/error_inspectors/node_load_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/node_load_error_inspector.rb
@@ -43,8 +43,6 @@ class Chef
           case exception
           when Net::HTTPServerException, Net::HTTPFatalError
             humanize_http_exception(error_description)
-          when *NETWORK_ERROR_CLASSES
-            describe_network_errors(error_description)
           when Chef::Exceptions::PrivateKeyMissing
             error_description.section("Private Key Not Found:",<<-E)
 Your private key could not be loaded. If the key file exists, ensure that it is
@@ -55,6 +53,8 @@ client_key        "#{api_key}"
 E
           when EOFError
             describe_eof_error(error_description)
+          when *NETWORK_ERROR_CLASSES
+            describe_network_errors(error_description)
           else
             error_description.section("Unexpected Error:","#{exception.class.name}: #{exception.message}")
           end

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -101,7 +101,7 @@ class Chef
             fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
-            hours, minutes, _ = time_difference_in_hms(node["ohai_time"])
+            hours, minutes, = time_difference_in_hms(node["ohai_time"])
             hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
             minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"
             run_list = "#{node['run_list']}" if config[:run_list]

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -165,7 +165,7 @@ class Chef
           if @action_nodes.length == 0
             ui.fatal("No nodes returned from search!")
           else
-            ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes":"node"} found, " +
+            ui.fatal("#{@action_nodes.length} #{@action_nodes.length > 1 ? "nodes": "node"} found, " +
                      "but does not have the required attribute to establish the connection. " +
                      "Try setting another attribute to open the connection using --attribute.")
           end

--- a/lib/chef/provider/batch.rb
+++ b/lib/chef/provider/batch.rb
@@ -24,7 +24,7 @@ class Chef
 
       provides :batch, os: "windows"
 
-      def initialize (new_resource, run_context)
+      def initialize(new_resource, run_context)
         super(new_resource, run_context, ".bat")
       end
 

--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -25,7 +25,7 @@ class Chef
 
       provides :powershell_script, os: "windows"
 
-      def initialize (new_resource, run_context)
+      def initialize(new_resource, run_context)
         super(new_resource, run_context, ".ps1")
         add_exit_status_wrapper
       end

--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -180,7 +180,7 @@ class Chef
             lock_user
             Chef::Log.info("#{@new_resource} locked")
           end
-         else
+        else
           Chef::Log.debug("#{@new_resource} already locked - nothing to do")
         end
       end

--- a/lib/chef/run_list/run_list_item.rb
+++ b/lib/chef/run_list/run_list_item.rb
@@ -69,7 +69,7 @@ class Chef
       end
 
       def to_s
-        "#{@type}[#{@name}#{@version ? "@#{@version}" :""}]"
+        "#{@type}[#{@name}#{@version ? "@#{@version}" : ""}]"
       end
 
       def role?

--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -39,7 +39,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only, :not_supported_o
   let(:run_status)   { double("Run Status", {run_id: run_id, elapsed_time: elapsed_time }) }
   let(:event_log)    { EventLog.new("Application") }
   let!(:offset)      { event_log.read_last_event.record_number }
-  let(:mock_exception) { double("Exception", {message: rand, backtrace:[rand, rand]})}
+  let(:mock_exception) { double("Exception", {message: rand, backtrace: [rand, rand]})}
 
   it "is available" do
     expect(Chef::EventLoggers::WindowsEventLogger.available?).to be_truthy

--- a/spec/functional/resource/directory_spec.rb
+++ b/spec/functional/resource/directory_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Resource::Directory do
   end
 
   let(:resource) do
-  	create_resource
+    create_resource
   end
 
   it_behaves_like "a directory resource"

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -191,7 +191,7 @@ describe Chef::Application::Knife do
     end
 
     it "should load the environment from the CLI options" do
-      with_argv(*%W{noop knife command -E development}) do
+      with_argv(*%w{noop knife command -E development}) do
         expect(@knife).to receive(:exit).with(0)
         @knife.run
       end

--- a/spec/unit/formatters/error_inspectors/cookbook_resolve_error_inspector_spec.rb
+++ b/spec/unit/formatters/error_inspectors/cookbook_resolve_error_inspector_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Formatters::ErrorInspectors::CookbookResolveErrorInspector do
   describe "when explaining a 403 error" do
     before do
 
-      @response_body = %Q({"error": [{"message": "gtfo"}])
+      @response_body = %q({"error": [{"message": "gtfo"}])
       @response = Net::HTTPForbidden.new("1.1", "403", "(response) forbidden")
       allow(@response).to receive(:body).and_return(@response_body)
       @exception = Net::HTTPServerException.new("(exception) forbidden", @response)

--- a/spec/unit/key_spec.rb
+++ b/spec/unit/key_spec.rb
@@ -231,7 +231,7 @@ EOS
 
       it "should include the expiration_date field when present" do
         new_key.expiration_date "2020-12-24T21:00:00Z"
-        expect(new_key.to_json).to include(%Q{"expiration_date":"2020-12-24T21:00:00Z"})
+        expect(new_key.to_json).to include(%q{"expiration_date":"2020-12-24T21:00:00Z"})
       end
 
       it "should not include the expiration_date if not present" do

--- a/spec/unit/provider/service/debian_service_spec.rb
+++ b/spec/unit/provider/service/debian_service_spec.rb
@@ -276,7 +276,7 @@ insserv: dryrun, not creating .depend.boot, .depend.start, and .depend.stop
     context "when the service is enabled" do
       before do
         @current_resource.enabled(true)
-	@current_resource.priority(80)
+  @current_resource.priority(80)
       end
 
       context "and the service sets no priority" do


### PR DESCRIPTION
   3 Performance/CaseWhenSplat: Place when conditions with a splat at the end of the when branches.
   1 Style/ElseAlignment: Align else with if.
   1 Style/EvenOdd: Replace with Fixnum#even?.
   1 Style/MethodDefParentheses: Use def with parentheses when there are parameters.
   3 Style/PercentQLiterals: Do not use %Q unless interpolation is needed.  Use %q.
   3 Style/SpaceAfterColon: Space missing after colon.
   2 Style/SpaceAfterMethodName: Do not put a space between a method name and the opening parenthesis.
   2 Style/Tab: Tab detected.
   1 Style/TrailingUnderscoreVariable: Do not use trailing _s in parallel assignment.
   1 Style/UnneededCapitalW: Do not use %W unless interpolation is needed.  If not, use %w.