### PR TITLE
Clean up subscribes internals and notification storage.

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -260,6 +260,18 @@ class Chef
     end
 
     #
+    # Token class to hold an unresolved subscribes call with an associated
+    # run context.
+    #
+    # @api private
+    # @see Resource#subscribes
+    class UnresolvedSubscribes < self
+      # The full key ise given as the name in {Resource#subscribes}
+      alias_method :to_s, :name
+      alias_method :declared_key, :name
+    end
+
+    #
     # Subscribes to updates from other resources, causing a particular action to
     # run on *this* resource when the other resource is updated.
     #
@@ -326,7 +338,7 @@ class Chef
       resources = [resources].flatten
       resources.each do |resource|
         if resource.is_a?(String)
-          resource = Chef::Resource.new(resource, run_context)
+          resource = UnresolvedSubscribes.new(resource, run_context)
         end
         if resource.run_context.nil?
           resource.run_context = run_context

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -194,6 +194,9 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_before(notification)
+      # Note for the future, notification.notifying_resource may be an instance
+      # of Chef::Resource::UnresolvedSubscribes when calling {Resource#subscribes}
+      # with a string value.
       before_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 
@@ -203,6 +206,9 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_immediately(notification)
+      # Note for the future, notification.notifying_resource may be an instance
+      # of Chef::Resource::UnresolvedSubscribes when calling {Resource#subscribes}
+      # with a string value.
       immediate_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 
@@ -212,6 +218,9 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_delayed(notification)
+      # Note for the future, notification.notifying_resource may be an instance
+      # of Chef::Resource::UnresolvedSubscribes when calling {Resource#subscribes}
+      # with a string value.
       delayed_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -194,12 +194,7 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_before(notification)
-      nr = notification.notifying_resource
-      if nr.instance_of?(Chef::Resource)
-        before_notification_collection[nr.name] << notification
-      else
-        before_notification_collection[nr.declared_key] << notification
-      end
+      before_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 
     #
@@ -208,12 +203,7 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_immediately(notification)
-      nr = notification.notifying_resource
-      if nr.instance_of?(Chef::Resource)
-        immediate_notification_collection[nr.name] << notification
-      else
-        immediate_notification_collection[nr.declared_key] << notification
-      end
+      immediate_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 
     #
@@ -222,12 +212,7 @@ class Chef
     # @param [Chef::Resource::Notification] The notification to add.
     #
     def notifies_delayed(notification)
-      nr = notification.notifying_resource
-      if nr.instance_of?(Chef::Resource)
-        delayed_notification_collection[nr.name] << notification
-      else
-        delayed_notification_collection[nr.declared_key] << notification
-      end
+      delayed_notification_collection[notification.notifying_resource.declared_key] << notification
     end
 
     #
@@ -245,50 +230,29 @@ class Chef
     #
     # Get the list of before notifications sent by the given resource.
     #
-    # TODO seriously, this is actually wrong.  resource.name is not unique,
-    # you need the type as well.
-    #
     # @return [Array[Notification]]
     #
     def before_notifications(resource)
-      if resource.instance_of?(Chef::Resource)
-        return before_notification_collection[resource.name]
-      else
-        return before_notification_collection[resource.declared_key]
-      end
+      return before_notification_collection[resource.declared_key]
     end
 
     #
     # Get the list of immediate notifications sent by the given resource.
     #
-    # TODO seriously, this is actually wrong.  resource.name is not unique,
-    # you need the type as well.
-    #
     # @return [Array[Notification]]
     #
     def immediate_notifications(resource)
-      if resource.instance_of?(Chef::Resource)
-        return immediate_notification_collection[resource.name]
-      else
-        return immediate_notification_collection[resource.declared_key]
-      end
+      return immediate_notification_collection[resource.declared_key]
     end
 
     #
     # Get the list of delayed (end of run) notifications sent by the given
     # resource.
     #
-    # TODO seriously, this is actually wrong.  resource.name is not unique,
-    # you need the type as well.
-    #
     # @return [Array[Notification]]
     #
     def delayed_notifications(resource)
-      if resource.instance_of?(Chef::Resource)
-        return delayed_notification_collection[resource.name]
-      else
-        return delayed_notification_collection[resource.declared_key]
-      end
+      return delayed_notification_collection[resource.declared_key]
     end
 
     #


### PR DESCRIPTION
John K and I are 99% sure those branches have never been used outside of
unit tests. Fingers crossed!