### PR TITLE
adding logic for handling multi fileset bff packages

### DIFF
--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -102,6 +102,9 @@ class Chef
               @candidate_version = candidate
               new_resource.version(candidate)
               Chef::Log.debug("#{new_resource} setting install candidate version to #{@candidate_version}")
+              candidate
+            else
+              nil
             end
           end
         end
@@ -146,6 +149,10 @@ class Chef
           end
           ret.stdout.each_line do |line|
             case line
+            # installp will return lines with product:file_set:version
+            # So we are searching for products or filesets that match the package name
+            # Example line:
+            # samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
             when /(^|:)#{new_resource.package_name}:/
               fields = line.split(":")
               file_sets.push([fields[1], fields[2]])

--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -45,29 +45,29 @@ class Chef
         end
 
         def load_current_resource
-          @current_resource = Chef::Resource::Package.new(@new_resource.name)
-          @current_resource.package_name(@new_resource.package_name)
+          @current_resource = Chef::Resource::Package.new(new_resource.name)
+          @current_resource.package_name(new_resource.package_name)
 
           file_sets = []
 
-          if @new_resource.source
-            @package_source_found = ::File.exists?(@new_resource.source)
+          if new_resource.source
+            @package_source_found = ::File.exists?(new_resource.source)
             if @package_source_found
-              Chef::Log.debug("#{@new_resource} checking pkg status")
+              Chef::Log.debug("#{new_resource} checking pkg status")
               src_version, file_sets = filter_source_device { |fs| file_sets << fs }
               raise Chef::Exceptions::Package, "package source #{new_resource.source} does not provide package #{new_resource.package_name}" unless src_version
               new_resource.version(src_version)
             end
           end
 
-          Chef::Log.debug("#{@new_resource} checking install state")
+          Chef::Log.debug("#{new_resource} checking install state")
           installed_file_sets = []
           ret = shell_out_with_timeout("lslpp -lcq | grep :#{@current_resource.package_name}")
           ret.stdout.each_line do |line|
             case line
             when /#{@current_resource.package_name}/
               fields = line.split(":")
-              Chef::Log.debug("#{@new_resource} version #{fields[2]} is already installed")
+              Chef::Log.debug("#{new_resource} version #{fields[2]} is already installed")
               installed_file_sets.push([fields[1], fields[2]])
             end
           end
@@ -100,8 +100,8 @@ class Chef
             candidate, _ = filter_source_device
             if candidate
               @candidate_version = candidate
-              @new_resource.version(candidate)
-              Chef::Log.debug("#{@new_resource} setting install candidate version to #{@candidate_version}")
+              new_resource.version(candidate)
+              Chef::Log.debug("#{new_resource} setting install candidate version to #{@candidate_version}")
             end
           end
         end
@@ -114,35 +114,35 @@ class Chef
         # So far, the code has been tested only with standalone packages.
         #
         def install_package(name, version)
