### PR TITLE
Add learn-chef for Windows to top-cookbooks test

### DIFF
--- a/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/libraries/top_cookbooks.rb
+++ b/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/libraries/top_cookbooks.rb
@@ -11,5 +11,10 @@ class TopCookbooks < Chef::Resource
       repository "learn-chef/learn-chef-acceptance"
       cookbook_relative_dir "cookbooks/learn-the-basics-ubuntu"
     end
+
+    cookbook_kitchen "#{command} learn-the-basics-windows" do
+      repository "learn-chef/learn-chef-acceptance"
+      cookbook_relative_dir "cookbooks/learn-the-basics-windows"
+    end
   end
 end

--- a/acceptance/top-cookbooks/.kitchen.learn-the-basics-windows.yml
+++ b/acceptance/top-cookbooks/.kitchen.learn-the-basics-windows.yml
@@ -1,0 +1,4 @@
+suites:
+  - name: learn-the-basics-windows-default
+    run_list: ["recipe[learn-the-basics-windows::default]"]
+    includes: [windows-2012r2]


### PR DESCRIPTION
Add a Windows learn-chef test to the top cookbooks.

@chef/client-core @sersut @jkeiser @tyler-ball 