### PR TITLE
Lazy'ing candidate_version in package provider

### DIFF
--- a/lib/chef/decorator.rb
+++ b/lib/chef/decorator.rb
@@ -1,0 +1,81 @@
+#--
+# Copyright:: Copyright 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "delegate"
+
+class Chef
+  class Decorator < SimpleDelegator
+    NULL = ::Object.new
+
+    def initialize(obj: NULL)
+      super(obj) unless obj == NULL
+      @__defined_methods__ = []
+    end
+
+    # if we wrap a nil then decorator.nil? should be true
+    def nil?
+      __getobj__.nil?
+    end
+
+    # if we wrap a Hash then decorator.is_a?(Hash) should be true
+    def is_a?(klass)
+      __getobj__.is_a?(klass) || super
+    end
+
+    # if we wrap a Hash then decorator.kind_of?(Hash) should be true
+    def kind_of?(klass)
+      __getobj__.kind_of?(klass) || super
+    end
+
+    # reset our methods on the instance if the object changes under us (this also
+    # clears out the closure over the target we create in method_missing below)
+    def __setobj__(obj)
+      __reset_methods__
+      super
+    end
+
+    # this is the ruby 2.2/2.3 implementation of Delegator#method_missing() with
+    # adding the define_singleton_method call and @__defined_methods__ tracking
+    def method_missing(m, *args, &block)
+      r = true
+      target = self.__getobj__ { r = false }
+
+      if r && target.respond_to?(m)
+        # these next 4 lines are the patched code
+        define_singleton_method(m) do |*args, &block|
+          target.__send__(m, *args, &block)
+        end
+        @__defined_methods__.push(m)
+        target.__send__(m, *args, &block)
+      elsif ::Kernel.respond_to?(m, true)
+        ::Kernel.instance_method(m).bind(self).call(*args, &block)
+      else
+        super(m, *args, &block)
+      end
+    end
+
+    private
+
+    # used by __setobj__ to clear the methods we've built on the instance.
+    def __reset_methods__
+      @__defined_methods__.each do |m|
+        singleton_class.send(:undef_method, m)
+      end
+      @__defined_methods__ = []
+    end
+  end
+end

--- a/lib/chef/decorator.rb
+++ b/lib/chef/decorator.rb
@@ -21,9 +21,9 @@ class Chef
   class Decorator < SimpleDelegator
     NULL = ::Object.new
 
-    def initialize(obj: NULL)
-      super(obj) unless obj == NULL
+    def initialize(obj = NULL)
       @__defined_methods__ = []
+      super unless obj.equal?(NULL)
     end
 
     # if we wrap a nil then decorator.nil? should be true

--- a/lib/chef/decorator/lazy.rb
+++ b/lib/chef/decorator/lazy.rb
@@ -23,15 +23,25 @@ class Chef
     # called against the object.
     #
     # @example
-    #   a = Chef::Decorator::Lazy.new { puts "allocated" }
-    #   puts "start"
-    #   puts a.class
+    #
+    #     def foo
+    #       puts "allocated"
+    #       "value"
+    #     end
+    #
+    #     a = Chef::Decorator::Lazy.new { foo }
+    #
+    #     puts "started"
+    #     a
+    #     puts "still lazy"
+    #     puts a
     #
     #   outputs:
     #
-    #   start
-    #   allocated
-    #   String
+    #     started
+    #     still lazy
+    #     allocated
+    #     value
     #
     # @since 12.10.x
     class Lazy < Decorator

--- a/lib/chef/decorator/lazy.rb
+++ b/lib/chef/decorator/lazy.rb
@@ -1,0 +1,50 @@
+#--
+# Copyright:: Copyright 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/decorator"
+
+class Chef
+  class Decorator
+    # Lazy wrapper to delay construction of an object until a method is
+    # called against the object.
+    #
+    # @example
+    #   a = Chef::Decorator::Lazy.new { puts "allocated" }
+    #   puts "start"
+    #   puts a.class
+    #
+    #   outputs:
+    #
+    #   start
+    #   allocated
+    #   String
+    #
+    # @since 12.10.x
+    class Lazy < Decorator
+      def initialize(&block)
+        super
+        @block = block
+      end
+
+      def __getobj__
+        __setobj__(@block.call) unless defined?(@delegate_sd_obj)
+        super
+      end
+
+    end
+  end
+end

