### PR TITLE
noop apt_update similar to apt_repository

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -254,4 +254,4 @@ class Chef
   end
 end
 
-Chef::Provider::Noop.provides :apt_resource
+Chef::Provider::Noop.provides :apt_repository

--- a/lib/chef/provider/apt_update.rb
+++ b/lib/chef/provider/apt_update.rb
@@ -16,15 +16,17 @@
 # limitations under the License.
 #
 
-require "chef/resource"
-require "chef/dsl/declare_resource"
+require "chef/provider"
+require "chef/provider/noop"
 
 class Chef
   class Provider
     class AptUpdate < Chef::Provider
       use_inline_resources
 
-      provides :apt_update, os: "linux"
+      provides :apt_update do
+        uses_apt?
+      end
 
       APT_CONF_DIR = "/etc/apt/apt.conf.d"
       STAMP_DIR = "/var/lib/apt/periodic"
@@ -75,6 +77,13 @@ class Chef
         declare_resource(:execute, "apt-get -q update")
       end
 
+      def self.uses_apt?
+        ENV["PATH"] ||= ""
+        paths = %w{ /bin /usr/bin /sbin /usr/sbin } + ENV["PATH"].split(::File::PATH_SEPARATOR)
+        paths.any? { |path| ::File.executable?(::File.join(path, "apt-get")) }
+      end
     end
   end
 end
+
+Chef::Provider::Noop.provides :apt_update

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -19,8 +19,10 @@
 require "spec_helper"
 
 describe Chef::Resource::AptRepository do
-
-  let(:resource) { Chef::Resource::AptRepository.new("multiverse") }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::AptRepository.new("multiverse", run_context) }
 
   it "should create a new Chef::Resource::AptUpdate" do
     expect(resource).to be_a_kind_of(Chef::Resource)
@@ -34,5 +36,15 @@ describe Chef::Resource::AptRepository do
   it "the default distribution should be nillable" do
     expect(resource.distribution(nil)).to eql(nil)
     expect(resource.distribution).to eql(nil)
+  end
+
+  it "should resolve to a Noop class when uses_apt? is false" do
+    expect(Chef::Provider::AptRepository).to receive(:uses_apt?).and_return(false)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "should resolve to a AptRepository class when uses_apt? is true" do
+    expect(Chef::Provider::AptRepository).to receive(:uses_apt?).and_return(true)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptRepository)
   end
 end

--- a/spec/unit/resource/apt_update_spec.rb
+++ b/spec/unit/resource/apt_update_spec.rb
@@ -19,8 +19,10 @@
 require "spec_helper"
 
 describe Chef::Resource::AptUpdate do
-
-  let(:resource) { Chef::Resource::AptUpdate.new("update") }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::AptUpdate.new("update", run_context) }
 
   it "should create a new Chef::Resource::AptUpdate" do
     expect(resource).to be_a_kind_of(Chef::Resource)
@@ -34,5 +36,15 @@ describe Chef::Resource::AptUpdate do
   it "the frequency should accept integers" do
     resource.frequency(400)
     expect(resource.frequency).to eql(400)
+  end
+
+  it "should resolve to a Noop class when uses_apt? is false" do
+    expect(Chef::Provider::AptUpdate).to receive(:uses_apt?).and_return(false)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "should resolve to a AptUpdate class when uses_apt? is true" do
+    expect(Chef::Provider::AptUpdate).to receive(:uses_apt?).and_return(true)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptUpdate)
   end
 end


### PR DESCRIPTION
makes apt_update behave similarly to apt_repository when invoked on non-apt-using distros