### PR TITLE
Clear test directory before file resource examples

### DIFF
--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -1035,6 +1035,7 @@ shared_context Chef::Resource::File do
   end
 
   before do
+    FileUtils.rm_rf(test_file_dir)
     FileUtils.mkdir_p(test_file_dir)
   end
 


### PR DESCRIPTION
This is another fix for ensuring aborted functional tests do not corrupt subsequent runs. Here we make sure that the test directory is deleted in case it was not cleared out by the aborted run.