### PR TITLE
Add option to set knife ssh timeout

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -80,6 +80,12 @@ class Chef
         :description => "The ssh port",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_port] = key.strip }
 
+      option :ssh_timeout,
+        :short => "-t SECONDS",
+        :long => "--ssh-timeout SECONDS",
+        :description => "The ssh connection timeout",
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_timeout] = key.strip }
+
       option :ssh_gateway,
         :short => "-G GATEWAY",
         :long => "--ssh-gateway GATEWAY",
@@ -258,6 +264,9 @@ class Chef
           # Handle port overrides for the main connection.
           session_opts[:port] = Chef::Config[:knife][:ssh_port] if Chef::Config[:knife][:ssh_port]
           session_opts[:port] = config[:ssh_port] if config[:ssh_port]
+          # Handle connection timeout
+          session_opts[:timeout] = Chef::Config[:knife][:ssh_timeout] if Chef::Config[:knife][:ssh_timeout]
+          session_opts[:timeout] = config[:ssh_timeout] if config[:ssh_timeout]
           # Create the hostspec.
           hostspec = session_opts[:user] ? "#{session_opts.delete(:user)}@#{host}" : host
           # Connect a new session on the multi.

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -203,6 +203,23 @@ describe Chef::Knife::Ssh do
       expect(@knife.session.servers[0].port).to eq(123)
     end
 
+    it "uses the timeout from Chef Config" do
+      Chef::Config[:knife][:ssh_timeout] = 5
+      @knife.session_from_list([["the.b.org", nil]])
+      expect(@knife.session.servers[0].options[:timeout]).to eq(5)
+    end
+
+    it "uses the timeout from knife config" do
+      @knife.config[:ssh_timeout] = 6
+      @knife.session_from_list([["the.b.org", nil]])
+      expect(@knife.session.servers[0].options[:timeout]).to eq(6)
+    end
+
+    it "defaults to no timeout" do
+      @knife.session_from_list([["the.b.org", nil]])
+      expect(@knife.session.servers[0].options[:timeout]).to eq(nil)
+    end
+
     it "uses the user from an ssh config file" do
       @knife.session_from_list([["the.b.org", 123]])
       expect(@knife.session.servers[0].user).to eq("locutus")


### PR DESCRIPTION
This adds a config to 'knife ssh' to allow a connection timeout to be specified.
This will prevent knife ssh from hanging if one of the hosts is down or not reachable.

@chef/client-core @tyler-ball 