### PR TITLE
Consolidate shell_out usage when calling git within it's HWRP.

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -199,10 +199,10 @@ class Chef
             #   which we can fix by replacing them all with our target url (hence the --replace-all option)
 
             if multiple_remotes?(remote_status) || !remote_matches?(remote_url, remote_status)
-                run_git_command(["config", "--replace-all", "remote.#{remote_name}.url", remote_url], { cwd: cwd })
+              run_git_command(["config", "--replace-all", "remote.#{remote_name}.url", remote_url], { cwd: cwd })
             end
           when 1
-              run_git_command(["remote", "add", remote_name, remote_url], { cwd: cwd })
+            run_git_command(["remote", "add", remote_name, remote_url], { cwd: cwd })
           end
         end
       end

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -105,7 +105,7 @@ class Chef
       end
 
       def git_minor_version
-        @git_minor_version ||= Gem::Version.new((run_git_command ["--version"]).stdout.split.last)
+        @git_minor_version ||= Gem::Version.new( git("--version").stdout.split.last )
       end
 
       def existing_git_clone?
@@ -120,7 +120,7 @@ class Chef
         Chef::Log.debug("#{@new_resource} finding current git revision")
         if ::File.exist?(::File.join(cwd, ".git"))
           # 128 is returned when we're not in a git repo. this is fine
-          result = (run_git_command(["rev-parse", "HEAD"], { cwd: cwd, returns: [0, 128] })).stdout.strip
+          result = git(["rev-parse", "HEAD"], { cwd: cwd, returns: [0, 128] }).stdout.strip
         end
         sha_hash?(result) ? result : nil
       end
@@ -148,7 +148,7 @@ class Chef
           clone_cmd << "\"#{@new_resource.destination}\""
 
           Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
-          run_git_command clone_cmd
+          git clone_cmd
         end
       end
 
@@ -157,8 +157,8 @@ class Chef
 
         converge_by("checkout ref #{sha_ref} branch #{@new_resource.revision}") do
           # checkout into a local branch rather than a detached HEAD
-          run_git_command(["branch", "-f", @new_resource.checkout_branch, sha_ref], { cwd: cwd })
-          run_git_command(["checkout", @new_resource.checkout_branch], { cwd: cwd })
+          git(["branch", "-f", @new_resource.checkout_branch, sha_ref], { cwd: cwd })
+          git(["checkout", @new_resource.checkout_branch], { cwd: cwd })
           Chef::Log.info "#{@new_resource} checked out branch: #{@new_resource.revision} onto: #{@new_resource.checkout_branch} reference: #{sha_ref}"
         end
       end
@@ -167,10 +167,10 @@ class Chef
         if @new_resource.enable_submodules
           converge_by("enable git submodules for #{@new_resource}") do
             Chef::Log.info "#{@new_resource} synchronizing git submodules"
-            run_git_command(%w{submodule sync}, { cwd: cwd })
+            git(%w{submodule sync}, { cwd: cwd })
             Chef::Log.info "#{@new_resource} enabling git submodules"
             # the --recursive flag means we require git 1.6.5+ now, see CHEF-1827
-            run_git_command(["submodule", "update", "--init", "--recursive"], { cwd: cwd })
+            git(["submodule", "update", "--init", "--recursive"], { cwd: cwd })
           end
         end
       end
@@ -180,9 +180,9 @@ class Chef
         converge_by("fetch updates for #{@new_resource.remote}") do
           # since we're in a local branch already, just reset to specified revision rather than merge
           Chef::Log.debug "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
-          run_git_command(["fetch", @new_resource.remote], { cwd: cwd })
-          run_git_command(["fetch", @new_resource.remote, "--tags"], { cwd: cwd })
-          run_git_command(["reset", "--hard", target_revision], { cwd: cwd })
+          git(["fetch", @new_resource.remote], { cwd: cwd })
+          git(["fetch", @new_resource.remote, "--tags"], { cwd: cwd })
+          git(["reset", "--hard", target_revision], { cwd: cwd })
         end
       end
 
@@ -190,7 +190,7 @@ class Chef
         converge_by("set up remote tracking branches for #{remote_url} at #{remote_name}") do
           Chef::Log.debug "#{@new_resource} configuring remote tracking branches for repository #{remote_url} " + "at remote #{remote_name}"
           check_remote_command = ["config", "--get", "remote.#{remote_name}.url"]
