### PR TITLE
Bump chef-zero to 4.6.

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", "~> 4.5"
+  s.add_dependency "chef-zero", "~> 4.6"
 
   s.add_dependency "plist", "~> 3.2"
 


### PR DESCRIPTION
This pulls in the org-scoped user keys endpoints:
`/organizations/:org/users/:user/keys(/:key)`