### PR TITLE
Stop setting LC_ALL to nil because it breaks non-interactive apt install

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -176,7 +176,7 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(command)
-          shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil })
+          shell_out_with_timeout!(command, :env => { "DEBIAN_FRONTEND" => "noninteractive" })
         end
 
       end


### PR DESCRIPTION
run_noninteractive is broken because LC_ALL gets set to nil rather than a sane default. This change allows Chef::Mixin::ShellOut.shell_out to pick a default locale.

Repro steps:
```
include_recipe 'apt::default'

apt_repository 'docker' do
  uri 'https://apt.dockerproject.org/repo'
  distribution '%s-%s' % [node['platform'], node['lsb']['codename']]
  components ['main']
  arch 'amd64'
  keyserver 'hkp://p80.pool.sks-keyservers.net:80'
  key '58118E89F3A912897C070ADBF76221572C52609D'
  notifies :run, 'execute[apt-get update]', :immediately
end
	​
template '/etc/default/docker' do
  source 'docker.erb'
  owner 'root'
  group 'root'
  mode '0755'
​end

​package 'docker-engine'
```
Produced the following error (I had to hack mixlib to print out the environment variables):
```
==> default: [2016-04-23T00:08:33+00:00] ERROR: apt_package[docker-engine] (wrapbox::docker line 8) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
==> default: environment: {"DEBIAN_FRONTEND"=>"noninteractive", "LC_ALL"=>nil, "LANGUAGE"=>"C.UTF-8", "LANG"=>"C.UTF-8"}
==> default: ---- Begin output of apt-get -q -y install docker-engine=1.11.0-0~trusty ----
==> default: STDOUT: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following packages were automatically installed and are no longer required:
==> default:   linux-headers-3.13.0-74 linux-headers-3.13.0-74-generic
==> default: Use 'apt-get autoremove' to remove them.
==> default: The following NEW packages will be installed:
==> default:   docker-engine
==> default: 0 upgraded, 1 newly installed, 0 to remove and 90 not upgraded.
==> default: Need to get 0 B/14.3 MB of archives.
==> default: After this operation, 72.6 MB of additional disk space will be used.
==> default: Selecting previously unselected package docker-engine.
==> default: (Reading database ... 139158 files and directories currently installed.)
==> default: Preparing to unpack .../docker-engine_1.11.0-0~trusty_amd64.deb ...
==> default: Unpacking docker-engine (1.11.0-0~trusty) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Setting up docker-engine (1.11.0-0~trusty) ...
==> default: STDERR: Configuration file '/etc/default/docker'
==> default:  ==> File on system created by you or by a script.
==> default:  ==> File also in package provided by package maintainer.
==> default:    What would you like to do about it ?  Your options are:
==> default:     Y or I  : install the package maintainer's version
==> default:     N or O  : keep your currently-installed version
==> default:       D     : show the differences between the versions
==> default:       Z     : start a shell to examine the situation
==> default:  The default action is to keep your current version.
==> default: *** docker (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package docker-engine (--configure):
==> default:  EOF on stdin at conffile prompt
==> default: Errors were encountered while processing:
==> default:  docker-engine
==> default: E: Sub-process /usr/bin/dpkg returned an error code (1)
==> default: ---- End output of apt-get -q -y install docker-engine=1.11.0-0~trusty ----
```

Sure enough, running apt-get with the variables in that output produced the same error:
```
root@host:~# DEBIAN_FRONTEND="noninteractive" LC_ALL="" LANGUAGE="C.UTF-8" LANG="C.UTF-8" apt-get install docker-engine=1.11.0-0~trusty
...snip...
Setting up docker-engine (1.11.0-0~trusty) ...

Configuration file '/etc/default/docker'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** docker (Y/I/N/O/D/Z) [default=N] ?
docker start/running, process 17569
Processing triggers for ureadahead (0.100.0-16) ...
W: Operation was interrupted before it could finish
root@host:~# sudo apt-get remove docker-engine=1.11.0-0~trusty
...snip...
root@host:~# DEBIAN_FRONTEND="noninteractive" LANGUAGE="C.UTF-8" LANG="C.UTF-8" apt-get install docker-engine=1.11.0-0~trusty
Reading package lists... Done
...snip...
Setting up docker-engine (1.11.0-0~trusty) ...
docker start/running, process 18709
root@host:~# 
```