### PR TITLE
In Travis use latest ruby releases + trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
+dist: trusty # this is only honored where sudo is true also
 
 # Early warning system to catch if Rubygems breaks something
 before_install:
@@ -30,17 +31,17 @@ env:
 
 matrix:
   include:
-  - rvm: 2.1
+  - rvm: 2.1.9
     sudo: true
     script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-  - rvm: 2.2
+  - rvm: 2.2.5
     sudo: true
     script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-  - rvm: 2.3.0
+  - rvm: 2.3.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
@@ -52,13 +53,13 @@ matrix:
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
       CHEFSTYLE: 1
-    rvm: 2.1
+    rvm: 2.1.9
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
   - env:
       AUDIT_CHECK: 1
-    rvm: 2.1
+    rvm: 2.1.9
     script: bundle exec bundle-audit check --update
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
@@ -68,23 +69,23 @@ matrix:
   - env:
       TEST_GEM: chef-provisioning
     script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: chef-provisioning-aws
     script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: chef-sugar
     script: tasks/bin/run_external_test $TEST_GEM rake
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       - TEST_GEM: chef-zero
     script: tasks/bin/run_external_test $TEST_GEM rake spec cheffs
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: cheffish
     script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: chefspec
     # The chefspec tests + bundler cache + "gem update --system" interact badly :/
@@ -93,26 +94,26 @@ matrix:
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
       - bundle config --local without server:docgen:maintenance:omnibus_package:development:ruby_prof:pry
     script: tasks/bin/run_external_test $TEST_GEM rake
-    rvm: 2.2.0
+    rvm: 2.2.5
   - env:
       TEST_GEM: foodcritic
     script: tasks/bin/run_external_test $TEST_GEM rake test
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: halite
     script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: knife-windows
     script: tasks/bin/run_external_test $TEST_GEM rake unit_spec
-    rvm: 2.2
+    rvm: 2.2.5
   - env:
       TEST_GEM: poise
     script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.2
+    rvm: 2.2.5
   ### START TEST KITCHEN ONLY ###
   #
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -129,7 +130,7 @@ matrix:
     env:
       - UBUNTU=12.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -146,7 +147,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -163,7 +164,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -180,7 +181,7 @@ matrix:
     env:
       - DEBIAN=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -197,7 +198,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -214,7 +215,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -231,7 +232,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.2
+  - rvm: 2.2.5
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -249,9 +250,8 @@ matrix:
       - FEDORA=23
       - KITCHEN_YAML=.kitchen.travis.yml
     ### END TEST KITCHEN ONLY ###
-  - rvm: 2.2
+  - rvm: 2.2.5
     sudo: required
-    dist: trusty
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
@@ -270,7 +270,7 @@ matrix:
       - sudo cat /var/log/squid3/access.log
 
   allow_failures:
-    - rvm: 2.3.0
+    - rvm: 2.3.1
     - rvm: rbx
 
 notifications:


### PR DESCRIPTION
The nice rvm aliases in Travis (2.1, 2.2, etc) have never been updated
and point to some really old releases. We should specify the latest
releases of these feature releases. Also if we require sudo then we're
running the GCE environment and we can also specify that we want to run
on the Trusty "beta" image which has much newer deps all around.

Signed-off-by: Tim Smith <tsmith@chef.io>