### PR TITLE
Depend on rack < 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group(:development, :test) do
   gem "simplecov"
-  gem "rack", "< 2.0"
+  gem "rack", "< 2.0" # 2.0 requires Ruby 2.2+
 
   # for testing new chefstyle rules
   # gem 'chefstyle', github: 'chef/chefstyle'

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group(:development, :test) do
   gem "simplecov"
-  gem "rack"
+  gem "rack", "< 2.0"
 
   # for testing new chefstyle rules
   # gem 'chefstyle', github: 'chef/chefstyle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,14 +97,14 @@ GEM
     addressable (2.4.0)
     appbundler (0.9.0)
       mixlib-cli (~> 1.4)
-    artifactory (2.3.2)
+    artifactory (2.3.3)
     ast (2.3.0)
-    aws-sdk (2.3.16)
-      aws-sdk-resources (= 2.3.16)
-    aws-sdk-core (2.3.16)
+    aws-sdk (2.3.18)
+      aws-sdk-resources (= 2.3.18)
+    aws-sdk-core (2.3.18)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.16)
-      aws-sdk-core (= 2.3.16)
+    aws-sdk-resources (2.3.18)
+      aws-sdk-core (= 2.3.18)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -145,7 +145,7 @@ GEM
       fauxhai (~> 3.2)
       rspec (~> 3.0)
     coderay (1.1.1)
-    colorize (0.7.7)
+    colorize (0.8.1)
     compat_resource (12.10.6)
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
@@ -157,10 +157,12 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fauxhai (3.5.0)
+    fauxhai (3.6.0)
       net-ssh
     ffi (1.9.10)
     ffi (1.9.10-x86-mingw32)
+    ffi-win32-extensions (1.0.2)
+      ffi
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
     foodcritic (6.3.0)
@@ -173,7 +175,7 @@ GEM
       yajl-ruby (~> 1.1)
     fuzzyurl (0.8.0)
     gherkin (4.0.0)
-    github_api (0.14.1)
+    github_api (0.14.2)
       addressable (~> 2.4.0)
       descendants_tracker (~> 0.0.4)
       faraday (~> 0.8, < 0.10)
@@ -187,10 +189,10 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    halite (1.2.1)
+    halite (1.3.0)
       bundler
       chef (~> 12.0)
-      stove (~> 3.2, >= 3.2.3)
+      stove (~> 4.0)
       thor
     hashie (3.4.4)
     highline (1.7.8)
@@ -220,7 +222,7 @@ GEM
       mixlib-log
     mixlib-cli (1.6.0)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.13)
+    mixlib-install (1.1.0)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -344,12 +346,12 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.59.3)
+    specinfra (2.59.4)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
       sfl
-    stove (3.2.8)
+    stove (4.1.1)
       chef-api (~> 0.5)
       logify (~> 0.2)
     syslog-logger (1.6.8)
@@ -377,8 +379,9 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (0.8.7)
+    win32-service (0.8.9)
       ffi
+      ffi-win32-extensions
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
     winrm (1.8.1)
@@ -421,7 +424,7 @@ DEPENDENCIES
   pry-byebug
   pry-remote
   pry-stack_explorer
-  rack
+  rack (< 2.0)
   rake
   rb-readline
   ruby-prof


### PR DESCRIPTION
Rack 2.0 was released today and it requires Ruby 2.2+ now, which is
breaking Travis runs on anything that depends on Chef. This should get
our builds running again.

Signed-off-by: Tim Smith <tsmith@chef.io>