### PR TITLE
add nillable apt_repository and nillable properties

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -72,6 +72,9 @@ class Chef
     #     property defaults to the same value as `name`. Equivalent to
     #     `default: lazy { name }`, except that #property_is_set? will
     #     return `true` if the property is set *or* if `name` is set.
+    #   @option options [Boolean] :nillable `true` opt-in to Chef-13 style behavior where
+    #     attempting to set a nil value will really set a nil value instead of issuing
+    #     a warning and operating like a getter
     #   @option options [Object] :default The value this property
     #     will return if the user does not set one. If this is `lazy`, it will
     #     be run in the context of the instance (and able to access other
@@ -233,7 +236,7 @@ class Chef
     #
     def validation_options
       @validation_options ||= options.reject { |k, v|
-        [:declared_in, :name, :instance_variable_name, :desired_state, :identity, :default, :name_property, :coerce, :required].include?(k)
+        [:declared_in, :name, :instance_variable_name, :desired_state, :identity, :default, :name_property, :coerce, :required, :nillable].include?(k)
       }
     end
 
@@ -262,7 +265,7 @@ class Chef
         return get(resource)
       end
 
-      if value.nil?
+      if value.nil? && !nillable?
         # In Chef 12, value(nil) does a *get* instead of a set, so we
         # warn if the value would have been changed. In Chef 13, it will be
         # equivalent to value = nil.
@@ -669,6 +672,10 @@ class Chef
       end
 
       result
+    end
+
+    def nillable?
+      !!options[:nillable]
     end
   end
 end

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -239,13 +239,15 @@ class Chef
 
         uri = '"' + uri + '"' unless uri.start_with?("'", '"')
         components = Array(components).join(" ")
-        options = ""
-        options << "arch=#{arch} " if arch
+        options = []
+        options << "arch=#{arch}" if arch
         options << "trusted=yes" if trusted
-        options = "[#{options}]" unless options.empty?
-        info = "#{options} #{uri} #{distribution} #{components}\n".lstrip
-        repo =  "deb      #{info}"
-        repo << "deb-src  #{info}" if add_src
+        optstr = unless options.empty?
+                   "[" + options.join(" ") + "]"
+                 end
+        info = [ optstr, uri, distribution, components ].compact.join(" ")
+        repo =  "deb      #{info}\n"
+        repo << "deb-src  #{info}\n" if add_src
         repo
       end
     end

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -26,7 +26,7 @@ class Chef
 
       property :repo_name, String, name_property: true
       property :uri, String
-      property :distribution, String, default: lazy { node["lsb"]["codename"] }
+      property :distribution, [ String, nil ], default: lazy { node["lsb"]["codename"] }, nillable: true
       property :components, Array, default: []
       property :arch, [String, nil], default: nil
       property :trusted, [TrueClass, FalseClass], default: false

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -26,17 +26,17 @@ class Chef
 
       property :repo_name, String, name_property: true
       property :uri, String
-      property :distribution, [ String, nil ], default: lazy { node["lsb"]["codename"] }, nillable: true
+      property :distribution, [ String, nil, false ], default: lazy { node["lsb"]["codename"] }, nillable: true, coerce: proc { |x| x ? x : nil }
       property :components, Array, default: []
-      property :arch, [String, nil], default: nil
+      property :arch, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
       property :trusted, [TrueClass, FalseClass], default: false
       # whether or not to add the repository as a source repo, too
       property :deb_src, [TrueClass, FalseClass], default: false
-      property :keyserver, [String, nil], default: "keyserver.ubuntu.com"
-      property :key, [String, nil], default: nil
-      property :key_proxy, [String, nil], default: nil
+      property :keyserver, [String, nil, false], default: "keyserver.ubuntu.com", nillable: true, coerce: proc { |x| x ? x : nil }
+      property :key, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
+      property :key_proxy, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
 
-      property :cookbook, [String, nil], default: nil, desired_state: false
+      property :cookbook, [String, nil, false], default: nil, desired_state: false, nillable: true, coerce: proc { |x| x ? x : nil }
       property :cache_rebuild, [TrueClass, FalseClass], default: true, desired_state: false
       property :sensitive, [TrueClass, FalseClass], default: false, desired_state: false
 

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -158,6 +158,11 @@ C5986B4F1257FFA86632CBA746181433FBB75451
       expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil)).to eql(target)
     end
 
+    it "should create a repository string with no distribution" do
+      target = %Q{deb      "http://test/uri" main\n}
+      expect(provider.build_repo("http://test/uri", nil, "main", false, nil)).to eql(target)
+    end
+
     it "should create a repository string with source" do
       target = %Q{deb      "http://test/uri" unstable main\ndeb-src  "http://test/uri" unstable main\n}
       expect(provider.build_repo("http://test/uri", "unstable", "main", false, nil, true)).to eql(target)

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -31,4 +31,8 @@ describe Chef::Resource::AptRepository do
     expect(resource.keyserver).to eql("keyserver.ubuntu.com")
   end
 
+  it "the default distribution should be nillable" do
+    expect(resource.distribution(nil)).to eql(nil)
+    expect(resource.distribution).to eql(nil)
+  end
 end


### PR DESCRIPTION
in Chef-13 nillable will become 'true' by default and we'll have
to deprecate and remove all nillable properties, but for now
this lets us opt-in, which was can't currently do in Chef-12.