### PR TITLE
Fix specify members of group on suse/openbsd/solaris2/hpux

### DIFF
--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -57,7 +57,7 @@ class Chef
           # This provider only supports adding members with
           # append. Only if the action is create we will go
           # ahead and add members.
-          if @new_resource.action == :create
+          if @new_resource.action.include?(:create)
             members.each do |member|
               add_member(member)
             end


### PR DESCRIPTION
Action is an array.  We need to check to see if create is in the action
array instead of checking to see if it's ";create" which it never will
be.

Fixed #3780

Signed-off-by: Tim Smith <tsmith@chef.io>