-          Chef::Log.debug("#{@new_resource} package install options: #{@new_resource.options}")
-          if @new_resource.options.nil?
-            shell_out_with_timeout!( "installp -aYF -d #{@new_resource.source} #{@new_resource.package_name}" )
-            Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
+          Chef::Log.debug("#{new_resource} package install options: #{new_resource.options}")
+          if new_resource.options.nil?
+            shell_out_with_timeout!( "installp -aYF -d #{new_resource.source} #{new_resource.package_name}" )
+            Chef::Log.debug("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
-            shell_out_with_timeout!( "installp -aYF #{expand_options(@new_resource.options)} -d #{@new_resource.source} #{@new_resource.package_name}" )
-            Chef::Log.debug("#{@new_resource} installed version #{@new_resource.version} from: #{@new_resource.source}")
+            shell_out_with_timeout!( "installp -aYF #{expand_options(new_resource.options)} -d #{new_resource.source} #{new_resource.package_name}" )
+            Chef::Log.debug("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           end
         end
 
         alias_method :upgrade_package, :install_package
 
         def remove_package(name, version)
-          if @new_resource.options.nil?
+          if new_resource.options.nil?
             shell_out_with_timeout!( "installp -u #{name}" )
-            Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
+            Chef::Log.debug("#{new_resource} removed version #{new_resource.version}")
           else
-            shell_out_with_timeout!( "installp -u #{expand_options(@new_resource.options)} #{name}" )
-            Chef::Log.debug("#{@new_resource} removed version #{@new_resource.version}")
+            shell_out_with_timeout!( "installp -u #{expand_options(new_resource.options)} #{name}" )
+            Chef::Log.debug("#{new_resource} removed version #{new_resource.version}")
           end
         end
 
         def filter_source_device
-          return unless  new_resource.source
+          return unless new_resource.source
 
           file_sets = []
           ret = shell_out_with_timeout("installp -L -d #{new_resource.source}")
           unless ret.exitstatus == 0
-            raise Chef::Exceptions::Package, "installp -L -d #{@new_resource.source} - #{ret.format_for_exception}!"
+            raise Chef::Exceptions::Package, "installp -L -d #{new_resource.source} - #{ret.format_for_exception}!"
           end
           ret.stdout.each_line do |line|
             case line

--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -97,7 +97,7 @@ class Chef
 
         def candidate_version
           @candidate_version ||= begin
-            candidate, _ = filter_source_device
+            candidate, fs = filter_source_device
             if candidate
               @candidate_version = candidate
               new_resource.version(candidate)

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -234,9 +234,11 @@ EOH
     end
 
     it "should lookup the candidate_version if the variable is not already set" do
-      status = double(:stdout => "", :exitstatus => 0)
+      bffinfo = "/usr/lib/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:
+  /etc/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:"
+      status = double(:stdout => bffinfo, :exitstatus => 0)
       expect(@provider).to receive(:shell_out).and_return(status)
-      @provider.candidate_version
+      expect(@provider.candidate_version).to eq("3.3.12.0")
     end
 
     it "should throw and exception if the exitstatus is not 0" do

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -64,20 +64,24 @@ describe Chef::Provider::Package::Aix do
     end
 
     it "should get the source package version from installp if provided" do
-      status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
+      info = <<EOH
+wacky.samba.base:wacky.samba.base:1.6.0.25::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+EOH
+      status = double("Status", :stdout => info, :exitstatus => 0)
       expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
       expect(@provider).to receive(:shell_out).with("lslpp -lcq | grep :samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("samba.base")
-      expect(@new_resource.version).to eq("3.3.12.0")
+      expect(@new_resource.version).to eq("1.6.0.3")
     end
 
     it "should get the source package version from the highest version available from installp" do
-      multi_file_set = <<-EOH
-        samba.base:samba.base.rte:1.6.0.25::I:C:::::N:Network Authentication Service Client::::0::
-        samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-      EOH
+      multi_file_set = <<EOH
+samba.base:samba.base.rte:1.6.0.25::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+EOH
       status = double("Status", :stdout => multi_file_set, :exitstatus => 0)
       expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
       expect(@provider).to receive(:shell_out).with("lslpp -lcq | grep :samba.base", timeout: 900).and_return(@empty_status)
@@ -139,18 +143,18 @@ describe Chef::Provider::Package::Aix do
 
       context "source has multiple filesets" do
         let(:src_filesets) do
-          <<-EOH
-            samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-            samba.base:samba.base.samples:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-          EOH
+          <<EOH
+samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base.samples:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+EOH
         end
 
         context "all filesets are installed but different version" do
           let(:current_filesets) do
-            <<-EOH
-              samba.base:samba.base.rte:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
-              samba.base:samba.base.samples:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
-            EOH
+            <<EOH
+samba.base:samba.base.rte:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base.samples:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
+EOH
           end
 
           it "sets current version to the installed versions" do
@@ -160,10 +164,10 @@ describe Chef::Provider::Package::Aix do
 
         context "all filesets are installed and same version" do
           let(:current_filesets) do
-            <<-EOH
-              samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-              samba.base:samba.base.samples:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-            EOH
+            <<EOH
+samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base.samples:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+EOH
           end
 
           it "sets current version to the installed versions" do
@@ -173,9 +177,7 @@ describe Chef::Provider::Package::Aix do
 
         context "partial filesets are installed and same version" do
           let(:current_filesets) do
-            <<-EOH
-              samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-            EOH
+            "samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::"
           end
 
           it "does not set current version" do
@@ -185,10 +187,10 @@ describe Chef::Provider::Package::Aix do
 
         context "all filesets are installed and mixed versions" do
           let(:current_filesets) do
-            <<-EOH
-              samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
-              samba.base:samba.base.samples:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
-            EOH
+            <<EOH
+samba.base:samba.base.rte:1.6.0.3::I:C:::::N:Network Authentication Service Client::::0::
+samba.base:samba.base.samples:1.6.0.2::I:C:::::N:Network Authentication Service Client::::0::
+EOH
           end
 
           it "does not set current version" do


### PR DESCRIPTION
bff packages can include multiple "filesets" under a single "software product". The individual filesets are the actual installed artifact and nodes can cherry pick these filesets or just provide the product name thereby installing all filesets in the product.

As the bff/aix pacjkage provider stands today, it only treats package names that refer to individual filesets idempotently. I can install an entire product but when given the product name, it is not idempotent and will  converge the resource on every run.

This PR attempts to add idempotency to bff install scenarios where users specify a product name that may include multiple filesets to install. Here is the basic logic used:
* Scan the source for all filesets matching provided package name on either product name or fileset name
* Filter this list to the latest version in case there are more than one
* Scan the filesets installed for those matching provided package name
* filter these installed filesets to those that match the filesets in the source
Now if all filesets installed are the same version as source, Rejoice and do nothing. Otherwise, converge.

In the process of tacking this issue, a couple other potential (likely edge) bugs are addressed:
1. source device locations may have multiple versions and now we ensure the latest is chosen
2. We were searching candates using a `*<package_name>` pattern potentially finding false matches