### PR TITLE
bug fix: correctly write out data collector metadata file

### DIFF
--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -148,8 +148,8 @@ class Chef
         end
 
         def update_metadata(key, value)
-          metadata[key] = value
-          Chef::FileCache.store(metadata_filename, metadata.to_json, 0644)
+          updated_metadata = metadata.tap { |x| x[key] = value }
+          Chef::FileCache.store(metadata_filename, updated_metadata.to_json, 0644)
         end
 
         def metadata_filename

--- a/spec/unit/data_collector/messages/helpers_spec.rb
+++ b/spec/unit/data_collector/messages/helpers_spec.rb
@@ -171,20 +171,16 @@ describe Chef::DataCollector::Messages::Helpers do
   end
 
   describe '#update_metadata' do
-    let(:metadata) { double("metadata") }
-
     it "updates the file" do
       allow(TestMessage).to receive(:metadata_filename).and_return("fake_metadata_file.json")
-      allow(TestMessage).to receive(:metadata).and_return(metadata)
-      expect(metadata).to receive(:[]=).with("new_key", "new_value")
-      expect(metadata).to receive(:to_json).and_return("metadata_json")
+      allow(TestMessage).to receive(:metadata).and_return({ "key" => "current_value" })
       expect(Chef::FileCache).to receive(:store).with(
         "fake_metadata_file.json",
-        "metadata_json",
+        '{"key":"updated_value"}',
         0644
       )
 
-      TestMessage.update_metadata("new_key", "new_value")
+      TestMessage.update_metadata("key", "updated_value")
     end
   end
 end


### PR DESCRIPTION
When we changed the messages from class instances to a module, the
reading of metadata into an instance variable was removed and
introduced a bug when updating metadata. This bug causes the
metadata to be properly read from disk, updated, but then the
metadata from disk is simply re-written to disk without the
intended updates.