### PR TITLE
Don't let knife cookbook delete tests print to stdout

### DIFF
--- a/spec/functional/knife/cookbook_delete_spec.rb
+++ b/spec/functional/knife/cookbook_delete_spec.rb
@@ -20,86 +20,75 @@ require "spec_helper"
 require "tiny_server"
 
 describe Chef::Knife::CookbookDelete do
-  before(:each) do
-    @server = TinyServer::Manager.new
-    @server.start
+  let(:server) { TinyServer::Manager.new }
+  let(:api) { TinyServer::API.instance }
+  let(:knife_stdout) { StringIO.new }
+  let(:knife_stderr) { StringIO.new }
+  let(:knife) do
+    knife = Chef::Knife::CookbookDelete.new
+    allow(knife.ui).to receive(:stdout).and_return(knife_stdout)
+    allow(knife.ui).to receive(:stderr).and_return(knife_stderr)
+    knife
   end
 
-  after(:each) do
-    @server.stop
-  end
-
   before(:each) do
-    @knife = Chef::Knife::CookbookDelete.new
-    @api = TinyServer::API.instance
-    @api.clear
+    server.start
+    api.clear
 
     Chef::Config[:node_name] = nil
     Chef::Config[:client_key] = nil
     Chef::Config[:chef_server_url] = "http://localhost:9000"
   end
 
+  after(:each) do
+    server.stop
+  end
+
   context "when the cookbook doesn't exist" do
-    let(:log_output) { StringIO.new }
-
     before do
-      @knife.name_args = %w{no-such-cookbook}
-      @api.get("/cookbooks/no-such-cookbook", 404, Chef::JSONCompat.to_json({ "error" => "dear Tim, no. -Sent from my iPad" }))
-    end
-
-    around do |ex|
-      old_logger = Chef::Log.logger
-      old_level = Chef::Log.level
-      begin
-        Chef::Log.logger = Logger.new(log_output)
-        Chef::Log.level = :debug
-        ex.run
-      ensure
-        Chef::Log.logger = old_logger
-        Chef::Log.level = old_level
-      end
+      knife.name_args = %w{no-such-cookbook}
+      api.get("/cookbooks/no-such-cookbook", 404, Chef::JSONCompat.to_json({ "error" => "dear Tim, no. -Sent from my iPad" }))
     end
 
     it "logs an error and exits" do
-      allow(@knife.ui).to receive(:stderr).and_return(log_output)
-      expect { @knife.run }.to raise_error(SystemExit)
-      expect(log_output.string).to match(/Cannot find a cookbook named no-such-cookbook to delete/)
+      expect { knife.run }.to raise_error(SystemExit)
+      expect(knife_stderr.string).to match(/Cannot find a cookbook named no-such-cookbook to delete/)
     end
 
   end
 
   context "when there is only one version of a cookbook" do
     before do
-      @knife.name_args = %w{obsolete-cookbook}
+      knife.name_args = %w{obsolete-cookbook}
       @cookbook_list = { "obsolete-cookbook" => { "versions" => ["version" => "1.0.0"] } }
-      @api.get("/cookbooks/obsolete-cookbook", 200, Chef::JSONCompat.to_json(@cookbook_list))
+      api.get("/cookbooks/obsolete-cookbook", 200, Chef::JSONCompat.to_json(@cookbook_list))
     end
 
     it "asks for confirmation, then deletes the cookbook" do
       stdin, stdout = StringIO.new("y\n"), StringIO.new
-      allow(@knife.ui).to receive(:stdin).and_return(stdin)
-      allow(@knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife.ui).to receive(:stdin).and_return(stdin)
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
 
       cb100_deleted = false
-      @api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
 
