### PR TITLE
Sftp remote file support

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-yajl", "~> 2.2"
   s.add_dependency "net-ssh", ">= 2.9", "< 4.0"
   s.add_dependency "net-ssh-multi", "~> 1.1"
+  s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
   s.add_dependency "highline", "~> 1.6", ">= 1.6.9"
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"

--- a/lib/chef/provider/remote_file/fetcher.rb
+++ b/lib/chef/provider/remote_file/fetcher.rb
@@ -31,6 +31,8 @@ class Chef
               Chef::Provider::RemoteFile::HTTP.new(uri, new_resource, current_resource)
             when "ftp"
               Chef::Provider::RemoteFile::FTP.new(uri, new_resource, current_resource)
+            when "sftp"
+              Chef::Provider::RemoteFile::SFTP.net(uri, new_resource, current_resource)
             when "file"
               Chef::Provider::RemoteFile::LocalFile.new(uri, new_resource, current_resource)
             else

--- a/lib/chef/provider/remote_file/fetcher.rb
+++ b/lib/chef/provider/remote_file/fetcher.rb
@@ -32,7 +32,7 @@ class Chef
             when "ftp"
               Chef::Provider::RemoteFile::FTP.new(uri, new_resource, current_resource)
             when "sftp"
-              Chef::Provider::RemoteFile::SFTP.net(uri, new_resource, current_resource)
+              Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource)
             when "file"
               Chef::Provider::RemoteFile::LocalFile.new(uri, new_resource, current_resource)
             else

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -1,6 +1,6 @@
 #
-# Author:: Jesse Campbell (<hikeit@gmail.com>)
-# Copyright:: Copyright 2013-2016, Jesse Campbell
+# Author:: John Kerry (<john@kerryhouse.net>)
+# Copyright:: Copyright 2013-2016, John Kerry
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -77,8 +77,6 @@ class Chef
           if filename.length == 0 || filename.end_with?( "/" )
             raise ArgumentError, "no filename: #{path.inspect}"
           end
-
-          @directories, @filename = directories, filename
         end
 
         def validate_userinfo!

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -16,17 +16,16 @@
 # limitations under the License.
 #
 
-require 'uri'
-require 'tempfile'
-require 'net/sftp'
-require 'chef/provider/remote_file'
-require 'chef/file_content_management/tempfile'
+require "uri"
+require "tempfile"
+require "net/sftp"
+require "chef/provider/remote_file"
+require "chef/file_content_management/tempfile"
 
 class Chef
   class Provider
     class RemoteFile
       class SFTP
-
         attr_reader :uri
         attr_reader :new_resource
         attr_reader :current_resource
@@ -77,10 +76,10 @@ class Chef
 
         def validate_userinfo!
           if uri.userinfo
-            if !(uri.user)
+            unless uri.user
               raise ArgumentError, "no user name provided in the sftp URI"
             end
-            if !(uri.password)
+            unless uri.password
               raise ArgumentError, "no password provided in the sftp URI"
             end
           else
@@ -90,14 +89,15 @@ class Chef
 
         # Fetches using Net::FTP, returns a Tempfile with the content
         def get
-          tempfile = Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
+          tempfile =
+            Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
           sftp.download!(uri.path, tempfile.path)
           tempfile.close if tempfile
           tempfile
         end
 
         def parse_path
