### PR TITLE
reject malformed ini content in systemd_unit resource

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -20,6 +20,7 @@ require "chef/provider"
 require "chef/mixin/which"
 require "chef/mixin/shell_out"
 require "chef/resource/file"
+require "iniparse"
 
 class Chef
   class Provider
@@ -41,6 +42,15 @@ class Chef
         current_resource.triggers_reload(new_resource.triggers_reload)
 
         current_resource
+      end
+
+      def define_resource_requirements
+        super
+
+        requirements.assert(:create) do |a|
+          a.assertion { IniParse.parse(new_resource.to_ini) }
+          a.failure_message "Unit content is not valid INI text"
+        end
       end
 
       def action_create


### PR DESCRIPTION
was thinking about this the other day, and wanted to send a PR to raise the subject:

currently, we pass the content string through as-is, which means it's possible to give bad input to systemd. this fixes it so that it will at least be enforced as a well-formed ini-formatted string, but it's not perfect...

pro: ensure well-formed ini content string by attempting to parse as ini before converting back to string

con: `IniParse.parse(str).to_s` reformats the string with spaces between the `=` and an empty line between headings, so it's possible that a valid ini string may not match the exact string as rendered on disk, thus breaking idempotency :frowning:...

maybe this is a case that should just be covered by integration testing, but i figured i'd raise the subject and see what Chef maintainers thought about how best to handle it.