### PR TITLE
Remove remaining chef-config test warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       mixlib-log (~> 1.3)
       rack (< 2)
       uuidtools (~> 2.1)
-    cheffish (3.0.0)
+    cheffish (3.0.1)
       chef-zero (~> 4.3)
       net-ssh
     coderay (1.1.1)

--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -235,7 +235,7 @@ module ChefConfig
       paths = paths.map { |home_path| home_path.gsub(path_separator, ::File::SEPARATOR) if home_path }
 
       # Filter out duplicate paths and paths that don't exist.
-      valid_paths = paths.select { |home_path| home_path && Dir.exists?(home_path.force_encoding("utf-8")) }
+      valid_paths = paths.select { |home_path| home_path && Dir.exist?(home_path.force_encoding("utf-8")) }
       valid_paths = valid_paths.uniq
 
       # Join all optional path elements at the end.

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
 
       context "and raises a ruby exception during evaluation" do
 
-        let(:config_content) { ":foo\n:bar\nraise 'oops'\n:baz\n" }
+        let(:config_content) { "raise 'oops'" }
 
         it "raises a ConfigurationError" do
           expect { config_loader.load }.to raise_error(ChefConfig::ConfigurationError)

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -475,28 +475,31 @@ end
   end
 
   # Fails on appveyor, but works locally on windows and on windows hosts in Ci.
-  context "when using recipe-url", :skip_appveyor do
-    before(:each) do
-      start_tiny_server
-    end
+  when_the_repository "is empty" do
 
-    after(:each) do
-      stop_tiny_server
-    end
+    context "when using recipe-url", :skip_appveyor do
+      before(:each) do
+        start_tiny_server
+      end
 
-    let(:tmp_dir) { Dir.mktmpdir("recipe-url") }
+      after(:each) do
+        stop_tiny_server
+      end
 
-    it "should complete with success when passed -z and --recipe-url" do
-      file "config/client.rb", <<EOM
-chef_repo_path "#{tmp_dir}"
+      let(:tmp_dir) { Dir.mktmpdir("recipe-url") }
+
+      it "should complete with success when passed -z and --recipe-url" do
+        file "config/client.rb", <<EOM
+cookbook_path "#{path_to('cookbooks')}"
 EOM
-      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", :cwd => tmp_dir)
-      result.error!
-    end
+        result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" --recipe-url=http://localhost:9000/recipes.tgz -o 'x::default' -z", :cwd => tmp_dir)
+        result.error!
+      end
 
-    it "should fail when passed --recipe-url and not passed -z" do
-      result = shell_out("#{chef_client} --recipe-url=http://localhost:9000/recipes.tgz", :cwd => tmp_dir)
-      expect(result.exitstatus).not_to eq(0)
+      it "should fail when passed --recipe-url and not passed -z" do
+        result = shell_out("#{chef_client} --recipe-url=http://localhost:9000/recipes.tgz", :cwd => tmp_dir)
+        expect(result.exitstatus).not_to eq(0)
+      end
     end
   end
 end

--- a/spec/integration/knife/chef_repo_path_spec.rb
+++ b/spec/integration/knife/chef_repo_path_spec.rb
@@ -362,7 +362,6 @@ EOM
             knife("show --local /clients/blah.json").should_succeed <<EOM
 /clients/blah.json:
 {
-
 }
 EOM
           end
@@ -462,7 +461,6 @@ EOM
             knife("show --local /environments/blah.json").should_succeed <<EOM
 /environments/blah.json:
 {
-
 }
 EOM
           end
@@ -477,7 +475,6 @@ EOM
             knife("show --local /nodes/blah.json").should_succeed <<EOM
 /nodes/blah.json:
 {
-
 }
 EOM
           end
@@ -492,7 +489,6 @@ EOM
             knife("show --local /roles/blah.json").should_succeed <<EOM
 /roles/blah.json:
 {
-
 }
 EOM
           end
@@ -507,7 +503,6 @@ EOM
             knife("show --local /users/blah.json").should_succeed <<EOM
 /users/blah.json:
 {
-
 }
 EOM
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -150,7 +150,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :windows_domain_joined_only => true unless windows_domain_joined?
   config.filter_run_excluding :windows_not_domain_joined_only => true if windows_domain_joined?
   config.filter_run_excluding :solaris_only => true unless solaris?
-  config.filter_run_excluding :system_windows_service_gem_only => true unless system_windows_service_gem?
+  config.filter_run_excluding :system_windows_service_gem_only => true unless windows? && system_windows_service_gem?
   config.filter_run_excluding :unix_only => true unless unix?
   config.filter_run_excluding :linux_only => true unless linux?
   config.filter_run_excluding :aix_only => true unless aix?

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -66,7 +66,7 @@ end
 # win32/service gem. windows_service_manager tests create a windows
 # service that starts with the system ruby and requires this gem.
 def system_windows_service_gem?
