### PR TITLE
Update rubygems provider to support local install of gems if so specified

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -517,7 +517,9 @@ class Chef
               install_via_gem_command(name, version)
             end
           elsif @new_resource.gem_binary.nil?
-            @gem_env.install(@new_resource.source)
+            # domain is used by Gem::DependencyInstaller rather than by Chef code
+            # domain can be :local, :remote or :both
+            @gem_env.install(@new_resource.source, domain: :local)
           else
             install_via_gem_command(name, version)
           end
@@ -531,6 +533,7 @@ class Chef
         def install_via_gem_command(name, version)
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
+            src = " --local" unless source_is_remote?
           elsif @new_resource.clear_sources
             src = " --clear-sources"
             src << (@new_resource.source && " --source=#{@new_resource.source}" || "")

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -562,9 +562,10 @@ describe Chef::Provider::Package::Rubygems do
 
         context "when source is a path" do
           let(:source) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
+          let(:domain) { { domain: :local } }
 
           it "installs the gem from file via the gems api" do
-            expect(provider.gem_env).to receive(:install).with(source)
+            expect(provider.gem_env).to receive(:install).with(source, domain)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end
@@ -572,10 +573,11 @@ describe Chef::Provider::Package::Rubygems do
 
         context "when the gem name is a file path and source is nil" do
           let(:gem_name) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
+          let(:domain) { { domain: :local } }
 
           it "installs the gem from file via the gems api" do
             expect(new_resource.source).to eq(gem_name)
-            expect(provider.gem_env).to receive(:install).with(gem_name)
+            expect(provider.gem_env).to receive(:install).with(gem_name, domain)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end
@@ -693,9 +695,10 @@ describe Chef::Provider::Package::Rubygems do
         context "when source is a path" do
           let(:source) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
           let(:target_version) { ">= 0" }
+          let(:domain) { " --local" }
 
           it "installs the gem by shelling out to gem install" do
-            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{source} -q --no-rdoc --no-ri -v \"#{target_version}\"", env: nil, timeout: 900)
+            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{source} -q --no-rdoc --no-ri -v \"#{target_version}\"#{domain}", env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end
@@ -704,10 +707,11 @@ describe Chef::Provider::Package::Rubygems do
         context "when the package is a path and source is nil" do
           let(:gem_name) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
           let(:target_version) { ">= 0" }
+          let(:domain) { " --local" }
 
           it "installs the gem from file by shelling out to gem install when the package is a path and the source is nil" do
             expect(new_resource.source).to eq(gem_name)
-            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{gem_name} -q --no-rdoc --no-ri -v \"#{target_version}\"", env: nil, timeout: 900)
+            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{gem_name} -q --no-rdoc --no-ri -v \"#{target_version}\"#{domain}", env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end


### PR DESCRIPTION
```
➜  chef git:(ksubrama+praj/FLOW-298/local_gem) ✗ gem uninstall a
Successfully uninstalled a-0.1.1

##Disable internet before testing

➜  chef git:(ksubrama+praj/FLOW-298/local_gem) ✗ bundle exec sudo bin/chef-apply -e "gem_package '/Users/prajaktapurohit/Downloads/a-0.1.1.gem'"

Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * gem_package[/Users/prajaktapurohit/Downloads/a-0.1.1.gem] action install[2016-04-19T12:32:39-07:00] WARN:  gem package /Users/prajaktapurohit/Downloads/a-0.1.1.gem does not satisfy the requirements /Users/prajaktapurohit/Downloads/a-0.1.1.gem (>= 0)

    - install version  of package /Users/prajaktapurohit/Downloads/a-0.1.1.gem

➜  chef git:(ksubrama+praj/FLOW-298/local_gem) ✗ gem list | grep "a ("
a (0.1.1)
aruba (0.14.1, 0.11.2, 0.10.2)
```
/cc #@chef/client-core @ksubrama @mwrock 