### PR TITLE
use --local for chef-config bundle install

### DIFF
--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -29,7 +29,7 @@ begin
   task :component_specs do
     Dir.chdir("chef-config") do
       Bundler.with_clean_env do
-        sh("bundle install")
+        sh("bundle install --local")
         sh("bundle exec rake spec")
       end
     end


### PR DESCRIPTION
This ensures that we only use local gems when running chef-config specs and effectively honors the top level lock file.