### PR TITLE
deprecate Chef::DSL::Recipe::FullDSL

### DIFF
--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -120,7 +120,7 @@ class Chef
         end
       end
 
-      # This module is deprecated and will be removed in Chef 13
+      # @deprecated Use Chef::DSL::Recipe instead, will be removed in Chef 13
       module FullDSL
         include Chef::DSL::Recipe
         extend Chef::Mixin::LazyModuleInclude

--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -23,6 +23,14 @@ require "chef/mixin/powershell_out"
 require "chef/dsl/resources"
 require "chef/dsl/definitions"
 require "chef/dsl/declare_resource"
+require "chef/dsl/data_query"
+require "chef/dsl/platform_introspection"
+require "chef/dsl/include_recipe"
+require "chef/dsl/registry_helper"
+require "chef/dsl/reboot_pending"
+require "chef/dsl/audit"
+require "chef/dsl/powershell"
+require "chef/mixin/lazy_module_include"
 require "chef/mixin/lazy_module_include"
 
 class Chef
@@ -34,6 +42,13 @@ class Chef
       include Chef::Mixin::ShellOut
       include Chef::Mixin::PowershellOut
 
+      include Chef::DSL::DataQuery
+      include Chef::DSL::PlatformIntrospection
+      include Chef::DSL::IncludeRecipe
+      include Chef::DSL::RegistryHelper
+      include Chef::DSL::RebootPending
+      include Chef::DSL::Audit
+      include Chef::DSL::Powershell
       include Chef::DSL::Resources
       include Chef::DSL::Definitions
       include Chef::DSL::DeclareResource
@@ -105,27 +120,10 @@ class Chef
         end
       end
 
+      # This module is deprecated and will be removed in Chef 13
       module FullDSL
-        require "chef/dsl/data_query"
-        require "chef/dsl/platform_introspection"
-        require "chef/dsl/include_recipe"
-        require "chef/dsl/registry_helper"
-        require "chef/dsl/reboot_pending"
-        require "chef/dsl/audit"
-        require "chef/dsl/powershell"
-        require "chef/mixin/lazy_module_include"
-
-        include Chef::DSL::DataQuery
-        include Chef::DSL::PlatformIntrospection
-        include Chef::DSL::IncludeRecipe
         include Chef::DSL::Recipe
-        include Chef::DSL::RegistryHelper
-        include Chef::DSL::RebootPending
-        include Chef::DSL::Audit
-        include Chef::DSL::Powershell
-
         extend Chef::Mixin::LazyModuleInclude
-
       end
     end
   end

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -392,7 +392,7 @@ class Chef
       end
 
       require "chef/dsl/recipe"
-      include Chef::DSL::Recipe::FullDSL
+      include Chef::DSL::Recipe
     end
 
     protected

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -35,7 +35,7 @@ class Chef
   # A Recipe object is the context in which Chef recipes are evaluated.
   class Recipe
 
-    include Chef::DSL::Recipe::FullDSL
+    include Chef::DSL::Recipe
 
     include Chef::Mixin::FromFile
     include Chef::Mixin::Deprecation

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -755,16 +755,16 @@ describe "LWRP" do
     it "lets you extend the recipe DSL" do
       expect(Chef::Recipe).to receive(:include).with(MyAwesomeDSLExensionClass)
       expect(Chef::Provider::InlineResources).to receive(:include).with(MyAwesomeDSLExensionClass)
-      Chef::DSL::Recipe::FullDSL.send(:include, MyAwesomeDSLExensionClass)
+      Chef::DSL::Recipe.send(:include, MyAwesomeDSLExensionClass)
     end
 
     it "lets you call your DSL from a recipe" do
-      Chef::DSL::Recipe::FullDSL.send(:include, MyAwesomeDSLExensionClass)
+      Chef::DSL::Recipe.send(:include, MyAwesomeDSLExensionClass)
       expect(recipe.my_awesome_dsl_extension("foo")).to eql("foo")
     end
 
     it "lets you call your DSL from a provider" do
-      Chef::DSL::Recipe::FullDSL.send(:include, MyAwesomeDSLExensionClass)
+      Chef::DSL::Recipe.send(:include, MyAwesomeDSLExensionClass)
 
       resource = MyAwesomeResource.new("name", run_context)
       run_context.resource_collection << resource


### PR DESCRIPTION
this module was created out of a bit of excessive paranoia instead of
simply adding mixins that we always use with Chef::DSL::Recipe directly
to Chef::DSL::Recipe.  lets try and YAGNI this class and just add it
directly.  these modules are already injected into everyone's recipes
and providers, so I can't imagine a huge amount of backcompat breaks.