### PR TITLE
Add Hash type to launchd:keep_alive

### DIFF
--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -68,7 +68,7 @@ class Chef
       property :hard_resource_limits, Hash
       property :inetd_compatibility, Hash
       property :init_groups, [ TrueClass, FalseClass ]
-      property :keep_alive, [ TrueClass, FalseClass ]
+      property :keep_alive, [ TrueClass, FalseClass, Hash ]
       property :launch_only_once, [ TrueClass, FalseClass ]
       property :ld_group, String
       property :limit_load_from_hosts, Array


### PR DESCRIPTION
The launchd resource only allows True/False values for the keep_alive property. This allows you to pass hash values as well, which are valid values for LaunchDaemons/Agents.