### PR TITLE
Use symbols instead of strings as keys for systemd user property

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -78,10 +78,10 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     if new_resource.user
       uid = node["etc"]["passwd"][new_resource.user]["uid"]
       options = {
-        "environment" => {
+        :environment => {
           "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/#{uid}/bus",
         },
-        "user" => new_resource.user,
+        :user => new_resource.user,
       }
       args = "--user"
     else

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -225,8 +225,8 @@ class Chef
         @systemctl_opts ||=
           if new_resource.user
             {
-              "user" => new_resource.user,
-              "environment" => {
+              :user => new_resource.user,
+              :environment => {
                 "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/#{node['etc']['passwd'][new_resource.user]['uid']}/bus",
               },
             }

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -196,14 +196,14 @@ describe Chef::Provider::Service::Systemd do
         context "when a user is specified" do
           it "should call '#{systemctl_path} --user start service_name' if no start command is specified" do
             current_resource.user("joe")
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { "environment" => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, "user" => "joe" }).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" }).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --user start service_name' if it is already running" do
             current_resource.running(true)
             current_resource.user("joe")
-            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { "environment" => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, "user" => "joe" })
+            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" })
             provider.start_service
           end
         end

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -58,8 +58,8 @@ describe Chef::Provider::SystemdUnit do
 
   let(:user_cmd_opts) do
     {
-      "user" => "joe",
-      "environment" => {
+      :user => "joe",
+      :environment => {
         "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/1000/bus",
       },
     }


### PR DESCRIPTION
Using the user property of the service resource when using systemd (on omnibus chef-12.13.30-1 (possibly older versions as well)) causes:
TypeError: no implicit conversion of Hash into String

This appears to be stemming from https://bugs.ruby-lang.org/issues/10708 - the type of hash key used influences how args are handled when splat / doublesplat are in play - both of which are used in newer mixin/shell_out function definitions (older "def shell_out(*command_args)" versus newer "def shell_out(*args, **options)").  Changing the hash keys to symbols in get_systemctl_options_args addresses this.

Sample code to demonstrate problem:
https://gist.github.com/joshuamiller01/43f4ccc86d69d1e3ba8f5dc357b7062e 