### PR TITLE
Cleanup static libs at build time

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -71,6 +71,8 @@ if windows?
   dependency "ruby-windows-devkit-bash"
 end
 
+dependency "clean-static-libs"
+
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
 end


### PR DESCRIPTION
Add step for unused static lib cleanup at build time

@chef/client-core @lamont-granquist 