### PR TITLE
Warn if not installing an individual bff fileset

### DIFF
--- a/lib/chef/provider/package/aix.rb
+++ b/lib/chef/provider/package/aix.rb
@@ -55,7 +55,11 @@ class Chef
               ret = shell_out_with_timeout("installp -L -d #{@new_resource.source}")
               ret.stdout.each_line do |line|
                 case line
-                when /#{@new_resource.package_name}:/
+                when /:#{@new_resource.package_name}:/
+                  fields = line.split(":")
+                  @new_resource.version(fields[2])
+                when /^#{@new_resource.package_name}:/
+                  Chef::Log.warn("You are installing a bff package by product name. For idempotent installs, please install individual filesets")
                   fields = line.split(":")
                   @new_resource.version(fields[2])
                 end

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -73,6 +73,19 @@ describe Chef::Provider::Package::Aix do
       expect(@new_resource.version).to eq("3.3.12.0")
     end
 
+    it "should warn if the package is not a fileset" do
+      info = "samba.base:samba.base.samples:3.3.12.0::COMMITTED:I:Samba for AIX:
+  /etc/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:"
+      status = double("Status", :stdout => info, :exitstatus => 0)
+      expect(@provider).to receive(:shell_out).with("installp -L -d /tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out).with("lslpp -lcq samba.base", timeout: 900).and_return(@empty_status)
+      expect(Chef::Log).to receive(:warn).once.with(%r{bff package by product name})
+      @provider.load_current_resource
+
+      expect(@provider.current_resource.package_name).to eq("samba.base")
+      expect(@new_resource.version).to eq("3.3.12.0")
+    end
+
     it "should return the current version installed if found by lslpp" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       @stdout = StringIO.new(@bffinfo)


### PR DESCRIPTION
bff packages can include multiple "filesets" under a single "software product". The individual filesets are the actual installed artifact and nodes can cherry pick these filesets or just provide the product name thereby installing all filesets in the product.

As the bff/aix pacjkage provider stands today, it only treats package names that refer to individual filesets idempotently. I can install an entire product but when given the product name, it is not idempotent and will converge the resource on every run.

#5071 was an attempt to "fix" this but it was agreed that shoehorning a "group" concept into this provider was not the right path. So this PR basically extends an olive branch to users who wonder why their packages always converge. It warns them that the package is not an individual fileset and will not be idempotent and suggests that they install by fileset instead.

