### PR TITLE
Don't log error for reporting audit data in when in chef-zero

### DIFF
--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -140,7 +140,11 @@ class Chef
               # Save the audit report to local disk
               error_file = "failed-audit-data.json"
               Chef::FileCache.store(error_file, Chef::JSONCompat.to_json_pretty(run_data), 0640)
-              Chef::Log.error("Failed to post audit report to server. Saving report to #{Chef::FileCache.load(error_file, false)}")
+              if Chef::Config.chef_zero.enabled
+                Chef::Log.debug("Saving audit report to #{Chef::FileCache.load(error_file, false)}")
+              else
+                Chef::Log.error("Failed to post audit report to server. Saving report to #{Chef::FileCache.load(error_file, false)}")
+              end
             end
           else
             Chef::Log.error("Failed to post audit report to server (#{e})")


### PR DESCRIPTION
This changes the log message to `debug` when running in local-mode as it's not an error that the audit-data could not be sent to the server.

I'm not very familiar with the internals of `chef/chef` so any feedback is appreciated.

Fixes https://github.com/chef/chef/issues/4728