--- a/lib/chef/decorator/lazy_array.rb
+++ b/lib/chef/decorator/lazy_array.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef/decorator"
+require "chef/decorator/lazy"
 
 class Chef
   class Decorator

--- a/lib/chef/decorator/lazy_array.rb
+++ b/lib/chef/decorator/lazy_array.rb
@@ -1,0 +1,44 @@
+#--
+# Copyright:: Copyright 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/decorator"
+
+class Chef
+  class Decorator
+    # Lazy wrapper to delay construction of an object until a method is
+    # called against the object.
+    #
+    # @example
+    #   a = Chef::Decorator::Lazy.new { puts "allocated" }
+    #   puts "start"
+    #   puts a.class
+    #
+    #   outputs:
+    #
+    #   start
+    #   allocated
+    #   String
+    #
+    # @since 12.10.x
+    class LazyArray < Lazy
+      def [](idx)
+        block = @block
+        Lazy.new { block.call[idx] }
+      end
+    end
+  end
+end

--- a/lib/chef/decorator/lazy_array.rb
+++ b/lib/chef/decorator/lazy_array.rb
@@ -19,19 +19,34 @@ require "chef/decorator/lazy"
 
 class Chef
   class Decorator
-    # Lazy wrapper to delay construction of an object until a method is
-    # called against the object.
+    # Lazy Array around Lazy Objects
+    #
+    # This only lazys access through `#[]`.  In order to implement #each we need to
+    # know how many items we have and what their indexes are, so we'd have to evalute
+    # the proc which makes that impossible.  You can call methods like #each and the
+    # decorator will forward the method, but item access will not be lazy.
+    #
+    # #at() and #fetch() are not implemented but technically could be.
     #
     # @example
-    #   a = Chef::Decorator::Lazy.new { puts "allocated" }
-    #   puts "start"
-    #   puts a.class
+    #     def foo
+    #         puts "allocated"
+    #           "value"
+    #     end
+    #
+    #     a = Chef::Decorator::LazyArray.new { [ foo ] }
+    #
+    #     puts "started"
+    #     a[0]
+    #     puts "still lazy"
+    #     puts a[0]
     #
     #   outputs:
     #
-    #   start
-    #   allocated
-    #   String
+    #     started
+    #     still lazy
+    #     allocated
+    #     value
     #
     # @since 12.10.x
     class LazyArray < Lazy

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -267,12 +267,13 @@ class Chef
       # The current_version should probably be dropped out of the method signature, it should
       # always be the first argument.
       #
-      # The name is not just bad, but completely misleading, consider:
+      # The name is not just bad, but i find it completely misleading, consider:
       #
       #    target_version_already_installed?(current_version, new_version)
+      #    target_version_already_installed?(current_version, candidate_version)
       #
-      # does not involve any comparison using the target_version but the target_version is
-      # in the method name.
+      # which of those is the 'target_version'?  i'd say the new_version and i'm confused when
+      # i see it called with the candidate_version.
       #
       # `current_version_equals?(version)` would be a better name
       def target_version_already_installed?(current_version, target_version)

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -22,7 +22,6 @@ require "chef/mixin/subclass_directive"
 require "chef/log"
 require "chef/file_cache"
 require "chef/platform"
-require "chef/decorator/lazy"
 require "chef/decorator/lazy_array"
 
 class Chef

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -23,9 +23,9 @@ class Chef
   class Provider
     class Package
       class Dpkg < Chef::Provider::Package
-        DPKG_REMOVED = /^Status: deinstall ok config-files/
+        DPKG_REMOVED   = /^Status: deinstall ok config-files/
         DPKG_INSTALLED = /^Status: install ok installed/
-        DPKG_VERSION = /^Version: (.+)$/
+        DPKG_VERSION   = /^Version: (.+)$/
 
         provides :dpkg_package, os: "linux"
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -482,21 +482,28 @@ class Chef
 
         def candidate_version
           @candidate_version ||= begin
