### PR TITLE
deal with 0.37.2 renamed cops

### DIFF
--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -45,7 +45,7 @@ task :register => EVT_SHARED_OBJECT do
       :source => "Application",
       :key_name => "Chef",
       :event_message_file => dll_file,
-      :category_message_file => dll_file,
+      :category_message_file => dll_file
     )
   rescue Errno::EIO => e
     puts "Skipping event log registration due to missing privileges: #{e}"

--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -53,7 +53,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        :regex => /^[\-[:alnum:]_\.]+$/,
+        :regex => /^[\-[:alnum:]_\.]+$/
       )
     end
 
@@ -65,7 +65,7 @@ class Chef
       set_or_return(
         :admin,
         arg,
-        :kind_of => [ TrueClass, FalseClass ],
+        :kind_of => [ TrueClass, FalseClass ]
       )
     end
 
@@ -77,7 +77,7 @@ class Chef
       set_or_return(
         :public_key,
         arg,
-        :kind_of => String,
+        :kind_of => String
       )
     end
 
@@ -90,7 +90,7 @@ class Chef
       set_or_return(
         :validator,
         arg,
-        :kind_of => [TrueClass, FalseClass],
+        :kind_of => [TrueClass, FalseClass]
       )
     end
 
@@ -102,7 +102,7 @@ class Chef
       set_or_return(
         :private_key,
         arg,
-        :kind_of => [String, FalseClass],
+        :kind_of => [String, FalseClass]
       )
     end
 

--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -152,7 +152,7 @@ class Chef
                                             :api_version => "0",
                                             :client_name => Chef::Config[:validation_client_name],
                                             :signing_key_filename => Chef::Config[:validation_key],
-                                          },
+                                          }
                                          )
       end
 

--- a/lib/chef/api_client_v1.rb
+++ b/lib/chef/api_client_v1.rb
@@ -76,7 +76,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        :regex => /^[\-[:alnum:]_\.]+$/,
+        :regex => /^[\-[:alnum:]_\.]+$/
       )
     end
 
@@ -88,7 +88,7 @@ class Chef
       set_or_return(
         :admin,
         arg,
-        :kind_of => [ TrueClass, FalseClass ],
+        :kind_of => [ TrueClass, FalseClass ]
       )
     end
 
@@ -100,7 +100,7 @@ class Chef
       set_or_return(
         :public_key,
         arg,
-        :kind_of => String,
+        :kind_of => String
       )
     end
 
@@ -113,7 +113,7 @@ class Chef
       set_or_return(
         :validator,
         arg,
-        :kind_of => [TrueClass, FalseClass],
+        :kind_of => [TrueClass, FalseClass]
       )
     end
 
@@ -126,7 +126,7 @@ class Chef
       set_or_return(
         :private_key,
         arg,
-        :kind_of => [String, TrueClass, FalseClass],
+        :kind_of => [String, TrueClass, FalseClass]
       )
     end
 
@@ -138,7 +138,7 @@ class Chef
       set_or_return(
         :create_key,
         arg,
-        :kind_of => [ TrueClass, FalseClass ],
+        :kind_of => [ TrueClass, FalseClass ]
       )
     end
 

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -215,7 +215,7 @@ class Chef
           @chef_client_json,
           override_runlist: override_runlist,
           specific_recipes: specific_recipes,
-          runlist: config[:runlist],
+          runlist: config[:runlist]
         )
         @chef_client_json = nil
 

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -198,7 +198,7 @@ class Chef
           result = shell_out(
             "chef-client.bat #{config_params}",
             :timeout => Chef::Config[:windows_service][:watchdog_timeout],
-            :logger => Chef::Log,
+            :logger => Chef::Log
           )
           Chef::Log.debug "#{result.stdout}"
           Chef::Log.debug "#{result.stderr}"

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -124,11 +124,11 @@ class Chef
               :binary_path_name   => cmd,
               :service_start_name => @service_start_name,
               :password           => @password,
-              :dependencies       => @dependencies,
+              :dependencies       => @dependencies
             )
             ::Win32::Service.configure(
               :service_name     => @service_name,
-              :delayed_start    => @delayed_start,
+              :delayed_start    => @delayed_start
             ) unless @delayed_start.nil?
             puts "Service '#{@service_name}' has successfully been installed."
           end

--- a/lib/chef/chef_fs/data_handler/acl_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/acl_data_handler.rb
@@ -12,7 +12,7 @@ class Chef
             "update" => {},
             "delete" => {},
             "grant" => {},
-            },)
+            })
           result.keys.each do |key|
             result[key] = normalize_hash(result[key], { "actors" => [], "groups" => [] })
             result[key]["actors"] = result[key]["actors"].sort

--- a/lib/chef/chef_fs/data_handler/container_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/container_data_handler.rb
@@ -8,7 +8,7 @@ class Chef
           normalize_hash(container, {
             "containername" => remove_dot_json(entry.name),
             "containerpath" => remove_dot_json(entry.name),
-          },)
+          })
         end
 
         def preserve_key?(key)

--- a/lib/chef/chef_fs/data_handler/cookbook_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/cookbook_data_handler.rb
@@ -16,11 +16,11 @@ class Chef
             "chef_type" => "cookbook_version",
             "frozen?" => false,
             "metadata" => {},
-          },)
+          })
           result["metadata"] = normalize_hash(result["metadata"], {
             "version" => version,
             "name" => name,
-          },)
+          })
         end
 
         def preserve_key?(key)

--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -14,7 +14,7 @@ class Chef
           # use those in knife-essentials.
           normalize_hash(data_bag_item, {
             "id" => remove_dot_json(entry.name),
-          },)
+          })
         end
 
         def normalize_for_post(data_bag_item, entry)

--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -13,7 +13,7 @@ class Chef
           # chef_type and data_bag come back in PUT and POST results, but we don't
           # use those in knife-essentials.
           normalize_hash(data_bag_item, {
-            "id" => remove_dot_json(entry.name)
+            "id" => remove_dot_json(entry.name),
           },)
         end
 

--- a/lib/chef/chef_fs/data_handler/environment_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/environment_data_handler.rb
@@ -14,7 +14,7 @@ class Chef
             "override_attributes" => {},
             "json_class" => "Chef::Environment",
             "chef_type" => "environment",
-          },)
+          })
         end
 
         def preserve_key?(key)

--- a/lib/chef/chef_fs/data_handler/node_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/node_data_handler.rb
@@ -16,7 +16,7 @@ class Chef
             "default" => {},
             "automatic" => {},
             "run_list" => [],
-          },)
+          })
           result["run_list"] = normalize_run_list(result["run_list"])
           result
         end

--- a/lib/chef/chef_fs/data_handler/organization_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/organization_data_handler.rb
@@ -11,7 +11,7 @@ class Chef
             "org_type" => "Business",
             "clientname" => "#{entry.org}-validator",
             "billing_plan" => "platform-free",
-          },)
+          })
           result
         end
 

--- a/lib/chef/chef_fs/data_handler/role_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/role_data_handler.rb
@@ -15,7 +15,7 @@ class Chef
             "override_attributes" => {},
             "run_list" => [],
             "env_run_lists" => {},
-          },)
+          })
           result["run_list"] = normalize_run_list(result["run_list"])
           result["env_run_lists"].each_pair do |env, run_list|
             result["env_run_lists"][env] = normalize_run_list(run_list)

--- a/lib/chef/chef_fs/data_handler/user_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/user_data_handler.rb
@@ -15,7 +15,7 @@ class Chef
             "salt" => nil,
             "password" => nil,
             "openid" => nil,
-          },)
+          })
         end
 
         def preserve_key?(key)

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -177,7 +177,7 @@ class Chef
         set_or_return(
           :maintainer,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -192,7 +192,7 @@ class Chef
         set_or_return(
           :maintainer_email,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -207,7 +207,7 @@ class Chef
         set_or_return(
           :license,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -222,7 +222,7 @@ class Chef
         set_or_return(
           :description,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -237,7 +237,7 @@ class Chef
         set_or_return(
           :long_description,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -268,7 +268,7 @@ class Chef
         set_or_return(
           :name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -492,7 +492,7 @@ class Chef
             :source_url => { :kind_of => String },
             :issues_url => { :kind_of => String },
             :privacy => { :kind_of => [ TrueClass, FalseClass ] },
-          },
+          }
         )
         options[:required] = remap_required_attribute(options[:required]) unless options[:required].nil?
         validate_choice_array(options)
@@ -509,7 +509,7 @@ class Chef
           {
             :title => { :kind_of => String },
             :description => { :kind_of => String },
-          },
+          }
         )
         @groupings[name] = options
         @groupings[name]
@@ -648,7 +648,7 @@ class Chef
         set_or_return(
           :source_url,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -663,7 +663,7 @@ class Chef
         set_or_return(
           :issues_url,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -680,7 +680,7 @@ class Chef
         set_or_return(
           :privacy,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 

--- a/lib/chef/cookbook_manifest.rb
+++ b/lib/chef/cookbook_manifest.rb
@@ -195,7 +195,7 @@ class Chef
         :resources => Array.new,
         :providers => Array.new,
         :root_files => Array.new,
-      },)
+      })
       @checksums = {}
 
       if !root_paths || root_paths.size == 0
@@ -217,7 +217,7 @@ class Chef
             :path => path,
             :checksum => csum,
             :specificity => specificity,
-          },)
+          })
 
           manifest[segment] << rs
         end

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -52,7 +52,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        :regex => VALID_NAME,
+        :regex => VALID_NAME
       )
     end
 

--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -86,7 +86,7 @@ class Chef
       set_or_return(
         :data_bag,
         arg,
-        :regex => /^[\-[:alnum:]_]+$/,
+        :regex => /^[\-[:alnum:]_]+$/
       )
     end
 

--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -100,7 +100,7 @@ class Chef
           run_context:         run_context,
           cookbook_name:       cookbook_name,
           recipe_name:         recipe_name,
-          enclosing_provider:  self.is_a?(Chef::Provider) ? self : nil,
+          enclosing_provider:  self.is_a?(Chef::Provider) ? self : nil
         ).build(&resource_attrs_block)
       end
     end

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -59,7 +59,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String },
+        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String }
       )
     end
 
@@ -67,7 +67,7 @@ class Chef
       set_or_return(
         :description,
         arg,
-        :kind_of => String,
+        :kind_of => String
       )
     end
 
@@ -75,7 +75,7 @@ class Chef
       set_or_return(
         :default_attributes,
         arg,
-        :kind_of => Hash,
+        :kind_of => Hash
       )
     end
 
@@ -87,7 +87,7 @@ class Chef
       set_or_return(
         :override_attributes,
         arg,
-        :kind_of => Hash,
+        :kind_of => Hash
       )
     end
 
@@ -104,7 +104,7 @@ class Chef
           :callbacks => {
             "should be a valid set of cookbook version requirements" => lambda { |cv| Chef::Environment.validate_cookbook_versions(cv) },
           },
-        },
+        }
       )
     end
 
@@ -115,7 +115,7 @@ class Chef
         :version => {
           :callbacks => { "should be a valid version requirement" => lambda { |v| Chef::Environment.validate_cookbook_version(v) } },
         },
-      },)
+      })
       @cookbook_versions[cookbook] = version
     end
 

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -59,7 +59,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String }
+        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String },
       )
     end
 
@@ -102,7 +102,7 @@ class Chef
         {
           :kind_of => Hash,
           :callbacks => {
-            "should be a valid set of cookbook version requirements" => lambda { |cv| Chef::Environment.validate_cookbook_versions(cv) }
+            "should be a valid set of cookbook version requirements" => lambda { |cv| Chef::Environment.validate_cookbook_versions(cv) },
           },
         },
       )
@@ -110,11 +110,11 @@ class Chef
 
     def cookbook(cookbook, version)
       validate({
-        :version => version
+        :version => version,
       }, {
         :version => {
-          :callbacks => { "should be a valid version requirement" => lambda { |v| Chef::Environment.validate_cookbook_version(v) } }
-        }
+          :callbacks => { "should be a valid version requirement" => lambda { |v| Chef::Environment.validate_cookbook_version(v) } },
+        },
       },)
       @cookbook_versions[cookbook] = version
     end

--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -50,7 +50,7 @@ class Chef
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_START_EVENT_ID,
-          :data => [version],
+          :data => [version]
         )
       end
 
@@ -60,7 +60,7 @@ class Chef
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_STARTED_EVENT_ID,
-          :data => [run_status.run_id],
+          :data => [run_status.run_id]
         )
       end
 
@@ -69,7 +69,7 @@ class Chef
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => RUN_COMPLETED_EVENT_ID,
-          :data => [@run_status.run_id, @run_status.elapsed_time.to_s],
+          :data => [@run_status.run_id, @run_status.elapsed_time.to_s]
         )
       end
 
@@ -92,7 +92,7 @@ class Chef
           :event_id => RUN_FAILED_EVENT_ID,
           :data => data + [e.class.name,
                            e.message,
-                           e.backtrace.join("\n")],
+                           e.backtrace.join("\n")]
         )
       end
 

--- a/lib/chef/file_cache.rb
+++ b/lib/chef/file_cache.rb
@@ -105,10 +105,10 @@ class Chef
       def load(path, read = true)
         validate(
           {
-            :path => path
+            :path => path,
           },
           {
-            :path => { :kind_of => String }
+            :path => { :kind_of => String },
           },
         )
         cache_path = create_cache_path(path, false)
@@ -131,10 +131,10 @@ class Chef
       def delete(path)
         validate(
           {
-            :path => path
+            :path => path,
           },
           {
-            :path => { :kind_of => String }
+            :path => { :kind_of => String },
           },
         )
         cache_path = create_cache_path(path, false)
@@ -178,10 +178,10 @@ class Chef
       def has_key?(path)
         validate(
           {
-            :path => path
+            :path => path,
           },
           {
-            :path => { :kind_of => String }
+            :path => { :kind_of => String },
           },
         )
         full_path = create_cache_path(path, false)

--- a/lib/chef/file_cache.rb
+++ b/lib/chef/file_cache.rb
@@ -48,7 +48,7 @@ class Chef
           {
             :path => { :kind_of => String },
             :contents => { :kind_of => String },
-          },
+          }
         )
 
         file_path_array = File.split(path)
@@ -74,7 +74,7 @@ class Chef
           {
             :file => { :kind_of => String },
             :path => { :kind_of => String },
-          },
+          }
         )
 
         file_path_array = File.split(path)
@@ -82,7 +82,7 @@ class Chef
         if File.exists?(file) && File.writable?(file)
           FileUtils.mv(
             file,
-            File.join(create_cache_path(File.join(file_path_array), true), file_name),
+            File.join(create_cache_path(File.join(file_path_array), true), file_name)
           )
         else
           raise RuntimeError, "Cannot move #{file} to #{path}!"
@@ -109,7 +109,7 @@ class Chef
           },
           {
             :path => { :kind_of => String },
-          },
+          }
         )
         cache_path = create_cache_path(path, false)
         raise Chef::Exceptions::FileNotFound, "Cannot find #{cache_path} for #{path}!" unless File.exists?(cache_path)
@@ -135,7 +135,7 @@ class Chef
           },
           {
             :path => { :kind_of => String },
-          },
+          }
         )
         cache_path = create_cache_path(path, false)
         if File.exists?(cache_path)
@@ -182,7 +182,7 @@ class Chef
           },
           {
             :path => { :kind_of => String },
-          },
+          }
         )
         full_path = create_cache_path(path, false)
         if File.exists?(full_path)

--- a/lib/chef/key.rb
+++ b/lib/chef/key.rb
@@ -117,7 +117,7 @@ class Chef
 
     def to_hash
       result = {
-        @actor_field_name => @actor
+        @actor_field_name => @actor,
       }
       result["name"] = @name if @name
       result["public_key"] = @public_key if @public_key

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -255,11 +255,11 @@ class Chef
         @client_builder = Chef::Knife::Bootstrap::ClientBuilder.new(
           chef_config: Chef::Config,
           knife_config: config,
-          ui: ui,
+          ui: ui
         )
         @chef_vault_handler = Chef::Knife::Bootstrap::ChefVaultHandler.new(
           knife_config: config,
-          ui: ui,
+          ui: ui
         )
       end
 
@@ -340,7 +340,7 @@ class Chef
           config,
           config[:run_list],
           Chef::Config,
-          secret,
+          secret
         )
       end
 

--- a/lib/chef/knife/data_bag_create.rb
+++ b/lib/chef/knife/data_bag_create.rb
@@ -66,7 +66,7 @@ class Chef
                 Chef::EncryptedDataBagItem.encrypt_data_bag_item(output, read_secret)
               else
                 output
-              end
+              end,
             )
             item.data_bag(@data_bag_name)
             rest.post("data/#{@data_bag_name}", item)

--- a/lib/chef/knife/data_bag_create.rb
+++ b/lib/chef/knife/data_bag_create.rb
@@ -66,7 +66,7 @@ class Chef
                 Chef::EncryptedDataBagItem.encrypt_data_bag_item(output, read_secret)
               else
                 output
-              end,
+              end
             )
             item.data_bag(@data_bag_name)
             rest.post("data/#{@data_bag_name}", item)

--- a/lib/chef/log/winevt.rb
+++ b/lib/chef/log/winevt.rb
@@ -54,7 +54,7 @@ class Chef
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => INFO_EVENT_ID,
-          :data => [msg],
+          :data => [msg]
         )
       end
 
@@ -63,7 +63,7 @@ class Chef
           :event_type => ::Win32::EventLog::WARN_TYPE,
           :source => SOURCE,
           :event_id => WARN_EVENT_ID,
-          :data => [msg],
+          :data => [msg]
         )
       end
 
@@ -72,7 +72,7 @@ class Chef
           :event_type => ::Win32::EventLog::INFO_TYPE,
           :source => SOURCE,
           :event_id => DEBUG_EVENT_ID,
-          :data => [msg],
+          :data => [msg]
         )
       end
 
@@ -81,7 +81,7 @@ class Chef
           :event_type => ::Win32::EventLog::ERROR_TYPE,
           :source => SOURCE,
           :event_id => ERROR_EVENT_ID,
-          :data => [msg],
+          :data => [msg]
         )
       end
 
@@ -90,7 +90,7 @@ class Chef
           :event_type => ::Win32::EventLog::ERROR_TYPE,
           :source => SOURCE,
           :event_id => FATAL_EVENT_ID,
-          :data => [msg],
+          :data => [msg]
         )
       end
 

--- a/lib/chef/mixin/powershell_out.rb
+++ b/lib/chef/mixin/powershell_out.rb
@@ -66,7 +66,7 @@ class Chef
         with_os_architecture(nil, architecture: arch) do
           shell_out(
             build_powershell_command(script),
-            options,
+            options
           )
         end
       end

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -24,7 +24,7 @@ class Chef
         set_or_return(
           :owner,
           arg,
-          :regex => Chef::Config[:user_valid_regex],
+          :regex => Chef::Config[:user_valid_regex]
         )
       end
 
@@ -34,7 +34,7 @@ class Chef
         set_or_return(
           :group,
           arg,
-          :regex => Chef::Config[:group_valid_regex],
+          :regex => Chef::Config[:group_valid_regex]
         )
       end
 
@@ -55,7 +55,7 @@ class Chef
                 Integer(m) <= 07777 && Integer(m) >= 0
               end
             },
-          },
+          }
         )
       end
 
@@ -156,7 +156,7 @@ class Chef
             set_or_return(
               name,
               rights,
-              {},
+              {}
             )
           end
         end
@@ -171,7 +171,7 @@ class Chef
           set_or_return(
             :inherits,
             arg,
-            :kind_of => [ TrueClass, FalseClass ],
+            :kind_of => [ TrueClass, FalseClass ]
           )
         end
       end

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -54,7 +54,7 @@ class Chef
               else
                 Integer(m) <= 07777 && Integer(m) >= 0
               end
-            }
+            },
           },
         )
       end

--- a/lib/chef/mixin/windows_env_helper.rb
+++ b/lib/chef/mixin/windows_env_helper.rb
@@ -47,7 +47,7 @@ class Chef
           Chef::ReservedNames::Win32::Error.raise!
         end
         if  SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, FFI::MemoryPointer.from_string(
-            utf8_to_wide("Environment"),
+            utf8_to_wide("Environment")
         ).address, flags, 5000, nil) == 0
           Chef::ReservedNames::Win32::Error.raise!
         end

--- a/lib/chef/mixin/windows_env_helper.rb
+++ b/lib/chef/mixin/windows_env_helper.rb
@@ -47,7 +47,7 @@ class Chef
           Chef::ReservedNames::Win32::Error.raise!
         end
         if  SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, FFI::MemoryPointer.from_string(
-            utf8_to_wide("Environment")
+            utf8_to_wide("Environment"),
         ).address, flags, 5000, nil) == 0
           Chef::ReservedNames::Win32::Error.raise!
         end

--- a/lib/chef/monologger.rb
+++ b/lib/chef/monologger.rb
@@ -79,7 +79,7 @@ class MonoLogger < Logger
 
     def add_log_header(file)
       file.write(
-        "# Logfile created on %s by %s\n" % [Time.now.to_s, Logger::ProgName],
+        "# Logfile created on %s by %s\n" % [Time.now.to_s, Logger::ProgName]
       )
     end
 

--- a/lib/chef/monologger.rb
+++ b/lib/chef/monologger.rb
@@ -79,7 +79,7 @@ class MonoLogger < Logger
 
     def add_log_header(file)
       file.write(
-        "# Logfile created on %s by %s\n" % [Time.now.to_s, Logger::ProgName]
+        "# Logfile created on %s by %s\n" % [Time.now.to_s, Logger::ProgName],
       )
     end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -114,7 +114,7 @@ class Chef
                  { :name => arg },
                  { :name => { :kind_of => String,
                               :cannot_be => :blank,
-                              :regex => /^[\-[:alnum:]_:.]+$/ }
+                              :regex => /^[\-[:alnum:]_:.]+$/ },
                  },)
         @name = arg
       else
@@ -126,7 +126,7 @@ class Chef
       set_or_return(
         :chef_environment,
         arg,
-        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String }
+        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String },
       )
     end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -103,7 +103,7 @@ class Chef
         Chef::Config[:chef_server_url],
         client_name: Chef::Config[:node_name],
         signing_key_filename: Chef::Config[:client_key],
-        validate_utf8: false,
+        validate_utf8: false
       )
     end
 
@@ -115,7 +115,7 @@ class Chef
                  { :name => { :kind_of => String,
                               :cannot_be => :blank,
                               :regex => /^[\-[:alnum:]_:.]+$/ },
-                 },)
+                 })
         @name = arg
       else
         @name
@@ -126,7 +126,7 @@ class Chef
       set_or_return(
         :chef_environment,
         arg,
-        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String },
+        { :regex => /^[\-[:alnum:]_]+$/, :kind_of => String }
       )
     end
 

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -124,7 +124,7 @@ class Chef
             :provider => {
               :kind_of => [ String, Symbol, Class ],
             },
-          },
+          }
         )
         if args.has_key?(:platform)
           if args.has_key?(:version)

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -119,10 +119,10 @@ class Chef
               :required => false,
             },
             :resource => {
-              :kind_of => Symbol
+              :kind_of => Symbol,
             },
             :provider => {
-              :kind_of => [ String, Symbol, Class ]
+              :kind_of => [ String, Symbol, Class ],
             },
           },
         )
@@ -133,14 +133,14 @@ class Chef
                 platforms[args[:platform]][args[:version]][args[:resource].to_sym] = args[:provider]
               else
                 platforms[args[:platform]][args[:version]] = {
-                  args[:resource].to_sym => args[:provider]
+                  args[:resource].to_sym => args[:provider],
                 }
               end
             else
               platforms[args[:platform]] = {
                 args[:version] => {
-                  args[:resource].to_sym => args[:provider]
-                }
+                  args[:resource].to_sym => args[:provider],
+                },
               }
             end
           else
@@ -155,8 +155,8 @@ class Chef
             else
               platforms[args[:platform]] = {
                 :default => {
-                  args[:resource].to_sym => args[:provider]
-                }
+                  args[:resource].to_sym => args[:provider],
+                },
               }
             end
           end
