### PR TITLE
Fix property coercion

### DIFF
--- a/lib/chef/mixin/properties.rb
+++ b/lib/chef/mixin/properties.rb
@@ -95,7 +95,7 @@ class Chef
         def property(name, type = NOT_PASSED, **options)
           name = name.to_sym
 
-          options.each { |k, v| options[k.to_sym] = v if k.is_a?(String) }
+          options = options.inject({}) { |memo, (key, value)| memo[key.to_sym] = value; memo }
 
           options[:instance_variable_name] = :"@#{name}" if !options.has_key?(:instance_variable_name)
           options[:name] = name

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -87,7 +87,7 @@ class Chef
     #     is fully initialized.
     #
     def initialize(**options)
-      options.each { |k, v| options[k.to_sym] = v; options.delete(k) if k.is_a?(String) }
+      options = options.inject({}) { |memo, (key, value)| memo[key.to_sym] = value; memo }
       @options = options
       options[:name] = options[:name].to_sym if options[:name]
       options[:instance_variable_name] = options[:instance_variable_name].to_sym if options[:instance_variable_name]


### PR DESCRIPTION
Because they were different and one in Chef::Mixin::Properties would result in duplicated values for string keys.

Very specifically not adding a new test for string keys on `property` because I think this is not part of our declared API (we only state support for symbol keys) and we probably shouldn't test formally undefined behavior.