### PR TITLE
s/escape_glob/escape_glob_dir/

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -128,6 +128,17 @@ module ChefConfig
       abs_path
     end
 
+    # This is the INVERSE of Pathname#cleanpath, it converts forward
+    # slashes to backwhacks for Windows.  Since the Ruby API and the
+    # Windows APIs all consume forward slashes, this helper function
+    # should only be used for *DISPLAY* logic to send strings back
+    # to the user with backwhacks.  Internally, filename paths should
+    # generally be stored with forward slashes for consistency.  It is
+    # not necessary or desired to blindly convert pathnames to have
+    # backwhacks on Windows.
+    #
+    # Generally, if the user isn't going to be seeing it, you should be
+    # using Pathname#cleanpath intead of this function.
     def self.cleanpath(path)
       path = Pathname.new(path).cleanpath.to_s
       # ensure all forward slashes are backslashes

--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -114,7 +114,7 @@ class Chef
       end
 
       def ruby_files
-        path  = Chef::Util::PathHelper.escape_glob(cookbook_path)
+        path  = Chef::Util::PathHelper.escape_glob_dir(cookbook_path)
         files = Dir[File.join(path, "**", "*.rb")]
         files = remove_ignored_files(files)
         files = remove_uninteresting_ruby_files(files)
@@ -133,7 +133,7 @@ class Chef
       end
 
       def template_files
-        remove_ignored_files Dir[File.join(Chef::Util::PathHelper.escape_glob(cookbook_path), "**/templates/**", "*.erb")]
+        remove_ignored_files Dir[File.join(Chef::Util::PathHelper.escape_glob_dir(cookbook_path), "**/templates/**", "*.erb")]
       end
 
       def untested_template_files

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -179,7 +179,7 @@ class Chef
       @all_files_in_repo_paths ||=
         begin
           @repo_paths.inject([]) do |all_children, repo_path|
-            all_children += Dir[File.join(Chef::Util::PathHelper.escape_glob(repo_path), "*")]
+            all_children += Dir[File.join(Chef::Util::PathHelper.escape_glob_dir(repo_path), "*")]
           end
         end
     end

--- a/lib/chef/deprecation/provider/file.rb
+++ b/lib/chef/deprecation/provider/file.rb
@@ -181,7 +181,7 @@ class Chef
 
             # Clean up after the number of backups
             slice_number = @new_resource.backup
-            backup_files = Dir[Chef::Util::PathHelper.escape_glob(prefix, ".#{@new_resource.path}") + ".chef-*"].sort { |a, b| b <=> a }
+            backup_files = Dir[Chef::Util::PathHelper.escape_glob_dir(prefix, ".#{@new_resource.path}") + ".chef-*"].sort { |a, b| b <=> a }
             if backup_files.length >= @new_resource.backup
               remainder = backup_files.slice(slice_number..-1)
               remainder.each do |backup_to_delete|

--- a/lib/chef/deprecation/provider/remote_directory.rb
+++ b/lib/chef/deprecation/provider/remote_directory.rb
@@ -33,7 +33,7 @@ class Chef
 
         # List all excluding . and ..
         def ls(path)
-          files = Dir.glob(::File.join(Chef::Util::PathHelper.escape_glob(path), "**", "*"),
+          files = Dir.glob(::File.join(Chef::Util::PathHelper.escape_glob_dir(path), "**", "*"),
                            ::File::FNM_DOTMATCH)
 
           # Remove current directory and previous directory

--- a/lib/chef/file_cache.rb
+++ b/lib/chef/file_cache.rb
@@ -158,9 +158,9 @@ class Chef
       # [String] - An array of file cache keys matching the glob
       def find(glob_pattern)
         keys = Array.new
-        Dir[File.join(Chef::Util::PathHelper.escape_glob(file_cache_path), glob_pattern)].each do |f|
+        Dir[File.join(Chef::Util::PathHelper.escape_glob_dir(file_cache_path), glob_pattern)].each do |f|
           if File.file?(f)
-            keys << f[/^#{Regexp.escape(Dir[Chef::Util::PathHelper.escape_glob(file_cache_path)].first) + File::Separator}(.+)/, 1]
+            keys << f[/^#{Regexp.escape(Dir[Chef::Util::PathHelper.escape_glob_dir(file_cache_path)].first) + File::Separator}(.+)/, 1]
           end
         end
         keys

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -77,7 +77,7 @@ class Chef
           http_client.cert_store.set_default_paths
         end
         if config.trusted_certs_dir
-          certs = Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(config.trusted_certs_dir), "*.{crt,pem}"))
+          certs = Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(config.trusted_certs_dir), "*.{crt,pem}"))
           certs.each do |cert_file|
             cert = OpenSSL::X509::Certificate.new(File.read(cert_file))
             add_trusted_cert(cert)

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -199,7 +199,7 @@ CONFIG
         def trusted_certs_content
           content = ""
           if @chef_config[:trusted_certs_dir]
