### PR TITLE
modernize shell_out method syntax

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -30,18 +30,13 @@ class Chef
       # generally must support UTF-8 unicode.
       def shell_out(*args, **options)
         args = args.dup
-        options ||= { :environment => {
-            "LC_ALL" => Chef::Config[:internal_locale],
-            "LANGUAGE" => Chef::Config[:internal_locale],
-            "LANG" => Chef::Config[:internal_locale],
-          } }
         options = options.dup
         env_key = options.has_key?(:env) ? :env : :environment
-        options[env_key] ||= {}
-        options[env_key] = options[env_key].dup
-        options[env_key]["LC_ALL"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LC_ALL")
-        options[env_key]["LANGUAGE"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANGUAGE")
-        options[env_key]["LANG"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANG")
+        options[env_key] = {
+          "LC_ALL" => Chef::Config[:internal_locale],
+          "LANGUAGE" => Chef::Config[:internal_locale],
+          "LANG" => Chef::Config[:internal_locale],
+        }.update(options[env_key] || {})
         shell_out_command(*args, **options)
       end
 

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -29,7 +29,6 @@ class Chef
       # we use 'en_US.UTF-8' by default because we parse localized strings in English as an API and
       # generally must support UTF-8 unicode.
       def shell_out(*args, **options)
-        args = args.dup
         options = options.dup
         env_key = options.has_key?(:env) ? :env : :environment
         options[env_key] = {

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -88,7 +88,7 @@ class Chef
       end
 
       def deprecate_option(old_option, new_option)
-        Chef::Log.logger.warn "DEPRECATION: Chef::Mixin::ShellOut option :#{old_option} is deprecated. Use :#{new_option}"
+        Chef.log_deprecation "DEPRECATION: Chef::Mixin::ShellOut option :#{old_option} is deprecated. Use :#{new_option}"
       end
 
       def io_for_live_stream

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -28,26 +28,21 @@ class Chef
 
       # we use 'en_US.UTF-8' by default because we parse localized strings in English as an API and
       # generally must support UTF-8 unicode.
-      def shell_out(*command_args)
-        args = command_args.dup
-        if args.last.is_a?(Hash)
-          options = args.pop.dup
-          env_key = options.has_key?(:env) ? :env : :environment
-          options[env_key] ||= {}
-          options[env_key] = options[env_key].dup
-          options[env_key]["LC_ALL"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LC_ALL")
-          options[env_key]["LANGUAGE"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANGUAGE")
-          options[env_key]["LANG"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANG")
-          args << options
-        else
-          args << { :environment => {
+      def shell_out(*args, **options)
+        args = args.dup
+        options ||= { :environment => {
             "LC_ALL" => Chef::Config[:internal_locale],
             "LANGUAGE" => Chef::Config[:internal_locale],
             "LANG" => Chef::Config[:internal_locale],
           } }
-        end
-
-        shell_out_command(*args)
+        options = options.dup
+        env_key = options.has_key?(:env) ? :env : :environment
+        options[env_key] ||= {}
+        options[env_key] = options[env_key].dup
+        options[env_key]["LC_ALL"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LC_ALL")
+        options[env_key]["LANGUAGE"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANGUAGE")
+        options[env_key]["LANG"] ||= Chef::Config[:internal_locale] unless options[env_key].has_key?("LANG")
+        shell_out_command(*args, **options)
       end
 
       # call shell_out (using en_US.UTF-8) and raise errors

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -34,6 +34,10 @@ describe Chef::Mixin::ShellOut do
     let!(:capture_log_output) { Chef::Log.logger = Logger.new(output) }
     let(:assume_deprecation_log_level) { allow(Chef::Log).to receive(:level).and_return(:warn) }
 
+    before do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+    end
+
     context "without options" do
       let(:command_args) { [ cmd ] }
 


### PR DESCRIPTION
**options has worked ever since we've deprecated ruby 1.9.x