### PR TITLE
better chef+ruby rspec constraints

### DIFF
--- a/spec/functional/resource/bash_spec.rb
+++ b/spec/functional/resource/bash_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Resource::Bash, :unix_only do
     # in Chef-12 the `command` attribute is largely useless, but does set the identity attribute
     # so that notifications need to target the value of the command.  it will not run the `command`
     # and if it is given without a code block then it does nothing and always succeeds.
-    describe "in Chef-12", :chef_lt_13_only do
+    describe "in Chef-12", chef: "< 13" do
       it "gets the commmand attribute from the name" do
         expect(resource.command).to eql("foo_resource")
       end
@@ -61,7 +61,7 @@ describe Chef::Resource::Bash, :unix_only do
     end
 
     # in Chef-13 the `command` attribute needs to be for internal use only
-    describe "in Chef-13", :chef_gte_13_only do
+    describe "in Chef-13", chef: ">= 13" do
       it "should raise an exception when trying to set the command" do
         expect { resource.command command }.to raise_error # FIXME: add a real error in Chef-13
       end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -159,14 +159,14 @@ EOM
             file "cookbooks/x/metadata.rb", "name 'x'; version '1.0.0'; depends 'x'"
           end
 
-          it "should warn", :chef_lt_13_only do
+          it "should warn", chef: "< 13" do
             knife("upload /cookbooks").should_succeed(
               stdout: "Updated /cookbooks/x\n",
               stderr: "WARN: Ignoring self-dependency in cookbook x, please remove it (in the future this will be fatal).\n"
             )
             knife("diff --name-status /").should_succeed ""
           end
-          it "should fail in Chef 13", :chef_gte_13_only do
+          it "should fail in Chef 13", chef: ">= 13" do
             knife("upload /cookbooks").should_fail ""
             # FIXME: include the error message here
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -154,11 +154,6 @@ RSpec.configure do |config|
   config.filter_run_excluding :debian_family_only => true unless debian_family?
   config.filter_run_excluding :supports_cloexec => true unless supports_cloexec?
   config.filter_run_excluding :selinux_only => true unless selinux_enabled?
-  config.filter_run_excluding :ruby_20_only => true unless ruby_20?
-  # chef_gte_XX_only and chef_lt_XX_only pair up correctly with the same XX
-  # number.  please conserve this pattern & resist filling out all the operators
-  config.filter_run_excluding :chef_gte_13_only => true unless chef_gte_13?
-  config.filter_run_excluding :chef_lt_13_only => true unless chef_lt_13?
   config.filter_run_excluding :requires_root => true unless root?
   config.filter_run_excluding :requires_root_or_running_windows => true unless root? || windows?
   config.filter_run_excluding :requires_unprivileged_user => true if root?
@@ -169,6 +164,10 @@ RSpec.configure do |config|
   config.filter_run_excluding :broken => true
   config.filter_run_excluding :not_wpar => true unless wpar?
   config.filter_run_excluding :not_supported_under_fips => true if fips?
+
+  # these let us use chef: ">= 13" or ruby: "~> 2.0.0" or any other Gem::Dependency-style constraint
+  config.filter_run_excluding chef: DependencyProc.with(Chef::VERSION)
+  config.filter_run_excluding ruby: DependencyProc.with(RUBY_VERSION)
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -22,10 +22,6 @@ class DependencyProc < Proc
   end
 end
 
-class ShellHelpers
-  extend Chef::Mixin::ShellOut
-end
-
 def ruby_64bit?
   !!(RbConfig::CONFIG["host_cpu"] =~ /x86_64/)
 end

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -6,24 +6,24 @@ class ShellHelpers
   extend Chef::Mixin::ShellOut
 end
 
-def ruby_lt_20?
-  !ruby_gte_20?
+# magic stolen from bundler/spec/support/less_than_proc.rb
+class DependencyProc < Proc
+  attr_accessor :present
+
+  def self.with(present)
+    provided = Gem::Version.new(present.dup)
+    new do |required|
+      !Gem::Requirement.new(required).satisfied_by?(provided)
+    end.tap { |l| l.present = present }
+  end
+
+  def inspect
+    "\"#{present}\""
+  end
 end
 