@@ -165,7 +165,7 @@ class Chef
             platforms[:default][args[:resource].to_sym] = args[:provider]
           else
             platforms[:default] = {
-              args[:resource].to_sym => args[:provider]
+              args[:resource].to_sym => args[:provider],
             }
           end
         end

--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -105,7 +105,7 @@ class Chef
         def has_systemd_service_unit?(svc_name)
           %w{ /etc /usr/lib /lib /run }.any? do |load_path|
             ::File.exist?(
-              Chef.path_to("#{load_path}/systemd/system/#{svc_name.gsub(/@.*$/, '@')}.service"),
+              Chef.path_to("#{load_path}/systemd/system/#{svc_name.gsub(/@.*$/, '@')}.service")
             )
           end
         end

--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -105,7 +105,7 @@ class Chef
         def has_systemd_service_unit?(svc_name)
           %w{ /etc /usr/lib /lib /run }.any? do |load_path|
             ::File.exist?(
-              Chef.path_to("#{load_path}/systemd/system/#{svc_name.gsub(/@.*$/, '@')}.service")
+              Chef.path_to("#{load_path}/systemd/system/#{svc_name.gsub(/@.*$/, '@')}.service"),
             )
           end
         end

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -237,7 +237,7 @@ class Chef
 
       def setup_run_list_override
         runlist_override_sanity_check!
-        unless(override_runlist.empty?)
+        unless override_runlist.empty?
           node.override_runlist(*override_runlist)
           Chef::Log.warn "Run List override has been provided."
           Chef::Log.warn "Original Run List: [#{node.primary_runlist}]"
@@ -253,7 +253,7 @@ class Chef
         end
         @override_runlist = [override_runlist].flatten.compact
         override_runlist.map! do |item|
-          if(item.is_a?(Chef::RunList::RunListItem))
+          if item.is_a?(Chef::RunList::RunListItem)
             item
           else
             Chef::RunList::RunListItem.new(item)

--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -72,7 +72,7 @@ class Chef
       def local_configuration_manager
         @local_configuration_manager ||= Chef::Util::DSC::LocalConfigurationManager.new(
           node,
-          nil,
+          nil
         )
       end
 
@@ -158,7 +158,7 @@ class Chef
         cmdlet = Chef::Util::Powershell::Cmdlet.new(
           node,
           "Invoke-DscResource #{switches}",
-          output_format,
+          output_format
         )
         cmdlet.run!({}, { :timeout => new_resource.timeout })
       end
@@ -176,7 +176,7 @@ class Chef
       def create_reboot_resource
         @reboot_resource = Chef::Resource::Reboot.new(
           "Reboot for #{@new_resource.name}",
-          run_context,
+          run_context
         ).tap do |r|
           r.reason("Reboot for #{@new_resource.resource}.")
         end

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -117,7 +117,7 @@ class Chef
 
       def sentinel_file
         Pathname.new(Chef::Util::PathHelper.cleanpath(
-           ( cwd && creates_relative? ) ? ::File.join(cwd, creates) : creates
+           ( cwd && creates_relative? ) ? ::File.join(cwd, creates) : creates,
         ))
       end
     end

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -117,7 +117,7 @@ class Chef
 
       def sentinel_file
         Pathname.new(Chef::Util::PathHelper.cleanpath(
-           ( cwd && creates_relative? ) ? ::File.join(cwd, creates) : creates,
+           ( cwd && creates_relative? ) ? ::File.join(cwd, creates) : creates
         ))
       end
     end

--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -90,7 +90,7 @@ class Chef
           @change_desc << "change gid #{@current_resource.gid} to #{@new_resource.gid}"
         end
 
-        if(@new_resource.append)
+        if @new_resource.append
           missing_members = []
           @new_resource.members.each do |member|
             next if has_current_group_member?(member)

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -72,7 +72,7 @@ class Chef
         def get_free_gid(search_limit = 1000)
           gid = nil; next_gid_guess = 200
           groups_gids = safe_dscl("list /Groups gid")
-          while(next_gid_guess < search_limit + 200)
+          while next_gid_guess < search_limit + 200
             if groups_gids =~ Regexp.new("#{Regexp.escape(next_gid_guess.to_s)}\n")
               next_gid_guess += 1
             else

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -42,7 +42,7 @@ class Chef
         # and false for a "304 Not Modified" response
         modified = @http.head(
           "#{@new_resource.url}",
-          @new_resource.headers,
+          @new_resource.headers
         )
         Chef::Log.info("#{@new_resource} HEAD to #{@new_resource.url} successful")
         Chef::Log.debug("#{@new_resource} HEAD request response: #{modified}")
@@ -59,7 +59,7 @@ class Chef
           message = check_message(@new_resource.message)
           body = @http.get(
             "#{@new_resource.url}",
-            @new_resource.headers,
+            @new_resource.headers
           )
           Chef::Log.info("#{@new_resource} GET to #{@new_resource.url} successful")
           Chef::Log.debug("#{@new_resource} GET request response: #{body}")
@@ -73,7 +73,7 @@ class Chef
           body = @http.put(
             "#{@new_resource.url}",
             message,
-            @new_resource.headers,
+            @new_resource.headers
           )
           Chef::Log.info("#{@new_resource} PUT to #{@new_resource.url} successful")
           Chef::Log.debug("#{@new_resource} PUT request response: #{body}")
@@ -87,7 +87,7 @@ class Chef
           body = @http.post(
             "#{@new_resource.url}",
             message,
-            @new_resource.headers,
+            @new_resource.headers
           )
           Chef::Log.info("#{@new_resource} POST to #{@new_resource.url} message: #{message.inspect} successful")
           Chef::Log.debug("#{@new_resource} POST request response: #{body}")
@@ -99,7 +99,7 @@ class Chef
         converge_by("#{@new_resource} DELETE to #{@new_resource.url}") do
           body = @http.delete(
             "#{@new_resource.url}",
-            @new_resource.headers,
+            @new_resource.headers
           )
           @new_resource.updated_by_last_action(true)
           Chef::Log.info("#{@new_resource} DELETE to #{@new_resource.url} successful")

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -109,7 +109,7 @@ class Chef
             command = add_command
             converge_by ("run #{command} to add #{@new_resource}") do
               run_command(
-                :command => command,
+                :command => command
               )
               Chef::Log.info("#{@new_resource} added")
             end
@@ -127,7 +127,7 @@ class Chef
             command = enable_command
             converge_by ("run #{command} to enable #{@new_resource}") do
               run_command(
-                :command => command,
+                :command => command
               )
               Chef::Log.info("#{@new_resource} enabled")
             end
@@ -141,7 +141,7 @@ class Chef
           command = delete_command
           converge_by ("run #{command} to delete #{@new_resource}") do
             run_command(
-              :command => command,
+              :command => command
             )
             Chef::Log.info("#{@new_resource} deleted")
           end
@@ -158,7 +158,7 @@ class Chef
           command = disable_command
           converge_by ("run #{command} to disable #{@new_resource}") do
             run_command(
-              :command => command,
+              :command => command
             )
             Chef::Log.info("#{@new_resource} disabled")
           end

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -40,7 +40,7 @@ class Chef
         :path,
         :source,
         :session_type,
-        :type
+        :type,
       ]
 
       def load_current_resource
@@ -51,7 +51,7 @@ class Chef
       def gen_path_from_type
         types = {
           "daemon" => "/Library/LaunchDaemons/#{label}.plist",
-          "agent" => "/Library/LaunchAgents/#{label}.plist"
+          "agent" => "/Library/LaunchAgents/#{label}.plist",
         }
         types[type]
       end

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -52,7 +52,7 @@ class Chef
         if file_class.symlink?(@current_resource.target_file)
           @current_resource.link_type(:symbolic)
           @current_resource.to(
-            canonicalize(file_class.readlink(@current_resource.target_file))
+            canonicalize(file_class.readlink(@current_resource.target_file)),
           )
         else
           @current_resource.link_type(:hard)

--- a/lib/chef/provider/link.rb
+++ b/lib/chef/provider/link.rb
@@ -52,7 +52,7 @@ class Chef
         if file_class.symlink?(@current_resource.target_file)
           @current_resource.link_type(:symbolic)
           @current_resource.to(
-            canonicalize(file_class.readlink(@current_resource.target_file)),
+            canonicalize(file_class.readlink(@current_resource.target_file))
           )
         else
           @current_resource.link_type(:hard)

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -44,7 +44,7 @@ class Chef
           # only check for existence of non-remote devices
           if device_should_exist? && !::File.exists?(device_real)
             raise Chef::Exceptions::Mount, "Device #{@new_resource.device} does not exist"
-          elsif( @new_resource.mount_point != "none" && !::File.exists?(@new_resource.mount_point) )
+          elsif @new_resource.mount_point != "none" && !::File.exists?(@new_resource.mount_point)
             raise Chef::Exceptions::Mount, "Mount point #{@new_resource.mount_point} does not exist"
           end
           return true

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -40,7 +40,7 @@ class Chef
         all_profiles = get_installed_profiles
         @new_resource.profile(
           @new_resource.profile ||
-          @new_resource.profile_name
+          @new_resource.profile_name,
         )
 
         @new_profile_hash = get_profile_hash(@new_resource.profile)
@@ -141,7 +141,7 @@ class Chef
 
       def get_cache_dir
         cache_dir = Chef::FileCache.create_cache_path(
-          "profiles/#{@new_resource.cookbook_name}"
+          "profiles/#{@new_resource.cookbook_name}",
         )
       end
 
@@ -151,7 +151,7 @@ class Chef
             "profiles",
             @new_resource.cookbook_name,
             ::File.dirname(cookbook_file),
-          )
+          ),
         )
         remote_file = Chef::Resource::CookbookFile.new(
           ::File.join(

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -40,7 +40,7 @@ class Chef
         all_profiles = get_installed_profiles
         @new_resource.profile(
           @new_resource.profile ||
-          @new_resource.profile_name,
+          @new_resource.profile_name
         )
 
         @new_profile_hash = get_profile_hash(@new_resource.profile)
@@ -141,7 +141,7 @@ class Chef
 
       def get_cache_dir
         cache_dir = Chef::FileCache.create_cache_path(
-          "profiles/#{@new_resource.cookbook_name}",
+          "profiles/#{@new_resource.cookbook_name}"
         )
       end
 
@@ -150,15 +150,15 @@ class Chef
           ::File.join(
             "profiles",
             @new_resource.cookbook_name,
-            ::File.dirname(cookbook_file),
-          ),
+            ::File.dirname(cookbook_file)
+          )
         )
         remote_file = Chef::Resource::CookbookFile.new(
           ::File.join(
             get_cache_dir,
-            "#{cookbook_file}.remote",
+            "#{cookbook_file}.remote"
           ),
-          run_context,
+          run_context
         )
         remote_file.cookbook_name = @new_resource.cookbook_name
         remote_file.source(cookbook_file)
@@ -179,7 +179,7 @@ class Chef
         # Make a UUID of the profile contents and return as string
         UUIDTools::UUID.sha1_create(
           UUIDTools::UUID_DNS_NAMESPACE,
-          profile.to_s,
+          profile.to_s
         ).to_s
       end
 

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -162,7 +162,7 @@ EOS
         # lets us mock out an incorrect value for testing.
         def choco_install_path
           @choco_install_path ||= powershell_out!(
-            PATHFINDING_POWERSHELL_COMMAND
+            PATHFINDING_POWERSHELL_COMMAND,
             ).stdout.chomp
         end
 

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -155,14 +155,14 @@ EOS
           @choco_exe ||= ::File.join(
             choco_install_path,
             "bin",
-            "choco.exe",
+            "choco.exe"
             )
         end
 
         # lets us mock out an incorrect value for testing.
         def choco_install_path
           @choco_install_path ||= powershell_out!(
-            PATHFINDING_POWERSHELL_COMMAND,
+            PATHFINDING_POWERSHELL_COMMAND
             ).stdout.chomp
         end
 

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -54,7 +54,7 @@ class Chef
 
           repos = %w{extra core community}
 
-          if(::File.exists?("/etc/pacman.conf"))
+          if ::File.exists?("/etc/pacman.conf")
             pacman = ::File.read("/etc/pacman.conf")
             repos = pacman.scan(/\[(.+)\]/).flatten
           end

--- a/lib/chef/provider/package/paludis.rb
+++ b/lib/chef/provider/package/paludis.rb
@@ -54,7 +54,7 @@ class Chef
         end
 
         def install_package(name, version)
-          if(version)
+          if version
             pkg = "=#{name}-#{version}"
           else
             pkg = "#{@new_resource.package_name}"
@@ -67,7 +67,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          if(version)
+          if version
             pkg = "=#{@new_resource.package_name}-#{version}"
           else
             pkg = "#{@new_resource.package_name}"

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -41,7 +41,7 @@ class Chef
           globsafe_pkg = Chef::Util::PathHelper.escape_glob(pkg)
           possibilities = Dir["/var/db/pkg/#{globsafe_category || "*"}/#{globsafe_pkg}-*"].map { |d| d.sub(%r{/var/db/pkg/}, "") }
           versions = possibilities.map do |entry|
-            if(entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)})
+            if entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)}
               [$&, $1]
             end
           end.compact
@@ -108,7 +108,7 @@ class Chef
         def install_package(name, version)
           pkg = "=#{name}-#{version}"
 
-          if(version =~ /^\~(.+)/)
+          if version =~ /^\~(.+)/
             # If we start with a tilde
             pkg = "~#{name}-#{$1}"
           end
@@ -121,7 +121,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          if(version)
+          if version
             pkg = "=#{@new_resource.package_name}-#{version}"
           else
             pkg = "#{@new_resource.package_name}"

--- a/lib/chef/provider/reboot.rb
+++ b/lib/chef/provider/reboot.rb
@@ -40,7 +40,7 @@ class Chef
           :delay_mins => @new_resource.delay_mins,
           :reason => @new_resource.reason,
           :timestamp => Time.now,
-          :requested_by => @new_resource.name,
+          :requested_by => @new_resource.name
           )
       end
 

--- a/lib/chef/provider/service/gentoo.rb
+++ b/lib/chef/provider/service/gentoo.rb
@@ -39,7 +39,7 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
         readable = ::File.readable? file
         Chef::Log.debug "#{@new_resource} exists: #{exists}, readable: #{readable}"
         exists and readable
-      end,
+      end
     )
     Chef::Log.debug "#{@new_resource} enabled: #{@current_resource.enabled}"
 

--- a/lib/chef/provider/service/gentoo.rb
+++ b/lib/chef/provider/service/gentoo.rb
@@ -39,7 +39,7 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
         readable = ::File.readable? file
         Chef::Log.debug "#{@new_resource} exists: #{exists}, readable: #{readable}"
         exists and readable
-      end
+      end,
     )
     Chef::Log.debug "#{@new_resource} enabled: #{@current_resource.enabled}"
 

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -224,7 +224,7 @@ class Chef
           # plist files can come in XML or Binary formats. this command
           # will make sure we get XML every time.
           plist_xml = shell_out_with_systems_locale!(
-            "plutil -convert xml1 -o - #{@plist}"
+            "plutil -convert xml1 -o - #{@plist}",
           ).stdout
 
           plist_doc = REXML::Document.new(plist_xml)
@@ -236,7 +236,7 @@ class Chef
           plists = PLIST_DIRS.inject([]) do |results, dir|
             edir = ::File.expand_path(dir)
             entries = Dir.glob(
-              "#{edir}/*#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}*.plist"
+              "#{edir}/*#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}*.plist",
             )
             entries.any? ? results << entries : results
           end

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -224,7 +224,7 @@ class Chef
           # plist files can come in XML or Binary formats. this command
           # will make sure we get XML every time.
           plist_xml = shell_out_with_systems_locale!(
-            "plutil -convert xml1 -o - #{@plist}",
+            "plutil -convert xml1 -o - #{@plist}"
           ).stdout
 
           plist_doc = REXML::Document.new(plist_xml)
@@ -236,7 +236,7 @@ class Chef
           plists = PLIST_DIRS.inject([]) do |results, dir|
             edir = ::File.expand_path(dir)
             entries = Dir.glob(
-              "#{edir}/*#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}*.plist",
+              "#{edir}/*#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}*.plist"
             )
             entries.any? ? results << entries : results
           end

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -306,7 +306,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
     Chef::Log.debug "#{@new_resource.name} setting start_type to #{type}"
     Win32::Service.configure(
       :service_name => @new_resource.service_name,
-      :start_type => allowed_types[type],
+      :start_type => allowed_types[type]
     )
     @new_resource.updated_by_last_action(true)
   end

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -415,7 +415,7 @@ user password using shadow hash.")
                 salt,
                 iterations,
                 128,
-                OpenSSL::Digest::SHA512.new,
+                OpenSSL::Digest::SHA512.new
               )
             end
 
@@ -700,7 +700,7 @@ user password using shadow hash.")
             salt,
             current_resource.iterations,
             128,
-            OpenSSL::Digest::SHA512.new,
+            OpenSSL::Digest::SHA512.new
           ).unpack("H*").first == current_resource.password
         end
 

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -230,7 +230,7 @@ user password using shadow hash.")
           base_uid = new_resource.system ? 200 : 500
           next_uid_guess = base_uid
           users_uids = run_dscl("list /Users uid")
