### PR TITLE
Pass windows architecture to kitchen provisioner

### DIFF
--- a/acceptance/.shared/kitchen_acceptance/.kitchen.ec2.yml
+++ b/acceptance/.shared/kitchen_acceptance/.kitchen.ec2.yml
@@ -201,6 +201,8 @@ platforms:
   # Windows
   #
   - name: windows-2012r2
+    provisioner:
+      architecture: <%= ENV["KITCHEN_CHEF_WIN_ARCHITECTURE"] %>
     driver:
       image_search:
         name: Windows_Server-2012-R2*-English-*-Base-*


### PR DESCRIPTION
This will allow us to force `i386` when calling from chefdk build