### PR TITLE
Expand data_collector resource list to include all resources

### DIFF
--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -70,15 +70,15 @@ class Chef
           "message_type"           => "run_converge",
           "node_name"              => run_status.node.name,
           "organization_name"      => organization,
-          "resources"              => reporter_data[:completed_resources].map(&:for_json),
+          "resources"              => reporter_data[:resources].map(&:report_data),
           "run_id"                 => run_status.run_id,
           "run_list"               => run_status.node.run_list.for_json,
           "start_time"             => run_status.start_time.utc.iso8601,
           "end_time"               => run_status.end_time.utc.iso8601,
           "source"                 => collector_source,
           "status"                 => reporter_data[:status],
-          "total_resource_count"   => reporter_data[:completed_resources].count,
-          "updated_resource_count" => reporter_data[:completed_resources].select { |r| r.status == "updated" }.count,
+          "total_resource_count"   => reporter_data[:resources].count,
+          "updated_resource_count" => reporter_data[:resources].select { |r| r.report_data["status"] == "updated" }.count,
         }
 
         message["error"] = {

--- a/spec/unit/data_collector/messages_spec.rb
+++ b/spec/unit/data_collector/messages_spec.rb
@@ -62,12 +62,12 @@ describe Chef::DataCollector::Messages do
 
   describe '#run_end_message' do
     let(:run_status) { Chef::RunStatus.new(Chef::Node.new, Chef::EventDispatch::Dispatcher.new) }
-    let(:resource1)  { double("resource1", for_json: "resource_data", status: "updated") }
-    let(:resource2)  { double("resource2", for_json: "resource_data", status: "skipped") }
+    let(:report1)  { double("report1", report_data: { "status" => "updated" }) }
+    let(:report2)  { double("report2", report_data: { "status" => "skipped" }) }
     let(:reporter_data) do
       {
         run_status: run_status,
-        completed_resources: [resource1, resource2],
+        resources: [report1, report2],
       }
     end
 


### PR DESCRIPTION
Historically when a Chef run fails, the event handlers only report
on resources that have been processed during the run. This change
allows the Data Collector to report those resources in the resource
collection that have not yet been processed so users can better
ascertain how much of their run was completed, and specifically
what resources were not processed as a result of the Chef failure.

Instead of building up a list of resources as they are processed,
this change instead creates a resource report for each resource+action
in the resource collection and then modifies each of those reports
once the resource is processed.