### PR TITLE
Add client keys handling to ChefFS

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -150,8 +150,12 @@ module ChefConfig
     default(:acl_path) { derive_path_from_chef_repo_path("acls") }
 
     # Location of clients on disk. String or array of strings.
-    # Defaults to <chef_repo_path>/acls.
+    # Defaults to <chef_repo_path>/clients.
     default(:client_path) { derive_path_from_chef_repo_path("clients") }
+
+    # Location of client keys on disk. String or array of strings.
+    # Defaults to <chef_repo_path>/client_keys.
+    default(:client_key_path) { derive_path_from_chef_repo_path("client_keys") }
 
     # Location of containers on disk. String or array of strings.
     # Defaults to <chef_repo_path>/containers.

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -31,6 +31,7 @@ class Chef
       # out here:
       INFLECTIONS = {
         "acls" => "acl",
+        "client_keys" => "client_key",
         "clients" => "client",
         "cookbooks" => "cookbook",
         "cookbook_artifacts" => "cookbook_artifact",
@@ -68,7 +69,7 @@ class Chef
       CHEF_11_OSS_STATIC_OBJECTS = %w{cookbooks cookbook_artifacts data_bags environments roles}.freeze
       CHEF_11_OSS_DYNAMIC_OBJECTS = %w{clients nodes users}.freeze
       RBAC_OBJECT_NAMES = %w{acls containers groups }.freeze
-      CHEF_12_OBJECTS = %w{ cookbook_artifacts policies policy_groups }.freeze
+      CHEF_12_OBJECTS = %w{ cookbook_artifacts policies policy_groups client_keys }.freeze
 
       STATIC_MODE_OBJECT_NAMES = CHEF_11_OSS_STATIC_OBJECTS
       EVERYTHING_MODE_OBJECT_NAMES = (CHEF_11_OSS_STATIC_OBJECTS + CHEF_11_OSS_DYNAMIC_OBJECTS).freeze

--- a/lib/chef/chef_fs/data_handler/client_key_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/client_key_data_handler.rb
@@ -1,0 +1,11 @@
+require "chef/chef_fs/data_handler/data_handler_base"
+require "chef/api_client"
+
+class Chef
+  module ChefFS
+    module DataHandler
+      class ClientKeyDataHandler < DataHandlerBase
+      end
+    end
+  end
+end

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_client_keys_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_client_keys_dir.rb
@@ -1,0 +1,38 @@
+#
+# Author:: Jordan Running (<jr@chef.io>)
+# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/chef_fs/file_system/repository/chef_repository_file_system_entry"
+require "chef/chef_fs/data_handler/client_key_data_handler"
+
+class Chef
+  module ChefFS
+    module FileSystem
+      module Repository
+        class ChefRepositoryFileSystemClientKeysDir < ChefRepositoryFileSystemEntry
+          def initialize(name, parent, path = nil)
+            super(name, parent, path, Chef::ChefFS::DataHandler::ClientKeyDataHandler.new)
+          end
+
+          def can_have_child?(name, is_dir)
+            is_dir && !name.start_with?(".")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -21,11 +21,13 @@ require "chef/chef_fs/file_system/repository/chef_repository_file_system_acls_di
 require "chef/chef_fs/file_system/repository/cookbooks_dir"
 require "chef/chef_fs/file_system/repository/cookbook_artifacts_dir"
 require "chef/chef_fs/file_system/repository/data_bags_dir"
+require "chef/chef_fs/file_system/repository/chef_repository_file_system_client_keys_dir"
 require "chef/chef_fs/file_system/repository/chef_repository_file_system_entry"
 require "chef/chef_fs/file_system/repository/chef_repository_file_system_policies_dir"
 require "chef/chef_fs/file_system/repository/versioned_cookbooks_dir"
 require "chef/chef_fs/file_system/multiplexed_dir"
 require "chef/chef_fs/data_handler/client_data_handler"
+require "chef/chef_fs/data_handler/client_key_data_handler"
 require "chef/chef_fs/data_handler/environment_data_handler"
 require "chef/chef_fs/data_handler/node_data_handler"
 require "chef/chef_fs/data_handler/policy_data_handler"
@@ -178,6 +180,8 @@ class Chef
               dirs = paths.map { |path| DataBagsDir.new(name, self, path) }
             when "acls"
               dirs = paths.map { |path| ChefRepositoryFileSystemAclsDir.new(name, self, path) }
+            when "client_keys"
+              dirs = paths.map { |path| ChefRepositoryFileSystemClientKeysDir.new(name, self, path) }
             else
               data_handler = case name
                              when "clients"


### PR DESCRIPTION
Supports work to bring chef-zero closer to parity with chef-server. See chef/chef-zero#199.