### PR TITLE
Allow MD5 only for cookbook upload / checksum in FIPS mode

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -917,7 +917,8 @@ module ChefConfig
       require "digest/sha1"
       require "digest/md5"
       Digest.const_set("SHA1", OpenSSL::Digest::SHA1)
-      OpenSSL::Digest.const_set("MD5", Digest::MD5)
+      Digest.const_set("MD5_", Digest::MD5)
+      Digest.send(:remove_const, "MD5")
     end
   end
 end

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -919,6 +919,7 @@ module ChefConfig
       Digest.const_set("SHA1", OpenSSL::Digest::SHA1)
       Digest.const_set("MD5_", Digest::MD5)
       Digest.send(:remove_const, "MD5")
+      OpenSSL::Digest.send(:remove_const, "MD5")
     end
   end
 end

--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -18,6 +18,7 @@
 
 require "chef/chef_fs/file_system/base_fs_object"
 require "chef/http/simple"
+require "chef/mixin/fips"
 require "openssl"
 
 class Chef
@@ -25,6 +26,8 @@ class Chef
     module FileSystem
       module ChefServer
         class CookbookFile < BaseFSObject
+          include Chef::Mixin::FIPS
+
           def initialize(name, parent, file)
             super(name, parent)
             @file = file
@@ -75,7 +78,9 @@ class Chef
           private
 
           def calc_checksum(value)
-            OpenSSL::Digest::MD5.hexdigest(value)
+            with_fips_md5_exception do
+              OpenSSL::Digest::MD5.hexdigest(value)
+            end
           end
         end
       end

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -39,6 +39,7 @@ class Chef
 
     include Comparable
     include Chef::Mixin::FIPS
+    extend Chef::Mixin::FIPS
 
     COOKBOOK_SEGMENTS = [ :resources, :providers, :recipes, :definitions, :libraries, :attributes, :files, :templates, :root_files ]
 

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -26,6 +26,7 @@ require "chef/version_class"
 require "chef/digester"
 require "chef/cookbook_manifest"
 require "chef/server_api"
+require "chef/mixin/fips"
 
 class Chef
 
@@ -37,6 +38,7 @@ class Chef
   class CookbookVersion
 
     include Comparable
+    include Chef::Mixin::FIPS
 
     COOKBOOK_SEGMENTS = [ :resources, :providers, :recipes, :definitions, :libraries, :attributes, :files, :templates, :root_files ]
 
@@ -97,7 +99,9 @@ class Chef
     # This is the one and only method that knows how cookbook files'
     # checksums are generated.
     def self.checksum_cookbook_file(filepath)
-      Chef::Digester.generate_md5_checksum_for_file(filepath)
+      with_fips_md5_exception do
+        Chef::Digester.generate_md5_checksum_for_file(filepath)
+      end
     rescue Errno::ENOENT
       Chef::Log.debug("File #{filepath} does not exist, so there is no checksum to generate")
       nil

--- a/lib/chef/mixin/fips.rb
+++ b/lib/chef/mixin/fips.rb
@@ -27,19 +27,25 @@ class Chef
       # with a working MD5 implementation.
       # @api private
       def with_fips_md5_exception
-        if Chef::Config[:fips]
-          Digest.const_set("MD5", Digest::MD5_)
-          OpenSSL::Digest.const_set("MD5", Digest::MD5_)
-        end
+        allow_md5 if Chef::Config[:fips]
 
         begin
           yield
         ensure
-          if Chef::Config[:fips]
-            Digest.send(:remove_const, "MD5")
-            OpenSSL::Digest.send(:remove_const, "MD5")
-          end
+          disallow_md5 if Chef::Config[:fips]
         end
+      end
+
+      # @api private
+      def allow_md5
+        Digest.const_set("MD5", Digest::MD5_)
+        OpenSSL::Digest.const_set("MD5", Digest::MD5_)
+      end
+
+      # @api private
+      def disallow_md5
+        Digest.send(:remove_const, "MD5")
+        OpenSSL::Digest.send(:remove_const, "MD5")
       end
     end
   end

