### PR TITLE
Bug fix: updated_resource_count should only include updated resources

### DIFF
--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -70,15 +70,15 @@ class Chef
           "message_type"           => "run_converge",
           "node_name"              => run_status.node.name,
           "organization_name"      => organization,
-          "resources"              => reporter_data[:updated_resources].map(&:for_json),
+          "resources"              => reporter_data[:completed_resources].map(&:for_json),
           "run_id"                 => run_status.run_id,
           "run_list"               => run_status.node.run_list.for_json,
           "start_time"             => run_status.start_time.utc.iso8601,
           "end_time"               => run_status.end_time.utc.iso8601,
           "source"                 => collector_source,
           "status"                 => reporter_data[:status],
-          "total_resource_count"   => reporter_data[:total_resource_count],
-          "updated_resource_count" => reporter_data[:updated_resources].count,
+          "total_resource_count"   => reporter_data[:completed_resources].count,
+          "updated_resource_count" => reporter_data[:completed_resources].select { |r| r.status == "updated" }.count,
         }
 
         message["error"] = {

--- a/spec/unit/data_collector/messages_spec.rb
+++ b/spec/unit/data_collector/messages_spec.rb
@@ -61,12 +61,13 @@ describe Chef::DataCollector::Messages do
   end
 
   describe '#run_end_message' do
-    let(:run_status)    { Chef::RunStatus.new(Chef::Node.new, Chef::EventDispatch::Dispatcher.new) }
-    let(:resource)      { double("resource", for_json: "resource_data") }
+    let(:run_status) { Chef::RunStatus.new(Chef::Node.new, Chef::EventDispatch::Dispatcher.new) }
+    let(:resource1)  { double("resource1", for_json: "resource_data", status: "updated") }
+    let(:resource2)  { double("resource2", for_json: "resource_data", status: "skipped") }
     let(:reporter_data) do
       {
         run_status: run_status,
-        updated_resources: [resource],
+        completed_resources: [resource1, resource2],
       }
     end
 
@@ -115,6 +116,12 @@ describe Chef::DataCollector::Messages do
           !required_fields.include?(key) && !optional_fields.include?(key)
         end
         expect(extra_fields).to eq([])
+      end
+
+      it "only includes updated resources in its count" do
+        message = Chef::DataCollector::Messages.run_end_message(reporter_data)
+        expect(message["total_resource_count"]).to eq(2)
+        expect(message["updated_resource_count"]).to eq(1)
       end
     end
 

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -226,15 +226,9 @@ describe Chef::DataCollector::Reporter do
     let(:resource_report) { double("resource_report") }
 
     before do
-      allow(reporter).to receive(:increment_resource_count)
       allow(reporter).to receive(:nested_resource?)
       allow(reporter).to receive(:current_resource_report).and_return(resource_report)
       allow(resource_report).to receive(:up_to_date)
-    end
-
-    it "increments the resource count" do
-      expect(reporter).to receive(:increment_resource_count)
-      reporter.resource_up_to_date(new_resource, action)
     end
 
     context "when the resource is a nested resource" do
@@ -261,15 +255,9 @@ describe Chef::DataCollector::Reporter do
     let(:resource_report) { double("resource_report") }
 
     before do
-      allow(reporter).to receive(:increment_resource_count)
       allow(reporter).to receive(:nested_resource?)
       allow(reporter).to receive(:current_resource_report).and_return(resource_report)
       allow(resource_report).to receive(:skipped)
-    end
-
-    it "increments the resource count" do
-      expect(reporter).to receive(:increment_resource_count)
-      reporter.resource_skipped(new_resource, action, conditional)
     end
 
     context "when the resource is a nested resource" do
@@ -307,11 +295,6 @@ describe Chef::DataCollector::Reporter do
       allow(resource_report).to receive(:updated)
     end
 
-    it "increments the resource count" do
-      expect(reporter).to receive(:increment_resource_count)
-      reporter.resource_updated("new_resource", "action")
-    end
-
     it "marks the resource report as updated" do
       expect(resource_report).to receive(:updated)
       reporter.resource_updated("new_resource", "action")
@@ -326,17 +309,11 @@ describe Chef::DataCollector::Reporter do
     let(:resource_report) { double("resource_report") }
 
     before do
-      allow(reporter).to receive(:increment_resource_count)
       allow(reporter).to receive(:update_error_description)
       allow(reporter).to receive(:current_resource_report).and_return(resource_report)
       allow(resource_report).to receive(:failed)
       allow(Chef::Formatters::ErrorMapper).to receive(:resource_failed).and_return(error_mapper)
       allow(error_mapper).to receive(:for_json)
-    end
-
-    it "increments the resource count" do
-      expect(reporter).to receive(:increment_resource_count)
-      reporter.resource_failed(new_resource, action, exception)
     end
 
     it "updates the error description" do
@@ -372,7 +349,7 @@ describe Chef::DataCollector::Reporter do
     let(:resource_report) { double("resource_report") }
 
     before do
-      allow(reporter).to receive(:add_updated_resource)
+      allow(reporter).to receive(:add_completed_resource)
       allow(reporter).to receive(:update_current_resource_report)
       allow(resource_report).to receive(:finish)
     end
@@ -380,7 +357,7 @@ describe Chef::DataCollector::Reporter do
     context "when there is no current resource report" do
       it "does not add the updated resource" do
         allow(reporter).to receive(:current_resource_report).and_return(nil)
-        expect(reporter).not_to receive(:add_updated_resource)
+        expect(reporter).not_to receive(:add_completed_resource)
         reporter.resource_completed(new_resource)
       end
     end
@@ -393,7 +370,7 @@ describe Chef::DataCollector::Reporter do
       context "when the resource is a nested resource" do
         it "does not add the updated resource" do
           allow(reporter).to receive(:nested_resource?).with(new_resource).and_return(true)
-          expect(reporter).not_to receive(:add_updated_resource)
+          expect(reporter).not_to receive(:add_completed_resource)
           reporter.resource_completed(new_resource)
         end
       end
@@ -409,7 +386,7 @@ describe Chef::DataCollector::Reporter do
         end
 
         it "adds the resource to the updated resource list" do
-          expect(reporter).to receive(:add_updated_resource).with(resource_report)
+          expect(reporter).to receive(:add_completed_resource).with(resource_report)
           reporter.resource_completed(new_resource)
         end
 


### PR DESCRIPTION
After adding up-to-date and skipped resources to the DataCollector
resource list, the logic that computed the number of resources
updated needed to change accordingly. This change fixes that
bug and also eliminates an unnecessary counter that tracks
the total number of resources.