### PR TITLE
Execute chef-acceptance without elevated privileges

### DIFF
--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -92,7 +92,6 @@ if [ "x$ACCEPTANCE" != "x" ]; then
   cd /opt/$PROJECT_NAME
   CHEF_GEM=`bundle show chef`
   PATH=$OLD_PATH
-  cd $CHEF_GEM/acceptance
 
   # On acceptance testers we have Chef DK. We will use its Ruby environment
   # to cut down the gem installation time.
@@ -100,10 +99,13 @@ if [ "x$ACCEPTANCE" != "x" ]; then
   export PATH
 
   # Test against the Chef bundle
-  sudo env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID pwd
-  sudo env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config
-  sudo env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install
-  sudo env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test --force-destroy --data-path $WORKSPACE/chef-acceptance-data
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID pwd
+  # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
+  # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
+  # saves us from having to add a `sudo` to any of the `bundle` commands.
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile $CHEF_GEM/acceptance/Gemfile
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test --force-destroy --data-path $WORKSPACE/chef-acceptance-data
 else
   PATH=/opt/$PROJECT_NAME/bin:/opt/$PROJECT_NAME/embedded/bin:$PATH
   export PATH


### PR DESCRIPTION
We output all data generated during a chef-acceptance run to the workspace
of the executing Jenkins job using chef-acceptance's `--data-path` option.
If the `chef-acceptance` commands are executed with elevated privileges
(using `sudo`) the generated files are owned by `root`:
https://gist.github.com/schisamo/7ce7262813f2bc81b7314d9eab53afa0

This is an issue as the generated data cannot be properly archived OR
cleaned up when the next job runs:
https://gist.github.com/schisamo/b7246987d49534b27b8a4ad72f9ad965

/cc @chef/engineering-services