### PR TITLE
adding directory caching

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/directory.rb
+++ b/lib/chef/chef_fs/file_system/repository/directory.rb
@@ -31,6 +31,8 @@ class Chef
           alias_method :display_path, :path
           alias_method :display_name, :name
           alias_method :bare_name, :name
+          
+          @@dir_cache = Hash.new
 
           def initialize(name, parent, file_path = nil)
             @parent = parent
@@ -68,9 +70,11 @@ class Chef
           end
 
           def children
-            dir_ls.sort.
+            return @@dir_cache[file_path] if @@dir_cache.key?(file_path)
+            @@dir_cache[file_path] = dir_ls.sort.
               map { |child_name| make_child_entry(child_name) }.
               select { |new_child| new_child.fs_entry_valid? && can_have_child?(new_child.name, new_child.dir?) }
+            @@dir_cache[file_path]
           rescue Errno::ENOENT => e
             raise Chef::ChefFS::FileSystem::NotFoundError.new(self, e)
           end


### PR DESCRIPTION
I recently started using chef version 12.11.18 and noticed that running chef-client on a windows vagrant instance went from 30 seconds to over 5 minutes. My company has a lot of cookbooks (~200) and the children method below was taking 10 seconds to run through them all. It was being called 23 times (I guess because the runlist included a lot of cookbooks/dependencies). Anyway, that's what accounted for the increased time. When I added the caching the run time went back down to 30 seconds.