### PR TITLE
remove deprecated Thread.exclusive

### DIFF
--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -22,6 +22,7 @@ require "chef/exceptions"
 class Chef
   module DSL
     module DeclareResource
+      BUILD_RESOURCE_SEMAPHORE = Mutex.new
 
       #
       # Instantiates a resource (via #build_resource), then adds it to the
@@ -88,7 +89,7 @@ class Chef
       #
       def build_resource(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
-        Thread.exclusive do
+        BUILD_RESOURCE_SEMAPHORE.synchronize do
           require "chef/resource_builder" unless defined?(Chef::ResourceBuilder)
         end
 

--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -22,7 +22,6 @@ require "chef/exceptions"
 class Chef
   module DSL
     module DeclareResource
-      BUILD_RESOURCE_SEMAPHORE = Mutex.new
 
       #
       # Instantiates a resource (via #build_resource), then adds it to the
@@ -89,9 +88,7 @@ class Chef
       #
       def build_resource(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
-        BUILD_RESOURCE_SEMAPHORE.synchronize do
-          require "chef/resource_builder" unless defined?(Chef::ResourceBuilder)
-        end
+        require "chef/resource_builder" unless defined?(Chef::ResourceBuilder)
 
         Chef::ResourceBuilder.new(
           type:                type,


### PR DESCRIPTION
currently, Chef blows up under ruby 2.3 (e.g. [this travis build](https://travis-ci.org/nathwill/chef-hekad/builds/115222568)), this fixes that

closes #4359