### PR TITLE
cookbook site install : tar error on windows

### DIFF
--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -144,11 +144,11 @@ class Chef
         extract_command = "tar zxvf \"#{convert_path upstream_file}\""
         if Chef::Platform.windows?
           # FIXED: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
-          tar_version = shell_out("tar --version").stdout.tr("\n"," ")
-          if /GNU tar/.match(tar_version)
+          tar_version = shell_out("tar --version").stdout.tr("\n", " ")
+          if tar_version =~ /GNU tar/
             ui.info("GNU tar detected")
             extract_command << " --force-local"
-          elsif /bsdtar/.match(tar_version)
+          elsif tar_version =~ /bsdtar/
             ui.info("BSD tar detected")
           end
         end

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -141,8 +141,17 @@ class Chef
 
       def extract_cookbook(upstream_file, version)
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
-        # FIXME: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
         extract_command = "tar zxvf \"#{convert_path upstream_file}\""
+        if Chef::Platform.windows?
+          # FIXED: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
+          tar_version = `tar --version`.tr("\n"," ")
+          if /GNU tar/.match(tar_version)
+            ui.info("GNU tar detected")
+            extract_command << " --force-local"
+          elsif /bsdtar/.match(tar_version)
+            ui.info("BSD tar detected")
+          end
+        end
         shell_out!(extract_command, :cwd => @install_path)
       end
 

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -143,9 +143,6 @@ class Chef
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
         # FIXME: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
         extract_command = "tar zxvf \"#{convert_path upstream_file}\""
-        if Chef::Platform.windows?
-          extract_command << " --force-local"
-        end
         shell_out!(extract_command, :cwd => @install_path)
       end
 

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -145,10 +145,10 @@ class Chef
         if Chef::Platform.windows?
           tar_version = shell_out("tar --version").stdout.tr("\n", " ")
           if tar_version =~ /GNU tar/
-            ui.debug("GNU tar detected, adding --force-local")
+            Chef::Log.debug("GNU tar detected, adding --force-local")
             extract_command << " --force-local"
           else
-            ui.debug("non-GNU tar detected, not adding --force-local")
+            Chef::Log.debug("non-GNU tar detected, not adding --force-local")
           end
         end
         shell_out!(extract_command, :cwd => @install_path)

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -143,13 +143,12 @@ class Chef
         ui.info("Uncompressing #{@cookbook_name} version #{version}.")
         extract_command = "tar zxvf \"#{convert_path upstream_file}\""
         if Chef::Platform.windows?
-          # FIXED: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
           tar_version = shell_out("tar --version").stdout.tr("\n", " ")
           if tar_version =~ /GNU tar/
-            ui.info("GNU tar detected")
+            ui.debug("GNU tar detected, adding --force-local")
             extract_command << " --force-local"
-          elsif tar_version =~ /bsdtar/
-            ui.info("BSD tar detected")
+          else
+            ui.debug("non-GNU tar detected, not adding --force-local")
           end
         end
         shell_out!(extract_command, :cwd => @install_path)

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -144,7 +144,7 @@ class Chef
         extract_command = "tar zxvf \"#{convert_path upstream_file}\""
         if Chef::Platform.windows?
           # FIXED: Detect if we have the bad tar from git on Windows: https://github.com/opscode/chef/issues/1753
-          tar_version = `tar --version`.tr("\n"," ")
+          tar_version = shell_out("tar --version").stdout.tr("\n"," ")
           if /GNU tar/.match(tar_version)
             ui.info("GNU tar detected")
             extract_command << " --force-local"


### PR DESCRIPTION
tar.exe  bundled with chef-dk on windows don't support the --force-local option

> STDERR: tar: Option --force-local is not supported


- fixes : #4862