### PR TITLE
Remove the extra fetch operation from the git resource

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -183,7 +183,6 @@ class Chef
         converge_by("fetch updates for #{@new_resource.remote}") do
           # since we're in a local branch already, just reset to specified revision rather than merge
           Chef::Log.debug "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
-          git("fetch", @new_resource.remote, cwd: cwd)
           git("fetch", @new_resource.remote, "--tags", cwd: cwd)
           git("reset", "--hard", target_revision, cwd: cwd)
         end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -370,12 +370,10 @@ SHAS
 
   it "runs a sync command with default options" do
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd1 = "git fetch origin"
+    expected_cmd1 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    expected_cmd2 = "git fetch origin --tags"
+    expected_cmd2 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
@@ -385,18 +383,13 @@ SHAS
     @resource.group("thisis")
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
 
-    expected_cmd1 = "git fetch origin"
+    expected_cmd1 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir",
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
                                                                   :environment => { "HOME" => "/home/whois" })
-    expected_cmd2 = "git fetch origin --tags"
+    expected_cmd2 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir",
-                                                                  :user => "whois", :group => "thisis",
-                                                                  :log_tag => "git[web2.0 app]",
-                                                                  :environment => { "HOME" => "/home/whois" })
-    expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir",
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
                                                                   :environment => { "HOME" => "/home/whois" })
@@ -406,24 +399,20 @@ SHAS
   it "configures remote tracking branches when remote is ``origin''" do
     @resource.remote "origin"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command1 = "git fetch origin"
+    fetch_command1 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch origin --tags"
+    fetch_command2 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 
   it "configures remote tracking branches when remote is not ``origin''" do
     @resource.remote "opscode"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command1 = "git fetch opscode"
+    fetch_command1 = "git fetch opscode --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch opscode --tags"
+    fetch_command2 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
-    expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     @provider.fetch_updates
   end
 


### PR DESCRIPTION
It appears that with each fetch we are performing an extra unneeded fetch operation.

Within the code (https://github.com/chef/chef/blob/master/lib/chef/provider/git.rb#L186) we are performing:

```
git fetch {remote}
git fetch {remote} --tags
git reset {remote} --hard 
```
According to the documentation on fetching: https://git-scm.com/docs/git-fetch
> --tags
> Fetch all tags from the remote (i.e., fetch remote tags refs/tags/* into local tags with the same name), in addition to whatever else would otherwise be fetched. Using this option alone does not subject tags to pruning, even if --prune is used (though tags may be pruned anyway if they are also the destination of an explicit refspec; see --prune).

Based on the above adding '--tags' not only fetches remote tags but also **whatever else would otherwise be fetched.**

This seems to imply that we don't need to perform the first fetch operation, and only need to perform the fetch which includes the '--tags'.

This PR removed the extra fetch and updates the tests accordingly.
Thanks!
