### PR TITLE
Remove final cleanup from ci verify scripts

### DIFF
--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -58,7 +58,3 @@ IF "%PIPELINE_NAME%" == "chef-fips" (
 	set CHEF_FIPS=1
 )
 call bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional
-
-REM ; Destroy everything at the end for good measure.
-RMDIR /S /Q %TEMP%
-MKDIR %TEMP%

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -113,6 +113,3 @@ else
   fi
   sudo env PATH=$PATH TERM=xterm CHEF_FIPS=$CHEF_FIPS bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional
 fi
-
-# Clean up the tmpdir at the end for good measure.
-rm -rf $TMPDIR


### PR DESCRIPTION
@chef/ship-it 
The "good measure" cleanup logic overrides the script exit status.  Since we do a cleanup at the start of the script this should meet our immediate needs.