### PR TITLE
Verify systemd_unit file during create

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -193,6 +193,7 @@ class Chef
           f.group "root"
           f.mode "0644"
           f.content new_resource.to_ini
+          f.verify systemd_analyze_cmd if systemd_analyze_path
         end.run_action(action)
       end
 
@@ -232,6 +233,14 @@ class Chef
           else
             {}
           end
+      end
+
+      def systemd_analyze_cmd
+        @systemd_analyze_cmd ||= "#{systemd_analyze_path} verify %{path}"
+      end
+
+      def systemd_analyze_path
+        @systemd_analyze_path ||= which("systemd-analyze")
       end
     end
   end


### PR DESCRIPTION
Fixes #5200 

I realise there are no tests for this feature. That is because I wasn't able to find any pre-existing tests relating to the internal file block on which to base any new ones.