### PR TITLE
RFC 31 - Default solo to local mode

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -392,7 +392,11 @@ module ChefConfig
     default :rest_timeout, 300
     default :yum_timeout, 900
     default :yum_lock_timeout, 30
-    default :solo,  false
+    default :solo, false
+
+    # Are we running in old Chef Solo legacy mode?
+    default :solo_legacy_mode, false
+
     default :splay, nil
     default :why_run, false
     default :color, false

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -150,7 +150,7 @@ class Chef::Application::Apply < Chef::Application
   end
 
   def get_recipe_and_run_context
-    Chef::Config[:solo] = true
+    Chef::Config[:solo_legacy_mode] = true
     @chef_client = Chef::Client.new(@json_attribs)
     @chef_client.run_ohai
     @chef_client.load_node

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -201,7 +201,7 @@ class Chef::Application::Solo < Chef::Application
     :description    => "DANGEROUS: does what it says, only useful with --recipe-url",
     :boolean        => true
 
-  option :og_chef_solo,
+  option :solo_legacy_mode,
     :long           => "--legacy-mode",
     :description    => "Run chef-solo in legacy mode",
     :boolean        => true
@@ -212,7 +212,7 @@ class Chef::Application::Solo < Chef::Application
   def run
     setup_signal_handlers
     reconfigure
-    if !Chef::Config[:og_chef_solo]
+    if !Chef::Config[:solo_legacy_mode]
       Chef::Application::Client.new.run
     else
       setup_application
@@ -228,11 +228,11 @@ class Chef::Application::Solo < Chef::Application
     set_specific_recipes
 
     Chef::Config[:solo] = true
-    # Chef::Config[:og_chef_solo] = true
+    # Chef::Config[:solo_legacy_mode] = true
 
     Chef::Log.deprecation("-r MUST be changed to --recipe-url, the -r option will be changed in Chef 13.0") if ARGV.include?("-r")
 
-    if !Chef::Config[:og_chef_solo]
+    if !Chef::Config[:solo_legacy_mode]
       Chef::Config[:local_mode] = true
     else
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -228,7 +228,6 @@ class Chef::Application::Solo < Chef::Application
     set_specific_recipes
 
     Chef::Config[:solo] = true
-    # Chef::Config[:solo_legacy_mode] = true
 
     Chef::Log.deprecation("-r MUST be changed to --recipe-url, the -r option will be changed in Chef 13.0") if ARGV.include?("-r")
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -262,7 +262,7 @@ class Chef
         enforce_path_sanity
         run_ohai
 
-        register unless Chef::Config[:solo]
+        register unless Chef::Config[:solo_legacy_mode]
 
         load_node
 
@@ -533,7 +533,7 @@ class Chef
     # @api private
     #
     def save_updated_node
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         # nothing to do
       elsif policy_builder.temporary_policy?
         Chef::Log.warn("Skipping final node save because override_runlist was given")
@@ -936,7 +936,7 @@ class Chef
     end
 
     def assert_cookbook_path_not_empty(run_context)
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         # Check for cookbooks in the path given
         # Chef::Config[:cookbook_path] can be a string or an array
         # if it's an array, go through it and check each one, raise error at the last one if no files are found

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -43,7 +43,7 @@ class Chef
     end
 
     def cleanup_file_cache
-      unless Chef::Config[:solo] || skip_removal
+      unless Chef::Config[:solo_legacy_mode] || skip_removal
         # Delete each file in the cache that we didn't encounter in the
         # manifest.
         cache.find(File.join(%w{cookbooks ** {*,.*}})).each do |cache_filename|

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -91,7 +91,7 @@ class Chef
     end
 
     def self.list(inflate = false)
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         paths = Array(Chef::Config[:data_bag_path])
         names = []
         paths.each do |path|
@@ -118,7 +118,7 @@ class Chef
 
     # Load a Data Bag by name via either the RESTful API or local data_bag_path if run in solo mode
     def self.load(name)
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         paths = Array(Chef::Config[:data_bag_path])
         data_bag = {}
         paths.each do |path|