-def chef_gte_13?
-  Chef::VERSION.split(".").first.to_i >= 13
-end
-
-def chef_lt_13?
-  Chef::VERSION.split(".").first.to_i < 13
-end
-
-def ruby_gte_19?
-  RUBY_VERSION.to_f >= 1.9
-end
-
-def ruby_20?
-  !!(RUBY_VERSION =~ /^2.0/)
+class ShellHelpers
+  extend Chef::Mixin::ShellOut
 end
 
 def ruby_64bit?

--- a/spec/support/shared/unit/execute_resource.rb
+++ b/spec/support/shared/unit/execute_resource.rb
@@ -76,13 +76,13 @@ shared_examples_for "an execute resource" do
     expect(@resource.group).to eql(1)
   end
 
-  it "should accept an array for the execution path in Chef-12 and log deprecation message", :chef_lt_13_only do
+  it "should accept an array for the execution path in Chef-12 and log deprecation message", chef: "< 13" do
     expect(Chef::Log).to receive(:warn).at_least(:once)
     @resource.path ["woot"]
     expect(@resource.path).to eql(["woot"])
   end
 
-  it "should raise an exception in chef-13", :chef_gte_13_only do
+  it "should raise an exception in chef-13", chef: ">= 13" do
     expect(@resource.path [ "woot" ]).to raise_error
   end
 

--- a/spec/support/shared/unit/script_resource.rb
+++ b/spec/support/shared/unit/script_resource.rb
@@ -30,11 +30,11 @@ shared_examples_for "a script resource" do
     expect(script_resource.resource_name).to eql(resource_name)
   end
 
-  it "should set command to nil on the resource", :chef_gte_13_only do
+  it "should set command to nil on the resource", chef: ">= 13" do
     expect(script_resource.command).to be nil
   end
 
-  it "should set command to the name on the resource", :chef_lt_13_only do
+  it "should set command to the name on the resource", chef: "< 13" do
     expect(script_resource.command).to eql script_resource.name
   end
 
@@ -48,11 +48,11 @@ shared_examples_for "a script resource" do
     expect(script_resource.flags).to eql("-f")
   end
 
-  it "should raise an exception if users set command on the resource", :chef_gte_13_only do
+  it "should raise an exception if users set command on the resource", chef: ">= 13" do
     expect { script_resource.command("foo") }.to raise_error(Chef::Exceptions::Script)
   end
 
-  it "should not raise an exception if users set command on the resource", :chef_lt_13_only do
+  it "should not raise an exception if users set command on the resource", chef: "< 13" do
     expect { script_resource.command("foo") }.not_to raise_error
   end
 

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -308,7 +308,7 @@ describe Chef::Cookbook::Metadata do
       end
     end
 
