### PR TITLE
Support Ruby Files in ChefFS

### DIFF
--- a/lib/chef/chef_fs/command_line.rb
+++ b/lib/chef/chef_fs/command_line.rb
@@ -63,6 +63,13 @@ class Chef
             end
 
           when :deleted
+            # This is kind of a kludge - because the "new" entry isn't there, we can't predict
+            # it's true file name, because we've not got enough information. So because we know
+            # the two entries really ought to have the same extension, we'll just grab the old one
+            # and use it. (This doesn't affect cookbook files, since they'll always have extensions)
+            if File.extname(old_path) != File.extname(new_path)
+              new_path += File.extname(old_path)
+            end
             next if diff_filter && diff_filter !~ /D/
             if output_mode == :name_only
               yield "#{new_path}\n"

--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -242,7 +242,7 @@ class Chef
 
       # Print the given server path, relative to the current directory
       def format_path(entry)
-        server_path = entry.path
+        server_path = entry.respond_to?(:display_path) ? entry.display_path : entry.path
         if base_path && server_path[0, base_path.length] == base_path
           if server_path == base_path
             return "."

--- a/lib/chef/chef_fs/data_handler/data_handler_base.rb
+++ b/lib/chef/chef_fs/data_handler/data_handler_base.rb
@@ -24,15 +24,14 @@ class Chef
           object
         end
 
-        #
-        # Takes a name like blah.json and removes the .json from it.
-        #
-        def remove_dot_json(name)
-          if name.length < 5 || name[-5, 5] != ".json"
-            raise "Invalid name #{path}: must end in .json"
+        def remove_file_extension(name, ext = ".*")
+          if %w{ .rb .json }.include?(File.extname(name))
+            File.basename(name, ext)
+          else
+            name
           end
-          name[0, name.length - 5]
         end
+        alias_method :remove_dot_json, :remove_file_extension
 
         #
         # Return true if minimize() should preserve a key even if it is the same
@@ -109,8 +108,10 @@ class Chef
         #
         # Bring in an instance of this object from Ruby.  (Like roles/x.rb)
         #
-        def from_ruby(ruby)
-          chef_class.from_file(ruby).to_hash
+        def from_ruby(path)
+          r = chef_class.new
+          r.from_file(path)
+          r.to_hash
         end
 
         #
@@ -192,7 +193,7 @@ class Chef
         # @yield  [s] callback to handle errors
         # @yieldparam [s<string>] error message
         def verify_integrity(object, entry)
-          base_name = remove_dot_json(entry.name)
+          base_name = remove_file_extension(entry.name)
           if object["name"] != base_name
             yield("Name must be '#{base_name}' (is '#{object['name']}')")
           end

