### PR TITLE
Handle negative content length headers too.

### DIFF
--- a/lib/chef/http/validate_content_length.rb
+++ b/lib/chef/http/validate_content_length.rb
@@ -86,7 +86,7 @@ class Chef
         transfer_encoding = http_response["transfer-encoding"]
         content_encoding  = http_response["content-encoding"]
 
-        if content_length.nil?
+        if content_length.nil? || content_length < 0
           Chef::Log.debug "HTTP server did not include a Content-Length header in response, cannot identify truncated downloads."
           return true
         end

--- a/lib/chef/http/validate_content_length.rb
+++ b/lib/chef/http/validate_content_length.rb
@@ -86,8 +86,13 @@ class Chef
         transfer_encoding = http_response["transfer-encoding"]
         content_encoding  = http_response["content-encoding"]
 
-        if content_length.nil? || content_length < 0
+        if content_length.nil?
           Chef::Log.debug "HTTP server did not include a Content-Length header in response, cannot identify truncated downloads."
+          return true
+        end
+
+        if content_length < 0
+          Chef::Log.debug "HTTP server responded with a negative Content-Length header (#{content_length}), cannot identify truncated downloads."
           return true
         end
 

--- a/spec/unit/http/validate_content_length_spec.rb
+++ b/spec/unit/http/validate_content_length_spec.rb
@@ -119,6 +119,21 @@ describe Chef::HTTP::ValidateContentLength do
     end
   end
 
+  describe "with negative Content-Length header" do
+    let(:content_length_value) { '-1' }
+
+    %w{direct streaming}.each do |req_type|
+      describe "when running #{req_type} request" do
+        let(:request_type) { req_type.to_sym }
+
+        it "should skip validation and log for debug" do
+          run_content_length_validation
+          expect(debug_output).to include("HTTP server did not include a Content-Length header in response")
+        end
+      end
+    end
+  end
+
   describe "with correct Content-Length header" do
     %w{direct streaming}.each do |req_type|
       describe "when running #{req_type} request" do

--- a/spec/unit/http/validate_content_length_spec.rb
+++ b/spec/unit/http/validate_content_length_spec.rb
@@ -128,7 +128,7 @@ describe Chef::HTTP::ValidateContentLength do
 
         it "should skip validation and log for debug" do
           run_content_length_validation
-          expect(debug_output).to include("HTTP server did not include a Content-Length header in response")
+          expect(debug_output).to include("HTTP server responded with a negative Content-Length header (-1), cannot identify truncated downloads.")
         end
       end
     end

--- a/spec/unit/http/validate_content_length_spec.rb
+++ b/spec/unit/http/validate_content_length_spec.rb
@@ -120,7 +120,7 @@ describe Chef::HTTP::ValidateContentLength do
   end
 
   describe "with negative Content-Length header" do
-    let(:content_length_value) { '-1' }
+    let(:content_length_value) { "-1" }
 
     %w{direct streaming}.each do |req_type|
       describe "when running #{req_type} request" do


### PR DESCRIPTION
This is equivalent to not passing one, we can't check for bad downloads.

For an example, run `curl -ivs -o /dev/null "https://www.isc.org/downloads/file/dhcp-4-3-3-p1/?version=tar-gz"`

Curl displays `Negative content-length: -1, closing after transfer`. I can't find any standard for this behavior, but it seems to be shared by all the browsers I tried. ¯\_(ツ)_/¯