### PR TITLE
Warn users not to tweak Chef::Config[:file_atomic_update] setting

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -703,6 +703,9 @@ module ChefConfig
     # Use atomic updates (i.e. move operation) while updating contents
     # of the files resources. When set to false copy operation is
     # used to update files.
+    #
+    # NOTE: CHANGING THIS SETTING MAY CAUSE CORRUPTION, DATA LOSS AND
+    # INSTABILITY.
     default :file_atomic_update, true
 
     # There are 3 possible values for this configuration setting.


### PR DESCRIPTION
people are actually doing this in order to work around issues with
writing /etc/hosts in docker containers.  they should seriously
stop doing it and fix this problem in the cookbooks.