### PR TITLE
Add acceptance tests for running chef-client with the FIPS mode

### DIFF
--- a/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
+++ b/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
@@ -38,8 +38,10 @@ fedora-21
 # freebsd-8
 # ubuntu-12.04
 # centos-7
-# centos-6
-
+  - name: centos-6
+    driver:
+      box: opscode-centos-6.6
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
 <% %w(
 2012r2
 2012

--- a/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
+++ b/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
@@ -40,8 +40,7 @@ fedora-21
 # centos-7
   - name: centos-6
     driver:
-      box: opscode-centos-6.6
-      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+      box: bento/centos-6.7
 <% %w(
 2012r2
 2012

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -6,7 +6,9 @@ gem "test-kitchen", github: "sersut/test-kitchen", branch: "sersut/mixlib-instal
 gem "kitchen-ec2", github: "test-kitchen/kitchen-ec2", branch: "jk/image-search-only"
 gem "kitchen-inspec"
 gem "inspec"
-gem "kitchen-vagrant"
+# Pinning to github for kitchen-vagrant because 0.19.0 incorrectly
+# puts in a box_url for bento when a vagrant box in atlas is specified
+gem "kitchen-vagrant", github: "test-kitchen/kitchen-vagrant"
 gem "windows_chef_zero"
 gem "winrm-transport"
 gem "berkshelf"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/.gitignore
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/.gitignore
@@ -1,0 +1,2 @@
+nodes/
+tmp/

--- a/acceptance/fips/.acceptance/acceptance-cookbook/metadata.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/metadata.rb
@@ -1,0 +1,2 @@
+name "acceptance-cookbook"
+depends "kitchen_acceptance"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/destroy.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/destroy.rb
@@ -1,0 +1,1 @@
+kitchen "destroy"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/provision.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/provision.rb
@@ -1,0 +1,1 @@
+kitchen "converge"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/verify.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/verify.rb
@@ -1,0 +1,1 @@
+kitchen "verify"

--- a/acceptance/fips/.kitchen.yml
+++ b/acceptance/fips/.kitchen.yml
@@ -1,4 +1,4 @@
 suites:
   - name: fips
-    includes: [centos-6]
+    includes: [centos-6, windows-2012r2]
     run_list:

--- a/acceptance/fips/.kitchen.yml
+++ b/acceptance/fips/.kitchen.yml
@@ -1,0 +1,4 @@
+suites:
+  - name: fips
+    includes: [centos-6]
+    run_list:

--- a/acceptance/fips/test/integration/fips/serverspec/Gemfile
+++ b/acceptance/fips/test/integration/fips/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'mixlib-shellout'

--- a/acceptance/fips/test/integration/fips/serverspec/Gemfile
+++ b/acceptance/fips/test/integration/fips/serverspec/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'mixlib-shellout'
+gem "mixlib-shellout"

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -1,5 +1,5 @@
-require 'mixlib/shellout'
-require 'bundler'
+require "mixlib/shellout"
+require "bundler"
 
 describe "Chef Fips Specs" do
   def windows?
@@ -12,9 +12,9 @@ describe "Chef Fips Specs" do
 
   let(:chef_dir) do
     if windows?
-      Dir.glob('c:/opscode/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
+      Dir.glob("c:/opscode/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*").last
     else
-      Dir.glob('/opt/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
+      Dir.glob("/opt/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*").last
     end
   end
 
@@ -26,13 +26,13 @@ describe "Chef Fips Specs" do
     end
   end
 
-  it 'passes the unit and functional specs' do
+  it "passes the unit and functional specs" do
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
-        'bundle exec rspec spec/unit spec/functional', :env => {'PATH' => "#{ENV['PATH']}:#{path}",
-                                                                'GEM_PATH' => nil, 'GEM_CACHE'=>nil, 'GEM_HOME'=>nil,
-                                                                'CHEF_FIPS'=>'1'},
-        :live_stream => STDOUT, :cwd => chef_dir)
+        "bundle exec rspec spec/unit spec/functional", :env => { "PATH" => "#{ENV['PATH']}:#{path}",
+                                                                 "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
+                                                                 "CHEF_FIPS" => "1" },
+                                                       :live_stream => STDOUT, :cwd => chef_dir)
       expect { ruby_cmd.run_command.error! }.not_to raise_exception
     end
   end

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -1,0 +1,17 @@
+require 'mixlib/shellout'
+require 'bundler'
+
+describe "Chef Fips Specs" do
+  it 'passes the unit and functional specs' do
+    chef_dir = Dir.glob('/opt/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
+    Bundler.with_clean_env do
+      ruby_cmd = Mixlib::ShellOut.new(
+        'bundle exec rspec spec/unit spec/functional', :env => {'PATH' => "#{ENV['PATH']}:/opt/chef/embedded/bin",
+                                                                'GEM_PATH' => nil, 'GEM_CACHE'=>nil, 'GEM_HOME'=>nil,
+                                                                'CHEF_FIPS'=>'1'},
+        :live_stream => STDOUT, :cwd => chef_dir)
+      expect { ruby_cmd.run_command.error! }.not_to raise_exception
+    end
+  end
+end
+

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -2,11 +2,34 @@ require 'mixlib/shellout'
 require 'bundler'
 
 describe "Chef Fips Specs" do
+  def windows?
+    if RUBY_PLATFORM =~ /mswin|mingw|windows/
+      true
+    else
+      false
+    end
+  end
+
+  let(:chef_dir) do
+    if windows?
+      Dir.glob('c:/opscode/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
+    else
+      Dir.glob('/opt/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
+    end
+  end
+
+  let(:path) do
+    if windows?
+      'C:\opscode\chef\embedded\bin'
+    else
+      "/opt/chef/embedded/bin"
+    end
+  end
+
   it 'passes the unit and functional specs' do
-    chef_dir = Dir.glob('/opt/chef/embedded/lib/ruby/gems/*/gems/chef-[0-9]*').last
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
-        'bundle exec rspec spec/unit spec/functional', :env => {'PATH' => "#{ENV['PATH']}:/opt/chef/embedded/bin",
+        'bundle exec rspec spec/unit spec/functional', :env => {'PATH' => "#{ENV['PATH']}:#{path}",
                                                                 'GEM_PATH' => nil, 'GEM_CACHE'=>nil, 'GEM_HOME'=>nil,
                                                                 'CHEF_FIPS'=>'1'},
         :live_stream => STDOUT, :cwd => chef_dir)
@@ -14,4 +37,3 @@ describe "Chef Fips Specs" do
     end
   end
 end
-

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -29,9 +29,9 @@ describe "Chef Fips Specs" do
   it "passes the unit and functional specs" do
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
-        "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => "#{ENV['PATH']}:#{path}",
+        "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => [ENV['PATH'], path].join(File::PATH_SEPARATOR),
                                                                                   "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
-                                                                                  "CHEF_FIPS" => "1" },
+                                                                                  "CHEF_FIPS" => "1"},
                                                                                   :live_stream => STDOUT, :cwd => chef_dir, :timeout => 3600)
       expect { ruby_cmd.run_command.error! }.not_to raise_exception
     end

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -29,7 +29,7 @@ describe "Chef Fips Specs" do
   it "passes the unit and functional specs" do
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
-        "bundle exec rspec spec/unit spec/functional", :env => { "PATH" => "#{ENV['PATH']}:#{path}",
+        "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => "#{ENV['PATH']}:#{path}",
                                                                  "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
                                                                  "CHEF_FIPS" => "1" },
                                                        :live_stream => STDOUT, :cwd => chef_dir)

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -30,9 +30,9 @@ describe "Chef Fips Specs" do
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
         "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => "#{ENV['PATH']}:#{path}",
-                                                                 "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
-                                                                 "CHEF_FIPS" => "1" },
-                                                       :live_stream => STDOUT, :cwd => chef_dir)
+                                                                                  "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
+                                                                                  "CHEF_FIPS" => "1" },
+                                                                                  :live_stream => STDOUT, :cwd => chef_dir, :timeout => 3600)
       expect { ruby_cmd.run_command.error! }.not_to raise_exception
     end
   end

