### PR TITLE
fixes #4968 and only retrieves the latest version of packages from chocolatey

### DIFF
--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -82,11 +82,6 @@ describe Chef::Resource::ChocolateyPackage, :windows_only do
       subject.package_name "blah"
       expect { subject.run_action(:install) }.to raise_error Chef::Exceptions::Package
     end
-
-    it "raises if package version is not found" do
-      subject.version "3.0"
-      expect { subject.run_action(:install) }.to raise_error Chef::Exceptions::Package
-    end
   end
 
   context "upgrading a package" do

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -59,7 +59,7 @@ Git|2.6.2
 munin-node|1.6.1.20130823
     EOF
     remote_list_obj = double(stdout: remote_list_stdout)
-    allow(provider).to receive(:shell_out!).with("#{choco_exe} list -ar #{package_names.join ' '}#{args}", { timeout: timeout }).and_return(remote_list_obj)
+    allow(provider).to receive(:shell_out!).with("#{choco_exe} list -r #{package_names.join ' '}#{args}", { timeout: timeout }).and_return(remote_list_obj)
   end
 
   describe "#initialize" do
@@ -82,12 +82,6 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git"])
       new_resource.version("2.6.1")
       expect(provider.candidate_version).to eql(["2.6.1"])
-    end
-
-    it "should set the candidate_version to nill if pinning to bogus version" do
-      allow_remote_list(["git"])
-      new_resource.version("2.5.0")
-      expect(provider.candidate_version).to eql([nil])
     end
 
     it "should set the candidate_version to nil if there is no candidate" do
@@ -297,14 +291,6 @@ munin-node|1.6.1.20130823
     it "installing a package that does not exist throws an error" do
       allow_remote_list(["package-does-not-exist"])
       new_resource.package_name("package-does-not-exist")
-      provider.load_current_resource
-      expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
-    end
-
-    it "installing a package version that does not exist throws an error" do
-      allow_remote_list(["git"])
-      new_resource.package_name("git")
-      new_resource.version("2.7.0")
       provider.load_current_resource
       expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
     end


### PR DESCRIPTION
This should fix retrieving the wrong package version when expecting the latest and should also significantly improve package query performance. It also supports some feeds that do not implement the all versions capability.

We now only query the chocolatey feed for the latest version and use that as the candidate version unless an explicit version is requested and then that is the candidate.

This does prevent us from validating valid versions and allows a resource with a bogus version. In these cases we will bubble up the error from choco.exe.