### PR TITLE
Forward package cookbook_name to underlying remote_file

### DIFF
--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -201,6 +201,7 @@ class Chef
         def resource_for_provider
           @resource_for_provider = Chef::Resource::WindowsPackage.new(new_resource.name).tap do |r|
             r.source(Chef::Util::PathHelper.validate_path(source_location)) unless source_location.nil?
+            r.cookbook_name = new_resource.cookbook_name
             r.version(new_resource.version)
             r.timeout(new_resource.timeout)
             r.returns(new_resource.returns)
@@ -216,6 +217,7 @@ class Chef
         def source_resource
           @source_resource ||= Chef::Resource::RemoteFile.new(default_download_cache_path, run_context).tap do |r|
             r.source(new_resource.source)
+            r.cookbook_name = new_resource.cookbook_name
             r.checksum(new_resource.checksum)
             r.backup(false)
 


### PR DESCRIPTION
Hello,

The package providers is instantiating the remote_file resource manually, i.e. not using the DSL.
This means the cookbook_name attribute of the resource is not set; it's sometimes useful to have this information.

I patched the windows_package using the DSL (see chef-cookbooks/windows#318), but this time I decided to only forward the cookbook_name to the newly created resources.
That means maybe other attributes may be missing. I can change my PR if you want :)

Regards!

Cc: @aboten