### PR TITLE
Fixed regex for zypper version 1.13.*. 

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -38,15 +38,15 @@ class Chef
           status = shell_out_with_timeout!("zypper --non-interactive info #{package_name}")
           status.stdout.each_line do |line|
             case line
-            when /^Version: (.+)$/
-              candidate_version = $1
-              Chef::Log.debug("#{new_resource} version #{$1}")
-            when /^Installed: Yes$/
+            when /^Version *: (.+) *$/
+              candidate_version = $1.strip
+              Chef::Log.debug("#{new_resource} version #{candidate_version}")
+            when /^Installed *: Yes *$/
               is_installed = true
               Chef::Log.debug("#{new_resource} is installed")
-            when /^Status: out-of-date \(version (.+) installed\)$/
-              current_version = $1
-              Chef::Log.debug("#{new_resource} out of date version #{$1}")
+            when /^Status *: out-of-date \(version (.+) installed\) *$/
+              current_version = $1.strip
+              Chef::Log.debug("#{new_resource} out of date version #{current_version}")
             end
           end
           current_version = candidate_version if is_installed

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -72,7 +72,7 @@ describe Chef::Provider::Package::Zypper do
       provider.load_current_resource
     end
 
-    it "should set the installed version if zypper info has one" do
+    it "should set the installed version if zypper info has one (zypper version < 1.13.0)" do
       status = double(:stdout => "Version: 1.0\nInstalled: Yes\n", :exitstatus => 0)
 
       allow(provider).to receive(:shell_out!).and_return(status)
@@ -80,8 +80,24 @@ describe Chef::Provider::Package::Zypper do
       provider.load_current_resource
     end
 
-    it "should set the candidate version if zypper info has one" do
+    it "should set the installed version if zypper info has one (zypper version >= 1.13.0)" do
+      status = double(:stdout => "Version        : 1.0                             \nInstalled      : Yes                             \n", :exitstatus => 0)
+
+      allow(provider).to receive(:shell_out!).and_return(status)
+      expect(current_resource).to receive(:version).with(["1.0"]).and_return(true)
+      provider.load_current_resource
+    end
+
+    it "should set the candidate version if zypper info has one (zypper version < 1.13.0)" do
       status = double(:stdout => "Version: 1.0\nInstalled: No\nStatus: out-of-date (version 0.9 installed)", :exitstatus => 0)
+
+      allow(provider).to receive(:shell_out!).and_return(status)
+      provider.load_current_resource
+      expect(provider.candidate_version).to eql(["1.0"])
+    end
+
+    it "should set the candidate version if zypper info has one (zypper version >= 1.13.0)" do
+      status = double(:stdout => "Version        : 1.0                             \nInstalled      : No                              \nStatus         : out-of-date (version 0.9 installed)", :exitstatus => 0)
 
       allow(provider).to receive(:shell_out!).and_return(status)
       provider.load_current_resource


### PR DESCRIPTION
This is backward compatible with zypper version 1.12.* (used by SLES11SP4).