### PR TITLE
add systemd_unit try-restart, reload-or-restart, reload-or-try-restart actions

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -133,6 +133,24 @@ class Chef
         end
       end
 
+      def action_try_restart
+        converge_by("try-restarting unit: #{new_resource.name}") do
+          systemctl_execute!("try-restart", new_resource.name)
+        end
+      end
+
+      def action_reload_or_restart
+        converge_by("reload-or-restarting unit: #{new_resource.name}") do
+          systemctl_execute!("reload-or-restart", new_resource.name)
+        end
+      end
+
+      def action_reload_or_try_restart
+        converge_by("reload-or-try-restarting unit: #{new_resource.name}") do
+          systemctl_execute!("reload-or-try-restart", new_resource.name)
+        end
+      end
+
       def active?
         systemctl_execute("is-active", new_resource.name).exitstatus == 0
       end

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -29,7 +29,9 @@ class Chef
                       :enable, :disable,
                       :mask, :unmask,
                       :start, :stop,
-                      :restart, :reload
+                      :restart, :reload,
+                      :try_restart, :reload_or_restart,
+                      :reload_or_try_restart
 
       property :enabled, [TrueClass, FalseClass]
       property :active, [TrueClass, FalseClass]

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -629,6 +629,69 @@ describe Chef::Provider::SystemdUnit do
         end
       end
 
+      describe "try-restarts the unit" do
+        context "when a user is specified" do
+          it "try-restarts the unit" do
+            current_resource.user(user_name)
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --user try-restart #{unit_name}", user_cmd_opts)
+                                  .and_return(shell_out_success)
+            provider.action_try_restart
+          end
+        end
+
+        context "when no user is specified" do
+          it "try-restarts the unit" do
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --system try-restart #{unit_name}", {})
+                                  .and_return(shell_out_success)
+            provider.action_try_restart
+          end
+        end
+      end
+
+      describe "reload-or-restarts the unit" do
+        context "when a user is specified" do
+          it "reload-or-restarts the unit" do
+            current_resource.user(user_name)
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --user reload-or-restart #{unit_name}", user_cmd_opts)
+                                  .and_return(shell_out_success)
+            provider.action_reload_or_restart
+          end
+        end
+
+        context "when no user is specified" do
+          it "reload-or-restarts the unit" do
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --system reload-or-restart #{unit_name}", {})
+                                  .and_return(shell_out_success)
+            provider.action_reload_or_restart
+          end
+        end
+      end
+
+      describe "reload-or-try-restarts the unit" do
+        context "when a user is specified" do
+          it "reload-or-try-restarts the unit" do
+            current_resource.user(user_name)
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --user reload-or-try-restart #{unit_name}", user_cmd_opts)
+                                  .and_return(shell_out_success)
+            provider.action_reload_or_try_restart
+          end
+        end
+
+        context "when no user is specified" do
+          it "reload-or-try-restarts the unit" do
+            expect(provider).to receive(:shell_out_with_systems_locale!)
+                                  .with("#{systemctl_path} --system reload-or-try-restart #{unit_name}", {})
+                                  .and_return(shell_out_success)
+            provider.action_reload_or_try_restart
+          end
+        end
+      end
+
       describe "#active?" do
         before(:each) do
           provider.current_resource = current_resource


### PR DESCRIPTION
systemd has some fancy unit commands that do roughly the equivalent of the service resource's "supports" behavior for reloads, where you can say "reload-or-restart" and it'll issue a restart if the unit doesn't support reloading (as defined by the ExecReload directive);

they're defined as:

- try-restart: Restart one or more units if active
- reload-or-restart: Reload one or more units if possible, otherwise start or restart
- reload-or-try-restart: Reload one or more units if possible, otherwise restart if active
