### PR TITLE
Allow any 3.x version of plist

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-zero", "~> 4.5"
 
-  s.add_dependency "plist", "~> 3.1.0"
+  s.add_dependency "plist", "~> 3.1"
 
   # Audit mode requires these, so they are non-developmental dependencies now
   %w{rspec-core rspec-expectations rspec-mocks}.each { |gem| s.add_dependency gem, "~> 3.4" }


### PR DESCRIPTION
This matches the constraint in ohai, which will make Chef and ohai use the same version.