-          remote_status = run_git_command(check_remote_command, { cwd: cwd, returns: [0, 1, 2] })
+          remote_status = git(check_remote_command, { cwd: cwd, returns: [0, 1, 2] })
           case remote_status.exitstatus
           when 0, 2
             # * Status 0 means that we already have a remote with this name, so we should update the url
@@ -199,10 +199,10 @@ class Chef
             #   which we can fix by replacing them all with our target url (hence the --replace-all option)
 
             if multiple_remotes?(remote_status) || !remote_matches?(remote_url, remote_status)
-              run_git_command(["config", "--replace-all", "remote.#{remote_name}.url", remote_url], { cwd: cwd })
+              git(["config", "--replace-all", "remote.#{remote_name}.url", remote_url], { cwd: cwd })
             end
           when 1
-            run_git_command(["remote", "add", remote_name, remote_url], { cwd: cwd })
+            git(["remote", "add", remote_name, remote_url], { cwd: cwd })
           end
         end
       end
@@ -279,7 +279,7 @@ class Chef
       end
 
       def git_ls_remote(rev_pattern)
-        (run_git_command ["ls-remote", "\"#{@new_resource.repository}\"", "\"#{rev_pattern}\""]).stdout
+        git(["ls-remote", "\"#{@new_resource.repository}\"", "\"#{rev_pattern}\""]).stdout
       end
 
       def refs_search(refs, pattern)
@@ -315,12 +315,8 @@ class Chef
         @new_resource.destination
       end
 
-      def git(*args)
-        ["git", *args].compact.join(" ")
-      end
-
-      def run_git_command(args, run_opts = {})
-        git_command = git(args)
+      def git(args, run_opts = {})
+        git_command = ["git", *args].compact.join(" ")
         Chef::Log.debug "running #{git_command}"
         shell_out!(git_command, run_options(run_opts))
       end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -274,7 +274,7 @@ SHAS
     @resource.ssh_wrapper "do_it_this_way.sh"
     expected_cmd = "git clone \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     expect(@provider).to receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
-                                                                 :log_tag=>"git[web2.0 app]",
+                                                                 :log_tag => "git[web2.0 app]",
                                                                  :environment => { "HOME" => "/home/deployNinja",
                                                                                    "GIT_SSH" => "do_it_this_way.sh" })
     @provider.clone
@@ -351,19 +351,19 @@ SHAS
 
     expected_cmd1 = "git fetch origin"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir",
-                                                                 :user => "whois", :group => "thisis",
-                                                                 :log_tag => "git[web2.0 app]",
-                                                                 :environment => { "HOME" => "/home/whois" })
+                                                                  :user => "whois", :group => "thisis",
+                                                                  :log_tag => "git[web2.0 app]",
+                                                                  :environment => { "HOME" => "/home/whois" })
     expected_cmd2 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir",
-                                                                 :user => "whois", :group => "thisis",
-                                                                 :log_tag => "git[web2.0 app]",
-                                                                 :environment => { "HOME" => "/home/whois" })
+                                                                  :user => "whois", :group => "thisis",
+                                                                  :log_tag => "git[web2.0 app]",
+                                                                  :environment => { "HOME" => "/home/whois" })
     expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir",
-                                                                 :user => "whois", :group => "thisis",
-                                                                 :log_tag => "git[web2.0 app]",
-                                                                 :environment => { "HOME" => "/home/whois" })
+                                                                  :user => "whois", :group => "thisis",
+                                                                  :log_tag => "git[web2.0 app]",
+                                                                  :environment => { "HOME" => "/home/whois" })
     @provider.fetch_updates
   end
 

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -218,7 +218,7 @@ SHAS
   context "with an ssh wrapper" do
     let(:deploy_user)  { "deployNinja" }
     let(:wrapper)      { "do_it_this_way.sh" }
