### PR TITLE
The kitchen logs per instance per suite for acceptance are now in ci

### DIFF
--- a/acceptance/.shared/kitchen_acceptance/libraries/kitchen.rb
+++ b/acceptance/.shared/kitchen_acceptance/libraries/kitchen.rb
@@ -46,6 +46,14 @@ module KitchenAcceptance
           "ARTIFACTORY_PASSWORD" => artifactory_password
         }.merge(new_resource.env))
       end
+      ruby_block "copy_kitchen_logs_to_data_path" do
+        block do
+          suite = kitchen_dir.split("/").last
+          kitchen_log_path = ENV["WORKSPACE"] ? "#{ENV["WORKSPACE"]}/chef-acceptance-data/logs" : "#{kitchen_dir}/../.acceptance_data/logs/kitchen"
+          FileUtils.mkdir_p("#{kitchen_log_path}/#{suite}")
+          FileUtils.cp_r("#{kitchen_dir}/.kitchen/logs/", "#{kitchen_log_path}/#{suite}")
+        end
+      end
     end
   end
 end

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -10,13 +10,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    artifactory (2.3.2)
-    aws-sdk (2.3.14)
-      aws-sdk-resources (= 2.3.14)
-    aws-sdk-core (2.3.14)
+    artifactory (2.3.3)
+    aws-sdk (2.3.18)
+      aws-sdk-resources (= 2.3.18)
+    aws-sdk-core (2.3.18)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.14)
-      aws-sdk-core (= 2.3.14)
+    aws-sdk-resources (2.3.18)
+      aws-sdk-core (= 2.3.18)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -60,11 +60,11 @@ GEM
     cleanroom (1.0.0)
     coderay (1.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.28.0)
+    docker-api (1.29.0)
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
-    excon (0.49.0)
+    excon (0.50.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
@@ -112,7 +112,7 @@ GEM
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-config (2.2.1)
-    mixlib-install (1.0.13)
+    mixlib-install (1.1.0)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -124,7 +124,7 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.1.1)
+    net-ssh (3.2.0)
     nio4r (1.2.1)
     nori (2.6.0)
     octokit (4.3.0)
@@ -180,7 +180,7 @@ GEM
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
-    test-kitchen (1.9.2)
+    test-kitchen (1.10.2)
       mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -190,7 +190,7 @@ GEM
     thor (0.19.1)
     timers (4.0.4)
       hitimes
-    train (0.13.1)
+    train (0.14.2)
       docker-api (~> 1.26)
       json (~> 1.8)
       mixlib-shellout (~> 2.0)
@@ -211,7 +211,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0)
-    winrm-fs (0.4.2)
+    winrm-fs (0.4.3)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)


### PR DESCRIPTION
Let me know if I should leave the updated Gemfile.lock in there.

locally:
```➜  acceptance git:(praj/FLOW-370/acceptance_logging) ✗ ls .acceptance_data/logs/kitchen/basics/logs/
chef-current-install-ubuntu-1404.log kitchen.log
```

on ci:
http://manhattan.ci.chef.co/job/chef-test/57/architecture=x86_64,platform=acceptance,project=chef,role=tester/artifact/chef-acceptance-data/logs/