### PR TITLE
Turn off fips with an empty environment var

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -519,7 +519,16 @@ module ChefConfig
 
     # Set to true if Chef is to set OpenSSL to run in FIPS mode
     default(:fips) do
-      !ENV["CHEF_FIPS"].nil? || ChefConfig.fips?
+      # CHEF_FIPS is used in testing to override checking for system level
+      # enablement. There are 3 possible values that this variable may have:
+      # nil - no override and the system will be checked
+      # empty - FIPS is NOT enabled
+      # a non empty value - FIPS is enabled
+      if ENV["CHEF_FIPS"] == ""
+        false
+      else
+        !ENV["CHEF_FIPS"].nil? || ChefConfig.fips?
+      end
     end
 
     # Initialize openssl

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -186,6 +186,16 @@ RSpec.describe ChefConfig::Config do
             expect(ChefConfig::Config[:fips]).to eq(false)
           end
 
+          context "when ENV['CHEF_FIPS'] is empty" do
+            before do
+              ENV["CHEF_FIPS"] = ""
+            end
+
+            it "returns false" do
+              expect(ChefConfig::Config[:fips]).to eq(false)
+            end
+          end
+
           context "when ENV['CHEF_FIPS'] is set" do
             before do
               ENV["CHEF_FIPS"] = "1"


### PR DESCRIPTION
This PR fixes build breaks in the chef-dk jenkins debian and redhat testers when they run chef unit tests. They currently fail due to a mocking expectationi error on `::File.read` because `ChefConfig` reads `/proc/sys/crypto/fips_enabled` early in the run. and the breaking tests expect a different path.

As an alternative to mocking the call to `read` on the fips path which would be irrelevant to the test and likely raise questions as to why that is being mocked, this PR allows the fips check to have a forced `false` value if the `FIPS_ENABLED` variable is present but empty and if so, the check of the fips file is avoided.

So the following `FIPS_ENABLED` values have the following impact:

value | impact
------- | ----------
`nil` | unknown and the systems settings are checked incurring a call to read `/proc/sys/crypto/fips_enabled`
`empty` | FIPS is NOT enabled
Not empty | Fips is enabled
`