### PR TITLE
Keeping static libraries previously deleted by jenkins builds

### DIFF
--- a/omnibus/config/software/chef-complete.rb
+++ b/omnibus/config/software/chef-complete.rb
@@ -17,5 +17,3 @@ if windows?
   dependency "ruby-windows-devkit"
   dependency "ruby-windows-devkit-bash"
 end
-
-dependency "clean-static-libs"


### PR DESCRIPTION
From what I can tell by looking at jenkins build logs, Windows is the only platform where actual files are deleted by this build delendency defined [here](https://github.com/chef/omnibus-software/blob/master/config/software/clean-static-libs.rb). The files deleted on Windows are:
```
Deleting C:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/libyajl2-1.2.0/ext/libyajl2/libyajldll.a
Deleting C:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/libyajl2-1.2.0/lib/libyajl2/vendored-libyajl2/lib/libyajldll.a
```
These files are each about 32k. Further, the `ffi-yajl` gem depends on these libraries. So if a user attempts to install a different version of lib-yajl or a gem that depends on it, they will receive compilation errors blocking the install.