### PR TITLE
remove Chef::Mixin::Command use

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -30,7 +30,6 @@ class Chef
         require "readline"
         require "chef/exceptions"
         require "chef/search/query"
-        require "chef/mixin/command"
         require "chef/util/path_helper"
         require "mixlib/shellout"
       end
@@ -530,8 +529,6 @@ class Chef
       end
 
       def run
-        extend Chef::Mixin::Command
-
         @longest = 0
 
         configure_user


### PR DESCRIPTION
we don't use run_command anywhere and this can apparently cause uninitialized
constant issues when knife ssh is invoked via other knife commands (i.e.
bootstrap) where apparently the transitive lazy deps aren't getting
invoked correctly.  there's another bug there, but we do not have any
run_command statements in knife anymore so we should be able to drop
this as a much easier fix.

closes #4546