### PR TITLE
zypper multipackage performance fix

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -54,7 +54,7 @@ class Chef
         end
 
         def versions
-          @versions =
+          @versions ||=
             begin
               raw_versions = package_name_array.map do |package_name|
                 get_versions(package_name)


### PR DESCRIPTION
obvious fix to remember the results so we don't re-compute every single time on access