### PR TITLE
Fix portage provider to support version with character

### DIFF
--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -41,7 +41,7 @@ class Chef
           globsafe_pkg = Chef::Util::PathHelper.escape_glob_dir(pkg)
           possibilities = Dir["/var/db/pkg/#{globsafe_category || "*"}/#{globsafe_pkg}-*"].map { |d| d.sub(%r{/var/db/pkg/}, "") }
           versions = possibilities.map do |entry|
-            if entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)}
+            if entry =~ %r{[^/]+/#{Regexp.escape(pkg)}\-(\d[\.\d]*[a-z]?((_(alpha|beta|pre|rc|p)\d*)*)?(-r\d+)?)}
               [$&, $1]
             end
           end.compact

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -56,6 +56,12 @@ describe Chef::Provider::Package::Portage, "load_current_resource" do
       expect(@provider.current_resource.version).to eq("1.0.0-r1")
     end
 
+    it "should return a current resource with the correct version if the package is found with version with character" do
+      allow(::Dir).to receive(:[]).with("/var/db/pkg/dev-util/git-*").and_return(["/var/db/pkg/dev-util/git-1.0.0d"])
+      @provider.load_current_resource
+      expect(@provider.current_resource.version).to eq("1.0.0d")
+    end
+
     it "should return a current resource with a nil version if the package is not found" do
       allow(::Dir).to receive(:[]).with("/var/db/pkg/dev-util/git-*").and_return(["/var/db/pkg/dev-util/notgit-1.0.0"])
       @provider.load_current_resource


### PR DESCRIPTION
I ran into an issue where chef 12 installs openssl 1.0.2d even if it's already installed. It doesn't support the character on the version, `d`.

According to `man 5 ebuild`

> 
Versions  are  normally made up of two or three numbers separated by periods, such as 1.2 or 4.5.2.  This string may be followed by a character such as 1.2a or 4.5.2z.  Note that this letter is not meant to indicate alpha,  beta,  etc...  status.   For  that,  use  the  optional  suffix;  either  _alpha,  _beta,  _pre (pre-release),  _rc  (release candidate), or _p (patch).

I added a test which failed before I added the fix. `bundle exec rspec spec/unit/provider/package/portage_spec.rb ` shows passing tests.

This is my first PR on chef so let me know if I need to change anything.