### PR TITLE
fallback to netmsg.dll error table if error message is not found in system errors

### DIFF
--- a/lib/chef/win32/api/error.rb
+++ b/lib/chef/win32/api/error.rb
@@ -874,6 +874,20 @@ class Chef
         SEM_NOGPFAULTERRORBOX      = 0x0002
         SEM_NOOPENFILEERRORBOX     = 0x8000
 
+        # Flags for LoadLibraryEx
+
+        DONT_RESOLVE_DLL_REFERENCES = 0x00000001
+        LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010
+        LOAD_LIBRARY_AS_DATAFILE = 0x00000002
+        LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040
+        LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020
+        LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200
+        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000
+        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100
+        LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
+        LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400
+        LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+
         ###############################################
         # Win32 API Bindings
         ###############################################
@@ -891,8 +905,8 @@ DWORD WINAPI FormatMessage(
   __in_opt  va_list *Arguments
 );
 =end
-        safe_attach_function :FormatMessageA, [:DWORD, :LPCVOID, :DWORD, :DWORD, :LPTSTR, :DWORD, :varargs], :DWORD
-        safe_attach_function :FormatMessageW, [:DWORD, :LPCVOID, :DWORD, :DWORD, :LPWSTR, :DWORD, :varargs], :DWORD
+        safe_attach_function :FormatMessageA, [:DWORD, :HANDLE, :DWORD, :DWORD, :LPTSTR, :DWORD, :varargs], :DWORD
+        safe_attach_function :FormatMessageW, [:DWORD, :HANDLE, :DWORD, :DWORD, :LPWSTR, :DWORD, :varargs], :DWORD
 
 =begin
 DWORD WINAPI GetLastError(void);
@@ -916,6 +930,23 @@ UINT WINAPI SetErrorMode(
 =end
         safe_attach_function :SetErrorMode, [:UINT], :UINT
 
+=begin
+https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx
+HMODULE WINAPI LoadLibraryEx(
+  _In_       LPCTSTR lpFileName,
+  _Reserved_ HANDLE  hFile,
+  _In_       DWORD   dwFlags
+);
+=end
+        safe_attach_function :LoadLibraryExW, [:LPCTSTR, :HANDLE, :DWORD], :HANDLE
+
+=begin
+https://msdn.microsoft.com/en-us/library/windows/desktop/ms683152(v=vs.85).aspx
+BOOL WINAPI FreeLibrary(
+  _In_ HMODULE hModule
+);
+=end
+        safe_attach_function :FreeLibrary, [:HANDLE], :BOOL
       end
     end
   end


### PR DESCRIPTION
This fixes the build pipeline for Windows Server 2012 (R1)

This was a very weird one and I can only reproduce errors on Azure server 2012 images and not from ISOs via MSDN. (The build numbers are slightly different). On azure, when one attempts to get a formatted error message of a [Network Management Error Code](https://msdn.microsoft.com/en-us/library/aa370674(v=vs.85).aspx), such as `2220`, the following error is raised:
```
irb(main):001:0> require 'chef'
=> true
irb(main):002:0> Chef::ReservedNames::Win32::Error.format_message(2220)
Chef::Exceptions::Win32APIError: The resource loader failed to find MUI file.
---- Begin Win32 API output ----
System Error Code: 15100
System Error Message: The resource loader failed to find MUI file.
---- End Win32 API output ----

        from C:/opscode/angrychef/embedded/lib/ruby/gems/2.0.0/gems/chef-12.6.0-universal-mingw32/lib/chef/win32/error.r
b:69:in `raise!'
        from C:/opscode/angrychef/embedded/lib/ruby/gems/2.0.0/gems/chef-12.6.0-universal-mingw32/lib/chef/win32/error.r
b:38:in `format_message'
        from (irb):2
        from C:/opscode/angrychef/embedded/bin/irb:12:in `<main>'
```
This error is windows complaining that it could not find a file containing needed localized strings. The network error messages are kept in `netmsg.dll`.

It is able to find System Errior codes just fine.

I've googled this to death and I have found one mail group where it was mentions that `FormatMessage` will fall back to netmsg.dll if no errors are found in the system list. In ProcessMonitor on a MSDN issued 2012 image, I can see netmsg being accessed but not on azure.

This fix essentially performs this fallback explicitly.