### PR TITLE
HTTP 1.1 keepalives re-re-redux

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.2
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -291,7 +291,7 @@ class Chef
     end
 
     def server_api
-      Chef::ServerAPI.new(Chef::Config[:chef_server_url])
+      Thread.current[:server_api] ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url])
     end
 
   end

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -291,7 +291,7 @@ class Chef
     end
 
     def server_api
-      Thread.current[:server_api] ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url])
+      Thread.current[:server_api] ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], keepalives: true)
     end
 
   end

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -227,20 +227,23 @@ class Chef
     end
 
     def http_client(base_url = nil)
-      base_url ||= url
-      if chef_zero_uri?(base_url)
-        # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
-        # via chef-zero and that hits DNS (at *require* time) which may timeout,
-        # when for most knife/chef-client work we never need/want this loaded.
+      @http_client =
+        begin
+          base_url ||= url
+          if chef_zero_uri?(base_url)
+            # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
+            # via chef-zero and that hits DNS (at *require* time) which may timeout,
+            # when for most knife/chef-client work we never need/want this loaded.
 
-        unless defined?(SocketlessChefZeroClient)
-          require "chef/http/socketless_chef_zero_client"
+            unless defined?(SocketlessChefZeroClient)
+              require "chef/http/socketless_chef_zero_client"
+            end
+
+            SocketlessChefZeroClient.new(base_url)
+          else
+            BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
+          end
         end
-
-        SocketlessChefZeroClient.new(base_url)
-      else
-        BasicClient.new(base_url, :ssl_policy => Chef::HTTP::APISSLPolicy)
-      end
     end
 
     protected

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -227,7 +227,11 @@ class Chef
     end
 
     def http_client(base_url = nil)
-      @http_client =
+      # the per-host per-port cache here gets peristent connections correct in the
+      # face of redirects to different servers
+      @http_client ||= {}
+      @http_client[base_url.host] ||= {}
+      @http_client[base_url.host][base_url.port] ||=
         begin
           base_url ||= url
           if chef_zero_uri?(base_url)

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -232,16 +232,15 @@ class Chef
 
     def http_client(base_url = nil)
       base_url ||= url
-      client = build_http_client(base_url)
       if keepalives && !base_url.nil?
         # only reuse the http_client if we want keepalives and have a base_url
         @http_client ||= {}
         # the per-host per-port cache here gets peristent connections correct when
         # redirecting to different servers
         @http_client[base_url.host] ||= {}
-        @http_client[base_url.host][base_url.port] ||= client
+        @http_client[base_url.host][base_url.port] ||= build_http_client(base_url)
       else
-        client
+        build_http_client(base_url)
       end
     end
 

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -237,8 +237,12 @@ class Chef
         @http_client ||= {}
         # the per-host per-port cache here gets peristent connections correct when
         # redirecting to different servers
-        @http_client[base_url.host] ||= {}
-        @http_client[base_url.host][base_url.port] ||= build_http_client(base_url)
+        if base_url.is_a?(String) # sigh, this kind of abuse can't happen with strongly typed languages
+          @http_client[base_url] ||= build_http_client(base_url)
+        else
+          @http_client[base_url.host] ||= {}
+          @http_client[base_url.host][base_url.port] ||= build_http_client(base_url)
+        end
       else
         build_http_client(base_url)
       end

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -114,7 +114,7 @@ class Chef
 
         http_client.read_timeout = config[:rest_timeout]
         http_client.open_timeout = config[:rest_timeout]
-        http_client
+        http_client.start
       end
 
       def config

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -45,7 +45,10 @@ class Chef
         @url = url
         @ssl_policy = opts[:ssl_policy] || DefaultSSLPolicy
         @keepalives = opts[:keepalives] || false
-        @http_client = build_http_client
+      end
+
+      def http_client
+        @http_client ||= build_http_client
       end
 
       def host

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -34,6 +34,7 @@ class Chef
       attr_reader :url
       attr_reader :http_client
       attr_reader :ssl_policy
+      attr_reader :keepalives
 
       # Instantiate a BasicClient.
       # === Arguments:
@@ -43,6 +44,7 @@ class Chef
       def initialize(url, opts = {})
         @url = url
         @ssl_policy = opts[:ssl_policy] || DefaultSSLPolicy
+        @keepalives = opts[:keepalives] || false
         @http_client = build_http_client
       end
 
@@ -114,7 +116,11 @@ class Chef
 
         http_client.read_timeout = config[:rest_timeout]
         http_client.open_timeout = config[:rest_timeout]