--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -147,7 +147,7 @@ class Chef
 
     # Load a Data Bag Item by name via either the RESTful API or local data_bag_path if run in solo mode
     def self.load(data_bag, name)
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         bag = Chef::DataBag.load(data_bag)
         raise Exceptions::InvalidDataBagItemID, "Item #{name} not found in data bag #{data_bag}. Other items found: #{bag.keys.join(", ")}" unless bag.include?(name)
         item = bag[name]

--- a/lib/chef/deprecation/provider/remote_file.rb
+++ b/lib/chef/deprecation/provider/remote_file.rb
@@ -56,7 +56,7 @@ class Chef
         def source_file(source, current_checksum, &block)
           if absolute_uri?(source)
             fetch_from_uri(source, &block)
-          elsif !Chef::Config[:solo]
+          elsif !Chef::Config[:solo_legacy_mode]
             fetch_from_chef_server(source, current_checksum, &block)
           else
             fetch_from_local_cookbook(source, &block)

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -244,7 +244,7 @@ class Chef
     end
 
     def self.load(name)
-      if Chef::Config[:solo]
+      if Chef::Config[:solo_legacy_mode]
         load_from_file(name)
       else
         self.from_hash(chef_server_rest.get("environments/#{name}"))
@@ -310,7 +310,7 @@ class Chef
 
     def self.validate_cookbook_version(version)
       begin
-        if Chef::Config[:solo]
+        if Chef::Config[:solo_legacy_mode]
           raise Chef::Exceptions::IllegalVersionConstraint,
                 "Environment cookbook version constraints not allowed in chef-solo"
         else

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -66,7 +66,7 @@ class Chef
         Chef::Log.debug("Building node object for #{node_name}")
 
         @node =
-          if Chef::Config[:solo]
+          if Chef::Config[:solo_legacy_mode]
             Chef::Node.build(node_name)
           else
             Chef::Node.find_or_create(node_name)

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -69,7 +69,7 @@ class Chef
       end
 
       def setup_run_context(specific_recipes = nil)
-        if Chef::Config[:solo]
+        if Chef::Config[:solo_legacy_mode]
           Chef::Cookbook::FileVendor.fetch_from_disk(Chef::Config[:cookbook_path])
           cl = Chef::CookbookLoader.new(Chef::Config[:cookbook_path])
           cl.load_cookbooks
@@ -118,7 +118,7 @@ class Chef
         Chef::Log.debug("Building node object for #{node_name}")
 
         @node =
-          if Chef::Config[:solo]
+          if Chef::Config[:solo_legacy_mode]
             Chef::Node.build(node_name)
           else
             Chef::Node.find_or_create(node_name)
@@ -167,7 +167,7 @@ class Chef
 
       # Expands the node's run list. Stores the run_list_expansion object for later use.
       def expand_run_list
-        @run_list_expansion = if Chef::Config[:solo]
+        @run_list_expansion = if Chef::Config[:solo_legacy_mode]
                                 node.expand!("disk")
                               else
                                 node.expand!("server")

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -68,7 +68,7 @@ class Chef
 
         @node = nil
 
-        if Chef::Config[:solo]
+        if Chef::Config[:solo_legacy_mode]
           raise UnsupportedFeature, "Policyfile does not support chef-solo. Use chef-client local mode instead."
         end
 

--- a/lib/chef/shell/shell_session.rb
+++ b/lib/chef/shell/shell_session.rb
@@ -150,7 +150,7 @@ module Shell
     private
 
     def rebuild_node
-      Chef::Config[:solo] = true
+      Chef::Config[:solo_legacy_mode] = true
       @client = Chef::Client.new(nil, Chef::Config[:shell_config])
       @client.run_ohai
       @client.load_node
@@ -182,7 +182,7 @@ module Shell
 
     def rebuild_node
       # Tell the client we're chef solo so it won't try to contact the server
-      Chef::Config[:solo] = true
+      Chef::Config[:solo_legacy_mode] = true
       @client = Chef::Client.new(nil, Chef::Config[:shell_config])
       @client.run_ohai
       @client.load_node