-  windows_service_gem_check_command = %q{ruby -r "win32/daemon" -e ":noop"}
+  windows_service_gem_check_command = %q{gem which win32/daemon}
   if defined?(Bundler)
     Bundler.with_clean_env do
       # This returns true if the gem can be loaded

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -24,6 +24,7 @@ require "chef/json_compat"
 require "chef/server_api"
 require "support/shared/integration/knife_support"
 require "support/shared/integration/app_server_support"
+require "chef_zero/rspec"
 require "cheffish/rspec/chef_run_support"
 require "spec_helper"
 
@@ -34,24 +35,13 @@ module Cheffish
 end
 
 module IntegrationSupport
-  include ChefZero::RSpec
-
   def self.included(includer_class)
+    includer_class.extend(ChefZero::RSpec)
     includer_class.extend(Cheffish::RSpec::ChefRunSupport)
     includer_class.extend(ClassMethods)
   end
 
   module ClassMethods
-    include ChefZero::RSpec
-
-    def when_the_repository(desc, *tags, &block)
-      context("when the chef repo #{desc}", *tags) do
-        include_context "with a chef repo"
-
-        module_eval(&block)
-      end
-    end
-
     def with_versioned_cookbooks(&block)
       context("with versioned cookbooks") do
         include_context "with versioned cookbooks"
@@ -64,41 +54,6 @@ module IntegrationSupport
     Chef::ServerAPI.new
   end
 
-  def directory(relative_path, &block)
-    old_parent_path = @parent_path
-    @parent_path = path_to(relative_path)
-    FileUtils.mkdir_p(@parent_path)
-    instance_eval(&block) if block
-    @parent_path = old_parent_path
-  end
-
-  def file(relative_path, contents)
-    filename = path_to(relative_path)
-    dir = File.dirname(filename)
-    FileUtils.mkdir_p(dir) unless dir == "."
-    File.open(filename, "w") do |file|
-      raw = case contents
-            when Hash, Array
-              Chef::JSONCompat.to_json_pretty(contents)
-            else
-              contents
-            end
-      file.write(raw)
-    end
-  end
-
-  def symlink(relative_path, relative_dest)
-    filename = path_to(relative_path)
-    dir = File.dirname(filename)
-    FileUtils.mkdir_p(dir) unless dir == "."
-    dest_filename = path_to(relative_dest)
-    File.symlink(dest_filename, filename)
-  end
-
-  def path_to(relative_path)
-    File.expand_path(relative_path, (@parent_path || @repository_dir))
-  end
-
   def cb_metadata(name, version, extra_text = "")
     "name #{name.inspect}; version #{version.inspect}#{extra_text}"
   end
@@ -106,36 +61,6 @@ module IntegrationSupport
   def cwd(relative_path)
     @old_cwd = Dir.pwd
     Dir.chdir(path_to(relative_path))
-  end
-
-  RSpec.shared_context "with a chef repo" do
-    before :each do
-      raise "Can only create one directory per test" if @repository_dir
-      @repository_dir = Dir.mktmpdir("chef_repo")
-      Chef::Config.chef_repo_path = @repository_dir
-      %w{client cookbook data_bag environment node role user}.each do |object_name|
-        Chef::Config.delete("#{object_name}_path".to_sym)
-      end
-    end
-
-    after :each do
-      if @repository_dir
-        begin
-          %w{client cookbook data_bag environment node role user}.each do |object_name|
-            Chef::Config.delete("#{object_name}_path".to_sym)
-          end
-          Chef::Config.delete(:chef_repo_path)
-          # TODO: "force" actually means "silence all exceptions". this
-          # silences a weird permissions error on Windows that we should track
-          # down, but for now there's no reason for it to blow up our CI.
-          FileUtils.remove_entry_secure(@repository_dir, force = Chef::Platform.windows?)
-        ensure
-          @repository_dir = nil
-        end
-      end
-      Dir.chdir(@old_cwd) if @old_cwd
-    end
-
   end
 
   # Versioned cookbooks


### PR DESCRIPTION
This fixes these two warnings:

```
rspec spec/unit/workstation_config_loader_spec.rb:284 spec/unit/workstation_config_loader_spec.rb:216
Run options:
  include {:focus=>true, :locations=>{"./spec/unit/workstation_config_loader_spec.rb"=>[284, 216]}}
  exclude {:windows_only=>true}

Randomized with seed 50388

ChefConfig::WorkstationConfigLoader
  loading the config file
    when no explicit config is specifed and no implicit config is found
/Users/jkeiser/src/chef/chef-config/lib/chef-config/path_helper.rb:238: warning: Dir.exists? is a deprecated name, use Dir.exist? instead
      skips loading
    when the config file exists
      and raises a ruby exception during evaluation
/var/folders/gf/0cklbzl144xg_pbtgpnj_4vc0000gq/T/Chef-WorkstationConfigLoader-rspec-test20160823-71386-1si9j4v:1: warning: unused literal ignored
/var/folders/gf/0cklbzl144xg_pbtgpnj_4vc0000gq/T/Chef-WorkstationConfigLoader-rspec-test20160823-71386-1si9j4v:2: warning: unused literal ignored
        raises a ConfigurationError

Finished in 0.04604 seconds (files took 0.25896 seconds to load)
2 examples, 0 failures
```