-            Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
+            Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
               content << "cat > /etc/chef/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
                 IO.read(File.expand_path(cert)) + "\nEOP\n"
             end

--- a/lib/chef/knife/core/gem_glob_loader.rb
+++ b/lib/chef/knife/core/gem_glob_loader.rb
@@ -47,7 +47,7 @@ class Chef
 
         def find_subcommands_via_dirglob
           # The "require paths" of the core knife subcommands bundled with chef
-          files = Dir[File.join(Chef::Util::PathHelper.escape_glob(File.expand_path("../../../knife", __FILE__)), "*.rb")]
+          files = Dir[File.join(Chef::Util::PathHelper.escape_glob_dir(File.expand_path("../../../knife", __FILE__)), "*.rb")]
           subcommand_files = {}
           files.each do |knife_file|
             rel_path = knife_file[/#{CHEF_ROOT}#{Regexp.escape(File::SEPARATOR)}(.*)\.rb/, 1]
@@ -82,7 +82,7 @@ class Chef
 
           if check_load_path
             files = $LOAD_PATH.map { |load_path|
-              Dir["#{File.expand_path glob, Chef::Util::PathHelper.escape_glob(load_path)}#{Gem.suffix_pattern}"]
+              Dir["#{File.expand_path glob, Chef::Util::PathHelper.escape_glob_dir(load_path)}#{Gem.suffix_pattern}"]
             }.flatten.select { |file| File.file? file.untaint }
           end
 
@@ -116,7 +116,7 @@ class Chef
                    spec.require_paths.first
                  end
 
-          glob = File.join(Chef::Util::PathHelper.escape_glob(spec.full_gem_path, dirs), glob)
+          glob = File.join(Chef::Util::PathHelper.escape_glob_dir(spec.full_gem_path, dirs), glob)
 
           Dir[glob].map { |f| f.untaint }
         end

--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -71,14 +71,14 @@ class Chef
         #
         # @api public
         def find_all_objects(path)
-          path = File.join(Chef::Util::PathHelper.escape_glob(File.expand_path(path)), "*")
+          path = File.join(Chef::Util::PathHelper.escape_glob_dir(File.expand_path(path)), "*")
           path << ".{json,rb}"
           objects = Dir.glob(path)
           objects.map { |o| File.basename(o) }
         end
 
         def find_all_object_dirs(path)
-          path = File.join(Chef::Util::PathHelper.escape_glob(File.expand_path(path)), "*")
+          path = File.join(Chef::Util::PathHelper.escape_glob_dir(File.expand_path(path)), "*")
           objects = Dir.glob(path)
           objects.delete_if { |o| !File.directory?(o) }
           objects.map { |o| File.basename(o) }

--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -139,7 +139,7 @@ class Chef
       #
       def find_subcommands_via_dirglob
         # The "require paths" of the core knife subcommands bundled with chef
-        files = Dir[File.join(Chef::Util::PathHelper.escape_glob(File.expand_path("../../../knife", __FILE__)), "*.rb")]
+        files = Dir[File.join(Chef::Util::PathHelper.escape_glob_dir(File.expand_path("../../../knife", __FILE__)), "*.rb")]
         subcommand_files = {}
         files.each do |knife_file|
           rel_path = knife_file[/#{CHEF_ROOT}#{Regexp.escape(File::SEPARATOR)}(.*)\.rb/, 1]
@@ -197,12 +197,12 @@ Please use Chef::Knife::SubcommandLoader.for_config(chef_config_dir, env)"
         user_specific_files = []
 
         if chef_config_dir
-          user_specific_files.concat Dir.glob(File.expand_path("plugins/knife/*.rb", Chef::Util::PathHelper.escape_glob(chef_config_dir)))
+          user_specific_files.concat Dir.glob(File.expand_path("plugins/knife/*.rb", Chef::Util::PathHelper.escape_glob_dir(chef_config_dir)))
         end
 
         # finally search ~/.chef/plugins/knife/*.rb
         Chef::Util::PathHelper.home(".chef", "plugins", "knife") do |p|
-          user_specific_files.concat Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(p), "*.rb"))
+          user_specific_files.concat Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(p), "*.rb"))
         end
 
         user_specific_files

