### PR TITLE
Fix policyfile_zero provisioner in 12.7

### DIFF
--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -497,7 +497,7 @@ class Chef
       def compat_mode_manifest_for(cookbook_name, lock_data)
         xyz_version = lock_data["dotted_decimal_identifier"]
         rel_url = "cookbooks/#{cookbook_name}/#{xyz_version}"
-        http_api.get(rel_url)
+        inflate_cbv_object(http_api.get(rel_url))
       rescue Exception => e
         message = "Error loading cookbook #{cookbook_name} at version #{xyz_version} from #{rel_url}: #{e.class} - #{e.message}"
         err = Chef::Exceptions::CookbookNotFound.new(message)

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -686,14 +686,18 @@ describe Chef::PolicyBuilder::Policyfile do
 
             before do
               expect(http_api).to receive(:get).with(cookbook1_url).
-                and_return(example1_cookbook_object)
+                and_return(example1_cookbook_data)
               expect(http_api).to receive(:get).with(cookbook2_url).
+                and_return(example2_cookbook_data)
+
+              expect(Chef::CookbookVersion).to receive(:from_cb_artifact_data).with(example1_cookbook_data).
+                and_return(example1_cookbook_object)
+              expect(Chef::CookbookVersion).to receive(:from_cb_artifact_data).with(example2_cookbook_data).
                 and_return(example2_cookbook_object)
             end
 
             include_examples "fetching cookbooks when they exist"
           end
-
         end
 
         context "when using native API mode (policy_document_native_api == true)" do


### PR DESCRIPTION
The change from `Chef::REST` to `Chef::ServerAPI` ([here](https://github.com/chef/chef/commit/d99e306a41b1402209d320cb7119b12a3bbb962f)) seems to have broken the `policyfile_zero` test-kitchen provisioner (I'm not sure where else the Policyfile `compat_mode_manifest_for` method is used).

You can see the different here:

```
[3] pry(#<Chef::PolicyBuilder::Policyfile>)> rest_api = Chef::REST.new(config[:chef_server_url])
[4] pry(#<Chef::PolicyBuilder::Policyfile>)> rest_api.get("cookbooks/#{name}/#{lock_data['dotted_decimal_identifier']}")
[2016-02-12T07:45:10+00:00] WARN: Auto inflation of JSON data is deprecated. Please use Chef::CookbookVersion#from_hash at (pry):4:in `block in cookbooks_to_sync'
=> #<Chef::CookbookVersion:0x000000048fedd8
 @attribute_filenames=[],
 @attribute_filenames_by_short_filename={},
 @chef_server_rest=nil,
 @cookbook_manifest=
.....
```

Against

```
[6] pry(#<Chef::PolicyBuilder::Policyfile>)> server_api = Chef::ServerAPI.new(config[:chef_server_url])
[6] pry(#<Chef::PolicyBuilder::Policyfile>)> server_api.get("cookbooks/#{name}/#{lock_data['dotted_decimal_identifier']}")
=> {"recipes"=>
  [{"name"=>"default.rb",
    "path"=>"recipes/default.rb",
    "checksum"=>"228d3fc5cf401718903f2b00e045cb8e",
    "specificity"=>"default",
    "url"=>
....
```

Without the fix when you use the policyfile_zero provisioner with test-kitchen, you receive an error on converge: `NoMethodError: undefined method 'name' for #<Hash:0x0000000452b828>`