### PR TITLE
Update MSI ManufacturerName to be a cleaner string

### DIFF
--- a/omnibus/resources/chef/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef/msi/localization-en-us.wxl.erb
@@ -3,7 +3,7 @@
   <!-- http://wix.codeplex.com/SourceControl/changeset/view/792e101c5cf7#src%2fext%2fUIExtension%2fwixlib%2fWixUI_en-us.wxl -->
   <String Id="LANG">1033</String>
   <String Id="ProductName"><%= friendly_name %></String>
-  <String Id="ManufacturerName"><%= maintainer.encode(:xml => :attr) %></String>
+  <String Id="ManufacturerName">Chef Software, Inc.</String>
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>


### PR DESCRIPTION
Our PublisherName shows up in Add/Remove Control Panel as a quoted string - this looks ugly, and is not the standard way to represent the package in the ARP.  The reason is we are doing an XML escape of the Manufacturer property in the MSI.  This PR puts a cleaner version of the string in the loc erb - sans the maintainers email address (which also doesn't belong in the PublisherName property).

@chef/client-core @chef/omnibus-maintainers @adamedx 