@@ -213,7 +213,7 @@ module Shell
 
     def rebuild_node
       # Make sure the client knows this is not chef solo
-      Chef::Config[:solo] = false
+      Chef::Config[:solo_legacy_mode] = false
       @client = Chef::Client.new(nil, Chef::Config[:shell_config])
       @client.run_ohai
       @client.register

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -15,7 +15,7 @@ describe "chef-solo" do
 
   let(:cookbook_ancient_100_metadata_rb) { cb_metadata("ancient", "1.0.0") }
 
-  let(:chef_solo) { "ruby bin/chef-solo --minimal-ohai" }
+  let(:chef_solo) { "ruby bin/chef-solo --legacy-mode --minimal-ohai" }
 
   when_the_repository "has a cookbook with a basic recipe" do
     before do

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -24,13 +24,13 @@ describe Chef::Application::Apply do
     allow(@app).to receive(:configure_logging).and_return(true)
     allow(Chef::Log).to receive(:debug).with("FIPS mode is enabled.")
     @recipe_text = "package 'nyancat'"
-    Chef::Config[:solo] = true
+    Chef::Config[:solo_legacy_mode] = true
   end
 
   describe "configuring the application" do
     it "should set solo mode to true" do
       @app.reconfigure
-      expect(Chef::Config[:solo]).to be_truthy
+      expect(Chef::Config[:solo_legacy_mode]).to be_truthy
     end
   end
   describe "read_recipe_file" do

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -30,141 +30,171 @@ describe Chef::Application::Solo do
 
     Chef::Config[:json_attribs] = false
     Chef::Config[:solo] = true
+    Chef::Config[:solo_legacy_mode] = true
 
     # protect the unit tests against accidental --delete-entire-chef-repo from firing
     # for real during tests.  DO NOT delete this line.
     expect(FileUtils).not_to receive(:rm_rf)
   end
 