--- a/lib/chef/mixin/fips.rb
+++ b/lib/chef/mixin/fips.rb
@@ -44,8 +44,8 @@ class Chef
 
       # @api private
       def disallow_md5
-        Digest.send(:remove_const, "MD5")
-        OpenSSL::Digest.send(:remove_const, "MD5")
+        Digest.send(:remove_const, "MD5") if defined?(Digest::MD5)
+        OpenSSL::Digest.send(:remove_const, "MD5") if defined?(OpenSSL::Digest::MD5)
       end
     end
   end

--- a/lib/chef/mixin/fips.rb
+++ b/lib/chef/mixin/fips.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright 2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/config"
+require "digest/md5"
+require "openssl"
+
+class Chef
+  module Mixin
+    module FIPS
+
+      # When FIPS mode is enabled, yield to the block
+      # with a working MD5 implementation.
+      # @api private
+      def with_fips_md5_exception
+        if Chef::Config[:fips]
+          Digest.const_set("MD5", Digest::MD5_)
+          OpenSSL::Digest.const_set("MD5", Digest::MD5_)
+        end
+
+        begin
+          yield
+        ensure
+          if Chef::Config[:fips]
+            Digest.send(:remove_const, "MD5")
+            OpenSSL::Digest.send(:remove_const, "MD5")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -148,7 +148,7 @@ class Chef
           path = sanitized_cache_file_path(sanitized_cache_file_basename)
           if Chef::FileCache.has_key?(path)
             Chef::FileCache.load(path)
-          else
+          elsif !Chef::Config[:fips]
             old_path = sanitized_cache_file_path(sanitized_cache_file_basename_md5)
             if Chef::FileCache.has_key?(old_path)
               # We found an old cache control data file. We started using sha256 instead of md5

--- a/spec/functional/http/simple_spec.rb
+++ b/spec/functional/http/simple_spec.rb
@@ -38,10 +38,10 @@ describe Chef::HTTP::Simple do
     it "successfully downloads a streaming request" do
       tempfile = http_client.streaming_request(source, {})
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
     end
     it "successfully does a non-streaming GET request" do
