### PR TITLE
Don't dup the Cheffish "with a chef repo" context

### DIFF
--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -64,41 +64,6 @@ module IntegrationSupport
     Chef::ServerAPI.new
   end
 
-  def directory(relative_path, &block)
-    old_parent_path = @parent_path
-    @parent_path = path_to(relative_path)
-    FileUtils.mkdir_p(@parent_path)
-    instance_eval(&block) if block
-    @parent_path = old_parent_path
-  end
-
-  def file(relative_path, contents)
-    filename = path_to(relative_path)
-    dir = File.dirname(filename)
-    FileUtils.mkdir_p(dir) unless dir == "."
-    File.open(filename, "w") do |file|
-      raw = case contents
-            when Hash, Array
-              Chef::JSONCompat.to_json_pretty(contents)
-            else
-              contents
-            end
-      file.write(raw)
-    end
-  end
-
-  def symlink(relative_path, relative_dest)
-    filename = path_to(relative_path)
-    dir = File.dirname(filename)
-    FileUtils.mkdir_p(dir) unless dir == "."
-    dest_filename = path_to(relative_dest)
-    File.symlink(dest_filename, filename)
-  end
-
-  def path_to(relative_path)
-    File.expand_path(relative_path, (@parent_path || @repository_dir))
-  end
-
   def cb_metadata(name, version, extra_text = "")
     "name #{name.inspect}; version #{version.inspect}#{extra_text}"
   end
@@ -106,36 +71,6 @@ module IntegrationSupport
   def cwd(relative_path)
     @old_cwd = Dir.pwd
     Dir.chdir(path_to(relative_path))
-  end
-
-  RSpec.shared_context "with a chef repo" do
-    before :each do
-      raise "Can only create one directory per test" if @repository_dir
-      @repository_dir = Dir.mktmpdir("chef_repo")
-      Chef::Config.chef_repo_path = @repository_dir
-      %w{client cookbook data_bag environment node role user}.each do |object_name|
-        Chef::Config.delete("#{object_name}_path".to_sym)
-      end
-    end
-
-    after :each do
-      if @repository_dir
-        begin
-          %w{client cookbook data_bag environment node role user}.each do |object_name|
-            Chef::Config.delete("#{object_name}_path".to_sym)
-          end
-          Chef::Config.delete(:chef_repo_path)
-          # TODO: "force" actually means "silence all exceptions". this
-          # silences a weird permissions error on Windows that we should track
-          # down, but for now there's no reason for it to blow up our CI.
-          FileUtils.remove_entry_secure(@repository_dir, force = Chef::Platform.windows?)
-        ensure
-          @repository_dir = nil
-        end
-      end
-      Dir.chdir(@old_cwd) if @old_cwd
-    end
-
   end
 
   # Versioned cookbooks


### PR DESCRIPTION
This fixes this warning at the beginning of the tests:

```
WARNING: Shared example group 'with a chef repo' has been previously defined at:
  /usr/local/var/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cheffish-3.0.0/lib/cheffish/rspec/repository_support.rb:12
...and you are now defining it at:
  /Users/jkeiser/src/chef/spec/support/shared/integration/integration_helper.rb:111
The new definition will overwrite the original one.
```