### PR TITLE
Explicitly use before_install on each entry in travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,33 +32,63 @@ matrix:
   - rvm: 2.1
     sudo: true
     bundler_args: --without server docgen maintenance
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     sudo: true
     bundler_args: --without server docgen maintenance
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: rbx
     sudo: true
     bundler_args: --without server docgen maintenance ruby_prof
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chef-zero', github: 'chef/chef-zero'\""
     script: bundle exec rake chef_zero_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'cheffish', github: 'chef/cheffish'\""
     script: bundle exec rake cheffish_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chef-provisioning', github: 'chef/chef-provisioning'\""
     script: bundle exec rake chef_provisioning_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chef-provisioning-aws', github: 'chef/chef-provisioning-aws'\""
     script: bundle exec rake chef_provisioning_aws_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chefspec'\""
     script: bundle exec rake chefspec_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'chef-sugar'\""
     script: bundle exec rake chef_sugar_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'knife-windows', github: 'chef/knife-windows'\""
     script: bundle exec rake knife_windows_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   # Requires vagrant
   # - rvm: 2.2
   #   cache:
@@ -67,19 +97,30 @@ matrix:
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'foodcritic', github: 'acrmp/foodcritic', branch: 'v5.0.0'\""
     script: bundle exec rake foodcritic_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     before_install:
     env: "GEMFILE_MOD=\"gem 'halite', github: 'poise/halite'\""
     script: bundle exec rake halite_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   - rvm: 2.2
     env: "GEMFILE_MOD=\"gem 'poise', github: 'poise/poise'\""
     script: bundle exec rake poise_spec
+    before_install:
+      - gem update --system
+      - gem install bundler
   ### START TEST KITCHEN ONLY ###
   - rvm: 2.2
     gemfile: kitchen-tests/Gemfile
     before_install:
     - echo -n $DO_KEY_CHUNK_{0..30} >> ~/.ssh/id_aws.base64
     - cat ~/.ssh/id_aws.base64 | tr -d ' ' | base64 --decode > ~/.ssh/id_aws.pem
+    - gem update --system
+    - gem install bundler
     before_script:
     - cd kitchen-tests
     script:


### PR DESCRIPTION
Something in travis seems to have change. Perhaps we were never
running our `before_install`, and just relying on the fact that
bundler was there. See https://github.com/travis-ci/travis-ci/issues/5578

Or `before_install` broke.

We can try reverting this change next week to see if the issue
is resolved.