### PR TITLE
Need to run apt update on EC2 ubuntu images for acceptance tests

### DIFF
--- a/acceptance/top-cookbooks/.kitchen.git.yml
+++ b/acceptance/top-cookbooks/.kitchen.git.yml
@@ -1,6 +1,7 @@
 suites:
   - name: git-default
-    run_list: ["recipe[git]"]
+    # Ubuntu images need to run apt update
+    run_list: ["recipe[apt]","recipe[git]"]
     includes: [ubuntu-14.04]
   - name: git-source
     run_list: ["recipe[git::source]"]


### PR DESCRIPTION
\cc @mwrock @chef/client-maintainers 

We need to run apt becuase thats what the [cookbook also does](https://github.com/chef-cookbooks/git/blob/master/.kitchen.yml#L18-L21)