### PR TITLE
Handle numeric id for the user value in the git resource

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -307,7 +307,7 @@ class Chef
             when Integer
               Etc.getpwuid(@new_resource.user).dir
             else
-              Chef::Log.error("The `owneuser` parameter of the #@new_resource resource is set to an invalid value (#{new_resource.owner.inspect})")
+              Chef::Log.error("The `user` parameter of the #@new_resource resource is set to an invalid value (#{new_resource.owner.inspect})")
               raise ArgumentError, "cannot resolve #{new_resource.owner.inspect} to uid, owner must be a string or integer"
             end
             

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -302,13 +302,10 @@ class Chef
           env["HOME"] = begin
             require "etc"
             case @new_resource.user
-            when String
-              Etc.getpwnam(@new_resource.user).dir
             when Integer
               Etc.getpwuid(@new_resource.user).dir
             else
-              Chef::Log.error("The `user` parameter of the #@new_resource resource is set to an invalid value (#{new_resource.owner.inspect})")
-              raise ArgumentError, "cannot resolve #{new_resource.owner.inspect} to uid, owner must be a string or integer"
+              Etc.getpwnam(@new_resource.user.to_s).dir
             end
             
           rescue ArgumentError # user not found

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -301,7 +301,16 @@ class Chef
           # user who is executing `git` not the user running Chef.
           env["HOME"] = begin
             require "etc"
-            Etc.getpwnam(@new_resource.user).dir
+            case @new_resource.user
+            when String
+              Etc.getpwnam(@new_resource.user).dir
+            when Integer
+              Etc.getpwuid(@new_resource.user).dir
+            else
+              Chef::Log.error("The `owneuser` parameter of the #@new_resource resource is set to an invalid value (#{new_resource.owner.inspect})")
+              raise ArgumentError, "cannot resolve #{new_resource.owner.inspect} to uid, owner must be a string or integer"
+            end
+            
           rescue ArgumentError # user not found
             raise Chef::Exceptions::User, "Could not determine HOME for specified user '#{@new_resource.user}' for resource '#{@new_resource.name}'"
           end

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -307,7 +307,6 @@ class Chef
             else
               Etc.getpwnam(@new_resource.user.to_s).dir
             end
-            
           rescue ArgumentError # user not found
             raise Chef::Exceptions::User, "Could not determine HOME for specified user '#{@new_resource.user}' for resource '#{@new_resource.name}'"
           end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -269,7 +269,7 @@ SHAS
 
   context "with a user id" do
     let(:deploy_user)  { 123 }
-    let(:expected_cmd) { 'git clone  "git://github.com/opscode/chef.git" "/my/deploy/dir"' }
+    let(:expected_cmd) { 'git clone "git://github.com/opscode/chef.git" "/my/deploy/dir"' }
     let(:default_options) do
       {
         :user => 123,

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -297,7 +297,7 @@ SHAS
       end
       before { @resource.environment(override_home) }
       it "clones a repo with amended git options with specific home" do
-        expect(@provider).to receive(:shell_out!).with(expected_cmd, overrided_options)
+        expect(@provider).to receive(:shell_out!).with(expected_cmd, hash_including(overrided_options))
         @provider.clone
       end
     end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -267,6 +267,42 @@ SHAS
     end
   end
 
+  context "with a user id" do
+    let(:deploy_user)  { 123 }
+    let(:expected_cmd) { 'git clone  "git://github.com/opscode/chef.git" "/my/deploy/dir"' }
+    let(:default_options) do
+      {
+        :user => 123,
+        :environment => { "HOME" => "/home/deployNinja" },
+        :log_tag => "git[web2.0 app]",
+      }
+    end
+    before do
+      @resource.user deploy_user
+      allow(Etc).to receive(:getpwuid).and_return(double("Struct::Passwd", :name => @resource.user, :dir => "/home/deployNinja"))
+    end
+    context "with a specific home" do
+      let (:override_home) do
+        { "HOME" => "/home/masterNinja" }
+      end
+      let(:overrided_options) do
+        {
+          :user => 123,
+          :environment => { "HOME" => "/home/masterNinja" },
+          :log_tag => "git[web2.0 app]",
+        }
+      end
+      before do
+        @resource.environment(override_home)
+      end
+      before { @resource.environment(override_home) }
+      it "clones a repo with amended git options with specific home" do
+        expect(@provider).to receive(:shell_out!).with(expected_cmd, overrided_options)
+        @provider.clone
+      end
+    end
+  end
+
   it "runs a clone command with escaped destination" do
     @resource.user "deployNinja"
     allow(Etc).to receive(:getpwnam).and_return(double("Struct::Passwd", :name => @resource.user, :dir => "/home/deployNinja"))


### PR DESCRIPTION
## Description

The user property of the git resource fails when passing the user id instead of the user name. Similarly to what is described in #2860. The problem comes from the fact that the function used to retrieve the user's home only takes a String as input. The changes in this PR allows to retrieve the user's home when the user id is being used. 

## Chef Version

Latest available RPM installed automatically via vagrant

## Platform Version

Centos 6.5

## Replication Case

```
git /tmp/mydir do
  repository 'ssh://git@somehost.tld/myrepo.git'
  revision 'master'
  user <user id>
  group <group id>
end
```
## Client Output

From memory (will update later with proper output I can't access now):

```
TypeError: no implicit conversion of Integer into String
```
Raised at this line: https://github.com/chef/chef/blob/master/lib/chef/provider/git.rb#L300