### PR TITLE
Stop logging "SIGQUIT is not a command" in tests

### DIFF
--- a/spec/functional/assets/testchefsubsys
+++ b/spec/functional/assets/testchefsubsys
@@ -5,7 +5,6 @@ sleep 120 &
 
 pid="$!"
 
-trap 'echo I am going down, so killing off my processes..; kill $pid; exit' SIGHUP SIGINT
- SIGQUIT SIGTERM
+trap 'echo I am going down, so killing off my processes..; kill $pid; exit' SIGHUP SIGINT SIGQUIT SIGTERM
 
 wait


### PR DESCRIPTION
This looks like a typo was introduced; we're seeing this in the logs on nodes.