### PR TITLE
supresses parser gem errors

### DIFF
--- a/spec/unit/mixin/path_sanity_spec.rb
+++ b/spec/unit/mixin/path_sanity_spec.rb
@@ -57,7 +57,7 @@ describe Chef::Mixin::PathSanity do
     end
 
     it "creates path with utf-8 encoding" do
-      env = { "PATH" => "/usr/bin:/sbin:/bin:/b\x81t".force_encoding("ISO-8859-1") }
+      env = { "PATH" => "/usr/bin:/sbin:/bin:/b#{0x81.chr}t".force_encoding("ISO-8859-1") }
       @sanity.enforce_path_sanity(env)
       expect(env["PATH"].encoding.to_s).to eq("UTF-8")
     end

--- a/spec/unit/mixin/xml_escape_spec.rb
+++ b/spec/unit/mixin/xml_escape_spec.rb
@@ -49,6 +49,6 @@ describe Chef::Mixin::XMLEscape do
   end
 
   it "converts win 1252 characters correctly" do
-    expect(@escaper.xml_escape("\x80")).to eq('&#8364;')
+    expect(@escaper.xml_escape("#{0x80.chr}")).to eq('&#8364;')
   end
 end

--- a/spec/unit/util/diff_spec.rb
+++ b/spec/unit/util/diff_spec.rb
@@ -76,7 +76,7 @@ shared_examples_for "a diff util" do
 
   describe "when the old_file has binary content" do
     before do
-      old_tempfile.write("\x01\xff")
+      old_tempfile.write("#{0x01.chr}#{0xFF.chr}")
       old_tempfile.close
     end
 
@@ -91,7 +91,7 @@ shared_examples_for "a diff util" do
 
   describe "when the new_file has binary content" do
     before do
-      new_tempfile.write("\x01\xff")
+      new_tempfile.write("#{0x01.chr}#{0xFF.chr}")
       new_tempfile.close
     end
 
@@ -553,8 +553,8 @@ describe Chef::Util::Diff, :uses_diff => true do
   let(:plain_ascii) { "This is a text file.\nWith more than one line.\nAnd a \tTab.\nAnd lets make sure that other printable chars work too: ~!@\#$%^&*()`:\"<>?{}|_+,./;'[]\\-=\n" }
   # these are all byte sequences that are illegal in the other encodings... (but they may legally transcode)
   let(:utf_8) { "testing utf-8 unicode...\n\n\non a new line: \xE2\x80\x93\n" } # unicode em-dash
-  let(:latin_1) { "It is more metal.\nif you have an \xFDmlaut.\n" } # NB: changed to y-with-diaresis, but i'm American so I don't know the difference
-  let(:shift_jis) { "I have no idea what this character is:\n \x83\x80.\n" } # seriously, no clue, but \x80 is nice and illegal in other encodings
+  let(:latin_1) { "It is more metal.\nif you have an #{0xFD.chr}mlaut.\n" } # NB: changed to y-with-diaresis, but i'm American so I don't know the difference
+  let(:shift_jis) { "I have no idea what this character is:\n #{0x83.chr}#{0x80.chr}.\n" } # seriously, no clue, but \x80 is nice and illegal in other encodings
 
   let(:differ) do # subject
     differ = Chef::Util::Diff.new


### PR DESCRIPTION
see https://github.com/whitequark/parser/issues/283

if rubocop works around this bug then we can revert this patch.