--- a/lib/chef/knife/data_bag_from_file.rb
+++ b/lib/chef/knife/data_bag_from_file.rb
@@ -102,7 +102,7 @@ class Chef
         paths = Array.new
         args.each do |path|
           if File.directory?(path)
-            paths.concat(Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(path), "*.json")))
+            paths.concat(Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path), "*.json")))
           else
             paths << path
           end

--- a/lib/chef/provider/deploy.rb
+++ b/lib/chef/provider/deploy.rb
@@ -242,7 +242,7 @@ class Chef
       end
 
       def all_releases
-        Dir.glob(Chef::Util::PathHelper.escape_glob(@new_resource.deploy_to) + "/releases/*").sort
+        Dir.glob(Chef::Util::PathHelper.escape_glob_dir(@new_resource.deploy_to) + "/releases/*").sort
       end
 
       def update_cached_repo

--- a/lib/chef/provider/deploy/revision.rb
+++ b/lib/chef/provider/deploy/revision.rb
@@ -44,7 +44,7 @@ class Chef
 
           known_releases = sorted_releases
 
-          Dir["#{Chef::Util::PathHelper.escape_glob(new_resource.deploy_to)}/releases/*"].each do |release_dir|
+          Dir["#{Chef::Util::PathHelper.escape_glob_dir(new_resource.deploy_to)}/releases/*"].each do |release_dir|
             unless known_releases.include?(release_dir)
               converge_by("Remove unknown release in #{release_dir}") do
                 FileUtils.rm_rf(release_dir)
@@ -87,7 +87,7 @@ class Chef
         end
 
         def sorted_releases_from_filesystem
-          Dir.glob(Chef::Util::PathHelper.escape_glob(new_resource.deploy_to) + "/releases/*").sort_by { |d| ::File.ctime(d) }
+          Dir.glob(Chef::Util::PathHelper.escape_glob_dir(new_resource.deploy_to) + "/releases/*").sort_by { |d| ::File.ctime(d) }
         end
 
         def load_cache

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -88,7 +88,7 @@ class Chef
           end
 
           def file_candidate_version_path
-            Dir[Chef::Util::PathHelper.escape_glob("#{@new_resource.source}/#{@current_resource.package_name}") + "*"][-1].to_s
+            Dir[Chef::Util::PathHelper.escape_glob_dir("#{@new_resource.source}/#{@current_resource.package_name}") + "*"][-1].to_s
           end
 
           def file_candidate_version

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -37,8 +37,8 @@ class Chef
 
           category, pkg = %r{^#{PACKAGE_NAME_PATTERN}$}.match(@new_resource.package_name)[1, 2]
 
-          globsafe_category = category ? Chef::Util::PathHelper.escape_glob(category) : nil
-          globsafe_pkg = Chef::Util::PathHelper.escape_glob(pkg)
+          globsafe_category = category ? Chef::Util::PathHelper.escape_glob_dir(category) : nil
+          globsafe_pkg = Chef::Util::PathHelper.escape_glob_dir(pkg)
           possibilities = Dir["/var/db/pkg/#{globsafe_category || "*"}/#{globsafe_pkg}-*"].map { |d| d.sub(%r{/var/db/pkg/}, "") }
           versions = possibilities.map do |entry|
             if entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)}