-          while(next_uid_guess < search_limit + base_uid)
+          while next_uid_guess < search_limit + base_uid
             if users_uids =~ Regexp.new("#{Regexp.escape(next_uid_guess.to_s)}\n")
               next_uid_guess += 1
             else

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -173,7 +173,7 @@ class Chef
         arg.each do |action|
           validate(
             { action: action },
-            { action: { kind_of: Symbol, equal_to: allowed_actions } },
+            { action: { kind_of: Symbol, equal_to: allowed_actions } }
           )
         end
         @action = arg

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -26,7 +26,7 @@ class Chef
 
       property :gem_binary, default: "#{RbConfig::CONFIG['bindir']}/gem",
                             callbacks: {
-                 "The chef_gem resource is restricted to the current gem environment, use gem_package to install to other environments." => proc { |v| v == "#{RbConfig::CONFIG['bindir']}/gem" }
+                 "The chef_gem resource is restricted to the current gem environment, use gem_package to install to other environments." => proc { |v| v == "#{RbConfig::CONFIG['bindir']}/gem" },
                }
       property :compile_time, [ true, false, nil ], default: lazy { Chef::Config[:chef_gem_compile_time] }, desired_state: false
 

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -60,7 +60,7 @@ class Chef
         set_or_return(
           :minute,
           converted_arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -77,7 +77,7 @@ class Chef
         set_or_return(
           :hour,
           converted_arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -94,7 +94,7 @@ class Chef
         set_or_return(
           :day,
           converted_arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -111,7 +111,7 @@ class Chef
         set_or_return(
           :month,
           converted_arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -135,7 +135,7 @@ class Chef
         set_or_return(
           :weekday,
           converted_arg,
-          :kind_of => [String, Symbol],
+          :kind_of => [String, Symbol]
         )
       end
 
@@ -143,7 +143,7 @@ class Chef
         set_or_return(
           :time,
           arg,
-          :equal_to => Chef::Provider::Cron::SPECIAL_TIME_VALUES,
+          :equal_to => Chef::Provider::Cron::SPECIAL_TIME_VALUES
         )
       end
 
@@ -151,7 +151,7 @@ class Chef
         set_or_return(
           :mailto,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -159,7 +159,7 @@ class Chef
         set_or_return(
           :path,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -167,7 +167,7 @@ class Chef
         set_or_return(
           :home,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -175,7 +175,7 @@ class Chef
         set_or_return(
           :shell,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -183,7 +183,7 @@ class Chef
         set_or_return(
           :command,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -191,7 +191,7 @@ class Chef
         set_or_return(
           :user,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -199,7 +199,7 @@ class Chef
         set_or_return(
           :environment,
           arg,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 

--- a/lib/chef/resource/deploy.rb
+++ b/lib/chef/resource/deploy.rb
@@ -103,7 +103,7 @@ class Chef
         set_or_return(
           :depth,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
 
@@ -112,7 +112,7 @@ class Chef
         set_or_return(
           :deploy_to,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -120,7 +120,7 @@ class Chef
         set_or_return(
           :repo,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
       alias :repository :repo
@@ -129,7 +129,7 @@ class Chef
         set_or_return(
           :remote,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -137,7 +137,7 @@ class Chef
         set_or_return(
           :role,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -146,7 +146,7 @@ class Chef
         set_or_return(
           :restart_command,
           arg,
-          :kind_of => [ String, Proc ],
+          :kind_of => [ String, Proc ]
         )
       end
       alias :restart :restart_command
@@ -155,7 +155,7 @@ class Chef
         set_or_return(
           :migrate,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -163,7 +163,7 @@ class Chef
         set_or_return(
           :migration_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -171,7 +171,7 @@ class Chef
         set_or_return(
           :rollback_on_error,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -179,7 +179,7 @@ class Chef
         set_or_return(
           :user,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -187,7 +187,7 @@ class Chef
         set_or_return(
           :group,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -195,7 +195,7 @@ class Chef
         set_or_return(
           :enable_submodules,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -203,7 +203,7 @@ class Chef
         set_or_return(
           :shallow_clone,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -211,7 +211,7 @@ class Chef
         set_or_return(
           :repository_cache,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -219,7 +219,7 @@ class Chef
         set_or_return(
           :copy_exclude,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -227,7 +227,7 @@ class Chef
         set_or_return(
           :revision,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
       alias :branch :revision
@@ -236,7 +236,7 @@ class Chef
         set_or_return(
           :git_ssh_wrapper,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
       alias :ssh_wrapper :git_ssh_wrapper
@@ -245,7 +245,7 @@ class Chef
         set_or_return(
           :svn_username,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -253,7 +253,7 @@ class Chef
         set_or_return(
           :svn_password,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -261,7 +261,7 @@ class Chef
         set_or_return(
           :svn_arguments,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -281,7 +281,7 @@ class Chef
         set_or_return(
           :scm_provider,
           klass,
-          :kind_of => [ Class ],
+          :kind_of => [ Class ]
         )
       end
 
@@ -295,7 +295,7 @@ class Chef
         set_or_return(
           :svn_force_export,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -308,7 +308,7 @@ class Chef
         set_or_return(
           :environment,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 
@@ -328,7 +328,7 @@ class Chef
         set_or_return(
           :purge_before_symlink,
           arg,
-          :kind_of => Array,
+          :kind_of => Array
         )
       end
 
@@ -344,7 +344,7 @@ class Chef
         set_or_return(
           :create_dirs_before_symlink,
           arg,
-          :kind_of => Array,
+          :kind_of => Array
         )
       end
 
@@ -358,7 +358,7 @@ class Chef
         set_or_return(
           :symlinks,
           arg,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 
@@ -373,7 +373,7 @@ class Chef
         set_or_return(
           :symlink_before_migrate,
           arg,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 
@@ -405,7 +405,7 @@ class Chef
         set_or_return(
           :additional_remotes,
           arg,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 
@@ -413,7 +413,7 @@ class Chef
         set_or_return(
           :enable_checkout,
           arg,
-          :kind_of => [TrueClass, FalseClass],
+          :kind_of => [TrueClass, FalseClass]
         )
       end
 
@@ -421,7 +421,7 @@ class Chef
         set_or_return(
           :checkout_branch,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -434,7 +434,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => Integer,
+          :kind_of => Integer
         )
       end
 

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -45,7 +45,7 @@ class Chef
         set_or_return(
           :recursive,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -53,7 +53,7 @@ class Chef
         set_or_return(
           :path,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -103,7 +103,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
 

--- a/lib/chef/resource/dsc_script.rb
+++ b/lib/chef/resource/dsc_script.rb
@@ -43,7 +43,7 @@ class Chef
         set_or_return(
           :code,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -54,7 +54,7 @@ class Chef
         set_or_return(
           :configuration_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -65,7 +65,7 @@ class Chef
         set_or_return(
           :command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -76,7 +76,7 @@ class Chef
         set_or_return(
           :configuration_data,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -87,7 +87,7 @@ class Chef
         set_or_return(
           :configuration_data_script,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -108,7 +108,7 @@ class Chef
         set_or_return(
           :flags,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 
@@ -116,7 +116,7 @@ class Chef
         set_or_return(
           :cwd,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -124,7 +124,7 @@ class Chef
         set_or_return(
           :environment,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 
@@ -132,7 +132,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
     end

--- a/lib/chef/resource/env.rb
+++ b/lib/chef/resource/env.rb
@@ -41,7 +41,7 @@ class Chef
         set_or_return(
           :key_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -49,7 +49,7 @@ class Chef
         set_or_return(
           :value,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -57,7 +57,7 @@ class Chef
         set_or_return(
           :delim,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
     end

--- a/lib/chef/resource/erl_call.rb
+++ b/lib/chef/resource/erl_call.rb
@@ -44,7 +44,7 @@ class Chef
         set_or_return(
           :code,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :cookie,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -60,7 +60,7 @@ class Chef
         set_or_return(
           :distributed,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -68,7 +68,7 @@ class Chef
         set_or_return(
           :name_type,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -76,7 +76,7 @@ class Chef
         set_or_return(
           :node_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -56,7 +56,7 @@ class Chef
         set_or_return(
           :umask,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -64,7 +64,7 @@ class Chef
         set_or_return(
           :command,
           arg,
-          :kind_of => [ String, Array ],
+          :kind_of => [ String, Array ]
         )
       end
 
@@ -72,7 +72,7 @@ class Chef
         set_or_return(
           :creates,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -80,7 +80,7 @@ class Chef
         set_or_return(
           :cwd,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -88,7 +88,7 @@ class Chef
         set_or_return(
           :environment,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 
@@ -98,7 +98,7 @@ class Chef
         set_or_return(
           :group,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -115,7 +115,7 @@ class Chef
         set_or_return(
           :path,
           arg,
-          :kind_of => [ Array ],
+          :kind_of => [ Array ]
         )
       end
 
@@ -123,7 +123,7 @@ class Chef
         set_or_return(
           :returns,
           arg,
-          :kind_of => [ Integer, Array ],
+          :kind_of => [ Integer, Array ]
         )
       end
 
@@ -131,7 +131,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => [ Integer, Float ],
+          :kind_of => [ Integer, Float ]
         )
       end
 
@@ -139,7 +139,7 @@ class Chef
         set_or_return(
           :user,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -164,7 +164,7 @@ class Chef
         :environment,
         :group,
         :user,
-        :umask,
+        :umask
       )
 
     end

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -110,7 +110,7 @@ class Chef
           # is interpolated. Until `file` can be deprecated, interpolate both.
           Chef.log_deprecation(
             "%{file} is deprecated in verify command and will not be "\
-            "supported in Chef 13. Please use %{path} instead."
+            "supported in Chef 13. Please use %{path} instead.",
           ) if @command.include?("%{file}")
           command = @command % { :file => path, :path => path }
           interpreter = Chef::GuardInterpreter.for_resource(@parent_resource, command, @command_opts)

--- a/lib/chef/resource/file/verification.rb
+++ b/lib/chef/resource/file/verification.rb
@@ -110,7 +110,7 @@ class Chef
           # is interpolated. Until `file` can be deprecated, interpolate both.
           Chef.log_deprecation(
             "%{file} is deprecated in verify command and will not be "\
-            "supported in Chef 13. Please use %{path} instead.",
+            "supported in Chef 13. Please use %{path} instead."
           ) if @command.include?("%{file}")
           command = @command % { :file => path, :path => path }
           interpreter = Chef::GuardInterpreter.for_resource(@parent_resource, command, @command_opts)

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -31,7 +31,7 @@ class Chef
         set_or_return(
           :additional_remotes,
           arg,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -42,7 +42,7 @@ class Chef
         set_or_return(
           :group_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -50,7 +50,7 @@ class Chef
         set_or_return(
           :gid,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -59,7 +59,7 @@ class Chef
         set_or_return(
           :members,
           converted_members,
-          :kind_of => [ Array ],
+          :kind_of => [ Array ]
         )
       end
 
@@ -70,7 +70,7 @@ class Chef
         set_or_return(
           :excluded_members,
           converted_members,
-          :kind_of => [ Array ],
+          :kind_of => [ Array ]
         )
       end
 
@@ -78,7 +78,7 @@ class Chef
         set_or_return(
           :append,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -86,7 +86,7 @@ class Chef
         set_or_return(
           :system,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -94,7 +94,7 @@ class Chef
         set_or_return(
           :non_unique,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
     end

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -40,7 +40,7 @@ class Chef
         set_or_return(
           :url,
           args,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -49,7 +49,7 @@ class Chef
         set_or_return(
           :message,
           args,
-          :kind_of => Object,
+          :kind_of => Object
         )
       end
 
@@ -57,7 +57,7 @@ class Chef
         set_or_return(
           :headers,
           args,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -50,7 +50,7 @@ class Chef
         set_or_return(
           :target,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -58,7 +58,7 @@ class Chef
         set_or_return(
           :device,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -66,7 +66,7 @@ class Chef
         set_or_return(
           :hwaddr,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -74,7 +74,7 @@ class Chef
         set_or_return(
           :inet_addr,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -82,7 +82,7 @@ class Chef
         set_or_return(
           :bcast,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -90,7 +90,7 @@ class Chef
         set_or_return(
           :mask,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -98,7 +98,7 @@ class Chef
         set_or_return(
           :mtu,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -106,7 +106,7 @@ class Chef
         set_or_return(
           :metric,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -114,7 +114,7 @@ class Chef
         set_or_return(
           :onboot,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -122,7 +122,7 @@ class Chef
         set_or_return(
           :network,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -130,7 +130,7 @@ class Chef
         set_or_return(
           :bootproto,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -138,7 +138,7 @@ class Chef
         set_or_return(
           :onparent,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
     end

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -44,7 +44,7 @@ class Chef
         set_or_return(
           :to,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :target_file,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -61,7 +61,7 @@ class Chef
         set_or_return(
           :link_type,
           real_arg,
-          :equal_to => [ :symbolic, :hard ],
+          :equal_to => [ :symbolic, :hard ]
         )
       end
 
@@ -69,7 +69,7 @@ class Chef
         set_or_return(
           :group,
           arg,
-          :regex => Chef::Config[:group_valid_regex],
+          :regex => Chef::Config[:group_valid_regex]
         )
       end
 
@@ -77,7 +77,7 @@ class Chef
         set_or_return(
           :owner,
           arg,
-          :regex => Chef::Config[:user_valid_regex],
+          :regex => Chef::Config[:user_valid_regex]
         )
       end
 

--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -58,7 +58,7 @@ class Chef
         set_or_return(
           :message,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -67,7 +67,7 @@ class Chef
         set_or_return(
           :level,
           arg,
-          :equal_to => [ :debug, :info, :warn, :error, :fatal ],
+          :equal_to => [ :debug, :info, :warn, :error, :fatal ]
         )
       end
 

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -41,7 +41,7 @@ class Chef
         set_or_return(
           :plist,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -49,7 +49,7 @@ class Chef
         set_or_return(
           :session_type,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -46,7 +46,7 @@ class Chef
         set_or_return(
           :chunk,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
 
@@ -54,7 +54,7 @@ class Chef
         set_or_return(
           :devices,
           arg,
-          :kind_of => [ Array ],
+          :kind_of => [ Array ]
         )
       end
 
@@ -62,7 +62,7 @@ class Chef
         set_or_return(
           :exists,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -70,7 +70,7 @@ class Chef
         set_or_return(
           :level,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
 
@@ -78,7 +78,7 @@ class Chef
         set_or_return(
           :metadata,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -86,7 +86,7 @@ class Chef
         set_or_return(
           :bitmap,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -94,7 +94,7 @@ class Chef
         set_or_return(
           :raid_device,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :mount_point,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -60,7 +60,7 @@ class Chef
         set_or_return(
           :device,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -74,7 +74,7 @@ class Chef
         set_or_return(
           :device_type,
           real_arg,
-          :equal_to => valid_devices,
+          :equal_to => valid_devices
         )
       end
 
@@ -82,7 +82,7 @@ class Chef
         set_or_return(
           :fsck_device,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -90,7 +90,7 @@ class Chef
         set_or_return(
           :fstype,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -98,7 +98,7 @@ class Chef
         ret = set_or_return(
                             :options,
                             arg,
-                            :kind_of => [ Array, String ],
+                            :kind_of => [ Array, String ]
                             )
 
         if ret.is_a? String
@@ -112,7 +112,7 @@ class Chef
         set_or_return(
           :dump,
           arg,
-          :kind_of => [ Integer, FalseClass ],
+          :kind_of => [ Integer, FalseClass ]
         )
       end
 
@@ -120,7 +120,7 @@ class Chef
         set_or_return(
           :pass,
           arg,
-          :kind_of => [ Integer, FalseClass ],
+          :kind_of => [ Integer, FalseClass ]
         )
       end
 
@@ -128,7 +128,7 @@ class Chef
         set_or_return(
           :mounted,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -136,7 +136,7 @@ class Chef
         set_or_return(
           :enabled,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -154,7 +154,7 @@ class Chef
         set_or_return(
           :username,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -162,7 +162,7 @@ class Chef
         set_or_return(
           :password,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -170,7 +170,7 @@ class Chef
         set_or_return(
           :domain,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -37,7 +37,7 @@ class Chef
         set_or_return(
           :plugin,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -45,7 +45,7 @@ class Chef
         set_or_return(
           :name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
     end

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -41,7 +41,7 @@ class Chef
         set_or_return(
           :profile_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -49,7 +49,7 @@ class Chef
         set_or_return(
           :profile,
           arg,
-          :kind_of => [ String, Hash ],
+          :kind_of => [ String, Hash ]
         )
       end
 
@@ -57,7 +57,7 @@ class Chef
         set_or_return(
           :identifier,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -65,7 +65,7 @@ class Chef
         set_or_return(
           :path,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -31,7 +31,7 @@ class Chef
         set_or_return(
           :convert_boolean_return,
           arg,
-          :kind_of => [ FalseClass, TrueClass ],
+          :kind_of => [ FalseClass, TrueClass ]
         )
       end
 

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -71,7 +71,7 @@ class Chef
         set_or_return(
           :key,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -105,7 +105,7 @@ class Chef
         set_or_return(
           :recursive,
           arg,
-          :kind_of => [TrueClass, FalseClass],
+          :kind_of => [TrueClass, FalseClass]
         )
       end
 
@@ -113,7 +113,7 @@ class Chef
         set_or_return(
           :architecture,
           arg,
-          :kind_of => Symbol,
+          :kind_of => Symbol
         )
       end
 

--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -57,7 +57,7 @@ class Chef
         set_or_return(
           :source,
           args,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -65,7 +65,7 @@ class Chef
         set_or_return(
           :files_backup,
           arg,
-          :kind_of => [ Integer, FalseClass ],
+          :kind_of => [ Integer, FalseClass ]
         )
       end
 
@@ -73,7 +73,7 @@ class Chef
         set_or_return(
           :purge,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -81,7 +81,7 @@ class Chef
         set_or_return(
           :files_group,
           arg,
-          :regex => Chef::Config[:group_valid_regex],
+          :regex => Chef::Config[:group_valid_regex]
         )
       end
 
@@ -89,7 +89,7 @@ class Chef
         set_or_return(
           :files_mode,
           arg,
-          :regex => /^\d{3,4}$/,
+          :regex => /^\d{3,4}$/
         )
       end
 
@@ -97,7 +97,7 @@ class Chef
         set_or_return(
           :files_owner,
           arg,
-          :regex => Chef::Config[:user_valid_regex],
+          :regex => Chef::Config[:user_valid_regex]
         )
       end
 
@@ -105,7 +105,7 @@ class Chef
         set_or_return(
           :overwrite,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -113,7 +113,7 @@ class Chef
         set_or_return(
           :cookbook,
           args,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -76,7 +76,7 @@ class Chef
         set_or_return(
           :checksum,
           args,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -92,7 +92,7 @@ class Chef
         set_or_return(
           :use_etag,
           args,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -102,7 +102,7 @@ class Chef
         set_or_return(
           :use_last_modified,
           args,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -110,7 +110,7 @@ class Chef
         set_or_return(
           :ftp_active_mode,
           args,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -118,7 +118,7 @@ class Chef
         set_or_return(
           :headers,
           args,
-          :kind_of => Hash,
+          :kind_of => Hash
         )
       end
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -51,7 +51,7 @@ class Chef
         ret = set_or_return(:source,
                             arg,
                             { :callbacks => {
-                                :validate_source => method(:validate_source)
+                                :validate_source => method(:validate_source),
                               } })
         if ret.is_a? String
           Array(ret)

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -48,7 +48,7 @@ class Chef
         set_or_return(
           :networking,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -56,7 +56,7 @@ class Chef
         set_or_return(
           :networking_ipv6,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -64,7 +64,7 @@ class Chef
         set_or_return(
           :hostname,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -72,7 +72,7 @@ class Chef
         set_or_return(
           :domainname,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -80,7 +80,7 @@ class Chef
         set_or_return(
           :domain,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -88,7 +88,7 @@ class Chef
         set_or_return(
           :target,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -96,7 +96,7 @@ class Chef
         set_or_return(
           :netmask,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -104,7 +104,7 @@ class Chef
         set_or_return(
           :gateway,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -112,7 +112,7 @@ class Chef
         set_or_return(
           :metric,
           arg,
-          :kind_of => Integer,
+          :kind_of => Integer
         )
       end
 
@@ -120,7 +120,7 @@ class Chef
         set_or_return(
           :device,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -129,7 +129,7 @@ class Chef
         set_or_return(
           :route_type,
           real_arg,
-          :equal_to => [ :host, :net ],
+          :equal_to => [ :host, :net ]
         )
       end
     end

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -45,7 +45,7 @@ class Chef
         set_or_return(
           :block_name,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
     end

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -45,7 +45,7 @@ class Chef
         set_or_return(
           :destination,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -53,7 +53,7 @@ class Chef
         set_or_return(
           :repository,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -61,7 +61,7 @@ class Chef
         set_or_return(
           :revision,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -69,7 +69,7 @@ class Chef
         set_or_return(
           :user,
           arg,
-          :kind_of => [String, Integer],
+          :kind_of => [String, Integer]
         )
       end
 
@@ -77,7 +77,7 @@ class Chef
         set_or_return(
           :group,
           arg,
-          :kind_of => [String, Integer],
+          :kind_of => [String, Integer]
         )
       end
 
@@ -85,7 +85,7 @@ class Chef
         set_or_return(
           :svn_username,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -93,7 +93,7 @@ class Chef
         set_or_return(
           :svn_password,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -102,7 +102,7 @@ class Chef
         set_or_return(
           :svn_arguments,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -119,7 +119,7 @@ class Chef
         set_or_return(
           :depth,
           arg,
-          :kind_of => Integer,
+          :kind_of => Integer
         )
       end
 
@@ -127,7 +127,7 @@ class Chef
         set_or_return(
           :enable_submodules,
           arg,
-          :kind_of => [TrueClass, FalseClass],
+          :kind_of => [TrueClass, FalseClass]
         )
       end
 
@@ -135,7 +135,7 @@ class Chef
         set_or_return(
           :enable_checkout,
           arg,
-          :kind_of => [TrueClass, FalseClass],
+          :kind_of => [TrueClass, FalseClass]
         )
       end
 
@@ -143,7 +143,7 @@ class Chef
         set_or_return(
           :remote,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -151,7 +151,7 @@ class Chef
         set_or_return(
           :ssh_wrapper,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -159,7 +159,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => Integer,
+          :kind_of => Integer
         )
       end
 
@@ -167,7 +167,7 @@ class Chef
         set_or_return(
           :checkout_branch,
           arg,
-          :kind_of => String,
+          :kind_of => String
         )
       end
 
@@ -175,7 +175,7 @@ class Chef
         set_or_return(
           :environment,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 

--- a/lib/chef/resource/script.rb
+++ b/lib/chef/resource/script.rb
@@ -49,7 +49,7 @@ class Chef
         set_or_return(
           :code,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -57,7 +57,7 @@ class Chef
         set_or_return(
           :interpreter,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -65,7 +65,7 @@ class Chef
         set_or_return(
           :flags,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -52,7 +52,7 @@ class Chef
         set_or_return(
           :service_name,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -61,7 +61,7 @@ class Chef
         set_or_return(
           :pattern,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -70,7 +70,7 @@ class Chef
         set_or_return(
           :start_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -79,7 +79,7 @@ class Chef
         set_or_return(
           :stop_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -88,7 +88,7 @@ class Chef
         set_or_return(
           :status_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -97,7 +97,7 @@ class Chef
         set_or_return(
           :restart_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -105,7 +105,7 @@ class Chef
         set_or_return(
           :reload_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -118,7 +118,7 @@ class Chef
         set_or_return(
           :init_command,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -127,7 +127,7 @@ class Chef
         set_or_return(
           :enabled,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -136,7 +136,7 @@ class Chef
         set_or_return(
           :running,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -154,7 +154,7 @@ class Chef
         set_or_return(
           :priority,
           arg,
-          :kind_of => [ Integer, String, Hash ],
+          :kind_of => [ Integer, String, Hash ]
         )
       end
 
@@ -163,7 +163,7 @@ class Chef
         set_or_return(
           :timeout,
           arg,
-          :kind_of => Integer,
+          :kind_of => Integer
         )
       end
 
@@ -171,7 +171,7 @@ class Chef
         set_or_return(
           :parameters,
           arg,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -45,7 +45,7 @@ class Chef
         set_or_return(
           :source,
           file,
-          :kind_of => [ String, Array ],
+          :kind_of => [ String, Array ]
         )
       end
 
@@ -53,7 +53,7 @@ class Chef
         set_or_return(
           :variables,
           args,
-          :kind_of => [ Hash ],
+          :kind_of => [ Hash ]
         )
       end
 
@@ -61,7 +61,7 @@ class Chef
         set_or_return(
           :cookbook,
           args,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -69,7 +69,7 @@ class Chef
         set_or_return(
           :local,
           args,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -53,7 +53,7 @@ class Chef
         set_or_return(
           :username,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -61,7 +61,7 @@ class Chef
         set_or_return(
           :comment,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -69,7 +69,7 @@ class Chef
         set_or_return(
           :uid,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -77,7 +77,7 @@ class Chef
         set_or_return(
           :gid,
           arg,
-          :kind_of => [ String, Integer ],
+          :kind_of => [ String, Integer ]
         )
       end
 
@@ -87,7 +87,7 @@ class Chef
         set_or_return(
           :home,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -95,7 +95,7 @@ class Chef
         set_or_return(
           :shell,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -103,7 +103,7 @@ class Chef
         set_or_return(
           :password,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -111,7 +111,7 @@ class Chef
         set_or_return(
           :salt,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -119,7 +119,7 @@ class Chef
         set_or_return(
           :iterations,
           arg,
-          :kind_of => [ Integer ],
+          :kind_of => [ Integer ]
         )
       end
 
@@ -127,7 +127,7 @@ class Chef
         set_or_return(
           :system,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -135,7 +135,7 @@ class Chef
         set_or_return(
           :manage_home,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -143,7 +143,7 @@ class Chef
         set_or_return(
           :force,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 
@@ -151,7 +151,7 @@ class Chef
         set_or_return(
           :non_unique,
           arg,
-          :kind_of => [ TrueClass, FalseClass ],
+          :kind_of => [ TrueClass, FalseClass ]
         )
       end
 

--- a/lib/chef/resource/windows_script.rb
+++ b/lib/chef/resource/windows_script.rb
@@ -45,7 +45,7 @@ class Chef
         result = set_or_return(
           :architecture,
           arg,
-          :kind_of => Symbol,
+          :kind_of => Symbol
         )
       end
 

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -47,7 +47,7 @@ class Chef
         set_or_return(
           :startup_type,
           arg,
-          :equal_to => [ :automatic, :manual, :disabled ],
+          :equal_to => [ :automatic, :manual, :disabled ]
         )
       end
 
@@ -55,7 +55,7 @@ class Chef
         set_or_return(
           :run_as_user,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
 
@@ -63,7 +63,7 @@ class Chef
         set_or_return(
           :run_as_password,
           arg,
-          :kind_of => [ String ],
+          :kind_of => [ String ]
         )
       end
     end

--- a/lib/chef/role.rb
+++ b/lib/chef/role.rb
@@ -57,7 +57,7 @@ class Chef
       set_or_return(
         :name,
         arg,
-        :regex => /^[\-[:alnum:]_]+$/,
+        :regex => /^[\-[:alnum:]_]+$/
       )
     end
 
@@ -65,7 +65,7 @@ class Chef
       set_or_return(
         :description,
         arg,
-        :kind_of => String,
+        :kind_of => String
       )
     end
 
@@ -120,7 +120,7 @@ class Chef
       set_or_return(
         :default_attributes,
         arg,
-        :kind_of => Hash,
+        :kind_of => Hash
       )
     end
 
@@ -128,7 +128,7 @@ class Chef
       set_or_return(
         :override_attributes,
         arg,
-        :kind_of => Hash,
+        :kind_of => Hash
       )
     end
 

--- a/lib/chef/user_v1.rb
+++ b/lib/chef/user_v1.rb
@@ -114,7 +114,7 @@ class Chef
 
     def to_hash
       result = {
-        "username" => @username
+        "username" => @username,
       }
       result["display_name"] = @display_name unless @display_name.nil?
       result["first_name"] = @first_name unless @first_name.nil?

--- a/lib/chef/win32/security/sid.rb
+++ b/lib/chef/win32/security/sid.rb
@@ -275,7 +275,7 @@ class Chef
 
             status = ERROR_MORE_DATA
 
-            while(status == ERROR_MORE_DATA)
+            while status == ERROR_MORE_DATA
               status = NetUserEnum(servername, level, filter, bufptr, prefmaxlen, entriesread, totalentries, resume_handle)
 
               if status == NERR_Success || status == ERROR_MORE_DATA

--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -106,7 +106,7 @@ describe Chef::Resource::Execute do
 
     it "guard adds additional values in its :environment and runs" do
       resource.only_if %{ruby -e 'exit 1 if ENV["SGCE_SECRET"] != "regularsecret"'}, {
-        :environment => { "SGCE_SECRET" => "regularsecret" }
+        :environment => { "SGCE_SECRET" => "regularsecret" },
       }
       resource.run_action(:run)
       expect(resource).to be_updated_by_last_action
@@ -114,7 +114,7 @@ describe Chef::Resource::Execute do
 
     it "guard adds additional values in its :environment and does not run" do
       resource.only_if %{ruby -e 'exit 1 if ENV["SGCE_SECRET"] == "regularsecret"'}, {
-        :environment => { "SGCE_SECRET" => "regularsecret" }
+        :environment => { "SGCE_SECRET" => "regularsecret" },
       }
       resource.run_action(:run)
       expect(resource).not_to be_updated_by_last_action
@@ -122,7 +122,7 @@ describe Chef::Resource::Execute do
 
     it "guard overwrites value with its :environment and runs" do
       resource.only_if %{ruby -e 'exit 1 if ENV["SAWS_SECRET"] != "regularsecret"'}, {
-        :environment => { "SAWS_SECRET" => "regularsecret" }
+        :environment => { "SAWS_SECRET" => "regularsecret" },
       }
       resource.run_action(:run)
       expect(resource).to be_updated_by_last_action
@@ -130,7 +130,7 @@ describe Chef::Resource::Execute do
 
     it "guard overwrites value with its :environment and does not runs" do
       resource.only_if %{ruby -e 'exit 1 if ENV["SAWS_SECRET"] == "regularsecret"'}, {
-        :environment => { "SAWS_SECRET" => "regularsecret" }
+        :environment => { "SAWS_SECRET" => "regularsecret" },
       }
       resource.run_action(:run)
       expect(resource).not_to be_updated_by_last_action

--- a/spec/functional/resource/execute_spec.rb
+++ b/spec/functional/resource/execute_spec.rb
@@ -89,7 +89,7 @@ describe Chef::Resource::Execute do
       resource.environment({
         "SAWS_SECRET"  => "supersecret",
         "SAWS_KEY"     => "qwerty",
-      },)
+      })
     end
 
     it "guard inherits :environment value from resource and runs" do

--- a/spec/functional/resource/package_spec.rb
+++ b/spec/functional/resource/package_spec.rb
@@ -54,7 +54,7 @@ module AptServer
       :DocumentRoot => apt_data_dir + "/var/www/apt",
       # Make WEBrick quiet, comment out for debug.
       :Logger       => Logger.new(StringIO.new),
-      :AccessLog    => [ StringIO.new, WEBrick::AccessLog::COMMON_LOG_FORMAT ],
+      :AccessLog    => [ StringIO.new, WEBrick::AccessLog::COMMON_LOG_FORMAT ]
     )
   end
 

--- a/spec/functional/resource/user/dscl_spec.rb
+++ b/spec/functional/resource/user/dscl_spec.rb
@@ -186,7 +186,7 @@ c5adbbac718b7eb99463a7b679571e0f\
       end
     end
 
-    it ":remove action removes the user from the groups and deletes the user"do
+    it ":remove action removes the user from the groups and deletes the user" do
       user_resource.run_action(:remove)
       groups.each do |group|
         # Do not raise an error when group is empty

--- a/spec/functional/resource/windows_service_spec.rb
+++ b/spec/functional/resource/windows_service_spec.rb
@@ -50,7 +50,7 @@ describe Chef::Resource::WindowsService, :windows_only, :system_windows_service_
       service_display_name: "windows_service spec #{id}}",
       service_description: "Test service for running the windows_service functional spec.",
       service_file_path: global_service_file_path,
-      }, )
+      } )
   }
 
   let(:manager) {

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -218,13 +218,13 @@ depends "self"'
         it "knife deps prints each once" do
           knife("deps /cookbooks/foo /cookbooks/self").should_succeed(
             stdout: "/cookbooks/baz\n/cookbooks/bar\n/cookbooks/foo\n/cookbooks/self\n",
-            stderr: "WARN: Ignoring self-dependency in cookbook self, please remove it (in the future this will be fatal).\n",
+            stderr: "WARN: Ignoring self-dependency in cookbook self, please remove it (in the future this will be fatal).\n"
           )
         end
         it "knife deps --tree prints each once" do
           knife("deps --tree /cookbooks/foo /cookbooks/self").should_succeed(
             stdout: "/cookbooks/foo\n  /cookbooks/bar\n    /cookbooks/baz\n      /cookbooks/foo\n/cookbooks/self\n",
-            stderr: "WARN: Ignoring self-dependency in cookbook self, please remove it (in the future this will be fatal).\n",
+            stderr: "WARN: Ignoring self-dependency in cookbook self, please remove it (in the future this will be fatal).\n"
           )
         end
       end
@@ -258,42 +258,42 @@ EOM
           knife("deps /blah").should_fail(
             :exit_code => 2,
             :stdout => "/blah\n",
-            :stderr => "ERROR: /blah: No such file or directory\n",
+            :stderr => "ERROR: /blah: No such file or directory\n"
           )
         end
         it "knife deps /roles/x.json reports an error" do
           knife("deps /roles/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/roles/x.json\n",
-            :stderr => "ERROR: /roles/x.json: No such file or directory\n",
+            :stderr => "ERROR: /roles/x.json: No such file or directory\n"
           )
         end
         it "knife deps /nodes/x.json reports an error" do
           knife("deps /nodes/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/nodes/x.json\n",
-            :stderr => "ERROR: /nodes/x.json: No such file or directory\n",
+            :stderr => "ERROR: /nodes/x.json: No such file or directory\n"
           )
         end
         it "knife deps /environments/x.json reports an error" do
           knife("deps /environments/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/environments/x.json\n",
-            :stderr => "ERROR: /environments/x.json: No such file or directory\n",
+            :stderr => "ERROR: /environments/x.json: No such file or directory\n"
           )
         end
         it "knife deps /cookbooks/x reports an error" do
           knife("deps /cookbooks/x").should_fail(
             :exit_code => 2,
             :stdout => "/cookbooks/x\n",
-            :stderr => "ERROR: /cookbooks/x: No such file or directory\n",
+            :stderr => "ERROR: /cookbooks/x: No such file or directory\n"
           )
         end
         it "knife deps /data_bags/bag/item reports an error" do
           knife("deps /data_bags/bag/item").should_fail(
             :exit_code => 2,
             :stdout => "/data_bags/bag/item\n",
-            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n",
+            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n"
           )
         end
       end
@@ -305,7 +305,7 @@ EOM
           knife("deps /roles/starring.json").should_fail(
             :exit_code => 2,
             :stdout => "/cookbooks/quiche\n/roles/starring.json\n",
-            :stderr => "ERROR: /cookbooks/quiche: No such file or directory\n",
+            :stderr => "ERROR: /cookbooks/quiche: No such file or directory\n"
           )
         end
       end
@@ -317,7 +317,7 @@ EOM
           knife("deps /nodes/mort.json").should_fail(
             :exit_code => 2,
             :stdout => "/environments/desert.json\n/nodes/mort.json\n",
-            :stderr => "ERROR: /environments/desert.json: No such file or directory\n",
+            :stderr => "ERROR: /environments/desert.json: No such file or directory\n"
           )
         end
       end
@@ -329,7 +329,7 @@ EOM
           knife("deps /roles/starring.json").should_fail(
             :exit_code => 2,
             :stdout => "/roles/minor.json\n/roles/starring.json\n",
-            :stderr => "ERROR: /roles/minor.json: No such file or directory\n",
+            :stderr => "ERROR: /roles/minor.json: No such file or directory\n"
           )
         end
       end
@@ -343,7 +343,7 @@ EOM
           knife("deps /roles").should_fail(
             :exit_code => 2,
             :stderr => "ERROR: /roles: No such file or directory\n",
-            :stdout => "/roles\n",
+            :stdout => "/roles\n"
           )
         end
       end
@@ -357,7 +357,7 @@ EOM
         before { file "cookbooks/blah/metadata.rb", 'name "blah"' }
         it "knife deps on a cookbook file shows no dependencies" do
           knife("deps /cookbooks/blah/metadata.rb").should_succeed(
-            "/cookbooks/blah/metadata.rb\n",
+            "/cookbooks/blah/metadata.rb\n"
           )
         end
       end
@@ -596,42 +596,42 @@ EOM
           knife("deps --remote /blah").should_fail(
             :exit_code => 2,
             :stdout => "/blah\n",
-            :stderr => "ERROR: /blah: No such file or directory\n",
+            :stderr => "ERROR: /blah: No such file or directory\n"
           )
         end
         it "knife deps /roles/x.json reports an error" do
           knife("deps --remote /roles/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/roles/x.json\n",
-            :stderr => "ERROR: /roles/x.json: No such file or directory\n",
+            :stderr => "ERROR: /roles/x.json: No such file or directory\n"
           )
         end
         it "knife deps /nodes/x.json reports an error" do
           knife("deps --remote /nodes/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/nodes/x.json\n",
-            :stderr => "ERROR: /nodes/x.json: No such file or directory\n",
+            :stderr => "ERROR: /nodes/x.json: No such file or directory\n"
           )
         end
         it "knife deps /environments/x.json reports an error" do
           knife("deps --remote /environments/x.json").should_fail(
             :exit_code => 2,
             :stdout => "/environments/x.json\n",
-            :stderr => "ERROR: /environments/x.json: No such file or directory\n",
+            :stderr => "ERROR: /environments/x.json: No such file or directory\n"
           )
         end
         it "knife deps /cookbooks/x reports an error" do
           knife("deps --remote /cookbooks/x").should_fail(
             :exit_code => 2,
             :stdout => "/cookbooks/x\n",
-            :stderr => "ERROR: /cookbooks/x: No such file or directory\n",
+            :stderr => "ERROR: /cookbooks/x: No such file or directory\n"
           )
         end
         it "knife deps /data_bags/bag/item reports an error" do
           knife("deps --remote /data_bags/bag/item").should_fail(
             :exit_code => 2,
             :stdout => "/data_bags/bag/item\n",
-            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n",
+            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n"
           )
         end
       end
@@ -643,7 +643,7 @@ EOM
           knife("deps --remote /roles/starring.json").should_fail(
             :exit_code => 2,
             :stdout => "/cookbooks/quiche\n/roles/starring.json\n",
-            :stderr => "ERROR: /cookbooks/quiche: No such file or directory\n",
+            :stderr => "ERROR: /cookbooks/quiche: No such file or directory\n"
           )
         end
       end
@@ -655,7 +655,7 @@ EOM
           knife("deps --remote /nodes/mort.json").should_fail(
             :exit_code => 2,
             :stdout => "/environments/desert.json\n/nodes/mort.json\n",
-            :stderr => "ERROR: /environments/desert.json: No such file or directory\n",
+            :stderr => "ERROR: /environments/desert.json: No such file or directory\n"
           )
         end
       end
@@ -667,7 +667,7 @@ EOM
           knife("deps --remote /roles/starring.json").should_fail(
             :exit_code => 2,
             :stdout => "/roles/minor.json\n/roles/starring.json\n",
-            :stderr => "ERROR: /roles/minor.json: No such file or directory\n",
+            :stderr => "ERROR: /roles/minor.json: No such file or directory\n"
           )
         end
       end
@@ -693,7 +693,7 @@ EOM
         end
         it "knife deps on a cookbook file shows no dependencies" do
           knife("deps --remote /cookbooks/blah/metadata.rb").should_succeed(
-            "/cookbooks/blah/metadata.rb\n",
+            "/cookbooks/blah/metadata.rb\n"
           )
         end
       end

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -357,7 +357,7 @@ EOM
         before { file "cookbooks/blah/metadata.rb", 'name "blah"' }
         it "knife deps on a cookbook file shows no dependencies" do
           knife("deps /cookbooks/blah/metadata.rb").should_succeed(
-            "/cookbooks/blah/metadata.rb\n"
+            "/cookbooks/blah/metadata.rb\n",
           )
         end
       end
@@ -693,7 +693,7 @@ EOM
         end
         it "knife deps on a cookbook file shows no dependencies" do
           knife("deps --remote /cookbooks/blah/metadata.rb").should_succeed(
-            "/cookbooks/blah/metadata.rb\n"
+            "/cookbooks/blah/metadata.rb\n",
           )
         end
       end

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -1192,7 +1192,7 @@ EOM
             "policies" => {
               "x" => { "revision_id" => "1.0.0" },
               "blah" => { "revision_id" => "1.0.0" },
-            }
+            },
           }
           role "x", {}
         end
@@ -1283,7 +1283,7 @@ EOM
               "policies" => {
                 "x" => { "revision_id" => "1.0.1" },
                 "y" => { "revision_id" => "1.0.0" },
-              }
+              },
             }
             file "roles/x.json", { "run_list" => [ "blah" ] }
           end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -162,7 +162,7 @@ EOM
           it "should warn", :chef_lt_13_only do
             knife("upload /cookbooks").should_succeed(
               stdout: "Updated /cookbooks/x\n",
-              stderr: "WARN: Ignoring self-dependency in cookbook x, please remove it (in the future this will be fatal).\n",
+              stderr: "WARN: Ignoring self-dependency in cookbook x, please remove it (in the future this will be fatal).\n"
             )
             knife("diff --name-status /").should_succeed ""
           end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -1349,7 +1349,7 @@ EOM
               "policies" => {
                 "x" => { "revision_id" => "1.0.0" },
                 "blah" => { "revision_id" => "1.0.0" },
-              }
+              },
             }
             role "x", {}
           end
@@ -1403,7 +1403,7 @@ EOM
               "policies" => {
                 "x" => { "revision_id" => "1.0.1" },
                 "y" => { "revision_id" => "1.0.0" },
-              }
+              },
             }
             role "x", { "run_list" => [ "blah" ] }
           end

--- a/spec/support/shared/functional/http.rb
+++ b/spec/support/shared/functional/http.rb
@@ -81,7 +81,7 @@ module ChefHTTPShared
     # (expected_content should be uncompressed)
     @api.get("/nyan_cat_content_length.png", 200, nil,
       {
-        "Content-Length" => nyan_uncompressed_size.to_s
+        "Content-Length" => nyan_uncompressed_size.to_s,
       }
     ) {
       File.open(nyan_uncompressed_filename, "rb") do |f|
@@ -109,7 +109,7 @@ module ChefHTTPShared
     # (expected_content should be uncompressed)
     @api.get("/nyan_cat_truncated.png", 200, nil,
       {
-        "Content-Length" => (nyan_uncompressed_size + 1).to_s
+        "Content-Length" => (nyan_uncompressed_size + 1).to_s,
       }
     ) {
       File.open(nyan_uncompressed_filename, "rb") do |f|
@@ -151,7 +151,7 @@ module ChefHTTPShared
     #
     @api.get("/forbidden", 403, "Forbidden",
       {
-        "Content-Length" => "Forbidden".bytesize.to_s
+        "Content-Length" => "Forbidden".bytesize.to_s,
       }
     )
 

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -409,7 +409,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           allowed_acl(SID.Everyone, expected_read_perms) +
-          allowed_acl(SID.Guest, expected_modify_perms),
+          allowed_acl(SID.Guest, expected_modify_perms)
         )
       end
 
@@ -420,7 +420,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           denied_acl(SID.Guest, expected_modify_perms) +
-          allowed_acl(SID.Everyone, expected_read_perms),
+          allowed_acl(SID.Everyone, expected_read_perms)
         )
       end
 
@@ -431,7 +431,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           denied_acl(SID.Guest, expected_modify_perms) +
-          allowed_acl(SID.Everyone, expected_read_perms),
+          allowed_acl(SID.Everyone, expected_read_perms)
         )
       end
 

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -409,7 +409,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           allowed_acl(SID.Everyone, expected_read_perms) +
-          allowed_acl(SID.Guest, expected_modify_perms)
+          allowed_acl(SID.Guest, expected_modify_perms),
         )
       end
 
@@ -420,7 +420,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           denied_acl(SID.Guest, expected_modify_perms) +
-          allowed_acl(SID.Everyone, expected_read_perms)
+          allowed_acl(SID.Everyone, expected_read_perms),
         )
       end
 
@@ -431,7 +431,7 @@ shared_examples_for "a securable resource without existing target" do
 
         expect(explicit_aces).to eq(
           denied_acl(SID.Guest, expected_modify_perms) +
-          allowed_acl(SID.Everyone, expected_read_perms)
+          allowed_acl(SID.Everyone, expected_read_perms),
         )
       end
 

--- a/spec/support/shared/integration/app_server_support.rb
+++ b/spec/support/shared/integration/app_server_support.rb
@@ -27,7 +27,7 @@ module AppServerSupport
       Rack::Handler::WEBrick.run(app,
         :Port => 9018,
         :AccessLog => [],
-        :Logger => WEBrick::Log.new(StringIO.new, 7),
+        :Logger => WEBrick::Log.new(StringIO.new, 7)
       ) do |found_server|
         server = found_server
       end

--- a/spec/support/shared/unit/user_and_client_shared.rb
+++ b/spec/support/shared/unit/user_and_client_shared.rb
@@ -58,8 +58,8 @@ shared_examples_for "user or client create" do
       let(:chef_key) {
         {
           "chef_key" => {
-            "public_key" => "some_public_key"
-          }
+            "public_key" => "some_public_key",
+          },
         }
       }
 
@@ -75,7 +75,7 @@ shared_examples_for "user or client create" do
             "chef_key" => {
               "public_key" => "some_public_key",
               "private_key" => "some_private_key",
-            }
+            },
           }
         }
 

--- a/spec/unit/api_client/registration_spec.rb
+++ b/spec/unit/api_client/registration_spec.rb
@@ -71,7 +71,7 @@ describe Chef::ApiClient::Registration do
     {
       "uri" => "",
       "chef_key" => {
-        "public_key" => generated_public_key.to_pem
+        "public_key" => generated_public_key.to_pem,
       },
     }
   end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -85,7 +85,7 @@ describe Chef::Application::Client, "reconfigure" do
 "Unforked chef-client interval runs are disabled in Chef 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options.",
         )
         app.reconfigure
       end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -85,7 +85,7 @@ describe Chef::Application::Client, "reconfigure" do
 "Unforked chef-client interval runs are disabled in Chef 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options.",
+Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
         )
         app.reconfigure
       end

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -70,7 +70,7 @@ describe Chef::Application::Solo do
 "Unforked chef-client interval runs are disabled in Chef 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options.",
           )
           app.reconfigure
         end

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -70,7 +70,7 @@ describe Chef::Application::Solo do
 "Unforked chef-client interval runs are disabled in Chef 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options.",
+Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
           )
           app.reconfigure
         end

--- a/spec/unit/audit/audit_reporter_spec.rb
+++ b/spec/unit/audit/audit_reporter_spec.rb
@@ -75,7 +75,7 @@ describe Chef::Audit::AuditReporter do
 
       it "posts audit data to server endpoint" do
         headers = {
-          "X-Ops-Audit-Report-Protocol-Version" => Chef::Audit::AuditReporter::PROTOCOL_VERSION
+          "X-Ops-Audit-Report-Protocol-Version" => Chef::Audit::AuditReporter::PROTOCOL_VERSION,
         }
 
         expect(rest).to receive(:post).

--- a/spec/unit/chef_fs/config_spec.rb
+++ b/spec/unit/chef_fs/config_spec.rb
@@ -68,7 +68,7 @@ describe Chef::ChefFS::Config do
         role_path: "/base_path/roles",
         user_path: "/base_path/users",
         policy_path: "/base_path/policies",
-      },)
+      })
     end
 
     let(:chef_fs_config) { Chef::ChefFS::Config.new(chef_config, Dir.pwd) }

--- a/spec/unit/chef_fs/file_system_spec.rb
+++ b/spec/unit/chef_fs/file_system_spec.rb
@@ -68,7 +68,7 @@ describe Chef::ChefFS::FileSystem do
         },
         :x => "",
         :y => {},
-      },)
+      })
     }
     context "list" do
       it "/**" do

--- a/spec/unit/chef_fs/file_system_spec.rb
+++ b/spec/unit/chef_fs/file_system_spec.rb
@@ -63,7 +63,7 @@ describe Chef::ChefFS::FileSystem do
             :zz => "",
           },
           :ab => {
-            :c => ""
+            :c => "",
           },
         },
         :x => "",

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -311,7 +311,7 @@ describe Chef::Cookbook::Metadata do
     it "strips out self-dependencies", :chef_lt_13_only do
       metadata.name("foo")
       expect(Chef::Log).to receive(:warn).with(
-        "Ignoring self-dependency in cookbook foo, please remove it (in the future this will be fatal).",
+        "Ignoring self-dependency in cookbook foo, please remove it (in the future this will be fatal)."
       )
       metadata.depends("foo")
       expect(metadata.dependencies).to eql({})

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -311,7 +311,7 @@ describe Chef::Cookbook::Metadata do
     it "strips out self-dependencies", :chef_lt_13_only do
       metadata.name("foo")
       expect(Chef::Log).to receive(:warn).with(
-        "Ignoring self-dependency in cookbook foo, please remove it (in the future this will be fatal)."
+        "Ignoring self-dependency in cookbook foo, please remove it (in the future this will be fatal).",
       )
       metadata.depends("foo")
       expect(metadata.dependencies).to eql({})

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -109,7 +109,7 @@ describe Chef::CookbookSynchronizer do
 
   let(:cookbook_manifest) do
     {
-      "cookbook_a" => cookbook_a
+      "cookbook_a" => cookbook_a,
     }
   end
 

--- a/spec/unit/cookbook_site_streaming_uploader_spec.rb
+++ b/spec/unit/cookbook_site_streaming_uploader_spec.rb
@@ -108,7 +108,7 @@ describe Chef::CookbookSiteStreamingUploader do
 
     it "should be able to receive strings to attach as argument" do
       Chef::CookbookSiteStreamingUploader.make_request(:put, @uri, "bill", @secret_filename, {
-        :mystring => "Lorem ipsum"
+        :mystring => "Lorem ipsum",
       })
     end
 

--- a/spec/unit/cookbook_version_file_specificity_spec.rb
+++ b/spec/unit/cookbook_version_file_specificity_spec.rb
@@ -197,7 +197,7 @@ describe Chef::CookbookVersion, "file specificity" do
          :checksum => "csum4-platver-full-2",
          :specificity => "fakeos-1",
        },
-      ]
+      ],
     }
 
   end

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -417,8 +417,8 @@ describe Chef::Environment do
           "name" => "foo",
           "default_attributes" => {
             "foo" => {
-              "bar" => 1
-            }
+              "bar" => 1,
+            },
           },
           "json_class" => "Chef::Environment",
           "description" => "desc",

--- a/spec/unit/http/basic_client_spec.rb
+++ b/spec/unit/http/basic_client_spec.rb
@@ -113,7 +113,7 @@ describe "HTTP Connection" do
     context "when an empty proxy is set by the environment" do
       let(:env) do
         {
-          "https_proxy" => ""
+          "https_proxy" => "",
         }
       end
 

--- a/spec/unit/http/validate_content_length_spec.rb
+++ b/spec/unit/http/validate_content_length_spec.rb
@@ -39,7 +39,7 @@ describe Chef::HTTP::ValidateContentLength do
   let(:response_body) { "Thanks for checking in." }
   let(:response_headers) {
     {
-      "content-length" => content_length_value
+      "content-length" => content_length_value,
     }
   }
 

--- a/spec/unit/key_spec.rb
+++ b/spec/unit/key_spec.rb
@@ -532,7 +532,7 @@ EOS
             allow(rest).to receive(:put).with(url, key.to_hash).and_return({
                                                                                   "key" => "key_name",
                                                                                   "public_key" => public_key_string,
-                                                                                },)
+                                                                                })
 
           end
 

--- a/spec/unit/knife/client_delete_spec.rb
+++ b/spec/unit/knife/client_delete_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::ClientDelete do
     @knife = Chef::Knife::ClientDelete.new
     # defaults
     @knife.config = {
-      :delete_validators => false
+      :delete_validators => false,
     }
     @knife.name_args = [ "adam" ]
   end

--- a/spec/unit/knife/cookbook_delete_spec.rb
+++ b/spec/unit/knife/cookbook_delete_spec.rb
@@ -129,7 +129,7 @@ describe Chef::Knife::CookbookDelete do
       expect(@knife).to receive(:rest).and_return(@rest_mock)
       @cookbook_data = { "foobar" => { "versions" => [{ "version" => "1.0.0" },
                                                       { "version" => "1.1.0" },
-                                                      { "version" => "2.0.0" } ] }
+                                                      { "version" => "2.0.0" } ] },
       }
     end
 

--- a/spec/unit/knife/cookbook_download_spec.rb
+++ b/spec/unit/knife/cookbook_download_spec.rb
@@ -73,7 +73,7 @@ describe Chef::Knife::CookbookDownload do
           and_return(@cookbook_mock)
       end
 
-      it "should determine which version if one was not explicitly specified"do
+      it "should determine which version if one was not explicitly specified" do
         allow(@cookbook_mock).to receive(:manifest).and_return({})
         expect(@knife).to receive(:determine_version).and_return("1.0.0")
         expect(File).to receive(:exists?).with("/var/tmp/chef/foobar-1.0.0").and_return(false)

--- a/spec/unit/knife/cookbook_show_spec.rb
+++ b/spec/unit/knife/cookbook_show_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Knife::CookbookShow do
               { "version" => "0.9.0", "url" => "http://url/cookbookx/cookbook_name/0.9.0" },
               { "version" => "0.8.0", "url" => "http://url/cookbooks/cookbook_name/0.8.0" },
             ],
-          }
+          },
         }
       end
 
@@ -94,7 +94,7 @@ describe Chef::Knife::CookbookShow do
               :checksum => "1234",
               :url => "http://example.org/files/default.rb",
             },
-          ]
+          ],
         }
         @cookbook_response.manifest = @manifest
         @response = { "name" => "default.rb", "url" => "http://example.org/files/default.rb", "checksum" => "1234", "path" => "recipes/default.rb" }
@@ -119,7 +119,7 @@ describe Chef::Knife::CookbookShow do
               :checksum => "1234",
               :url => "http://example.org/files/default.rb",
             },
-          ]
+          ],
         }
         @response = "Example recipe text"
       end
@@ -166,7 +166,7 @@ describe Chef::Knife::CookbookShow do
               :specificity => "default",
               :url => "http://example.org/files/4444",
             },
-          ]
+          ],
         }
 
         @response = "Example recipe text"

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -60,7 +60,7 @@ describe Chef::Knife::CookbookSiteShare do
       @bad_category_response = {
         "error_code" => "NOT_FOUND",
         "error_messages" => [
-            "Resource does not exist."
+            "Resource does not exist.",
         ],
       }
     end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -160,7 +160,7 @@ EXPECTED
   describe "when a bootstrap_version is specified" do
     let(:chef_config) do
       {
-        :knife => { :bootstrap_version => "11.12.4" }
+        :knife => { :bootstrap_version => "11.12.4" },
       }
     end
 
@@ -172,7 +172,7 @@ EXPECTED
   describe "when a pre-release bootstrap_version is specified" do
     let(:chef_config) do
       {
-        :knife => { :bootstrap_version => "11.12.4.rc.0" }
+        :knife => { :bootstrap_version => "11.12.4.rc.0" },
       }
     end
 
@@ -196,7 +196,7 @@ EXPECTED
     describe "when configured in config" do
       let(:chef_config) do
         {
-          :knife => { :ssl_verify_mode => :verify_peer }
+          :knife => { :ssl_verify_mode => :verify_peer },
         }
       end
 
@@ -222,7 +222,7 @@ EXPECTED
     describe "when configured in config" do
       let(:chef_config) do
         {
-          :knife => { :verify_api_cert => :false }
+          :knife => { :verify_api_cert => :false },
         }
       end
 

--- a/spec/unit/knife/core/custom_manifest_loader_spec.rb
+++ b/spec/unit/knife/core/custom_manifest_loader_spec.rb
@@ -23,10 +23,10 @@ describe Chef::Knife::SubcommandLoader::CustomManifestLoader do
     { "plugins" => {
         "knife-ec2" => {
           "paths" => [
-                      ec2_server_create_plugin
-                     ]
-        }
-      }
+                      ec2_server_create_plugin,
+                     ],
+        },
+      },
     }
   end
   let(:loader) do

--- a/spec/unit/knife/core/hashed_command_loader_spec.rb
+++ b/spec/unit/knife/core/hashed_command_loader_spec.rb
@@ -31,13 +31,13 @@ describe Chef::Knife::SubcommandLoader::HashedCommandLoader do
         },
         "plugins_by_category" => {
           "cool" => [
-            "cool_a"
+            "cool_a",
           ],
           "cooler" => [
-            "cooler_b"
+            "cooler_b",
           ],
         },
-      }
+      },
     }
   }
 

--- a/spec/unit/knife/core/node_editor_spec.rb
+++ b/spec/unit/knife/core/node_editor_spec.rb
@@ -91,7 +91,7 @@ describe Chef::Knife::NodeEditor do
           "normal" => { "alpha" => { "bravo" => "hotel2" }, "tags" => [ "xyz" ] },
           "policy_name" => "mypolicy",
           "policy_group" => "prod",
-          "run_list" => %w{role[drama] recipe[mystery]},
+          "run_list" => %w{role[drama] recipe[mystery]}
         )
       end
 
@@ -123,7 +123,7 @@ describe Chef::Knife::NodeEditor do
           "override"  => { "alpha" => { "bravo" => "foxtrot2", "delta" => "golf2" } },
           "policy_name" => "mypolicy",
           "policy_group" => "prod",
-          "run_list" => %w{role[drama] recipe[mystery]},
+          "run_list" => %w{role[drama] recipe[mystery]}
         )
       end
 
@@ -159,7 +159,7 @@ describe Chef::Knife::NodeEditor do
             "override"  => { "alpha" => { "bravo" => "foxtrot2", "delta" => "golf2" } },
             "policy_name"  => "mypolicy",
             "policy_group" => "prod",
-            "run_list" => %w{role[drama] recipe[mystery]},
+            "run_list" => %w{role[drama] recipe[mystery]}
           )
         end
 

--- a/spec/unit/knife/core/ui_spec.rb
+++ b/spec/unit/knife/core/ui_spec.rb
@@ -414,7 +414,7 @@ EOM
             { "version" => "2.0.0", "url" => "http://url/cookbooks/2.0.0" },
             { "version" => "1.0.0", "url" => "http://url/cookbooks/1.0.0" },
           ],
-        }
+        },
       }
     end
 
@@ -430,7 +430,7 @@ EOM
           "cookbook_name" => {
             "1.0.0" => "http://url/cookbooks/1.0.0",
             "2.0.0" => "http://url/cookbooks/2.0.0",
-            "3.0.0" => "http://url/cookbooks/3.0.0" }
+            "3.0.0" => "http://url/cookbooks/3.0.0" },
         }
         @ui.config[:with_uri] = true
         expect(@ui.format_cookbook_list_for_display(@item)).to eq(response)

--- a/spec/unit/knife/key_create_spec.rb
+++ b/spec/unit/knife/key_create_spec.rb
@@ -102,7 +102,7 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
     context "when the command is run" do
       let(:expected_hash) {
         {
-          actor_field_name => "charmander"
+          actor_field_name => "charmander",
         }
       }
 

--- a/spec/unit/knife/key_edit_spec.rb
+++ b/spec/unit/knife/key_edit_spec.rb
@@ -99,7 +99,7 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
     context "when the command is run" do
       let(:expected_hash) {
         {
-          actor_field_name => "charmander"
+          actor_field_name => "charmander",
         }
       }
       let(:new_keyname) { "charizard-key" }

--- a/spec/unit/knife/node_delete_spec.rb
+++ b/spec/unit/knife/node_delete_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::NodeDelete do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::NodeDelete.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "adam" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/node_from_file_spec.rb
+++ b/spec/unit/knife/node_from_file_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::NodeFromFile do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::NodeFromFile.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "adam.rb" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/node_run_list_add_spec.rb
+++ b/spec/unit/knife/node_run_list_add_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::NodeRunListAdd do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::NodeRunListAdd.new
     @knife.config = {
-      :after => nil
+      :after => nil,
     }
     @knife.name_args = [ "adam", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_bulk_delete_spec.rb
+++ b/spec/unit/knife/role_bulk_delete_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::RoleBulkDelete do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::RoleBulkDelete.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = ["."]
     @stdout = StringIO.new

--- a/spec/unit/knife/role_create_spec.rb
+++ b/spec/unit/knife/role_create_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::RoleCreate do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::RoleCreate.new
     @knife.config = {
-      :description => nil
+      :description => nil,
     }
     @knife.name_args = [ "adam" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_delete_spec.rb
+++ b/spec/unit/knife/role_delete_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::RoleDelete do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::RoleDelete.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "adam" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_env_run_list_add_spec.rb
+++ b/spec/unit/knife/role_env_run_list_add_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::RoleEnvRunListAdd do
 #    Chef::Config[:env_name]  = "QA"
     @knife = Chef::Knife::RoleEnvRunListAdd.new
     @knife.config = {
-      :after => nil
+      :after => nil,
     }
     @knife.name_args = [ "will", "QA", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_env_run_list_clear_spec.rb
+++ b/spec/unit/knife/role_env_run_list_clear_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Knife::RoleEnvRunListClear do
 
     @knife = Chef::Knife::RoleEnvRunListClear.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = %w{will QA}
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_env_run_list_remove_spec.rb
+++ b/spec/unit/knife/role_env_run_list_remove_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Knife::RoleEnvRunListRemove do
 
     @knife = Chef::Knife::RoleEnvRunListRemove.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "QA", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_env_run_list_replace_spec.rb
+++ b/spec/unit/knife/role_env_run_list_replace_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Knife::RoleEnvRunListReplace do
 
     @knife = Chef::Knife::RoleEnvRunListReplace.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "QA", "role[dude]", "role[person]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_env_run_list_set_spec.rb
+++ b/spec/unit/knife/role_env_run_list_set_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Knife::RoleEnvRunListSet do
 
     @knife = Chef::Knife::RoleEnvRunListSet.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "QA", "role[owen]", "role[mauntel]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_from_file_spec.rb
+++ b/spec/unit/knife/role_from_file_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::RoleFromFile do
     Chef::Config[:node_name] = "webmonkey.example.com"
     @knife = Chef::Knife::RoleFromFile.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "adam.rb" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_run_list_add_spec.rb
+++ b/spec/unit/knife/role_run_list_add_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::RoleRunListAdd do
 #    Chef::Config[:env_name]  = "QA"
     @knife = Chef::Knife::RoleRunListAdd.new
     @knife.config = {
-      :after => nil
+      :after => nil,
     }
     @knife.name_args = [ "will", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_run_list_clear_spec.rb
+++ b/spec/unit/knife/role_run_list_clear_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::RoleRunListClear do
 
     @knife = Chef::Knife::RoleRunListClear.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_run_list_remove_spec.rb
+++ b/spec/unit/knife/role_run_list_remove_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::RoleRunListRemove do
 
     @knife = Chef::Knife::RoleRunListRemove.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_run_list_replace_spec.rb
+++ b/spec/unit/knife/role_run_list_replace_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::RoleRunListReplace do
 
     @knife = Chef::Knife::RoleRunListReplace.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "role[dude]", "role[person]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/knife/role_run_list_set_spec.rb
+++ b/spec/unit/knife/role_run_list_set_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::RoleRunListSet do
 
     @knife = Chef::Knife::RoleRunListSet.new
     @knife.config = {
-      :print_after => nil
+      :print_after => nil,
     }
     @knife.name_args = [ "will", "role[owen]", "role[mauntel]" ]
     allow(@knife).to receive(:output).and_return(true)

--- a/spec/unit/mixin/params_validate_spec.rb
+++ b/spec/unit/mixin/params_validate_spec.rb
@@ -61,8 +61,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "string" },
         {
           :one => {
-            :kind_of => String
-          }
+            :kind_of => String,
+          },
         },
       )
     }.not_to raise_error
@@ -72,8 +72,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "string" },
         {
           :one => {
-            :kind_of => Array
-          }
+            :kind_of => Array,
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -85,8 +85,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "string" },
         {
           :one => {
-            :required => true
-          }
+            :required => true,
+          },
         },
       )
     }.not_to raise_error
@@ -96,8 +96,8 @@ describe Chef::Mixin::ParamsValidate do
         { :two => "string" },
         {
           :one => {
-            :required => true
-          }
+            :required => true,
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -107,8 +107,8 @@ describe Chef::Mixin::ParamsValidate do
         { :two => "string" },
         {
           :one => {
-            :required => false
-          }
+            :required => false,
+          },
         },
       )
     }.not_to raise_error
@@ -120,8 +120,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => @vo },
         {
           :one => {
-            :respond_to => "validate"
-          }
+            :respond_to => "validate",
+          },
         },
       )
     }.not_to raise_error
@@ -131,8 +131,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => @vo },
         {
           :one => {
-            :respond_to => "monkey"
-          }
+            :respond_to => "monkey",
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -144,8 +144,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => @vo },
         {
           :one => {
-            :respond_to => %w{validate music}
-          }
+            :respond_to => %w{validate music},
+          },
         },
       )
     }.not_to raise_error
@@ -155,8 +155,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => @vo },
         {
           :one => {
-            :respond_to => %w{monkey validate}
-          }
+            :respond_to => %w{monkey validate},
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -166,8 +166,8 @@ describe Chef::Mixin::ParamsValidate do
     arguments = Hash.new
     @vo.validate(arguments, {
       :one => {
-        :default => "is the loneliest number"
-      }
+        :default => "is the loneliest number",
+      },
     },)
     expect(arguments[:one]).to eq("is the loneliest number")
   end
@@ -178,8 +178,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "is good" },
         {
           :one => {
-            :regex => /^is good$/
-          }
+            :regex => /^is good$/,
+          },
         },
       )
     }.not_to raise_error
@@ -189,8 +189,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "is good" },
         {
           :one => {
-            :regex => /^is bad$/
-          }
+            :regex => /^is bad$/,
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -205,9 +205,9 @@ describe Chef::Mixin::ParamsValidate do
             :callbacks => {
               "should be equal to is good" => lambda { |a|
                 a == "is good"
-              }
-            }
-          }
+              },
+            },
+          },
         },
       )
     }.not_to raise_error
@@ -220,9 +220,9 @@ describe Chef::Mixin::ParamsValidate do
             :callbacks => {
               "should be equal to 'is good'" => lambda { |a|
                 a == "is good"
-              }
-            }
-          }
+              },
+            },
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -241,7 +241,7 @@ describe Chef::Mixin::ParamsValidate do
             :callbacks => {
               "should be your friend" => lambda { |a|
                 a == "is good"
-              }
+              },
             },
             :required => true,
           },
@@ -265,7 +265,7 @@ describe Chef::Mixin::ParamsValidate do
             :callbacks => {
               "should be your friend" => lambda { |a|
                 a == "is good"
-              }
+              },
             },
             :required => true,
           },
@@ -284,8 +284,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "two" },
         {
           :one => {
-            :busted => "check"
-          }
+            :busted => "check",
+          },
         },
       )
     }.to raise_error(ArgumentError)
@@ -303,8 +303,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => "string" },
         {
           :one => {
-            :kind_of => [ String, Array ]
-          }
+            :kind_of => [ String, Array ],
+          },
         },
       )
     }.not_to raise_error
@@ -313,8 +313,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => ["string"] },
         {
           :one => {
-            :kind_of => [ String, Array ]
-          }
+            :kind_of => [ String, Array ],
+          },
         },
       )
     }.not_to raise_error
@@ -323,8 +323,8 @@ describe Chef::Mixin::ParamsValidate do
         { :one => Hash.new },
         {
           :one => {
-            :kind_of => [ String, Array ]
-          }
+            :kind_of => [ String, Array ],
+          },
         },
       )
     }.to raise_error(ArgumentError)

--- a/spec/unit/mixin/params_validate_spec.rb
+++ b/spec/unit/mixin/params_validate_spec.rb
@@ -63,7 +63,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :kind_of => String,
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -74,7 +74,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :kind_of => Array,
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -87,7 +87,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :required => true,
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -98,7 +98,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :required => true,
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
 
@@ -109,7 +109,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :required => false,
           },
-        },
+        }
       )
     }.not_to raise_error
   end
@@ -122,7 +122,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :respond_to => "validate",
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -133,7 +133,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :respond_to => "monkey",
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -146,7 +146,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :respond_to => %w{validate music},
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -157,7 +157,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :respond_to => %w{monkey validate},
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -168,7 +168,7 @@ describe Chef::Mixin::ParamsValidate do
       :one => {
         :default => "is the loneliest number",
       },
-    },)
+    })
     expect(arguments[:one]).to eq("is the loneliest number")
   end
 
@@ -180,7 +180,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :regex => /^is good$/,
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -191,7 +191,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :regex => /^is bad$/,
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -208,7 +208,7 @@ describe Chef::Mixin::ParamsValidate do
               },
             },
           },
-        },
+        }
       )
     }.not_to raise_error
 
@@ -223,7 +223,7 @@ describe Chef::Mixin::ParamsValidate do
               },
             },
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -250,7 +250,7 @@ describe Chef::Mixin::ParamsValidate do
             :required => false,
           },
           :three => { :default => "neato mosquito" },
-        },
+        }
       )
     }.not_to raise_error
     expect(args[:three]).to eq("neato mosquito")
@@ -274,7 +274,7 @@ describe Chef::Mixin::ParamsValidate do
             :required => false,
           },
           :three => { :default => "neato mosquito" },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -286,7 +286,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :busted => "check",
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end
@@ -305,7 +305,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :kind_of => [ String, Array ],
           },
