### PR TITLE
Bump dependencies to bring in Ohai 8.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-log (1.6.0)
+    mixlib-log (1.7.0)
     mixlib-shellout (2.2.6)
     mixlib-shellout (2.2.6-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -301,7 +301,7 @@ GEM
       rack (>= 1.2, < 3)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.17.1)
+    ohai (8.18.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -388,7 +388,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.60.2)
+    specinfra (2.60.3)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       buff-extensions (~> 1.0)
       varia_model (~> 0.4)
     buff-extensions (1.0.0)
-    buff-ignore (1.2.0)
+    buff-ignore (1.1.1)
     buff-ruby_engine (0.1.0)
     buff-shell_out (0.2.0)
       buff-ruby_engine (~> 0.1.0)
@@ -131,7 +131,7 @@ GEM
     cleanroom (1.0.0)
     coderay (1.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.29.2)
+    docker-api (1.30.0)
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
@@ -183,7 +183,7 @@ GEM
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-log (1.6.0)
+    mixlib-log (1.7.0)
     mixlib-shellout (2.2.6)
     mixlib-versioning (1.1.0)
     molinillo (0.4.5)
@@ -202,11 +202,11 @@ GEM
       slop (~> 3.4)
     rainbow (2.1.0)
     retryable (2.0.4)
-    ridley (4.6.0)
+    ridley (4.6.1)
       addressable
       buff-config (~> 1.0)
       buff-extensions (~> 1.0)
-      buff-ignore (~> 1.1)
+      buff-ignore (~> 1.1.1)
       buff-shell_out (~> 0.1)
       celluloid (~> 0.16.0)
       celluloid-io (~> 0.16.1)

--- a/kitchen-tests/Gemfile.lock
+++ b/kitchen-tests/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     excon (0.51.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.14)
     ffi (1.9.14-x86-mingw32)
     fuzzyurl (0.8.0)
     gssapi (1.2.0)

--- a/kitchen-tests/Gemfile.lock
+++ b/kitchen-tests/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       buff-extensions (~> 1.0)
       varia_model (~> 0.4)
     buff-extensions (1.0.0)
-    buff-ignore (1.2.0)
+    buff-ignore (1.1.1)
     buff-ruby_engine (0.1.0)
     buff-shell_out (0.2.0)
       buff-ruby_engine (~> 0.1.0)
@@ -52,14 +52,13 @@ GEM
     cleanroom (1.0.0)
     coderay (1.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.29.2)
+    docker-api (1.30.0)
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
     excon (0.51.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.14)
     ffi (1.9.14-x86-mingw32)
     fuzzyurl (0.8.0)
     gssapi (1.2.0)
@@ -113,7 +112,7 @@ GEM
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-log (1.6.0)
+    mixlib-log (1.7.0)
     mixlib-shellout (2.2.6)
     mixlib-shellout (2.2.6-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -135,11 +134,11 @@ GEM
       slop (~> 3.4)
     rainbow (2.1.0)
     retryable (2.0.4)
-    ridley (4.6.0)
+    ridley (4.6.1)
       addressable
       buff-config (~> 1.0)
       buff-extensions (~> 1.0)
-      buff-ignore (~> 1.1)
+      buff-ignore (~> 1.1.1)
       buff-shell_out (~> 0.1)
       celluloid (~> 0.16.0)
       celluloid-io (~> 0.16.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       buff-extensions (~> 1.0)
       varia_model (~> 0.4)
     buff-extensions (1.0.0)
-    buff-ignore (1.2.0)
+    buff-ignore (1.1.1)
     buff-ruby_engine (0.1.0)
     buff-shell_out (0.2.0)
       buff-ruby_engine (~> 0.1.0)
@@ -133,7 +133,7 @@ GEM
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-log (1.6.0)
+    mixlib-log (1.7.0)
     mixlib-shellout (2.2.6)
     mixlib-shellout (2.2.6-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -149,7 +149,7 @@ GEM
     nori (2.6.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.17.1)
+    ohai (8.18.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -174,11 +174,11 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     retryable (2.0.4)
-    ridley (4.6.0)
+    ridley (4.6.1)
       addressable
       buff-config (~> 1.0)
       buff-extensions (~> 1.0)
-      buff-ignore (~> 1.1)
+      buff-ignore (~> 1.1.1)
       buff-shell_out (~> 0.1)
       celluloid (~> 0.16.0)
       celluloid-io (~> 0.16.1)


### PR DESCRIPTION
Replaces #5168

Manually added back ffi line in kitchen-tests/Gemfile.lock that was failing travis.