### PR TITLE
Don't use berks when bumping version--can't possibly change.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,7 @@ ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "Chef") do |packag
   package.generate_version_class = true
 end
 # Add a conservative dependency update to version:bump (which was created by PackageTask)
-task "version:bump" => %w{version:bump_patch version:update} do
-  Rake::Task["dependencies:update"].invoke("conservative")
-end
+task "version:bump" => %w{version:bump_patch version:update bundle:install}
 
 task :pedant, :chef_zero_spec
 


### PR DESCRIPTION
Just change the top level bundle.

I suspect this is the issue causing version bumper to fail.