### PR TITLE
Remove override of number of workers to be used.

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -44,10 +44,6 @@ build_retries 3
 fetcher_retries 3
 fetcher_read_timeout 120
 
-# We limit this to 10 workers to eliminate transient timing issues in the
-# way Ruby (and other components) compiles on some more esoteric *nixes.
-workers 10
-
 # Load additional software
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']


### PR DESCRIPTION
This should be set in the make scripts and cookbooks for the
esoteric platforms that need it. Overriding this to 10 workers
on all platforms is slowing things down and causing massive
resource constrains and failures on smaller platforms (like ARM).