### PR TITLE
Extend service resource to support systemd user services

### DIFF
--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -62,7 +62,16 @@ class Chef
         end
       end
 
+      # subclasses should override this if they do implement user services
+      def user_services_requirements
+        requirements.assert(:all_actions) do |a|
+          a.assertion { @new_resource.user.nil? }
+          a.failure_message Chef::Exceptions::UnsupportedAction, "#{self} does not support user services"
+        end
+      end
+
       def shared_resource_requirements
+        user_services_requirements
       end
 
       def define_resource_requirements

--- a/lib/chef/provider/service/solaris.rb
+++ b/lib/chef/provider/service/solaris.rb
@@ -49,6 +49,11 @@ class Chef
           @current_resource
         end
 
+        def define_resource_requirements
+          # FIXME? need reload from service.rb
+          shared_resource_requirements
+        end
+
         def enable_service
           shell_out!(default_init_command, "clear", @new_resource.service_name) if @maintenance
           shell_out!(default_init_command, "enable", "-s", @new_resource.service_name)

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -72,17 +72,17 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def get_systemctl_options_args
     if new_resource.user
-      uid = node['etc']['passwd'][new_resource.user]['uid']
+      uid = node["etc"]["passwd"][new_resource.user]["uid"]
       options = {
-        'environment' => {
-          'DBUS_SESSION_BUS_ADDRESS' => "unix:path=/run/user/#{uid}/bus",
+        "environment" => {
+          "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/#{uid}/bus",
         },
-        'user' => new_resource.user,
+        "user" => new_resource.user,
       }
-      args = '--user'
+      args = "--user"
     else
       options = {}
-      args = '--system'
+      args = "--system"
     end
 
     return options, args

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -60,6 +60,10 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     current_resource
   end
 
+  # systemd supports user services just fine
+  def user_services_requirements
+  end
+
   def define_resource_requirements
     shared_resource_requirements
     requirements.assert(:all_actions) do |a|

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -47,6 +47,7 @@ class Chef
         @priority = nil
         @timeout = nil
         @run_levels = nil
+        @user = nil
         @supports = { :restart => nil, :reload => nil, :status => nil }
       end
 
@@ -191,6 +192,14 @@ class Chef
           :run_levels,
           arg,
           :kind_of => [ Array ] )
+      end
+
+      def user(arg = nil)
+        set_or_return(
+          :user,
+          arg,
+          :kind_of => [ String ]
+        )
       end
 
       def supports(args = {})

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -171,14 +171,14 @@ describe Chef::Provider::Service::Systemd do
           provider.start_service
         end
 
-        it "should call '#{systemctl_path} start service_name' if no start command is specified" do
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}").and_return(shell_out_success)
+        it "should call '#{systemctl_path} --system start service_name' if no start command is specified" do
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name}", {}).and_return(shell_out_success)
           provider.start_service
         end
 
-        it "should not call '#{systemctl_path} start service_name' if it is already running" do
+        it "should not call '#{systemctl_path} --system start service_name' if it is already running" do
           current_resource.running(true)
-          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} start #{service_name}")
+          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name}", {})
           provider.start_service
         end
 
@@ -189,9 +189,9 @@ describe Chef::Provider::Service::Systemd do
           provider.restart_service
         end
 
-        it "should call '#{systemctl_path} restart service_name' if no restart command is specified" do
+        it "should call '#{systemctl_path} --system restart service_name' if no restart command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} restart #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system restart #{service_name}", {}).and_return(shell_out_success)
           provider.restart_service
         end
 
@@ -206,9 +206,9 @@ describe Chef::Provider::Service::Systemd do
           end
 
           context "when a reload command is not specified" do
-            it "should call '#{systemctl_path} reload service_name' if the service is running" do
+            it "should call '#{systemctl_path} --system reload service_name' if the service is running" do
               current_resource.running(true)
-              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} reload #{service_name}").and_return(shell_out_success)
+              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system reload #{service_name}", {}).and_return(shell_out_success)
               provider.reload_service
             end
 
@@ -227,15 +227,15 @@ describe Chef::Provider::Service::Systemd do
           provider.stop_service
         end
 
-        it "should call '#{systemctl_path} stop service_name' if no stop command is specified" do
+        it "should call '#{systemctl_path} --system stop service_name' if no stop command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}").and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name}", {}).and_return(shell_out_success)
           provider.stop_service
         end
 
-        it "should not call '#{systemctl_path} stop service_name' if it is already stopped" do
+        it "should not call '#{systemctl_path} --system stop service_name' if it is already stopped" do
           current_resource.running(false)
-          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} stop #{service_name}")
+          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name}", {})
           provider.stop_service
         end
       end
@@ -247,13 +247,13 @@ describe Chef::Provider::Service::Systemd do
           allow(provider).to receive(:which).with("systemctl").and_return("#{systemctl_path}")
         end
 
-        it "should call '#{systemctl_path} enable service_name' to enable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} enable #{service_name}").and_return(shell_out_success)
+        it "should call '#{systemctl_path} --system enable service_name' to enable the service" do
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system enable #{service_name}", {}).and_return(shell_out_success)
           provider.enable_service
         end
 
-        it "should call '#{systemctl_path} disable service_name' to disable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} disable #{service_name}").and_return(shell_out_success)
+        it "should call '#{systemctl_path} --system disable service_name' to disable the service" do
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system disable #{service_name}", {}).and_return(shell_out_success)
           provider.disable_service
         end
       end