-          path = uri.path.sub(%r{\A/}, '%2F') # re-encode the beginning slash because uri library decodes it.
+          path = uri.path.sub(%r{\A/}, "%2F") # re-encode the beginning slash because uri library decodes it.
           directories = path.split(%r{/}, -1)
           directories.each {|d|
             d.gsub!(/%([0-9A-Fa-f][0-9A-Fa-f])/) { [$1].pack("H2") }

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Jesse Campbell (<hikeit@gmail.com>)
+# Copyright:: Copyright 2013-2016, Jesse Campbell
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'uri'
+require 'tempfile'
+require 'net/sftp'
+require 'chef/provider/remote_file'
+require 'chef/file_content_management/tempfile'
+
+class Chef
+  class Provider
+    class RemoteFile
+      class SFTP
+      end
+    end
+  end
+end

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -94,7 +94,6 @@ class Chef
           end
         end
 
-        # Fetches using Net::FTP, returns a Tempfile with the content
         def get
           tempfile =
             Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -124,6 +124,7 @@ require "chef/provider/deploy/revision"
 require "chef/provider/deploy/timestamped"
 
 require "chef/provider/remote_file/ftp"
+require "chef/provider/remote_file/sftp"
 require "chef/provider/remote_file/http"
 require "chef/provider/remote_file/local_file"
 require "chef/provider/remote_file/network_file"

--- a/spec/unit/provider/remote_file/sftp_spec.rb
+++ b/spec/unit/provider/remote_file/sftp_spec.rb
@@ -20,7 +20,24 @@ require "spec_helper"
 
 describe Chef::Provider::RemoteFile::SFTP do
   #built out dependencies
-  let(:uri) { URI.Parse("sftp://opscode.com/seattle.txt") }
+  let(:enclosing_directory) {
+    canonicalize_path(File.expand_path(File.join(CHEF_SPEC_DATA, "templates")))
+  }
+  let(:resource_path) {
+    canonicalize_path(File.expand_path(File.join(enclosing_directory, "seattle.txt")))
+  }
+
+  let(:new_resource) do
+    r = Chef::Resource::RemoteFile.new("remote file ftp backend test (new resource)")
+    r.path(resource_path)
+    r
+  end
+
+  let(:current_resource) do
+    Chef::Resource::RemoteFile.new("remote file ftp backend test (current resource)'")
+  end
+
+  let(:uri) { URI.parse("sftp://opscode.com/seattle.txt") }
 
   describe "on initialization" do
 

--- a/spec/unit/provider/remote_file/sftp_spec.rb
+++ b/spec/unit/provider/remote_file/sftp_spec.rb
@@ -37,8 +37,6 @@ describe Chef::Provider::RemoteFile::SFTP do
     Chef::Resource::RemoteFile.new("remote file sftp backend test (current resource)'")
   end
 
-
-
   let(:uri) { URI.parse("sftp://conan:cthu1hu@opscode.com/seattle.txt") }
 
   let(:sftp) do
@@ -99,7 +97,6 @@ describe Chef::Provider::RemoteFile::SFTP do
       uri.path = "/the/whole/path/"
       expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
     end
-
 
   end
 

--- a/spec/unit/provider/remote_file/sftp_spec.rb
+++ b/spec/unit/provider/remote_file/sftp_spec.rb
@@ -28,23 +28,126 @@ describe Chef::Provider::RemoteFile::SFTP do
   }
 
   let(:new_resource) do
-    r = Chef::Resource::RemoteFile.new("remote file ftp backend test (new resource)")
+    r = Chef::Resource::RemoteFile.new("remote file sftp backend test (new resource)")
     r.path(resource_path)
     r
   end
 
   let(:current_resource) do
-    Chef::Resource::RemoteFile.new("remote file ftp backend test (current resource)'")
+    Chef::Resource::RemoteFile.new("remote file sftp backend test (current resource)'")
   end
 
-  let(:uri) { URI.parse("sftp://opscode.com/seattle.txt") }
 
-  describe "on initialization" do
+
+  let(:uri) { URI.parse("sftp://conan:cthu1hu@opscode.com/seattle.txt") }
+
+  let(:sftp) do
+    sftp = double(Net::SFTP, {})
+    allow(sftp).to receive(:download!)
+    sftp
+  end
+
+  let(:tempfile_path) { "/tmp/somedir/remote-file-sftp-backend-spec-test" }
+
+  let(:tempfile) do
+    t = StringIO.new
+    allow(t).to receive(:path).and_return(tempfile_path)
+    t
+  end
+
+  before(:each) do
+    allow(Net::SFTP).to receive(:start).with(any_args).and_return(sftp)
+    allow(Tempfile).to receive(:new).and_return(tempfile)
+  end
+  describe "on initialization without user and password provided in the URI" do
+    it "throws an argument exception with no userinfo is given" do
+      uri.userinfo = nil
+      uri.password = nil
+      uri.user = nil
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+    it "throws an argument exception with no user name is given" do
+      uri.userinfo = ":cthu1hu"
+      uri.password = "cthu1hu"
+      uri.user = nil
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+    it "throws an argument exception with no password is given" do
+      uri.userinfo = "conan:"
+      uri.password = nil
+      uri.user = "conan"
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+  end
+
+  describe "on initialization with user and password provided in the URI" do
 
     it "throws an argument exception when no path is given" do
       uri.path = ""
       expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
     end
 
