### PR TITLE
Setting init_command should be accepted instead of specific command overrides

### DIFF
--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -60,6 +60,12 @@ class Chef
             a.failure_message Chef::Exceptions::Service, "#{chkconfig_file} dbleoes not exist!"
           end
 
+          requirements.assert(:enable) do |a|
+            a.assertion { !@service_missing }
+            a.failure_message Chef::Exceptions::Service, "#{new_resource}: Service is not known to chkconfig."
+            a.whyrun "Assuming service would be disabled. The init script is not presently installed."
+          end
+
           requirements.assert(:start, :reload, :restart) do |a|
             a.assertion do
               new_resource.init_command || custom_command_for_action?(action) || !@service_missing

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -60,9 +60,9 @@ class Chef
             a.failure_message Chef::Exceptions::Service, "#{chkconfig_file} dbleoes not exist!"
           end
 
-          requirements.assert(:start, :enable, :reload, :restart) do |a|
+          requirements.assert(:start, :reload, :restart) do |a|
             a.assertion do
-              custom_command_for_action?(action) || !@service_missing
+              new_resource.init_command || custom_command_for_action?(action) || !@service_missing
             end
             a.failure_message Chef::Exceptions::Service, "#{new_resource}: No custom command for #{action} specified and unable to locate the init.d script!"
             a.whyrun "Assuming service would be disabled. The init script is not presently installed."

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -57,13 +57,13 @@ class Chef
           requirements.assert(:all_actions) do |a|
             chkconfig_file = "/sbin/chkconfig"
             a.assertion { ::File.exists? chkconfig_file  }
-            a.failure_message Chef::Exceptions::Service, "#{chkconfig_file} dbleoes not exist!"
+            a.failure_message Chef::Exceptions::Service, "#{chkconfig_file} does not exist!"
           end
 
           requirements.assert(:enable) do |a|
             a.assertion { !@service_missing }
             a.failure_message Chef::Exceptions::Service, "#{new_resource}: Service is not known to chkconfig."
-            a.whyrun "Assuming service would be disabled. The init script is not presently installed."
+            a.whyrun "Assuming service would be enabled. The init script is not presently installed."
           end
 
           requirements.assert(:start, :reload, :restart) do |a|
@@ -71,7 +71,7 @@ class Chef
               new_resource.init_command || custom_command_for_action?(action) || !@service_missing
             end
             a.failure_message Chef::Exceptions::Service, "#{new_resource}: No custom command for #{action} specified and unable to locate the init.d script!"
-            a.whyrun "Assuming service would be disabled. The init script is not presently installed."
+            a.whyrun "Assuming service would be enabled. The init script is not presently installed."
           end
         end
 

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -157,6 +157,20 @@ describe "Chef::Provider::Service::Redhat" do
           end
         end
 
+        %w{start reload restart}.each do |action|
+          it "should not raise an error when the action is #{action} and init_command is set" do
+            @new_resource.init_command("/etc/init.d/chef")
+            @provider.action = action
+            expect { @provider.process_resource_requirements }.not_to raise_error
+          end
+
+          it "should not raise an error when the action is #{action} and #{action}_command is set" do
+            @new_resource.send("#{action}_command", "/etc/init.d/chef #{action}")
+            @provider.action = action
+            expect { @provider.process_resource_requirements }.not_to raise_error
+          end
+        end
+
         %w{stop disable}.each do |action|
           it "should not raise an error when the action is #{action}" do
             @provider.action = action


### PR DESCRIPTION
Also remove `:enable` from that list because `enable_command` isn't a thing on the service resource. Not clear to me why `:enable` ever worked there.

Alternatively we could modify `custom_command_for_action?` to always return true if `init_command` is set, but that feels weirder to me.

Ping @chef/client-core @chef/client-enterprise-linux for review.