### PR TITLE
Fix a bug that was causing DataBagItem.to_hash to mutate the data bag item

### DIFF
--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -107,9 +107,9 @@ class Chef
     end
 
     def to_hash
-      result = self.raw_data
+      result = self.raw_data.dup
       result["chef_type"] = "data_bag_item"
-      result["data_bag"] = self.data_bag
+      result["data_bag"] = self.data_bag.to_s
       result
     end
 

--- a/spec/unit/data_bag_item_spec.rb
+++ b/spec/unit/data_bag_item_spec.rb
@@ -146,6 +146,8 @@ describe Chef::DataBagItem do
       data_bag_item
     }
 
+    let!(:original_data_bag_keys) { data_bag_item.keys }
+
     let(:to_hash) { data_bag_item.to_hash }
 
     it "should return a hash" do
@@ -163,6 +165,11 @@ describe Chef::DataBagItem do
 
     it "should have the data_bag set" do
       expect(to_hash["data_bag"]).to eq("still_lost")
+    end
+
+    it "should not mutate the data_bag_item" do
+      data_bag_item.to_hash
+      expect(data_bag_item.keys).to eq(original_data_bag_keys)
     end
   end
 


### PR DESCRIPTION
Fixes issue #4614.

Make a copy of the raw_data (that is then mutated with "data_bag" and "chef_type" keys) to return, rather than the actual raw_data object.