### PR TITLE
Make mount idempotent on Windows

### DIFF
--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -80,6 +80,12 @@ class Chef
           end
         end
 
+        private
+
+        def mount_options_unchanged?
+          @current_resource.device == @new_resource.device
+        end
+
       end
     end
   end

--- a/spec/unit/provider/mount/windows_spec.rb
+++ b/spec/unit/provider/mount/windows_spec.rb
@@ -120,6 +120,18 @@ describe Chef::Provider::Mount::Windows do
         @provider.mount_fs
       end
 
+      context "mount_options_unchanged?" do
+        it "should return true if mounted device is the same" do
+          allow(@current_resource).to receive(:device).and_return(GUID)
+          expect(@provider.send :mount_options_unchanged?).to be true
+        end
+
+        it "should return false if mounted device has changed" do
+          allow(@current_resource).to receive(:device).and_return("XXXX")
+          expect(@provider.send :mount_options_unchanged?).to be false
+        end
+      end
+
       it "should not mount the filesystem if it is mounted and the options have not changed" do
         expect(@vol).to_not receive(:add)
         allow(@current_resource).to receive(:mounted).and_return(true)


### PR DESCRIPTION
Mounting a device was not idempotent on Windows, and would fail with an error:

    Chef::Exceptions::UnsupportedAction
    -----------------------------------
    #<Chef::Provider::Mount::Windows:0x36abe70> does not implement #mount_options_unchanged?

The options check functionality was added by this change, but missed Windows: https://github.com/chef/chef/commit/43620a7e3d663ca83bc4394a5baaf724fecf06d8

Fix is to add the missing function.

@chef/client-core @mwrock 
