### PR TITLE
Add `chef_data_bag_item` to Cheffish DSL methods

### DIFF
--- a/lib/chef/dsl/cheffish.rb
+++ b/lib/chef/dsl/cheffish.rb
@@ -27,6 +27,7 @@ class Chef
         chef_acl
         chef_client
         chef_container
+        chef_data_bag_item
         chef_data_bag
         chef_environment
         chef_group


### PR DESCRIPTION
This method is included in the docs: https://docs.chef.io/resource_chef_data_bag_item.html and Cheffish's README: https://github.com/chef/cheffish but was missed when we made chef-provisioning and cheffish lazy-load in 010392858c2a3a036578b681085704ed1971ab21

@chef/client-core 