### PR TITLE
Fix TinyServer races by waiting for stop() and start() callbacks

### DIFF
--- a/spec/functional/http/simple_spec.rb
+++ b/spec/functional/http/simple_spec.rb
@@ -26,11 +26,11 @@ describe Chef::HTTP::Simple do
   let(:http_client) { described_class.new(source) }
   let(:http_client_disable_gzip) { described_class.new(source, { :disable_gzip => true } ) }
 
-  before(:all) do
+  before(:each) do
     start_tiny_server
   end
 
-  after(:all) do
+  after(:each) do
     stop_tiny_server
   end
 

--- a/spec/functional/knife/cookbook_delete_spec.rb
+++ b/spec/functional/knife/cookbook_delete_spec.rb
@@ -20,9 +20,13 @@ require "spec_helper"
 require "tiny_server"
 
 describe Chef::Knife::CookbookDelete do
-  before(:all) do
+  before(:each) do
     @server = TinyServer::Manager.new
     @server.start
+  end
+
+  after(:each) do
+    @server.stop
   end
 
   before(:each) do
@@ -33,10 +37,6 @@ describe Chef::Knife::CookbookDelete do
     Chef::Config[:node_name] = nil
     Chef::Config[:client_key] = nil
     Chef::Config[:chef_server_url] = "http://localhost:9000"
-  end
-
-  after(:all) do
-    @server.stop
   end
 
   context "when the cookbook doesn't exist" do

--- a/spec/functional/knife/exec_spec.rb
+++ b/spec/functional/knife/exec_spec.rb
@@ -20,9 +20,13 @@ require "spec_helper"
 require "tiny_server"
 
 describe Chef::Knife::Exec do
-  before(:all) do
+  before(:each) do
     @server = TinyServer::Manager.new #(:debug => true)
     @server.start
+  end
+
+  after(:each) do
+    @server.stop
   end
 
   before(:each) do
@@ -35,10 +39,6 @@ describe Chef::Knife::Exec do
     Chef::Config[:chef_server_url] = "http://localhost:9000"
 
     $output = StringIO.new
-  end
-
-  after(:all) do
-    @server.stop
   end
 
   it "executes a script in the context of the chef-shell main context" do

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -21,13 +21,13 @@ require "tiny_server"
 
 describe Chef::Knife::Ssh do
 
-  before(:all) do
+  before(:each) do
     Chef::Knife::Ssh.load_deps
     @server = TinyServer::Manager.new
     @server.start
   end
 
-  after(:all) do
+  after(:each) do
     @server.stop
   end
 

--- a/spec/functional/rest_spec.rb
+++ b/spec/functional/rest_spec.rb
@@ -83,11 +83,11 @@ describe Chef::REST do
     Chef::Config[:treat_deprecation_warnings_as_errors] = false
   end
 
-  before(:all) do
+  before(:each) do
     start_tiny_server
   end
 
-  after(:all) do
+  after(:each) do
     stop_tiny_server
   end
 

--- a/spec/functional/tiny_server_spec.rb
+++ b/spec/functional/tiny_server_spec.rb
@@ -65,14 +65,15 @@ end
 
 describe TinyServer::Manager do
   it "runs the server" do
-    @server = TinyServer::Manager.new
-    @server.start
+    server = TinyServer::Manager.new
+    server.start
+    begin
+      TinyServer::API.instance.get("/index", 200, "[\"hello\"]")
 
-    TinyServer::API.instance.get("/index", 200, "[\"hello\"]")
-
-    rest = Chef::HTTP.new("http://localhost:9000")
-    expect(rest.get("index")).to eq("[\"hello\"]")
-
-    @server.stop
+      rest = Chef::HTTP.new("http://localhost:9000")
+      expect(rest.get("index")).to eq("[\"hello\"]")
+    ensure
+      server.stop
+    end
   end
 end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -476,11 +476,11 @@ end
 
   # Fails on appveyor, but works locally on windows and on windows hosts in Ci.
   context "when using recipe-url", :skip_appveyor do
-    before(:all) do
+    before(:each) do
       start_tiny_server
     end
 
-    after(:all) do
+    after(:each) do
       stop_tiny_server
     end
 


### PR DESCRIPTION
1. Wait for the start callback rather than the do block, as it happens
   later. This prevents us from getting into many conditions where the
   start returns before the server is fully initialized, where if stop()
   is called too soon after start returns, it would cause exceptions.
2. Wait for the thread to finish completely
3. Use Thread.current.abort_on_exception` to show the actual listen errors,
   so that problems like this can be diagnosed.
4. Use :each to start and stop TinyServer so that race conditions like this
   are exposed earlier and more often (this will let us rid ourselves of them
   more quickly).
5. Use WEBrick::HTTPServer directly, which gets rid of the need for the
   complicated trap workaround (rack is the one that traps).