### PR TITLE
gem metadata command needs Gem.clear_paths

### DIFF
--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -59,6 +59,7 @@ class Chef
                 Chef::Log.info(so.stdout)
               end
             end
+            Gem.clear_paths
           rescue Exception => e
             events.cookbook_gem_failed(e)
             raise


### PR DESCRIPTION
otherwise it'll crash on the first run and have to be re-run