-        },
+        }
       )
     }.not_to raise_error
     expect {
@@ -315,7 +315,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :kind_of => [ String, Array ],
           },
-        },
+        }
       )
     }.not_to raise_error
     expect {
@@ -325,7 +325,7 @@ describe Chef::Mixin::ParamsValidate do
           :one => {
             :kind_of => [ String, Array ],
           },
-        },
+        }
       )
     }.to raise_error(ArgumentError)
   end

--- a/spec/unit/mixin/powershell_out_spec.rb
+++ b/spec/unit/mixin/powershell_out_spec.rb
@@ -31,7 +31,7 @@ describe Chef::Mixin::PowershellOut do
       ret = double("Mixlib::ShellOut")
       expect(object).to receive(:shell_out).with(
         "powershell.exe #{flags} -Command \"Get-Process\"",
-        {},
+        {}
       ).and_return(ret)
       expect(object.powershell_out("Get-Process")).to eql(ret)
     end
@@ -40,7 +40,7 @@ describe Chef::Mixin::PowershellOut do
       ret = double("Mixlib::ShellOut")
       expect(object).to receive(:shell_out).with(
         "powershell.exe #{flags} -Command \"Get-Process\"",
-        timeout: 600,
+        timeout: 600
       ).and_return(ret)
       expect(object.powershell_out("Get-Process", timeout: 600)).to eql(ret)
     end