-    let(:expected_cmd) { 'git clone  "git://github.com/opscode/chef.git" "/my/deploy/dir"' }
+    let(:expected_cmd) { 'git clone "git://github.com/opscode/chef.git" "/my/deploy/dir"' }
     let(:default_options) do
       {
         :user => deploy_user,
@@ -272,7 +272,7 @@ SHAS
     allow(Etc).to receive(:getpwnam).and_return(double("Struct::Passwd", :name => @resource.user, :dir => "/home/deployNinja"))
     @resource.destination "/Application Support/with/space"
     @resource.ssh_wrapper "do_it_this_way.sh"
-    expected_cmd = "git clone  \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
+    expected_cmd = "git clone \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     expect(@provider).to receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
                                                                  :log_tag=>"git[web2.0 app]",
                                                                  :environment => { "HOME" => "/home/deployNinja",

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Provider::Git do
     it "determines the current revision when there is one" do
       expect(::File).to receive(:exist?).with("/my/deploy/dir/.git").and_return(true)
       @stdout = "9b4d8dc38dd471246e7cfb1c3c1ad14b0f2bee13\n"
-      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", { :cwd => "/my/deploy/dir", :returns => [0, 128] }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", { :cwd => "/my/deploy/dir", :returns => [0, 128], :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.find_current_revision).to eql("9b4d8dc38dd471246e7cfb1c3c1ad14b0f2bee13")
     end
 
@@ -66,7 +66,7 @@ describe Chef::Provider::Git do
       expect(::File).to receive(:exist?).with("/my/deploy/dir/.git").and_return(true)
       @stderr = "fatal: Not a git repository (or any of the parent directories): .git"
       @stdout = ""
-      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", :cwd => "/my/deploy/dir", :returns => [0, 128]).and_return(double("ShellOut result", :stdout => "", :stderr => @stderr))
+      expect(@provider).to receive(:shell_out!).with("git rev-parse HEAD", :cwd => "/my/deploy/dir", :returns => [0, 128], :log_tag => "git[web2.0 app]" ).and_return(double("ShellOut result", :stdout => "", :stderr => @stderr))
       expect(@provider.find_current_revision).to be_nil
     end
   end
@@ -274,9 +274,9 @@ SHAS
     @resource.ssh_wrapper "do_it_this_way.sh"
     expected_cmd = "git clone  \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     expect(@provider).to receive(:shell_out!).with(expected_cmd, :user => "deployNinja",
-                                                                 :environment => { "GIT_SSH" => "do_it_this_way.sh",
-                                                                                   "HOME" => "/home/deployNinja" },
-                                                                 :log_tag => "git[web2.0 app]")
+                                                                 :log_tag=>"git[web2.0 app]",
+                                                                 :environment => { "HOME" => "/home/deployNinja",
+                                                                                   "GIT_SSH" => "do_it_this_way.sh" })
     @provider.clone
   end
 
@@ -334,8 +334,12 @@ SHAS
 
   it "runs a sync command with default options" do
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    expected_cmd1 = "git fetch origin"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    expected_cmd2 = "git fetch origin --tags"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
@@ -344,8 +348,19 @@ SHAS
     allow(Etc).to receive(:getpwnam).and_return(double("Struct::Passwd", :name => @resource.user, :dir => "/home/whois"))
     @resource.group("thisis")
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd, :cwd => "/my/deploy/dir",
+
+    expected_cmd1 = "git fetch origin"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir",
+                                                                 :user => "whois", :group => "thisis",
+                                                                 :log_tag => "git[web2.0 app]",
+                                                                 :environment => { "HOME" => "/home/whois" })
+    expected_cmd2 = "git fetch origin --tags"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir",
+                                                                 :user => "whois", :group => "thisis",
+                                                                 :log_tag => "git[web2.0 app]",
+                                                                 :environment => { "HOME" => "/home/whois" })
+    expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir",
                                                                  :user => "whois", :group => "thisis",
                                                                  :log_tag => "git[web2.0 app]",
                                                                  :environment => { "HOME" => "/home/whois" })
@@ -355,16 +370,24 @@ SHAS
   it "configures remote tracking branches when remote is ``origin''" do
     @resource.remote "origin"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command = "git fetch origin && git fetch origin --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command1 = "git fetch origin"
+    expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command2 = "git fetch origin --tags"
+    expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
   it "configures remote tracking branches when remote is not ``origin''" do
     @resource.remote "opscode"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command = "git fetch opscode && git fetch opscode --tags && git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command1 = "git fetch opscode"
+    expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command2 = "git fetch opscode --tags"
+    expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
+    fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
+    expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 


### PR DESCRIPTION
@lamont-granquist has been gracious enough to provide specific feedback around https://github.com/chef/chef/pull/4771  I’ll be breaking out changes into the smallest atomic PRs that can be created.  

This pull request is _just_ the changes specific to the consolidation of the git shell_out usage.

**Overview**
The git HWRP currently has a number of instances where git is called directly via ‘shell_out’.  This PR attempts to consolidate the number of code paths to shell_out.

As always feedback is much appreciated.
Thanks! :)
