### PR TITLE
Data Collector server URL validation, and disable on host down

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -382,16 +382,16 @@ class Chef
 
       def validate_data_collector_server_url!
         raise Chef::Exceptions::ConfigurationError,
-          "data_collector.server_url is configured but empty. Please supply a valid URL." if data_collector_server_url.empty?
+          "Chef::Config[:data_collector][:server_url] is empty. Please supply a valid URL." if data_collector_server_url.empty?
 
         begin
           uri = URI(data_collector_server_url)
         rescue URI::InvalidURIError
-          raise Chef::Exceptions::ConfigurationError, "data_collector.server_url (#{data_collector_server_url}) is not a valid URI."
+          raise Chef::Exceptions::ConfigurationError, "Chef::Config[:data_collector][:server_url] (#{data_collector_server_url}) is not a valid URI."
         end
 
         raise Chef::Exceptions::ConfigurationError,
-          "data_collector.server_url (#{data_collector_server_url}) is a URI with no host. Please upply a valid URL." if uri.host.nil?
+          "Chef::Config[:data_collector][:server_url] (#{data_collector_server_url}) is a URI with no host. Please supply a valid URL." if uri.host.nil?
       end
     end
   end

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -57,6 +57,8 @@ class Chef
                   :current_resource_report, :enabled
 
       def initialize
+        validate_data_collector_server_url!
+
         @all_resource_reports    = []
         @current_resource_loaded = nil
         @error_descriptions      = {}
@@ -236,7 +238,8 @@ class Chef
         yield
       rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
              Errno::ECONNREFUSED, EOFError, Net::HTTPBadResponse,
-             Net::HTTPHeaderSyntaxError, Net::ProtocolError, OpenSSL::SSL::SSLError => e
+             Net::HTTPHeaderSyntaxError, Net::ProtocolError, OpenSSL::SSL::SSLError,
+             Errno::EHOSTDOWN => e
         disable_data_collector_reporter
         code = if e.respond_to?(:response) && e.response.code
                  e.response.code.to_s
@@ -375,6 +378,20 @@ class Chef
       # output.
       def nested_resource?(new_resource)
         @current_resource_report && @current_resource_report.new_resource != new_resource
+      end
+
+      def validate_data_collector_server_url!
+        raise Chef::Exceptions::ConfigurationError,
+          "data_collector.server_url is configured but empty. Please supply a valid URL." if data_collector_server_url.empty?
+
+        begin
+          uri = URI(data_collector_server_url)
+        rescue URI::InvalidURIError
+          raise Chef::Exceptions::ConfigurationError, "data_collector.server_url (#{data_collector_server_url}) is not a valid URI."
+        end
+
+        raise Chef::Exceptions::ConfigurationError,
+          "data_collector.server_url (#{data_collector_server_url}) is a URI with no host. Please upply a valid URL." if uri.host.nil?
       end
     end
   end

--- a/lib/chef/data_collector/resource_report.rb
+++ b/lib/chef/data_collector/resource_report.rb
@@ -80,6 +80,7 @@ class Chef
         if new_resource.cookbook_name
           hash["cookbook_name"]    = new_resource.cookbook_name
           hash["cookbook_version"] = new_resource.cookbook_version.version
+          hash["recipe_name"]      = new_resource.recipe_name
         end
 
         hash["conditional"]   = conditional.to_text if status == "skipped"


### PR DESCRIPTION
If a user configured data_collector.server_url in their Chef config
as an empty string, we blissfully passed it along to Chef::HTTP
which would eventually raise a TypeError when trying to dup the
URI's host. This change validates the server_url when setting up
the Data Collector and gives helpful error messages to the user.

We also count Errno::EHOSTDOWN as an error worthy of disabling
the Data Collector reporter for a given run if the user so chooses.