### PR TITLE
Remove deprecated Thread.exclusive around require call.

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -232,11 +232,11 @@ class Chef
         # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
         # via chef-zero and that hits DNS (at *require* time) which may timeout,
         # when for most knife/chef-client work we never need/want this loaded.
-        Thread.exclusive {
-          unless defined?(SocketlessChefZeroClient)
-            require "chef/http/socketless_chef_zero_client"
-          end
-        }
+
+        unless defined?(SocketlessChefZeroClient)
+          require "chef/http/socketless_chef_zero_client"
+        end
+
         SocketlessChefZeroClient.new(base_url)
       else
         BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)


### PR DESCRIPTION
Similar to https://github.com/chef/chef/pull/4693 .

With ruby 2.3, chef-client run throws warnings like `Thread.exclusive is deprecated, use Mutex`.
This has been confirmed with chef version  `12.10.24`.

Removing Thread.exclusive based on [this comment](https://github.com/chef/chef/pull/4693#issuecomment-195597601) and [this comment](https://github.com/bundler/bundler/pull/4245#discussion_r51481284).

Please let me know if there is something else necessary.