### PR TITLE
To access audit count from outside

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -9,7 +9,6 @@ class Chef
     class Doc < Formatters::Base
 
       attr_reader :start_time, :end_time, :successful_audits, :failed_audits
-      private :successful_audits, :failed_audits
 
       cli_name(:doc)
 


### PR DESCRIPTION
To get audit success and failure from report handler, this configuration is need to delete.

If do not accept this, could you please advise how to get this?