-                                   if target_version_already_installed?(@current_resource.version, @new_resource.version)
-                                     nil
-                                   elsif source_is_remote?
-                                     @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
-                                   else
-                                     @gem_env.candidate_version_from_file(gem_dependency, @new_resource.source).to_s
-                                   end
-                                 end
+                                  if source_is_remote?
+                                    @gem_env.candidate_version_from_remote(gem_dependency, *gem_sources).to_s
+                                  else
+                                    @gem_env.candidate_version_from_file(gem_dependency, @new_resource.source).to_s
+                                  end
+                                end
         end
 
         def target_version_already_installed?(current_version, new_version)
-          return false unless current_version
-          return false if new_version.nil?
+          match_version(current_version, new_version, false)
+        end
 
-          Gem::Requirement.new(new_version).satisfied_by?(Gem::Version.new(current_version))
+        def version_requirement_satisfied?(current_version, version_requirement)
+          match_version(current_version, version_requirement, true)
+        end
+
+        def match_version(current_version, new_version, fuzzy_match)
+          return false unless current_version && new_version
+
+          requirement = Gem::Requirement.new(new_version)
+          (fuzzy_match || requirement.exact?) &&
+            requirement.satisfied_by?(Gem::Version.new(current_version))
         end
 
         ##

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -490,20 +490,9 @@ class Chef
                                 end
         end
 
-        def target_version_already_installed?(current_version, new_version)
-          match_version(current_version, new_version, false)
-        end
-
-        def version_requirement_satisfied?(current_version, version_requirement)
-          match_version(current_version, version_requirement, true)
-        end
-
-        def match_version(current_version, new_version, fuzzy_match)
+        def version_requirement_satisfied?(current_version, new_version)
           return false unless current_version && new_version
-
-          requirement = Gem::Requirement.new(new_version)
-          (fuzzy_match || requirement.exact?) &&
-            requirement.satisfied_by?(Gem::Version.new(current_version))
+          Gem::Requirement.new(new_version).satisfied_by?(Gem::Version.new(current_version))
         end
 
         ##

--- a/spec/unit/decorator/lazy_array_spec.rb
+++ b/spec/unit/decorator/lazy_array_spec.rb
@@ -1,0 +1,58 @@
+#
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Decorator::LazyArray do
+  def foo
+    @foo ||= 1
+  end
+
+  def bar
+    @bar ||= 2
+  end
+
+  let(:decorator) do
+    Chef::Decorator::LazyArray.new { [ foo, bar ] }
+  end
+
+  it "behaves like an array" do
+    expect(decorator[0]).to eql(1)
+    expect(decorator[1]).to eql(2)
+  end
+
+  it "accessing the array elements is lazy" do
+    expect(decorator[0].class).to eql(Chef::Decorator::Lazy)
+    expect(decorator[1].class).to eql(Chef::Decorator::Lazy)
+    expect(@foo).to be nil
+    expect(@bar).to be nil
+  end
+
+  it "calling a method on the array element runs the proc (and both elements are autovivified)" do
+    expect(decorator[0].nil?).to be false
+    expect(@foo).to equal(1)
+    expect(@bar).to equal(2)
+  end
+
+  it "if we loop over the elements and do nothing then its not lazy" do
+    # we don't know how many elements there are unless we evaluate the proc
+    decorator.each { |i| }
+    expect(@foo).to equal(1)
+    expect(@bar).to equal(2)
+  end
+end

--- a/spec/unit/decorator/lazy_spec.rb
+++ b/spec/unit/decorator/lazy_spec.rb
@@ -1,0 +1,39 @@
+#
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Decorator::Lazy do
+  let(:decorator) do
+    @a = 0
+    Chef::Decorator::Lazy.new { @a = @a + 1 }
+  end
+
+  it "decorates an object" do
+    expect(decorator.even?).to be false
+  end
+
+  it "the proc runs and does work" do
+    expect(decorator).to eql(1)
+  end
+
+  it "creating the decorator does not cause the proc to run" do
+    decorator
+    expect(@a).to eql(0)
+  end
+end