-  describe "configuring the application" do
-    it "should call set_specific_recipes" do
-      expect(app).to receive(:set_specific_recipes)
-      app.reconfigure
+  context "in legacy mode" do
+    describe "configuring the application" do
+      it "should call set_specific_recipes" do
+        expect(app).to receive(:set_specific_recipes)
+        app.reconfigure
+      end
+
+      it "should set solo mode to true" do
+        app.reconfigure
+        expect(Chef::Config[:solo]).to be_truthy
+      end
+
+      it "should set audit-mode to :disabled" do
+        app.reconfigure
+        expect(Chef::Config[:audit_mode]).to be :disabled
+      end
+
+      describe "when configured to not fork the client process" do
+        before do
+          Chef::Config[:client_fork] = false
+          Chef::Config[:daemonize] = false
+          Chef::Config[:interval] = nil
+          Chef::Config[:splay] = nil
+        end
+
+        context "when interval is given" do
+          before do
+            Chef::Config[:interval] = 600
+          end
+
+          it "should terminate with message" do
+            expect(Chef::Application).to receive(:fatal!).with(
+              "Unforked chef-client interval runs are disabled in Chef 12.
+Configuration settings:
+  interval  = 600 seconds
+Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+            )
+            app.reconfigure
+          end
+        end
+      end
+
+      describe "when in daemonized mode and no interval has been set" do
+        before do
+          Chef::Config[:daemonize] = true
+        end
+
+        it "should set the interval to 1800" do
+          Chef::Config[:interval] = nil
+          app.reconfigure
+          expect(Chef::Config[:interval]).to eq(1800)
+        end
+      end
+
+      describe "when the json_attribs configuration option is specified" do
+        let(:json_attribs) { { "a" => "b" } }
+        let(:config_fetcher) { double(Chef::ConfigFetcher, :fetch_json => json_attribs) }
+        let(:json_source) { "https://foo.com/foo.json" }
+
+        before do
+          Chef::Config[:json_attribs] = json_source
+          expect(Chef::ConfigFetcher).to receive(:new).with(json_source).
+            and_return(config_fetcher)
+        end
+
+        it "reads the JSON attributes from the specified source" do
+          app.reconfigure
+          expect(app.chef_client_json).to eq(json_attribs)
+        end
+      end
+
+      it "downloads a tarball when the recipe_url configuration option is specified" do
+        Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
+        Chef::Config[:recipe_url] = "http://junglist.gen.nz/recipes.tgz"
+
+        expect(FileUtils).to receive(:mkdir_p).with("#{Dir.tmpdir}/chef-solo").and_return(true)
+
+        tarfile = StringIO.new("remote_tarball_content")
+        target_file = StringIO.new
+
+        expect(app).to receive(:open).with("http://junglist.gen.nz/recipes.tgz").and_yield(tarfile)
+        expect(File).to receive(:open).with("#{Dir.tmpdir}/chef-solo/recipes.tgz", "wb").and_yield(target_file)
+
+        shellout = instance_double("Mixlib::ShellOut", run_command: nil, error!: nil, stdout: "")
+
+        expect(app).to receive(:shell_out!).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo").and_return(shellout)
+        app.reconfigure
+        expect(target_file.string).to eq("remote_tarball_content")
+      end
+
+      it "fetches the recipe_url first when both json_attribs and recipe_url are specified" do
+        json_attribs = { "a" => "b" }
+        config_fetcher = instance_double("Chef::ConfigFetcher", :fetch_json => json_attribs)
+
+        Chef::Config[:json_attribs] = "https://foo.com/foo.json"
+        Chef::Config[:recipe_url] = "http://icanhas.cheezburger.com/lolcats"
+        Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
+        expect(FileUtils).to receive(:mkdir_p).with("#{Dir.tmpdir}/chef-solo").and_return(true)
+
+        allow(Chef::Mixin::Command).to receive(:run_command).and_return(true)
+
+        shellout = instance_double("Mixlib::ShellOut", run_command: nil, error!: nil, stdout: "")
+
+        expect(app).to receive(:shell_out!).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo").and_return(shellout)
+        expect(app).to receive(:fetch_recipe_tarball).ordered
+        expect(Chef::ConfigFetcher).to receive(:new).ordered.and_return(config_fetcher)
+        app.reconfigure
+      end
     end
 
-    it "should set solo mode to true" do
+    describe "after the application has been configured" do
+      before do
+        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
+
+        allow(Chef::Daemon).to receive(:change_privilege)
+        chef_client = double("Chef::Client")
+        allow(Chef::Client).to receive(:new).and_return(chef_client)
+        # this is all stuff the reconfigure method needs
+        allow(app).to receive(:configure_opt_parser).and_return(true)
+        allow(app).to receive(:configure_chef).and_return(true)
+        allow(app).to receive(:configure_logging).and_return(true)
+      end
+
+      it "should change privileges" do
+        expect(Chef::Daemon).to receive(:change_privilege).and_return(true)
+        app.setup_application
+      end
+    end
+
+    it_behaves_like "an application that loads a dot d" do
+      let(:dot_d_config_name) { :solo_d_dir }
+    end
+  end
+
+  context "in local mode" do
+    before do
+      Chef::Config[:solo_legacy_mode] = false
+    end
+
+    it "sets solo mode to true" do
       app.reconfigure
       expect(Chef::Config[:solo]).to be_truthy
     end
 
-    it "should set audit-mode to :disabled" do
+    it "sets local mode to true" do
       app.reconfigure
-      expect(Chef::Config[:audit_mode]).to be :disabled
+      expect(Chef::Config[:local_mode]).to be_truthy
     end
 
