### PR TITLE
Adding node object to Data collector run_converge message

### DIFF
--- a/acceptance/data-collector/test/integration/default/serverspec/default_spec.rb
+++ b/acceptance/data-collector/test/integration/default/serverspec/default_spec.rb
@@ -110,6 +110,7 @@ shared_examples_for "run_converge.success payload check" do
         expanded_run_list
         message_type
         message_version
+        node
         node_name
         organization_name
         resources
@@ -150,6 +151,7 @@ shared_examples_for "run_converge.failure payload check" do
         expanded_run_list
         message_type
         message_version
+        node
         node_name
         organization_name
         resources
@@ -178,44 +180,6 @@ shared_examples_for "run_converge.failure payload check" do
   end
 end
 
-shared_examples_for "node-update payload check" do
-  describe "node update message" do
-    let(:required_fields) do
-      %w{
-        entity_name
-        entity_type
-        entity_uuid
-        id
-        message_type
-        message_version
-        organization_name
-        recorded_at
-        remote_hostname
-        requestor_name
-        requestor_type
-        run_id
-        service_hostname
-        source
-        task
-        user_agent
-      }
-    end
-    let(:optional_fields) { %{data} }
-
-    it "is not missing any required fields" do
-      payload = JSON.load(command("curl http://localhost:9292/cache/action").stdout)
-      missing_fields = required_fields.select { |key| !payload.key?(key) }
-      expect(missing_fields).to eq([])
-    end
-
-    it "does not have any extra fields" do
-      payload = JSON.load(command("curl http://localhost:9292/cache/action").stdout)
-      extra_fields = payload.keys.select { |key| !required_fields.include?(key) && !optional_fields.include?(key) }
-      expect(extra_fields).to eq([])
-    end
-  end
-end
-
 describe "CCR with no data collector URL configured" do
   include_examples "successful chef run", "chef-client -z -c /etc/chef/no-endpoint.rb"
   include_examples "counter checks", { "run_start" => nil, "run_converge.success" => nil, "run_converge.failure" => nil }
@@ -226,7 +190,6 @@ describe "CCR, local mode, config in solo mode" do
   include_examples "counter checks", { "run_start" => 1, "run_converge.success" => 1, "run_converge.failure" => nil }
   include_examples "run_start payload check"
   include_examples "run_converge.success payload check"
-  include_examples "node-update payload check"
 end
 
 describe "CCR, local mode, config in client mode" do
@@ -239,7 +202,6 @@ describe "CCR, local mode, config in both mode" do
   include_examples "counter checks", { "run_start" => 1, "run_converge.success" => 1, "run_converge.failure" => nil }
   include_examples "run_start payload check"
   include_examples "run_converge.success payload check"
-  include_examples "node-update payload check"
 end
 
 describe "CCR, local mode, config in solo mode, failed run" do
@@ -247,5 +209,4 @@ describe "CCR, local mode, config in solo mode, failed run" do
   include_examples "counter checks", { "run_start" => 1, "run_converge.success" => nil, "run_converge.failure" => 1 }
   include_examples "run_start payload check"
   include_examples "run_converge.failure payload check"
-  include_examples "node-update payload check"
 end

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -279,7 +279,6 @@ class Chef
         # we have nothing to report.
         return unless run_status
 
