### PR TITLE
Add inspec in Chef client's embedded gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "nokogiri"
+  gem "inspec"
 end
 group(:omnibus_package, :pry) do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,11 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    docker-api (1.26.2)
+      excon (>= 0.38.0)
+      json
     erubis (2.7.0)
+    excon (0.49.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fauxhai (3.4.0)
@@ -205,6 +209,16 @@ GEM
     httpclient (2.8.0)
     inifile (3.0.0)
     iniparse (1.4.2)
+    inspec (0.20.1)
+      json (~> 1.8)
+      method_source (~> 0.8)
+      pry (~> 0)
+      r-train (~> 0.11)
+      rainbow (~> 2)
+      rspec (~> 3)
+      rspec-its (~> 1.2)
+      rubyzip (~> 1.1)
+      thor (~> 0.19)
     ipaddress (0.8.3)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
@@ -305,6 +319,14 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    r-train (0.11.2)
+      docker-api (~> 1.26.2)
+      json (~> 1.8)
+      mixlib-shellout (~> 2.0)
+      net-scp (~> 1.2)
+      net-ssh (>= 2.9, < 4.0)
+      winrm (~> 1.6)
+      winrm-fs (~> 0.3)
     rack (1.6.4)
     rainbow (2.1.0)
     rake (11.1.2)
@@ -339,6 +361,7 @@ GEM
     ruby-progressbar (1.8.0)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.0)
+    rubyzip (1.2.0)
     rufus-lru (1.0.5)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
@@ -400,6 +423,11 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0)
+    winrm-fs (0.4.2)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 1.5)
     wmi-lite (1.0.0)
     yajl-ruby (1.2.1)
     yard (0.8.7.6)
@@ -424,6 +452,7 @@ DEPENDENCIES
   foodcritic
   github_changelog_generator
   halite
+  inspec
   knife-windows
   netrc
   nokogiri


### PR DESCRIPTION
Currently the Chef audit cookbook tries to install inspec from rubygems.org.

Bundling the inspec gem in with chef-client significantly simplifies the inspec gem install for customers that reside behind a firewall.