### PR TITLE
Make apt package provider use_multipackage_api aware

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -558,7 +558,7 @@ class Chef
       # @param args [String] variable number of string arguments
       # @return [String] nicely concatenated string or empty string
       def a_to_s(*args)
-        args.reject { |i| i.nil? || i == "" }.join(" ")
+        args.flatten.reject { |i| i.nil? || i == "" }.join(" ")
       end
     end
   end

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -65,10 +65,7 @@ class Chef
           run_noninteractive("apt-cache", default_release_options, "policy", pkg).stdout.each_line do |line|
             case line
             when /^\s{2}Installed: (.+)$/
-              installed_version = $1
-              if installed_version == "(none)"
-                installed_version = nil
-              end
+              installed_version = ( $1 != "(none)" ) ? $1 : nil
             when /^\s{2}Candidate: (.+)$/
               candidate_version = $1
               if candidate_version == "(none)"

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -113,9 +113,6 @@ class Chef
           "-o APT::Default-Release=#{new_resource.default_release}" if new_resource.respond_to?(:default_release) && new_resource.default_release
         end
 
-        # FIXME: need spec to check that candidate_version is set correctly on a virtual package
-        # FIXME: need spec to check that packages missing a candidate_version can be removed/purged
-
         def resolve_package_versions(pkg)
           current_version = nil
           candidate_version = nil

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -73,7 +73,7 @@ class Chef
         def install_package(name, version)
           package_name = name.zip(version).map do |n, v|
             package_data[n][:virtual] ? n : "#{n}=#{v}"
-          end.join(" ")
+          end
           run_noninteractive("apt-get -q -y", default_release_options, new_resource.options, "install", package_name)
         end
 
@@ -82,11 +82,17 @@ class Chef
         end
 
         def remove_package(name, version)
-          run_noninteractive("apt-get -q -y", new_resource.options, "remove", name)
+          package_name = name.map do |n|
+            package_data[n][:virtual] ? resolve_virtual_package_name(n) : n
+          end
+          run_noninteractive("apt-get -q -y", new_resource.options, "remove", package_name)
         end
 
         def purge_package(name, version)
-          run_noninteractive("apt-get -q -y", new_resource.options, "purge", name)
+          package_name = name.map do |n|
+            package_data[n][:virtual] ? resolve_virtual_package_name(n) : n
+          end
+          run_noninteractive("apt-get -q -y", new_resource.options, "purge", package_name)
         end
 
         def preseed_package(preseed_file)

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -59,7 +59,6 @@ class Chef
 
         def check_package_state(pkg)
           is_virtual_package = false
-          installed          = false
           installed_version  = nil
           candidate_version  = nil
 
@@ -68,11 +67,7 @@ class Chef
             when /^\s{2}Installed: (.+)$/
               installed_version = $1
               if installed_version == "(none)"
-                Chef::Log.debug("#{new_resource} current version is nil")
                 installed_version = nil
-              else
-                Chef::Log.debug("#{new_resource} current version is #{installed_version}")
-                installed = true
               end
             when /^\s{2}Candidate: (.+)$/
               candidate_version = $1
@@ -93,7 +88,6 @@ class Chef
                 # Check if the package providing this virtual package is installed
                 Chef::Log.info("#{new_resource} is a virtual package, actually acting on package[#{providers.keys.first}]")
                 ret = check_package_state(providers.keys.first)
-                installed = ret[:installed]
                 installed_version = ret[:installed_version]
               else
                 Chef::Log.debug("#{new_resource} candidate version is #{$1}")
@@ -103,7 +97,6 @@ class Chef
 
           return {
             installed_version:   installed_version,
-            installed:           installed,
             candidate_version:   candidate_version,
             is_virtual_package:  is_virtual_package,
           }
@@ -112,12 +105,10 @@ class Chef
         def check_all_packages_state(package)
           installed_version = {}
           candidate_version = {}