@@ -265,13 +265,13 @@ describe Chef::Provider::Service::Systemd do
           allow(provider).to receive(:which).with("systemctl").and_return("#{systemctl_path}")
         end
 
-        it "should call '#{systemctl_path} mask service_name' to mask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} mask #{service_name}").and_return(shell_out_success)
+        it "should call '#{systemctl_path} --system mask service_name' to mask the service" do
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system mask #{service_name}", {}).and_return(shell_out_success)
           provider.mask_service
         end
 
-        it "should call '#{systemctl_path} unmask service_name' to unmask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} unmask #{service_name}").and_return(shell_out_success)
+        it "should call '#{systemctl_path} --system unmask service_name' to unmask the service" do
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system unmask #{service_name}", {}).and_return(shell_out_success)
           provider.unmask_service
         end
       end
@@ -283,13 +283,13 @@ describe Chef::Provider::Service::Systemd do
           allow(provider).to receive(:which).with("systemctl").and_return("#{systemctl_path}")
         end
 
-        it "should return true if '#{systemctl_path} is-active service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name} --quiet").and_return(shell_out_success)
+        it "should return true if '#{systemctl_path} --system is-active service_name' returns 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name} --quiet", {}).and_return(shell_out_success)
           expect(provider.is_active?).to be true
         end
 
-        it "should return false if '#{systemctl_path} is-active service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-active #{service_name} --quiet").and_return(shell_out_failure)
+        it "should return false if '#{systemctl_path} --system is-active service_name' returns anything except 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name} --quiet", {}).and_return(shell_out_failure)
           expect(provider.is_active?).to be false
         end
       end
@@ -301,13 +301,13 @@ describe Chef::Provider::Service::Systemd do
           allow(provider).to receive(:which).with("systemctl").and_return("#{systemctl_path}")
         end
 
-        it "should return true if '#{systemctl_path} is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name} --quiet").and_return(shell_out_success)
+        it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name} --quiet", {}).and_return(shell_out_success)
           expect(provider.is_enabled?).to be true
         end
 
-        it "should return false if '#{systemctl_path} is-enabled service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name} --quiet").and_return(shell_out_failure)
+        it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name} --quiet", {}).and_return(shell_out_failure)
           expect(provider.is_enabled?).to be false
         end
       end
@@ -319,23 +319,23 @@ describe Chef::Provider::Service::Systemd do
           allow(provider).to receive(:which).with("systemctl").and_return("#{systemctl_path}")
         end
 
-        it "should return true if '#{systemctl_path} is-enabled service_name' returns 'masked' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}").and_return(double(:stdout => "masked", :exitstatus => shell_out_failure))
+        it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 'masked' and returns anything except 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "masked", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
-        it "should return true if '#{systemctl_path} is-enabled service_name' outputs 'masked-runtime' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}").and_return(double(:stdout => "masked-runtime", :exitstatus => shell_out_failure))
+        it "should return true if '#{systemctl_path} --system is-enabled service_name' outputs 'masked-runtime' and returns anything except 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "masked-runtime", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
-        it "should return false if '#{systemctl_path} is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}").and_return(double(:stdout => "enabled", :exitstatus => shell_out_success))
+        it "should return false if '#{systemctl_path} --system is-enabled service_name' returns 0" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "enabled", :exitstatus => shell_out_success))
           expect(provider.is_masked?).to be false
         end
 
-        it "should return false if '#{systemctl_path} is-enabled service_name' returns anything except 0 and outputs an error'" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} is-enabled #{service_name}").and_return(double(:stdout => "Failed to get unit file state for #{service_name}: No such file or directory", :exitstatus => shell_out_failure))
+        it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0 and outputs an error'" do
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "Failed to get unit file state for #{service_name}: No such file or directory", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be false
         end
       end

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -26,8 +26,8 @@ describe Chef::Provider::Service::Systemd do
     node.default["etc"] = Hash.new
     node.default["etc"]["passwd"] = {
       "joe" => {
-        "uid" => 10000
-      }
+        "uid" => 10000,
+      },
     }
     node
   }
@@ -196,14 +196,14 @@ describe Chef::Provider::Service::Systemd do
         context "when a user is specified" do
           it "should call '#{systemctl_path} --user start service_name' if no start command is specified" do
             current_resource.user("joe")
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", {"environment"=>{"DBUS_SESSION_BUS_ADDRESS"=>"unix:path=/run/user/10000/bus"}, "user" => "joe"}).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { "environment" => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, "user" => "joe" }).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --user start service_name' if it is already running" do
             current_resource.running(true)
             current_resource.user("joe")
-            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", {"environment"=>{"DBUS_SESSION_BUS_ADDRESS"=>"unix:path=/run/user/10000/bus"}, "user" => "joe"})
+            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { "environment" => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, "user" => "joe" })
             provider.start_service
           end
         end


### PR DESCRIPTION
systemd support the concept of user services (https://wiki.archlinux.org/index.php/Systemd/User), which are like system services, but are run and supervised within a user session.

This patch adds support for managing user services within the `service` resource, e.g. by doing
```
service 'foo' do
  user 'bar'
  action [:enable, :start]
end
```
the  service `foo` will be enabled and started whenever the user `baz` logs in.

I'm a Facebook employee and @jaymzh will do the final merge.