### PR TITLE
Use ruby 2.1.8 on both windows and unix

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -34,17 +34,10 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-if windows?
-  override :ruby, version: "2.0.0-p645"
-  # Leave dev-kit pinned to 4.5 because 4.7 is 20MB larger and we don't want
-  # to unnecessarily make the client any fatter.
-  if windows_arch_i386?
-    override :'ruby-windows-devkit', version: "4.5.2-20111229-1559"
-  end
-else
-  override :ruby, version: "2.1.6"
-end
-
+override :ruby, version: "2.1.8"
+# Leave dev-kit pinned to 4.5 because 4.7 is 20MB larger and we don't want
+# to unnecessarily make the client any fatter.
+override :'ruby-windows-devkit', version: "4.5.2-20111229-1559" if windows? && windows_arch_i386?
 override :bundler,      version: "1.11.2"
 override :rubygems,     version: "2.5.2"
 


### PR DESCRIPTION
This has passed through the build+test matrix. Windows upgrades from 2.0 to 2.1, and unix gets a patch bump from 2.1.6 to 2.1.8.

NOTE: we will not merge this until after 12.8 is released, to give us more time before the next release to sort out any issues that crop up.