### PR TITLE
Revert https://github.com/chef/chef/pull/4781 because jmespath was relased with an update to prevent loading issues with json vs json_pure

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -3,10 +3,6 @@ source "https://rubygems.org"
 gem "omnibus", git: "https://github.com/chef/omnibus.git"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git"
 
-# omnibus pulls in aws-sdk which pulls in aws-sdk-core which pulls in jmespath which pulls in json_pure
-# json_pure breaks us. jmespath added it in 1.2.2. Pin to 1.1.
-gem "jmespath", "< 1.2"
-
 # pedump pessimistically pins multipart-post to a version from 2013 which makes
 # bundler very unhappy. Remove this when upstream has merged zed-0xff/pedump#6 .
 gem "pedump", git: "https://github.com/ksubrama/pedump.git", branch: "patch-1"


### PR DESCRIPTION
\cc @jkeiser @mwrock @randomcamel @chefsalim 

Reverts https://github.com/chef/chef/pull/4781 because https://github.com/jmespath/jmespath.rb/issues/20 was fixed