### PR TITLE
Hook up the recipe_file_loaded event which was defined but not actually called

### DIFF
--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -232,11 +232,11 @@ class Chef
       end
 
       # Called after the recipe has been loaded
-      def recipe_file_loaded(path)
+      def recipe_file_loaded(path, recipe)
       end
 
       # Called after a recipe file fails to load
-      def recipe_file_load_failed(path, exception)
+      def recipe_file_load_failed(path, exception, recipe)
       end
 
       # Called when a recipe cannot be resolved

--- a/lib/chef/formatters/base.rb
+++ b/lib/chef/formatters/base.rb
@@ -203,12 +203,12 @@ class Chef
       end
 
       # Delegates to #file_loaded
-      def recipe_file_loaded(path)
+      def recipe_file_loaded(path, recipe)
         file_loaded(path)
       end
 
       # Delegates to #file_load_failed
-      def recipe_file_load_failed(path, exception)
+      def recipe_file_load_failed(path, exception, recipe)
         file_load_failed(path, exception)
       end
 

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -137,13 +137,14 @@ class Chef
         @events.recipe_load_start(run_list_expansion.recipes.size)
         run_list_expansion.recipes.each do |recipe|
           begin
+            path = resolve_recipe(recipe)
             @run_context.load_recipe(recipe)
+            @events.recipe_file_loaded(path, recipe)
           rescue Chef::Exceptions::RecipeNotFound => e
             @events.recipe_not_found(e)
             raise
           rescue Exception => e
-            path = resolve_recipe(recipe)
-            @events.recipe_file_load_failed(path, e)
+            @events.recipe_file_load_failed(path, e, recipe)
             raise
           end
         end

--- a/spec/unit/event_dispatch/dispatcher_spec.rb
+++ b/spec/unit/event_dispatch/dispatcher_spec.rb
@@ -52,8 +52,8 @@ describe Chef::EventDispatch::Dispatcher do
       dispatcher.synchronized_cookbook("apache2", cookbook_version)
 
       exception = StandardError.new("foo")
-      expect(event_sink).to receive(:recipe_file_load_failed).with("/path/to/file.rb", exception)
-      dispatcher.recipe_file_load_failed("/path/to/file.rb", exception)
+      expect(event_sink).to receive(:recipe_file_load_failed).with("/path/to/file.rb", exception, "myrecipe")
+      dispatcher.recipe_file_load_failed("/path/to/file.rb", exception, "myrecipe")
     end
 
     context "when an event sink has fewer arguments for an event" do

--- a/spec/unit/run_context/cookbook_compiler_spec.rb
+++ b/spec/unit/run_context/cookbook_compiler_spec.rb
@@ -163,7 +163,9 @@ describe Chef::RunContext::CookbookCompiler do
     describe "event dispatch" do
       let(:recipe) { "dependency1::default" }
       let(:recipe_path) do
-        File.expand_path("../../../data/run_context/cookbooks/dependency1/recipes/default.rb", __FILE__)
+        File.expand_path("../../../data/run_context/cookbooks/dependency1/recipes/default.rb", __FILE__).tap do |path|
+          path.gsub!(File::SEPARATOR, File::ALT_SEPARATOR) if File::ALT_SEPARATOR
+        end
       end
       before do
         node.run_list(recipe)


### PR DESCRIPTION
This also extends two of the recipe events to get the recipe name in addition to the path because that's usually useful for display. These arguments are both added at the end so the auto-magic argument trimmer will keep backwards compat.

Ping @chef/client-core for review. We should probably do a general audit on all the events to see if any others were defined and never cabled.