### PR TITLE
The easy_install provider and resource are deprecated and will be removed in Chef 13

### DIFF
--- a/lib/chef/provider/package/easy_install.rb
+++ b/lib/chef/provider/package/easy_install.rb
@@ -112,6 +112,7 @@ class Chef
         end
 
         def install_package(name, version)
+          Chef.log_deprecation("The easy_install package provider is deprecated and will be removed in Chef 13.")
           run_command(:command => "#{easy_install_binary_path}#{expand_options(@new_resource.options)} \"#{name}==#{version}\"")
         end
 
@@ -120,6 +121,7 @@ class Chef
         end
 
         def remove_package(name, version)
+          Chef.log_deprecation("The easy_install package provider is deprecated and will be removed in Chef 13.")
           run_command(:command => "#{easy_install_binary_path }#{expand_options(@new_resource.options)} -m #{name}")
         end
 

--- a/spec/unit/provider/package/easy_install_spec.rb
+++ b/spec/unit/provider/package/easy_install_spec.rb
@@ -61,6 +61,7 @@ describe Chef::Provider::Package::EasyInstall do
 
   describe "actions_on_package" do
     it "should run easy_install with the package name and version" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install \"boto==1.8d\"",
       })
@@ -68,6 +69,7 @@ describe Chef::Provider::Package::EasyInstall do
     end
 
     it "should run easy_install with the package name and version and specified options" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install --always-unzip \"boto==1.8d\"",
       })
@@ -76,6 +78,7 @@ describe Chef::Provider::Package::EasyInstall do
     end
 
     it "should run easy_install with the package name and version" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install \"boto==1.8d\"",
       })
@@ -83,6 +86,7 @@ describe Chef::Provider::Package::EasyInstall do
     end
 
     it "should run easy_install -m with the package name and version" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -m boto",
       })
@@ -90,6 +94,7 @@ describe Chef::Provider::Package::EasyInstall do
     end
 
     it "should run easy_install -m with the package name and version and specified options" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -x -m boto",
       })
@@ -98,6 +103,7 @@ describe Chef::Provider::Package::EasyInstall do
     end
 
     it "should run easy_install -m with the package name and version" do
+      expect(Chef).to receive(:log_deprecation).with(/easy_install package provider is deprecated/)
       expect(@provider).to receive(:run_command).with({
         :command => "easy_install -m boto",
       })


### PR DESCRIPTION
This is because easy_install itself is long-since deprecated by the Python community and has been de-facto unmaintained for around 5 years.

Ping @chef/client-core for review.