### PR TITLE
tweak 3694 warnings

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -531,8 +531,6 @@ class Chef
       end
     end
 
-    protected
-
     #
     # The options this Property will use for get/set behavior and validation.
     #
@@ -583,6 +581,7 @@ class Chef
         (options.has_key?(:is) && resource.send(:_pv_is, { name => nil }, name, options[:is], raise_error: false))
     end
 
+    # @api private
     def get_value(resource)
       if instance_variable_name
         resource.instance_variable_get(instance_variable_name)
@@ -591,6 +590,7 @@ class Chef
       end
     end
 
+    # @api private
     def set_value(resource, value)
       if instance_variable_name
         resource.instance_variable_set(instance_variable_name, value)
@@ -599,6 +599,7 @@ class Chef
       end
     end
 
+    # @api private
     def value_is_set?(resource)
       if instance_variable_name
         resource.instance_variable_defined?(instance_variable_name)
@@ -607,6 +608,7 @@ class Chef
       end
     end
 
+    # @api private
     def reset_value(resource)
       if instance_variable_name
         if value_is_set?(resource)
@@ -616,6 +618,8 @@ class Chef
         raise ArgumentError, "Property #{name} has no instance variable defined and cannot be reset"
       end
     end
+
+    private
 
     def exec_in_resource(resource, proc, *args)
       if resource

--- a/spec/support/lib/chef/resource/zen_master.rb
+++ b/spec/support/lib/chef/resource/zen_master.rb
@@ -24,18 +24,8 @@ class Chef
     class ZenMaster < Chef::Resource
       allowed_actions :win, :score
 
-      attr_reader :peace
-
-      def peace(tf)
-        @peace = tf
-      end
-
-      def something(arg = nil)
-        if !arg.nil?
-          @something = arg
-        end
-        @something
-      end
+      property :peace
+      property :something
     end
   end
 end

--- a/spec/support/lib/chef/resource/zen_master.rb
+++ b/spec/support/lib/chef/resource/zen_master.rb
@@ -24,8 +24,18 @@ class Chef
     class ZenMaster < Chef::Resource
       allowed_actions :win, :score
 
-      property :peace
-      property :something
+      attr_reader :peace
+
+      def peace(tf)
+        @peace = tf
+      end
+
+      def something(arg = nil)
+        if !arg.nil?
+          @something = arg
+        end
+        @something
+      end
     end
   end
 end


### PR DESCRIPTION
- clean up "ZenMaster" resource
- clean up 3694 detection to use properties
- unlazy the resource_name in the trivial resource check
- fixes an issue with resources-as-definitions pattern emitting
  3694 errors for trivial resources