-      expect(Digest::MD5.hexdigest(http_client.get(source))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(http_client.get(source))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
     end
   end
 
@@ -69,12 +69,12 @@ describe Chef::HTTP::Simple do
     it "fails with a Net::HTTPServerException for a streaming request" do
       tempfile = http_client.streaming_request(source)
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
       expect { http_client.streaming_request(source2) }.to raise_error(Net::HTTPServerException)
     end
 
     it "fails with a Net::HTTPServerException for a GET request" do
-      expect(Digest::MD5.hexdigest(http_client.get(source))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(http_client.get(source))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
       expect { http_client.get(source2) }.to raise_error(Net::HTTPServerException)
     end
   end

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -24,14 +24,14 @@ describe Chef::Knife::Ssh do
   include Chef::Mixin::FIPS
 
   before(:all) do
-    allow_md5
+    allow_md5 if fips?
     Chef::Knife::Ssh.load_deps
     @server = TinyServer::Manager.new
     @server.start
   end
 
   after(:all) do
-    disallow_md5
+    disallow_md5 if fips?
     @server.stop
   end
 

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -18,16 +18,20 @@
 
 require "spec_helper"
 require "tiny_server"
+require "chef/mixin/fips"
 
 describe Chef::Knife::Ssh do
+  include Chef::Mixin::FIPS
 
   before(:all) do
+    allow_md5
     Chef::Knife::Ssh.load_deps
     @server = TinyServer::Manager.new
     @server.start
   end
 
   after(:all) do
+    disallow_md5
     @server.stop
   end
 

--- a/spec/functional/rest_spec.rb
+++ b/spec/functional/rest_spec.rb
@@ -19,6 +19,7 @@
 require "spec_helper"
 require "tiny_server"
 require "support/shared/functional/http"
+require "openssl"
 
 describe Chef::REST do
   include ChefHTTPShared
@@ -30,13 +31,13 @@ describe Chef::REST do
     it "successfully downloads a streaming request" do
       tempfile = http_client.streaming_request(source, {})
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
     end
 
     it "successfully downloads a GET request" do
       tempfile = http_client.get(source, {})
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
     end
   end
 
@@ -65,14 +66,14 @@ describe Chef::REST do
     it "fails with a Net::HTTPServerException on a streaming download" do
       tempfile = http_client.streaming_request(source, {})
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
       expect { http_client.streaming_request(source2, {}) }.to raise_error(Net::HTTPServerException)
     end
 
     it "fails with a Net::HTTPServerException on a GET request" do
       tempfile = http_client.get(source, {})
       tempfile.close
-      expect(Digest::MD5.hexdigest(binread(tempfile.path))).to eq(Digest::MD5.hexdigest(expected_content))
+      expect(OpenSSL::Digest::SHA256.hexdigest(binread(tempfile.path))).to eq(OpenSSL::Digest::SHA256.hexdigest(expected_content))
       expect { http_client.get(source2, {}) }.to raise_error(Net::HTTPServerException)
     end
   end

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+require 'chef/mixin/fips'
+
 CHEF_SPEC_DATA = File.expand_path(File.dirname(__FILE__) + "/../data/")
 CHEF_SPEC_ASSETS = File.expand_path(File.dirname(__FILE__) + "/../functional/assets/")
 CHEF_SPEC_BACKUP_PATH = File.join(Dir.tmpdir, "test-backup-path")
@@ -92,4 +95,21 @@ def which(cmd)
     return filename if File.executable?(filename)
   end
   false
+end
+
+class MD5Safe
+  extend Chef::Mixin::FIPS
+end
+
+def safe_md5(data)
+  if fips?
+    begin
+      MD5Safe.allow_md5
+      OpenSSL::Digest::MD5.hexdigest(data)
+    ensure
+      MD5Safe.disallow_md5
+    end
+  else
+    OpenSSL::Digest::MD5.hexdigest(data)
+  end
 end

--- a/spec/support/shared/context/md5.rb
+++ b/spec/support/shared/context/md5.rb
@@ -1,0 +1,15 @@
+require "chef/config"
+require "chef/mixin/fips"
+require "spec_helper"
+
+shared_context "allow md5" do
+  include Chef::Mixin::FIPS
+  before do
+    allow_md5 if fips?
+  end
+
+  after do
+    disallow_md5 if fips?
+  end
+
+end

--- a/spec/unit/cookbook_manifest_spec.rb
+++ b/spec/unit/cookbook_manifest_spec.rb
@@ -144,7 +144,7 @@ describe Chef::CookbookManifest do
         {
           "name"        => File.basename(path),
           "path"        => relative_path,
-          "checksum"    => Chef::Digester.generate_md5_checksum_for_file(path),
+          "checksum"    => safe_md5(IO.read(path)),
           "specificity" => "default",
         }
       end

--- a/spec/unit/digester_spec.rb
+++ b/spec/unit/digester_spec.rb
@@ -19,8 +19,11 @@
 #
 
 require "spec_helper"
+require "support/shared/context/md5"
 
 describe Chef::Digester do
+  include_context "allow md5"
+
   before(:each) do
     @cache = Chef::Digester.instance
   end

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "spec_helper"
-require "digest/md5"
+require "openssl"
 require "tmpdir"
 require "chef/mixin/file_class"
 
@@ -136,13 +136,13 @@ describe Chef::Provider::RemoteDirectory do
 
         File.open(@destination_dir + "/remote_dir_file1.txt", "a") { |f| f.puts "blah blah blah" }
         File.open(@destination_dir + "/remotesubdir/remote_subdir_file1.txt", "a") { |f| f.puts "blah blah blah" }
-        file1md5 = Digest::MD5.hexdigest(File.read(@destination_dir + "/remote_dir_file1.txt"))
-        subdirfile1md5 = Digest::MD5.hexdigest(File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt"))
+        file1sha256 = OpenSSL::Digest::SHA256.hexdigest(File.read(@destination_dir + "/remote_dir_file1.txt"))
+        subdirfile1sha256 = OpenSSL::Digest::SHA256.hexdigest(File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt"))
 
         @provider.run_action(:create_if_missing)
 
-        expect(file1md5.eql?(Digest::MD5.hexdigest(File.read(@destination_dir + "/remote_dir_file1.txt")))).to be_truthy
-        expect(subdirfile1md5.eql?(Digest::MD5.hexdigest(File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt")))).to be_truthy
+        expect(file1sha256.eql?(OpenSSL::Digest::SHA256.hexdigest(File.read(@destination_dir + "/remote_dir_file1.txt")))).to be_truthy
+        expect(subdirfile1sha256.eql?(OpenSSL::Digest::SHA256.hexdigest(File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt")))).to be_truthy
       end
     end
 
@@ -209,11 +209,11 @@ describe Chef::Provider::RemoteDirectory do
         @provider.run_action(:create)
         ::File.open(@destination_dir + "/remote_dir_file1.txt", "a") { |f| f.puts "blah blah blah" }
         ::File.open(@destination_dir + "/remotesubdir/remote_subdir_file1.txt", "a") { |f| f.puts "blah blah blah" }
-        file1md5 = Digest::MD5.hexdigest(::File.read(@destination_dir + "/remote_dir_file1.txt"))
-        subdirfile1md5 = Digest::MD5.hexdigest(::File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt"))
+        file1sha256 = OpenSSL::Digest::SHA256.hexdigest(::File.read(@destination_dir + "/remote_dir_file1.txt"))
+        subdirfile1sha256 = OpenSSL::Digest::SHA256.hexdigest(::File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt"))
         @provider.run_action(:create)
-        expect(file1md5.eql?(Digest::MD5.hexdigest(::File.read(@destination_dir + "/remote_dir_file1.txt")))).to be_truthy
-        expect(subdirfile1md5.eql?(Digest::MD5.hexdigest(::File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt")))).to be_truthy
+        expect(file1sha256.eql?(OpenSSL::Digest::SHA256.hexdigest(::File.read(@destination_dir + "/remote_dir_file1.txt")))).to be_truthy
+        expect(subdirfile1sha256.eql?(OpenSSL::Digest::SHA256.hexdigest(::File.read(@destination_dir + "/remotesubdir/remote_subdir_file1.txt")))).to be_truthy
       end
     end
 

--- a/spec/unit/provider/remote_file/cache_control_data_spec.rb
+++ b/spec/unit/provider/remote_file/cache_control_data_spec.rb
@@ -42,7 +42,7 @@ describe Chef::Provider::RemoteFile::CacheControlData do
   # the checksum of the file we have on disk already
   let(:current_file_checksum) { "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 
-  context "when loading data for an unknown URI" do
+  context "when loading data for an unknown URI", :not_supported_under_fips do
 
     before do
       expect(Chef::FileCache).to receive(:has_key?).with(cache_path).and_return(false)
@@ -146,7 +146,7 @@ describe Chef::Provider::RemoteFile::CacheControlData do
       end
     end
 
-    context "when the filename uses md5" do
+    context "when the filename uses md5", :not_supported_under_fips do
       before do
         expect(Chef::FileCache).to receive(:has_key?).with(cache_path).and_return(false)
         expect(Chef::FileCache).to receive(:has_key?).with(old_cache_path).and_return(true)


### PR DESCRIPTION
This patch requires explicitly asking that MD5 be patched in for FIPS. The tests that used MD5 but didn't require it were modified to use SHA256 instead. The tests that need it include a context that enables it.

This disables upgrading the cache control data for remote file in fips mode as it requires MD5. Since there have been no releases of this feature, you cannot possibly need to upgrade your cache control data file.