### PR TITLE
Add cookbooks for 64-bit Windows test matrix

### DIFF
--- a/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/libraries/top_cookbooks.rb
+++ b/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/libraries/top_cookbooks.rb
@@ -19,5 +19,25 @@ class TopCookbooks < Chef::Resource
       repository "learn-chef/learn-chef-acceptance"
       cookbook_relative_dir "cookbooks/learn-the-basics-windows"
     end
+
+    cookbook_kitchen "#{command} powershell" do
+    end
+
+    cookbook_kitchen "#{command} windows" do
+    end
+
+    cookbook_kitchen "#{command} iis" do
+    end
+
+    cookbook_kitchen "#{command} sql_server" do
+    end
+
+    cookbook_kitchen "#{command} winbox" do
+      repository "adamedx/winbox"
+    end
+
+    cookbook_kitchen "#{command} chocolatey" do
+      repository "chocolatey/chocolatey-cookbook"
+    end
   end
 end

--- a/acceptance/top-cookbooks/.kitchen.chocolatey.yml
+++ b/acceptance/top-cookbooks/.kitchen.chocolatey.yml
@@ -1,0 +1,6 @@
+suites:
+  - name: default
+    run_list:
+      - recipe[chocolatey::default]
+      - recipe[chocolatey_test::default]
+    includes: [windows-2012r2]

--- a/acceptance/top-cookbooks/.kitchen.iis.yml
+++ b/acceptance/top-cookbooks/.kitchen.iis.yml
@@ -1,0 +1,4 @@
+suites:
+  - name: iis
+    run_list: ["recipe[iis::default]"]
+    includes: [windows-2012r2]

--- a/acceptance/top-cookbooks/.kitchen.powershell.yml
+++ b/acceptance/top-cookbooks/.kitchen.powershell.yml
@@ -1,0 +1,4 @@
+suites:
+  - name: powershell
+    run_list: ["recipe[powershell::powershell2]"]
+    includes: [windows-2012r2]

--- a/acceptance/top-cookbooks/.kitchen.sql_server.yml
+++ b/acceptance/top-cookbooks/.kitchen.sql_server.yml
@@ -1,0 +1,5 @@
+suites:
+  - name: sql_server
+    run_list: ["recipe[sql_server::default]"]
+    attributes: { sql_server: { accept_eula: true } }
+    includes: [windows-2012r2]

--- a/acceptance/top-cookbooks/.kitchen.winbox.yml
+++ b/acceptance/top-cookbooks/.kitchen.winbox.yml
@@ -1,0 +1,8 @@
+suites:
+  - name: default
+    run_list:
+      - recipe[winbox::default]
+    includes: [windows-2012r2]
+
+verifier:
+  name: dummy

--- a/acceptance/top-cookbooks/.kitchen.windows.yml
+++ b/acceptance/top-cookbooks/.kitchen.windows.yml
@@ -1,0 +1,38 @@
+suites:
+  # Waiting on https://github.com/chef-cookbooks/windows/pull/350
+  # - name: tasks
+  #   run_list:
+  #     - recipe[windows::default]
+  #     - recipe[minimal::tasks]
+  #   includes: [windows-2012r2]
+  - name: path
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::path]
+    includes: [windows-2012r2]
+  - name: certificate
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::certificate]
+    includes: [windows-2012r2]
+  # Package is deprecated
+  # - name: package
+  #   run_list:
+  #     - recipe[windows::default]
+  #     - recipe[minimal::package]
+  #   includes: [windows-2012r2]
+  - name: feature
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::feature]
+    includes: [windows-2012r2]
+  - name: http_acl
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::http_acl]
+    includes: [windows-2012r2]
+  - name: font
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::font]
+    includes: [windows-2012r2]


### PR DESCRIPTION
This PR adds some new cookbooks to chef-acceptance that exercise functionality deemed important to validate for the 64-bit Chef on Windows test-matrix - see:
https://docs.google.com/spreadsheets/d/1i_H8skdOLyhLDNfL4VWrOCSRbyBR5BE56vp48KZ1rR0/edit

@client-core @jkeiser @tyler-ball 