### PR TITLE
don't remove trailing newlines on json output

### DIFF
--- a/lib/chef/json_compat.rb
+++ b/lib/chef/json_compat.rb
@@ -114,7 +114,7 @@ class Chef
         options_map = {}
         options_map[:pretty] = true
         options_map[:indent] = opts[:indent] if opts.has_key?(:indent)
-        to_json(obj, options_map).chomp
+        to_json(obj, options_map)
       end
 
       # Map +json_class+ to a Class object. We use a +case+ instead of a Hash


### PR DESCRIPTION
permits ChefFS to produce json objects that don't make git complain