### PR TITLE
Point to the right license file for chef.

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -19,7 +19,7 @@ friendly_name "Chef Client"
 maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 license "Apache-2.0"
-license_file "LICENSE"
+license_file "../LICENSE"
 
 build_iteration 1
 current_file ||= __FILE__


### PR DESCRIPTION
/cc: @tyler-ball 

So this path needs to be relative to the `project_root` which is the omnibus directory. So we need to point to the parent to pick up the LICENSE.

Sorry for the break.