### PR TITLE
Removing non-existent members from group should not fail

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -94,6 +94,7 @@ class Chef
           missing_members = []
           @new_resource.members.each do |member|
             next if has_current_group_member?(member)
+            validate_member!(member)
             missing_members << member
           end
           if missing_members.length > 0
@@ -120,6 +121,12 @@ class Chef
 
       def has_current_group_member?(member)
         @current_resource.members.include?(member)
+      end
+
+      def validate_member!(member)
+        # Sub-classes can do any validation if needed
+        # and raise an error if validation fails
+        true
       end
 
       def action_create

--- a/lib/chef/provider/group/windows.rb
+++ b/lib/chef/provider/group/windows.rb
@@ -100,7 +100,7 @@ class Chef
           begin
             Chef::ReservedNames::Win32::Security.lookup_account_name(locally_qualified_name(account_name))[1].to_s
           rescue Chef::Exceptions::Win32APIError
-            Chef::Log.warn("SID for '#{locally_qualified_name}' could not be found")
+            Chef::Log.warn("SID for '#{locally_qualified_name(account_name)}' could not be found")
             ""
           end
         end

--- a/lib/chef/provider/group/windows.rb
+++ b/lib/chef/provider/group/windows.rb
@@ -61,7 +61,7 @@ class Chef
           if @new_resource.append
             members_to_be_added = [ ]
             @new_resource.members.each do |member|
-              members_to_be_added << member if ! has_current_group_member?(member)
+              members_to_be_added << member if ! has_current_group_member?(member) && validate_member!(member)
             end
 
             # local_add_members will raise ERROR_MEMBER_IN_ALIAS if a
@@ -70,7 +70,7 @@ class Chef
 
             members_to_be_removed = [ ]
             @new_resource.excluded_members.each do |member|
-              member_sid = local_group_name_to_sid(member)
+              member_sid = lookup_account_name(member)
               members_to_be_removed << member if has_current_group_member?(member)
             end
             @net_group.local_delete_members(members_to_be_removed) unless members_to_be_removed.empty?
@@ -80,7 +80,7 @@ class Chef
         end
 
         def has_current_group_member?(member)
-          member_sid = local_group_name_to_sid(member)
+          member_sid = lookup_account_name(member)
           @current_resource.members.include?(member_sid)
         end
 
@@ -88,10 +88,23 @@ class Chef
           @net_group.local_delete
         end
 
-        def local_group_name_to_sid(group_name)
-          locally_qualified_name = group_name.include?("\\") ? group_name : "#{ENV['COMPUTERNAME']}\\#{group_name}"
-          Chef::ReservedNames::Win32::Security.lookup_account_name(locally_qualified_name)[1].to_s
+        def locally_qualified_name(account_name)
+          account_name.include?("\\") ? account_name : "#{ENV['COMPUTERNAME']}\\#{account_name}"
         end
+
+        def validate_member!(member)
+          Chef::ReservedNames::Win32::Security.lookup_account_name(locally_qualified_name(member))[1].to_s
+        end
+
+        def lookup_account_name(account_name)
+          begin
+            Chef::ReservedNames::Win32::Security.lookup_account_name(locally_qualified_name(account_name))[1].to_s
+          rescue Chef::Exceptions::Win32APIError
+            Chef::Log.warn("SID for '#{locally_qualified_name}' could not be found")
+            ""
+          end
+        end
+
       end
     end
   end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -267,14 +267,14 @@ describe Chef::Resource::Group, :requires_root_or_running_windows, :not_supporte
     end
 
     describe "when removing members" do
-      it "raises an error for a non well-formed domain name" do
+      it "does not raise an error for a non well-formed domain name" do
         group_resource.excluded_members [invalid_domain_user_name]
-        expect { group_resource.run_action(tested_action) }.to raise_error Chef::Exceptions::Win32APIError
+        expect { group_resource.run_action(tested_action) }.to_not raise_error Chef::Exceptions::Win32APIError
       end
 
-      it "raises an error for a nonexistent domain" do
+      it "does not raise an error for a nonexistent domain" do
         group_resource.excluded_members [nonexistent_domain_user_name]
-        expect { group_resource.run_action(tested_action) }.to raise_error Chef::Exceptions::Win32APIError
+        expect { group_resource.run_action(tested_action) }.to_not raise_error Chef::Exceptions::Win32APIError
       end
     end
   end

--- a/spec/unit/provider/group/windows_spec.rb
+++ b/spec/unit/provider/group/windows_spec.rb
@@ -55,7 +55,8 @@ describe Chef::Provider::Group::Windows do
       allow(Chef::Util::Windows::NetGroup).to receive(:new).and_return(@net_group)
       allow(@net_group).to receive(:local_add_members)
       allow(@net_group).to receive(:local_set_members)
-      allow(@provider).to receive(:local_group_name_to_sid)
+      allow(@provider).to receive(:lookup_account_name)
+      allow(@provider).to receive(:validate_member!).and_return(true)
       @provider.current_resource = @current_resource
     end
 

--- a/spec/unit/provider/group/windows_spec.rb
+++ b/spec/unit/provider/group/windows_spec.rb
@@ -51,6 +51,7 @@ describe Chef::Provider::Group::Windows do
       @new_resource.members([ "us" ])
       @current_resource = Chef::Resource::Group.new("staff")
       @current_resource.members %w{all your base}
+      @new_resource.excluded_members %w{all}
 
       allow(Chef::Util::Windows::NetGroup).to receive(:new).and_return(@net_group)
       allow(@net_group).to receive(:local_add_members)
@@ -72,6 +73,12 @@ describe Chef::Provider::Group::Windows do
       @provider.manage_group
     end
 
+    it "should call @net_group.local_delete_members" do
+      allow(@new_resource).to receive(:append).and_return(true)
+      allow(@provider).to receive(:lookup_account_name).with("all").and_return("all")
+      expect(@net_group).to receive(:local_delete_members).with(@new_resource.excluded_members)
+      @provider.manage_group
+    end
   end
 
   describe "remove_group" do


### PR DESCRIPTION
This resolves the following issue : https://chefio.atlassian.net/browse/TRI-96

Currently, if removing users from a group, where the user is malformed or does not exist, we error out and fail the recipe. The new behavior is to not fail in this case - we now just log a warning and keep going.

@chef/client-core @tyler-ball @jkeiser 