### PR TITLE
Transitive dependency licensing information for Chef Client

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
-gem "omnibus", github: "chef/omnibus", branch: "ksubrama/gcc_investigate"
-gem "omnibus-software", github: "chef/omnibus-software", branch: "ksubrama/ruby23"
+gem "omnibus", github: "chef/omnibus", branch: "sersut/ff-ksubrama/gcc_investigate"
+gem "omnibus-software", github: "chef/omnibus-software", branch: "sersut/ff-ksubrama/ruby23"
+gem "license_scout", github: "chef/license_scout"
 
 # pedump pessimistically pins multipart-post to a version from 2013 which makes
 # bundler very unhappy. Remove this when upstream has merged zed-0xff/pedump#6 .

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,22 +1,31 @@
 GIT
+  remote: git://github.com/chef/license_scout.git
+  revision: b9393f9330c3cafb59083aa60e93b31b0188fb05
+  specs:
+    license_scout (0.1.0)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (~> 2.2)
+
+GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: b1a068c75d4eb0833c6c3884f7e0692ab1f29fb1
-  branch: ksubrama/ruby23
+  revision: 676b89e48a213f34567f847c1c2aa20f08d5a2b7
+  branch: sersut/ff-ksubrama/ruby23
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
-      omnibus (>= 5.2.0)
+      omnibus (>= 5.5.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 7461ec540c52251800258286ba8984725125ebe2
-  branch: ksubrama/gcc_investigate
+  revision: 96d4695285c9530ff3b6b8160bc46e3ac6b19dd0
+  branch: sersut/ff-ksubrama/gcc_investigate
   specs:
-    omnibus (5.4.0)
+    omnibus (5.5.0)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
+      license_scout
       mixlib-shellout (~> 2.0)
       mixlib-versioning
       ohai (~> 8.0)
@@ -41,12 +50,12 @@ GEM
     addressable (2.4.0)
     artifactory (2.3.3)
     awesome_print (1.7.0)
-    aws-sdk (2.5.3)
-      aws-sdk-resources (= 2.5.3)
-    aws-sdk-core (2.5.3)
+    aws-sdk (2.5.4)
+      aws-sdk-resources (= 2.5.4)
+    aws-sdk-core (2.5.4)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.5.3)
-      aws-sdk-core (= 2.5.3)
+    aws-sdk-resources (2.5.4)
+      aws-sdk-core (= 2.5.4)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -149,14 +158,14 @@ GEM
     nori (2.6.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.19.1)
+    ohai (8.19.2)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli
       mixlib-config (~> 2.0)
-      mixlib-log
+      mixlib-log (>= 1.7.1, < 2.0)
       mixlib-shellout (~> 2.0)
       plist (~> 3.1)
       systemu (~> 2.6.4)
@@ -243,6 +252,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf (~> 4.0)
   kitchen-vagrant (~> 0.19.0)
+  license_scout!
   omnibus!
   omnibus-software!
   pedump!

--- a/omnibus/config/software/chef-appbundle.rb
+++ b/omnibus/config/software/chef-appbundle.rb
@@ -2,6 +2,7 @@ name "chef-appbundle"
 default_version "local_source"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 source path: project.files_path
 

--- a/omnibus/config/software/chef-complete.rb
+++ b/omnibus/config/software/chef-complete.rb
@@ -1,6 +1,7 @@
 name "chef-complete"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 dependency "chef"
 dependency "chef-appbundle"

--- a/omnibus/config/software/chef-gem-binding_of_caller.rb
+++ b/omnibus/config/software/chef-gem-binding_of_caller.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/banister/binding_of_caller/blob/master/LICENSE"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-byebug.rb
+++ b/omnibus/config/software/chef-gem-byebug.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/deivid-rodriguez/byebug/blob/master/LICENSE"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-debug_inspector.rb
+++ b/omnibus/config/software/chef-gem-debug_inspector.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/banister/debug_inspector/blob/master/README.md"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-ffi-yajl.rb
+++ b/omnibus/config/software/chef-gem-ffi-yajl.rb
@@ -7,5 +7,6 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/chef/ffi-yajl/blob/master/LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "chef-gem-libyajl2"

--- a/omnibus/config/software/chef-gem-ffi.rb
+++ b/omnibus/config/software/chef-gem-ffi.rb
@@ -5,7 +5,8 @@
 require_relative "../../files/chef-gem/build-chef-gem/gem-install-software-def"
 BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
-license "BSD-3-CLAUSE"
+license "BSD-3-Clause"
 license_file "https://github.com/ffi/ffi/blob/master/LICENSE"
 license_file "https://github.com/ffi/ffi/blob/master/COPYING"
 license_file "https://github.com/ffi/ffi/blob/master/LICENSE.SPECS"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-json.rb
+++ b/omnibus/config/software/chef-gem-json.rb
@@ -8,3 +8,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 license "Ruby"
 license_file "https://github.com/flori/json/blob/master/README.md"
 license_file "https://www.ruby-lang.org/en/about/license.txt"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-libyajl2.rb
+++ b/omnibus/config/software/chef-gem-libyajl2.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "Apache-2.0"
 license_file "https://github.com/chef/libyajl2-gem/blob/master/LICENSE"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-mini_portile2.rb
+++ b/omnibus/config/software/chef-gem-mini_portile2.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/flavorjones/mini_portile/blob/master/LICENSE.txt"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-nokogiri.rb
+++ b/omnibus/config/software/chef-gem-nokogiri.rb
@@ -7,6 +7,7 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "MIT"
 license_file "https://github.com/ruby-prof/ruby-prof/blob/master/LICENSE"
+skip_transitive_dependency_licensing true
 
 dependency "chef-gem-pkg-config"
 dependency "chef-gem-mini_portile2"

--- a/omnibus/config/software/chef-gem-pkg-config.rb
+++ b/omnibus/config/software/chef-gem-pkg-config.rb
@@ -7,3 +7,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
 license "LGPL-2.1"
 license_file "https://github.com/ruby-gnome2/pkg-config/blob/master/LGPL-2.1"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-ruby-prof.rb
+++ b/omnibus/config/software/chef-gem-ruby-prof.rb
@@ -5,5 +5,6 @@
 require_relative "../../files/chef-gem/build-chef-gem/gem-install-software-def"
 BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 
-license "BSD-2-CLAUSE"
+license "BSD-2-Clause"
 license_file "https://github.com/ruby-prof/ruby-prof/blob/master/LICENSE"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-gem-ruby-shadow.rb
+++ b/omnibus/config/software/chef-gem-ruby-shadow.rb
@@ -8,3 +8,4 @@ BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
 license "Public-Domain"
 license_file "https://github.com/apalmblad/ruby-shadow/blob/master/LICENSE"
 license_file "http://creativecommons.org/licenses/publicdomain/"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef-remove-docs.rb
+++ b/omnibus/config/software/chef-remove-docs.rb
@@ -17,6 +17,7 @@
 name "chef-remove-docs"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   # This is where we get the definitions below

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -48,3 +48,5 @@ fetcher_read_timeout 120
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+
+fatal_transitive_dependency_licensing_warnings true


### PR DESCRIPTION
This PR goes with https://github.com/chef/omnibus/pull/705 and https://github.com/chef/omnibus-software/pull/714 and adds licensing information collection for the transitive dependencies of Chef Client. 

An ad_hoc build with all these branches are tested at:
http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/157/downstreambuildview/

Note that the PRs linked from here do not contain the msys2 changes that are currently sitting in the private branches of `omnibus` and `omnibus-software` pointed to by this project. Once they are merged we will need to rebase the private branches on top of master and re-test.