### PR TITLE
tweak chef-solo run_lock timing test

### DIFF
--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -115,7 +115,7 @@ ruby_block "sleeping" do
     retries = 200
     while IO.read(Chef::Config[:log_location]) !~ /Chef client [0-9]+ is running, will wait for it to finish and then run./
       sleep 0.1
-      last if ( retries -= 1 ) <= 0
+      raise "we ran out of retries" if ( retries -= 1 ) <= 0
     end
   end
 end
@@ -151,11 +151,11 @@ EOM
       # checks in one example.
       run_log = File.read(path_to("logs/runs.log"))
 
-      # both of the runs should succeed
-      expect(run_log.lines.reject { |l| !l.include? "INFO: Chef Run complete in" }.length).to eq(2)
-
       # second run should have a message which indicates it's waiting for the first run
       expect(run_log).to match(/Chef client [0-9]+ is running, will wait for it to finish and then run./)
+
+      # both of the runs should succeed
+      expect(run_log.lines.reject { |l| !l.include? "INFO: Chef Run complete in" }.length).to eq(2)
     end
 
   end


### PR DESCRIPTION
- fix the 'last' statements (my perl brain occassionally crops up
  in ruby code) and replace with a raise.  of course this just swaps
  one exception for another, but this time its really intended to
  work this way.

- swap the order of the expecations so that if we fails to see the
  waiting on the other process statement, but we blow up in both
  threads in the exception that was just added, we know we actually
  have a legit run_lock race condition that this code just found.

does not fix this bug, just gets us a bit more information if it
reoccurs.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>