### PR TITLE
Fix four issues with FreeBSD ports installation

### DIFF
--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -60,6 +60,15 @@ class Chef
             make_v = shell_out_with_timeout!("make -V #{variable}", options.merge!(:env => nil, :returns => [0, 1]))
             make_v.exitstatus.zero? ? make_v.stdout.strip.split($\).first : nil # $\ is the line separator, i.e. newline.
           end
+
+          # The name of the package (without the version number) as understood by pkg, pkg_add and pkg_info.
+          def get_package_name_from_ports
+            if makefile_variable_value("PKGNAME", port_dir) =~ /^(.+)-[^-]+$/
+              $1
+            else
+              raise Chef::Exceptions::Package, "Unexpected form for PKGNAME variable in #{port_dir}/Makefile"
+            end
+          end
         end
 
         class Base < Chef::Provider::Package

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -71,7 +71,7 @@ class Chef
           end
 
           def load_current_resource
-            @current_resource.package_name(@new_resource.package_name)
+            @current_resource.package_name(package_name)
 
             @current_resource.version(current_installed_version)
             Chef::Log.debug("#{@new_resource} current version is #{@current_resource.version}") if @current_resource.version
@@ -80,6 +80,10 @@ class Chef
             Chef::Log.debug("#{@new_resource} candidate version is #{@candidate_version}") if @candidate_version
 
             @current_resource
+          end
+
+          def package_name
+            @new_resource.package_name
           end
         end
 

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -54,16 +54,11 @@ class Chef
             shell_out_with_timeout!("pkg_delete #{package_name}-#{version || @current_resource.version}", :env => nil).status
           end
 
-          # The name of the package (without the version number) as understood by pkg_add and pkg_info.
           def package_name
             if supports_ports?
-              if makefile_variable_value("PKGNAME", port_path) =~ /^(.+)-[^-]+$/
-                $1
-              else
-                raise Chef::Exceptions::Package, "Unexpected form for PKGNAME variable in #{port_path}/Makefile"
-              end
+              get_package_name_from_ports
             else
-              @new_resource.package_name
+              super
             end
           end
 

--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -33,13 +33,8 @@ class Chef
             shell_out_with_timeout!("make deinstall", :timeout => 300, :env => nil, :cwd => port_dir).status
           end
 
-          # The name of the package (without the version number) as understood by pkg_add and pkg_info.
           def package_name
-            if makefile_variable_value("PKGNAME", port_dir) =~ /^(.+)-[^-]+$/
-              $1
-            else
-              raise Chef::Exceptions::Package, "Unexpected form for PKGNAME variable in #{port_dir}/Makefile"
-            end
+            get_package_name_from_ports
           end
 
           def current_installed_version

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -49,13 +49,13 @@ class Chef
       end
 
       def assign_provider
-        @provider = if source.to_s =~ /^ports$/i
-                      Chef::Provider::Package::Freebsd::Port
-                    elsif supports_pkgng?
-                      Chef::Provider::Package::Freebsd::Pkgng
-                    else
-                      Chef::Provider::Package::Freebsd::Pkg
-                    end
+        @provider ||= if source.to_s =~ /^ports$/i
+                        Chef::Provider::Package::Freebsd::Port
+                      elsif supports_pkgng?
+                        Chef::Provider::Package::Freebsd::Pkgng
+                      else
+                        Chef::Provider::Package::Freebsd::Pkg
+                      end
       end
     end
   end


### PR DESCRIPTION
1. Fix `package_name`. If port name is different from package name Chef will fail to detect that port was already installed, it will compile again and fail to install it.
2. According to documentation a provider may be specified in resource so it should not be overridden by Chef.