### PR TITLE
Update gem_package with version constraint on :upgrade action

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -482,21 +482,28 @@ class Chef
 
         def candidate_version
           @candidate_version ||= begin
-                                   if target_version_already_installed?(@current_resource.version, @new_resource.version)
-                                     nil
-                                   elsif source_is_remote?
-                                     @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
-                                   else
-                                     @gem_env.candidate_version_from_file(gem_dependency, @new_resource.source).to_s
-                                   end
-                                 end
+                                  if source_is_remote?
+                                    @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
+                                  else
+                                    @gem_env.candidate_version_from_file(gem_dependency, @new_resource.source).to_s
+                                  end
+                                end
         end
 
         def target_version_already_installed?(current_version, new_version)
-          return false unless current_version
-          return false if new_version.nil?
+          match_version(current_version, new_version, false)
+        end
 
-          Gem::Requirement.new(new_version).satisfied_by?(Gem::Version.new(current_version))
+        def version_requirement_satisfied?(current_version, version_requirement)
+          match_version(current_version, version_requirement, true)
+        end
+
+        def match_version(current_version, new_version, fuzzy_match)
+          return false unless current_version && new_version
+
+          requirement = Gem::Requirement.new(new_version)
+          (fuzzy_match || requirement.exact?) &&
+            requirement.satisfied_by?(Gem::Version.new(current_version))
         end
 
         ##

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -496,12 +496,35 @@ describe Chef::Provider::Package::Rubygems do
         provider.load_current_resource
       end
 
-      it "does not query for available versions when the current version is the target version" do
-        expect(provider.candidate_version).to be_nil
+      context "when the current version is the target version" do
+        it "does not query for available versions" do
+          expect(provider.gem_env).not_to receive(:candidate_version_from_remote)
+          expect(provider.gem_env).not_to receive(:install)
+          provider.run_action(:upgrade)
+          expect(new_resource).not_to be_updated_by_last_action
+        end
       end
 
-      context "when the current version is not the target version" do
-        let(:target_version) { "9000.0.2" }
+      context "when the current version satisfies the target version requirement" do
+        let(:target_version) { ">= 0" }
+
+        it "does not query for available versions on install" do
+          expect(provider.gem_env).not_to receive(:candidate_version_from_remote)
+          expect(provider.gem_env).not_to receive(:install)
+          provider.run_action(:install)
+          expect(new_resource).not_to be_updated_by_last_action
+        end
+
+        it "queries for available versions on upgrade" do
+          expect(provider.gem_env).to receive(:candidate_version_from_remote).
+            and_return(Gem::Version.new("9000.0.2"))
+          expect(provider.gem_env).to receive(:install)
+          provider.run_action(:upgrade)
+          expect(new_resource).to be_updated_by_last_action
+        end
+      end
+
+      context "when the requested source is a remote server" do
         let(:source) { "http://mygems.example.com" }
 
         it "determines the candidate version by querying the remote gem servers" do
@@ -667,6 +690,11 @@ describe Chef::Provider::Package::Rubygems do
               expect(provider.gem_env).not_to receive(:install)
               provider.run_action(:install)
             end
+
+            it "performs the upgrade" do
+              expect(provider.gem_env).to receive(:install)
+              provider.run_action(:upgrade)
+            end
           end
 
           context "if the fuzzy operator is used" do
@@ -676,6 +704,11 @@ describe Chef::Provider::Package::Rubygems do
             it "it matches an existing gem" do
               expect(provider.gem_env).not_to receive(:install)
               provider.run_action(:install)
+            end
+
+            it "it upgrades an existing gem" do
+              expect(provider.gem_env).to receive(:install)
+              provider.run_action(:upgrade)
             end
           end
         end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -566,8 +566,11 @@ describe "Chef::Provider::Package - Multi" do
   let(:new_resource) { Chef::Resource::Package.new(%w{emacs vi}) }
   let(:current_resource) { Chef::Resource::Package.new(%w{emacs vi}) }
   let(:candidate_version) { [ "1.0", "6.2" ] }
+  class MyPackageProvider < Chef::Provider::Package
+    use_multipackage_api
+  end
   let(:provider) do
-    provider = Chef::Provider::Package.new(new_resource, run_context)
+    provider = MyPackageProvider.new(new_resource, run_context)
     provider.current_resource = current_resource
     provider.candidate_version = candidate_version
     provider
@@ -731,7 +734,7 @@ describe "Chef::Provider::Package - Multi" do
 
     it "should remove the packages if all are installed" do
       expect(provider).to be_removing_package
-      expect(provider).to receive(:remove_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:remove_package).with(%w{emacs vi}, [nil])
       provider.run_action(:remove)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -740,7 +743,7 @@ describe "Chef::Provider::Package - Multi" do
     it "should remove the packages if some are installed" do
       current_resource.version ["1.0", nil]
       expect(provider).to be_removing_package
-      expect(provider).to receive(:remove_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:remove_package).with(%w{emacs vi}, [nil])
       provider.run_action(:remove)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -787,7 +790,7 @@ describe "Chef::Provider::Package - Multi" do
 
     it "should purge the packages if all are installed" do
       expect(provider).to be_removing_package
-      expect(provider).to receive(:purge_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:purge_package).with(%w{emacs vi}, [nil])
       provider.run_action(:purge)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -796,7 +799,7 @@ describe "Chef::Provider::Package - Multi" do
     it "should purge the packages if some are installed" do
       current_resource.version ["1.0", nil]
       expect(provider).to be_removing_package
-      expect(provider).to receive(:purge_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:purge_package).with(%w{emacs vi}, [nil])
       provider.run_action(:purge)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action


### PR DESCRIPTION
(fixes #3867)

Additional tests might be needed to cover various edge-cases I haven't thought of, but I think something like this should allow fuzzy-version-constrained gems to continue to be upgraded when new versions are released.