### PR TITLE
Skip node attribute saving with named run lists

### DIFF
--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -194,12 +194,13 @@ class Chef
         cookbooks_to_sync
       end
 
-      # Whether or not this is a temporary policy. Since PolicyBuilder doesn't
-      # support override_runlist, this is always false.
+      # Whether or not this is a temporary policy, which means a
+      # named_run_list was provided. Chef::Client uses this to decide whether
+      # to do the final node save at the end of the run or not.
       #
       # @return [false]
       def temporary_policy?
-        false
+        named_run_list_requested?
       end
 
       ## Internal Public API ##

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -583,6 +583,10 @@ describe Chef::PolicyBuilder::Policyfile do
               expect(Chef::CookbookCacheCleaner.instance.skip_removal).to be(true)
             end
 
+            it "gives `true` for #temporary_policy?" do
+              expect(policy_builder.temporary_policy?).to be(true)
+            end
+
           end
 
         end


### PR DESCRIPTION
[Policyfile.rb documentation](https://docs.chef.io/config_rb_policyfile.html) suggests named run lists can be used as an alternative to an override run list. A natural assumption then is that node attribute saving also behaves the same with an override run list as with named run lists.

Quoting the Policyfile.rb documentation:

> named_run_list "NAME", "ITEM1", "ITEM2", ...
> Specify a named run-list to be used as an alternative to the override run-list. This setting should be used carefully and for specific use cases, like running a small set of recipes to quickly converge configuration for a single application on a host or for one-time setup tasks.

This change marks the policy as temporary if a named run list is requested, so that chef-client will not save node attributes at the end of the run, just as with an override run list.
### Version:

Chef 12.10.45
### Environment:

chef-client runs in policyfile mode
### Scenario:

We want to run a subset of recipes (e.g., `cookbook_name::deploy`) using a named run list and not save the node's run_list at the end of the chef-client run in order not to break Chef searches such as `recipes:cookbook_name\:\:appserver`. This works with an override run list, but not in policyfile mode with named run lists.
### Steps to Reproduce:
1. Run `chef-client` with `policy_name` and `policy_group` set in `/etc/chef/client.rb`, then run `knife node show <node_name>`.
2. Run `chef-client -n <named_run_list>` (where the named run list uses a different set of recipes than the default run list) and run `knife node show <node_name` again.
3. Compare the output of `knife node show` before and after the second chef-client run.
### Expected Result:

The list of recipes and other node attributes have not changed between client runs.
### Actual Result:

The list of recipes and possibly node attributes have changed.
