### PR TITLE
fixes knife ssl check on windows

### DIFF
--- a/lib/chef/knife/ssl_check.rb
+++ b/lib/chef/knife/ssl_check.rb
@@ -257,7 +257,8 @@ ADVICE
 
       def trusted_certificates
         if configuration.trusted_certs_dir && Dir.exist?(configuration.trusted_certs_dir)
-          Dir.glob(File.join(configuration.trusted_certs_dir, "*.{crt,pem}"))
+          glob_dir = ChefConfig::PathHelper.escape_glob_dir(configuration.trusted_certs_dir)
+          Dir.glob(File.join(glob_dir, "*.{crt,pem}"))
         else
           []
         end

--- a/spec/unit/knife/ssl_check_spec.rb
+++ b/spec/unit/knife/ssl_check_spec.rb
@@ -114,6 +114,22 @@ E
       allow(ssl_check).to receive(:verify_cert_host).and_return(true)
     end
 
+    context "when the trusted certificates directory is not glob escaped", :windows_only do
+      let(:trusted_certs_dir) { File.join(CHEF_SPEC_DATA.tr("/", "\\"), "trusted_certs") }
+
+      before do
+        allow(ssl_check).to receive(:trusted_certificates).and_call_original
+        allow(store).to receive(:verify).with(certificate).and_return(true)
+      end
+
+      it "escpaes the trusted certificates directory" do
+        expect(Dir).to receive(:glob)
+          .with("#{ChefConfig::PathHelper.escape_glob_dir(trusted_certs_dir)}/*.{crt,pem}")
+          .and_return([trusted_cert_file])
+        ssl_check.run
+      end
+    end
+
     context "when the trusted certificates have valid X509 properties" do
       before do
         allow(store).to receive(:verify).with(certificate).and_return(true)


### PR DESCRIPTION
On windows when we `glob` the trusted certs directoty, we always return an empty list of files even if there are certs present because we don't properly delimit the path for `glob`