@@ -51,7 +51,7 @@ describe Chef::Mixin::PowershellOut do
       mixlib_shellout = double("Mixlib::ShellOut")
       expect(object).to receive(:shell_out).with(
         "powershell.exe #{flags} -Command \"Get-Process\"",
-        {},
+        {}
       ).and_return(mixlib_shellout)
       expect(mixlib_shellout).to receive(:error!)
       expect(object.powershell_out!("Get-Process")).to eql(mixlib_shellout)
@@ -61,7 +61,7 @@ describe Chef::Mixin::PowershellOut do
       mixlib_shellout = double("Mixlib::ShellOut")
       expect(object).to receive(:shell_out).with(
         "powershell.exe #{flags} -Command \"Get-Process\"",
-        timeout: 600,
+        timeout: 600
       ).and_return(mixlib_shellout)
       expect(mixlib_shellout).to receive(:error!)
       expect(object.powershell_out!("Get-Process", timeout: 600)).to eql(mixlib_shellout)

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -143,7 +143,7 @@ describe Chef::Mixin::ShellOut do
                 "LC_ALL"   => Chef::Config[:internal_locale],
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
-              }
+              },
             },).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -156,7 +156,7 @@ describe Chef::Mixin::ShellOut do
                 "LC_ALL"   => Chef::Config[:internal_locale],
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
-              }
+              },
             },).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:environment].has_key?("LC_ALL")).to be false
@@ -184,7 +184,7 @@ describe Chef::Mixin::ShellOut do
                 "LC_ALL"   => Chef::Config[:internal_locale],
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
-              }
+              },
             },).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
@@ -197,7 +197,7 @@ describe Chef::Mixin::ShellOut do
                 "LC_ALL"   => Chef::Config[:internal_locale],
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
-              }
+              },
             },).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:env].has_key?("LC_ALL")).to be false
@@ -227,7 +227,7 @@ describe Chef::Mixin::ShellOut do
               "LC_ALL"   => Chef::Config[:internal_locale],
               "LANG"     => Chef::Config[:internal_locale],
               "LANGUAGE" => Chef::Config[:internal_locale],
-            }
+            },
           },).and_return(true)
           shell_out_obj.shell_out(cmd)
         end

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -144,7 +144,7 @@ describe Chef::Mixin::ShellOut do
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
               },
-            },).and_return(true)
+            }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
@@ -157,7 +157,7 @@ describe Chef::Mixin::ShellOut do
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
               },
-            },).and_return(true)
+            }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:environment].has_key?("LC_ALL")).to be false
           end
@@ -185,7 +185,7 @@ describe Chef::Mixin::ShellOut do
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
               },
-            },).and_return(true)
+            }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
@@ -198,7 +198,7 @@ describe Chef::Mixin::ShellOut do
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
               },
-            },).and_return(true)
+            }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
             expect(options[:env].has_key?("LC_ALL")).to be false
           end
@@ -214,7 +214,7 @@ describe Chef::Mixin::ShellOut do
                 "LANG"     => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
               },
-            },).and_return(true)
+            }).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
         end
@@ -228,7 +228,7 @@ describe Chef::Mixin::ShellOut do
               "LANG"     => Chef::Config[:internal_locale],
               "LANGUAGE" => Chef::Config[:internal_locale],
             },
-          },).and_return(true)
+          }).and_return(true)
           shell_out_obj.shell_out(cmd)
         end
       end

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -162,7 +162,7 @@ describe Chef::Node::Attribute do
       "hot" => { "day" => "sunday" },
       "fire" => "still burn",
       "music" => {
-        "mars_volta" => "cicatriz"
+        "mars_volta" => "cicatriz",
       },
     }
     @automatic_hash = { "week" => "friday" }
@@ -1003,7 +1003,7 @@ describe Chef::Node::Attribute do
           %w{one six},
           %w{snack cookies},
           ["snakes", "on a plane"],
-        ]
+        ],
       )
     end
   end

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -558,7 +558,7 @@ describe Chef::Node::Attribute do
           "one" => { "six" => "seven" },
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -606,7 +606,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -644,7 +644,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -680,7 +680,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -716,7 +716,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -760,7 +760,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
       @empty = Chef::Node::Attribute.new({}, {}, {}, {})
     end
@@ -794,7 +794,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -851,7 +851,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -896,7 +896,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -937,7 +937,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -973,7 +973,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
     end
 
@@ -1003,7 +1003,7 @@ describe Chef::Node::Attribute do
           %w{one six},
           %w{snack cookies},
           ["snakes", "on a plane"],
-        ],
+        ]
       )
     end
   end
@@ -1023,7 +1023,7 @@ describe Chef::Node::Attribute do
           "one" => "six",
           "snack" => "cookies",
         },
-        {},
+        {}
       )
 
       @empty = Chef::Node::Attribute.new({}, {}, {}, {})

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -615,7 +615,7 @@ describe Chef::Node do
 
         expect( node["mysql"]["server"] ).to eql({
           "data_dir" => "/my_raid_volume/lib/mysql",
-        },)
+        })
       end
 
       it "removes all values from the precedence level when setting" do
@@ -631,7 +631,7 @@ describe Chef::Node do
         expect( node["mysql"]["server"]["data_dir"] ).to eql("/my_raid_volume/lib/mysql")
         expect( node["mysql"]["server"] ).to eql({
           "data_dir" => "/my_raid_volume/lib/mysql",
-        },)
+        })
       end
 
       it "higher precedence levels are not removed" do
@@ -649,7 +649,7 @@ describe Chef::Node do
         expect( node["mysql"]["server"] ).to eql({
           "service_name" => "fancypants-sql",
           "data_dir" => "/my_raid_volume/lib/mysql",
-        },)
+        })
       end
 
       it "will autovivify" do
@@ -674,7 +674,7 @@ describe Chef::Node do
         expect( node["mysql"]["server"] ).to eql({
           "service_name" => "fancypants-sql",
           "data_dir" => "/my_raid_volume/lib/mysql",
-        },)
+        })
       end
 
       it "when overwriting a non-hash/array" do
@@ -693,7 +693,7 @@ describe Chef::Node do
         }
         expect( node["mysql"]["server"] ).to eql({
           "data_dir" => "/my_raid_volume/lib/mysql",
-        },)
+        })
       end
     end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -438,13 +438,13 @@ describe Chef::Node do
       context "with real arrays" do
         before do
           node.role_default["mysql"]["server"] = [ {
-            "port" => 1234
+            "port" => 1234,
           } ]
           node.normal["mysql"]["server"] = [ {
-            "port" => 2345
+            "port" => 2345,
           } ]
           node.override["mysql"]["server"] = [ {
-            "port" => 3456
+            "port" => 3456,
           } ]
         end
 
@@ -610,11 +610,11 @@ describe Chef::Node do
         node.force_default["mysql"]["server"]["port"] = 2345
 
         node.force_default!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
 
         expect( node["mysql"]["server"] ).to eql({
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         },)
       end
 
@@ -624,13 +624,13 @@ describe Chef::Node do
         node.force_default["mysql"]["server"]["port"] = 3456
 
         node.force_default!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
 
         expect( node["mysql"]["server"]["port"] ).to be_nil
         expect( node["mysql"]["server"]["data_dir"] ).to eql("/my_raid_volume/lib/mysql")
         expect( node["mysql"]["server"] ).to eql({
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         },)
       end
 
@@ -641,7 +641,7 @@ describe Chef::Node do
         node.override["mysql"]["server"]["service_name"] = "fancypants-sql"
 
         node.force_default!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
 
         expect( node["mysql"]["server"]["port"] ).to be_nil
@@ -654,7 +654,7 @@ describe Chef::Node do
 
       it "will autovivify" do
         node.force_default!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
         expect( node["mysql"]["server"]["data_dir"] ).to eql("/my_raid_volume/lib/mysql")
       end
@@ -666,7 +666,7 @@ describe Chef::Node do
         node.default["mysql"]["server"]["service_name"] = "fancypants-sql"
 
         node.force_override!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
 
         expect( node["mysql"]["server"]["port"] ).to be_nil
