### PR TITLE
no more missing constants for LWRP class

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -423,9 +423,9 @@ class Chef
 
     module DeprecatedLWRPClass
       def const_missing(class_name)
-        if deprecated_constants[class_name.to_sym]
+        if Chef::Provider.deprecated_constants[class_name.to_sym]
           Chef.log_deprecation("Using an LWRP provider by its name (#{class_name}) directly is no longer supported in Chef 12 and will be removed.  Use Chef::ProviderResolver.new(node, resource, action) instead.")
-          deprecated_constants[class_name.to_sym]
+          Chef::Provider.deprecated_constants[class_name.to_sym]
         else
           raise NameError, "uninitialized constant Chef::Provider::#{class_name}"
         end
@@ -438,13 +438,12 @@ class Chef
         if Chef::Provider.const_defined?(class_name, false)
           Chef::Log.warn "Chef::Provider::#{class_name} already exists!  Cannot create deprecation class for #{provider_class}"
         else
-          deprecated_constants[class_name.to_sym] = provider_class
+          Chef::Provider.deprecated_constants[class_name.to_sym] = provider_class
         end
       end
 
-      private
-
       def deprecated_constants
+        raise "Deprecated constants should be called only on Chef::Provider" unless self == Chef::Provider
         @deprecated_constants ||= {}
       end
     end


### PR DESCRIPTION
http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/28/downstreambuildview/

```
➜  test-custom-resource-bug kitchen converge original-chef-12-9-41
-----> Starting Kitchen (v1.7.3)
-----> Creating <original-chef-12-9-41>...
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Importing base box 'bento/ubuntu-14.04'...
       ==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/ubuntu-14.04' is up to date...
       ==> default: A newer version of the box 'bento/ubuntu-14.04' is available! You currently
       ==> default: have version '2.2.5'. The latest is version '2.2.7'. Run
       ==> default: `vagrant box update` to update.
       ==> default: Setting the name of the VM: kitchen-test-custom-resource-bug-original-chef-12-9-41_default_1465241273190_44789
       ==> default: Fixed port collision for 22 => 2222. Now on port 2202.
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 => 2202 (adapter 1)
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           default: SSH address: 127.0.0.1:2202
           default: SSH username: vagrant
           default: SSH auth method: private key
           default: Warning: Remote connection disconnect. Retrying...
           default: Warning: Remote connection disconnect. Retrying...
           default:
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default:
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
       ==> default: Setting hostname...
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <original-chef-12-9-41> created.
       Finished creating <original-chef-12-9-41> (0m38.05s).
-----> Converging <original-chef-12-9-41>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 4.3.3...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
-----> Installing Chef Omnibus (install only if missing)
       Downloading https://omnitruck.chef.io/current/install.sh to file /tmp/install.sh
       Trying wget...
       Download complete.
       ubuntu 14.04 x86_64
       Getting information for chef current  for ubuntu...
       downloading https://omnitruck.chef.io/current/chef/metadata?v=&p=ubuntu&pv=14.04&m=x86_64
         to file /tmp/install.sh.1376/metadata.txt
       trying wget...
       sha1     bc4a6642d6093b54de856da31f0651a56b0fdc8e
       sha256   f1cf5d0f6dd12d2d2296ec6d8dbb16363f8541f5c15298cafa70e65ff2b5a22f
       url      https://packages.chef.io/current/ubuntu/14.04/chef_12.11.18-1_amd64.deb
       version  12.11.18
       downloaded metadata file looks valid...
       downloading https://packages.chef.io/current/ubuntu/14.04/chef_12.11.18-1_amd64.deb
         to file /tmp/install.sh.1376/chef_12.11.18-1_amd64.deb
       trying wget...
       Comparing checksum with sha256sum...

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       You are installing an omnibus package without a version pin.  If you are installing
       on production servers via an automated process this is DANGEROUS and you will
       be upgraded without warning on new releases, even to new major releases.
       Letting the version float is only appropriate in desktop, test, development or
       CI/CD environments.

       WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING

       Installing chef
       installing with dpkg...
       Selecting previously unselected package chef.
(Reading database ... 38789 files and directories currently installed.)
       Preparing to unpack .../chef_12.11.18-1_amd64.deb ...
       Unpacking chef (12.11.18-1) ...
       Setting up chef (12.11.18-1) ...
       Thank you for installing Chef!
       Transferring files to <original-chef-12-9-41>
       Successfully installed appbundler-0.9.0
       Parsing documentation for appbundler-0.9.0
       Installing ri documentation for appbundler-0.9.0
       Done installing documentation for appbundler after 0 seconds
Fetching: appbundle-updater-0.2.12.gem (100%)
       Successfully installed appbundle-updater-0.2.12
       Parsing documentation for appbundle-updater-0.2.12
       Installing ri documentation for appbundle-updater-0.2.12
       Done installing documentation for appbundle-updater after 0 seconds
       2 gems installed
-----> Cleaning chef checkout
-----> Creating /opt/chef/embedded/apps directory
-----> Installing Packages
           running: apt-get -y update
           running: apt-get -q -y install build-essential git
-----> Extracting chef from https://github.com/chef/chef/archive/praj/FLOW-927/s3cmd.tar.gz
       Unkown tar entry: pax_global_header type: g.
-----> Installing dependencies
           running: /opt/chef/embedded/bin/ruby /opt/chef/embedded/bin/bundle install --without server docgen test development
-----> Installing gem
           running: /opt/chef/embedded/bin/ruby /opt/chef/embedded/bin/bundle exec /opt/chef/embedded/bin/rake install
-----> Updating appbundler binstubs for chef
           running: /opt/chef/embedded/bin/ruby /opt/chef/embedded/bin/appbundler /opt/chef/embedded/apps/chef /opt/chef/bin
-----> Finished!
       Starting Chef Client, version 12.11.18
       Creating a new client identity for original-chef-12-9-41 using the validator key.
       resolving cookbooks for run list: ["s3"]
       Synchronizing Cookbooks:
         - s3 (0.1.0)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       AptRepository
       AptUpdate
       Batch
       Breakpoint
       ConvergeActions
       CookbookFile
       Cron
       DEPRECATED_OPTIONS
       Deploy
       DeprecatedLWRPClass
       Directory
       DscResource
       DscScript
       Env
       ErlCall
       Execute
       File
       Git
       Group
       HttpRequest
       Ifconfig
       InlineResources
       LWRPBase
       Launchd
       Link
       Log
       Mdadm
       Mount
       Noop
       Ohai
       OsxProfile
       Package
       PlatformDependentValue
       PlatformFamilyDependentValue
       PowershellScript
       Reboot
       RegistryKey
       RemoteDirectory
       RemoteFile
       ResourceRequirements
       Route
       RubyBlock
       Script
       Service
       Subversion
       SystemdUnit
       Template
       TemplateFinder
       User
       WhyrunSafeRubyBlock
       WindowsScript
       Converging 1 resources
       Recipe: s3::default
         * deploy_revision[/root/lessons] action nothing (skipped due to action :nothing)

       Running handlers:
       Running handlers complete

       Deprecated features used!
         Using an LWRP provider by its name (S3Scm) directly is no longer supported in Chef 12 and will be removed.  Use Chef::ProviderResolver.new(node, resource, action) instead. at 1 location:
           - /tmp/kitchen/cache/cookbooks/s3/recipes/default.rb:4:in `block in from_file'

       Chef Client finished, 0/1 resources updated in 01 seconds
       Finished converging <original-chef-12-9-41> (1m44.31s).
-----> Kitchen is finished. (2m23.02s)
➜  test-custom-resource-bug
```