### PR TITLE
Fix #4949 and Avoid Errno::EBUSY on docker containers

### DIFF
--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -245,6 +245,19 @@ class Chef
         end
       end
 
+      # Shamelessly stolen from https://github.com/sethvargo/chef-sugar/blob/master/lib/chef/sugar/docker.rb
+      # Given a node object, returns whether the node is a docker container.
+      #
+      # === Parameters
+      # node:: [Chef::Node] The node to check.
+      #
+      # === Returns
+      # true:: if the current node is a docker container
+      # false:: if the current node is not a docker container
+      def docker?(node)
+        ::File.exist?('/.dockerinit') || ::File.exist?('/.dockerenv')
+      end
+
     end
   end
 end

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -254,8 +254,11 @@ class Chef
       # === Returns
       # true:: if the current node is a docker container
       # false:: if the current node is not a docker container
-      def docker?(node)
-        ::File.exist?("/.dockerinit") || ::File.exist?("/.dockerenv")
+      def docker?(node = run_context.nil? ? nil : run_context.node)
+        # Using "File.exist?('/.dockerinit') || File.exist?('/.dockerenv')" makes Travis sad,
+        # and that makes us sad too.
+        node && node[:virtualization] && node[:virtualization][:systems] &&
+          node[:virtualization][:systems][:docker] && node[:virtualization][:systems][:docker] == "guest"
       end
 
     end

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -255,7 +255,7 @@ class Chef
       # true:: if the current node is a docker container
       # false:: if the current node is not a docker container
       def docker?(node)
-        ::File.exist?('/.dockerinit') || ::File.exist?('/.dockerenv')
+        ::File.exist?("/.dockerinit") || ::File.exist?("/.dockerenv")
       end
 
     end

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -67,13 +67,7 @@ class Chef
       def initialize(new_resource, run_context)
         @content_class ||= Chef::Provider::File::Content
         if new_resource.respond_to?(:atomic_update)
-          # Resolves https://github.com/chef/chef/issues/4949
-          if docker_guest?(run_context.node) && (new_resource.path == "/etc/resolv.conf" ||
-                                                 new_resource.path == "/etc/hostname")
-            @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(false)
-          else
-            @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(new_resource.atomic_update)
-          end
+          @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(new_resource.atomic_update)
         end
         super
       end
@@ -198,12 +192,6 @@ class Chef
       end
 
       private
-
-      # Return true if we are running in a docker guest, or false otherwise.
-      def docker_guest?(node)
-        node[:virtualization] && node[:virtualization][:systems] &&
-          node[:virtualization][:systems][:docker] && node[:virtualization][:systems][:docker] == "guest"
-      end
 
       # What to check in this resource to see if we're going to be actively managing
       # content (for things like doing checksums in load_current_resource).  Expected to

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -67,7 +67,13 @@ class Chef
       def initialize(new_resource, run_context)
         @content_class ||= Chef::Provider::File::Content
         if new_resource.respond_to?(:atomic_update)
-          @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(new_resource.atomic_update)
+          # Resolves https://github.com/chef/chef/issues/4949
+          if docker_guest?(run_context.node) && (new_resource.path == "/etc/resolv.conf" ||
+                                                 new_resource.path == "/etc/hostname")
+            @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(false)
+          else
+            @deployment_strategy = Chef::FileContentManagement::Deploy.strategy(new_resource.atomic_update)
+          end
         end
         super
       end
@@ -192,6 +198,12 @@ class Chef
       end
 
       private
+
+      # Return true if we are running in a docker guest, or false otherwise.
+      def docker_guest?(node)
+        node[:virtualization] && node[:virtualization][:systems] &&
+          node[:virtualization][:systems][:docker] && node[:virtualization][:systems][:docker] == "guest"
+      end
 
       # What to check in this resource to see if we're going to be actively managing
       # content (for things like doing checksums in load_current_resource).  Expected to

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -50,7 +50,7 @@ class Chef
       allowed_actions :create, :delete, :touch, :create_if_missing
 
       property :path, String, name_property: true, identity: true
-      property :atomic_update, [ true, false ], desired_state: false, default: lazy { |r| r.docker?(r.node) && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] }
+      property :atomic_update, [ true, false ], desired_state: false, default: lazy { |r| r.docker? && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] }
       property :backup, [ Integer, false ], desired_state: false, default: 5
       property :checksum, [ /^[a-zA-Z0-9]{64}$/, nil ]
       property :content, [ String, nil ], desired_state: false

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -50,8 +50,7 @@ class Chef
       allowed_actions :create, :delete, :touch, :create_if_missing
 
       property :path, String, name_property: true, identity: true
-      property :atomic_update, [ true, false ], desired_state: false,
-        default: lazy { |r| r.docker?(r.node) && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] }
+      property :atomic_update, [ true, false ], desired_state: false, default: lazy { |r| r.docker?(r.node) && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] }
       property :backup, [ Integer, false ], desired_state: false, default: 5
       property :checksum, [ /^[a-zA-Z0-9]{64}$/, nil ]
       property :content, [ String, nil ], desired_state: false
@@ -82,7 +81,7 @@ class Chef
       end
 
       def special_docker_files?(file)
-        %w(/etc/hostname /etc/resolv.conf).include?(Pathname(file).cleanpath.to_path)
+        %w{/etc/hostname /etc/resolv.conf}.include?(Pathname(file).cleanpath.to_path)
       end
     end
   end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -81,7 +81,7 @@ class Chef
       end
 
       def special_docker_files?(file)
-        %w{/etc/hostname /etc/resolv.conf}.include?(Pathname(file).cleanpath.to_path)
+        %w{/etc/hosts /etc/hostname /etc/resolv.conf}.include?(Pathname(file).cleanpath.to_path)
       end
     end
   end

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -21,6 +21,7 @@ require "chef/resource"
 require "chef/platform/query_helpers"
 require "chef/mixin/securable"
 require "chef/resource/file/verification"
+require "pathname"
 
 class Chef
   class Resource
@@ -49,7 +50,8 @@ class Chef
       allowed_actions :create, :delete, :touch, :create_if_missing
 
       property :path, String, name_property: true, identity: true
-      property :atomic_update, [ true, false ], desired_state: false, default: lazy { Chef::Config[:file_atomic_update] }
+      property :atomic_update, [ true, false ], desired_state: false,
+        default: lazy { |r| r.docker?(r.node) && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] }
       property :backup, [ Integer, false ], desired_state: false, default: 5
       property :checksum, [ /^[a-zA-Z0-9]{64}$/, nil ]
       property :content, [ String, nil ], desired_state: false
@@ -77,6 +79,10 @@ class Chef
           state_attrs[:checksum] = final_checksum
         end
         state_attrs
+      end
+
+      def special_docker_files?(file)
+        %w(/etc/hostname /etc/resolv.conf).include?(Pathname(file).cleanpath.to_path)
       end
     end
   end


### PR DESCRIPTION
This commit fixes https://github.com/chef/chef/issues/4949 by adding
ohai-based docker detection code and statically checking for
/etc/hostname or /etc/resolv.conf.

cc @lamont-granquist 