-    it "strips out self-dependencies", :chef_lt_13_only do
+    it "strips out self-dependencies", chef: "< 13" do
       metadata.name("foo")
       expect(Chef::Log).to receive(:warn).with(
         "Ignoring self-dependency in cookbook foo, please remove it (in the future this will be fatal)."
@@ -317,7 +317,7 @@ describe Chef::Cookbook::Metadata do
       expect(metadata.dependencies).to eql({})
     end
 
-    it "errors on self-dependencies", :chef_gte_13_only do
+    it "errors on self-dependencies", chef: ">= 13" do
       metadata.name("foo")
       expect { metadata.depends("foo") }.to raise_error
       # FIXME: add the error type

--- a/spec/unit/encrypted_data_bag_item/check_encrypted_spec.rb
+++ b/spec/unit/encrypted_data_bag_item/check_encrypted_spec.rb
@@ -83,7 +83,7 @@ describe Chef::EncryptedDataBagItem::CheckEncrypted do
       end
     end
 
-    context "when encryption version is 3", :aes_256_gcm_only, :ruby_20_only do
+    context "when encryption version is 3", :aes_256_gcm_only, ruby: "~> 2.0.0" do
       include_examples "encryption detected" do
         let(:version) { 3 }
         let(:encryptor) { Chef::EncryptedDataBagItem::Encryptor::Version3Encryptor }

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -97,7 +97,7 @@ describe Chef::EncryptedDataBagItem::Encryptor do
       Chef::Config[:data_bag_encrypt_version] = 3
     end
 
-    context "on supported platforms", :aes_256_gcm_only, :ruby_20_only do
+    context "on supported platforms", :aes_256_gcm_only, ruby: "~> 2.0.0" do
 
       it "creates a version 3 encryptor" do
         expect(encryptor).to be_a_instance_of(Chef::EncryptedDataBagItem::Encryptor::Version3Encryptor)
@@ -166,7 +166,7 @@ describe Chef::EncryptedDataBagItem::Decryptor do
 
   context "when decrypting a version 3 (JSON+aes-256-gcm+random iv+auth tag) encrypted value" do
 
-    context "on supported platforms", :aes_256_gcm_only, :ruby_20_only do
+    context "on supported platforms", :aes_256_gcm_only, ruby: "~> 2.0.0" do
 
       let(:encrypted_value) do
         Chef::EncryptedDataBagItem::Encryptor::Version3Encryptor.new(plaintext_data, encryption_key).for_encrypted_item

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1511,7 +1511,7 @@ describe Chef::Node do
             # added the policyfile attributes to the node JSON, therefore
             # policyfile users need to be on 12.3 minimum when upgrading Chef
             # Client to 13+
-            it "lets the 400 pass through", :chef_gte_13_only do
+            it "lets the 400 pass through", chef: ">= 13" do
               expect { node.save }.to raise_error(http_exception)
             end
 

--- a/spec/unit/policy_builder/expand_node_object_spec.rb
+++ b/spec/unit/policy_builder/expand_node_object_spec.rb
@@ -38,7 +38,7 @@ describe Chef::PolicyBuilder::ExpandNodeObject do
       expect(policy_builder).to respond_to(:load_node)
     end
 
-    it "has removed the deprecated #load_node method", :chef_gte_13_only do
+    it "has removed the deprecated #load_node method", chef: ">= 13" do
       expect(policy_builder).to_not respond_to(:load_node)
     end
 

--- a/spec/unit/provider/execute_spec.rb
+++ b/spec/unit/provider/execute_spec.rb
@@ -118,7 +118,7 @@ describe Chef::Provider::Execute do
         new_resource.creates "foo_resource"
       end
 
-      it "should warn in Chef-12", :chef_lt_13_only do
+      it "should warn in Chef-12", chef: "< 13" do
         expect(Chef::Log).to receive(:warn).with(/relative path/)
         expect(FileTest).to receive(:exist?).with(new_resource.creates).and_return(true)
         expect(provider).not_to receive(:shell_out!)
@@ -126,7 +126,7 @@ describe Chef::Provider::Execute do
         expect(new_resource).not_to be_updated
       end
 
-      it "should raise if user specified relative path without cwd for Chef-13", :chef_gte_13_only do
+      it "should raise if user specified relative path without cwd for Chef-13", chef: ">= 13" do
         expect(Chef::Log).to receive(:warn).with(/relative path/)
         expect(FileTest).to receive(:exist?).with(new_resource.creates).and_return(true)
         expect(provider).not_to receive(:shell_out!)

--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -70,14 +70,14 @@ describe Chef::Resource::ChefGem, "gem_binary" do
       expect(Chef::Resource::ChefGem).to receive(:new).and_return(resource)
     end
 
-    it "runs the install at compile-time by default", :chef_lt_13_only do
+    it "runs the install at compile-time by default", chef: "< 13" do
       expect(resource).to receive(:run_action).with(:install)
       expect(Chef::Log).to receive(:deprecation).at_least(:once)
       recipe.chef_gem "foo"
     end
 
     # the default behavior will change in Chef-13
-    it "does not runs the install at compile-time by default", :chef_gte_13_only do
+    it "does not runs the install at compile-time by default", chef: ">= 13" do
       expect(resource).not_to receive(:run_action).with(:install)
       expect(Chef::Log).not_to receive(:deprecation)
       recipe.chef_gem "foo"

--- a/spec/unit/run_list/versioned_recipe_list_spec.rb
+++ b/spec/unit/run_list/versioned_recipe_list_spec.rb
@@ -186,7 +186,7 @@ describe Chef::RunList::VersionedRecipeList do
     end
   end
 
-  context "with duplicated names", :chef_gte_13_only do
+  context "with duplicated names", chef: ">= 13" do
     it "should fail in Chef 13" do
       expect(list).to_not respond_to(:with_duplicate_names)
     end


### PR DESCRIPTION
lets us use Gem::Dependency constraints directly as rspec
constraints for matching Chef::Version and RUBY_VERSION.

copies some magic sauce from bundler that does something
similar