### PR TITLE
Break out Ohai in maintainers files and add myself

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -50,11 +50,11 @@ To mention the team, use @chef/ohai
 
 ### Lieutenant
 
-* [Bryan McLellan](https://github.com/btm)
+* [Claire McQuin](https://github.com/mcquin)
 
 ### Maintainers
 
-* [Claire McQuin](https://github.com/mcquin)
+* [Bryan McLellan](https://github.com/btm)
 * [Tim Smith](https://github.com/tas50)
 
 ## Dev Tools

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,6 +44,19 @@ To mention the team, use @chef/client-core
 * [Ranjib Dey](https://github.com/ranjib)
 * [Matt Wrock](https://github.com/mwrock)
 
+## Ohai
+
+To mention the team, use @chef/ohai
+
+### Lieutenant
+
+* [Bryan McLellan](https://github.com/btm)
+
+### Maintainers
+
+* [Claire McQuin](https://github.com/mcquin)
+* [Tim Smith](https://github.com/tas50)
+
 ## Dev Tools
 
 ChefDK, Chef Zero, Knife, Chef Apply and Chef Shell.
@@ -160,6 +173,30 @@ To mention the team, use @chef/client-debian
 ### Maintainers
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
+
+## Cisco NX-OS
+
+To mention the team, use @chef/client-nxos
+
+### Lieutenant
+
+* [Carl Perry](https://github.com/edolnx)
+
+### Maintainers
+
+* [Carl Perry](https://github.com/edolnx)
+
+## Cisco IOS XR
+
+To mention the team, use @chef/client-iosxr
+
+### Lieutenant
+
+* [Carl Perry](https://github.com/edolnx)
+
+### Maintainers
+
+* [Carl Perry](https://github.com/edolnx)
 
 ## Fedora
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -55,10 +55,10 @@ another component.
         title = "Ohai"
         team = "ohai"
 
-        lieutenant = "btm"
+        lieutenant = "mcquin"
 
         maintainers = [
-          "mcquin",
+          "btm",
           "tas50"
         ]
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -51,6 +51,17 @@ another component.
         "mwrock"
       ]
 
+      [Org.Components.Ohai]
+        title = "Ohai"
+        team = "ohai"
+
+        lieutenant = "btm"
+
+        maintainers = [
+          "mcquin",
+          "tas50"
+        ]
+
     [Org.Components.DevTools]
       title = "Dev Tools"
       team = "client-dev-tools"
@@ -360,3 +371,7 @@ The specific components of Chef related to a given platform - including (but not
   [people.cperry]
     Name = "Carl Perry"
     GitHub = "edolnx"
+
+  [people.tas50]
+    Name = "Tim Smith"
+    GitHub = "tas50"


### PR DESCRIPTION
https://github.com/chef/ohai/pull/687 was opened to create a maintainers file in Ohai and it was mentioned that it really should go in chef/chef as its own team.  Here it is.