### PR TITLE
Add insights_url to Chef::Config

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -386,6 +386,23 @@ module ChefConfig
     default :ez, false
     default :enable_reporting, true
     default :enable_reporting_url_fatals, false
+
+    ###
+    # Insights
+    #
+    # Insights is a product that integrates analytics, metrics, and data for Chef,
+    # Delivery Workflow, and more.
+    #
+    configurable(:insights_url).writes_value do |uri|
+      unless is_valid_url? uri
+        raise ConfigurationError, "#{uri} is an invalid insights_url."
+      end
+      uri.to_s.strip
+    end
+
+    # Sending data to Insights is disabled when the URL is unconfigured
+    default(:insights_enabled) { !self.configuration[:insights_url].nil? }
+
     # Possible values for :audit_mode
     # :enabled, :disabled, :audit_only,
     #

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -802,6 +802,29 @@ RSpec.describe ChefConfig::Config do
 
   end
 
+  describe "insights integration" do
+
+    it "marks insights disabled by default" do
+      expect(ChefConfig::Config.insights_url).to be_nil
+      expect(ChefConfig::Config.insights_enabled).to eq(false)
+    end
+
+    it "errors on invalid insights_url" do
+      expect { ChefConfig::Config.insights_url = "127.0.0.1" }.to raise_error(ChefConfig::ConfigurationError)
+    end
+
+    context "when insights_url is set with valid url" do
+      before do
+        ChefConfig::Config.insights_url = "https://insights.example.com"
+      end
+
+      it "marks insights as enabled" do
+        expect(ChefConfig::Config.insights_url).to eq("https://insights.example.com")
+        expect(ChefConfig::Config.insights_enabled).to eq(true)
+      end
+    end
+  end
+
   describe "Treating deprecation warnings as errors" do
 
     context "when using our default RSpec configuration" do


### PR DESCRIPTION
This adds a new `insights_url` value to `Chef::Config`. This value will be used in the future to determine where audit/reporting data for insights will be sent. By default, the value is `nil`, which will disable any interaction with future Insights code. 

cc/ @chef/client-core 