@@ -681,7 +681,7 @@ describe Chef::Node do
         node.override["mysql"] = false
         node.force_override["mysql"] = true
         node.force_override!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
         expect( node["mysql"]["server"]["data_dir"] ).to eql("/my_raid_volume/lib/mysql")
       end
@@ -689,10 +689,10 @@ describe Chef::Node do
       it "when overwriting an array with a hash" do
         node.force_override["mysql"][0] = true
         node.force_override!["mysql"]["server"] = {
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         }
         expect( node["mysql"]["server"] ).to eql({
-          "data_dir" => "/my_raid_volume/lib/mysql"
+          "data_dir" => "/my_raid_volume/lib/mysql",
         },)
       end
     end
@@ -1372,7 +1372,7 @@ describe Chef::Node do
                 "interfaces" => {
                   "eth0" => {},
                   "eth1" => {},
-                }
+                },
               },
             },
             "default" => {}, "normal" => {}, "override" => {}
@@ -1381,12 +1381,12 @@ describe Chef::Node do
           selected_data = {
             "automatic" => {
               "filesystem" => {
-                "/dev/disk0s2" => { "size" => "10mb" }
+                "/dev/disk0s2" => { "size" => "10mb" },
               },
               "network" => {
                 "interfaces" => {
-                  "eth0" => {}
-                }
+                  "eth0" => {},
+                },
               },
             },
             "default" => {}, "normal" => {}, "override" => {}
@@ -1400,30 +1400,30 @@ describe Chef::Node do
 
         it "should save false-y whitelisted attributes" do
           Chef::Config[:default_attribute_whitelist] = [
-            "foo/bar/baz"
+            "foo/bar/baz",
           ]
 
           data = {
             "default" => {
               "foo" => {
                 "bar" => {
-                  "baz" => false
+                  "baz" => false,
                 },
                 "other" => {
-                  "stuff" => true
+                  "stuff" => true,
                 },
-              }
-            }
+              },
+            },
           }
 
           selected_data = {
             "default" => {
               "foo" => {
                 "bar" => {
-                  "baz" => false
-                }
-              }
-            }
+                  "baz" => false,
+                },
+              },
+            },
           }
 
           node.name("falsey-monkey")
@@ -1440,7 +1440,7 @@ describe Chef::Node do
               "filesystem" => {
                 "/dev/disk0s2"   => { "size" => "10mb" },
                 "map - autohome" => { "size" => "10mb" },
-              }
+              },
             },
             "default" => {}, "normal" => {}, "override" => {}
           }

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -34,7 +34,7 @@ describe Chef::Platform do
       Chef::Platform.platforms = {
         :darwin => {
           ">= 10.11" => {
-            :file => "new_darwinian"
+            :file => "new_darwinian",
           },
           "9.2.2" => {
             :file => "darwinian",

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -183,18 +183,18 @@ describe Chef::Platform do
            :platform => :darwin,
            :version => "9.2.2",
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:darwin]["9.2.2"][:file]).to eql("masterful")
       Chef::Platform.set(
            :platform => :darwin,
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:darwin][:default][:file]).to eql("masterful")
       Chef::Platform.set(
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:default][:file]).to eql("masterful")
 
@@ -202,13 +202,13 @@ describe Chef::Platform do
            :platform => :hero,
            :version => "9.2.2",
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:hero]["9.2.2"][:file]).to eql("masterful")
 
       Chef::Platform.set(
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:default][:file]).to eql("masterful")
 
@@ -216,7 +216,7 @@ describe Chef::Platform do
 
       Chef::Platform.set(
            :resource => :file,
-           :provider => "masterful",
+           :provider => "masterful"
       )
       expect(Chef::Platform.platforms[:default][:file]).to eql("masterful")
 
@@ -230,7 +230,7 @@ describe Chef::Platform do
       Chef::Platform.set(
         :resource => :file,
         :platform => :default,
-        :provider => "new school",
+        :provider => "new school"
       )
       expect(Chef::Platform.platforms[:default][:file]).to eql("new school")
       expect(Chef::Platform.platforms[:default][:cat]).to eql("nice")

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -560,7 +560,7 @@ describe Chef::PolicyBuilder::Policyfile do
             let(:parsed_policyfile_json) do
               basic_valid_policy_data.dup.tap do |p|
                 p["named_run_lists"] = {
-                  "deploy-app" => [ "recipe[example1::default]" ]
+                  "deploy-app" => [ "recipe[example1::default]" ],
                 }
               end
             end

--- a/spec/unit/property/state_spec.rb
+++ b/spec/unit/property/state_spec.rb
@@ -228,7 +228,7 @@ describe "Chef::Resource#identity and #state" do
           expect(resource.state_for_resource_reporter).to eq(custom_property: 6)
           expect(resource_class.properties[:custom_property].desired_state?).to be_truthy
           expect(resource_class.state_properties).to eq [
-            resource_class.properties[:custom_property]
+            resource_class.properties[:custom_property],
           ]
         end
         it "identity_properties does not change custom_property's getter or setter" do
@@ -393,7 +393,7 @@ describe "Chef::Resource#identity and #state" do
 
         expect(resource_class.properties[:x].desired_state?).to be_truthy
         expect(resource_class.state_properties).to eq [
-          resource_class.properties[:x]
+          resource_class.properties[:x],
         ]
         expect(resource.state_for_resource_reporter).to eq(x: 10)
       end
@@ -430,11 +430,11 @@ describe "Chef::Resource#identity and #state" do
         expect(resource_class.properties[:x].desired_state?).to be_truthy
         expect(resource_class.properties[:x].identity?).to be_truthy
         expect(resource_class.identity_properties).to eq [
-          resource_class.properties[:x]
+          resource_class.properties[:x],
         ]
         expect(resource.identity).to eq(10)
         expect(resource_class.state_properties).to eq [
-          resource_class.properties[:x]
+          resource_class.properties[:x],
         ]
         expect(resource.state_for_resource_reporter).to eq(x: 10)
       end
@@ -448,7 +448,7 @@ describe "Chef::Resource#identity and #state" do
         expect(resource_class.properties[:x].desired_state?).to be_falsey
         expect(resource_class.properties[:y].desired_state?).to be_truthy
         expect(resource_class.state_properties).to eq [
-          resource_class.properties[:y]
+          resource_class.properties[:y],
         ]
         expect(resource.state_for_resource_reporter).to eq(y: 20)
       end
@@ -474,11 +474,11 @@ describe "Chef::Resource#identity and #state" do
           expect(subresource_class.properties[:x].desired_state?).to be_truthy
           expect(subresource_class.properties[:x].identity?).to be_truthy
           expect(subresource_class.identity_properties).to eq [
-            subresource_class.properties[:x]
+            subresource_class.properties[:x],
           ]
           expect(subresource.identity).to eq(10)
           expect(subresource_class.state_properties).to eq [
-            subresource_class.properties[:x]
+            subresource_class.properties[:x],
           ]
           expect(subresource.state_for_resource_reporter).to eq(x: 10)
         end
@@ -491,13 +491,13 @@ describe "Chef::Resource#identity and #state" do
           expect(subresource_class.properties[:x].object_id).to eq old_value.object_id
           expect(subresource_class.properties[:y].desired_state?).to be_truthy
           expect(subresource_class.state_properties).to eq [
-            subresource_class.properties[:y]
+            subresource_class.properties[:y],
           ]
           expect(subresource.state_for_resource_reporter).to eq(y: 20)
 
           expect(subresource_class.properties[:x].identity?).to be_truthy
           expect(subresource_class.identity_properties).to eq [
-            subresource_class.properties[:x]
+            subresource_class.properties[:x],
           ]
           expect(subresource.identity).to eq(10)
         end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -38,7 +38,7 @@ describe Chef::Provider::Group::Groupadd, "set_options" do
   end
 
   field_list = {
-    :gid => "-g"
+    :gid => "-g",
   }
 
   field_list.each do |attribute, option|

--- a/spec/unit/provider/group_spec.rb
+++ b/spec/unit/provider/group_spec.rb
@@ -39,7 +39,7 @@ describe Chef::Provider::User do
     @pw_group = double("Struct::Group",
       :name => "wheel",
       :gid => 20,
-      :mem => %w{root aj},
+      :mem => %w{root aj}
       )
     allow(Etc).to receive(:getgrnam).with("wheel").and_return(@pw_group)
   end

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -58,7 +58,7 @@ XML
         "Hourly" => 10,
         "Weekday" => 7,
       },
-      "TimeOut" => 300
+      "TimeOut" => 300,
     } end
 
     before(:each) do

--- a/spec/unit/provider/ohai_spec.rb
+++ b/spec/unit/provider/ohai_spec.rb
@@ -34,7 +34,7 @@ describe Chef::Provider::Ohai do
       :platform => @platform,
       :platform_version => @platform_version,
       :data => {
-        :origdata => "somevalue"
+        :origdata => "somevalue",
       },
       :data2 => {
         :origdata => "somevalue",

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Provider::OsxProfile do
           "ProfileType" => "Configuration",
           "ProfileUUID" => "6e95927c-f200-54b4-85c7-52ab99b61c47",
           "ProfileVerificationState" => "unsigned",
-          "ProfileVersion" => 1 }]
+          "ProfileVersion" => 1 }],
       }
     end
       # If anything is changed within this profile, be sure to update the
@@ -86,11 +86,11 @@ describe Chef::Provider::OsxProfile do
                 "Forced" => [
                   {
                     "mcx_preference_settings" => {
-                      "idleTime" => 0
-                    }
+                      "idleTime" => 0,
+                    },
                   },
-                ]
-              }
+                ],
+              },
             },
           },
         ],
@@ -131,7 +131,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.profile test_profile
       provider.load_current_resource
       expect(
-        provider.instance_variable_get(:@new_profile_identifier)
+        provider.instance_variable_get(:@new_profile_identifier),
         ).to eql(test_profile["PayloadIdentifier"])
     end
 
@@ -214,7 +214,7 @@ describe Chef::Provider::OsxProfile do
           "ProfileType" => "Configuration",
           "ProfileUUID" => "1781fbec-3325-565f-9022-8aa28135c3cc",
           "ProfileVerificationState" => "unsigned",
-          "ProfileVersion" => 1 }]
+          "ProfileVersion" => 1 }],
       }
     end
     before(:each) do
@@ -226,7 +226,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.profile_name "com.testprofile.screensaver"
       new_resource.action(:remove)
       provider.load_current_resource
-      expect(provider.instance_variable_get(:@new_profile_identifier)
+      expect(provider.instance_variable_get(:@new_profile_identifier),
         ).to eql(new_resource.profile_name)
     end
 
@@ -234,7 +234,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.identifier "com.testprofile.screensaver"
       new_resource.action(:remove)
       provider.load_current_resource
-      expect(provider.instance_variable_get(:@new_profile_identifier)
+      expect(provider.instance_variable_get(:@new_profile_identifier),
         ).to eql(new_resource.identifier)
     end
 

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -131,7 +131,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.profile test_profile
       provider.load_current_resource
       expect(
-        provider.instance_variable_get(:@new_profile_identifier),
+        provider.instance_variable_get(:@new_profile_identifier)
         ).to eql(test_profile["PayloadIdentifier"])
     end
 
@@ -226,7 +226,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.profile_name "com.testprofile.screensaver"
       new_resource.action(:remove)
       provider.load_current_resource
-      expect(provider.instance_variable_get(:@new_profile_identifier),
+      expect(provider.instance_variable_get(:@new_profile_identifier)
         ).to eql(new_resource.profile_name)
     end
 
@@ -234,7 +234,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.identifier "com.testprofile.screensaver"
       new_resource.action(:remove)
       provider.load_current_resource
-      expect(provider.instance_variable_get(:@new_profile_identifier),
+      expect(provider.instance_variable_get(:@new_profile_identifier)
         ).to eql(new_resource.identifier)
     end
 

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -52,7 +52,7 @@ irssi:
         it "should create a current resource with the name of the new_resource" do
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy #{@new_resource.package_name}",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
 
@@ -95,7 +95,7 @@ libmysqlclient15-dev:
           virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy libmysqlclient15-dev",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(virtual_package)
           showpkg_out = <<-SHOWPKG_STDOUT
 Package: libmysqlclient15-dev
@@ -118,7 +118,7 @@ libmysqlclient-dev 5.1.41-3ubuntu12
           showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache showpkg libmysqlclient15-dev",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(showpkg)
           real_package_out = <<-RPKG_STDOUT
 libmysqlclient-dev:
@@ -136,7 +136,7 @@ libmysqlclient-dev:
           real_package = double(:stdout => real_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy libmysqlclient-dev",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(real_package)
           @provider.load_current_resource
         end
@@ -152,7 +152,7 @@ mp3-decoder:
           virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy mp3-decoder",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(virtual_package)
           showpkg_out = <<-SHOWPKG_STDOUT
 Package: mp3-decoder
@@ -178,7 +178,7 @@ mpg123 1.12.1-0ubuntu1
           showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache showpkg mp3-decoder",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(showpkg)
           expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
         end
@@ -191,7 +191,7 @@ mpg123 1.12.1-0ubuntu1
           allow(@new_resource).to receive(:provider).and_return(nil)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache -o APT::Default-Release=lenny-backports policy irssi",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
         end
@@ -200,7 +200,7 @@ mpg123 1.12.1-0ubuntu1
           @new_resource.source "pluto"
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy #{@new_resource.package_name}",
-            :timeout => @timeout,
+            :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
           @provider.define_resource_requirements
@@ -220,7 +220,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!). with(
               "apt-get -q -y install irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.install_package("irssi", "0.8.12-7")
           end
@@ -229,7 +229,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes install irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @new_resource.options("--force-yes")
             @provider.install_package("irssi", "0.8.12-7")
@@ -245,7 +245,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y -o APT::Default-Release=lenny-backports install irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
 
             @provider.install_package("irssi", "0.8.12-7")
@@ -266,7 +266,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y remove irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.remove_package("irssi", "0.8.12-7")
           end
@@ -275,7 +275,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes remove irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @new_resource.options("--force-yes")
 
@@ -289,7 +289,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y purge irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.purge_package("irssi", "0.8.12-7")
           end
@@ -298,7 +298,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes purge irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @new_resource.options("--force-yes")
 
@@ -317,7 +317,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "debconf-set-selections /tmp/irssi-0.8.12-7.seed",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
 
             @provider.preseed_package(file)
@@ -327,7 +327,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "debconf-set-selections /tmp/irssi-0.8.12-7.seed",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             file = @provider.get_preseed_file("irssi", "0.8.12-7")
             @provider.preseed_package(file)
@@ -348,7 +348,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "dpkg-reconfigure irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.reconfig_package("irssi", "0.8.12-7")
           end
@@ -360,7 +360,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y install libmysqlclient-dev",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.install_package("libmysqlclient-dev", "not_a_real_version")
           end
@@ -374,7 +374,7 @@ mpg123 1.12.1-0ubuntu1
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y install libmysqlclient-dev irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
-              :timeout => @timeout,
+              :timeout => @timeout
             )
             @provider.install_package(["libmysqlclient-dev", "irssi"], ["not_a_real_version", "0.8.12-7"])
           end

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -132,7 +132,7 @@ munin-node|1.6.1.20130823
     it "should load and downcase names in the installed_packages hash" do
       provider.load_current_resource
       expect(provider.send(:installed_packages)).to eql(
-        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" },
+        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" }
       )
     end
 
@@ -140,7 +140,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git"])
       provider.load_current_resource
       expect(provider.send(:available_packages)).to eql(
-        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.1", "git" => "2.6.2", "munin-node" => "1.6.1.20130823" },
+        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.1", "git" => "2.6.2", "munin-node" => "1.6.1.20130823" }
       )
     end
 

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -132,7 +132,7 @@ munin-node|1.6.1.20130823
     it "should load and downcase names in the installed_packages hash" do
       provider.load_current_resource
       expect(provider.send(:installed_packages)).to eql(
-        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" }
+        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.0" },
       )
     end
 
@@ -140,7 +140,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git"])
       provider.load_current_resource
       expect(provider.send(:available_packages)).to eql(
-        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.1", "git" => "2.6.2", "munin-node" => "1.6.1.20130823" }
+        { "chocolatey" => "0.9.9.11", "conemu" => "15.10.25.1", "git" => "2.6.2", "munin-node" => "1.6.1.20130823" },
       )
     end
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -199,7 +199,7 @@ Section: ruby
 
     it "and we should raise if we get any other exit codes from dpkg -s" do
       dpkg_s_status = double(
-        exitstatus: 3, stderr: "i am very, very angry with you.  i'm very, very cross.  go to your room.", stdout: ""
+        exitstatus: 3, stderr: "i am very, very angry with you.  i'm very, very cross.  go to your room.", stdout: "",
       )
       expect(provider).to receive(:shell_out!).with("dpkg -s #{package}", returns: [0, 1], timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
       expect { provider.load_current_resource }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -199,7 +199,7 @@ Section: ruby
 
     it "and we should raise if we get any other exit codes from dpkg -s" do
       dpkg_s_status = double(
-        exitstatus: 3, stderr: "i am very, very angry with you.  i'm very, very cross.  go to your room.", stdout: "",
+        exitstatus: 3, stderr: "i am very, very angry with you.  i'm very, very cross.  go to your room.", stdout: ""
       )
       expect(provider).to receive(:shell_out!).with("dpkg -s #{package}", returns: [0, 1], timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
       expect { provider.load_current_resource }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)

--- a/spec/unit/provider/package/easy_install_spec.rb
+++ b/spec/unit/provider/package/easy_install_spec.rb
@@ -62,14 +62,14 @@ describe Chef::Provider::Package::EasyInstall do
   describe "actions_on_package" do
     it "should run easy_install with the package name and version" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install \"boto==1.8d\""
+        :command => "easy_install \"boto==1.8d\"",
       },)
       @provider.install_package("boto", "1.8d")
     end
 
     it "should run easy_install with the package name and version and specified options" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install --always-unzip \"boto==1.8d\""
+        :command => "easy_install --always-unzip \"boto==1.8d\"",
       },)
       allow(@new_resource).to receive(:options).and_return("--always-unzip")
       @provider.install_package("boto", "1.8d")
@@ -77,21 +77,21 @@ describe Chef::Provider::Package::EasyInstall do
 
     it "should run easy_install with the package name and version" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install \"boto==1.8d\""
+        :command => "easy_install \"boto==1.8d\"",
       },)
       @provider.upgrade_package("boto", "1.8d")
     end
 
     it "should run easy_install -m with the package name and version" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install -m boto"
+        :command => "easy_install -m boto",
       },)
       @provider.remove_package("boto", "1.8d")
     end
 
     it "should run easy_install -m with the package name and version and specified options" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install -x -m boto"
+        :command => "easy_install -x -m boto",
       },)
       allow(@new_resource).to receive(:options).and_return("-x")
       @provider.remove_package("boto", "1.8d")
@@ -99,7 +99,7 @@ describe Chef::Provider::Package::EasyInstall do
 
     it "should run easy_install -m with the package name and version" do
       expect(@provider).to receive(:run_command).with({
-        :command => "easy_install -m boto"
+        :command => "easy_install -m boto",
       },)
       @provider.purge_package("boto", "1.8d")
     end

--- a/spec/unit/provider/package/easy_install_spec.rb
+++ b/spec/unit/provider/package/easy_install_spec.rb
@@ -63,14 +63,14 @@ describe Chef::Provider::Package::EasyInstall do
     it "should run easy_install with the package name and version" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install \"boto==1.8d\"",
-      },)
+      })
       @provider.install_package("boto", "1.8d")
     end
 
     it "should run easy_install with the package name and version and specified options" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install --always-unzip \"boto==1.8d\"",
-      },)
+      })
       allow(@new_resource).to receive(:options).and_return("--always-unzip")
       @provider.install_package("boto", "1.8d")
     end
@@ -78,21 +78,21 @@ describe Chef::Provider::Package::EasyInstall do
     it "should run easy_install with the package name and version" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install \"boto==1.8d\"",
-      },)
+      })
       @provider.upgrade_package("boto", "1.8d")
     end
 
     it "should run easy_install -m with the package name and version" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -m boto",
-      },)
+      })
       @provider.remove_package("boto", "1.8d")
     end
 
     it "should run easy_install -m with the package name and version and specified options" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -x -m boto",
-      },)
+      })
       allow(@new_resource).to receive(:options).and_return("-x")
       @provider.remove_package("boto", "1.8d")
     end
@@ -100,7 +100,7 @@ describe Chef::Provider::Package::EasyInstall do
     it "should run easy_install -m with the package name and version" do
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -m boto",
-      },)
+      })
       @provider.purge_package("boto", "1.8d")
     end
 

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -56,7 +56,7 @@ describe Chef::Provider::Package::Openbsd do
               instance_double("shellout", :stdout => "#{name}-#{version}\n"))
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}",
-              { :env => { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
+              { :env => { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
             ) { OpenStruct.new :status => true }
             provider.run_action(:install)
           end
@@ -88,7 +88,7 @@ describe Chef::Provider::Package::Openbsd do
                 instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor}\n"))
               expect(provider).to receive(:shell_out!).with(
                 "pkg_add -r #{name}-#{version}-#{flavor}",
-                { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
+                { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
               ) { OpenStruct.new :status => true }
               provider.run_action(:install)
             end
@@ -104,7 +104,7 @@ describe Chef::Provider::Package::Openbsd do
             new_resource.version("#{version}-#{flavor_b}")
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}-#{flavor_b}",
-              { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
+              { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
             ) { OpenStruct.new :status => true }
             provider.run_action(:install)
           end

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -56,7 +56,7 @@ describe Chef::Provider::Package::Openbsd do
               instance_double("shellout", :stdout => "#{name}-#{version}\n"))
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}",
-              { :env => { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
+              { :env => { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
             ) { OpenStruct.new :status => true }
             provider.run_action(:install)
           end
@@ -88,7 +88,7 @@ describe Chef::Provider::Package::Openbsd do
                 instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor}\n"))
               expect(provider).to receive(:shell_out!).with(
                 "pkg_add -r #{name}-#{version}-#{flavor}",
-                { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
+                { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
               ) { OpenStruct.new :status => true }
               provider.run_action(:install)
             end
@@ -104,7 +104,7 @@ describe Chef::Provider::Package::Openbsd do
             new_resource.version("#{version}-#{flavor_b}")
             expect(provider).to receive(:shell_out!).with(
               "pkg_add -r #{name}-#{version}-#{flavor_b}",
-              { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 },
+              { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
             ) { OpenStruct.new :status => true }
             provider.run_action(:install)
           end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -133,7 +133,7 @@ describe Chef::Provider::Package::Yum do
       it "should set the arch if no existing package_name is found and new_package_name+new_arch is available" do
         @new_resource = Chef::Resource::YumPackage.new("testing.noarch")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache"
+          "Chef::Provider::Yum::YumCache",
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -188,7 +188,7 @@ describe Chef::Provider::Package::Yum do
       it "should not set the arch when an existing package_name is found" do
         @new_resource = Chef::Resource::YumPackage.new("testing.beta3")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache"
+          "Chef::Provider::Yum::YumCache",
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # installed for package_name
@@ -224,7 +224,7 @@ describe Chef::Provider::Package::Yum do
       it "should not set the arch when no existing package_name or new_package_name+new_arch is found" do
         @new_resource = Chef::Resource::YumPackage.new("testing.beta3")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache"
+          "Chef::Provider::Yum::YumCache",
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -256,7 +256,7 @@ describe Chef::Provider::Package::Yum do
         @new_resource = Chef::Resource::YumPackage.new("testing.i386")
         @new_resource.arch("x86_64")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache"
+          "Chef::Provider::Yum::YumCache",
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -524,7 +524,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5"
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5",
       )
       @provider.install_package("cups", "1.2.4-11.19.el5")
     end
@@ -532,7 +532,7 @@ describe Chef::Provider::Package::Yum do
     it "should run yum localinstall if given a path to an rpm" do
       allow(@new_resource).to receive(:source).and_return("/tmp/emacs-21.4-20.el5.i386.rpm")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
+        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm",
       )
       @provider.install_package("emacs", "21.4-20.el5")
     end
@@ -543,7 +543,7 @@ describe Chef::Provider::Package::Yum do
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/emacs-21.4-20.el5.i386.rpm")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
+        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm",
       )
       @provider.install_package("/tmp/emacs-21.4-20.el5.i386.rpm", "21.4-20.el5")
     end
@@ -553,7 +553,7 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386"
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386",
       )
       @provider.install_package("cups", "1.2.4-11.19.el5")
     end
@@ -564,7 +564,7 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y --disablerepo epmd install cups-11"
+        "-d0 -e0 -y --disablerepo epmd install cups-11",
       )
       @provider.install_package(@new_resource.name, @provider.candidate_version)
     end
@@ -624,7 +624,7 @@ describe Chef::Provider::Package::Yum do
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
       )
       @provider.install_package("cups", "1.2.4-11.15.el5")
     end
@@ -648,7 +648,7 @@ describe Chef::Provider::Package::Yum do
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y downgrade cups-1.2.4-11.15.el5"
+        "-d0 -e0 -y downgrade cups-1.2.4-11.15.el5",
       )
       @provider.install_package("cups", "1.2.4-11.15.el5")
     end
