### PR TITLE
Fix databag globbing issues for chef-solo on windows

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -154,7 +154,7 @@ module ChefConfig
     # This is because only forwardslashes should be used with dir (even for windows)
     def self.escape_glob_dir(*parts)
       path = Pathname.new(join(*parts)).cleanpath.to_s
-      path.gsub(/[\\\{\}\[\]\*\?]/) { |x| "\\"+x }
+      path.gsub(/[\\\{\}\[\]\*\?]/) { |x| "\\" + x }
     end
 
     def self.relative_path_from(from, to)

--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -141,12 +141,20 @@ module ChefConfig
       canonical_path(path1) == canonical_path(path2)
     end
 
+    # Note: this method is deprecated. Please use escape_glob_dirs
     # Paths which may contain glob-reserved characters need
     # to be escaped before globbing can be done.
     # http://stackoverflow.com/questions/14127343
     def self.escape_glob(*parts)
       path = cleanpath(join(*parts))
       path.gsub(/[\\\{\}\[\]\*\?]/) { |x| "\\" + x }
+    end
+
+    # This function does not switch to backslashes for windows
+    # This is because only forwardslashes should be used with dir (even for windows)
+    def self.escape_glob_dir(*parts)
+      path = Pathname.new(join(*parts)).cleanpath.to_s
+      path.gsub(/[\\\{\}\[\]\*\?]/) { |x| "\\"+x }
     end
 
     def self.relative_path_from(from, to)

--- a/chef-config/spec/unit/path_helper_spec.rb
+++ b/chef-config/spec/unit/path_helper_spec.rb
@@ -266,6 +266,23 @@ RSpec.describe ChefConfig::PathHelper do
     end
   end
 
+  describe "escape_glob_dir" do
+    it "escapes characters reserved by glob" do
+      path = "C:\\this\\*path\\[needs]\\escaping?"
+      escaped_path = "C:\\\\this\\\\\\*path\\\\\\[needs\\]\\\\escaping\\?"
+      expect(path_helper.escape_glob_dir(path)).to eq(escaped_path)
+    end
+
+    context "when given more than one argument" do
+      it "joins, cleanpaths, and escapes characters reserved by glob" do
+        args = ["this/*path", "[needs]", "escaping?"]
+        escaped_path = "this/\\*path/\\[needs\\]/escaping\\?"
+        expect(path_helper).to receive(:join).with(*args).and_call_original
+        expect(path_helper.escape_glob_dir(*args)).to eq(escaped_path)
+      end
+    end
+  end  
+
   describe "all_homes" do
     before do
       stub_const("ENV", env)

--- a/chef-config/spec/unit/path_helper_spec.rb
+++ b/chef-config/spec/unit/path_helper_spec.rb
@@ -267,9 +267,9 @@ RSpec.describe ChefConfig::PathHelper do
   end
 
   describe "escape_glob_dir" do
-    it "escapes characters reserved by glob" do
-      path = "C:\\this\\*path\\[needs]\\escaping?"
-      escaped_path = "C:\\\\this\\\\\\*path\\\\\\[needs\\]\\\\escaping\\?"
+    it "escapes characters reserved by glob without using backslashes for path separators" do
+      path = "C:/this/*path/[needs]/escaping?"
+      escaped_path = "C:/this/\\*path/\\[needs\\]/escaping\\?"
       expect(path_helper.escape_glob_dir(path)).to eq(escaped_path)
     end
 
@@ -281,7 +281,7 @@ RSpec.describe ChefConfig::PathHelper do
         expect(path_helper.escape_glob_dir(*args)).to eq(escaped_path)
       end
     end
-  end  
+  end
 
   describe "all_homes" do
     before do

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -98,8 +98,9 @@ class Chef
           unless File.directory?(path)
             raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' is invalid"
           end
-            
-          names += Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path), "*")).map{|f|File.basename(f)}.sort
+
+          names += Dir.glob(File.join(
+            Chef::Util::PathHelper.escape_glob_dir(path), "*")).map { |f| File.basename(f) }.sort
         end
         names.inject({}) { |h, n| h[n] = n; h }
       else

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -98,8 +98,8 @@ class Chef
           unless File.directory?(path)
             raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' is invalid"
           end
-
-          names += Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(path), "*")).map { |f| File.basename(f) }.sort
+            
+          names += Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path), "*")).map{|f|File.basename(f)}.sort
         end
         names.inject({}) { |h, n| h[n] = n; h }
       else
@@ -125,7 +125,7 @@ class Chef
             raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' is invalid"
           end
 
-          Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(path, name.to_s), "*.json")).inject({}) do |bag, f|
+          Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path, name.to_s), "*.json")).inject({}) do |bag, f|
             item = Chef::JSONCompat.parse(IO.read(f))
 
             # Check if we have multiple items with similar names (ids) and raise if their content differs


### PR DESCRIPTION
Backslashes should not be passed to Dir, as it does not work
when globbing in many cases.

Created new function that can be used with dir on windows.
`escape_glob_dir` should be used when the result is going
to be passed into Dir.

Fixes #4194
Replaces #4195