### PR TITLE
do not include source parameter when removing a chocolatey package and ensure source is used on all functional tests

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -126,7 +126,7 @@ EOS
         # @param names [Array<String>] array of package names to install
         # @param versions [Array<String>] array of versions to install
         def remove_package(names, versions)
-          choco_command("uninstall -y", cmd_args, *names)
+          choco_command("uninstall -y", cmd_args(include_source: false), *names)
         end
 
         # Support :uninstall as an action in order for users to easily convert
@@ -206,10 +206,11 @@ EOS
 
         # Helper to construct optional args out of new_resource
         #
+        # @param include_source [Boolean] should the source parameter be added
         # @return [String] options from new_resource or empty string
-        def cmd_args
+        def cmd_args(include_source: true)
           cmd_args = [ new_resource.options ]
-          cmd_args.push( "-source #{new_resource.source}" ) if new_resource.source
+          cmd_args.push( "-source #{new_resource.source}" ) if new_resource.source && include_source
           args_to_string(*cmd_args)
         end
 

--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -35,12 +35,12 @@ describe Chef::Resource::ChocolateyPackage, :windows_only do
   subject do
     new_resource = Chef::Resource::ChocolateyPackage.new("test choco package", run_context)
     new_resource.package_name package_name
-    new_resource.source package_source if package_source
+    new_resource.source package_source
     new_resource
   end
 
   context "installing a package" do
-    after { Chef::Resource::ChocolateyPackage.new(package_name, run_context).run_action(:remove) }
+    after { remove_package }
 
     it "installs the latest version" do
       subject.run_action(:install)
@@ -90,7 +90,7 @@ describe Chef::Resource::ChocolateyPackage, :windows_only do
   end
 
   context "upgrading a package" do
-    after { Chef::Resource::ChocolateyPackage.new(package_name, run_context).run_action(:remove) }
+    after { remove_package }
 
     it "upgrades to a specific version" do
       subject.version "1.0"
@@ -117,8 +117,14 @@ describe Chef::Resource::ChocolateyPackage, :windows_only do
   context "removing a package" do
     it "removes an installed package" do
       subject.run_action(:install)
-      Chef::Resource::ChocolateyPackage.new(package_name, run_context).run_action(:remove)
+      remove_package
       expect(package_list.call).to eq("")
     end
+  end
+
+  def remove_package
+    pkg_to_remove = Chef::Resource::ChocolateyPackage.new(package_name, run_context)
+    pkg_to_remove.source = package_source
+    pkg_to_remove.run_action(:remove)
   end
 end


### PR DESCRIPTION
This covers 2 problems:

* Ensures we specify the internal source repo location on chocolatey functional tests
* Remove the `--source` parameter when calling `choco uninstall` since that is illegal. Note that the resource `:remove` action still needs the source for the idempotence check

I ran the tests with a wireshark trace running to ensure nothing was leaking to the public choco repo with the exception of the initial choco.exe install