### PR TITLE
Improved method for getting currently installed profiles

### DIFF
--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -220,12 +220,7 @@ class Chef
 
       def dump_installed_profiles
         cmd = "profiles -P -o stdout-xml"
-        shellout_results = shell_out!(cmd)
-        if shellout_results.exitstatus == 0
-          shellout_results.stdout
-        else
-          raise Mixlib::ShellOut::ShellCommandFailed, "profiles command failed"
-        end
+        shell_out!(cmd).stdout
       end
 
       def read_plist(xml_file)

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -224,7 +224,7 @@ class Chef
         if shellout_results.exitstatus == 0
           shellout_results.stdout
         else
-          raise Mixlib::ShellOut::ShellCommandFailed, 'profiles command failed'
+          raise Mixlib::ShellOut::ShellCommandFailed, "profiles command failed"
         end
       end
 

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -220,7 +220,7 @@ class Chef
 
       def dump_installed_profiles
         cmd = "profiles -P -o stdout-xml"
-        shellout_results = shell_out(cmd)
+        shellout_results = shell_out!(cmd)
         if shellout_results.exitstatus == 0
           shellout_results.stdout
         else

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -169,7 +169,7 @@ class Chef
 
       def get_profile_hash(new_profile)
         if new_profile.is_a?(Hash)
-          return new_profile.to_hash
+          return new_profile
         elsif new_profile.is_a?(String)
           return load_profile_hash(new_profile)
         end

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -20,7 +20,10 @@ require "spec_helper"
 
 describe Chef::Provider::OsxProfile do
   let(:shell_out_success) do
-    double("shell_out", :exitstatus => 0, :error? => false)
+    double("shell_out", :exitstatus => 0, :error? => false, :stdout => 0)
+  end
+  let(:shell_out_fail) do
+    double("shell_out", :exitstatus => 1, :error? => false, :stdout => 0)
   end
   describe "action_create" do
     let(:node) { Chef::Node.new }
@@ -111,12 +114,9 @@ describe Chef::Provider::OsxProfile do
 
     it "should build the get all profiles shellout command correctly" do
       profile_name = "com.testprofile.screensaver.mobileconfig"
-      tempfile = "/tmp/allprofiles.plist"
       new_resource.profile_name profile_name
-      allow(provider).to receive(:generate_tempfile).and_return(tempfile)
       allow(provider).to receive(:get_installed_profiles).and_call_original
-      allow(provider).to receive(:read_plist).and_return(all_profiles)
-      expect(provider).to receive(:shell_out!).with("profiles -P -o '/tmp/allprofiles.plist'")
+      expect(provider).to receive(:shell_out).with("profiles -P -o stdout-xml").and_return(shell_out_success)
       provider.load_current_resource
     end
 

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -116,7 +116,7 @@ describe Chef::Provider::OsxProfile do
       profile_name = "com.testprofile.screensaver.mobileconfig"
       new_resource.profile_name profile_name
       allow(provider).to receive(:get_installed_profiles).and_call_original
-      expect(provider).to receive(:shell_out).with("profiles -P -o stdout-xml").and_return(shell_out_success)
+      expect(provider).to receive(:shell_out!).with("profiles -P -o stdout-xml").and_return(shell_out_success)
       provider.load_current_resource
     end
 


### PR DESCRIPTION
This improves how I was getting currently installed profiles. Previously, I was dumping all profiles to disk and then reading them back to figure out what was installed. This was pretty stupid as I could just read them out directly using stdout-xml (in the man page for the profiles command, but not --help. Thanks Apple).

As usual, I am with Facebook and this PR must be merged by PhilD.