### PR TITLE
removing disabling of readline in chef-shell

### DIFF
--- a/bin/chef-shell
+++ b/bin/chef-shell
@@ -31,7 +31,4 @@ $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
 
 require "chef/shell"
 
-# On Windows only, enable irb --noreadline because of input problems --
-# See CHEF-3284.
-IRB.conf[:USE_READLINE] = false if Chef::Platform.windows?
 Shell.start


### PR DESCRIPTION
I have tested this on windows 10, 2012R2 and 2008R2 and all worked fine.