### PR TITLE
Support libraries with sub directories

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_dir.rb
@@ -53,7 +53,7 @@ class Chef
             :attributes => { :ruby_only => true },
             :definitions => { :ruby_only => true },
             :recipes => { :ruby_only => true },
-            :libraries => { :ruby_only => true },
+            :libraries => { :recursive => true },
             :templates => { :recursive => true },
             :files => { :recursive => true },
             :resources => { :ruby_only => true, :recursive => true },

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -86,7 +86,7 @@ class Chef
         load_as(:attribute_filenames, "attributes", "*.rb")
         load_as(:definition_filenames, "definitions", "*.rb")
         load_as(:recipe_filenames, "recipes", "*.rb")
-        load_recursively_as(:library_filenames, "libraries", "*.rb")
+        load_recursively_as(:library_filenames, "libraries", "*")
         load_recursively_as(:template_filenames, "templates", "*")
         load_recursively_as(:file_filenames, "files", "*")
         load_recursively_as(:resource_filenames, "resources", "*.rb")

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -186,6 +186,7 @@ class Chef
 
       def load_libraries_from_cookbook(cookbook_name)
         files_in_cookbook_by_segment(cookbook_name, :libraries).each do |filename|
+          next unless File.extname(filename) == ".rb"
           begin
             Chef::Log.debug("Loading cookbook #{cookbook_name}'s library file: #{filename}")
             Kernel.load(filename)

--- a/spec/integration/knife/chef_repository_file_system_spec.rb
+++ b/spec/integration/knife/chef_repository_file_system_spec.rb
@@ -231,6 +231,10 @@ EOM
 /cookbooks/cookbook1/files/c/e.json
 /cookbooks/cookbook1/libraries/
 /cookbooks/cookbook1/libraries/a.rb
+/cookbooks/cookbook1/libraries/b.json
+/cookbooks/cookbook1/libraries/c/
+/cookbooks/cookbook1/libraries/c/d.rb
+/cookbooks/cookbook1/libraries/c/e.json
 /cookbooks/cookbook1/providers/
 /cookbooks/cookbook1/providers/a.rb
 /cookbooks/cookbook1/providers/c/


### PR DESCRIPTION
:construction: For Discussion :construction:
Some widely used chef-solo cookbooks, like edelight/chef-solo-search, have subdirectories in their libraries directory.
The libraries directory can also contain non-ruby files (in the chef-solo-search case, the treetop search parser from chef 10).
This PR adds support for this, and would be necessary for chef-zolo support.