### PR TITLE
MVP to fix gem metadata command

### DIFF
--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -53,9 +53,7 @@ class Chef
                   tf.puts "gem #{args.map { |i| "'#{i}'" }.join(' ')}"
                 end
                 tf.close
-                Dir.chdir(dir) do
-                  so = shell_out!("bundle install")
-                end
+                so = shell_out!("bundle install", pwd: dir)
               end
             end
           rescue Exception => e

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -66,60 +66,6 @@ class Chef
 
         events.cookbook_gem_finished
       end
-
-      # Bundler::UI object so that we can intercept and log the output
-      # of the in-memory bundle install that we are going to do.
-      #
-      class ChefBundlerUI < Bundler::UI::Silent
-        attr_accessor :events
-
-        def initialize(events)
-          @events = events
-          super()
-        end
-
-        def confirm(msg, newline = nil)
-          # looks like "Installing time_ago_in_words 0.1.1" when installing
-          if msg =~ /Installing\s+(\S+)\s+(\S+)/
-            events.cookbook_gem_installing($1, $2)
-          end
-          Chef::Log.info(msg)
-        end
-
-        def error(msg, newline = nil)
-          Chef::Log.error(msg)
-        end
-
-        def debug(msg, newline = nil)
-          Chef::Log.debug(msg)
-        end
-
-        def info(msg, newline = nil)
-          # looks like "Using time_ago_in_words 0.1.1" when using, plus other misc output
-          if msg =~ /Using\s+(\S+)\s+(\S+)/
-            events.cookbook_gem_using($1, $2)
-          end
-          Chef::Log.info(msg)
-        end
-
-        def warn(msg, newline = nil)
-          Chef::Log.warn(msg)
-        end
-      end
-
-      private
-
-      # Helper to handle older bundler versions that do not support injecting the UI
-      # object.  On older bundler versions, we work, but you get no output other than
-      # on STDOUT.
-      #
-      def inline_gemfile(&block)
-        # requires https://github.com/bundler/bundler/pull/4245
-        gemfile(true, ui: ChefBundlerUI.new(events), &block)
-      rescue ArgumentError # Method#arity doesn't inspect optional arguments, so we rescue
-        # requires bundler 1.10.0
-        gemfile(true, &block)
-      end
     end
   end
 end

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -50,7 +50,7 @@ class Chef
               File.open("#{dir}/Gemfile", "w+") do |tf|
                 tf.puts "source '#{Chef::Config[:rubygems_url]}'"
                 cookbook_gems.each do |args|
-                  tf.puts "gem #{args.map { |i| "'#{i}'" }.join(' ')}"
+                  tf.puts "gem(*#{args.inspect})"
                 end
                 tf.close
                 so = shell_out!("bundle install", cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -53,6 +53,8 @@ class Chef
                   tf.puts "gem(*#{args.inspect})"
                 end
                 tf.close
+                Chef::Log.debug("generated Gemfile contents:")
+                Chef::Log.debug(IO.read(tf.path))
                 so = shell_out!("bundle install", cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
                 Chef::Log.info(so.stdout)
               end

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -53,7 +53,8 @@ class Chef
                   tf.puts "gem #{args.map { |i| "'#{i}'" }.join(' ')}"
                 end
                 tf.close
-                so = shell_out!("bundle install", pwd: dir)
+                so = shell_out!("bundle install", cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
+                Chef::Log.info(so.stdout)
               end
             end
           rescue Exception => e
@@ -63,6 +64,17 @@ class Chef
         end
 
         events.cookbook_gem_finished
+      end
+
+      private
+
+      # path_sanity appends the ruby_bin, but I want the ruby_bin prepended
+      def path_with_prepended_ruby_bin
+        env_path = ENV["PATH"].dup || ""
+        existing_paths = env_path.split(File::PATH_SEPARATOR)
+        existing_paths.unshift(RbConfig::CONFIG["bindir"])
+        env_path = existing_paths.join(File::PATH_SEPARATOR)
+        env_path.encode("utf-8", invalid: :replace, undef: :replace)
       end
     end
   end


### PR DESCRIPTION
The gem command in the cookbook metadata uses the bundler API but needs to not leave the chef-client in a 'bundled' state.

Trying to do this in-process always results in a bundled state.  The result is that /other/ cookbooks that access other gems such as a cookbook with:

```ruby
chef_gem "mysql"
require "mysql"
```

Will fail.  Since we can't convert every cookbook from using chef_gem to get metadata (for backcompat reasons, practicality reasons, and because of native gems and build-essentials deps) we need a workaround.

Best workaround I can come up with is to simply fork off a process.  Since windows does not support fork, the easiest way to implement this is to shell_out to `bundle install`.  When the bundle install returns, we are guaranteed that the spawned process hasn't twiddled at all with our own internal state.

This, however, breaks the ability to get `requires` lines in the gem metadata to work since those would only execute in the subprocess and are flushed with the rest of the state.

closes #4710 