### PR TITLE
correct typo in knife bootstrap context

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -54,7 +54,7 @@ class Chef
         end
 
         def client_d
-          @cliend_d ||= client_d_content
+          @client_d ||= client_d_content
         end
 
         def encrypted_data_bag_secret


### PR DESCRIPTION
We want client_d, not cliend_d