-    describe "when configured to not fork the client process" do
-      before do
-        Chef::Config[:client_fork] = false
-        Chef::Config[:daemonize] = false
-        Chef::Config[:interval] = nil
-        Chef::Config[:splay] = nil
-      end
-
-      context "when interval is given" do
-        before do
-          Chef::Config[:interval] = 600
-        end
-
-        it "should terminate with message" do
-          expect(Chef::Application).to receive(:fatal!).with(
-"Unforked chef-client interval runs are disabled in Chef 12.
-Configuration settings:
-  interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
-          )
-          app.reconfigure
-        end
-      end
-    end
-
-    describe "when in daemonized mode and no interval has been set" do
-      before do
-        Chef::Config[:daemonize] = true
-      end
-
-      it "should set the interval to 1800" do
-        Chef::Config[:interval] = nil
-        app.reconfigure
-        expect(Chef::Config[:interval]).to eq(1800)
-      end
-    end
-
-    describe "when the json_attribs configuration option is specified" do
-      let(:json_attribs) { { "a" => "b" } }
-      let(:config_fetcher) { double(Chef::ConfigFetcher, :fetch_json => json_attribs) }
-      let(:json_source) { "https://foo.com/foo.json" }
-
-      before do
-        Chef::Config[:json_attribs] = json_source
-        expect(Chef::ConfigFetcher).to receive(:new).with(json_source).
-          and_return(config_fetcher)
-      end
-
-      it "reads the JSON attributes from the specified source" do
-        app.reconfigure
-        expect(app.chef_client_json).to eq(json_attribs)
-      end
-    end
-
-    it "downloads a tarball when the recipe_url configuration option is specified" do
-      Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
-      Chef::Config[:recipe_url] = "http://junglist.gen.nz/recipes.tgz"
-
-      expect(FileUtils).to receive(:mkdir_p).with("#{Dir.tmpdir}/chef-solo").and_return(true)
-
-      tarfile = StringIO.new("remote_tarball_content")
-      target_file = StringIO.new
-
-      expect(app).to receive(:open).with("http://junglist.gen.nz/recipes.tgz").and_yield(tarfile)
-      expect(File).to receive(:open).with("#{Dir.tmpdir}/chef-solo/recipes.tgz", "wb").and_yield(target_file)
-
-      shellout = instance_double("Mixlib::ShellOut", run_command: nil, error!: nil, stdout: "")
-
-      expect(app).to receive(:shell_out!).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo").and_return(shellout)
-      app.reconfigure
-      expect(target_file.string).to eq("remote_tarball_content")
-    end
-
-    it "fetches the recipe_url first when both json_attribs and recipe_url are specified" do
-      json_attribs = { "a" => "b" }
-      config_fetcher = instance_double("Chef::ConfigFetcher", :fetch_json => json_attribs)
-
-      Chef::Config[:json_attribs] = "https://foo.com/foo.json"
-      Chef::Config[:recipe_url] = "http://icanhas.cheezburger.com/lolcats"
-      Chef::Config[:cookbook_path] = "#{Dir.tmpdir}/chef-solo/cookbooks"
-      expect(FileUtils).to receive(:mkdir_p).with("#{Dir.tmpdir}/chef-solo").and_return(true)
-
-      allow(Chef::Mixin::Command).to receive(:run_command).and_return(true)
-
-      shellout = instance_double("Mixlib::ShellOut", run_command: nil, error!: nil, stdout: "")
-
-      expect(app).to receive(:shell_out!).with("tar zxvf #{Dir.tmpdir}/chef-solo/recipes.tgz -C #{Dir.tmpdir}/chef-solo").and_return(shellout)
-      expect(app).to receive(:fetch_recipe_tarball).ordered
-      expect(Chef::ConfigFetcher).to receive(:new).ordered.and_return(config_fetcher)
-      app.reconfigure
-    end
-  end
-
-  describe "after the application has been configured" do
-    before do
-      Chef::Config[:solo] = true
-
-      allow(Chef::Daemon).to receive(:change_privilege)
-      chef_client = double("Chef::Client")
-      allow(Chef::Client).to receive(:new).and_return(chef_client)
-      # this is all stuff the reconfigure method needs
-      allow(app).to receive(:configure_opt_parser).and_return(true)
+    it "runs chef-client in local mode" do
+      allow(app).to receive(:setup_application).and_return(true)
+      allow(app).to receive(:run_application).and_return(true)
       allow(app).to receive(:configure_chef).and_return(true)
       allow(app).to receive(:configure_logging).and_return(true)