--- a/spec/unit/decorator_spec.rb
+++ b/spec/unit/decorator_spec.rb
@@ -1,0 +1,142 @@
+#
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+def impersonates_a(klass)
+  it "#is_a?(#{klass}) is true" do
+    expect(decorator.is_a?(klass)).to be true
+  end
+
+  it "#is_a?(Chef::Decorator) is true" do
+    expect(decorator.is_a?(Chef::Decorator)).to be true
+  end
+
+  it "#kind_of?(#{klass}) is true" do
+    expect(decorator.kind_of?(klass)).to be true
+  end
+
+  it "#kind_of?(Chef::Decorator) is true" do
+    expect(decorator.kind_of?(Chef::Decorator)).to be true
+  end
+
+  it "#instance_of?(#{klass}) is false" do
+    expect(decorator.instance_of?(klass)).to be false
+  end
+
+  it "#instance_of?(Chef::Decorator) is true" do
+    expect(decorator.instance_of?(Chef::Decorator)).to be true
+  end
+
+  it "#class is Chef::Decorator" do
+    expect(decorator.class).to eql(Chef::Decorator)
+  end
+end
+
+describe Chef::Decorator do
+  let(:obj) {}
+  let(:decorator) { Chef::Decorator.new(obj) }
+
+  context "when the obj is a string" do
+    let(:obj) { "STRING" }
+
+    impersonates_a(String)
+
+    it "#nil? is false" do
+      expect(decorator.nil?).to be false
+    end
+
+    it "!! is true" do
+      expect(!!decorator).to be true
+    end
+
+    it "dup returns a decorator" do
+      expect(decorator.dup.class).to be Chef::Decorator
+    end
+
+    it "dup dup's the underlying thing" do
+      expect(decorator.dup.__getobj__).not_to equal(decorator.__getobj__)
+    end
+  end
+
+  context "when the obj is a nil" do
+    let(:obj) { nil }
+
+    it "#nil? is true" do
+      expect(decorator.nil?).to be true
+    end
+
+    it "!! is false" do
+      expect(!!decorator).to be false
+    end
+
+    impersonates_a(NilClass)
+  end
+
+  context "when the obj is an empty Hash" do
+    let(:obj) { {} }
+
+    impersonates_a(Hash)
+
+    it "formats it correctly through ffi-yajl and not the JSON gem" do
+      # this relies on a quirk of pretty formatting whitespace between yajl and ruby's JSON
+      expect(FFI_Yajl::Encoder.encode(decorator, pretty: true)).to eql("{\n\n}\n")
+    end
+  end
+
+  context "whent he obj is a Hash with elements" do
+    let(:obj) { { foo: "bar", baz: "qux" } }
+
+    impersonates_a(Hash)
+
+    it "dup is shallow on the Hash" do
+      expect(decorator.dup[:baz]).to equal(decorator[:baz])
+    end
+
+    it "deep mutating the dup'd hash mutates the origin" do
+      decorator.dup[:baz] << "qux"
+      expect(decorator[:baz]).to eql("quxqux")
+    end
+  end
+
+  context "memoizing methods" do
+    let(:obj) { {} }
+
+    it "calls method_missing only once" do
+      expect(decorator).to receive(:method_missing).once.and_call_original
+      expect(decorator.keys).to eql([])
+      expect(decorator.keys).to eql([])
+    end
+
+    it "switching a Hash to an Array responds to keys then does not" do
+      expect(decorator.respond_to?(:keys)).to be true
+      expect(decorator.keys).to eql([])
+      decorator.__setobj__([])
+      expect(decorator.respond_to?(:keys)).to be false
+      expect { decorator.keys }.to raise_error(NoMethodError)
+    end
+
+    it "memoization of methods happens on the instances, not the classes" do
+      decorator2 = Chef::Decorator.new([])
+      expect(decorator.respond_to?(:keys)).to be true
+      expect(decorator.keys).to eql([])
+      expect(decorator2.respond_to?(:keys)).to be false
+      expect { decorator2.keys }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -498,6 +498,7 @@ describe Chef::Provider::Package::Rubygems do
 
       context "when the current version is the target version" do
         it "does not query for available versions" do
