### PR TITLE
Revert PR #1796: make mount resource options-ignorant again.

### DIFF
--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -42,17 +42,13 @@ class Chef
       end
 
       def action_mount
-        if current_resource.mounted
-          if mount_options_unchanged?
-            Chef::Log.debug("#{new_resource} is already mounted")
-          else
-            action_remount
-          end
-        else
+        unless current_resource.mounted
           converge_by("mount #{current_resource.device} to #{current_resource.mount_point}") do
             mount_fs
             Chef::Log.info("#{new_resource} mounted")
           end
+        else
+          Chef::Log.debug("#{new_resource} is already mounted")
         end
       end
 

--- a/spec/unit/provider/mount/aix_spec.rb
+++ b/spec/unit/provider/mount/aix_spec.rb
@@ -126,10 +126,9 @@ ENABLED
       @provider.run_action(:mount)
     end
 
-    it "should not mount resource if it is already mounted and the options have not changed" do
+    it "should not mount resource if it is already mounted" do
       stub_mounted_enabled(@provider, @mounted_output, "")
 
-      allow(@provider).to receive(:mount_options_unchanged?).and_return(true)
       expect(@provider).not_to receive(:mount_fs)
 
       @provider.run_action(:mount)

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -323,12 +323,6 @@ describe Chef::Provider::Mount::Mount do
         @provider.mount_fs()
       end
 
-      it "should not mount the filesystem if it is mounted and the options have not changed" do
-        allow(@current_resource).to receive(:mounted).and_return(true)
-        expect(@provider).to_not receive(:shell_out!)
-        @provider.mount_fs()
-      end
-
     end
 
     describe "umount_fs" do

--- a/spec/unit/provider/mount/windows_spec.rb
+++ b/spec/unit/provider/mount/windows_spec.rb
@@ -112,14 +112,6 @@ describe Chef::Provider::Mount::Windows do
         @provider.mount_fs
       end
 
-      it "should remount the filesystem if it is mounted and the options have changed" do
-        expect(@vol).to receive(:add).with(:remote => @new_resource.device,
-                                           :username => @new_resource.username,
-                                           :domainname => @new_resource.domain,
-                                           :password => @new_resource.password)
-        @provider.mount_fs
-      end
-
       context "mount_options_unchanged?" do
         it "should return true if mounted device is the same" do
           allow(@current_resource).to receive(:device).and_return(GUID)
@@ -130,12 +122,6 @@ describe Chef::Provider::Mount::Windows do
           allow(@current_resource).to receive(:device).and_return("XXXX")
           expect(@provider.send :mount_options_unchanged?).to be false
         end
-      end
-
-      it "should not mount the filesystem if it is mounted and the options have not changed" do
-        expect(@vol).to_not receive(:add)
-        allow(@current_resource).to receive(:mounted).and_return(true)
-        @provider.mount_fs
       end
     end
 

--- a/spec/unit/provider/mount_spec.rb
+++ b/spec/unit/provider/mount_spec.rb
@@ -60,25 +60,6 @@ describe Chef::Provider::Mount do
       provider.run_action(:mount)
       expect(new_resource).to be_updated_by_last_action
     end
-
-    it "should remount the filesystem if it is mounted and the options have changed" do
-      allow(current_resource).to receive(:mounted).and_return(true)
-      allow(provider).to receive(:mount_options_unchanged?).and_return(false)
-      expect(provider).to receive(:umount_fs).and_return(true)
-      expect(provider).to receive(:wait_until_unmounted)
-      expect(provider).to receive(:mount_fs).and_return(true)
-      provider.run_action(:mount)
-      expect(new_resource).to be_updated_by_last_action
-    end
-
-    it "should not mount the filesystem if it is mounted and the options have not changed" do
-      allow(current_resource).to receive(:mounted).and_return(true)
-      expect(provider).to receive(:mount_options_unchanged?).and_return(true)
-      expect(provider).not_to receive(:mount_fs)
-      provider.run_action(:mount)
-      expect(new_resource).not_to be_updated_by_last_action
-    end
-
   end
 
   describe "when the target state is an unmounted filesystem" do


### PR DESCRIPTION
Closes issue #4056, although as discussed in that issue, we still need followup design and
implementation work to make the mount resource behave in a safe and unsurprising way.