### PR TITLE
ChefDK was mistakenly left out of the Chef maintenance policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -46,7 +46,7 @@ To mention the team, use @chef/client-core
 
 ## Dev Tools
 
-Chef Zero, Knife, Chef Apply and Chef Shell.
+ChefDK, Chef Zero, Knife, Chef Apply and Chef Shell.
 To mention the team, use @chef/client-dev-tools
 
 ### Maintainers
@@ -197,7 +197,7 @@ To mention the team, use @chef/client-freebsd
 
 * [Cory Stephenson](https://github.com/Aevin1387)
 * [David Aronsohn](https://github.com/tbunnyman)
-* [Bryant Lippert](https://github.com/agentmeerkat)
+* [Bryant Lippert](https://github.com/AgentMeerkat)
 
 ## OpenBSD
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -54,7 +54,7 @@ another component.
     [Org.Components.DevTools]
       title = "Dev Tools"
       team = "client-dev-tools"
-      text = "Chef Zero, Knife, Chef Apply and Chef Shell."
+      text = "ChefDK, Chef Zero, Knife, Chef Apply and Chef Shell."
 
       paths = [
         "lib/chef/knife.rb",


### PR DESCRIPTION
\cc @chef/maintainers 

ChefDK should have been listed in here under Dev Tools - this just bring the doc in line with reality