### PR TITLE
Remote resource should respect sensitive flag

### DIFF
--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -209,6 +209,8 @@ class Chef
       def cookbook_file_resource(target_path, relative_source_path)
         res = Chef::Resource::CookbookFile.new(target_path, run_context)
         res.cookbook_name = resource_cookbook
+        # Set the sensitivity level
+        res.sensitive(new_resource.sensitive)
         res.source(::File.join(source, relative_source_path))
         if Chef::Platform.windows? && files_rights
           files_rights.each_pair do |permission, *args|

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -99,6 +99,21 @@ describe Chef::Provider::RemoteDirectory do
       expect(cookbook_file.owner).to          eq("toor")
       expect(cookbook_file.backup).to         eq(23)
     end
+
+    it "respects sensitive flag" do
+      @resource.cookbook "gondola_rides"
+      @resource.sensitive true
+      cookbook_file = @provider.send(:cookbook_file_resource,
+                                    "/target/destination/path.txt",
+                                    "relative/source/path.txt")
+      expect(cookbook_file.sensitive).to eq(true)
+
+      @resource.sensitive false
+      cookbook_file = @provider.send(:cookbook_file_resource,
+                                    "/target/destination/path.txt",
+                                    "relative/source/path.txt")
+      expect(cookbook_file.sensitive).to eq(false)
+    end
   end
 
   describe "when creating the remote directory" do


### PR DESCRIPTION
```
➜  remote_directory_example git:(master) ✗ sudo bundle exec chef-client -z -o remote_directory[2016-06-13T17:35:20-07:00] WARN: No config file found or specified on command line, using command line options.
Starting Chef Client, version 12.12.2
[2016-06-13T17:35:27-07:00] WARN: Run List override has been provided.
[2016-06-13T17:35:27-07:00] WARN: Original Run List: []
[2016-06-13T17:35:27-07:00] WARN: Overridden Run List: [recipe[remote_directory]]
resolving cookbooks for run list: ["remote_directory"]
Synchronizing Cookbooks:
  - remote_directory (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: remote_directory::default
  * remote_directory[/var/www/html] action create
    - create new directory /var/www/html
    - change mode from '' to '0755'
  Recipe: <Dynamically Defined Resource>
    * cookbook_file[/var/www/html/foo.html] action create
      - create new file /var/www/html/foo.html
      - update content in file /var/www/html/foo.html from none to 806772
      - suppressed sensitive resource
      - change mode from '' to '0644'
    * cookbook_file[/var/www/html/index.html] action create
      - create new file /var/www/html/index.html
      - update content in file /var/www/html/index.html from none to 64ec88
      - suppressed sensitive resource
      - change mode from '' to '0644'

[2016-06-13T17:35:27-07:00] WARN: Skipping final node save because override_runlist was given

Running handlers:
Running handlers complete
Chef Client finished, 3/3 resources updated in 05 seconds
```