--- a/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
+++ b/acceptance/fips/test/integration/fips/serverspec/fips_spec.rb
@@ -29,10 +29,10 @@ describe "Chef Fips Specs" do
   it "passes the unit and functional specs" do
     Bundler.with_clean_env do
       ruby_cmd = Mixlib::ShellOut.new(
-        "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => [ENV['PATH'], path].join(File::PATH_SEPARATOR),
+        "bundle exec rspec -t ~requires_git spec/unit spec/functional", :env => { "PATH" => [ENV["PATH"], path].join(File::PATH_SEPARATOR),
                                                                                   "GEM_PATH" => nil, "GEM_CACHE" => nil, "GEM_HOME" => nil,
-                                                                                  "CHEF_FIPS" => "1"},
-                                                                                  :live_stream => STDOUT, :cwd => chef_dir, :timeout => 3600)
+                                                                                  "CHEF_FIPS" => "1" },
+                                                                        :live_stream => STDOUT, :cwd => chef_dir, :timeout => 3600)
       expect { ruby_cmd.run_command.error! }.not_to raise_exception
     end
   end

--- a/spec/functional/resource/deploy_revision_spec.rb
+++ b/spec/functional/resource/deploy_revision_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 require "tmpdir"
 
 # Deploy relies heavily on symlinks, so it doesn't work on windows.
-describe Chef::Resource::DeployRevision, :unix_only => true do
+describe Chef::Resource::DeployRevision, :unix_only => true, :requires_git => true do
 
   let(:file_cache_path) { Dir.mktmpdir }
   let(:deploy_directory) { Dir.mktmpdir }

--- a/spec/functional/resource/git_spec.rb
+++ b/spec/functional/resource/git_spec.rb
@@ -22,7 +22,7 @@ require "tmpdir"
 require "shellwords"
 
 # Deploy relies heavily on symlinks, so it doesn't work on windows.
-describe Chef::Resource::Git do
+describe Chef::Resource::Git, :requires_git => true do
   include Chef::Mixin::ShellOut
   let(:file_cache_path) { Dir.mktmpdir }
   # Some versions of git complains when the deploy directory is


### PR DESCRIPTION
Adding a test to the accepting framework for FIPS. When a package gets built, it will toggle FIPS mode for the platforms we care about and run the rspec tests. This keeps us from mucking around with the test matrix in jenkins.