### PR TITLE
Convert the 3694 warning to a deprecation so it will be subject to the usual deprecation formatting (collected at the bottom, can be made an error, etc).

### DIFF
--- a/lib/chef/resource_builder.rb
+++ b/lib/chef/resource_builder.rb
@@ -124,9 +124,10 @@ class Chef
     end
 
     def emit_cloned_resource_warning
-      Chef::Log.warn("Cloning resource attributes for #{resource} from prior resource (CHEF-3694)")
-      Chef::Log.warn("Previous #{prior_resource}: #{prior_resource.source_line}") if prior_resource.source_line
-      Chef::Log.warn("Current  #{resource}: #{resource.source_line}") if resource.source_line
+      message = "Cloning resource attributes for #{resource} from prior resource (CHEF-3694)"
+      message << "\nPrevious #{prior_resource}: #{prior_resource.source_line}" if prior_resource.source_line
+      message << "\nCurrent  #{resource}: #{resource.source_line}" if resource.source_line
+      Chef.log_deprecation(message)
     end
 
     def emit_harmless_cloning_debug

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -195,9 +195,7 @@ describe Chef::Recipe do
 
     describe "when cloning resources" do
       def expect_warning
-        expect(Chef::Log).to receive(:warn).with(/3694/)
-        expect(Chef::Log).to receive(:warn).with(/Previous/)
-        expect(Chef::Log).to receive(:warn).with(/Current/)
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
       end
 
       it "should emit a 3694 warning when attributes change" do
@@ -244,7 +242,7 @@ describe Chef::Recipe do
 
       it "should not emit a 3694 warning for completely trivial resource cloning" do
         recipe.zen_master "klopp"
-        expect(Chef::Log).to_not receive(:warn)
+        expect(Chef).to_not receive(:log_deprecation)
         recipe.zen_master "klopp"
       end
 
@@ -252,7 +250,7 @@ describe Chef::Recipe do
         recipe.zen_master "klopp" do
           action :nothing
         end
-        expect(Chef::Log).to_not receive(:warn)
+        expect(Chef).to_not receive(:log_deprecation)
         recipe.zen_master "klopp" do
           action :score
         end
@@ -262,7 +260,7 @@ describe Chef::Recipe do
         recipe.zen_master "klopp" do
           action :score
         end
-        expect(Chef::Log).to_not receive(:warn)
+        expect(Chef).to_not receive(:log_deprecation)
         recipe.zen_master "klopp" do
           action :nothing
         end
@@ -299,6 +297,7 @@ describe Chef::Recipe do
       end
 
       it "will insert another resource if create_if_missing is not set (cloned resource as of Chef-12)" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         zm_resource
         recipe.declare_resource(:zen_master, "klopp")
         expect(run_context.resource_collection.count).to eql(2)
@@ -421,15 +420,18 @@ describe Chef::Recipe do
       end
 
       it "copies attributes from the first resource" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         expect(duplicated_resource.something).to eq("bvb09")
       end
 
       it "does not copy the action from the first resource" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         expect(original_resource.action).to eq([:score])
         expect(duplicated_resource.action).to eq([:nothing])
       end
 
       it "does not copy the source location of the first resource" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         # sanity check source location:
         expect(original_resource.source_line).to include(__FILE__)
         expect(duplicated_resource.source_line).to include(__FILE__)
@@ -438,10 +440,12 @@ describe Chef::Recipe do
       end
 
       it "sets the cookbook name on the cloned resource to that resource's cookbook" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         expect(duplicated_resource.cookbook_name).to eq("second_cb")
       end
 
       it "sets the recipe name on the cloned resource to that resoure's recipe" do
+        expect(Chef).to receive(:log_deprecation).with(/^Cloning resource attributes for zen_master\[klopp\]/)
         expect(duplicated_resource.recipe_name).to eq("second_recipe")
       end
 


### PR DESCRIPTION
Ping @chef/client-core  and @lamont-granquist in particular.