-          installed = {}
 
           [package].flatten.each do |pkg|
             ret = check_package_state(pkg)
             is_virtual_package[pkg] = ret[:is_virtual_package]
-            installed[pkg]          = ret[:installed]
             installed_version[pkg]  = ret[:installed_version]
             candidate_version[pkg]  = ret[:candidate_version]
           end

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -52,6 +52,7 @@ irssi:
         it "should create a current resource with the name of the new_resource" do
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy #{@new_resource.package_name}",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
@@ -95,6 +96,7 @@ libmysqlclient15-dev:
           virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy libmysqlclient15-dev",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(virtual_package)
           showpkg_out = <<-SHOWPKG_STDOUT
@@ -118,6 +120,7 @@ libmysqlclient-dev 5.1.41-3ubuntu12
           showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache showpkg libmysqlclient15-dev",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(showpkg)
           real_package_out = <<-RPKG_STDOUT
@@ -136,6 +139,7 @@ libmysqlclient-dev:
           real_package = double(:stdout => real_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy libmysqlclient-dev",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(real_package)
           @provider.load_current_resource
@@ -152,6 +156,7 @@ mp3-decoder:
           virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy mp3-decoder",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(virtual_package)
           showpkg_out = <<-SHOWPKG_STDOUT
@@ -178,6 +183,7 @@ mpg123 1.12.1-0ubuntu1
           showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache showpkg mp3-decoder",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(showpkg)
           expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
@@ -191,6 +197,7 @@ mpg123 1.12.1-0ubuntu1
           allow(@new_resource).to receive(:provider).and_return(nil)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache -o APT::Default-Release=lenny-backports policy irssi",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
             :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
@@ -200,11 +207,12 @@ mpg123 1.12.1-0ubuntu1
           @new_resource.source "pluto"
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache policy #{@new_resource.package_name}",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" } ,
             :timeout => @timeout
           ).and_return(@shell_out)
           @provider.load_current_resource
           @provider.define_resource_requirements
-          expect(@provider).to receive(:shell_out!).with("apt-cache policy irssi", { :timeout => 900 }).and_return(@shell_out)
+          expect(@provider).to receive(:shell_out!).with("apt-cache policy irssi", { :env => { "DEBIAN_FRONTEND" => "noninteractive" }, :timeout => 900 }).and_return(@shell_out)
           expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
         end
       end
