### PR TITLE
We still test Chef with versions that do not include our Registry monkeypatches, so better documenting when we can remove these

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200-x64"
+    # 21-x64 is failing right now
+    #- ruby_version: "21-x64"
     - ruby_version: "21"
 
 clone_folder: c:\projects\chef

--- a/lib/chef/monkey_patches/win32/registry.rb
+++ b/lib/chef/monkey_patches/win32/registry.rb
@@ -28,25 +28,28 @@ module Win32
 
       module_function
 
-      if RUBY_VERSION =~ /^2\.1/
-        # ::Win32::Registry#delete_value is broken in Ruby 2.1 (up to Ruby 2.1.6).
-        # This should be resolved in a later release (see note #9 in link below).
-        # https://bugs.ruby-lang.org/issues/10820
-        def DeleteValue(hkey, name)
-          check RegDeleteValueW(hkey, name.to_wstring)
-        end
+      # ::Win32::Registry#delete_value uses RegDeleteValue which
+      # is not an imported function after bug 10820 was solved.  So
+      # we overwrite it to call the correct imported function.
+      # https://bugs.ruby-lang.org/issues/10820
+      # Still a bug in trunk as of March 21, 2016 (Ruby 2.3.0)
+      def DeleteValue(hkey, name)
+        check RegDeleteValueW(hkey, name.to_wstring)
       end
 
       # ::Win32::Registry#delete_key uses RegDeleteKeyW. We need to use
       # RegDeleteKeyExW to properly support WOW64 systems.
+      # Still a bug in trunk as of March 21, 2016 (Ruby 2.3.0)
       def DeleteKey(hkey, name)
         check RegDeleteKeyExW(hkey, name.to_wstring, 0, 0)
       end
 
     end
 
-    if RUBY_VERSION =~ /^2.1/
-      # ::Win32::Registry#write does not correctly handle data in Ruby 2.1 (up to Ruby 2.1.6).
+    if RUBY_VERSION =~ /^2\.1/
+      # ::Win32::Registry#write does not correctly handle data in Ruby 2.1
+      # This bug is _reportedly_ resolved in Ruby 2.1.7 and 2.2.3
+      # but fails in appveyor on 2.1.8 unless we keep applying this monkeypatch
       # https://bugs.ruby-lang.org/issues/11439
       def write(name, type, data)
         case type


### PR DESCRIPTION
\cc @randomcamel @chefsalim @btm @chef/client-windows