### PR TITLE
Fix "URI.escape is obsolete" warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ PATH
   remote: .
   specs:
     chef (12.14.20)
+      addressable
       bundler (>= 1.10)
       chef-config (= 12.14.20)
       chef-zero (~> 4.8)
@@ -56,6 +57,7 @@ PATH
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
     chef (12.14.20-universal-mingw32)
+      addressable
       bundler (>= 1.10)
       chef-config (= 12.14.20)
       chef-zero (~> 4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ PATH
   remote: chef-config
   specs:
     chef-config (12.14.20)
+      addressable
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
@@ -244,7 +245,7 @@ GEM
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.1)
+    mixlib-config (2.2.2)
     mixlib-install (1.1.0)
       artifactory
       mixlib-shellout

--- a/chef-config/chef-config.gemspec
+++ b/chef-config/chef-config.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-shellout", "~> 2.0"
   spec.add_dependency "mixlib-config", "~> 2.0"
   spec.add_dependency "fuzzyurl"
+  spec.add_dependency "addressable"
 
   spec.add_development_dependency "rake", "~> 10.0"
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "plist", "~> 3.2"
   s.add_dependency "iniparse", "~> 1.4"
+  s.add_dependency "addressable"
 
   # Audit mode requires these, so they are non-developmental dependencies now
   %w{rspec-core rspec-expectations rspec-mocks}.each { |gem| s.add_dependency gem, "~> 3.5" }

--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -18,6 +18,7 @@
 
 require "chef/knife"
 require "chef/knife/core/node_presenter"
+require "addressable/uri"
 
 class Chef
   class Knife
@@ -85,8 +86,7 @@ class Chef
         end
 
         q = Chef::Search::Query.new
-        escaped_query = URI.escape(@query,
-                           Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+        escaped_query = Addressable::URI.encode_component(@query, Addressable::URI::CharacterClasses::QUERY)
 
         result_items = []
         result_count = 0

--- a/lib/chef/mixin/uris.rb
+++ b/lib/chef/mixin/uris.rb
@@ -17,6 +17,7 @@
 #
 
 require "uri"
+require "addressable/uri"
 
 class Chef
   module Mixin
@@ -34,7 +35,7 @@ class Chef
           URI.parse(source)
         rescue URI::InvalidURIError
           Chef::Log.warn("#{source} was an invalid URI. Trying to escape invalid characters")
-          URI.parse(URI.escape(source))
+          URI.parse(Addressable::URI.encode(source))
         end
       end
 

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -21,6 +21,7 @@ require "chef/exceptions"
 require "chef/server_api"
 
 require "uri"
+require "addressable/uri"
 
 class Chef
   class Search
@@ -134,15 +135,17 @@ WARNDEP
         args_h
       end
 
-      def escape(s)
-        s && URI.escape(s.to_s)
+      QUERY_PARAM_VALUE = Addressable::URI::CharacterClasses::QUERY + "\\&\\;"
+
+      def escape_value(s)
+        s && Addressable::URI.encode_component(s.to_s, QUERY_PARAM_VALUE)
       end
 
       def create_query_string(type, query, rows, start, sort)
-        qstr = "search/#{type}?q=#{escape(query)}"
-        qstr += "&sort=#{escape(sort)}" if sort
-        qstr += "&start=#{escape(start)}" if start
-        qstr += "&rows=#{escape(rows)}" if rows
+        qstr = "search/#{type}?q=#{escape_value(query)}"
+        qstr += "&sort=#{escape_value(sort)}" if sort
+        qstr += "&start=#{escape_value(start)}" if start
+        qstr += "&rows=#{escape_value(rows)}" if rows
         qstr
       end
 

--- a/spec/unit/provider/remote_file/local_file_spec.rb
+++ b/spec/unit/provider/remote_file/local_file_spec.rb
@@ -17,6 +17,8 @@
 #
 
 require "spec_helper"
+require "uri"
+require "addressable/uri"
 
 describe Chef::Provider::RemoteFile::LocalFile do
 
@@ -47,7 +49,7 @@ describe Chef::Provider::RemoteFile::LocalFile do
     end
 
     describe "when given local windows path with spaces" do
-      let(:uri) { URI.parse(URI.escape("file:///z:/windows/path/foo & bar.txt")) }
+      let(:uri) { URI.parse(Addressable::URI.encode("file:///z:/windows/path/foo & bar.txt")) }
       it "returns a valid windows local path" do
         expect(fetcher.source_path).to eq("z:/windows/path/foo & bar.txt")
       end
@@ -61,7 +63,7 @@ describe Chef::Provider::RemoteFile::LocalFile do
     end
 
     describe "when given unc windows path with spaces" do
-      let(:uri) { URI.parse(URI.escape("file:////server/share/windows/path/foo & bar.txt")) }
+      let(:uri) { URI.parse(Addressable::URI.encode("file:////server/share/windows/path/foo & bar.txt")) }
       it "returns a valid windows unc path" do
         expect(fetcher.source_path).to eq("//server/share/windows/path/foo & bar.txt")
       end


### PR DESCRIPTION
We'll use `Addressable::URI` instead. See http://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape#answer-13059657 for details on why.