### PR TITLE
Add a warning about using --interval on Windows.

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -351,8 +351,13 @@ class Chef::Application::Client < Chef::Application
       Chef::Config[:splay] = nil
     end
 
-    if !Chef::Config[:client_fork] && Chef::Config[:interval] && !Chef::Platform.windows?
-      Chef::Application.fatal!(unforked_interval_error_message)
+    if Chef::Config[:interval]
+      if Chef::Platform.windows?
+        Chef::Log.warn("Use of chef-client interval runs on Windows is discouraged. " +
+          "Please install chef-client as a Windows service or scheduled task instead.")
+      elsif !Chef::Config[:client_fork]
+        Chef::Application.fatal!(unforked_interval_error_message)
+      end
     end
 
     if Chef::Config[:json_attribs]

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -333,9 +333,9 @@ EOH
   end
 
   def unforked_interval_error_message
-    "Unforked chef-client interval runs are disabled in Chef 12." +
+    "Unforked chef-solo interval runs are disabled in Chef 12." +
       "\nConfiguration settings:" +
       "#{"\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]}" +
-      "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+      "\nEnable chef-solo interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
   end
 end

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -219,7 +219,14 @@ class Chef::Application::Solo < Chef::Application
       Chef::Config[:interval] ||= 1800
     end
 
-    Chef::Application.fatal!(unforked_interval_error_message) if !Chef::Config[:client_fork] && Chef::Config[:interval]
+    if Chef::Config[:interval]
+      if Chef::Platform.windows?
+        Chef::Log.warn("Use of chef-solo interval runs on Windows is discouraged. " +
+          "Please install chef-solo as a Windows service or scheduled task instead.")
+      elsif !Chef::Config[:client_fork]
+        Chef::Application.fatal!(unforked_interval_error_message)
+      end
+    end
 
     Chef::Log.deprecation("-r MUST be changed to --recipe-url, the -r option will be changed in Chef 13.0") if ARGV.include?("-r")
 


### PR DESCRIPTION
I think I got the if logic right, but a spot check would be good. Basically `--interval` on Windows works but is a really bad idea for all the reasons we hard-blocked non-forking interval runs on other platforms. We probably shouldn't actually break it on Windows, but from talking to Matt it sounds like nobody should be doing this so let's give them warning now and remove it in Chef 13 or something.

/cc @chef/client-windows for review.
