### PR TITLE
Make example resource classes return strings for Class.to_s

### DIFF
--- a/spec/integration/recipes/resource_converge_if_changed_spec.rb
+++ b/spec/integration/recipes/resource_converge_if_changed_spec.rb
@@ -21,7 +21,7 @@ describe "Resource::ActionClass#converge_if_changed" do
     let(:resource_name) { :"converge_if_changed_dsl#{Namer.current_index}" }
     let(:resource_class) {
       result = Class.new(Chef::Resource) do
-        def self.to_s; resource_name; end
+        def self.to_s; resource_name.to_s; end
 
         def self.inspect; resource_name.inspect; end
         property :identity1, identity: true, default: "default_identity1"

--- a/spec/integration/recipes/resource_load_spec.rb
+++ b/spec/integration/recipes/resource_load_spec.rb
@@ -20,7 +20,7 @@ describe "Resource.load_current_value" do
   let(:resource_name) { :"load_current_value_dsl#{Namer.current_index}" }
   let(:resource_class) {
     result = Class.new(Chef::Resource) do
-      def self.to_s; resource_name; end
+      def self.to_s; resource_name.to_s; end
 
       def self.inspect; resource_name.inspect; end
       property :x, default: lazy { "default #{Namer.incrementing_value}" }


### PR DESCRIPTION
You only see these test failures if you run the recipe integration tests before running the provider resolver tests. I can't say why these did not start failing until recently, since there didn't seem to be any related change in the test configuration that triggered the test failures.