### PR TITLE
add a hook for compat_resource

### DIFF
--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -658,9 +658,11 @@ ERROR_MESSAGE
       }.map { |x| x.to_sym }
 
       # Verify that we didn't miss any methods
-      missing_methods = superclass.instance_methods(false) - instance_methods(false) - CHILD_STATE
-      if !missing_methods.empty?
-        raise "ERROR: not all methods of RunContext accounted for in ChildRunContext! All methods must be marked as child methods with CHILD_STATE or delegated to the parent_run_context. Missing #{missing_methods.join(", ")}."
+      unless @__skip_method_checking # hook specifically for compat_resource
+        missing_methods = superclass.instance_methods(false) - instance_methods(false) - CHILD_STATE
+        if !missing_methods.empty?
+          raise "ERROR: not all methods of RunContext accounted for in ChildRunContext! All methods must be marked as child methods with CHILD_STATE or delegated to the parent_run_context. Missing #{missing_methods.join(", ")}."
+        end
       end
     end
   end


### PR DESCRIPTION
this is to address some of the regressions in compat_resource -- when we run this as a monkeypatch over old run_context classes we need to be able to skip these checks or it blows up if we have cheffish or chef-provisioning installed due to $REASONS.