### PR TITLE
Adding Chef Provisioning to the maintainers file.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,6 +84,20 @@ To mention the team, use @chef/client-test-tools
 * [Lamont Granquist](https://github.com/lamont-granquist)
 * [Ranjib Dey](https://github.com/ranjib)
 
+## Chef Provisioning
+
+Chef Provisioning and Drivers.  Supported Drivers are listed in the [README](https://github.com/chef/chef-provisioning/blob/master/README.md#chef-provisioning).
+
+To mention the team, use @chef/provisioning
+
+### Lieutenant
+
+* [Tyler Ball](https://github.com/tyler-ball)
+
+### Maintainers
+
+* [John Keiser](https://github.com/jkeiser)
+
 ## Platform Specific Components
 
 The specific components of Chef related to a given platform - including (but not limited to) resources, providers, and the core DSL.

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -95,6 +95,19 @@ another component.
         "ranjib"
       ]
 
+    [Org.Components.Provisioning]
+      title = "Chef Provisioning"
+      team = "provisioning"
+      text = """
+Chef Provisioning and Drivers.  Supported Drivers are listed in the [README](https://github.com/chef/chef-provisioning/blob/master/README.md#chef-provisioning).
+"""
+
+      lieutenant = "tyler-ball"
+
+      maintainers = [
+        "jkeiser",
+      ]
+
     [Org.Components.Subsystems]
       title = "Platform Specific Components"
       text = """
@@ -375,3 +388,7 @@ The specific components of Chef related to a given platform - including (but not
   [people.tas50]
     Name = "Tim Smith"
     GitHub = "tas50"
+
+  [people.jkeiser]
+    Name = "John Keiser"
+    GitHub = "jkeiser"


### PR DESCRIPTION
We're opening [Chef Provisioning](https://github.com/chef/chef-provisioning) and its drivers up to open source maintenance, in line with other components of Chef.

I've added myself as a Lieutenant and @jkeiser as a Maintainer.  We'll go through the [election process](https://github.com/chef/chef-rfc/blob/master/rfc030-maintenance-policy.md#how-to-become-a) to find more maintainers.

I'm going to have this discussed at the next developer's meeting.  I will also start advertising this potential change so any interested maintainers can come to the developer's meeting.