### PR TITLE
rewrite linux_user provider check_lock

### DIFF
--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -317,6 +317,9 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
         expect(provider).to receive(:shell_out).
           with("passwd", "-S", @new_resource.username, { :returns => [0, 1] }).
           and_return(passwd_status)
+        # ubuntu returns 252 on user-does-not-exist so will raise if #error! is called or if
+        # shell_out! is used
+        allow(passwd_status).to receive(:error!).and_raise(Mixlib::ShellOut::ShellCommandFailed)
         Chef::Config[:why_run] = true
       end
 


### PR DESCRIPTION
this removes the kinda brittle kinda insane parsing of the installed
rpm version.  now we're just less strict about the exit 1 code and
fail on the output not being what is expected.

this also likely fixes a bug in rhel in why-run mode where shell_out!
would have failed on the user-not-found and raised an exception that
would have ended the run.  the code before certainly looks buggy.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>