### PR TITLE
Lock php cookbook in kitchen tests to solvable version

### DIFF
--- a/kitchen-tests/Berksfile
+++ b/kitchen-tests/Berksfile
@@ -1,3 +1,5 @@
 source "https://supermarket.getchef.com"
 
 cookbook "webapp", :path => "cookbooks/webapp"
+
+cookbook "php", "~> 1.5.0"


### PR DESCRIPTION
Seems we're hitting a molinillo bug that prevents us from solving
dependencies correctly.

cc @jaym 