### PR TITLE
Adding myself as LT and Maintainer for Cisco platforms

### DIFF
--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -161,6 +161,26 @@ The specific components of Chef related to a given platform - including (but not
           "lamont-granquist"
         ]
 
+      [Org.Components.Subsystems.CiscoNXOS]
+        title = "Cisco NX-OS"
+        team = "client-nxos"
+
+        lieutenant = "cperry"
+
+        maintainers = [
+          "cperry"
+        ]
+
+      [Org.Components.Subsystems.CiscoIOSXR]
+        title = "Cisco IOS XR"
+        team = "client-isoxr"
+
+        lieutenant = "cperry"
+
+        maintainers = [
+          "cperry"
+        ]
+
     [Org.Components.Subsystems.Fedora]
         title = "Fedora"
         team = "client-fedora"
@@ -336,3 +356,7 @@ The specific components of Chef related to a given platform - including (but not
   [people.mwrock]
     Name = "Matt Wrock"
     GitHub = "mwrock"
+
+  [people.cperry]
+    Name = "Carl Perry"
+    GitHub = "edolnx"

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -173,7 +173,7 @@ The specific components of Chef related to a given platform - including (but not
 
       [Org.Components.Subsystems.CiscoIOSXR]
         title = "Cisco IOS XR"
-        team = "client-isoxr"
+        team = "client-iosxr"
 
         lieutenant = "cperry"
 


### PR DESCRIPTION
We added Cisco to Tier 1 support, and it's already available. Just filling out the paperwork.