### PR TITLE
Support for uploadpack.allowReachableSHA1InWant introduced in git 2.5

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -1,5 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
+# Author:: Joshua Burt (<joshburt@shapeandshare.com>)
 # Copyright:: Copyright 2008-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -16,15 +17,15 @@
 # limitations under the License.
 #
 
-require "chef/exceptions"
-require "chef/log"
-require "chef/provider"
-require "fileutils"
+require 'chef/exceptions'
+require 'chef/log'
+require 'chef/provider'
+require 'fileutils'
 
 class Chef
   class Provider
+    # Provides an alternative git interface with some enhancements
     class Git < Chef::Provider
-
       provides :git
 
       def whyrun_supported?
@@ -34,59 +35,269 @@ class Chef
       def load_current_resource
         @resolved_reference = nil
         @current_resource = Chef::Resource::Git.new(@new_resource.name)
-        if current_revision = find_current_revision
-          @current_resource.revision current_revision
-        end
+
+        current_revision = find_current_revision
+        @current_resource.revision current_revision if current_revision
       end
 
       def define_resource_requirements
         # Parent directory of the target must exist.
         requirements.assert(:checkout, :sync) do |a|
-          dirname = ::File.dirname(@new_resource.destination)
+          dirname = ::File.dirname(cwd)
           a.assertion { ::File.directory?(dirname) }
           a.whyrun("Directory #{dirname} does not exist, this run will fail unless it has been previously created. Assuming it would have been created.")
           a.failure_message(Chef::Exceptions::MissingParentDirectory,
-            "Cannot clone #{@new_resource} to #{@new_resource.destination}, the enclosing directory #{dirname} does not exist")
+                            "Cannot clone #{@new_resource} to #{cwd}, the enclosing directory #{dirname} does not exist")
         end
 
         requirements.assert(:all_actions) do |a|
