### PR TITLE
Allow flagging a resource property as sensitive

### DIFF
--- a/lib/chef/mixin/properties.rb
+++ b/lib/chef/mixin/properties.rb
@@ -79,6 +79,9 @@ class Chef
         #     part of desired state. Defaults to `true`.
         #   @option options [Boolean] :identity `true` if this property
         #     is part of object identity. Defaults to `false`.
+        #   @option options [Boolean] :sensitive `true` if this property could
+        #     contain sensitive information and whose value should be redacted
+        #     in any resource reporting / auditing output. Defaults to `false`.
         #
         # @example Bare property
         #   property :x

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -230,13 +230,24 @@ class Chef
     end
 
     #
+    # Whether this property is sensitive or not.
+    #
+    # Defaults to false.
+    #
+    # @return [Boolean]
+    #
+    def sensitive?
+      options.fetch(:sensitive, false)
+    end
+
+    #
     # Validation options.  (See Chef::Mixin::ParamsValidate#validate.)
     #
     # @return [Hash<Symbol,Object>]
     #
     def validation_options
       @validation_options ||= options.reject do |k, v|
-        [:declared_in, :name, :instance_variable_name, :desired_state, :identity, :default, :name_property, :coerce, :required, :nillable].include?(k)
+        [:declared_in, :name, :instance_variable_name, :desired_state, :identity, :default, :name_property, :coerce, :required, :nillable, :sensitive].include?(k)
       end
     end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -497,7 +497,7 @@ class Chef
       state_properties = self.class.state_properties
       state_properties.each do |property|
         if property.identity? || property.is_set?(self)
-          state[property.name] = send(property.name)
+          state[property.name] = property.sensitive? ? "*sensitive value suppressed*" : send(property.name)
         end
       end
       state

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -169,6 +169,26 @@ describe Chef::Resource do
     end
   end
 
+  describe "#state_for_resource_reporter" do
+    context "when a property is marked as sensitive" do
+      it "suppresses the sensitive property's value" do
+        resource_class = Class.new(Chef::Resource) { property :foo, String, sensitive: true }
+        resource = resource_class.new("sensitive_property_tests")
+        resource.foo = "some value"
+        expect(resource.state_for_resource_reporter[:foo]).to eq("*sensitive value suppressed*")
+      end
+    end
+
+    context "when a property is not marked as sensitive" do
+      it "does not suppress the property's value" do
+        resource_class = Class.new(Chef::Resource) { property :foo, String }
+        resource = resource_class.new("sensitive_property_tests")
+        resource.foo = "some value"
+        expect(resource.state_for_resource_reporter[:foo]).to eq("some value")
+      end
+    end
+  end
+
   describe "load_from" do
     let(:prior_resource) do
       prior_resource = Chef::Resource.new("funk")


### PR DESCRIPTION
## Summary
Some properties in custom resources may include sensitive data, such as a
password for a database server. When the Resource's state is built for use by
Data Collector or similar auditing tool, `Chef::Resource#state_for_resource_reporter`
builds a hash of all state properties for that resource and their values. This
leads to sensitive data being transmitted and potentially stored in the clear.

This change enhances properties with the ability to set an individual property
as sensitive and then have the value of that property suppressed when exporting
the Resource's state.

## User Story
As a Visibility user,
I want to be able to view my Chef runs which include custom resources,
which may include custom resources whose property values may be sensitive,
and ensure that the sensitive values are not transmitted to Visibility
similar to how the `sensitive` property operates for resources that 
can produce diffs/deltas.

## Issue Description
When the Data Collector component of Chef Client builds the payload, it calls upon the Resource instance to communicate the state of the resource before and after the change. The method, `Chef::Resource#state_for_resource_reporter`, iterates over a resource's state properties and adds them to the returned hash.

A user could create a custom resource which includes a property whose value is sensitive, such as a database password. The `#state_for_resource_reporter` method will gleefully grab this property and include it and its value in the data that the Data Collector uses to report to Visibility. Since this data is stored in cleartext in Elasticsearch, this can be considered a security issue for customers.

A proposed solution: allow a property to be defined as sensitive and redact any sensitive properties' values when building the resource state.

Example:
`property :my_app_password, String, sensitive: true`