### PR TITLE
Do not use bundle install to update Gemfile.lock after version bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,13 @@ require_relative "tasks/cbgb"
 require_relative "tasks/dependencies"
 require_relative "tasks/changelog"
 
-ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "Chef") do |package|
+ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "Chef", "chef") do |package|
   package.component_paths = ["chef-config"]
   package.generate_version_class = true
 end
 # Add a conservative dependency update to version:bump (which was created by PackageTask)
-task "version:bump" => %w{version:bump_patch version:update bundle:install}
+task "version:bump" => %w{version:bump_patch version:update}
+task "version:bump" => %w{version:bump_patch version:update}
 
 task :pedant, :chef_zero_spec
 

--- a/chef-config/Rakefile
+++ b/chef-config/Rakefile
@@ -1,6 +1,6 @@
 require "chef-config/package_task"
 
-ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "ChefConfig") do |package|
+ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "ChefConfig", "chef-config") do |package|
   package.module_path = "chef-config"
 end
 


### PR DESCRIPTION
Using bundle install to update the Gemfile.lock to update the Chef version will cause bundle to "unfreeze" chef and all its dependent gems, making them fair gem to update. We do not want that. Therefore, we modify the Gemfile.lock ourselves because we just roll that way.