### PR TITLE
remove tasks/bin/run_chef_tests; remove commented chef_rewind test; document bundler args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ before_install:
 
 bundler_args: --without changelog development docgen guard maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
 
+before_script:
+ - echo --color > .rspec
+ - echo -fp >> .rspec
+ - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers;
+
 # do not run expensive spec tests on PRs, only on branches
 branches:
   only:
@@ -36,6 +41,10 @@ matrix:
       CHEFSTYLE: 1
     rvm: 2.1
     script: bundle exec rake style
+  - env:
+      AUDIT_CHECK: 1
+    rvm: 2.1
+    script: bundle exec bundle-audit check --update
   - rvm: rbx
     sudo: true
     script: tasks/bin/run_chef_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ bundler_args: --without changelog development docgen guard maintenance omnibus_p
 before_script:
  - echo --color > .rspec
  - echo -fp >> .rspec
- - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers;
+ - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers || true
 
 # do not run expensive spec tests on PRs, only on branches
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,23 +31,35 @@ matrix:
   - rvm: 2.1
     sudo: true
     script: tasks/bin/run_chef_tests
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.2
     sudo: true
     script: tasks/bin/run_chef_tests
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.3.0
     sudo: true
     script: tasks/bin/run_chef_tests
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
       CHEFSTYLE: 1
     rvm: 2.1
     script: bundle exec rake style
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
       AUDIT_CHECK: 1
     rvm: 2.1
     script: bundle exec bundle-audit check --update
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: rbx
     sudo: true
     script: tasks/bin/run_chef_tests
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   #
   # External tests
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ before_install:
 bundler_args: --without changelog development docgen guard maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
 
 before_script:
+ # force all .rspec tests into progress display to reduce line count
  - echo --color > .rspec
  - echo -fp >> .rspec
+ # necessary for sudo: true tests, ingore failures on tests invoked with sudo: false
  - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers || true
 
 # do not run expensive spec tests on PRs, only on branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,6 @@ matrix:
       TEST_GEM: chef-provisioning-aws
     script: tasks/bin/run_external_test $TEST_GEM rake spec
     rvm: 2.2
-# requires vagrant
-#  - env: TEST_GEM=chef-rewind
-#    script: tasks/bin/run_external_test $TEST_GEM "rake spec"
-#    bundler_args: --without development
-#    rvm: 2.2
   - env:
       TEST_GEM: chef-sugar
     script: tasks/bin/run_external_test $TEST_GEM rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,22 @@ matrix:
   include:
   - rvm: 2.1
     sudo: true
-    script: tasks/bin/run_chef_tests
+    script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.2
     sudo: true
-    script: tasks/bin/run_chef_tests
+    script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.3.0
     sudo: true
-    script: tasks/bin/run_chef_tests
+    script: sudo -E $(which bundle) exec rake spec;
+    # also remove integration / external tests
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
+  - rvm: rbx
+    sudo: true
+    script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
@@ -53,11 +58,6 @@ matrix:
       AUDIT_CHECK: 1
     rvm: 2.1
     script: bundle exec bundle-audit check --update
-    # also remove integration / external tests
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-  - rvm: rbx
-    sudo: true
-    script: tasks/bin/run_chef_tests
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,24 +26,19 @@ matrix:
   - rvm: 2.1
     sudo: true
     script: tasks/bin/run_chef_tests
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.2
     sudo: true
     script: tasks/bin/run_chef_tests
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: 2.3.0
     sudo: true
     script: tasks/bin/run_chef_tests
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
       CHEFSTYLE: 1
     rvm: 2.1
     script: bundle exec rake style
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - rvm: rbx
     sudo: true
     script: tasks/bin/run_chef_tests
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   #
   # External tests
   #

--- a/tasks/bin/run_chef_tests
+++ b/tasks/bin/run_chef_tests
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Fail fast (e) and echo commands (vx)
-set -evx
-
-sudo -E $(which bundle) exec rake spec;

--- a/tasks/bin/run_chef_tests
+++ b/tasks/bin/run_chef_tests
@@ -3,14 +3,4 @@
 # Fail fast (e) and echo commands (vx)
 set -evx
 
-echo --color > .rspec
-echo -fp >> .rspec
-
-sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers;
-# If we have any args, just run the given command
-if [ -n "$1" ]; then
-  sudo -E $(which bundle) exec $@;
-else
-  sudo -E $(which bundle) exec rake spec;
-  bundle exec bundle-audit check --update;
-fi
+sudo -E $(which bundle) exec rake spec;


### PR DESCRIPTION
- the bundler args look entirely identical, it is very hard to detect that 'integration' is added to the --without args.
- chef_rewind is on the path to deprecation, we should focus on deprecating it, not fixing the test
- bin/run_chef_tests is removed

there's no additional code duplication with this (the run_chef_tests line gets replaced by the rake spec line everywhere) while the common code is moved back into the .travis.yml file.  IMO, this is good because then all the information is contained withing the .travis.yml file and there's no need for the additional context switch between .travis.yml to the run_chef_tests file when reading it -- removed an unnecessary layer of indirection