### PR TITLE
Ensure that chef-solo uses the expected repo dir

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -241,6 +241,13 @@ class Chef::Application::Solo < Chef::Application
         ARGV[dash_r] = "--recipe-url"
       end
 
+      # For back compat reasons, we need to ensure that we try and use the cache_path as a repo first
+      Chef::Log.debug "Current chef_repo_path is #{Chef::Config.chef_repo_path}"
+
+      if !Chef::Config.has_key?(:cookbook_path) && !Chef::Config.has_key?(:chef_repo_path)
+        Chef::Config.chef_repo_path = Chef::Config.find_chef_repo_path(Chef::Config[:cache_path])
+      end
+
       Chef::Config[:local_mode] = true
     else
       configure_legacy_mode!

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -212,6 +212,13 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       end
     end
 
+    it "sets the repo path" do
+      expect(Chef::Config).to receive(:find_chef_repo_path).and_return("/var/chef")
+      app.reconfigure
+      expect(Chef::Config.has_key?(:chef_repo_path)).to be_truthy
+      expect(Chef::Config[:chef_repo_path]).to eq ("/var/chef")
+    end
+
     it "runs chef-client in local mode" do
       allow(app).to receive(:setup_application).and_return(true)
       allow(app).to receive(:run_application).and_return(true)


### PR DESCRIPTION
Solo has always defaulted to `/var/chef` but local-mode uses the user's
home directory, so we need to ensure that we set the correct path before
entering local-mode.
Fixes: #5051

cc @chef/client-maintainers