+          # NOTE: odd use case -- we've equality pinned a version, but are calling :upgrade
           expect(provider.gem_env).not_to receive(:candidate_version_from_remote)
           expect(provider.gem_env).not_to receive(:install)
           provider.run_action(:upgrade)

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -566,8 +566,11 @@ describe "Chef::Provider::Package - Multi" do
   let(:new_resource) { Chef::Resource::Package.new(%w{emacs vi}) }
   let(:current_resource) { Chef::Resource::Package.new(%w{emacs vi}) }
   let(:candidate_version) { [ "1.0", "6.2" ] }
+  class MyPackageProvider < Chef::Provider::Package
+    use_multipackage_api
+  end
   let(:provider) do
-    provider = Chef::Provider::Package.new(new_resource, run_context)
+    provider = MyPackageProvider.new(new_resource, run_context)
     provider.current_resource = current_resource
     provider.candidate_version = candidate_version
     provider
@@ -731,7 +734,7 @@ describe "Chef::Provider::Package - Multi" do
 
     it "should remove the packages if all are installed" do
       expect(provider).to be_removing_package
-      expect(provider).to receive(:remove_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:remove_package).with(%w{emacs vi}, [nil])
       provider.run_action(:remove)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -740,7 +743,7 @@ describe "Chef::Provider::Package - Multi" do
     it "should remove the packages if some are installed" do
       current_resource.version ["1.0", nil]
       expect(provider).to be_removing_package
-      expect(provider).to receive(:remove_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:remove_package).with(%w{emacs vi}, [nil])
       provider.run_action(:remove)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -787,7 +790,7 @@ describe "Chef::Provider::Package - Multi" do
 
     it "should purge the packages if all are installed" do
       expect(provider).to be_removing_package
-      expect(provider).to receive(:purge_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:purge_package).with(%w{emacs vi}, [nil])
       provider.run_action(:purge)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action
@@ -796,7 +799,7 @@ describe "Chef::Provider::Package - Multi" do
     it "should purge the packages if some are installed" do
       current_resource.version ["1.0", nil]
       expect(provider).to be_removing_package
-      expect(provider).to receive(:purge_package).with(%w{emacs vi}, nil)
+      expect(provider).to receive(:purge_package).with(%w{emacs vi}, [nil])
       provider.run_action(:purge)
       expect(new_resource).to be_updated
       expect(new_resource).to be_updated_by_last_action


### PR DESCRIPTION
This does many things:

1.  Fixes a bug in handling `:update` actions where partial version matches in the new_resource.version like `~> 1.0` wouldn't update 1.1 to 1.2 when it came out.
2.  The rubygems provider was abusing the crap out of setting the candidate_version to nil and using side effects of lying about it to achieve its goals, which has been removed
3.  There's a lot of documentation added around the two badly-named subclass hooks now
4.  The candidate_version is now Lazy'd in the package provider so that we can walk all the arrays in parallel, while still not accessing the candidate_version and doing expensive operations even though we might wind up being completely idempotent.
5.  The LazyArray is necessary for getting multipackage's to be Lazied as well.
6.  The seeming complexity of the Decorator base class is me pulling in work from the attributes-v1.99 branch, it isn't strictly necessary to solve this problem, but it breaks things up a bit.

The Lazy and LazyArray stuff almost smells wrong to me.  We may be able to solve the problem using the lazy iterators already in ruby.  However to do that probably means re-thinking the approach I took to walking through the arrays with the `#each_package` helper, and I'd prefer to make the minimal fix possible to the overall superclass engine here.  Instead we can make one single one-line change to the superclass to implement the laziness and keep the rest of it the same.

The Decorator base class gives me a platform to start to build things on like the decorators that I have written in that attributes-v1.99 branch to unchain method calls and handle set_unless and the Chef-12 attributes APIs much better.  We could also build a consistent Monad class on top of that at some point.

closes #4608 
closes #3867
closes #4122 

I suspect this does not completely fix #4691, but might make things better, and certainly lays the groundwork for getting that fixed.

There were reasons I had in #4608 for wanting to address both #3867 and #4122 together and I think it was all the nasty magical coupling between the rubygems provider and the candidate_version in the superclass which had to be removed to make #3867 work, but make #4122 much worse...