### PR TITLE
Don't hardcode @cookbook_name as the root_dir name of a cookbook in get_filename

### DIFF
--- a/lib/chef/cookbook/file_system_file_vendor.rb
+++ b/lib/chef/cookbook/file_system_file_vendor.rb
@@ -40,14 +40,17 @@ class Chef
         raise ArgumentError, "You must specify at least one repo path" if @repo_paths.empty?
       end
 
+      def cookbooks
+        @cookbooks ||= Chef::CookbookLoader.new(@repo_paths).load_cookbooks
+      end
+
       # Implements abstract base's requirement. It looks in the
       # Chef::Config.cookbook_path file hierarchy for the requested
       # file.
       def get_filename(filename)
-        location = @repo_paths.inject(nil) do |memo, basepath|
-          candidate_location = File.join(basepath, @cookbook_name, filename)
-          memo = candidate_location if File.exist?(candidate_location)
-          memo
+        if cookbooks.has_key?(@cookbook_name)
+          location = File.join(cookbooks[@cookbook_name].root_dir, filename)
+          location = nil unless File.exist?(location)
         end
         raise "File #{filename} does not exist for cookbook #{@cookbook_name}" unless location
 


### PR DESCRIPTION
Redone a part of the original patch for https://tickets.opscode.com/browse/CHEF-3307 from chef/chef@5713a00

Just works.