--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -104,7 +104,7 @@ class Chef
       #
       def purge_unmanaged_files
         if purge
-          Dir.glob(::File.join(Chef::Util::PathHelper.escape_glob(path), "**", "*"), ::File::FNM_DOTMATCH).sort!.reverse!.each do |file|
+          Dir.glob(::File.join(Chef::Util::PathHelper.escape_glob_dir(path), "**", "*"), ::File::FNM_DOTMATCH).sort!.reverse!.each do |file|
             # skip '.' and '..'
             next if [".", ".."].include?(Pathname.new(file).basename().to_s)
 

--- a/lib/chef/provider/service/gentoo.rb
+++ b/lib/chef/provider/service/gentoo.rb
@@ -33,7 +33,7 @@ class Chef::Provider::Service::Gentoo < Chef::Provider::Service::Init
     super
 
     @current_resource.enabled(
-      Dir.glob("/etc/runlevels/**/#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}").any? do |file|
+      Dir.glob("/etc/runlevels/**/#{Chef::Util::PathHelper.escape_glob_dir(@current_resource.service_name)}").any? do |file|
         @found_script = true
         exists = ::File.exists? file
         readable = ::File.readable? file

--- a/lib/chef/provider/service/insserv.rb
+++ b/lib/chef/provider/service/insserv.rb
@@ -36,7 +36,7 @@ class Chef
           super
 
           # Look for a /etc/rc.*/SnnSERVICE link to signify that the service would be started in a runlevel
-          if Dir.glob("/etc/rc**/S*#{Chef::Util::PathHelper.escape_glob(current_resource.service_name)}").empty?
+          if Dir.glob("/etc/rc**/S*#{Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)}").empty?
             current_resource.enabled false
           else
             current_resource.enabled true

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -236,7 +236,7 @@ class Chef
           plists = PLIST_DIRS.inject([]) do |results, dir|
             edir = ::File.expand_path(dir)
             entries = Dir.glob(
-              "#{edir}/*#{Chef::Util::PathHelper.escape_glob(@current_resource.service_name)}*.plist"
+              "#{edir}/*#{Chef::Util::PathHelper.escape_glob_dir(@current_resource.service_name)}*.plist"
             )
             entries.any? ? results << entries : results
           end

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -331,7 +331,7 @@ user password using shadow hash.")
 
           src = current_resource.home
           FileUtils.mkdir_p(new_resource.home)
-          files = ::Dir.glob("#{Chef::Util::PathHelper.escape_glob(src)}/*", ::File::FNM_DOTMATCH) - ["#{src}/.", "#{src}/.."]
+          files = ::Dir.glob("#{Chef::Util::PathHelper.escape_glob_dir(src)}/*", ::File::FNM_DOTMATCH) - ["#{src}/.", "#{src}/.."]
           ::FileUtils.mv(files, new_resource.home, :force => true)
           ::FileUtils.rmdir(src)
           ::FileUtils.chown_R(new_resource.username, new_resource.gid.to_s, new_resource.home)

--- a/lib/chef/role.rb
+++ b/lib/chef/role.rb
@@ -253,7 +253,7 @@ class Chef
     def self.from_disk(name)
       paths = Array(Chef::Config[:role_path])
       paths.each do |path|
-        roles_files = Dir.glob(File.join(Chef::Util::PathHelper.escape_glob(path), "**", "**"))
+        roles_files = Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path), "**", "**"))
         js_files = roles_files.select { |file| file.match(/\/#{name}\.json$/) }
         rb_files = roles_files.select { |file| file.match(/\/#{name}\.rb$/) }
         if js_files.count > 1 or rb_files.count > 1

--- a/spec/functional/util/path_helper_spec.rb
+++ b/spec/functional/util/path_helper_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Util::PathHelper, "escape_glob" do
         File.new(File.join(dir, file), "w").close
       end
 
-      pattern = File.join(PathHelper.escape_glob(dir), "*")
+      pattern = File.join(PathHelper.escape_glob_dir(dir), "*")
       expect(Dir.glob(pattern).map { |x| File.basename(x) }).to match_array(files)
     end
   end


### PR DESCRIPTION
Removes all remaining references to the deprecated escape_glob
helper routine.