### PR TITLE
Re-enable and fix acceptance tests

### DIFF
--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/chef-acceptance.git
-  revision: 4abda84e2fadd0452b77a8a88d4fd534843ced55
+  revision: 47e931cec100dce8efae4369a5b03443eaf2b733
   specs:
     chef-acceptance (0.2.0)
       mixlib-shellout (~> 2.0)

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -98,12 +98,14 @@ if [ "x$ACCEPTANCE" != "x" ]; then
   PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
   export PATH
 
-  # Test against the Chef bundle
-  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID pwd
-  # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
-  # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
-  # saves us from having to add a `sudo` to any of the `bundle` commands.
-  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile $CHEF_GEM/acceptance/Gemfile
+  # copy acceptance suites into workspace
+  SUITE_PATH=$WORKSPACE/acceptance
+  mkdir -p $SUITE_PATH
+  cp -R $CHEF_GEM/acceptance/. $SUITE_PATH
+  sudo chown -R $USER:$USER $SUITE_PATH
+
+  cd $SUITE_PATH
+
   env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
   env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test --force-destroy --data-path $WORKSPACE/chef-acceptance-data
 else

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -87,26 +87,25 @@ export FORCE_FFI_YAJL
 # If is it set; we run the acceptance tests, otherwise run rspec tests.
 if [ "x$ACCEPTANCE" != "x" ]; then
   # Find the Chef gem and cd there.
-  # OLD_PATH=$PATH
-  # PATH=/opt/$PROJECT_NAME/bin:/opt/$PROJECT_NAME/embedded/bin:$PATH
-  # cd /opt/$PROJECT_NAME
-  # CHEF_GEM=`bundle show chef`
-  # PATH=$OLD_PATH
+  OLD_PATH=$PATH
+  PATH=/opt/$PROJECT_NAME/bin:/opt/$PROJECT_NAME/embedded/bin:$PATH
+  cd /opt/$PROJECT_NAME
+  CHEF_GEM=`bundle show chef`
+  PATH=$OLD_PATH
 
-  # # On acceptance testers we have Chef DK. We will use its Ruby environment
-  # # to cut down the gem installation time.
-  # PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
-  # export PATH
+  # On acceptance testers we have Chef DK. We will use its Ruby environment
+  # to cut down the gem installation time.
+  PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
+  export PATH
 
-  # # Test against the Chef bundle
-  # env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID pwd
-  # # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
-  # # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
-  # # saves us from having to add a `sudo` to any of the `bundle` commands.
-  # env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile $CHEF_GEM/acceptance/Gemfile
-  # env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
-  # env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test --force-destroy --data-path $WORKSPACE/chef-acceptance-data
-  exit 0
+  # Test against the Chef bundle
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID pwd
+  # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
+  # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
+  # saves us from having to add a `sudo` to any of the `bundle` commands.
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile $CHEF_GEM/acceptance/Gemfile
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
+  env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test --force-destroy --data-path $WORKSPACE/chef-acceptance-data
 else
   PATH=/opt/$PROJECT_NAME/bin:/opt/$PROJECT_NAME/embedded/bin:$PATH
   export PATH


### PR DESCRIPTION
All chef-acceptance logs and generated data is now properly archived with the job:
http://manhattan.ci.chef.co/job/chefdk-test/183/architecture=x86_64,platform=acceptance,project=chefdk,role=tester/artifact/chef-acceptance-data/chef-dk/

These changes were tested in the following ad hoc build:
http://manhattan.ci.chef.co/job/chef-test/6/architecture=x86_64,platform=acceptance,project=chef,role=tester/console

There was one failure in the `top-cookbooks` suite which appears to be an acceptance failure (as opposed to an error in the code that executes the acceptance suites):
http://manhattan.ci.chef.co/job/chef-test/6/architecture=x86_64,platform=acceptance,project=chef,role=tester/artifact/chef-acceptance-data/logs/top-cookbooks/provision.log/*view*/

/cc @chef/engineering-services @adamedx @btm @mwrock @PrajaktaPurohit @ksubrama 