### PR TITLE
Revert "bump to ruby 2.2.4"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,6 @@ gem "chef-config", path: "chef-config" if File.exist?(File.expand_path("../chef-
 # Ensure that we can always install rake, regardless of gem groups
 gem "rake"
 
-# we can go back to mainline when https://github.com/ffi/ffi/pull/490 is merged
-gem "ffi", github: "lamont-granquist/ffi", branch: "lcg/rb_gc_guard_ptr" if RUBY_PLATFORM.downcase =~ /aix/
-
 group(:docgen) do
   gem "yard"
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   matrix:
     # 21-x64 is failing right now
     #- ruby_version: "21-x64"
-    - ruby_version: "22"
+    - ruby_version: "21"
 
 clone_folder: c:\projects\chef
 clone_depth: 1

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -34,7 +34,7 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :ruby, version: "2.2.4"
+override :ruby, version: "2.1.8"
 # Leave dev-kit pinned to 4.5 because 4.7 is 20MB larger and we don't want
 # to unnecessarily make the client any fatter.
 override :'ruby-windows-devkit', version: "4.5.2-20111229-1559" if windows? && windows_arch_i386?

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -84,28 +84,6 @@ def canonicalize_path(path)
   windows? ? path.tr("/", '\\') : path
 end
 
-# Makes a temp directory with a canonical path on any platform.
-# Only really needed to work around an issue on Windows where
-# Ruby's temp library generates paths with short names.
-def make_canonical_temp_directory
-  temp_directory = Dir.mktmpdir
-  if windows?
-    # On Windows, temporary file / directory path names may have shortened
-    # subdirectory names due to reliance on the TMP and TEMP environment variables
-    # in some Windows APIs and duplicated logic in Ruby's temp file implementation.
-    # To work around this in the unit test context, we obtain the long (canonical)
-    # path name via a Windows system call so that this path name can be used
-    # in expectations that assume the ability to canonically name paths in comparisons.
-    # Note that this was not an issue prior to Ruby 2.2 -- with Ruby 2.2,
-    # some Chef code started to use long file names, while Ruby's temp file implementation
-    # continued to return the shortened names -- this would cause these particular tests to
-    # fail if the username happened to be longer than 8 characters.
-    Chef::ReservedNames::Win32::File.get_long_path_name(temp_directory)
-  else
-    temp_directory
-  end
-end
-
 # Check if a cmd exists on the PATH
 def which(cmd)
   paths = ENV["PATH"].split(File::PATH_SEPARATOR) + [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ]

--- a/spec/unit/knife/data_bag_from_file_spec.rb
+++ b/spec/unit/knife/data_bag_from_file_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Knife::DataBagFromFile do
     k
   end
 
-  let(:tmp_dir) { make_canonical_temp_directory }
+  let(:tmp_dir) { Dir.mktmpdir }
   let(:db_folder) { File.join(tmp_dir, data_bags_path, bag_name) }
   let(:db_file) { Tempfile.new(["data_bag_from_file_test", ".json"], db_folder) }
   let(:db_file2) { Tempfile.new(["data_bag_from_file_test2", ".json"], db_folder) }

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -106,7 +106,7 @@ describe Chef::Provider::RemoteDirectory do
       @node.automatic_attrs[:platform] = :just_testing
       @node.automatic_attrs[:platform_version] = :just_testing
 
-      @destination_dir = make_canonical_temp_directory << "/remote_directory_test"
+      @destination_dir = Dir.mktmpdir << "/remote_directory_test"
       @resource.path(@destination_dir)
     end
 


### PR DESCRIPTION
This reverts commit 3cb10016d142c45d5b2409ecb337b1b7bc295046.

Going back to Ruby 2.1 until we can get chef-acceptance passing.

@adamedx @lamont-granquist @chef/client-core 