### PR TITLE
Normalize full key name to avoid resource update on identical key names

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -153,7 +153,7 @@ class Chef
       end
 
       def install_key_from_uri
-        key_name = new_resource.key.split(%r{\/}).last
+        key_name = new_resource.key.gsub(/[^0-9A-Za-z\-]/, "_")
         cached_keyfile = ::File.join(Chef::Config[:file_cache_path], key_name)
         type = if new_resource.key.start_with?("http")
                  :remote_file


### PR DESCRIPTION
### Description

We have multiple apt repositories that have key names similar enough so the cookbook treats them as the same when performs `remote_file` cache (due to regex below).

Related: https://github.com/chef-cookbooks/apt/pull/207

### Issues Resolved

This PR makes sure that `remote_file` caches remote key with a unique name and thus avoids updating resources on every chef run.

### Check List
- [ ] All tests pass. 
- [x] The CLA has been signed.