-        send_to_data_collector(Chef::DataCollector::Messages.node_update_message(run_status).to_json)
         send_to_data_collector(
           Chef::DataCollector::Messages.run_end_message(
             run_status: run_status,

--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -68,6 +68,7 @@ class Chef
           "id"                     => run_status.run_id,
           "message_version"        => "1.0.0",
           "message_type"           => "run_converge",
+          "node"                   => run_status.node,
           "node_name"              => run_status.node.name,
           "organization_name"      => organization,
           "resources"              => reporter_data[:resources].map(&:report_data),
@@ -89,36 +90,6 @@ class Chef
         } if run_status.exception
 
         message
-      end
-
-      #
-      # Message payload that is sent to the DataCollector server at the
-      # end of a Chef run.
-      #
-      # @param run_status [Chef::RunStatus] The RunStatus instance for this node/run.
-      #
-      # @return [Hash] A hash containing the node object and related metadata.
-      #
-      def self.node_update_message(run_status)
-        {
-          "entity_name"       => run_status.node.name,
-          "entity_type"       => "node",
-          "entity_uuid"       => node_uuid,
-          "id"                => SecureRandom.uuid,
-          "message_version"   => "1.1.0",
-          "message_type"      => "action",
-          "organization_name" => organization,
-          "recorded_at"       => Time.now.utc.iso8601,
-          "remote_hostname"   => run_status.node["fqdn"],
-          "requestor_name"    => run_status.node.name,
-          "requestor_type"    => "client",
-          "run_id"            => run_status.run_id,
-          "service_hostname"  => chef_server_fqdn(run_status),
-          "source"            => collector_source,
-          "task"              => "update",
-          "user_agent"        => Chef::HTTP::HTTPRequest::DEFAULT_UA,
-          "data"              => run_status.node,
-        }
       end
     end
   end

--- a/lib/chef/data_collector/resource_report.rb
+++ b/lib/chef/data_collector/resource_report.rb
@@ -65,15 +65,16 @@ class Chef
 
       def to_hash
         hash = {
-          "type"     => new_resource.resource_name.to_sym,
-          "name"     => new_resource.name.to_s,
-          "id"       => new_resource.identity.to_s,
-          "after"    => new_resource.state_for_resource_reporter,
-          "before"   => current_resource ? current_resource.state_for_resource_reporter : {},
-          "duration" => elapsed_time_in_milliseconds.to_s,
-          "delta"    => new_resource.respond_to?(:diff) && potentially_changed? ? new_resource.diff : "",
-          "result"   => action.to_s,
-          "status"   => status,
+          "type"           => new_resource.resource_name.to_sym,
+          "name"           => new_resource.name.to_s,
+          "id"             => new_resource.identity.to_s,
+          "after"          => new_resource.state_for_resource_reporter,
+          "before"         => current_resource ? current_resource.state_for_resource_reporter : {},
+          "duration"       => elapsed_time_in_milliseconds.to_s,
+          "delta"          => new_resource.respond_to?(:diff) && potentially_changed? ? new_resource.diff : "",
+          "ignore_failure" => new_resource.ignore_failure,
+          "result"         => action.to_s,
+          "status"         => status,
         }
 
         if new_resource.cookbook_name

--- a/spec/unit/data_collector/messages_spec.rb
+++ b/spec/unit/data_collector/messages_spec.rb
@@ -86,6 +86,7 @@ describe Chef::DataCollector::Messages do
           expanded_run_list
           message_type
           message_version
+          node
           node_name
           organization_name
           resources
@@ -136,6 +137,7 @@ describe Chef::DataCollector::Messages do
           expanded_run_list
           message_type
           message_version
+          node
           node_name
           organization_name
           resources
@@ -167,48 +169,6 @@ describe Chef::DataCollector::Messages do
         end
         expect(extra_fields).to eq([])
       end
-    end
-  end
-
-  describe '#node_update_message' do
-    let(:run_status) { Chef::RunStatus.new(Chef::Node.new, Chef::EventDispatch::Dispatcher.new) }
-
-    let(:required_fields) do
-      %w{
-        entity_name
-        entity_type
-        entity_uuid
-        id
-        message_type
-        message_version
-        organization_name
-        recorded_at
-        remote_hostname
-        requestor_name
-        requestor_type
-        run_id
-        service_hostname
-        source
-        task
-        user_agent
-      }
-    end
-    let(:optional_fields) { %w{data} }
-
-    it "is not missing any required fields" do
-      missing_fields = required_fields.select do |key|
-        !Chef::DataCollector::Messages.node_update_message(run_status).key?(key)
-      end
-
-      expect(missing_fields).to eq([])
-    end
-
-    it "does not have any extra fields" do
-      extra_fields = Chef::DataCollector::Messages.node_update_message(run_status).keys.select do |key|
-        !required_fields.include?(key) && !optional_fields.include?(key)
-      end
-
-      expect(extra_fields).to eq([])
     end
   end
 end


### PR DESCRIPTION
Many use cases that involve consuming the run_converge messages and
displaying them to end users include needing additional data about
the node that generated the run_converge message. This change
consolidates the run_converge and node_update message into a single
message making it easier for users to filter run_converge messages
based on attributes and criteria of the node itself.