### PR TITLE
skip uid check for aix in user add functional tests

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -281,24 +281,17 @@ describe Chef::Provider::User::Useradd, metadata do
         end
       end
 
-      context "when a system user is specified" do
+      context "when a system user is specified", skip: aix? do
         let(:system) { true }
         let(:uid_min) do
-          case ohai[:platform]
-          when "aix"
-            # UIDs and GIDs below 200 are typically reserved for system accounts and services
-            # https://abcofaix.wordpress.com/tag/usermod/
-            200
-          else
-            # from `man useradd`, login user means uid will be between
-            # UID_SYS_MIN and UID_SYS_MAX defined in /etc/login.defs. On my
-            # Ubuntu 13.04 system, these are commented out, so we'll look at
-            # UID_MIN to find the lower limit of the non-system-user range, and
-            # use that value in our assertions.
-            login_defs = File.open("/etc/login.defs", "rb") { |f| f.read }
-            uid_min_scan = /^UID_MIN\s+(\d+)/
-            login_defs.match(uid_min_scan)[1]
-          end
+          # from `man useradd`, login user means uid will be between
+          # UID_SYS_MIN and UID_SYS_MAX defined in /etc/login.defs. On my
+          # Ubuntu 13.04 system, these are commented out, so we'll look at
+          # UID_MIN to find the lower limit of the non-system-user range, and
+          # use that value in our assertions.
+          login_defs = File.open("/etc/login.defs", "rb") { |f| f.read }
+          uid_min_scan = /^UID_MIN\s+(\d+)/
+          login_defs.match(uid_min_scan)[1]
         end
 
         it "ensures the user has the properties of a system user" do


### PR DESCRIPTION
Bug in AIX auto increments UIDs. So after 200 builds, this test fails.