-          a.assertion { !(@new_resource.revision =~ /^origin\//) }
+          a.assertion { !(@new_resource.revision =~ %r{^origin\/}) }
           a.failure_message Chef::Exceptions::InvalidRemoteGitReference,
-             "Deploying remote branches is not supported. " +
-            "Specify the remote branch as a local branch for " +
-            "the git repository you're deploying from " +
-            "(ie: '#{@new_resource.revision.gsub('origin/', '')}' rather than '#{@new_resource.revision}')."
+                            'Deploying remote branches is not supported. ' \
+                            'Specify the remote branch as a local branch for ' \
+                            'the git repository you\'re deploying from ' \
+                            "(ie: '#{@new_resource.revision.gsub('origin/', '')}' rather than '#{@new_resource.revision}')."
         end
 
         requirements.assert(:all_actions) do |a|
           # this can't be recovered from in why-run mode, because nothing that
           # we do in the course of a run is likely to create a valid target_revision
           # if we can't resolve it up front.
-          a.assertion { target_revision != nil }
+          a.assertion { !target_revision.nil? }
           a.failure_message Chef::Exceptions::UnresolvableGitReference,
-            "Unable to parse SHA reference for '#{@new_resource.revision}' in repository '#{@new_resource.repository}'. " +
-            "Verify your (case-sensitive) repository URL and revision.\n" +
-            "`git ls-remote '#{@new_resource.repository}' '#{rev_search_pattern}'` output: #{@resolved_reference}"
+                            "Unable to parse SHA reference for '#{@new_resource.revision}' in repository '#{@new_resource.repository}'. " \
+                            "Verify your (case-sensitive) repository URL and revision.\n" \
+                            "`git ls-remote '#{@new_resource.repository}' '#{rev_search_pattern}'` output: #{@resolved_reference}"
         end
+      end
+
+      def target_revision
+        @target_revision ||= sha_hash?(@new_resource.revision) ? @new_resource.revision : remote_resolve_reference
+      end
+
+      alias revision_slug target_revision
+
+      def clone
+        converge_by("clone from #{@new_resource.repository} into #{cwd}") do
+          if @new_resource.uploadpack_allow_reachable_sha1_in_want && (git_minor_version >= Gem::Version.new('2.5.0'))
+            # Introduced in git 2.5 // uploadpack.allowReachableSHA1InWant
+            # https://github.com/git/git/blob/v2.5.0/Documentation/config.txt#L2570
+            clone_by_any_ref
+          else
+            clone_by_advertized_ref
+          end
+        end
+      end
+
+      def checkout
+        sha_ref = target_revision
+        converge_by("checkout ref #{sha_ref} branch #{@new_resource.revision}") do
+          # checkout into a local branch rather than a detached HEAD
+          run_opts = { cwd: cwd }
+          git_standard_executor(['branch', '-f', @new_resource.checkout_branch, sha_ref], run_opts)
+          git_standard_executor(['checkout', @new_resource.checkout_branch], run_opts)
+          Chef::Log.info "#{@new_resource} checked out branch: #{@new_resource.revision} onto: #{@new_resource.checkout_branch} reference: #{sha_ref}"
+        end
+      end
+
+      def enable_submodules
+        if @new_resource.enable_submodules
+          converge_by("enable git submodules for #{@new_resource}") do
+            Chef::Log.info "#{@new_resource} synchronizing git submodules"
+            run_opts = { cwd: cwd }
+            git_standard_executor(['submodule', 'sync'], run_opts)
+
+            Chef::Log.info "#{@new_resource} enabling git submodules"
+            # the --recursive flag means we require git 1.6.5+ now, see CHEF-1827
+            git_standard_executor(['submodule', 'update', '--init', '--recursive'], run_opts)
+          end
+        end
+      end
+
+      def fetch_updates
+        converge_by("fetch updates for #{@new_resource.remote}") do
+          # uploadpack.allowReachableSHA1InWant introduced in git 2.5.0
+          if @new_resource.uploadpack_allow_reachable_sha1_in_want && (git_minor_version >= Gem::Version.new('2.5.0'))
+            fetch_by_any_ref
+          else
+            setup_remote_tracking_branches(@new_resource.remote, @new_resource.repository)
+            fetch_by_advertized_ref
+          end
+        end
+      end
+
+      def find_current_revision
+        Chef::Log.debug("#{@new_resource} finding current git revision")
+        if ::File.exist?(::File.join(cwd, '.git'))
+          # 128 is returned when we're not in a git repo. this is fine
+          run_opts = { cwd: cwd, returns: [0, 128] }
+          rev_parse_result = git_standard_executor(['rev-parse', 'HEAD'], run_opts)
+          rev = rev_parse_result.stdout.strip
+        end
+        sha_hash?(rev) ? rev : nil
+      end
+
+      def setup_remote_tracking_branches(remote_name, remote_url)
+        converge_by("set up remote tracking branches for #{remote_url} at #{remote_name}") do
+          Chef::Log.debug "#{@new_resource} configuring remote tracking branches for repository #{remote_url} at remote #{remote_name}"
+          run_opts = { cwd: cwd, returns: [0, 1, 2] }
+          remote_status = git_standard_executor(['config', '--get', "remote.#{remote_name}.url"], run_opts)
+
+          run_opts = { cwd: cwd }
+          case remote_status.exitstatus
+          when 0, 2
+            # * Status 0 means that we already have a remote with this name, so we should update the url
+            #   if it doesn't match the url we want.
+            # * Status 2 means that we have multiple urls assigned to the same remote (not a good idea)
+            #   which we can fix by replacing them all with our target url (hence the --replace-all option)
+
+            if multiple_remotes?(remote_status) || !remote_matches?(remote_url, remote_status)
+              git_standard_executor(['config', '--replace-all', "remote.#{remote_name}.url", remote_url], run_opts)
+            end
+          when 1
+            git_standard_executor(['remote', 'add', remote_name, remote_url], run_opts)
+          end
+        end
+      end
+
+      def add_remotes
+        unless @new_resource.additional_remotes.empty?
+          @new_resource.additional_remotes.each_pair do |remote_name, remote_url|
+            converge_by("add remote #{remote_name} from #{remote_url}") do
+              Chef::Log.info "#{@new_resource} adding git remote #{remote_name} = #{remote_url}"
+              setup_remote_tracking_branches(remote_name, remote_url)
+            end
+          end
+        end
+      end
+
+      def multiple_remotes?(check_remote_command_result)
+        check_remote_command_result.exitstatus == 2
+      end
+
+      def remote_matches?(remote_url, check_remote_command_result)
+        check_remote_command_result.stdout.strip.eql?(remote_url)
+      end
+
+      private
+
+      def run_options(run_opts = {})
+        run_opts[:group] = @new_resource.group if @new_resource.group
+        run_opts[:log_tag] = @new_resource.to_s
+        run_opts[:timeout] = @new_resource.timeout if @new_resource.timeout
+        run_opts[:user] = @new_resource.user if @new_resource.user
+        run_env = run_options_env
+        run_opts[:environment] = run_env unless run_env.empty?
+        run_opts
+      end
+
+      def run_options_env
+        env = {}
+        env_home = process_executor_home
+        env['HOME'] = env_home unless env_home.nil?
+        env['GIT_SSH'] = @new_resource.ssh_wrapper if @new_resource.ssh_wrapper
+        env.merge!(@new_resource.environment) if @new_resource.environment
+        env
+      end
+
+      def process_executor_home
+        env_home = nil
+        if @new_resource.user
+          # Certain versions of `git` misbehave if git configuration is
+          # inaccessible in $HOME. We need to ensure $HOME matches the
+          # user who is executing `git` not the user running Chef.
+          env_home = begin
+            require 'etc'
+            Etc.getpwnam(@new_resource.user).dir
+          rescue ArgumentError # user not found
+            raise Chef::Exceptions::User, "Could not determine HOME for specified user '#{@new_resource.user}' for resource '#{@new_resource.name}'"
+          end
+        end
+        env_home
+      end
+
+      def cwd
+        @new_resource.destination
+      end
+
+      def git(*args)
+        ['git', *args].compact.join(' ')
+      end
+
+      def git_standard_executor(args, run_opts = {})
+        git_command = git(args)
+        Chef::Log.debug "> #{git_command}"
+        shell_out!(git_command, run_options(run_opts))
+      end
+
+      def sha_hash?(string)
+        string =~ /^[0-9a-f]{40}$/
+      end
+
+      def refs_search(refs, pattern)
+        refs.find_all { |m| m[1] == pattern }
+      end
+
+      def git_ls_remote(rev_pattern)
+        stdout_obj = git_standard_executor ['ls-remote', "\"#{@new_resource.repository}\"", "\"#{rev_pattern}\""]
+        stdout_obj.stdout
+      end
+
+      def rev_search_pattern
+        if ['', 'HEAD'].include? @new_resource.revision
+          'HEAD'
+        else
+          @new_resource.revision + '*'
+        end
+      end
+
+      def rev_match_pattern(prefix, revision)
+        revision.start_with?(prefix) ? revision : prefix + revision
+      end
+
+      def find_revision(refs, revision, suffix = '')
+        found = refs_search(refs, rev_match_pattern('refs/tags/', revision) + suffix)
+        found = refs_search(refs, rev_match_pattern('refs/heads/', revision) + suffix) if found.empty?
+        found = refs_search(refs, revision + suffix) if found.empty?
+        found
+      end
+
+      def remote_resolve_reference
+        Chef::Log.debug("#{@new_resource} resolving remote reference")
+        # The sha pointed to by an annotated tag is identified by the
+        # '^{}' suffix appended to the tag. In order to resolve
+        # annotated tags, we have to search for "revision*" and
+        # post-process. Special handling for 'HEAD' to ignore a tag
+        # named 'HEAD'.
+        @resolved_reference = git_ls_remote(rev_search_pattern)
+        refs = @resolved_reference.split("\n").map { |line| line.split("\t") }
+        # First try for ^{} indicating the commit pointed to by an
+        # annotated tag.
+        # It is possible for a user to create a tag named 'HEAD'.
+        # Using such a degenerate annotated tag would be very
+        # confusing. We avoid the issue by disallowing the use of
+        # annotated tags named 'HEAD'.
+
+        found = rev_search_pattern != 'HEAD' ? find_revision(refs, @new_resource.revision, '^{}') : refs_search(refs, 'HEAD')
+        found = find_revision(refs, @new_resource.revision) if found.empty?
+        found.size == 1 ? found.first[0] : nil
       end
 
       def action_checkout
         if target_dir_non_existent_or_empty?
           clone
-          if @new_resource.enable_checkout
-            checkout
-          end
+          checkout if @new_resource.enable_checkout
           enable_submodules
           add_remotes
         else
-          Chef::Log.debug "#{@new_resource} checkout destination #{@new_resource.destination} already exists or is a non-empty directory"
+          Chef::Log.debug "#{@new_resource} checkout destination #{cwd} already exists or is a non-empty directory"
         end
       end
 
       def action_export
         action_checkout
-        converge_by("complete the export by removing #{@new_resource.destination}.git after checkout") do
-          FileUtils.rm_rf(::File.join(@new_resource.destination, ".git"))
+        converge_by("complete the export by removing #{cwd}.git after checkout") do
+          FileUtils.rm_rf(::File.join(cwd, '.git'))
         end
       end
 
@@ -105,228 +316,96 @@ class Chef
       end
 
       def git_minor_version
-        @git_minor_version ||= Gem::Version.new(shell_out!("git --version", run_options).stdout.split.last)
+        git_result = git_standard_executor ['--version']
+        @git_minor_version ||= Gem::Version.new(git_result.stdout.split.last)
       end
 
       def existing_git_clone?
-        ::File.exist?(::File.join(@new_resource.destination, ".git"))
+        ::File.exist?(::File.join(cwd, '.git'))
       end
 
       def target_dir_non_existent_or_empty?
-        !::File.exist?(@new_resource.destination) || Dir.entries(@new_resource.destination).sort == [".", ".."]
+        !::File.exist?(cwd) || Dir.entries(cwd).sort == ['.', '..']
       end
 
-      def find_current_revision
-        Chef::Log.debug("#{@new_resource} finding current git revision")
-        if ::File.exist?(::File.join(cwd, ".git"))
-          # 128 is returned when we're not in a git repo. this is fine
-          result = shell_out!("git rev-parse HEAD", :cwd => cwd, :returns => [0, 128]).stdout.strip
-        end
-        sha_hash?(result) ? result : nil
+      def clone_by_any_ref
+        Chef::Log.info "#{@new_resource} cloning [shallow] repo #{@new_resource.repository} to #{cwd}"
+
+        # build out the empty base
+        build_lightweight_clone_base
+
+        standard_args = build_standard_clone_args
+        # build our light weight fetch command
+        fetch_args = [@new_resource.revision]
+        fetch_args << standard_args unless standard_args.empty?
+        fetch_args << '--no-tags'
+        git_fetch('origin', fetch_args)
       end
 
-      def add_remotes
-        if @new_resource.additional_remotes.length > 0
-          @new_resource.additional_remotes.each_pair do |remote_name, remote_url|
-            converge_by("add remote #{remote_name} from #{remote_url}") do
-              Chef::Log.info "#{@new_resource} adding git remote #{remote_name} = #{remote_url}"
-              setup_remote_tracking_branches(remote_name, remote_url)
-            end
-          end
-        end
+      def build_lightweight_clone_base
+        # Creates a light weight local git repository
+        clone_init_cmd = ['init', "\"#{cwd}\""]
+        git_standard_executor clone_init_cmd
+        setup_remote_tracking_branches('origin', @new_resource.repository)
       end
 
-      def clone
-        converge_by("clone from #{@new_resource.repository} into #{@new_resource.destination}") do
-          remote = @new_resource.remote
+      def clone_by_advertized_ref
+        git_clone_by_advertized_ref_cmd = ['clone']
+        git_clone_by_advertized_ref_cmd << build_standard_clone_args
+        git_clone_by_advertized_ref_cmd << '--no-single-branch' if @new_resource.depth && (git_minor_version >= Gem::Version.new('1.7.10'))
+        git_clone_by_advertized_ref_cmd << "\"#{@new_resource.repository}\""
+        git_clone_by_advertized_ref_cmd << "\"#{@new_resource.destination}\""
 
-          args = []
-          args << "-o #{remote}" unless remote == "origin"
-          args << "--depth #{@new_resource.depth}" if @new_resource.depth
-          args << "--no-single-branch" if @new_resource.depth && git_minor_version >= Gem::Version.new("1.7.10")
-
-          Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
-
-          clone_cmd = "git clone #{args.join(' ')} \"#{@new_resource.repository}\" \"#{@new_resource.destination}\""
-          shell_out!(clone_cmd, run_options)
-        end
+        Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
+        git_standard_executor git_clone_by_advertized_ref_cmd
       end
 
-      def checkout
-        sha_ref = target_revision
-
-        converge_by("checkout ref #{sha_ref} branch #{@new_resource.revision}") do
-          # checkout into a local branch rather than a detached HEAD
-          shell_out!("git branch -f #{@new_resource.checkout_branch} #{sha_ref}", run_options(:cwd => @new_resource.destination))
-          shell_out!("git checkout #{@new_resource.checkout_branch}", run_options(:cwd => @new_resource.destination))
-          Chef::Log.info "#{@new_resource} checked out branch: #{@new_resource.revision} onto: #{@new_resource.checkout_branch} reference: #{sha_ref}"
-        end
+      def build_standard_clone_args
+        remote = @new_resource.remote
+        args = []
+        args << "-o #{remote}" unless remote == 'origin'
+        args << "--depth #{@new_resource.depth}" if @new_resource.depth
+        args
       end
 
-      def enable_submodules
-        if @new_resource.enable_submodules
-          converge_by("enable git submodules for #{@new_resource}") do
-            Chef::Log.info "#{@new_resource} synchronizing git submodules"
-            command = "git submodule sync"
-            shell_out!(command, run_options(:cwd => @new_resource.destination))
-            Chef::Log.info "#{@new_resource} enabling git submodules"
-            # the --recursive flag means we require git 1.6.5+ now, see CHEF-1827
-            command = "git submodule update --init --recursive"
-            shell_out!(command, run_options(:cwd => @new_resource.destination))
-          end
-        end
+      def fetch_by_any_ref
+        Chef::Log.info "Fetching [shallow] updates from #{new_resource.remote} and resetting to revision #{target_revision}"
+        fetch_args = [target_revision]
+        fetch_args << "--depth #{@new_resource.depth}" if @new_resource.depth
+        git_fetch('origin', fetch_args)
+        git_reset_hard
       end
 
-      def fetch_updates
-        setup_remote_tracking_branches(@new_resource.remote, @new_resource.repository)
-        converge_by("fetch updates for #{@new_resource.remote}") do
-          # since we're in a local branch already, just reset to specified revision rather than merge
-          fetch_command = "git fetch #{@new_resource.remote} && git fetch #{@new_resource.remote} --tags && git reset --hard #{target_revision}"
-          Chef::Log.debug "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
-          shell_out!(fetch_command, run_options(:cwd => @new_resource.destination))
-        end
+      def fetch_by_advertized_ref
+        # since we're in a local branch already, just reset to specified revision rather than merge
+        Chef::Log.info "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
+
+        fetch_args = ['--tags']
+        fetch_args << "--depth #{@new_resource.depth}" if @new_resource.depth
+
+        git_fetch(@new_resource.remote, fetch_args)
+        git_reset_hard
       end
 
-      def setup_remote_tracking_branches(remote_name, remote_url)
-        converge_by("set up remote tracking branches for #{remote_url} at #{remote_name}") do
-          Chef::Log.debug "#{@new_resource} configuring remote tracking branches for repository #{remote_url} " + "at remote #{remote_name}"
-          check_remote_command = "git config --get remote.#{remote_name}.url"
-          remote_status = shell_out!(check_remote_command, run_options(:cwd => @new_resource.destination, :returns => [0, 1, 2]))
-          case remote_status.exitstatus
-          when 0, 2
-            # * Status 0 means that we already have a remote with this name, so we should update the url
-            #   if it doesn't match the url we want.
-            # * Status 2 means that we have multiple urls assigned to the same remote (not a good idea)
-            #   which we can fix by replacing them all with our target url (hence the --replace-all option)
-
-            if multiple_remotes?(remote_status) || !remote_matches?(remote_url, remote_status)
-              update_remote_url_command = "git config --replace-all remote.#{remote_name}.url #{remote_url}"
-              shell_out!(update_remote_url_command, run_options(:cwd => @new_resource.destination))
-            end
-          when 1
-            add_remote_command = "git remote add #{remote_name} #{remote_url}"
-            shell_out!(add_remote_command, run_options(:cwd => @new_resource.destination))
-          end
-        end
+      def git_fetch(fetch_source, args = [])
+        git_fetch_command = ['fetch', fetch_source]
+        git_fetch_command << args unless args.empty?
+        run_opts = { cwd: cwd, returns: [0, 1, 128] }
+        git_standard_executor(git_fetch_command, run_opts)
       end
 
-      def multiple_remotes?(check_remote_command_result)
-        check_remote_command_result.exitstatus == 2
-      end
-
-      def remote_matches?(remote_url, check_remote_command_result)
-        check_remote_command_result.stdout.strip.eql?(remote_url)
+      def git_reset_hard(args = [])
+        git_reset_command = ['reset']
+        git_reset_command << args unless args.empty?
+        git_reset_command << '--hard'
+        git_reset_command << target_revision
+        run_opts = { cwd: cwd }
+        git_standard_executor(git_reset_command, run_opts)
       end
 
       def current_revision_matches_target_revision?
-        (!@current_resource.revision.nil?) && (target_revision.strip.to_i(16) == @current_resource.revision.strip.to_i(16))
+        !@current_resource.revision.nil? && (target_revision.strip.to_i(16) == @current_resource.revision.strip.to_i(16))
       end
-
-      def target_revision
-        @target_revision ||= begin
-          if sha_hash?(@new_resource.revision)
-            @target_revision = @new_resource.revision
-          else
-            @target_revision = remote_resolve_reference
-          end
-        end
-      end
-
-      alias :revision_slug :target_revision
-
-      def remote_resolve_reference
-        Chef::Log.debug("#{@new_resource} resolving remote reference")
-        # The sha pointed to by an annotated tag is identified by the
-        # '^{}' suffix appended to the tag. In order to resolve
-        # annotated tags, we have to search for "revision*" and
-        # post-process. Special handling for 'HEAD' to ignore a tag
-        # named 'HEAD'.
-        @resolved_reference = git_ls_remote(rev_search_pattern)
-        refs = @resolved_reference.split("\n").map { |line| line.split("\t") }
-        # First try for ^{} indicating the commit pointed to by an
-        # annotated tag.
-        # It is possible for a user to create a tag named 'HEAD'.
-        # Using such a degenerate annotated tag would be very
-        # confusing. We avoid the issue by disallowing the use of
-        # annotated tags named 'HEAD'.
-        if rev_search_pattern != "HEAD"
-          found = find_revision(refs, @new_resource.revision, "^{}")
-        else
-          found = refs_search(refs, "HEAD")
-        end
-        found = find_revision(refs, @new_resource.revision) if found.empty?
-        found.size == 1 ? found.first[0] : nil
-      end
-
-      def find_revision(refs, revision, suffix = "")
-        found = refs_search(refs, rev_match_pattern("refs/tags/", revision) + suffix)
-        found = refs_search(refs, rev_match_pattern("refs/heads/", revision) + suffix) if found.empty?
-        found = refs_search(refs, revision + suffix) if found.empty?
-        found
-      end
-
-      def rev_match_pattern(prefix, revision)
-        if revision.start_with?(prefix)
-          revision
-        else
-          prefix + revision
-        end
-      end
-
-      def rev_search_pattern
-        if ["", "HEAD"].include? @new_resource.revision
-          "HEAD"
-        else
-          @new_resource.revision + "*"
-        end
-      end
-
-      def git_ls_remote(rev_pattern)
-        command = git(%Q{ls-remote "#{@new_resource.repository}" "#{rev_pattern}"})
-        shell_out!(command, run_options).stdout
-      end
-
-      def refs_search(refs, pattern)
-        refs.find_all { |m| m[1] == pattern }
-      end
-
-      private
-
-      def run_options(run_opts = {})
-        env = {}
-        if @new_resource.user
-          run_opts[:user] = @new_resource.user
-          # Certain versions of `git` misbehave if git configuration is
-          # inaccessible in $HOME. We need to ensure $HOME matches the
-          # user who is executing `git` not the user running Chef.
-          env["HOME"] = begin
-            require "etc"
-            Etc.getpwnam(@new_resource.user).dir
-          rescue ArgumentError # user not found
-            raise Chef::Exceptions::User, "Could not determine HOME for specified user '#{@new_resource.user}' for resource '#{@new_resource.name}'"
-          end
-        end
-        run_opts[:group] = @new_resource.group if @new_resource.group
-        env["GIT_SSH"] = @new_resource.ssh_wrapper if @new_resource.ssh_wrapper
-        run_opts[:log_tag] = @new_resource.to_s
-        run_opts[:timeout] = @new_resource.timeout if @new_resource.timeout
-        env.merge!(@new_resource.environment) if @new_resource.environment
-        run_opts[:environment] = env unless env.empty?
-        run_opts
-      end
-
-      def cwd
-        @new_resource.destination
-      end
-
-      def git(*args)
-        ["git", *args].compact.join(" ")
-      end
-
-      def sha_hash?(string)
-        string =~ /^[0-9a-f]{40}$/
-      end
-
     end
   end
 end

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -1,5 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
+# Author:: Joshua Burt (<joshburt@shapeandshare.com>)
 # Copyright:: Copyright 2008-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -16,29 +17,43 @@
 # limitations under the License.
 #
 
-require "chef/resource/scm"
+require 'chef/resource/scm'
 
 class Chef
   class Resource
+    # Implementations a git interact for us
     class Git < Chef::Resource::Scm
+      provides :git
 
       def initialize(name, run_context = nil)
         super
+        @resource_name = :git
         @additional_remotes = Hash[]
+        @uploadpack_allow_reachable_sha1_in_want = false
       end
 
       def additional_remotes(arg = nil)
         set_or_return(
           :additional_remotes,
           arg,
-          :kind_of => Hash
+          kind_of: Hash
         )
       end
 
-      alias :branch :revision
-      alias :reference :revision
+      # Introduced in git 2.5 // uploadpack.allowReachableSHA1InWant
+      # https://github.com/git/git/blob/v2.5.0/Documentation/config.txt#L2570
+      def uploadpack_allow_reachable_sha1_in_want(arg = nil)
+        set_or_return(
+          :uploadpack_allow_reachable_sha1_in_want,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-      alias :repo :repository
+      alias branch revision
+      alias reference revision
+
+      alias repo repository
     end
   end
 end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Provider::Git do
     it "determines the current revision when there is one" do
       expect(::File).to receive(:exist?).with("/my/deploy/dir/.git").and_return(true)
       @stdout = "9b4d8dc38dd471246e7cfb1c3c1ad14b0f2bee13\n"
-      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", { :cwd => "/my/deploy/dir", :returns => [0, 128] }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", { :cwd => "/my/deploy/dir", :returns => [0, 128], :log_tag=>"git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.find_current_revision).to eql("9b4d8dc38dd471246e7cfb1c3c1ad14b0f2bee13")
     end
 
@@ -66,7 +66,7 @@ describe Chef::Provider::Git do
       expect(::File).to receive(:exist?).with("/my/deploy/dir/.git").and_return(true)
       @stderr = "fatal: Not a git repository (or any of the parent directories): .git"
       @stdout = ""
-      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", :cwd => "/my/deploy/dir", :returns => [0, 128]).and_return(double("ShellOut result", :stdout => "", :stderr => @stderr))
+      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", :cwd => "/my/deploy/dir", :returns => [0, 128], :log_tag=>"git[web2.0 app]").and_return(double("ShellOut result", :stdout => "", :stderr => @stderr))
       expect(@provider.find_current_revision).to be_nil
     end
   end
@@ -274,9 +274,10 @@ SHAS
     @resource.ssh_wrapper "do_it_this_way.sh"
     expected_cmd = "git clone  \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     expect(@provider).to receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
-                                                                 :environment => { "GIT_SSH" => "do_it_this_way.sh",
-                                                                                   "HOME" => "/home/deployNinja" },
-                                                                 :log_tag => "git[web2.0 app]")
+                                                                 :log_tag => "git[web2.0 app]",
+                                                                 :environment => { "HOME" => "/home/deployNinja",
+                                                                                   "GIT_SSH" => "do_it_this_way.sh" }
+                                                                 )
     @provider.clone
   end
 
@@ -334,8 +335,10 @@ SHAS
 
   it "runs a sync command with default options" do
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    expected1_cmd = "git fetch origin --tags"
+    expected2_cmd = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(expected1_cmd, :cwd => "/my/deploy/dir", :returns => [0, 1, 128], :log_tag => "git[web2.0 app]")
+    expect(@provider).to receive(:shell_out!).with(expected2_cmd, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
@@ -344,27 +347,38 @@ SHAS
     allow(Etc).to receive(:getpwnam).and_return(double("Struct::Passwd", :name => @resource.user, :dir => "/home/whois"))
     @resource.group("thisis")
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir",
-                                                                 :user => "whois", :group => "thisis",
-                                                                 :log_tag => "git[web2.0 app]",
-                                                                 :environment => { "HOME" => "/home/whois" })
+    expected1_cmd = "git fetch origin --tags"
+    expected2_cmd = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(expected1_cmd, :cwd => "/my/deploy/dir",
+                                                   :returns => [0, 1, 128],
+                                                   :user => "whois",
+                                                   :group => "thisis",
+                                                   :log_tag => "git[web2.0 app]",
+                                                   :environment => { "HOME" => "/home/whois" })
+    expect(@provider).to receive(:shell_out!).with(expected2_cmd, :cwd => "/my/deploy/dir",
+                                                   :user => "whois", :group => "thisis",
+                                                   :log_tag => "git[web2.0 app]",
+                                                   :environment => { "HOME" => "/home/whois" })
     @provider.fetch_updates
   end
 
   it "configures remote tracking branches when remote is ``origin''" do
     @resource.remote "origin"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch1_command = "git fetch origin --tags"
+    fetch2_command = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(fetch1_command, :cwd => "/my/deploy/dir", :returns => [0, 1, 128], :log_tag => "git[web2.0 app]")
+    expect(@provider).to receive(:shell_out!).with(fetch2_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
   it "configures remote tracking branches when remote is not ``origin''" do
     @resource.remote "opscode"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command = "git fetch opscode && git fetch opscode --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch1_command = "git fetch opscode --tags"
+    fetch2_command = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(fetch1_command, :cwd => "/my/deploy/dir", :returns => [0, 1, 128], :log_tag => "git[web2.0 app]")
+    expect(@provider).to receive(:shell_out!).with(fetch2_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 


### PR DESCRIPTION
Hello!  
We're introducing some deployments that leverage a new git feature added in version 2.5: uploadpack.allowReachableSHA1InWant, https://github.com/git/git/blob/v2.5.0/Documentation/config.txt#L2570

Summary
-----------------------------------------------------------
In order to accomplish this I've updated the git HWRP.  I thought you might enjoy the additional feature, bug fixes, and polish that was done along the way.

To ease review and management of the changes I've split all the work into several pull requests.  This first one adds a number of linting improvements to the current code base as well as uploadpack.allowReachableSHA1InWant support.

The remaining fixes are based off this PR and cover:
CHEF-3929 https://github.com/chef/chef/issues/3929
CHEF-4126 https://github.com/chef/chef/issues/4126
Once this PR is merged the other two can be submitted.


High Level Changes
----------------------------------------------------

1. Consolidated usage of shell_out
2. Consolidated git command building code
3. rubocop linting offenses are way down!
4. lots of methods moved to private that don't appear to have a need to be public
5. Unit tests updated
6. Added ability to fetch by any ref (if supported) introduced in git 2.5

Areas of Discussion
-----------------------------------------------------------

- Cooler attribute name than "uploadpack_allow_reachable_sha1_in_want"
- Linting issues encountered by your build/ci system (if any)
- whyrun support was not updated




I'd love some help with validation, feedback, etc.  Thanks!
Josh

