### PR TITLE
Create special tempdir and destroy it on each ci run

### DIFF
--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -13,13 +13,8 @@ ECHO.
 
 REM ; Set the temporary directory to a custom location, and wipe it before
 REM ; and after the tests run.
-IF %TEMP% (
-  SET TEMP=%TEMP%\cheftest
-  SET TMP=%TMP%\cheftest
-) ELSE (
-  SET TEMP=%TEMP%\cheftest
-  SET TMP=%TMP%\cheftest
-)
+SET TEMP=%TEMP%\cheftest
+SET TMP=%TMP%\cheftest
 RMDIR /S /Q %TEMP%
 MKDIR %TEMP%
 

--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -11,6 +11,18 @@ SET EMBEDDED_BIN_DIR=C:\opscode\%PROJECT_NAME%\embedded\bin
 
 ECHO.
 
+REM ; Set the temporary directory to a custom location, and wipe it before
+REM ; and after the tests run.
+IF %TEMP% (
+  SET TEMP=%TEMP%\cheftest
+  SET TMP=%TMP%\cheftest
+) ELSE (
+  SET TEMP=%TEMP%\cheftest
+  SET TMP=%TMP%\cheftest
+)
+RMDIR /S /Q %TEMP%
+MKDIR %TEMP%
+
 FOR %%b IN (
   chef-client
   knife
@@ -51,3 +63,7 @@ IF "%PIPELINE_NAME%" == "chef-fips" (
 	set CHEF_FIPS=1
 )
 call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/unit spec/functional
+
+REM ; Destroy everything at the end for good measure.
+RMDIR /S /Q %TEMP%
+MKDIR %TEMP%

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Set up a custom tmpdir, and clean it up before and after the tests
+TMPDIR="${TMPDIR:-/tmp}/cheftest"
+export TMPDIR
+rm -rf $TMPDIR
+mkdir -p $TMPDIR
+
 # $PROJECT_NAME is set by Jenkins, this allows us to use the same script to verify
 # Chef and Angry Chef
 PATH=/opt/$PROJECT_NAME/bin:$PATH
@@ -107,3 +113,6 @@ else
   fi
   sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit
 fi
+
+# Clean up the tmpdir at the end for good measure.
+rm -rf $TMPDIR

--- a/spec/functional/resource/aixinit_service_spec.rb
+++ b/spec/functional/resource/aixinit_service_spec.rb
@@ -29,11 +29,11 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
   # Platform specific validation routines.
   def service_should_be_started(file_name)
     # The existence of this file indicates that the service was started.
-    expect(File.exists?("/tmp/#{file_name}")).to be_truthy
+    expect(File.exists?("#{Dir.tmpdir}/#{file_name}")).to be_truthy
   end
 
   def service_should_be_stopped(file_name)
-    expect(File.exists?("/tmp/#{file_name}")).to be_falsey
+    expect(File.exists?("#{Dir.tmpdir}/#{file_name}")).to be_falsey
   end
 
   def valide_symlinks(expected_output, run_level = nil, status = nil, priority = nil)
@@ -51,7 +51,7 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
   end
 
   def delete_test_files
-    files = Dir.glob("/tmp/chefinit[a-z_]*.txt")
+    files = Dir.glob("#{Dir.tmpdir}/chefinit[a-z_]*.txt")
     File.delete(*files)
   end
 

--- a/spec/functional/resource/bff_spec.rb
+++ b/spec/functional/resource/bff_spec.rb
@@ -41,7 +41,7 @@ describe Chef::Resource::BffPackage, :requires_root, :external => ohai[:platform
 
   before(:all) do
     @pkg_name = "PkgA.rte"
-    @pkg_path = "/tmp/PkgA.1.0.0.0.bff"
+    @pkg_path = "#{Dir.tmpdir}/PkgA.1.0.0.0.bff"
     FileUtils.cp "spec/functional/assets/PkgA.1.0.0.0.bff" , @pkg_path
   end
 
@@ -69,14 +69,14 @@ describe Chef::Resource::BffPackage, :requires_root, :external => ohai[:platform
 
     after(:each) do
       shell_out("installp -u #{@pkg_name}")
-      FileUtils.rm "/tmp/installp.log"
+      FileUtils.rm "#{Dir.tmpdir}/installp.log"
     end
   end
 
   context "package upgrade action" do
     before(:each) do
       shell_out("installp -aYF -d #{@pkg_path} #{@pkg_name}")
-      @pkg_path = "/tmp/PkgA.2.0.0.0.bff"
+      @pkg_path = "#{Dir.tmpdir}/PkgA.2.0.0.0.bff"
       FileUtils.cp "spec/functional/assets/PkgA.2.0.0.0.bff" , @pkg_path
     end
 
@@ -114,7 +114,7 @@ describe Chef::Resource::BffPackage, :requires_root, :external => ohai[:platform
     end
 
     after(:each) do
-      FileUtils.rm "/tmp/installp.log"
+      FileUtils.rm "#{Dir.tmpdir}/installp.log"
     end
   end
 end

--- a/spec/functional/resource/rpm_spec.rb
+++ b/spec/functional/resource/rpm_spec.rb
@@ -60,12 +60,12 @@ describe Chef::Resource::RpmPackage, :requires_root, :external => exclude_test d
     when "aix"
       @pkg_name = "dummy"
       @pkg_version = "1-0"
-      @pkg_path = "/tmp/dummy-1-0.aix6.1.noarch.rpm"
+      @pkg_path = "#{Dir.tmpdir}/dummy-1-0.aix6.1.noarch.rpm"
       FileUtils.cp(File.join(CHEF_SPEC_ASSETS, "dummy-1-0.aix6.1.noarch.rpm") , @pkg_path)
     when "centos", "redhat", "suse"
       @pkg_name = "mytest"
       @pkg_version = "1.0-1"
-      @pkg_path = "/tmp/mytest-1.0-1.noarch.rpm"
+      @pkg_path = "#{Dir.tmpdir}/mytest-1.0-1.noarch.rpm"
       FileUtils.cp(File.join(CHEF_SPEC_ASSETS, "mytest-1.0-1.noarch.rpm") , @pkg_path)
     end
   end
@@ -101,11 +101,11 @@ describe Chef::Resource::RpmPackage, :requires_root, :external => exclude_test d
       shell_out("rpm -i #{@pkg_path}")
       if ohai[:platform] == "aix"
         @pkg_version = "2-0"
-        @pkg_path = "/tmp/dummy-2-0.aix6.1.noarch.rpm"
+        @pkg_path = "#{Dir.tmpdir}/dummy-2-0.aix6.1.noarch.rpm"
         FileUtils.cp(File.join(CHEF_SPEC_ASSETS, "dummy-2-0.aix6.1.noarch.rpm") , @pkg_path)
       else
         @pkg_version = "2.0-1"
-        @pkg_path = "/tmp/mytest-2.0-1.noarch.rpm"
+        @pkg_path = "#{Dir.tmpdir}/mytest-2.0-1.noarch.rpm"
         FileUtils.cp(File.join(CHEF_SPEC_ASSETS, "mytest-2.0-1.noarch.rpm") , @pkg_path)
       end
     end

--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -28,7 +28,7 @@ describe Chef::RunLock do
 
     let(:random_temp_root) do
       Kernel.srand(Time.now.to_i + Process.pid)
-      "/tmp/#{Kernel.rand(Time.now.to_i + Process.pid)}"
+      "#{Dir.tmpdir}/#{Kernel.rand(Time.now.to_i + Process.pid)}"
     end
 
     let(:lockfile) { "#{random_temp_root}/this/long/path/does/not/exist/chef-client-running.pid" }

--- a/spec/scripts/ssl-serve.rb
+++ b/spec/scripts/ssl-serve.rb
@@ -34,7 +34,7 @@ DEFAULT_OPTIONS = {
   :Host => "localhost",
   :environment => :none,
   :Logger => LOGGER,
-  :DocumentRoot => File.expand_path("/tmp/chef-118-sampledata")
+  :DocumentRoot => File.expand_path("#{Dir.tmpdir}/chef-118-sampledata")
   #:AccessLog => [] # Remove this option to enable the access log when debugging.
 }
 


### PR DESCRIPTION
Fixes the "disk space filling up" issue on chef testers.