@@ -658,7 +658,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
       )
       expect(@yum_cache).to receive(:reload).once
       @provider.install_package("cups", "1.2.4-11.15.el5")
@@ -669,7 +669,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
       )
       expect(@yum_cache).not_to receive(:reload)
       @provider.install_package("cups", "1.2.4-11.15.el5")
@@ -682,7 +682,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-11"
+        "-d0 -e0 -y install cups-11",
       )
       @provider.upgrade_package(@new_resource.name, @provider.candidate_version)
     end
@@ -693,7 +693,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-11"
+        "-d0 -e0 -y install cups-11",
       )
       @provider.upgrade_package(@new_resource.name, @provider.candidate_version)
     end
@@ -761,7 +761,7 @@ describe Chef::Provider::Package::Yum do
   describe "when removing a package" do
     it "should run yum remove with the package name" do
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0"
+        "-d0 -e0 -y remove emacs-1.0",
       )
       @provider.remove_package("emacs", "1.0")
     end
@@ -769,7 +769,7 @@ describe Chef::Provider::Package::Yum do
     it "should run yum remove with the package name and arch" do
       allow(@new_resource).to receive(:arch).and_return("x86_64")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0.x86_64"
+        "-d0 -e0 -y remove emacs-1.0.x86_64",
       )
       @provider.remove_package("emacs", "1.0")
     end
@@ -778,7 +778,7 @@ describe Chef::Provider::Package::Yum do
   describe "when purging a package" do
     it "should run yum remove with the package name" do
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0"
+        "-d0 -e0 -y remove emacs-1.0",
       )
       @provider.purge_package("emacs", "1.0")
     end
@@ -2211,7 +2211,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@yum_cache).to receive(:installed_version).with("cups", nil).and_return("1.2.4-11.18.el5")
       allow(@yum_cache).to receive(:installed_version).with("vim", nil).and_return("0.9")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5 vim-1.0"
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5 vim-1.0",
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end
@@ -2221,7 +2221,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386 vim-1.0.i386"
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386 vim-1.0.i386",
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end
@@ -2232,7 +2232,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@yum_cache).to receive(:installed_version).with("cups", nil).and_return("1.2.4-11.18.el5")
       allow(@yum_cache).to receive(:installed_version).with("vim", nil).and_return("0.9")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y --disablerepo epmd install cups-1.2.4-11.19.el5 vim-1.0"
+        "-d0 -e0 -y --disablerepo epmd install cups-1.2.4-11.19.el5 vim-1.0",
       )
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
@@ -2258,7 +2258,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
 
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.x86_64 vim-1.0"
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.x86_64 vim-1.0",
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::Package::Yum do
       :version_available? => true,
       :allow_multi_install => [ "kernel" ],
       :package_repository => "base",
-      :disable_extra_repo_control => true,
+      :disable_extra_repo_control => true
     )
     allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
     allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -133,7 +133,7 @@ describe Chef::Provider::Package::Yum do
       it "should set the arch if no existing package_name is found and new_package_name+new_arch is available" do
         @new_resource = Chef::Resource::YumPackage.new("testing.noarch")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache",
+          "Chef::Provider::Yum::YumCache"
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -188,7 +188,7 @@ describe Chef::Provider::Package::Yum do
       it "should not set the arch when an existing package_name is found" do
         @new_resource = Chef::Resource::YumPackage.new("testing.beta3")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache",
+          "Chef::Provider::Yum::YumCache"
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # installed for package_name
@@ -224,7 +224,7 @@ describe Chef::Provider::Package::Yum do
       it "should not set the arch when no existing package_name or new_package_name+new_arch is found" do
         @new_resource = Chef::Resource::YumPackage.new("testing.beta3")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache",
+          "Chef::Provider::Yum::YumCache"
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -256,7 +256,7 @@ describe Chef::Provider::Package::Yum do
         @new_resource = Chef::Resource::YumPackage.new("testing.i386")
         @new_resource.arch("x86_64")
         @yum_cache = double(
-          "Chef::Provider::Yum::YumCache",
+          "Chef::Provider::Yum::YumCache"
         )
         allow(@yum_cache).to receive(:installed_version) do |package_name, arch|
           # nothing installed for package_name/new_package_name
@@ -320,7 +320,7 @@ describe Chef::Provider::Package::Yum do
           :candidate_version => "2.0.1.el5",
           :package_available? => false,
           :version_available? => true,
-          :disable_extra_repo_control => true,
+          :disable_extra_repo_control => true
       )
       }
 
@@ -393,7 +393,7 @@ describe Chef::Provider::Package::Yum do
           :candidate_version => "2.0.1.el5",
           :package_available? => false,
           :version_available? => true,
-          :disable_extra_repo_control => true,
+          :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -415,7 +415,7 @@ describe Chef::Provider::Package::Yum do
         :candidate_version => "1.2.4-11.18.el5",
         :package_available? => false,
         :version_available? => true,
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -438,7 +438,7 @@ describe Chef::Provider::Package::Yum do
           :candidate_version => "2.0.1.el5",
           :package_available? => false,
           :version_available? => true,
-          :disable_extra_repo_control => true,
+          :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -463,7 +463,7 @@ describe Chef::Provider::Package::Yum do
         :candidate_version => "1.2.4-11.18.el5",
         :package_available? => false,
         :version_available? => true,
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -483,7 +483,7 @@ describe Chef::Provider::Package::Yum do
         :candidate_version => "1.2.4-11.18.el5",
         :package_available? => false,
         :version_available? => true,
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -508,7 +508,7 @@ describe Chef::Provider::Package::Yum do
         :candidate_version => "1.2.4-11.18.el5",
         :package_available? => false,
         :version_available? => true,
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -524,7 +524,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5",
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5"
       )
       @provider.install_package("cups", "1.2.4-11.19.el5")
     end
@@ -532,7 +532,7 @@ describe Chef::Provider::Package::Yum do
     it "should run yum localinstall if given a path to an rpm" do
       allow(@new_resource).to receive(:source).and_return("/tmp/emacs-21.4-20.el5.i386.rpm")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm",
+        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
       @provider.install_package("emacs", "21.4-20.el5")
     end
@@ -543,7 +543,7 @@ describe Chef::Provider::Package::Yum do
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/emacs-21.4-20.el5.i386.rpm")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm",
+        "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
       @provider.install_package("/tmp/emacs-21.4-20.el5.i386.rpm", "21.4-20.el5")
     end
@@ -553,7 +553,7 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386",
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386"
       )
       @provider.install_package("cups", "1.2.4-11.19.el5")
     end
@@ -564,7 +564,7 @@ describe Chef::Provider::Package::Yum do
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y --disablerepo epmd install cups-11",
+        "-d0 -e0 -y --disablerepo epmd install cups-11"
       )
       @provider.install_package(@new_resource.name, @provider.candidate_version)
     end
@@ -578,7 +578,7 @@ describe Chef::Provider::Package::Yum do
         :candidate_version => "1.2.4-11.18.el5_2.3",
         :package_available? => true,
         :version_available? => nil,
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -597,7 +597,7 @@ describe Chef::Provider::Package::Yum do
         :package_available? => true,
         :version_available? => true,
         :allow_multi_install => [ "kernel" ],
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -617,14 +617,14 @@ describe Chef::Provider::Package::Yum do
         :version_available? => true,
         :allow_multi_install => [ "cups" ],
         :package_repository => "base",
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       @provider.install_package("cups", "1.2.4-11.15.el5")
     end
@@ -641,14 +641,14 @@ describe Chef::Provider::Package::Yum do
         :version_available? => true,
         :allow_multi_install => [],
         :package_repository => "base",
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
       @provider = Chef::Provider::Package::Yum.new(@new_resource, @run_context)
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y downgrade cups-1.2.4-11.15.el5",
+        "-d0 -e0 -y downgrade cups-1.2.4-11.15.el5"
       )
       @provider.install_package("cups", "1.2.4-11.15.el5")
     end
@@ -658,7 +658,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).to receive(:reload).once
       @provider.install_package("cups", "1.2.4-11.15.el5")
@@ -669,7 +669,7 @@ describe Chef::Provider::Package::Yum do
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.15.el5",
+        "-d0 -e0 -y install cups-1.2.4-11.15.el5"
       )
       expect(@yum_cache).not_to receive(:reload)
       @provider.install_package("cups", "1.2.4-11.15.el5")
@@ -682,7 +682,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-11",
+        "-d0 -e0 -y install cups-11"
       )
       @provider.upgrade_package(@new_resource.name, @provider.candidate_version)
     end
@@ -693,7 +693,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-11",
+        "-d0 -e0 -y install cups-11"
       )
       @provider.upgrade_package(@new_resource.name, @provider.candidate_version)
     end
@@ -708,7 +708,7 @@ describe Chef::Provider::Package::Yum do
         :package_available? => true,
         :version_available? => true,
         :allow_multi_install => [ "kernel" ],
-        :disable_extra_repo_control => true,
+        :disable_extra_repo_control => true
       )
       allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
       allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -724,7 +724,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       expect(@provider).to receive(:upgrade_package).with(
         "cups",
-        "11",
+        "11"
       )
       @provider.run_action(:upgrade)
     end
@@ -743,7 +743,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:candidate_version).and_return("11")
       expect(@provider).to receive(:upgrade_package).with(
         "cups",
-        "11",
+        "11"
       )
       @provider.run_action(:upgrade)
     end
@@ -761,7 +761,7 @@ describe Chef::Provider::Package::Yum do
   describe "when removing a package" do
     it "should run yum remove with the package name" do
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0",
+        "-d0 -e0 -y remove emacs-1.0"
       )
       @provider.remove_package("emacs", "1.0")
     end
@@ -769,7 +769,7 @@ describe Chef::Provider::Package::Yum do
     it "should run yum remove with the package name and arch" do
       allow(@new_resource).to receive(:arch).and_return("x86_64")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0.x86_64",
+        "-d0 -e0 -y remove emacs-1.0.x86_64"
       )
       @provider.remove_package("emacs", "1.0")
     end
@@ -778,7 +778,7 @@ describe Chef::Provider::Package::Yum do
   describe "when purging a package" do
     it "should run yum remove with the package name" do
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y remove emacs-1.0",
+        "-d0 -e0 -y remove emacs-1.0"
       )
       @provider.purge_package("emacs", "1.0")
     end
@@ -790,7 +790,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:shell_out).and_return(@status)
       expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
-        { :timeout => Chef::Config[:yum_timeout] },
+        { :timeout => Chef::Config[:yum_timeout] }
       )
       @provider.yum_command("-d0 -e0 -y install emacs-1.0")
     end
@@ -800,7 +800,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:shell_out).and_return(@status)
       expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
-        { :timeout => Chef::Config[:yum_timeout] },
+        { :timeout => Chef::Config[:yum_timeout] }
       )
       expect { @provider.yum_command("-d0 -e0 -y install emacs-1.0") }.to raise_error(Chef::Exceptions::Exec)
     end
@@ -811,7 +811,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:shell_out).and_return(@status)
       expect(@provider).to receive(:shell_out).once.with(
         "yum -d0 -e0 -y install emacs-1.0",
-        { :timeout => Chef::Config[:yum_timeout] },
+        { :timeout => Chef::Config[:yum_timeout] }
       )
       # will still raise an exception, can't stub out the subsequent call
       expect { @provider.yum_command("-d0 -e0 -y install emacs-1.0") }.to raise_error(Chef::Exceptions::Exec)
@@ -823,7 +823,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:shell_out).and_return(@status)
       expect(@provider).to receive(:shell_out).twice.with(
         "yum -d0 -e0 -y install emacs-1.0",
-        { :timeout => Chef::Config[:yum_timeout] },
+        { :timeout => Chef::Config[:yum_timeout] }
       )
       # will still raise an exception, can't stub out the subsequent call
       expect { @provider.yum_command("-d0 -e0 -y install emacs-1.0") }.to raise_error(Chef::Exceptions::Exec)
@@ -837,7 +837,7 @@ describe Chef::Provider::Package::Yum do
       allow(@provider).to receive(:shell_out).and_return(@status)
       expect(@provider).to receive(:shell_out).once.with(
         "yum-deprecated -d0 -e0 -y install emacs-1.0",
-        { :timeout => Chef::Config[:yum_timeout] },
+        { :timeout => Chef::Config[:yum_timeout] }
       )
       @provider.yum_command("-d0 -e0 -y install emacs-1.0")
     end
@@ -2125,7 +2125,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       :version_available? => true,
       :allow_multi_install => [ "kernel" ],
       :package_repository => "base",
-      :disable_extra_repo_control => true,
+      :disable_extra_repo_control => true
     )
     allow(Chef::Provider::Package::Yum::YumCache).to receive(:instance).and_return(@yum_cache)
     allow(@yum_cache).to receive(:yum_binary=).with("yum")
@@ -2211,7 +2211,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@yum_cache).to receive(:installed_version).with("cups", nil).and_return("1.2.4-11.18.el5")
       allow(@yum_cache).to receive(:installed_version).with("vim", nil).and_return("0.9")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5 vim-1.0",
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5 vim-1.0"
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end
@@ -2221,7 +2221,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@new_resource).to receive(:arch).and_return("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386 vim-1.0.i386",
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386 vim-1.0.i386"
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end
@@ -2232,7 +2232,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
       allow(@yum_cache).to receive(:installed_version).with("cups", nil).and_return("1.2.4-11.18.el5")
       allow(@yum_cache).to receive(:installed_version).with("vim", nil).and_return("0.9")
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y --disablerepo epmd install cups-1.2.4-11.19.el5 vim-1.0",
+        "-d0 -e0 -y --disablerepo epmd install cups-1.2.4-11.19.el5 vim-1.0"
       )
       allow(@new_resource).to receive(:options).and_return("--disablerepo epmd")
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
@@ -2258,7 +2258,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
 
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
-        "-d0 -e0 -y install cups-1.2.4-11.19.el5.x86_64 vim-1.0",
+        "-d0 -e0 -y install cups-1.2.4-11.19.el5.x86_64 vim-1.0"
       )
       @provider.install_package(%w{cups vim}, ["1.2.4-11.19.el5", "1.0"])
     end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -61,7 +61,7 @@ describe Chef::Provider::Package::Zypper do
 
     it "should run zypper info with the package name" do
       shell_out_expectation!(
-        "zypper --non-interactive info #{new_resource.package_name}"
+        "zypper --non-interactive info #{new_resource.package_name}",
       ).and_return(status)
       provider.load_current_resource
     end
@@ -97,23 +97,23 @@ describe Chef::Provider::Package::Zypper do
     it "should run zypper install with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
       shell_out_expectation!(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0",
       )
       provider.install_package(["emacs"], ["1.0"])
     end
     it "should run zypper install without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
       )
       provider.install_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper install" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/
+        /All packages will be installed without gpg signature checks/,
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -123,29 +123,29 @@ describe Chef::Provider::Package::Zypper do
     it "should run zypper update with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
       shell_out_expectation!(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0",
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper update without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper upgrade" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/
+        /All packages will be installed without gpg signature checks/,
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper upgrade without gpg checks" do
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
@@ -157,7 +157,7 @@ describe Chef::Provider::Package::Zypper do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
         shell_out_expectation!(
-            "zypper --non-interactive remove emacs"
+            "zypper --non-interactive remove emacs",
         )
         provider.remove_package(["emacs"], [nil])
       end
@@ -167,23 +167,23 @@ describe Chef::Provider::Package::Zypper do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
         shell_out_expectation!(
-          "zypper --non-interactive remove emacs=1.0"
+          "zypper --non-interactive remove emacs=1.0",
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
       it "should run zypper remove without gpg checks" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
         shell_out_expectation!(
-            "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
+            "zypper --non-interactive --no-gpg-checks remove emacs=1.0",
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
       it "should warn about gpg checks on zypper remove" do
         expect(Chef::Log).to receive(:warn).with(
-          /All packages will be installed without gpg signature checks/
+          /All packages will be installed without gpg signature checks/,
         )
         shell_out_expectation!(
-          "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
+          "zypper --non-interactive --no-gpg-checks remove emacs=1.0",
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
@@ -193,23 +193,23 @@ describe Chef::Provider::Package::Zypper do
   describe "purge_package" do
     it "should run remove with the name and version and --clean-deps" do
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
     it "should run zypper purge without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper purge" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/
+        /All packages will be installed without gpg signature checks/,
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
@@ -223,7 +223,7 @@ describe Chef::Provider::Package::Zypper do
     describe "install_package" do
       it "should run zypper install with the package name and version" do
         shell_out_expectation!(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs",
         )
         provider.install_package(["emacs"], ["1.0"])
       end
@@ -232,7 +232,7 @@ describe Chef::Provider::Package::Zypper do
     describe "upgrade_package" do
       it "should run zypper update with the package name and version" do
         shell_out_expectation!(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs",
         )
         provider.upgrade_package(["emacs"], ["1.0"])
       end
@@ -241,7 +241,7 @@ describe Chef::Provider::Package::Zypper do
     describe "remove_package" do
       it "should run zypper remove with the package name" do
         shell_out_expectation!(
-           "zypper --no-gpg-checks remove -y emacs"
+           "zypper --no-gpg-checks remove -y emacs",
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
@@ -252,7 +252,7 @@ describe Chef::Provider::Package::Zypper do
     it "should install an array of package names and versions" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0 vim=2.0"
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0 vim=2.0",
       )
       provider.install_package(%w{emacs vim}, ["1.0", "2.0"])
     end
@@ -260,7 +260,7 @@ describe Chef::Provider::Package::Zypper do
     it "should remove an array of package names and versions" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove emacs=1.0 vim=2.0"
+        "zypper --non-interactive --no-gpg-checks remove emacs=1.0 vim=2.0",
       )
       provider.remove_package(%w{emacs vim}, ["1.0", "2.0"])
     end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -61,7 +61,7 @@ describe Chef::Provider::Package::Zypper do
 
     it "should run zypper info with the package name" do
       shell_out_expectation!(
-        "zypper --non-interactive info #{new_resource.package_name}",
+        "zypper --non-interactive info #{new_resource.package_name}"
       ).and_return(status)
       provider.load_current_resource
     end
@@ -97,23 +97,23 @@ describe Chef::Provider::Package::Zypper do
     it "should run zypper install with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
       shell_out_expectation!(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
     it "should run zypper install without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper install" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/,
+        /All packages will be installed without gpg signature checks/
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -123,29 +123,29 @@ describe Chef::Provider::Package::Zypper do
     it "should run zypper update with the package name and version" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
       shell_out_expectation!(
-        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive install --auto-agree-with-licenses emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper update without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper upgrade" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/,
+        /All packages will be installed without gpg signature checks/
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper upgrade without gpg checks" do
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
@@ -157,7 +157,7 @@ describe Chef::Provider::Package::Zypper do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
         shell_out_expectation!(
-            "zypper --non-interactive remove emacs",
+            "zypper --non-interactive remove emacs"
         )
         provider.remove_package(["emacs"], [nil])
       end
@@ -167,23 +167,23 @@ describe Chef::Provider::Package::Zypper do
       it "should run zypper remove with the package name" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
         shell_out_expectation!(
-          "zypper --non-interactive remove emacs=1.0",
+          "zypper --non-interactive remove emacs=1.0"
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
       it "should run zypper remove without gpg checks" do
         allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
         shell_out_expectation!(
-            "zypper --non-interactive --no-gpg-checks remove emacs=1.0",
+            "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
       it "should warn about gpg checks on zypper remove" do
         expect(Chef::Log).to receive(:warn).with(
-          /All packages will be installed without gpg signature checks/,
+          /All packages will be installed without gpg signature checks/
         )
         shell_out_expectation!(
-          "zypper --non-interactive --no-gpg-checks remove emacs=1.0",
+          "zypper --non-interactive --no-gpg-checks remove emacs=1.0"
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
@@ -193,23 +193,23 @@ describe Chef::Provider::Package::Zypper do
   describe "purge_package" do
     it "should run remove with the name and version and --clean-deps" do
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
     it "should run zypper purge without gpg checks" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
     it "should warn about gpg checks on zypper purge" do
       expect(Chef::Log).to receive(:warn).with(
-        /All packages will be installed without gpg signature checks/,
+        /All packages will be installed without gpg signature checks/
       )
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0",
+        "zypper --non-interactive --no-gpg-checks remove --clean-deps emacs=1.0"
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
@@ -223,7 +223,7 @@ describe Chef::Provider::Package::Zypper do
     describe "install_package" do
       it "should run zypper install with the package name and version" do
         shell_out_expectation!(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs",
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
         )
         provider.install_package(["emacs"], ["1.0"])
       end
@@ -232,7 +232,7 @@ describe Chef::Provider::Package::Zypper do
     describe "upgrade_package" do
       it "should run zypper update with the package name and version" do
         shell_out_expectation!(
-          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs",
+          "zypper --no-gpg-checks install --auto-agree-with-licenses -y emacs"
         )
         provider.upgrade_package(["emacs"], ["1.0"])
       end
@@ -241,7 +241,7 @@ describe Chef::Provider::Package::Zypper do
     describe "remove_package" do
       it "should run zypper remove with the package name" do
         shell_out_expectation!(
-           "zypper --no-gpg-checks remove -y emacs",
+           "zypper --no-gpg-checks remove -y emacs"
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
@@ -252,7 +252,7 @@ describe Chef::Provider::Package::Zypper do
     it "should install an array of package names and versions" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0 vim=2.0",
+        "zypper --non-interactive --no-gpg-checks install " + "--auto-agree-with-licenses emacs=1.0 vim=2.0"
       )
       provider.install_package(%w{emacs vim}, ["1.0", "2.0"])
     end
@@ -260,7 +260,7 @@ describe Chef::Provider::Package::Zypper do
     it "should remove an array of package names and versions" do
       allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(false)
       shell_out_expectation!(
-        "zypper --non-interactive --no-gpg-checks remove emacs=1.0 vim=2.0",
+        "zypper --non-interactive --no-gpg-checks remove emacs=1.0 vim=2.0"
       )
       provider.remove_package(%w{emacs vim}, ["1.0", "2.0"])
     end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -62,7 +62,7 @@ describe Chef::Provider::Package do
       ).and_return("/var/cache/preseed-test")
 
       expect(provider).to receive(:preseed_package).with(
-        "/var/cache/preseed-test"
+        "/var/cache/preseed-test",
       ).and_return(true)
       provider.run_action(:install)
     end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -58,11 +58,11 @@ describe Chef::Provider::Package do
       new_resource.response_file("foo")
       expect(provider).to receive(:get_preseed_file).with(
         new_resource.name,
-        provider.candidate_version,
+        provider.candidate_version
       ).and_return("/var/cache/preseed-test")
 
       expect(provider).to receive(:preseed_package).with(
-        "/var/cache/preseed-test",
+        "/var/cache/preseed-test"
       ).and_return(true)
       provider.run_action(:install)
     end
@@ -75,7 +75,7 @@ describe Chef::Provider::Package do
     it "should install the package at the candidate_version if it is not already installed" do
       expect(provider).to receive(:install_package).with(
         new_resource.name,
-        provider.candidate_version,
+        provider.candidate_version
       ).and_return(true)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -85,7 +85,7 @@ describe Chef::Provider::Package do
       new_resource.version("1.0")
       expect(provider).to receive(:install_package).with(
         new_resource.name,
-        new_resource.version,
+        new_resource.version
       ).and_return(true)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -96,7 +96,7 @@ describe Chef::Provider::Package do
       allow(current_resource).to receive(:version).and_return("0.99")
       expect(provider).to receive(:install_package).with(
         new_resource.name,
-        new_resource.version,
+        new_resource.version
       ).and_return(true)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -144,7 +144,7 @@ describe Chef::Provider::Package do
     it "should upgrade the package if the current version is not the candidate version" do
       expect(provider).to receive(:upgrade_package).with(
         new_resource.name,
-        provider.candidate_version,
+        provider.candidate_version
       ).and_return(true)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
@@ -468,7 +468,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:install_package).with(
       [ "vim" ],
-      [ "1.0" ],
+      [ "1.0" ]
     ).and_return(true)
     provider.run_action(:install)
     expect(new_resource).to be_updated_by_last_action
@@ -481,7 +481,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:install_package).with(
       [ "vim" ],
-      [ "1.0" ],
+      [ "1.0" ]
     ).and_return(true)
     provider.run_action(:install)
     expect(new_resource).to be_updated_by_last_action
@@ -494,7 +494,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:upgrade_package).with(
       [ "vim" ],
-      [ "1.0" ],
+      [ "1.0" ]
     ).and_return(true)
     provider.run_action(:upgrade)
     expect(new_resource).to be_updated_by_last_action
@@ -507,7 +507,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:upgrade_package).with(
       [ "vim" ],
-      [ "1.0" ],
+      [ "1.0" ]
     ).and_return(true)
     provider.run_action(:upgrade)
     expect(new_resource).to be_updated_by_last_action
@@ -521,7 +521,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:remove_package).with(
       [ "vim" ],
-      [ nil ],
+      [ nil ]
     ).and_return(true)
     provider.run_action(:remove)
     expect(new_resource).to be_updated_by_last_action
@@ -535,7 +535,7 @@ describe "Subclass with use_multipackage_api" do
     provider.candidate_version = [ "1.0" ]
     expect(provider).to receive(:purge_package).with(
       [ "vim" ],
-      [ nil ],
+      [ nil ]
     ).and_return(true)
     provider.run_action(:purge)
     expect(new_resource).to be_updated_by_last_action
@@ -552,7 +552,7 @@ describe "Subclass with use_multipackage_api" do
     allow(provider).to receive(:reconfig_package).and_return(true)
     expect(provider).to receive(:reconfig_package).with(
       [ "vim" ],
-      [ "1.0" ],
+      [ "1.0" ]
     ).and_return(true)
     provider.run_action(:reconfig)
     expect(new_resource).to be_updated_by_last_action
@@ -582,7 +582,7 @@ describe "Chef::Provider::Package - Multi" do
     it "installs the candidate versions when none are installed" do
       expect(provider).to receive(:install_package).with(
         %w{emacs vi},
-        ["1.0", "6.2"],
+        ["1.0", "6.2"]
       ).and_return(true)
       provider.run_action(:install)
       expect(new_resource).to be_updated
@@ -591,7 +591,7 @@ describe "Chef::Provider::Package - Multi" do
     it "installs the candidate versions when some are installed" do
       expect(provider).to receive(:install_package).with(
         [ "vi" ],
-        [ "6.2" ],
+        [ "6.2" ]
       ).and_return(true)
       current_resource.version(["1.0", nil])
       provider.run_action(:install)
@@ -675,7 +675,7 @@ describe "Chef::Provider::Package - Multi" do
       current_resource.version ["0.9", "6.1"]
       expect(provider).to receive(:upgrade_package).with(
         new_resource.package_name,
-        provider.candidate_version,
+        provider.candidate_version
       ).and_return(true)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
@@ -685,7 +685,7 @@ describe "Chef::Provider::Package - Multi" do
       current_resource.version ["1.0", "6.1"]
       expect(provider).to receive(:upgrade_package).with(
         ["vi"],
-        ["6.2"],
+        ["6.2"]
       ).and_return(true)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -259,7 +259,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Invokercd,
             )
             expect(provider_resolver.supported_handlers).to_not include(
-              Chef::Provider::Service::Upstart
+              Chef::Provider::Service::Upstart,
             )
           end
 
@@ -314,7 +314,7 @@ describe Chef::ProviderResolver do
 
           it "supports only the upstart handler" do
             expect(provider_resolver.supported_handlers).to include(
-              Chef::Provider::Service::Upstart
+              Chef::Provider::Service::Upstart,
             )
             expect(provider_resolver.supported_handlers).to_not include(
               Chef::Provider::Service::Debian,
@@ -591,35 +591,35 @@ describe Chef::ProviderResolver do
   #            service: [ Chef::Resource::InsservService, Chef::Provider::Service::Insserv ],
             },
             "5.0" => {
-              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ]
+              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
             },
           },
           "gcel" => {
             "3.1.4" => {
-              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ]
-            }
+              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
+            },
           },
           "linaro" => {
             "3.1.4" => {
-              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ]
-            }
+              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
+            },
           },
           "linuxmint" => {
             "3.1.4" => {
               ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
   #            service: [ Chef::Resource::UpstartService, Chef::Provider::Service::Upstart ],
-            }
+            },
           },
           "raspbian" => {
             "3.1.4" => {
-              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ]
-            }
+              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
+            },
           },
           "ubuntu" => {
             "11.10" => {
             },
             "10.04" => {
-              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ]
+              ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig ],
             },
           },
         },
