### PR TITLE
if no module name is found for a valid dsc resource default to PSDesiredStateConfiguration

### DIFF
--- a/lib/chef/provider/dsc_resource.rb
+++ b/lib/chef/provider/dsc_resource.rb
@@ -110,7 +110,7 @@ class Chef
                   "sure that it shows up when running Get-DscResource"
               when 1
                 if found[0]["Module"].nil?
-                  :none
+                  "PSDesiredStateConfiguration" # default DSC module
                 else
                   found[0]["Module"]["Name"]
                 end
@@ -151,10 +151,7 @@ class Chef
       def invoke_resource(method, output_format = :object)
         properties = translate_type(@new_resource.properties)
         switches = "-Method #{method} -Name #{@new_resource.resource}"\
-                   " -Property #{properties} -Verbose"
-        if module_name != :none
-          switches += " -Module #{module_name}"
-        end
+                   " -Property #{properties} -Module #{module_name} -Verbose"
         cmdlet = Chef::Util::Powershell::Cmdlet.new(
           node,
           "Invoke-DscResource #{switches}",

--- a/spec/functional/resource/dsc_resource_spec.rb
+++ b/spec/functional/resource/dsc_resource_spec.rb
@@ -38,7 +38,7 @@ describe Chef::Resource::DscResource, :windows_powershell_dsc_only do
     before do
       if !Chef::Platform.supports_dsc_invoke_resource?(node)
         skip "Requires Powershell >= 5.0.10018.0"
-      elsif !Chef::Platform.dsc_refresh_mode_disabled?(node)
+      elsif !Chef::Platform.supports_refresh_mode_enabled?(node) && !Chef::Platform.dsc_refresh_mode_disabled?(node)
         skip "Requires LCM RefreshMode is Disabled"
       end
     end


### PR DESCRIPTION
When converging a `dsc_resource`, we call `get-dscresource` to determine if the resource is present and if it belongs to a module. Some resources report no module associated but in these cases we should default to using `PSDesiredStateConfiguration` as the module to prevent some modules from failing.

This also allows functional tests to run on RTM wmf 5 with LCM enabled.