### PR TITLE
rearrange dsl mixins

### DIFF
--- a/lib/chef/dsl/core.rb
+++ b/lib/chef/dsl/core.rb
@@ -1,0 +1,42 @@
+#--
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Christopher Walters (<cw@chef.io>)
+# Copyright:: Copyright 2008-2016, 2009-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/mixin/shell_out"
+require "chef/mixin/powershell_out"
+require "chef/dsl/declare_resource"
+
+class Chef
+  module DSL
+    # This is the "Core DSL" with various bits of Sugar that are mixed into core providers as well
+    # as user LWRPs.  This module deliberately does not mixin the Resources or Defintions DSL bits
+    # so that cookbooks are not injeting random things into the samespace of core providers.
+    #
+    # - If you are writing cookbooks:  you have come to the wrong place, please inject things into
+    #   Chef::DSL::Recipe instead.
+    #
+    # - If you are writing core chef:  you have come to the right place, please drop your DSL modules
+    #   into here.
+    #
+    module Core
+      include Chef::Mixin::ShellOut
+      include Chef::Mixin::PowershellOut
+      include Chef::DSL::DeclareResource
+    end
+  end
+end

--- a/lib/chef/dsl/method_missing.rb
+++ b/lib/chef/dsl/method_missing.rb
@@ -1,0 +1,75 @@
+#--
+# Copyright:: Copyright 2008-2016, 2009-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  module DSL
+    # @deprecated scheduled to die in a Chef 13 fire
+    module MethodMissing
+      def describe_self_for_error
+        if respond_to?(:name)
+          %Q{`#{self.class} "#{name}"'}
+        elsif respond_to?(:recipe_name)
+          %Q{`#{self.class} "#{recipe_name}"'}
+        else
+          to_s
+        end
+      end
+
+      # DEPRECATED:
+      # method_missing must live for backcompat purposes until Chef 13.
+      def method_missing(method_symbol, *args, &block)
+        #
+        # If there is already DSL for this, someone must have called
+        # method_missing manually. Not a fan. Not. A. Fan.
+        #
+        if respond_to?(method_symbol)
+          Chef.log_deprecation("Calling method_missing(#{method_symbol.inspect}) directly is deprecated in Chef 12 and will be removed in Chef 13. Use public_send() or send() instead.")
+          return send(method_symbol, *args, &block)
+        end
+
+        #
+        # If a definition exists, then Chef::DSL::Definitions.add_definition was
+        # never called.  DEPRECATED.
+        #
+        if run_context.definitions.has_key?(method_symbol.to_sym)
+          Chef.log_deprecation("Definition #{method_symbol} (#{run_context.definitions[method_symbol.to_sym]}) was added to the run_context without calling Chef::DSL::Definitions.add_definition(#{method_symbol.to_sym.inspect}).  This will become required in Chef 13.")
+          Chef::DSL::Definitions.add_definition(method_symbol)
+          return send(method_symbol, *args, &block)
+        end
+
+        #
+        # See if the resource exists anyway.  If the user had set
+        # Chef::Resource::Blah = <resource>, a deprecation warning will be
+        # emitted and the DSL method 'blah' will be added to the DSL.
+        #
+        resource_class = Chef::ResourceResolver.resolve(method_symbol, node: run_context ? run_context.node : nil)
+        if resource_class
+          Chef::DSL::Resources.add_resource_dsl(method_symbol)
+          return send(method_symbol, *args, &block)
+        end
+
+        begin
+          super
+        rescue NoMethodError
+          raise NoMethodError, "No resource or method named `#{method_symbol}' for #{describe_self_for_error}"
+        rescue NameError
+          raise NameError, "No resource, method, or local variable named `#{method_symbol}' for #{describe_self_for_error}"
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -18,11 +18,8 @@
 #
 
 require "chef/exceptions"
-require "chef/mixin/shell_out"
-require "chef/mixin/powershell_out"
 require "chef/dsl/resources"
 require "chef/dsl/definitions"
-require "chef/dsl/declare_resource"
 require "chef/dsl/data_query"
 require "chef/dsl/platform_introspection"
 require "chef/dsl/include_recipe"
@@ -30,18 +27,24 @@ require "chef/dsl/registry_helper"
 require "chef/dsl/reboot_pending"
 require "chef/dsl/audit"
 require "chef/dsl/powershell"
-require "chef/mixin/lazy_module_include"
+require "chef/dsl/core"
+require "chef/dsl/method_missing"
 require "chef/mixin/lazy_module_include"
 
 class Chef
   module DSL
-    # == Chef::DSL::Recipe
-    # Provides the primary recipe DSL functionality for defining Chef resource
-    # objects via method calls.
+    # This is the "Recipe DSL" which is all the sugar, plus all the resources and definitions
+    # which are mixed into user LWRPs/Resources/Providers.
+    #
+    # - If you are writing cookbooks:  you have come to the right place, please inject things
+    #   into here if you want to make them available to all recipe and non-core provider code.
+    #
+    # - If you are writing core chef:  you have likely come to the wrong place, please consider
+    #   dropping your DSL modules into Chef::DSL::Core instead so that we can use them in core
+    #   providers (unless they are *only* intended for recipe code).
+    #
     module Recipe
-      include Chef::Mixin::ShellOut
-      include Chef::Mixin::PowershellOut
-
+      include Chef::DSL::Core
       include Chef::DSL::DataQuery
       include Chef::DSL::PlatformIntrospection
       include Chef::DSL::IncludeRecipe
@@ -51,7 +54,8 @@ class Chef
       include Chef::DSL::Powershell
       include Chef::DSL::Resources
       include Chef::DSL::Definitions
-      include Chef::DSL::DeclareResource
+      # method_missing will disappear in Chef 13
+      include Chef::DSL::MethodMissing
       extend Chef::Mixin::LazyModuleInclude
 
       def resource_class_for(snake_case_name)
@@ -64,60 +68,8 @@ class Chef
         false
       end
 
-      def describe_self_for_error
-        if respond_to?(:name)
-          %Q{`#{self.class} "#{name}"'}
-        elsif respond_to?(:recipe_name)
-          %Q{`#{self.class} "#{recipe_name}"'}
-        else
-          to_s
-        end
-      end
-
       def exec(args)
         raise Chef::Exceptions::ResourceNotFound, "exec was called, but you probably meant to use an execute resource.  If not, please call Kernel#exec explicitly.  The exec block called was \"#{args}\""
-      end
-
-      # DEPRECATED:
-      # method_missing must live for backcompat purposes until Chef 13.
-      def method_missing(method_symbol, *args, &block)
-        #
-        # If there is already DSL for this, someone must have called
-        # method_missing manually. Not a fan. Not. A. Fan.
-        #
-        if respond_to?(method_symbol)
-          Chef.log_deprecation("Calling method_missing(#{method_symbol.inspect}) directly is deprecated in Chef 12 and will be removed in Chef 13. Use public_send() or send() instead.")
-          return send(method_symbol, *args, &block)
-        end
-
-        #
-        # If a definition exists, then Chef::DSL::Definitions.add_definition was
-        # never called.  DEPRECATED.
-        #
-        if run_context.definitions.has_key?(method_symbol.to_sym)
-          Chef.log_deprecation("Definition #{method_symbol} (#{run_context.definitions[method_symbol.to_sym]}) was added to the run_context without calling Chef::DSL::Definitions.add_definition(#{method_symbol.to_sym.inspect}).  This will become required in Chef 13.")
-          Chef::DSL::Definitions.add_definition(method_symbol)
-          return send(method_symbol, *args, &block)
-        end
-
-        #
-        # See if the resource exists anyway.  If the user had set
-        # Chef::Resource::Blah = <resource>, a deprecation warning will be
-        # emitted and the DSL method 'blah' will be added to the DSL.
-        #
-        resource_class = Chef::ResourceResolver.resolve(method_symbol, node: run_context ? run_context.node : nil)
-        if resource_class
-          Chef::DSL::Resources.add_resource_dsl(method_symbol)
-          return send(method_symbol, *args, &block)
-        end
-
-        begin
-          super
-        rescue NoMethodError
-          raise NoMethodError, "No resource or method named `#{method_symbol}' for #{describe_self_for_error}"
-        rescue NameError
-          raise NameError, "No resource, method, or local variable named `#{method_symbol}' for #{describe_self_for_error}"
-        end
       end
 
       # @deprecated Use Chef::DSL::Recipe instead, will be removed in Chef 13

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -22,8 +22,8 @@ require "chef/mixin/convert_to_class_name"
 require "chef/mixin/enforce_ownership_and_permissions"
 require "chef/mixin/why_run"
 require "chef/mixin/shell_out"
-require "chef/mixin/powershell_out"
 require "chef/mixin/provides"
+require "chef/dsl/core"
 require "chef/platform/service_helpers"
 require "chef/node_map"
 require "forwardable"
@@ -31,12 +31,12 @@ require "forwardable"
 class Chef
   class Provider
     require "chef/mixin/why_run"
-    require "chef/mixin/shell_out"
     require "chef/mixin/provides"
     include Chef::Mixin::WhyRun
-    include Chef::Mixin::ShellOut
-    include Chef::Mixin::PowershellOut
     extend Chef::Mixin::Provides
+
+    # includes the "core" DSL and not the "recipe" DSL by design
+    include Chef::DSL::Core
 
     # supports the given resource and action (late binding)
     def self.supports?(resource, action)


### PR DESCRIPTION
- creates Chef::DSL::MethodMissing which will be nuked in Chef 13
- creates Chef::DSL::Core which is the mixins into core providers
- adds build_resource/define_resource to core providers

The intent here is to create Chef::DSL::Core which is intended to
become the DSL minus method_missing and things that are only intended
for recipes.  Right now I've only added build_resource/declare_resource
to core providers.  We should probably push more into the "Core" DSL
so that core providers could do things like use the search API.

I would have moved everything other than resources and definitions over
but the audit mode stuff is really only appropriate for recipes and not
provider code and probably should not be moved over.  We should probably
have an intermediate mixin which is the "Custom Provider" DSL that has
Resources and Definitions mixed into it, but which does not mix in the
audit stuff that should only go into the Recipe DSL.

There may also be a "Resources DSL" which has mixins for use with
not_if/only_if and I'm unclear if that should be the "Core DSL" or
another fourth mixin of DSL files.