+    it "throws an argument exception when only a / is given" do
+      uri.path = "/"
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+    it "throws an argument exception when no filename is given" do
+      uri.path = "/the/whole/path/"
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+
+  end
+
+  describe "when fetching the object" do
+
+    let(:cache_control_data) { Chef::Provider::RemoteFile::CacheControlData.new(uri) }
+    let(:current_resource_checksum) { "e2a8938cc31754f6c067b35aab1d0d4864272e9bf8504536ef3e79ebf8432305" }
+
+    subject(:fetcher) { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }
+
+    before do
+      current_resource.checksum(current_resource_checksum)
+    end
+
+    it "should attempt to download a file from the provided url and path" do
+      expect(sftp).to receive(:download!).with("/seattle.txt", "/tmp/somedir/remote-file-sftp-backend-spec-test")
+      fetcher.fetch
+    end
+
+    context "and the URI specifies an alternate port" do
+      let(:uri) { URI.parse("ftp://conan:cthu1hu@opscode.com:8021/seattle.txt") }
+
+      it "should connect on an alternate port when one is provided" do
+        expect(Net::SFTP).to receive(:start).with("opscode.com:8021", "conan", :password => "cthu1hu")
+        fetcher.fetch
+      end
+
+    end
+
+    context "and the uri specifies a nested path" do
+      let(:uri) { URI.parse("ftp://conan:cthu1hu@opscode.com/the/whole/path/seattle.txt") }
+
+      it "should fetch the file from the correct path" do
+        expect(sftp).to receive(:download!).with("the/whole/path/seattle.txt", "/tmp/somedir/remote-file-sftp-backend-spec-test")
+        fetcher.fetch
+      end
+    end
+
+    context "when not using last modified based conditional fetching" do
+      before do
+        new_resource.use_last_modified(false)
+      end
+
+      it "should return a tempfile in the result" do
+        result = fetcher.fetch
+        expect(result).to equal(tempfile)
+      end
+
+    end
   end
 end

--- a/spec/unit/provider/remote_file/sftp_spec.rb
+++ b/spec/unit/provider/remote_file/sftp_spec.rb
@@ -1,0 +1,33 @@
+#
+# Author:: John Kerry (<john@kerryhouse.net>)
+# Copyright:: Copyright 2013-2016, John Kerry
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Provider::RemoteFile::SFTP do
+  #built out dependencies
+  let(:uri) { URI.Parse("sftp://opscode.com/seattle.txt") }
+
+  describe "on initialization" do
+
+    it "throws an argument exception when no path is given" do
+      uri.path = ""
+      expect { Chef::Provider::RemoteFile::SFTP.new(uri, new_resource, current_resource) }.to raise_error(ArgumentError)
+    end
+
+  end
+end


### PR DESCRIPTION
This is a PR to fulfill #4043 .  The sftp_provider cookbook has gotten at least one PR since creation and sftp usage is strictly required for my employer's security policy. I think there's enough community need to consider a PR into core now. Additionally the sftp_provider cookbook creates an awkward gem dependency race condition that is addressed if that dependency is delivered with the chef-client install. I structured the spec to be as similar to the ftp spec as possible where appropriate to ensure the interface is similar.

Notable gaps include:
* network proxy capability
* ssh key usage ( username and password in uri are enforced )

These might be addressable but I'm not sure at this time if they are inside the capability of the net-sftp gem.