### PR TITLE
Encode registry enumerated values and keys to utf8 instead of the local codepage

### DIFF
--- a/lib/chef/monkey_patches/win32/registry.rb
+++ b/lib/chef/monkey_patches/win32/registry.rb
@@ -22,6 +22,17 @@ require "win32/registry"
 module Win32
   class Registry
 
+    # ::Win32::Registry#export_string is used when enumerating child
+    # keys and values and re encodes a UTF-16LE to the local codepage.
+    # This can result in encoding incompatibilities if the native codepage
+    # does not support the characters in the registry. There is an open bug
+    # in ruby at https://bugs.ruby-lang.org/issues/11410. Rather than converting
+    # the UTF-16LE originally returned by the win32 api, we encode to UTF-8
+    # which will likely not result in any conversion error.
+    def export_string(str, enc = Encoding.default_internal || "utf-8")
+      str.encode(enc)
+    end
+
     module API
 
       extend Chef::ReservedNames::Win32::API::Registry

--- a/spec/functional/win32/registry_spec.rb
+++ b/spec/functional/win32/registry_spec.rb
@@ -26,6 +26,7 @@ describe "Chef::Win32::Registry", :windows_only do
     #Create a registry item
     ::Win32::Registry::HKEY_CURRENT_USER.create "Software\\Root"
     ::Win32::Registry::HKEY_CURRENT_USER.create "Software\\Root\\Branch"
+    ::Win32::Registry::HKEY_CURRENT_USER.create "Software\\Root\\B®anch"
     ::Win32::Registry::HKEY_CURRENT_USER.create "Software\\Root\\Branch\\Flower"
     ::Win32::Registry::HKEY_CURRENT_USER.open('Software\\Root', Win32::Registry::KEY_ALL_ACCESS) do |reg|
       reg["RootType1", Win32::Registry::REG_SZ] = "fibrous"


### PR DESCRIPTION
This fixes #4897 and addresses a known bug documented [here](https://bugs.ruby-lang.org/issues/11410)