### PR TITLE
Clearer exception for loading non-existent data bag items in solo mode.

### DIFF
--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -150,6 +150,7 @@ class Chef
     def self.load(data_bag, name)
       if Chef::Config[:solo]
         bag = Chef::DataBag.load(data_bag)
+        raise Exceptions::InvalidDataBagItemID, "Item #{name} not found in data bag #{data_bag}. Other items found: #{bag.keys.join(", ")}" unless bag.include?(name)
         item = bag[name]
       else
         item = Chef::ServerAPI.new(Chef::Config[:chef_server_url]).get("data/#{data_bag}/#{name}")

--- a/spec/unit/data_bag_item_spec.rb
+++ b/spec/unit/data_bag_item_spec.rb
@@ -325,6 +325,11 @@ describe Chef::DataBagItem do
         expect(item).to be_a_kind_of(Chef::DataBagItem)
         expect(item).to eq(data_bag_item)
       end
+
+      it "raises an exception for unknown items" do
+        expect(Chef::DataBag).to receive(:load).with("users").and_return({ "charlie" => data_bag_item.to_hash })
+        expect { Chef::DataBagItem.load("users", "wonka") }.to raise_error Chef::Exceptions::InvalidDataBagItemID
+      end
     end
   end
 end


### PR DESCRIPTION
So on one hand it would be nice if this raised the same exception for both client and solo modes, on the other hand that would be a compat break and this is better than nothing. On the client code path is ends up raising `Net::HTTPServerException` with a 404. Mostly this matters because of 

If we don't fail here, it blows up a few lines later when running `from_hash(nil)`. This gets used in https://github.com/chef/chef-vault/blob/master/lib/chef-vault/item_keys.rb#L114-L127, found via a [report on StackOverflow](https://stackoverflow.com/questions/35761065/knife-solo-and-vault-data-bag-item-rb129in-from-hash-undefined-method-d).