### PR TITLE
Spec break on Windows due to temp dir and short path names

### DIFF
--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -84,6 +84,28 @@ def canonicalize_path(path)
   windows? ? path.tr("/", '\\') : path
 end
 
+# Makes a temp directory with a canonical path on any platform.
+# Only really needed to work around an issue on Windows where
+# Ruby's temp library generates paths with short names.
+def make_canonical_temp_directory
+  temp_directory = Dir.mktmpdir
+  if windows?
+    # On Windows, temporary file / directory path names may have shortened
+    # subdirectory names due to reliance on the TMP and TEMP environment variables
+    # in some Windows APIs and duplicated logic in Ruby's temp file implementation.
+    # To work around this in the unit test context, we obtain the long (canonical)
+    # path name via a Windows system call so that this path name can be used
+    # in expectations that assume the ability to canonically name paths in comparisons.
+    # Note that this was not an issue prior to Ruby 2.2 -- with Ruby 2.2,
+    # some Chef code started to use long file names, while Ruby's temp file implementation
+    # continued to return the shortened names -- this would cause these particular tests to
+    # fail if the username happened to be longer than 8 characters.
+    Chef::ReservedNames::Win32::File.get_long_path_name(temp_directory)
+  else
+    temp_directory
+  end
+end
+
 # Check if a cmd exists on the PATH
 def which(cmd)
   paths = ENV["PATH"].split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]

--- a/spec/unit/knife/data_bag_from_file_spec.rb
+++ b/spec/unit/knife/data_bag_from_file_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Knife::DataBagFromFile do
     k
   end
 
-  let(:tmp_dir) { Dir.mktmpdir }
+  let(:tmp_dir) { make_canonical_temp_directory }
   let(:db_folder) { File.join(tmp_dir, data_bags_path, bag_name) }
   let(:db_file) { Tempfile.new(["data_bag_from_file_test", ".json"], db_folder) }
   let(:db_file2) { Tempfile.new(["data_bag_from_file_test2", ".json"], db_folder) }

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -106,7 +106,7 @@ describe Chef::Provider::RemoteDirectory do
       @node.automatic_attrs[:platform] = :just_testing
       @node.automatic_attrs[:platform_version] = :just_testing
 
-      @destination_dir = Dir.mktmpdir << "/remote_directory_test"
+      @destination_dir = make_canonical_temp_directory << "/remote_directory_test"
       @resource.path(@destination_dir)
     end
 


### PR DESCRIPTION
This issue only surfaces on Windows with Ruby 2.2 only when the user name is longer than 8 characters -- the Windows TEMP environment variable will be set to a path that includes the user's name since it's contained in the user's profile directory, but it will force the usage of an 8 character file name. This causes an issue in the test because while Ruby has always used TEMP when creating temp dirs. used by our tests, some Chef code that operates on it used to also return such (improperly) shortened names, but as of Ruby 2.2 which has been used for Chef only starting in the last week it does not, perhaps due to some improvement in other parts of Ruby.

This fixes the tests so that long file names are expected. However, there may be a need to investigate whether the new Ruby 2.2 behavior could cause a regression in a separate issue.