### PR TITLE
Add default timeout

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -84,7 +84,8 @@ class Chef
         :short => "-t SECONDS",
         :long => "--ssh-timeout SECONDS",
         :description => "The ssh connection timeout",
-        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_timeout] = key.strip.to_i }
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_timeout] = key.strip.to_i },
+        :default => 120
 
       option :ssh_gateway,
         :short => "-G GATEWAY",

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -203,8 +203,14 @@ describe Chef::Knife::Ssh do
       expect(@knife.session.servers[0].port).to eq(123)
     end
 
+    it "defaults to a timeout of 120 seconds" do
+      @knife.session_from_list([["the.b.org", nil]])
+      expect(@knife.session.servers[0].options[:timeout]).to eq(120)
+    end
+
     it "uses the timeout from Chef Config" do
       Chef::Config[:knife][:ssh_timeout] = 5
+      @knife.config[:ssh_timeout] = nil
       @knife.session_from_list([["the.b.org", nil]])
       expect(@knife.session.servers[0].options[:timeout]).to eq(5)
     end
@@ -213,11 +219,6 @@ describe Chef::Knife::Ssh do
       @knife.config[:ssh_timeout] = 6
       @knife.session_from_list([["the.b.org", nil]])
       expect(@knife.session.servers[0].options[:timeout]).to eq(6)
-    end
-
-    it "defaults to no timeout" do
-      @knife.session_from_list([["the.b.org", nil]])
-      expect(@knife.session.servers[0].options[:timeout]).to eq(nil)
     end
 
     it "uses the user from an ssh config file" do


### PR DESCRIPTION
Adds a default timeout to the new knife ssh timeout option.

@tyler-ball @chef/client-core 