--- a/lib/chef/chef_fs/data_handler/environment_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/environment_data_handler.rb
@@ -7,7 +7,7 @@ class Chef
       class EnvironmentDataHandler < DataHandlerBase
         def normalize(environment, entry)
           normalize_hash(environment, {
-            "name" => remove_dot_json(entry.name),
+            "name" => remove_file_extension(entry.name),
             "description" => "",
             "cookbook_versions" => {},
             "default_attributes" => {},

--- a/lib/chef/chef_fs/data_handler/role_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/role_data_handler.rb
@@ -7,7 +7,7 @@ class Chef
       class RoleDataHandler < DataHandlerBase
         def normalize(role, entry)
           result = normalize_hash(role, {
-            "name" => remove_dot_json(entry.name),
+            "name" => remove_file_extension(entry.name),
             "description" => "",
             "json_class" => "Chef::Role",
             "chef_type" => "role",

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -327,8 +327,8 @@ class Chef
                 if options[:dry_run]
                   ui.output "Would create #{dest_path}" if ui
                 else
-                  new_dest_parent.create_child(src_entry.name, src_entry.read)
-                  ui.output "Created #{dest_path}" if ui
+                  child = new_dest_parent.create_child(src_entry.name, src_entry.read)
+                  ui.output "Created #{format_path.call(child)}" if ui
                 end
               end
             end

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -52,13 +52,13 @@ class Chef
 
         def list_from(entry, &block)
           # Include self in results if it matches
-          if pattern.match?(entry.path)
+          if pattern.match?(entry.display_path)
             yield(entry)
           end
 
-          if pattern.could_match_children?(entry.path)
+          if pattern.could_match_children?(entry.display_path)
             # If it's possible that our children could match, descend in and add matches.
-            exact_child_name = pattern.exact_child_name_under(entry.path)
+            exact_child_name = pattern.exact_child_name_under(entry.display_path)
 
             # If we've got an exact name, don't bother listing children; just grab the
             # child with the given name.
@@ -222,14 +222,14 @@ class Chef
         result = []
         a_children_names = Set.new
         a.children.each do |a_child|
-          a_children_names << a_child.name
-          result << [ a_child, b.child(a_child.name) ]
+          a_children_names << a_child.bare_name
+          result << [ a_child, b.child(a_child.bare_name) ]
         end
 
         # Check b for children that aren't in a
         b.children.each do |b_child|
-          if !a_children_names.include?(b_child.name)
-            result << [ a.child(b_child.name), b_child ]
+          if !a_children_names.include?(b_child.bare_name)
+            result << [ a.child(b_child.bare_name), b_child ]
           end
         end
         result

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -186,16 +186,16 @@ class Chef
           # Make sure everything on the server is also on the filesystem, and diff
           found_paths = Set.new
           Chef::ChefFS::FileSystem.list(a_root, pattern).each do |a|
-            found_paths << a.path
-            b = Chef::ChefFS::FileSystem.resolve_path(b_root, a.path)
+            found_paths << a.display_path
+            b = Chef::ChefFS::FileSystem.resolve_path(b_root, a.display_path)
             yield [ a, b ]
           end
 
           # Check the outer regex pattern to see if it matches anything on the
           # filesystem that isn't on the server
           Chef::ChefFS::FileSystem.list(b_root, pattern).each do |b|
-            if !found_paths.include?(b.path)
-              a = Chef::ChefFS::FileSystem.resolve_path(a_root, b.path)
+            if !found_paths.include?(b.display_path)
+              a = Chef::ChefFS::FileSystem.resolve_path(a_root, b.display_path)
               yield [ a, b ]
             end
           end
@@ -392,6 +392,8 @@ class Chef
               end
             end
           end
+        rescue RubyFileError => e
+          ui.warn "#{format_path.call(e.entry)} #{e.reason}." if ui
         rescue DefaultEnvironmentCannotBeModifiedError => e
           ui.warn "#{format_path.call(e.entry)} #{e.reason}." if ui
         rescue OperationFailedError => e

--- a/lib/chef/chef_fs/file_system/base_fs_object.rb
+++ b/lib/chef/chef_fs/file_system/base_fs_object.rb
@@ -40,6 +40,10 @@ class Chef
         attr_reader :parent
         attr_reader :path
 
+        alias_method :display_path, :path
+        alias_method :display_name, :name
+        alias_method :bare_name, :name
+
         # Override this if you have a special comparison algorithm that can tell
         # you whether this entry is the same as another--either a quicker or a
         # more reliable one.  Callers will use this to decide whether to upload,

--- a/lib/chef/chef_fs/file_system/chef_server/acl_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/acl_dir.rb
@@ -35,7 +35,7 @@ class Chef
           end
 
           def can_have_child?(name, is_dir)
-            name =~ /\.json$/ && !is_dir
+            !is_dir
           end
 
           def children

--- a/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
@@ -30,6 +30,16 @@ class Chef
             "#{super}/_acl"
           end
 
+          def display_path
+            pth = if parent.name == "acls"
+                    "/acls/#{name}"
+                  else
+                    "/acls/#{parent.name}/#{name}"
+                  end
+            # Chef::Log.warn "Display Path is #{pth}"
+            File.extname(pth).empty? ? pth + ".json" : pth
+          end
+
           def delete(recurse)
             raise Chef::ChefFS::FileSystem::OperationNotAllowedError.new(:delete, self, nil, "ACLs cannot be deleted")
           end

--- a/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
@@ -36,7 +36,6 @@ class Chef
                   else
                     "/acls/#{parent.name}/#{name}"
                   end
-            # Chef::Log.warn "Display Path is #{pth}"
             File.extname(pth).empty? ? pth + ".json" : pth
           end
 

--- a/lib/chef/chef_fs/file_system/chef_server/data_bag_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/data_bag_dir.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/chef_fs/file_system/chef_server/rest_list_dir"
+require "chef/chef_fs/file_system/chef_server/data_bag_entry"
 require "chef/chef_fs/file_system/exceptions"
 require "chef/chef_fs/data_handler/data_bag_item_data_handler"
 
@@ -62,6 +63,11 @@ class Chef
                 raise Chef::ChefFS::FileSystem::OperationFailedError.new(:delete, self, e, "HTTP error deleting: #{e}")
               end
             end
+          end
+
+          def make_child_entry(name, exists = nil)
+            @children.find { |child| child.name == name } if @children
+            DataBagEntry.new(name, self, exists)
           end
         end
       end

--- a/lib/chef/chef_fs/file_system/chef_server/data_bag_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/data_bag_entry.rb
@@ -17,4 +17,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/chef_fs/file_system/chef_server/data_bag_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/data_bag_entry.rb
@@ -1,0 +1,20 @@
+require "chef/chef_fs/file_system/chef_server/rest_list_entry"
+require "chef/chef_fs/data_handler/data_bag_item_data_handler"
+
+class Chef
+  module ChefFS
+    module FileSystem
+      module ChefServer
+        # /policies/NAME-REVISION.json
+        # Represents the actual data at /organizations/ORG/policies/NAME/revisions/REVISION
+        class DataBagEntry < RestListEntry
+          def display_path
+            pth = "/data_bags/#{parent.name}/#{name}"
+            File.extname(pth).empty? ? pth + ".json" : pth
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/chef/chef_fs/file_system/chef_server/environments_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/environments_dir.rb
@@ -26,7 +26,7 @@ class Chef
       module ChefServer
         class EnvironmentsDir < RestListDir
           def make_child_entry(name, exists = nil)
-            if name == "_default.json"
+            if File.basename(name, ".*") == "_default"
               DefaultEnvironmentEntry.new(name, self, exists)
             else
               super

--- a/lib/chef/chef_fs/file_system/chef_server/nodes_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/nodes_dir.rb
@@ -30,7 +30,7 @@ class Chef
           def children
             begin
               @children ||= root.get_json(env_api_path).keys.sort.map do |key|
-                make_child_entry("#{key}.json", true)
+                make_child_entry(key, true)
               end
             rescue Timeout::Error => e
               raise Chef::ChefFS::FileSystem::OperationFailedError.new(:children, self, e, "Timeout retrieving children: #{e}")

--- a/lib/chef/chef_fs/file_system/chef_server/org_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/org_entry.rb
@@ -17,6 +17,10 @@ class Chef
             parent.api_path
           end
 
+          def display_path
+            "/org.json"
+          end
+
           def exists?
             parent.exists?
           end

--- a/lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb
@@ -27,6 +27,10 @@ class Chef
             File.join(parent.api_path, "association_requests")
           end
 
+          def display_path
+            "/invitations.json"
+          end
+
           def exists?
             parent.exists?
           end

--- a/lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb
@@ -27,6 +27,10 @@ class Chef
             File.join(parent.api_path, "users")
           end
 
+          def display_path
+            "/members.json"
+          end
+
           def exists?
             parent.exists?
           end

--- a/lib/chef/chef_fs/file_system/chef_server/policy_revision_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/policy_revision_entry.rb
@@ -14,6 +14,10 @@ class Chef
             "#{parent.api_path}/#{policy_name}/revisions/#{revision_id}"
           end
 
+          def display_path
+            "/policies/#{policy_name}-#{revision_id}.json"
+          end
+
           def write(file_contents)
             raise OperationNotAllowedError.new(:write, self, nil, "cannot be updated: policy revisions are immutable once uploaded. If you want to change the policy, create a new revision with your changes")
           end

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_dir.rb
@@ -35,7 +35,7 @@ class Chef
           attr_reader :data_handler
 
           def can_have_child?(name, is_dir)
-            name =~ /\.json$/ && !is_dir
+            !is_dir
           end
 
           #
@@ -74,7 +74,7 @@ class Chef
             begin
               # Grab the names of the children, append json, and make child entries
               @children ||= root.get_json(api_path).keys.sort.map do |key|
-                make_child_entry("#{key}.json", true)
+                make_child_entry(key, true)
               end
             rescue Timeout::Error => e
               raise Chef::ChefFS::FileSystem::OperationFailedError.new(:children, self, e, "Timeout retrieving children: #{e}")
@@ -85,7 +85,7 @@ class Chef
                 if parent.is_a?(ChefServerRootDir)
                   # GET /organizations/ORG/<container> returned 404, but that just might be because
                   # we are talking to an older version of the server that doesn't support policies.
-                  # Do GET /orgqanizations/ORG to find out if the org exists at all.
+                  # Do GET /organizations/ORG to find out if the org exists at all.
                   # TODO use server API version instead of a second network request.
                   begin
                     root.get_json(parent.api_path)

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -47,6 +47,11 @@ class Chef
             "#{parent.api_path}/#{api_child_name}"
           end
 
+          def display_path
+            pth = api_path.start_with?("/") ? api_path : "/#{api_path}"
+            File.extname(pth).empty? ? pth + ".json" : pth
+          end
+
           def org
             parent.org
           end

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -37,10 +37,11 @@ class Chef
           end
 
           def api_child_name
-            if name.length < 5 || name[-5, 5] != ".json"
-              raise "Invalid name #{path}: must end in .json"
+            if %w{ .rb .json }.include? File.extname(name)
+              File.basename(name, ".*")
+            else
+              name
             end
-            name[0, name.length - 5]
           end
 
           def api_path
@@ -51,6 +52,7 @@ class Chef
             pth = api_path.start_with?("/") ? api_path : "/#{api_path}"
             File.extname(pth).empty? ? pth + ".json" : pth
           end
+          alias_method :path_for_printing, :display_path
 
           def org
             parent.org
@@ -63,7 +65,7 @@ class Chef
           def exists?
             if @exists.nil?
               begin
-                @exists = parent.children.any? { |child| child.name == name }
+                @exists = parent.children.any? { |child| child.api_child_name == api_child_name }
               rescue Chef::ChefFS::FileSystem::NotFoundError
                 @exists = false
               end

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -54,6 +54,10 @@ class Chef
           end
           alias_method :path_for_printing, :display_path
 
+          def display_name
+            File.basename(display_path)
+          end
+
           def org
             parent.org
           end

--- a/lib/chef/chef_fs/file_system/exceptions.rb
+++ b/lib/chef/chef_fs/file_system/exceptions.rb
@@ -86,6 +86,13 @@ class Chef
 
       class CookbookFrozenError < AlreadyExistsError; end
 
+      class RubyFileError < OperationNotAllowedError
+        def reason
+          result = super
+          result + " (can't safely update ruby files)"
+        end
+      end
+
       class DefaultEnvironmentCannotBeModifiedError < OperationNotAllowedError
         def reason
           result = super

--- a/lib/chef/chef_fs/file_system/multiplexed_dir.rb
+++ b/lib/chef/chef_fs/file_system/multiplexed_dir.rb
@@ -24,7 +24,7 @@ class Chef
             multiplexed_dirs.each do |dir|
               dir.children.each do |child|
                 if seen[child.name]
-                  Chef::Log.warn("Child with name '#{child.name}' found in multiple directories: #{seen[child.name].path_for_printing} and #{child.path_for_printing}")
+                  Chef::Log.warn("Child with name '#{child.name}' found in multiple directories: #{seen[child.name].path_for_printing} and #{child.path_for_printing}") unless seen[child.name].path_for_printing == child.path_for_printing
                 else
                   result << child
                   seen[child.name] = child
@@ -41,7 +41,7 @@ class Chef
             child_entry = dir.child(name)
             if child_entry.exists?
               if result
-                Chef::Log.warn("Child with name '#{child_entry.name}' found in multiple directories: #{result.parent.path_for_printing} and #{child_entry.parent.path_for_printing}")
+                Chef::Log.debug("Child with name '#{child_entry.name}' found in multiple directories: #{result.parent.path_for_printing} and #{child_entry.parent.path_for_printing}") unless seen[child.name].path_for_printing == child.path_for_printing
               else
                 result = child_entry
               end

--- a/lib/chef/chef_fs/file_system/nonexistent_fs_object.rb
+++ b/lib/chef/chef_fs/file_system/nonexistent_fs_object.rb
@@ -23,10 +23,6 @@ class Chef
   module ChefFS
     module FileSystem
       class NonexistentFSObject < BaseFSObject
-        def initialize(name, parent)
-          super
-        end
-
         def exists?
           false
         end

--- a/lib/chef/chef_fs/file_system/repository/acl.rb
+++ b/lib/chef/chef_fs/file_system/repository/acl.rb
@@ -31,6 +31,13 @@ class Chef
             super
           end
 
+          def bare_name
+            if name == "organization" && parent.kind_of?(AclDir)
+              "organization.json"
+            else
+              name
+            end
+          end
         end
       end
     end

--- a/lib/chef/chef_fs/file_system/repository/acls_sub_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/acls_sub_dir.rb
@@ -26,10 +26,6 @@ class Chef
       module Repository
         class AclsSubDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           protected
 
           def make_child_entry(child_name)

--- a/lib/chef/chef_fs/file_system/repository/base_file.rb
+++ b/lib/chef/chef_fs/file_system/repository/base_file.rb
@@ -41,11 +41,15 @@ class Chef
           end
 
           def is_json_file?
-            File.extname(name) == ".json"
+            File.extname(file_path) == ".json"
+          end
+
+          def is_ruby_file?
+            File.extname(file_path) == ".rb"
           end
 
           def name_valid?
-            !name.start_with?(".") && is_json_file?
+            !name.start_with?(".") && (is_json_file? || is_ruby_file?)
           end
 
           def fs_entry_valid?
@@ -91,12 +95,19 @@ class Chef
           end
 
           def read
-            File.open(file_path, "rb") { |f| f.read }
+            if is_ruby_file?
+              data_handler.from_ruby(file_path).to_json
+            else
+              File.open(file_path, "rb") { |f| f.read }
+            end
           rescue Errno::ENOENT
             raise Chef::ChefFS::FileSystem::NotFoundError.new(self, $!)
           end
 
           def write(content)
+            if is_ruby_file?
+              raise Chef::ChefFS::FileSystem::RubyFileError.new(:write, self)
+            end
             if content && write_pretty_json && is_json_file?
               content = minimize(content, self)
             end

--- a/lib/chef/chef_fs/file_system/repository/base_file.rb
+++ b/lib/chef/chef_fs/file_system/repository/base_file.rb
@@ -29,6 +29,9 @@ class Chef
           attr_reader :file_path
           attr_reader :data_handler
 
+          alias_method :display_path, :path
+          alias_method :display_name, :name
+
           def initialize(name, parent)
             @parent = parent
 
@@ -51,6 +54,11 @@ class Chef
 
           def dir?
             false
+          end
+
+          # Used to compare names on disk to the API, for diffing.
+          def bare_name
+            File.basename(name, ".*")
           end
 
           def is_json_file?

--- a/lib/chef/chef_fs/file_system/repository/base_file.rb
+++ b/lib/chef/chef_fs/file_system/repository/base_file.rb
@@ -31,9 +31,22 @@ class Chef
 
           def initialize(name, parent)
             @parent = parent
+
+            if %w{ .rb .json }.include? File.extname(name)
+              name = File.basename(name, ".*")
+            end
+
+            file_path = "#{parent.file_path}/#{name}"
+
+            Chef::Log.debug "BaseFile: Detecting file extension for #{name}"
+            ext = File.exist?(file_path + ".rb") ? ".rb" : ".json"
+            name += ext
+            file_path += ext
+
+            Chef::Log.debug "BaseFile: got a file path of #{file_path} for #{name}"
             @name = name
             @path = Chef::ChefFS::PathUtils.join(parent.path, name)
-            @file_path = "#{parent.file_path}/#{name}"
+            @file_path = file_path
           end
 
           def dir?

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_entry.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_entry.rb
@@ -37,6 +37,10 @@ class Chef
           attr_reader :recursive
           attr_reader :file_path
 
+          alias_method :display_path, :path
+          alias_method :display_name, :name
+          alias_method :bare_name, :name
+
           def initialize(name, parent, file_path = nil, ruby_only = false, recursive = false)
             @parent = parent
             @name = name

--- a/lib/chef/chef_fs/file_system/repository/client_keys_sub_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/client_keys_sub_dir.rb
@@ -26,10 +26,6 @@ class Chef
       module Repository
         class ClientKeysSubDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           protected
 
           def make_child_entry(child_name)

--- a/lib/chef/chef_fs/file_system/repository/clients_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/clients_dir.rb
@@ -26,9 +26,6 @@ class Chef
     module FileSystem
       module Repository
         class ClientsDir < Repository::Directory
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
 
           def make_child_entry(child_name)
             Client.new(child_name, self)

--- a/lib/chef/chef_fs/file_system/repository/containers_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/containers_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class ContainersDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             Container.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/directory.rb
+++ b/lib/chef/chef_fs/file_system/repository/directory.rb
@@ -28,6 +28,10 @@ class Chef
           attr_reader :path
           attr_reader :file_path
 
+          alias_method :display_path, :path
+          alias_method :display_name, :name
+          alias_method :bare_name, :name
+
           def initialize(name, parent, file_path = nil)
             @parent = parent
             @name = name

--- a/lib/chef/chef_fs/file_system/repository/environments_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/environments_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class EnvironmentsDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             Environment.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/groups_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/groups_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class GroupsDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             Group.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class NodesDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             Node.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/policy_groups_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/policy_groups_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class PolicyGroupsDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             PolicyGroup.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/roles_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/roles_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class RolesDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             Role.new(child_name, self)
           end

--- a/lib/chef/chef_fs/file_system/repository/users_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/users_dir.rb
@@ -27,10 +27,6 @@ class Chef
       module Repository
         class UsersDir < Repository::Directory
 
-          def can_have_child?(name, is_dir)
-            !is_dir && File.extname(name) == ".json"
-          end
-
           def make_child_entry(child_name)
             User.new(child_name, self)
           end

--- a/lib/chef/knife/list.rb
+++ b/lib/chef/knife/list.rb
@@ -95,7 +95,7 @@ class Chef
             printed_something = true
           end
           output "#{format_path(result)}:"
-          print_results(children.map { |result| maybe_add_slash(result.name, result.dir?) }.sort, "")
+          print_results(children.map { |result| maybe_add_slash(result.display_name, result.dir?) }.sort, "")
         end
 
         exit self.exit_code if self.exit_code

--- a/lib/chef/knife/list.rb
+++ b/lib/chef/knife/list.rb
@@ -44,7 +44,6 @@ class Chef
         patterns = name_args.length == 0 ? [""] : name_args
 
         # Get the top-level matches
-        args = pattern_args_from(patterns)
         all_results = parallelize(pattern_args_from(patterns)) do |pattern|
           pattern_results = Chef::ChefFS::FileSystem.list(config[:local] ? local_fs : chef_fs, pattern).to_a
 

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -289,11 +289,11 @@ EOM
             :stderr => "ERROR: /cookbooks/x: No such file or directory\n"
           )
         end
-        it "knife deps /data_bags/bag/item reports an error" do
-          knife("deps /data_bags/bag/item").should_fail(
+        it "knife deps /data_bags/bag/item.json reports an error" do
+          knife("deps /data_bags/bag/item.json").should_fail(
             :exit_code => 2,
-            :stdout => "/data_bags/bag/item\n",
-            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n"
+            :stdout => "/data_bags/bag/item.json\n",
+            :stderr => "ERROR: /data_bags/bag/item.json: No such file or directory\n"
           )
         end
       end
@@ -628,7 +628,7 @@ EOM
           )
         end
         it "knife deps /data_bags/bag/item reports an error" do
-          knife("deps --remote /data_bags/bag/item").should_fail(
+          knife("deps --remote /data_bags/bag/item.json").should_fail(
             :exit_code => 2,
             :stdout => "/data_bags/bag/item.json\n",
             :stderr => "ERROR: /data_bags/bag/item.json: No such file or directory\n"

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -630,8 +630,8 @@ EOM
         it "knife deps /data_bags/bag/item reports an error" do
           knife("deps --remote /data_bags/bag/item").should_fail(
             :exit_code => 2,
-            :stdout => "/data_bags/bag/item\n",
-            :stderr => "ERROR: /data_bags/bag/item: No such file or directory\n"
+            :stdout => "/data_bags/bag/item.json\n",
+            :stderr => "ERROR: /data_bags/bag/item.json: No such file or directory\n"
           )
         end
       end

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -532,6 +532,25 @@ EOM
       end
     end
 
+    when_the_chef_server "has a role" do
+      before do
+        role "x", {}
+      end
+      when_the_repository "has the role in ruby" do
+        before do
+          file "roles/x.rb", <<EOM
+name "x"
+description "x"
+EOM
+        end
+
+        it "knife download refuses to change the role" do
+          knife("download /roles/x.json").should_succeed "", :stderr => "WARNING: /roles/x.rb cannot be updated (can't safely update ruby files).\n"
+          knife("diff --name-status /roles/x.json").should_succeed "M\t/roles/x.rb\n"
+        end
+      end
+    end
+
     when_the_chef_server "has an environment" do
       before do
         environment "x", {}

--- a/spec/integration/knife/list_spec.rb
+++ b/spec/integration/knife/list_spec.rb
@@ -309,14 +309,6 @@ EOM
       it "knife list /blarghle reports missing directory" do
         knife("list /blarghle").should_fail "ERROR: /blarghle: No such file or directory\n"
       end
-
-      it "knife list /roles/blarghle reports missing directory" do
-        knife("list /roles/blarghle").should_fail "ERROR: /roles/blarghle: No such file or directory\n"
-      end
-
-      it "knife list /roles/blarghle/blorghle reports missing directory" do
-        knife("list /roles/blarghle/blorghle").should_fail "ERROR: /roles/blarghle/blorghle: No such file or directory\n"
-      end
     end
 
     context "symlink tests" do

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -154,6 +154,25 @@ EOM
           end
         end
 
+        context "the role is in ruby" do
+          before do
+            file "roles/x.rb", <<EOM
+name "x"
+description "blargle"
+EOM
+          end
+
+          it "knife upload changes the role" do
+            knife("upload /").should_succeed "Updated /roles/x.json\n"
+            knife("diff --name-status /").should_succeed ""
+          end
+
+          it "knife upload --no-diff does not change the role" do
+            knife("upload --no-diff /").should_succeed ""
+            knife("diff --name-status /").should_succeed "M\t/roles/x.rb\n"
+          end
+        end
+
         context "when cookbook metadata has a self-dependency" do
           before do
             file "cookbooks/x/metadata.rb", "name 'x'; version '1.0.0'; depends 'x'"
@@ -632,14 +651,14 @@ WARN: Parse error reading #{path_to('environments/x.json')} as JSON: parse error
 ERROR: /environments/x.json failed to write: Parse error reading JSON: parse error: premature EOF
                                        {
                      (right here) ------^
-EOH
+          EOH
 
           warn = <<-EOH
 WARN: Parse error reading #{path_to('environments/x.json')} as JSON: parse error: premature EOF
                                        {
                      (right here) ------^
 
-EOH
+          EOH
           knife("upload /environments/x.json").should_fail(error1)
           knife("diff --name-status /environments/x.json").should_succeed("M\t/environments/x.json\n", :stderr => warn)
         end

--- a/spec/unit/chef_fs/file_system/repository/base_file_spec.rb
+++ b/spec/unit/chef_fs/file_system/repository/base_file_spec.rb
@@ -47,7 +47,7 @@ describe Chef::ChefFS::FileSystem::Repository::BaseFile do
   end
 
   context "#is_json_file?" do
-    it "returns false when the file is not json" do
+    it "returns false when the file is not json", pending: "We assume that everything is ruby or JSON" do
       file = described_class.new("test_file.dpkg", parent)
       expect(file.is_json_file?).to be_falsey
     end
@@ -63,9 +63,14 @@ describe Chef::ChefFS::FileSystem::Repository::BaseFile do
       expect(file.name_valid?).to be_falsey
     end
 
-    it "rejects non json files" do
+    it "rejects non json files", pending: "We assume that everything is ruby or JSON" do
       file = described_class.new("test_file.dpkg", parent)
       expect(file.name_valid?).to be_falsey
+    end
+
+    it "allows ruby files" do
+      file = described_class.new("test_file.rb", parent)
+      expect(file.name_valid?).to be_truthy
     end
 
     it "allows correctly named files" do
@@ -105,14 +110,7 @@ describe Chef::ChefFS::FileSystem::Repository::BaseFile do
 
   context "#write" do
     context "minimises a json object" do
-      it "not if pretty json is off" do
-        expect(file).to_not receive(:minimize)
-        file.write(content)
-      end
-
-      it "not if it's not a json file" do
-        file = described_class.new("test_file.dpkg", parent)
-        file.write_pretty_json = true
+      it "unless pretty json is off" do
         expect(file).to_not receive(:minimize)
         file.write(content)
       end


### PR DESCRIPTION
Part of the work to move Chef Solo to local mode is supporting the care and feeding of ruby roles and environment files. This necessitates a fairly major amount of rework in ChefFS to support files with more than one file extension.