@@ -219,20 +227,20 @@ mpg123 1.12.1-0ubuntu1
           it "should run apt-get install with the package name and version" do
             expect(@provider).to receive(:shell_out!). with(
               "apt-get -q -y install irssi=0.8.12-7",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.install_package("irssi", "0.8.12-7")
+            @provider.install_package(["irssi"], ["0.8.12-7"])
           end
 
           it "should run apt-get install with the package name and version and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes install irssi=0.8.12-7",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             @new_resource.options("--force-yes")
-            @provider.install_package("irssi", "0.8.12-7")
+            @provider.install_package(["irssi"], ["0.8.12-7"])
           end
 
           it "should run apt-get install with the package name and version and default_release if there is one and provider is explicitly defined" do
@@ -244,19 +252,19 @@ mpg123 1.12.1-0ubuntu1
 
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y -o APT::Default-Release=lenny-backports install irssi=0.8.12-7",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
 
-            @provider.install_package("irssi", "0.8.12-7")
+            @provider.install_package(["irssi"], ["0.8.12-7"])
           end
         end
 
         describe resource_klass, "upgrade_package" do
 
           it "should run install_package with the name and version" do
-            expect(@provider).to receive(:install_package).with("irssi", "0.8.12-7")
-            @provider.upgrade_package("irssi", "0.8.12-7")
+            expect(@provider).to receive(:install_package).with(["irssi"], ["0.8.12-7"])
+            @provider.upgrade_package(["irssi"], ["0.8.12-7"])
           end
         end
 
@@ -265,21 +273,21 @@ mpg123 1.12.1-0ubuntu1
           it "should run apt-get remove with the package name" do
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y remove irssi",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.remove_package("irssi", "0.8.12-7")
+            @provider.remove_package(["irssi"], ["0.8.12-7"])
           end
 
           it "should run apt-get remove with the package name and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes remove irssi",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             @new_resource.options("--force-yes")
 
-            @provider.remove_package("irssi", "0.8.12-7")
+            @provider.remove_package(["irssi"], ["0.8.12-7"])
           end
         end
 
@@ -288,21 +296,21 @@ mpg123 1.12.1-0ubuntu1
           it "should run apt-get purge with the package name" do
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y purge irssi",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.purge_package("irssi", "0.8.12-7")
+            @provider.purge_package(["irssi"], ["0.8.12-7"])
           end
 
           it "should run apt-get purge with the package name and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y --force-yes purge irssi",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             @new_resource.options("--force-yes")
 
-            @provider.purge_package("irssi", "0.8.12-7")
+            @provider.purge_package(["irssi"], ["0.8.12-7"])
           end
         end
 
@@ -316,7 +324,7 @@ mpg123 1.12.1-0ubuntu1
 
             expect(@provider).to receive(:shell_out!).with(
               "debconf-set-selections /tmp/irssi-0.8.12-7.seed",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
 
@@ -326,7 +334,7 @@ mpg123 1.12.1-0ubuntu1
           it "should run debconf-set-selections on the preseed file if it has changed" do
             expect(@provider).to receive(:shell_out!).with(
               "debconf-set-selections /tmp/irssi-0.8.12-7.seed",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             file = @provider.get_preseed_file("irssi", "0.8.12-7")
@@ -347,7 +355,7 @@ mpg123 1.12.1-0ubuntu1
           it "should run dpkg-reconfigure package" do
             expect(@provider).to receive(:shell_out!).with(
               "dpkg-reconfigure irssi",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             @provider.reconfig_package("irssi", "0.8.12-7")
@@ -359,10 +367,10 @@ mpg123 1.12.1-0ubuntu1
             @provider.is_virtual_package["libmysqlclient-dev"] = true
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y install libmysqlclient-dev",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.install_package("libmysqlclient-dev", "not_a_real_version")
+            @provider.install_package(["libmysqlclient-dev"], ["not_a_real_version"])
           end
         end
 
@@ -373,7 +381,7 @@ mpg123 1.12.1-0ubuntu1
             @provider.is_virtual_package["irssi"] = false
             expect(@provider).to receive(:shell_out!).with(
               "apt-get -q -y install libmysqlclient-dev irssi=0.8.12-7",
-              :env => { "DEBIAN_FRONTEND" => "noninteractive", "LC_ALL" => nil },
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
             @provider.install_package(["libmysqlclient-dev", "irssi"], ["not_a_real_version", "0.8.12-7"])

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -83,6 +83,30 @@ sudo:
           expect(@provider.candidate_version).to eql(["1.7.2p1-1ubuntu5.3"])
         end
 
+        # it is the superclasses responsibility to throw most exceptions
+        it "if the package does not exist in the cache sets installed + candidate version to nil" do
+          @new_resource.package_name("conic-smarms")
+          policy_out = <<-POLICY_STDOUT
+N: Unable to locate package conic-smarms
+          POLICY_STDOUT
+          policy = double(:stdout => policy_out, :exitstatus => 0)
+          expect(@provider).to receive(:shell_out!).with(
+            "apt-cache policy conic-smarms",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
+            :timeout => @timeout
+          ).and_return(policy)
+          showpkg_out = <<-SHOWPKG_STDOUT
+N: Unable to locate package conic-smarms
+          SHOWPKG_STDOUT
+          showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
+          expect(@provider).to receive(:shell_out!).with(
+            "apt-cache showpkg conic-smarms",
+            :env => { "DEBIAN_FRONTEND" => "noninteractive" },
+            :timeout => @timeout
+          ).and_return(showpkg)
+          @provider.load_current_resource
+        end
+
         # libmysqlclient-dev is a real package in newer versions of debian + ubuntu
         # list of virtual packages: http://www.debian.org/doc/packaging-manuals/virtual-package-names-list.txt
         it "should not install the virtual package there is a single provider package and it is installed" do

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -248,7 +248,7 @@ mpg123 1.12.1-0ubuntu1
               candidate_version: "0.8.12-7",
               installed_version: nil,
             },
-            "libmysqlclient-dev" => {
+            "libmysqlclient15-dev" => {
               virtual: true,
               candidate_version: nil,
               installed_version: nil,
@@ -397,27 +397,49 @@ mpg123 1.12.1-0ubuntu1
 
         describe "when installing a virtual package" do
           it "should install the package without specifying a version" do
-            @provider.package_data["libmysqlclient-dev"][:virtual] = true
+            @provider.package_data["libmysqlclient15-dev"][:virtual] = true
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get -q -y install libmysqlclient-dev",
+              "apt-get -q -y install libmysqlclient15-dev",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.install_package(["libmysqlclient-dev"], ["not_a_real_version"])
+            @provider.install_package(["libmysqlclient15-dev"], ["not_a_real_version"])
+          end
+        end
+
+        describe "when removing a virtual package" do
+          it "should remove the resolved name instead of the virtual package name" do
+            expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
+            expect(@provider).to receive(:shell_out!).with(
+              "apt-get -q -y remove libmysqlclient-dev",
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
+              :timeout => @timeout
+            )
+            @provider.remove_package(["libmysqlclient15-dev"], ["not_a_real_version"])
+          end
+        end
+
+        describe "when purging a virtual package" do
+          it "should purge the resolved name instead of the virtual package name" do
+            expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
+            expect(@provider).to receive(:shell_out!).with(
+              "apt-get -q -y purge libmysqlclient-dev",
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
+              :timeout => @timeout
+            )
+            @provider.purge_package(["libmysqlclient15-dev"], ["not_a_real_version"])
           end
         end
 
         describe "when installing multiple packages" do
           it "can install a virtual package followed by a non-virtual package" do
             # https://github.com/chef/chef/issues/2914
-            @provider.package_data["libmysqlclient-dev"][:virtual] = true
-            @provider.package_data["irssi"][:virtual] = false
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get -q -y install libmysqlclient-dev irssi=0.8.12-7",
+              "apt-get -q -y install libmysqlclient15-dev irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
-            @provider.install_package(["libmysqlclient-dev", "irssi"], ["not_a_real_version", "0.8.12-7"])
+            @provider.install_package(["libmysqlclient15-dev", "irssi"], ["not_a_real_version", "0.8.12-7"])
           end
         end
 

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -458,8 +458,18 @@ describe "Subclass with use_multipackage_api" do
     expect(provider.use_multipackage_api?).to be true
   end
 
-  it "offers a_to_s to subclasses to convert an array of strings to a single string" do
-    expect(provider.send(:a_to_s, "a", nil, "b", "", "c", " ", "d e", "f-g")).to eq("a b c   d e f-g")
+  context "#a_to_s utility for subclasses" do
+    it "converts varargs of strings to a single string" do
+      expect(provider.send(:a_to_s, "a", nil, "b", "", "c", " ", "d e", "f-g")).to eq("a b c   d e f-g")
+    end
+
+    it "converts an array of strings to a single string" do
+      expect(provider.send(:a_to_s, ["a", nil, "b", "", "c", " ", "d e", "f-g"])).to eq("a b c   d e f-g")
+    end
+
+    it "converts a mishmash of array args to a single string" do
+      expect(provider.send(:a_to_s, "a", [ nil, "b", "", [ "c" ] ], " ", [ "d e", "f-g" ])).to eq("a b c   d e f-g")
+    end
   end
 
   it "when user passes string to package_name, passes arrays to install_package" do


### PR DESCRIPTION
general modernization of apt_package

- removing/purging virtual packages works now ( at least a virtual package with only one option -- which is all that we support installing)