### PR TITLE
Fix the Chocolatey-missing error again

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -150,12 +150,12 @@ EOS
           @choco_exe ||=
               # if this check is in #define_resource_requirements, it won't get
               # run before choco.exe gets called from #load_current_resource.
-              exe_path = ::File.join(choco_install_path, "bin", "choco.exe")
-              if !::File.exists?(exe_path.to_s)
-                raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG
-              else
-                exe_path
-              end
+              exe_path = ::File.join(choco_install_path.to_s, "bin", "choco.exe")
+          if !::File.exist?(exe_path)
+            raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG
+          else
+            exe_path
+          end
         end
 
         # lets us mock out an incorrect value for testing.

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -147,15 +147,13 @@ EOS
         #
         # @return [String] full path of choco.exe
         def choco_exe
-          @choco_exe ||=
+          @choco_exe ||= begin
               # if this check is in #define_resource_requirements, it won't get
               # run before choco.exe gets called from #load_current_resource.
               exe_path = ::File.join(choco_install_path.to_s, "bin", "choco.exe")
-          if !::File.exist?(exe_path)
-            raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG
-          else
-            exe_path
-          end
+              raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG unless ::File.exist?(exe_path)
+              exe_path
+            end
         end
 
         # lets us mock out an incorrect value for testing.

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -52,12 +52,7 @@ EOS
         def define_resource_requirements
           super
 
-          requirements.assert(:all_actions) do |a|
-            # GetEnvironmentVariable returns "" on failure.
-            a.assertion { !choco_install_path.to_s.empty? }
-            a.failure_message(Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG)
-            a.whyrun("Assuming Chocolatey is installed")
-          end
+          # The check that Chocolatey is installed is in #choco_exe.
 
           # Chocolatey source attribute points to an alternate feed
           # and not a package specific alternate source like other providers
@@ -152,11 +147,15 @@ EOS
         #
         # @return [String] full path of choco.exe
         def choco_exe
-          @choco_exe ||= ::File.join(
-            choco_install_path,
-            "bin",
-            "choco.exe"
-            )
+          @choco_exe ||=
+              # if this check is in #define_resource_requirements, it won't get
+              # run before choco.exe gets called from #load_current_resource.
+              exe_path = ::File.join(choco_install_path, "bin", "choco.exe")
+              if !::File.exists?(exe_path.to_s)
+                raise Chef::Exceptions::MissingLibrary, CHOCO_MISSING_MSG
+              else
+                exe_path
+              end
         end
 
         # lets us mock out an incorrect value for testing.

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -475,16 +475,27 @@ describe "behavior when Chocolatey is not installed" do
   end
 
   before {
-    allow(provider).to receive(:choco_install_path).and_return("")
+    # the shellout sometimes returns "", but test nil to be safe.
+    allow(provider).to receive(:choco_install_path).and_return(nil)
     provider.instance_variable_set("@choco_install_path", nil)
 
     # we don't care what this returns, but we have to let it be called.
     allow(provider).to receive(:shell_out!).and_return(double(:stdout => ""))
   }
 
+  let(:error_regex) {
+    /Could not locate.*install.*cookbook.*PowerShell.*GetEnvironmentVariable/m
+  }
+
   context "#choco_exe" do
     it "triggers a MissingLibrary exception when Chocolatey is not installed" do
-      expect { provider.send(:choco_exe) }.to raise_error(Chef::Exceptions::MissingLibrary, /Could not locate.*install.*cookbook.*PowerShell.*GetEnvironmentVariable/m)
+      expect { provider.send(:choco_exe) }.to raise_error(Chef::Exceptions::MissingLibrary, error_regex)
+    end
+  end
+
+  context "#load_current_resource" do
+    it "triggers a MissingLibrary exception when Chocolatey is not installed" do
+      expect { provider.load_current_resource }.to raise_error(Chef::Exceptions::MissingLibrary, error_regex)
     end
   end
 end

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -462,17 +462,6 @@ munin-node|1.6.1.20130823
       expect(new_resource).to be_updated_by_last_action
     end
   end
-
-  describe "#choco_exe" do
-    it "calls #choco_install_path" do
-      # un-stub #choco_exe from the before{} block.
-      allow(provider).to receive(:choco_exe).and_call_original
-      expect(provider).to receive(:choco_install_path).and_return("spork")
-      provider.instance_variable_set("@choco_exe", nil)
-
-      expect(provider.send(:choco_exe)).to match(%r{spork[/\\]bin[/\\]choco.exe})
-    end
-  end
 end
 
 describe "behavior when Chocolatey is not installed" do
@@ -493,12 +482,9 @@ describe "behavior when Chocolatey is not installed" do
     allow(provider).to receive(:shell_out!).and_return(double(:stdout => ""))
   }
 
-  context "#define_resource_requirements" do
+  context "#choco_exe" do
     it "triggers a MissingLibrary exception when Chocolatey is not installed" do
-      provider.action = :install
-      provider.load_current_resource
-      provider.define_resource_requirements
-      expect { provider.process_resource_requirements }.to raise_error(Chef::Exceptions::MissingLibrary, /Could not locate.*install.*cookbook.*PowerShell.*GetEnvironmentVariable/m)
+      expect { provider.send(:choco_exe) }.to raise_error(Chef::Exceptions::MissingLibrary, /Could not locate.*install.*cookbook.*PowerShell.*GetEnvironmentVariable/m)
     end
   end
 end


### PR DESCRIPTION
The previous implementation (in `define_resource_requirements`) failed acceptance testing because `choco.exe` gets called before that, in `load_current_resource`, so the detection needs to be a bit lower-level.

This includes a spec that replicates the acceptance test (by calling `load_current_resource`).