-      @knife.run
+      knife.run
 
       expect(stdout.string).to match(/#{Regexp.escape('Do you really want to delete obsolete-cookbook version 1.0.0? (Y/N)')}/)
       expect(cb100_deleted).to be_truthy
     end
 
     it "asks for confirmation before purging" do
-      @knife.config[:purge] = true
+      knife.config[:purge] = true
 
       stdin, stdout = StringIO.new("y\ny\n"), StringIO.new
-      allow(@knife.ui).to receive(:stdin).and_return(stdin)
-      allow(@knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife.ui).to receive(:stdin).and_return(stdin)
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
 
       cb100_deleted = false
-      @api.delete("/cookbooks/obsolete-cookbook/1.0.0?purge=true", 200) { cb100_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.0.0?purge=true", 200) { cb100_deleted = true; "[\"true\"]" }
 
-      @knife.run
+      knife.run
 
       expect(stdout.string).to match(/#{Regexp.escape('Are you sure you want to purge files')}/)
       expect(stdout.string).to match(/#{Regexp.escape('Do you really want to delete obsolete-cookbook version 1.0.0? (Y/N)')}/)
@@ -111,21 +100,21 @@ describe Chef::Knife::CookbookDelete do
 
   context "when there are several versions of a cookbook" do
     before do
-      @knife.name_args = %w{obsolete-cookbook}
+      knife.name_args = %w{obsolete-cookbook}
       versions = ["1.0.0", "1.1.0", "1.2.0"]
       with_version = lambda { |version| { "version" => version } }
       @cookbook_list = { "obsolete-cookbook" => { "versions" => versions.map(&with_version) } }
-      @api.get("/cookbooks/obsolete-cookbook", 200, Chef::JSONCompat.to_json(@cookbook_list))
+      api.get("/cookbooks/obsolete-cookbook", 200, Chef::JSONCompat.to_json(@cookbook_list))
     end
 
     it "deletes all versions of a cookbook when given the '-a' flag" do
-      @knife.config[:all] = true
-      @knife.config[:yes] = true
+      knife.config[:all] = true
+      knife.config[:yes] = true
       cb100_deleted = cb110_deleted = cb120_deleted = nil
-      @api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
-      @api.delete("/cookbooks/obsolete-cookbook/1.1.0", 200) { cb110_deleted = true; "[\"true\"]" }
-      @api.delete("/cookbooks/obsolete-cookbook/1.2.0", 200) { cb120_deleted = true; "[\"true\"]" }
-      @knife.run
+      api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.1.0", 200) { cb110_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.2.0", 200) { cb120_deleted = true; "[\"true\"]" }
+      knife.run
 
       expect(cb100_deleted).to be_truthy
       expect(cb110_deleted).to be_truthy
@@ -134,28 +123,28 @@ describe Chef::Knife::CookbookDelete do
 
     it "asks which version to delete and deletes that when not given the -a flag" do
       cb100_deleted = cb110_deleted = cb120_deleted = nil
-      @api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
       stdin, stdout = StringIO.new, StringIO.new
-      allow(@knife.ui).to receive(:stdin).and_return(stdin)
-      allow(@knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife.ui).to receive(:stdin).and_return(stdin)
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
       stdin << "1\n"
       stdin.rewind
-      @knife.run
+      knife.run
       expect(cb100_deleted).to be_truthy
       expect(stdout.string).to match(/Which version\(s\) do you want to delete\?/)
     end
 
     it "deletes all versions of the cookbook when not given the -a flag and the user chooses to delete all" do
       cb100_deleted = cb110_deleted = cb120_deleted = nil
-      @api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
-      @api.delete("/cookbooks/obsolete-cookbook/1.1.0", 200) { cb110_deleted = true; "[\"true\"]" }
-      @api.delete("/cookbooks/obsolete-cookbook/1.2.0", 200) { cb120_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.0.0", 200) { cb100_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.1.0", 200) { cb110_deleted = true; "[\"true\"]" }
+      api.delete("/cookbooks/obsolete-cookbook/1.2.0", 200) { cb120_deleted = true; "[\"true\"]" }
 
       stdin, stdout = StringIO.new("4\n"), StringIO.new
-      allow(@knife.ui).to receive(:stdin).and_return(stdin)
-      allow(@knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife.ui).to receive(:stdin).and_return(stdin)
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
 
-      @knife.run
+      knife.run
 
       expect(cb100_deleted).to be_truthy
       expect(cb110_deleted).to be_truthy


### PR DESCRIPTION
This removes a little extra STDOUT spew from the tests:

```
Chef::Knife::CookbookDelete
  when the cookbook doesn't exist
    logs an error and exits
  when there is only one version of a cookbook
    asks for confirmation, then deletes the cookbook
    asks for confirmation before purging
  when there are several versions of a cookbook
Deleted cookbook[obsolete-cookbook][1.0.0]
Deleted cookbook[obsolete-cookbook][1.1.0]
Deleted cookbook[obsolete-cookbook][1.2.0]
    deletes all versions of a cookbook when given the '-a' flag
Deleted cookbook[obsolete-cookbook][1.0.0]
    asks which version to delete and deletes that when not given the -a flag
Deleted cookbook[obsolete-cookbook][1.0.0]
Deleted cookbook[obsolete-cookbook][1.1.0]
Deleted cookbook[obsolete-cookbook][1.2.0]
    deletes all versions of the cookbook when not given the -a flag and the user chooses to delete all

Finished in 0.1047 seconds (files took 2.63 seconds to load)
6 examples, 0 failures
```