### PR TITLE
fix bundle locking on bundler 1.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,17 +4,12 @@ extend GemfileUtil
 
 source "https://rubygems.org"
 
-# Pick the gemspec for our platform
-gemspec_name = "chef"
-Dir.glob("chef-*.gemspec").each do |gemspec_filename|
-  gemspec_filename =~ /^chef-(.+).gemspec/
-  gemspec_platform = $1
-  if Gem::Platform.match(Gem::Platform.new(gemspec_platform))
-    Bundler.ui.info "Using gemspec #{gemspec_filename} for current platform."
-    gemspec_name = "chef-#{gemspec_platform}"
-  end
-end
-gemspec name: gemspec_name
+# Note we do not use the gemspec DSL which restricts to the
+# gemspec for the current platform and filters out other platforms
+# during a bundle lock operation. We actually want dependencies from
+# both of our gemspecs. Also note this this mimics gemspec behavior
+# of bundler versions prior to 1.12.0 (https://github.com/bundler/bundler/commit/193a14fe5e0d56294c7b370a0e59f93b2c216eed)
+gem "chef", path: "."
 
 gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.exist?(File.expand_path("../chef-config", __FILE__))
 # Ensure that we can always install rake, regardless of gem groups

--- a/tasks/bin/bundle-platform
+++ b/tasks/bin/bundle-platform
@@ -1,9 +1,13 @@
 #!/usr/bin/env ruby
 
 platforms = ARGV.shift
+platforms = platforms.split(" ").map { |p| Gem::Platform.new(p) }
+Gem::Platform.instance_eval { @local = platforms.last }
 old_platforms = Gem.platforms
-Gem.platforms = platforms.split(" ").map { |p| Gem::Platform.new(p) }
+Gem.platforms = platforms
 puts "bundle-platform set Gem.platforms to #{Gem.platforms.map { |p| p.to_s }} (was #{old_platforms.map { |p| p.to_s } })"
+
+desired_version = ARGV.shift.delete("_", "")
 
 # The rest of this is a normal bundler binstub
 require "pathname"
@@ -12,4 +16,4 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile",
 
 require "rubygems"
 
-load Gem.bin_path("bundler", "bundle")
+load Gem.bin_path("bundler", "bundle", desired_version)


### PR DESCRIPTION
As of bundler 1.12.0, running our rake bundler tasks wipes out the windows dependencies when run on mac/linux and wipes out the non-windows dependencies when run on windows. This change can be narrowed down to a change to the `gemspec` DSL in [this one line](https://github.com/bundler/bundler/blob/master/lib/bundler/dsl.rb#L71). v1.12.0.pre.1 added the `platform` parameter. Removing that parameter duplicates the behavior we see in 1.11.2. We can get this same behavior by not using `gemspec` and calling `gem` instead via `path: "."`.

I'm not crazy about this trickery but it appears to be the best way to support 1.12.4 and beyond.