@@ -630,7 +630,7 @@ describe Chef::ProviderResolver do
 
           "arch" => {
             "3.1.4" => {
-            }
+            },
           },
         },
 
@@ -640,7 +640,7 @@ describe Chef::ProviderResolver do
 
           "freebsd" => {
             "3.1.4" => {
-            }
+            },
           },
         },
         "suse" => {
@@ -649,7 +649,7 @@ describe Chef::ProviderResolver do
             "12.0" => {
             },
             %w{11.1 11.2 11.3} => {
-              group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ]
+              group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ],
             },
           },
           "opensuse" => {
@@ -659,7 +659,7 @@ describe Chef::ProviderResolver do
             "12.3" => {
             },
             "12.2" => {
-              group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ]
+              group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ],
             },
           },
         },
@@ -672,7 +672,7 @@ describe Chef::ProviderResolver do
 
           "gentoo" => {
             "3.1.4" => {
-            }
+            },
           },
         },
 
@@ -684,7 +684,7 @@ describe Chef::ProviderResolver do
           %w{amazon xcp xenserver ibm_powerkvm cloudlinux parallels} => {
             "3.1.4" => {
   #            service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
-            }
+            },
           },
           %w{redhat centos scientific oracle} => {
             "7.0" => {
@@ -713,9 +713,9 @@ describe Chef::ProviderResolver do
 
           "mac_os_x" => {
             "10.9.2" => {
-            }
+            },
           },
-        }
+        },
       },
 
       "windows" => {
@@ -734,8 +734,8 @@ describe Chef::ProviderResolver do
         "windows" => {
           %w{mswin mingw32 windows} => {
             "10.9.2" => {
-            }
-          }
+            },
+          },
         },
       },
 
@@ -754,8 +754,8 @@ describe Chef::ProviderResolver do
         "aix" => {
           "aix" => {
             "5.6" => {
-            }
-          }
+            },
+          },
         },
       },
 
@@ -763,20 +763,20 @@ describe Chef::ProviderResolver do
         "hpux" => {
           "hpux" => {
             "3.1.4" => {
-              group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ]
-            }
-          }
-        }
+              group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ],
+            },
+          },
+        },
       },
 
       "netbsd" => {
         "netbsd" => {
           "netbsd" => {
             "3.1.4" => {
-              group: [ Chef::Resource::Group, Chef::Provider::Group::Groupmod ]
-            }
-          }
-        }
+              group: [ Chef::Resource::Group, Chef::Provider::Group::Groupmod ],
+            },
+          },
+        },
       },
 
       "openbsd" => {
@@ -786,8 +786,8 @@ describe Chef::ProviderResolver do
         "openbsd" => {
           "openbsd" => {
             "3.1.4" => {
-            }
-          }
+            },
+          },
         },
       },
 
@@ -804,32 +804,32 @@ describe Chef::ProviderResolver do
 
           "smartos" => {
             "3.1.4" => {
-            }
+            },
           },
         },
 
         "solaris2" => {
           "nexentacore" => {
             "3.1.4" => {
-            }
+            },
           },
           "omnios" => {
             "3.1.4" => {
-              user: [ Chef::Resource::User, Chef::Provider::User::Solaris ]
-            }
+              user: [ Chef::Resource::User, Chef::Provider::User::Solaris ],
+            },
           },
           "openindiana" => {
             "3.1.4" => {
-            }
+            },
           },
           "opensolaris" => {
             "3.1.4" => {
-            }
+            },
           },
           "solaris2" => {
             user: [ Chef::Resource::User, Chef::Provider::User::Solaris ],
             "5.11" => {
-              package: [ Chef::Resource::IpsPackage, Chef::Provider::Package::Ips ]
+              package: [ Chef::Resource::IpsPackage, Chef::Provider::Package::Ips ],
             },
             "5.9" => {
             },
@@ -842,9 +842,9 @@ describe Chef::ProviderResolver do
         "solaris" => {
           "solaris" => {
             "3.1.4" => {
-            }
-          }
-        }
+            },
+          },
+        },
       },
 
       "exherbo" => {
@@ -852,10 +852,10 @@ describe Chef::ProviderResolver do
           "exherbo" => {
             "3.1.4" => {
               # TODO should be Chef::Resource::PaludisPackage
-              package: [ Chef::Resource::Package, Chef::Provider::Package::Paludis ]
-            }
-          }
-        }
+              package: [ Chef::Resource::Package, Chef::Provider::Package::Paludis ],
+            },
+          },
+        },
       },
     }
 

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -248,7 +248,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
               Chef::Provider::Service::Invokercd,
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
@@ -256,10 +256,10 @@ describe Chef::ProviderResolver do
             expect(provider_resolver.supported_handlers).to include(
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
-              Chef::Provider::Service::Invokercd,
+              Chef::Provider::Service::Invokercd
             )
             expect(provider_resolver.supported_handlers).to_not include(
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
@@ -279,7 +279,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
               Chef::Provider::Service::Invokercd,
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
@@ -288,7 +288,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
               Chef::Provider::Service::Invokercd,
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
@@ -308,18 +308,18 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
               Chef::Provider::Service::Invokercd,
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
           it "supports only the upstart handler" do
             expect(provider_resolver.supported_handlers).to include(
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
             expect(provider_resolver.supported_handlers).to_not include(
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
-              Chef::Provider::Service::Invokercd,
+              Chef::Provider::Service::Invokercd
             )
           end
 
@@ -339,7 +339,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
               Chef::Provider::Service::Invokercd,
-              Chef::Provider::Service::Upstart,
+              Chef::Provider::Service::Upstart
             )
           end
 
@@ -348,7 +348,7 @@ describe Chef::ProviderResolver do
               Chef::Provider::Service::Upstart,
               Chef::Provider::Service::Debian,
               Chef::Provider::Service::Init,
-              Chef::Provider::Service::Invokercd,
+              Chef::Provider::Service::Invokercd
             )
           end
 

--- a/spec/unit/resource/apt_package_spec.rb
+++ b/spec/unit/resource/apt_package_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::AptPackage, "initialize" do
     provider: Chef::Provider::Package::Apt,
     name: :apt_package,
     action: :install,
-    os: "linux",
+    os: "linux"
   )
 
   let(:resource) { Chef::Resource::AptPackage.new("foo") }

--- a/spec/unit/resource/breakpoint_spec.rb
+++ b/spec/unit/resource/breakpoint_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::Breakpoint do
     resource: Chef::Resource::Breakpoint,
     provider: Chef::Provider::Breakpoint,
     name: :breakpoint,
-    action: :break,
+    action: :break
   )
 
   before do

--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::ChefGem, "initialize" do
     resource: Chef::Resource::ChefGem,
     provider: Chef::Provider::Package::Rubygems,
     name: :chef_gem,
-    action: :install,
+    action: :install
   )
 
 end

--- a/spec/unit/resource/deploy_revision_spec.rb
+++ b/spec/unit/resource/deploy_revision_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::DeployRevision do
     resource: Chef::Resource::DeployRevision,
     provider: Chef::Provider::Deploy::Revision,
     name: :deploy_revision,
-    action: :deploy,
+    action: :deploy
   )
 
 end
@@ -36,7 +36,7 @@ describe Chef::Resource::DeployBranch do
     resource: Chef::Resource::DeployBranch,
     provider: Chef::Provider::Deploy::Revision,
     name: :deploy_branch,
-    action: :deploy,
+    action: :deploy
   )
 
 end

--- a/spec/unit/resource/deploy_spec.rb
+++ b/spec/unit/resource/deploy_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::Deploy do
     resource: Chef::Resource::Deploy,
     provider: Chef::Provider::Deploy::Timestamped,
     name: :deploy,
-    action: :deploy,
+    action: :deploy
   )
 
   class << self

--- a/spec/unit/resource/dpkg_package_spec.rb
+++ b/spec/unit/resource/dpkg_package_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::DpkgPackage, "initialize" do
     provider: Chef::Provider::Package::Dpkg,
     name: :dpkg_package,
     action: :install,
-    os: "linux",
+    os: "linux"
   )
 
 end

--- a/spec/unit/resource/easy_install_package_spec.rb
+++ b/spec/unit/resource/easy_install_package_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::EasyInstallPackage, "initialize" do
     resource: Chef::Resource::EasyInstallPackage,
     provider: Chef::Provider::Package::EasyInstall,
     name: :easy_install_package,
-    action: :install,
+    action: :install
   )
 
   before(:each) do

--- a/spec/unit/resource/gem_package_spec.rb
+++ b/spec/unit/resource/gem_package_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::GemPackage, "initialize" do
     resource: Chef::Resource::GemPackage,
     provider: Chef::Provider::Package::Rubygems,
     name: :gem_package,
-    action: :install,
+    action: :install
   )
 
 end

--- a/spec/unit/resource/git_spec.rb
+++ b/spec/unit/resource/git_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::Git do
     resource: Chef::Resource::Git,
     provider: Chef::Provider::Git,
     name: :git,
-    action: :sync,
+    action: :sync
   )
 
   before(:each) do

--- a/spec/unit/resource/homebrew_package_spec.rb
+++ b/spec/unit/resource/homebrew_package_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::HomebrewPackage, "initialize" do
     provider: Chef::Provider::Package::Homebrew,
     name: :homebrew_package,
     action: :install,
-    os: "mac_os_x",
+    os: "mac_os_x"
   )
 
   let(:resource) { Chef::Resource::HomebrewPackage.new("emacs") }

--- a/spec/unit/resource/ips_package_spec.rb
+++ b/spec/unit/resource/ips_package_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::IpsPackage, "initialize" do
     provider: Chef::Provider::Package::Ips,
     name: :ips_package,
     action: :install,
-    os: "solaris2",
+    os: "solaris2"
   )
 
   before(:each) do

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -6,7 +6,7 @@ describe Chef::Resource::Launchd do
   @launchd = Chef::Resource::Launchd.new("io.chef.chef-client")
   let(:resource) { Chef::Resource::Launchd.new(
     "io.chef.chef-client",
-    run_context,
+    run_context
   )}
 
   it "should create a new Chef::Resource::Launchd" do

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -6,7 +6,7 @@ describe Chef::Resource::Launchd do
   @launchd = Chef::Resource::Launchd.new("io.chef.chef-client")
   let(:resource) { Chef::Resource::Launchd.new(
     "io.chef.chef-client",
-    run_context
+    run_context,
   )}
 
   it "should create a new Chef::Resource::Launchd" do

--- a/spec/unit/resource/macports_package_spec.rb
+++ b/spec/unit/resource/macports_package_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::MacportsPackage, "initialize" do
     provider: Chef::Provider::Package::Macports,
     name: :macports_package,
     action: :install,
-    os: "mac_os_x",
+    os: "mac_os_x"
   )
 
 end

--- a/spec/unit/resource/pacman_package_spec.rb
+++ b/spec/unit/resource/pacman_package_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::PacmanPackage, "initialize" do
     provider: Chef::Provider::Package::Pacman,
     name: :pacman_package,
     action: :install,
-    os: "linux",
+    os: "linux"
   )
 
 end

--- a/spec/unit/resource/rpm_package_spec.rb
+++ b/spec/unit/resource/rpm_package_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Resource::RpmPackage, "initialize" do
       provider: Chef::Provider::Package::Rpm,
       name: :rpm_package,
       action: :install,
-      os: os,
+      os: os
     )
   end
 

--- a/spec/unit/resource/smartos_package_spec.rb
+++ b/spec/unit/resource/smartos_package_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Resource::SmartosPackage, "initialize" do
     name: :smartos_package,
     action: :install,
     os: "solaris2",
-    platform_family: "smartos",
+    platform_family: "smartos"
   )
 
 end

--- a/spec/unit/resource/solaris_package_spec.rb
+++ b/spec/unit/resource/solaris_package_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Resource::SolarisPackage, "initialize" do
       name: :solaris_package,
       action: :install,
       os: "solaris2",
-      platform_family: platform_family,
+      platform_family: platform_family
     )
   end
 

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::Subversion do
     resource: Chef::Resource::Subversion,
     provider: Chef::Provider::Subversion,
     name: :subversion,
-    action: :install,
+    action: :install
   )
 
   before do

--- a/spec/unit/resource/timestamped_deploy_spec.rb
+++ b/spec/unit/resource/timestamped_deploy_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::TimestampedDeploy, "initialize" do
     name: :timestamped_deploy,
     action: :deploy,
     os: "linux",
-    platform_family: "rhel",
+    platform_family: "rhel"
   )
 
 end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     provider: Chef::Provider::Package::Windows,
     os: "windows",
     name: :windows_package,
-    action: :start,
+    action: :start
   )
 
   let(:resource) { Chef::Resource::WindowsPackage.new("solitaire.msi") }

--- a/spec/unit/resource/windows_service_spec.rb
+++ b/spec/unit/resource/windows_service_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::WindowsService, "initialize" do
     provider: Chef::Provider::Service::Windows,
     os: "windows",
     name: :windows_service,
-    action: :start,
+    action: :start
   )
 
   let(:resource) { Chef::Resource::WindowsService.new("BITS") }

--- a/spec/unit/resource/yum_package_spec.rb
+++ b/spec/unit/resource/yum_package_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Resource::YumPackage, "initialize" do
     name: :yum_package,
     action: :install,
     os: "linux",
-    platform_family: "rhel",
+    platform_family: "rhel"
   )
 
 end

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -699,7 +699,7 @@ describe Chef::ResourceReporter do
           expect(method).to eq(:POST)
           expect(headers).to eq({ "Content-Encoding" => "gzip",
                                   "X-Ops-Reporting-Protocol-Version" => Chef::ResourceReporter::PROTOCOL_VERSION,
-          },)
+          })
           data_stream = Zlib::GzipReader.new(StringIO.new(data))
           data = data_stream.read
           expect(data).to eq(Chef::JSONCompat.to_json(@expected_data))

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -820,7 +820,7 @@ describe Chef::Resource do
       runner = Chef::Runner.new(run_context)
       Chef::Platform.set(
         :resource => :cat,
-        :provider => Chef::Provider::SnakeOil,
+        :provider => Chef::Provider::SnakeOil
       )
 
       resource1.only_if { snitch_var1 = 1 }

--- a/spec/unit/run_context_spec.rb
+++ b/spec/unit/run_context_spec.rb
@@ -57,31 +57,31 @@ describe Chef::RunContext do
     expect(run_context.node[:cookbooks]).to eql(
       {
         "circular-dep1" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "circular-dep2" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "dependency1" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "dependency2" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "include" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "no-default-attr" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "test" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "test-with-circular-deps" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
         "test-with-deps" => {
-          "version" => "0.0.0"
+          "version" => "0.0.0",
         },
       },
     )

--- a/spec/unit/run_context_spec.rb
+++ b/spec/unit/run_context_spec.rb
@@ -83,7 +83,7 @@ describe Chef::RunContext do
         "test-with-deps" => {
           "version" => "0.0.0",
         },
-      },
+      }
     )
   end
 

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -104,7 +104,7 @@ describe Chef::Runner do
       # set up old Chef::Platform resolution instead of provider_resolver
       Chef::Platform.set(
         :resource => :cat,
-        :provider => Chef::Provider::SnakeOil,
+        :provider => Chef::Provider::SnakeOil
       )
       allow(Chef::ProviderResolver).to receive(:new).and_return(provider_resolver)
       allow(provider_resolver).to receive(:maybe_dynamic_provider_resolution).with(first_resource, anything()).and_return(nil)

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -98,8 +98,8 @@ describe Chef::Search::Query do
                 "platform" => "nudibranch",
                 "version" => "1.9.3",
                 "target" => "ming-the-merciless",
-              }
-            }
+              },
+            },
           },
         },
         { "name" => "my-name-is-jonas",
@@ -112,8 +112,8 @@ describe Chef::Search::Query do
                 "platform" => "i386-mingw32",
                 "version" => "1.9.3",
                 "target" => "bilbo",
-              }
-            }
+              },
+            },
           },
         },
         { "name" => "my-name-is-flipper",
@@ -126,8 +126,8 @@ describe Chef::Search::Query do
                 "platform" => "centos",
                 "version" => "2.0.0",
                 "target" => "uno",
-              }
-            }
+              },
+            },
           },
         },
         { "name" => "my-name-is-butters",
@@ -140,8 +140,8 @@ describe Chef::Search::Query do
                 "platform" => "solaris2",
                 "version" => "2.1.2",
                 "target" => "random",
-              }
-            }
+              },
+            },
           },
         },
       ],

--- a/spec/unit/user_v1_spec.rb
+++ b/spec/unit/user_v1_spec.rb
@@ -508,7 +508,7 @@ describe Chef::UserV1 do
     describe "reregister" do
       let(:payload) {
         {
-          "username" => "some_username"
+          "username" => "some_username",
         }
       }
 

--- a/spec/unit/windows_service_spec.rb
+++ b/spec/unit/windows_service_spec.rb
@@ -52,7 +52,7 @@ describe "Chef::Application::WindowsService", :windows_only do
   it "passes DEFAULT_LOG_LOCATION to chef-client instead of STDOUT" do
     expect(subject).to receive(:shell_out).with(
       "chef-client.bat  --no-fork -c test_config_file -L #{Chef::Application::WindowsService::DEFAULT_LOG_LOCATION}",
-      shellout_options,
+      shellout_options
     ).and_return(shell_out_result)
     subject.service_main
   end
@@ -74,7 +74,7 @@ describe "Chef::Application::WindowsService", :windows_only do
     it "uses the configured log location" do
       expect(subject).to receive(:shell_out).with(
         "chef-client.bat  --no-fork -c test_config_file -L #{tempfile.path}",
-        shellout_options,
+        shellout_options
       ).and_return(shell_out_result)
       subject.service_main
     end
@@ -91,7 +91,7 @@ describe "Chef::Application::WindowsService", :windows_only do
       it "does not pass log location to new process" do
         expect(subject).to receive(:shell_out).with(
           "chef-client.bat  --no-fork -c test_config_file",
-          shellout_options,
+          shellout_options
         ).and_return(shell_out_result)
         subject.service_main
       end
@@ -108,7 +108,7 @@ describe "Chef::Application::WindowsService", :windows_only do
     it "passes watchdog timeout to new process" do
       expect(subject).to receive(:shell_out).with(
         "chef-client.bat  --no-fork -c test_config_file -L #{Chef::Application::WindowsService::DEFAULT_LOG_LOCATION}",
-        shellout_options,
+        shellout_options
       ).and_return(shell_out_result)
       subject.service_main
     end


### PR DESCRIPTION

```
252  Style/TrailingCommaInLiteral
84   Style/TrailingCommaInArguments
15   Style/SpaceAroundKeyword
--
351  Total
```

We already dealt with SpaceAroundKeyword under its old name
SpaceBeforeModifierKeyword, it looks like it got stricter about
spaces after keywords.

TrailingComma also got split, and it looks like the
TrailingCommaInArguments behavior is new?