### PR TITLE
Set inherit=false on the fallback provider constant lookup.

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -200,10 +200,10 @@ class Chef
           class_name = resource_type.class.name ? resource_type.class.name.split("::").last :
             convert_to_class_name(resource_type.resource_name.to_s)
 
-          if Chef::Provider.const_defined?(class_name)
+          if Chef::Provider.const_defined?(class_name, false)
             Chef::Log.warn("Class Chef::Provider::#{class_name} does not declare 'provides #{convert_to_snake_case(class_name).to_sym.inspect}'.")
             Chef::Log.warn("This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.")
-            return Chef::Provider.const_get(class_name)
+            return Chef::Provider.const_get(class_name, false)
           end
         end
         nil


### PR DESCRIPTION
This prevents really weirdo behavior with relative constant lookups like `Chef::Provider.const_get('Resource')` == `ChefVaultCookbook::Resource` which causes all kinds of fun.

Ruby docs tells me this param should exist on all supported rubies so probably just an oversight that we didn't do this before. We should also possibly consider restricting this fallback check to classes under `Chef::Resource` if `class.name` is set (/cc @jkeiser @lamont-granquist for that bit?). Ping @chef/client-core for review.