### PR TITLE
remove requires in Chef::Recipe that are no longer necessary

### DIFF
--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -18,16 +18,7 @@
 #
 
 require "chef/dsl/recipe"
-require "chef/dsl/data_query"
-require "chef/dsl/platform_introspection"
-require "chef/dsl/include_recipe"
-require "chef/dsl/registry_helper"
-require "chef/dsl/reboot_pending"
-require "chef/dsl/audit"
-require "chef/dsl/powershell"
-
 require "chef/mixin/from_file"
-
 require "chef/mixin/deprecation"
 
 class Chef


### PR DESCRIPTION
these are all covered under chef/dsl/recipe now