### PR TITLE
Added stop_start action to service resource

### DIFF
--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -161,7 +161,7 @@ class Chef
         load_new_resource_state
         @new_resource.running(false)
       end
-      
+
       def action_stop_start
         converge_by("stop then start service #{@new_resource}") do
           stop_service
@@ -172,7 +172,7 @@ class Chef
         load_new_resource_state
         @new_resource.running(true)
       end
-      
+
       def action_restart
         converge_by("restart service #{@new_resource}") do
           restart_service

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -161,7 +161,18 @@ class Chef
         load_new_resource_state
         @new_resource.running(false)
       end
-
+      
+      def action_stop_start
+        converge_by("stop then start service #{@new_resource}") do
+          stop_service
+          Chef::Log.info("#{@new_resource} stopped")
+          start_service
+          Chef::Log.info("#{@new_resource} started")
+        end
+        load_new_resource_state
+        @new_resource.running(true)
+      end
+      
       def action_restart
         converge_by("restart service #{@new_resource}") do
           restart_service

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -28,7 +28,7 @@ class Chef
 
       default_action :nothing
       allowed_actions :enable, :disable, :start, :stop, :restart, :reload,
-                      :mask, :unmask
+                      :mask, :unmask, :stop_start
 
       def initialize(name, run_context = nil)
         super

--- a/spec/unit/provider/service_spec.rb
+++ b/spec/unit/provider/service_spec.rb
@@ -97,6 +97,27 @@ describe Chef::Provider::Service do
     end
   end
 
+  describe "action_stop_start" do
+    before do
+      @current_resource.supports(:stop_start => true)
+    end
+
+    it "should stop and then start the service if it's supported and set the resource as updated" do
+      expect(@provider).to receive(:stop_service).and_return(true)
+      expect(@provider).to receive(:start_service).and_return(true)
+      @provider.run_action(:stop_start)
+      expect(@provider.new_resource).to be_updated
+    end
+
+    it "should stop then start the service even if it isn't running and set the resource as updated" do
+      allow(@current_resource).to receive(:running).and_return(false)
+      expect(@provider).to receive(:stop_service).and_return(true)
+      expect(@provider).to receive(:start_service).and_return(true)
+      @provider.run_action(:stop_start)
+      expect(@provider.new_resource).to be_updated
+    end
+  end
+
   describe "action_restart" do
     before do
       @current_resource.supports(:restart => true)


### PR DESCRIPTION
> #4877: Upstart service provider should provide a way to restart with a stop + start 

I added a stop_start action to the service provider, added a unit test and tested it, and added stop_start to the allowable actions.

I did not run it because I'm not certain of the process, therefore there was no functional testing done for this change. 

Additionally, I did not document the change because I was uncertain of where to do so. 

This is my first pull request into Chef, and I'm new to Ruby, so any guidance would be much appreciated.