### PR TITLE
Chocolatey Package Provider chomps nil object

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -256,7 +256,7 @@ EOS
         def parse_list_output(*args)
           list = []
           choco_command(*args).stdout.each_line do |line|
-            next if line.start_with?('Chocolatey v')
+            next if line.start_with?("Chocolatey v")
             name, version = line.split("|")
             list << [ name.downcase, version.chomp ]
           end

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -256,7 +256,7 @@ EOS
         def parse_list_output(*args)
           list = []
           choco_command(*args).stdout.each_line do |line|
-            next if line.start_with?('Chocolatey')
+            next if line.start_with?('Chocolatey v')
             name, version = line.split("|")
             list << [ name.downcase, version.chomp ]
           end

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -256,6 +256,7 @@ EOS
         def parse_list_output(*args)
           list = []
           choco_command(*args).stdout.each_line do |line|
+            next if line.start_with?('Chocolatey')
             name, version = line.split("|")
             list << [ name.downcase, version.chomp ]
           end

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -36,6 +36,7 @@ describe Chef::Provider::Package::Chocolatey do
   # installed packages (ConEmu is upgradable)
   let(:local_list_stdout) do
     <<-EOF
+Chocolatey v0.9.9.11
 chocolatey|0.9.9.11
 ConEmu|15.10.25.0
     EOF
@@ -50,6 +51,7 @@ ConEmu|15.10.25.0
 
   def allow_remote_list(package_names, args = nil)
     remote_list_stdout = <<-EOF
+Chocolatey v0.9.9.11
 chocolatey|0.9.9.11
 ConEmu|15.10.25.1
 Git|2.6.1


### PR DESCRIPTION
Ahoy! I am an employee at Facebook, @jaymzh will be doing the actual merging of this code for the sake of legal thingies.

I was testing the new chocolatey_package provider and found that it was throwing this error when I used it
```
Recipe: my_cookbook::install_things
  * chocolatey_package[something] action install
    ←[0m
    ================================================================================
    Error executing action `install` on resource 'chocolatey_package[something]'
    ================================================================================

    NoMethodError
    -------------
    undefined method `chomp' for nil:NilClass
```

Digging around I found that the expected output of the chocolatey command includes the program's header, which the `parse_list_output` method was not accounting for. The header line would be chomped, but because there are no `|` characters `version` would be nil, causing the error. Filtering out the header from the command output looks to fix the problem.