### PR TITLE
Support indented heredoc as systemd_unit file content

### DIFF
--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -56,6 +56,8 @@ class Chef
           end.to_s
         else
           content.to_s
+            .gsub(/^#{content.to_s.scan(/^[^\S\n]+/).min_by { |l| l.length }}/, "")
+            .strip + "\n"
         end
       end
     end

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -25,6 +25,19 @@ describe Chef::Resource::SystemdUnit do
 
   let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
 
+  let(:unit_content_heredoc) do
+    <<-EOF
+      [Unit]
+      Description = Run system activity accounting tool every 10 minutes
+
+      [Timer]
+      OnCalendar = *:00/10
+
+      [Install]
+      WantedBy = sysstat.service
+    EOF
+  end
+
   let(:unit_content_hash) do
     {
       "Unit" => {
@@ -123,6 +136,11 @@ describe Chef::Resource::SystemdUnit do
 
   it "serializes to ini with a string-formatted content property" do
     @resource.content(unit_content_string)
+    expect(@resource.to_ini).to eq unit_content_string
+  end
+
+  it "serializes to ini with a heredoc-formatted content property" do
+    @resource.content(unit_content_heredoc)
     expect(@resource.to_ini).to eq unit_content_string
   end
 


### PR DESCRIPTION
A little sugar for defining unit files using a heredoc until Chef moves to `2.3` and the `<<~` syntax becomes available.

It works by scaning the lines of the heredoc and gathering the leading spaces before finding the shortest (excluding completely blank lines) and removing the common whitespace from the start of all lines. Given the following resource:

```rb
systemd_unit 'foo' do
  content <<-EOF
    [Unit]
    Description=bar
  EOF
  action :create
end
```

Before:
```ini
    [Unit]
    Description=bar
```

After:
```ini
[Unit]
Description=bar
```

