### PR TITLE
Add `create_user_group` attribute to Useradd provider

### DIFF
--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -141,6 +141,14 @@ class Chef
         def useradd_options
           opts = []
           opts << "-r" if new_resource.system
+          # The default behavior is to follow whatever is in the
+          # USERGROUPS_ENAB variable in /etc/login.defs.
+          case new_resource.create_user_group
+          when true
+            opts << "-U"
+          when false
+            opts << "-N"
+          end
           opts
         end
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -41,6 +41,7 @@ class Chef
         @manage_home = false
         @force = false
         @non_unique = false
+        @create_user_group = nil
         @supports = {
           :manage_home => false,
           :non_unique => false,
@@ -155,6 +156,13 @@ class Chef
         )
       end
 
+      def create_user_group(arg = nil)
+        set_or_return(
+          :create_user_group,
+          arg,
+          :kind_of => [ TrueClass, FalseClass, NilClass ]
+        )
+      end
     end
   end
 end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -35,6 +35,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
     @new_resource.manage_home false
     @new_resource.force false
     @new_resource.non_unique false
+    @new_resource.create_user_group nil
     @current_resource = Chef::Resource::User.new("adam", @run_context)
     @current_resource.comment "Adam Jacob"
     @current_resource.uid 1000
@@ -46,6 +47,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
     @current_resource.manage_home false
     @current_resource.force false
     @current_resource.non_unique false
+    @current_resource.create_user_group nil
     @current_resource.supports({ :manage_home => false, :non_unique => false })
   end
 
@@ -97,6 +99,28 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       it "should set useradd -r" do
         @new_resource.system(true)
         expect(provider.useradd_options).to eq([ "-r" ])
+      end
+    end
+
+    describe "when we want to create a user-private group" do
+      after do
+        @new_resource.create_user_group(nil)
+      end
+
+      it "should set useradd -U" do
+        @new_resource.create_user_group(true)
+        expect(provider.useradd_options).to include("-U")
+      end
+    end
+
+    describe "when we do not want to create a user-private group" do
+      after do
+        @new_resource.create_user_group(nil)
+      end
+
+      it "should set useradd -N" do
+        @new_resource.create_user_group(false)
+        expect(provider.useradd_options).to include("-N")
       end
     end
 


### PR DESCRIPTION
Add a `create_user_group` attribute to Chef::Provider::User::Useradd.
The default value is `nil`, so there's no change in existing behavior.
But setting it to `true` or `false` will append the `-U` or `-N`
optional arguments, respectively, to the `useradd` commandline.

This may or may not be compatible with all useradd(1) variants (it
works on Ubuntu 12+ and CentOS 6+, at least), so additional OS/distro
compatibility testing may be desirable.
