### PR TITLE
Port a change made to chef-cookbooks/windows to fix issue chef-cookbooks/windows#89.

### DIFF
--- a/lib/chef/provider/package/windows/exe.rb
+++ b/lib/chef/provider/package/windows/exe.rb
@@ -80,13 +80,10 @@ class Chef
           def uninstall_command(uninstall_string)
             uninstall_string.delete!('"')
             uninstall_string = [
-              %q{/d"},
-              ::File.dirname(uninstall_string),
-              %q{" },
-              ::File.basename(uninstall_string),
+              uninstall_string,
               expand_options(new_resource.options),
               " ",
-              unattended_flags,
+              unattended_flags
             ].join
             %Q{start "" /wait #{uninstall_string} & exit %%%%ERRORLEVEL%%%%}
           end


### PR DESCRIPTION
* Fix and simplify the parsing of the uninstall string for removing a Windows package.

@mwrock This is the change I was attempting to submit into chef-cookbooks/windows.