+      expect(Chef::Application::Client).to receive_message_chain(:new, :run)
+      app.run
     end
 
-    it "should change privileges" do
-      expect(Chef::Daemon).to receive(:change_privilege).and_return(true)
-      app.setup_application
-    end
-  end
-
-  it_behaves_like "an application that loads a dot d" do
-    let(:dot_d_config_name) { :solo_d_dir }
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -462,7 +462,7 @@ describe Chef::Client do
 
   describe "assert_cookbook_path_not_empty" do
     before do
-      Chef::Config[:solo] = true
+      Chef::Config[:solo_legacy_mode] = true
       Chef::Config[:cookbook_path] = ["/path/to/invalid/cookbook_path"]
     end
 

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -50,7 +50,7 @@ describe Chef::CookbookCacheCleaner do
     end
 
     it "does not remove anything on chef-solo" do
-      Chef::Config[:solo] = true
+      Chef::Config[:solo_legacy_mode] = true
       allow(cleaner.cache).to receive(:find).and_return(%w{cookbooks/valid1/recipes/default.rb cookbooks/valid2/recipes/default.rb})
       expect(cleaner.cache).not_to receive(:delete)
       cleaner.cleanup_file_cache

--- a/spec/unit/data_bag_item_spec.rb
+++ b/spec/unit/data_bag_item_spec.rb
@@ -365,11 +365,11 @@ describe Chef::DataBagItem do
 
     describe "in solo mode" do
       before do
-        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
       end
 
       after do
-        Chef::Config[:solo] = false
+        Chef::Config[:solo_legacy_mode] = false
       end
 
       it "converts the raw data to a data bag item" do

--- a/spec/unit/data_bag_spec.rb
+++ b/spec/unit/data_bag_spec.rb
@@ -143,13 +143,13 @@ describe Chef::DataBag do
 
     shared_examples_for "data bag in solo mode" do |data_bag_path|
       before do
-        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
         Chef::Config[:data_bag_path] = data_bag_path
         @paths = Array(data_bag_path)
       end
 
       after do
-        Chef::Config[:solo] = false
+        Chef::Config[:solo_legacy_mode] = false
       end
 
       it "should get the data bag from the data_bag_path" do

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -288,11 +288,11 @@ describe Chef::Environment do
 
     describe "in solo mode" do
       before do
-        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
       end
 
       after do
-        Chef::Config[:solo] = false
+        Chef::Config[:solo_legacy_mode] = false
       end
 
       it "should raise and exception" do
@@ -392,12 +392,12 @@ describe Chef::Environment do
   describe "when loading" do
     describe "in solo mode" do
       before do
-        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
         Chef::Config[:environment_path] = "/var/chef/environments"
       end
 
       after do
-        Chef::Config[:solo] = false
+        Chef::Config[:solo_legacy_mode] = false
       end
 
       it "should get the environment from the environment_path" do

--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -254,7 +254,7 @@ describe Chef::PolicyBuilder::Dynamic do
       context "when running chef solo" do
 
         before do
-          Chef::Config[:solo] = true
+          Chef::Config[:solo_legacy_mode] = true
           expect(Chef::Node).to receive(:build).with(node_name).and_return(node)
           expect(policy_builder).to receive(:select_implementation).with(node)
           expect(implementation).to receive(:finish_load_node).with(node)

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -115,7 +115,7 @@ describe Chef::PolicyBuilder::Policyfile do
     end
 
     context "chef-solo" do
-      before { Chef::Config[:solo] = true }
+      before { Chef::Config[:solo_legacy_mode] = true }
 
       it "errors on create" do
         expect { initialize_pb }.to raise_error(err_namespace::UnsupportedFeature)


### PR DESCRIPTION
This switches the default operation of chef-solo to be equivalent to `chef-client -z`, but allows for the old style chef-solo by uttering `chef-solo --legacy-mode`.

cc @chef/client-maintainers