### PR TITLE
ensure paths maintain utf-8ness in non ascii encodings

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -224,7 +224,7 @@ module ChefConfig
       paths = paths.map { |home_path| home_path.gsub(path_separator, ::File::SEPARATOR) if home_path }
 
       # Filter out duplicate paths and paths that don't exist.
-      valid_paths = paths.select { |home_path| home_path && Dir.exists?(home_path) }
+      valid_paths = paths.select { |home_path| home_path && Dir.exists?(home_path.force_encoding("utf-8")) }
       valid_paths = valid_paths.uniq
 
       # Join all optional path elements at the end.

--- a/lib/chef/mixin/path_sanity.rb
+++ b/lib/chef/mixin/path_sanity.rb
@@ -37,7 +37,7 @@ class Chef
               env_path = env["PATH"].dup
               env_path << path_separator unless env["PATH"].empty?
               env_path << sane_path
-              env["PATH"] = env_path
+              env["PATH"] = env_path.encode("utf-8", invalid: :replace, undef: :replace)
             end
           end
         end

--- a/spec/unit/mixin/path_sanity_spec.rb
+++ b/spec/unit/mixin/path_sanity_spec.rb
@@ -56,6 +56,12 @@ describe Chef::Mixin::PathSanity do
       expect(env["PATH"]).to eq("/usr/bin:/sbin:/bin:#{@ruby_bindir}:#{@gem_bindir}:/usr/local/sbin:/usr/local/bin:/usr/sbin")
     end
 
+    it "creates path with utf-8 encoding" do
+      env = { "PATH" => "/usr/bin:/sbin:/bin:/b\x81t".force_encoding("ISO-8859-1") }
+      @sanity.enforce_path_sanity(env)
+      expect(env["PATH"].encoding.to_s).to eq("UTF-8")
+    end
+
     it "adds the current executing Ruby's bindir and Gem bindir to the PATH" do
       env = { "PATH" => "" }
       @sanity.enforce_path_sanity(env)


### PR DESCRIPTION
On windows (I'm assuming this is limited to windows) when using anon ascii encoding like (CP850) and with non ASCII characters (like like an umlaut `\x81`) in `ENV['PATH']` or `ENV['HOME']`, chef runs fail.

I have found 2 key areas that lead to this failure:
* `path_helper`
* `path_sanity`

`path_helper` fails because `Dir.home` has a `Windows-1252` encoding and when a character like `\x81` is present, checking the directory with `File.exists?` fails due to an invalid byte sequence.

`path_sanity` creates a path that is far from sane if a character like `\x81` is in the path. This results in creating a `ENV['PATH']` with a `Encoding:8BIT` that can wreak havoc in several possible places throughout a chef run.

Note that this can only be reproduced when the node has a non US langiage pack. I used German.