### PR TITLE
Update MAINTAINERS.md for Chef Provisioning

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -97,6 +97,7 @@ To mention the team, use @chef/provisioning
 ### Maintainers
 
 * [John Keiser](https://github.com/jkeiser)
+* [Stuart Preston](https://github.com/stuartpreston)
 
 ## Platform Specific Components
 


### PR DESCRIPTION
Adding Stuart Preston to the list of Chef Provisioning maintainers.