### PR TITLE
Fix bootstraps ssl_verify option from not being set

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -224,6 +224,7 @@ class Chef
           unless valid_values.include?(v)
             raise "Invalid value '#{v}' for --node-ssl-verify-mode. Valid values are: #{valid_values.join(", ")}"
           end
+          Chef::Config[:knife][:node_ssl_verify_mode] = v
         }
 
       option :node_verify_api_cert,


### PR DESCRIPTION
This just came up in jenkins acceptance.

I'm perplexed as to why this passes travis and why it just started to fail in jenkins.