### PR TITLE
Disable unit tests in later stages of CD pipeline

### DIFF
--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -57,7 +57,7 @@ IF NOT EXIST "Gemfile.lock" (
 IF "%PIPELINE_NAME%" == "chef-fips" (
 	set CHEF_FIPS=1
 )
-call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/unit spec/functional
+call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional
 
 REM ; Destroy everything at the end for good measure.
 RMDIR /S /Q %TEMP%

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -111,7 +111,7 @@ else
       CHEF_FIPS=1
       export CHEF_FIPS
   fi
-  sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional spec/unit
+  sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional
 fi
 
 # Clean up the tmpdir at the end for good measure.


### PR DESCRIPTION
Travis/Appveyor already run the unit tests at the appropriate gate earlier in the build process. Running the tests on each platform we build a package for should give the same result and really just serves to slow the overall delivery process down.

This is per a meeting we had earlier to improve build speeds.

/cc @chef/engineering-services @chef/ship-it @chef/workflow @chef/ecosystem-team 