-        http_client.start
+        if keepalives
+          http_client.start
+        else
+          http_client
+        end
       end
 
       def config

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -414,6 +414,13 @@ describe Chef::CookbookSynchronizer do
       and_return("/file-cache/cookbooks/cookbook_a/templates/default/apache2.conf.erb")
   end
 
+  describe "#server_api" do
+    it "sets keepalive to true" do
+      expect(Chef::ServerAPI).to receive(:new).with(Chef::Config[:chef_server_url], keepalives: true)
+      synchronizer.server_api
+    end
+  end
+
   describe "when syncing cookbooks with the server" do
     let(:server_api) { double("Chef::ServerAPI (mock)") }
 

--- a/spec/unit/http/basic_client_spec.rb
+++ b/spec/unit/http/basic_client_spec.rb
@@ -33,7 +33,7 @@ describe "HTTP Connection" do
     it "calls .start when doing keepalives" do
       basic_client = Chef::HTTP::BasicClient.new(uri, keepalives: true)
       expect(basic_client).to receive(:configure_ssl)
-      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=": nil, "read_timeout=": nil, "open_timeout=": nil)
+      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=" => nil, "read_timeout=" => nil, "open_timeout=" => nil)
       expect(net_http_mock).to receive(:start).and_return(net_http_mock)
       expect(Net::HTTP).to receive(:new).and_return(net_http_mock)
       expect(basic_client.http_client).to eql(net_http_mock)
@@ -42,7 +42,7 @@ describe "HTTP Connection" do
     it "does not call .start when not doing keepalives" do
       basic_client = Chef::HTTP::BasicClient.new(uri)
       expect(basic_client).to receive(:configure_ssl)
-      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=": nil, "read_timeout=": nil, "open_timeout=": nil)
+      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=" => nil, "read_timeout=" => nil, "open_timeout=" => nil)
       expect(net_http_mock).not_to receive(:start)
       expect(Net::HTTP).to receive(:new).and_return(net_http_mock)
       expect(basic_client.http_client).to eql(net_http_mock)

--- a/spec/unit/http/basic_client_spec.rb
+++ b/spec/unit/http/basic_client_spec.rb
@@ -29,6 +29,26 @@ describe "HTTP Connection" do
     end
   end
 
+  describe "#initialize" do
+    it "calls .start when doing keepalives" do
+      basic_client = Chef::HTTP::BasicClient.new(uri, keepalives: true)
+      expect(basic_client).to receive(:configure_ssl)
+      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=": nil, "read_timeout=": nil, "open_timeout=": nil)
+      expect(net_http_mock).to receive(:start).and_return(net_http_mock)
+      expect(Net::HTTP).to receive(:new).and_return(net_http_mock)
+      expect(basic_client.http_client).to eql(net_http_mock)
+    end
+
+    it "does not call .start when not doing keepalives" do
+      basic_client = Chef::HTTP::BasicClient.new(uri)
+      expect(basic_client).to receive(:configure_ssl)
+      net_http_mock = instance_double(Net::HTTP, proxy_address: nil, "proxy_port=": nil, "read_timeout=": nil, "open_timeout=": nil)
+      expect(net_http_mock).not_to receive(:start)
+      expect(Net::HTTP).to receive(:new).and_return(net_http_mock)
+      expect(basic_client.http_client).to eql(net_http_mock)
+    end
+  end
+
   describe "#build_http_client" do
     it "should build an http client" do
       subject.build_http_client

--- a/spec/unit/http_spec.rb
+++ b/spec/unit/http_spec.rb
@@ -43,6 +43,20 @@ describe Chef::HTTP do
 
   end
 
+  describe "#intialize" do
+    it "accepts a keepalive option and passes it to the http_client" do
+      http = Chef::HTTP.new(uri, keepalives: true)
+      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, keepalives: true).and_call_original
+      expect(http.http_client).to be_a_kind_of(Chef::HTTP::BasicClient)
+    end
+
+    it "the default is not to use keepalives" do
+      http = Chef::HTTP.new(uri)
+      expect(Chef::HTTP::BasicClient).to receive(:new).with(uri, ssl_policy: Chef::HTTP::APISSLPolicy, keepalives: false).and_call_original
+      expect(http.http_client).to be_a_kind_of(Chef::HTTP::BasicClient)
+    end
+  end
+
   describe "create_url" do
 
     it "should return a correctly formatted url 1/3 CHEF-5261" do


### PR DESCRIPTION
- leverages ruby 2.x so no need for net/http/persistent
- does not try to do everything and just solves the problem for clients that correctly reuse their Net::HTTP objects
- patches the cookbook synchronizer to reuse Net::HTTP objects which is probably 90% of the battle

closes #1617 
replaces #1792