### PR TITLE
Add shorthand :syslog and :win_evt for log_location config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,3 +36,12 @@ from Chef::Provider when mixing `use_inline_resources` into classes that only in
 class.  If any code has been written like this, it should be modified to correctly inherit from
 Chef::Provider::LWRPBase instead (which will have the side effect of fixing it so that it correctly works
 on Chef 11.0-12.5 as well).
+
+## Shorthand options for `log_location`
+
+The `log_location` setting now accepts shorthand `:syslog` and
+`:win_evt` options. `:syslog` is shorthand for `Chef::Log::Syslog.new`
+and `:win_evt` is shorthand for `Chef::Log::WinEvt.new`. All previously
+valid options are still valid, including Logger or Logger-like
+instances, e.g. `Chef::Log::Syslog.new` with other args than the
+defaults.

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -247,6 +247,33 @@ describe Chef::Application do
 
         it_behaves_like "log_level_is_auto"
       end
+
+      describe "log_location" do
+        shared_examples("sets log_location") do |config_value, expected_class|
+          context "when the configured value is #{config_value.inspect}" do
+            let(:logger_instance) { instance_double(expected_class).as_null_object }
+
+            before do
+              allow(expected_class).to receive(:new).and_return(logger_instance)
+              Chef::Config[:log_location] = config_value
+            end
+
+            it "it sets log_location to an instance of #{expected_class}" do
+              expect(expected_class).to receive(:new).with no_args
+              @app.configure_logging
+              expect(Chef::Config[:log_location]).to be logger_instance
+            end
+          end
+        end
+
+        if Chef::Platform.windows?
+          it_behaves_like "sets log_location", :win_evt, Chef::Log::WinEvt
+          it_behaves_like "sets log_location", "win_evt", Chef::Log::WinEvt
+        else
+          it_behaves_like "sets log_location", :syslog, Chef::Log::Syslog
+          it_behaves_like "sets log_location", "syslog", Chef::Log::Syslog
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Adds `:syslog` and `:win_evt` as possible values for the `log_location` option for easier configuration via node attributes.