### PR TITLE
Pin oc-chef-pedant to prevent unintended test slippage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -131,6 +132,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -148,6 +150,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -165,6 +168,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -182,11 +186,13 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
       - bundle exec kitchen test debian-8
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
@@ -199,6 +205,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -216,6 +223,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -233,6 +241,7 @@ matrix:
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     before_script:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
@@ -252,6 +261,7 @@ matrix:
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
       - sudo apt-get update
       - sudo apt-get -y install squid3 git curl
+    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     env:
       - PROXY_TESTS_DIR=proxy_tests/files/default/scripts
       - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,10 @@ group(:integration) do
   gem "poise-boiler", git: "https://github.com/poise/poise-boiler"
   gem "knife-windows"
   gem "foodcritic"
+
   gem "cucumber-core", "< 2.0.0"
+  # We pin oc-chef-pedant to prevent it from updating out of lockstep with chef-zero
+  gem "oc-chef-pedant", git: "https://github.com/chef/chef-server"
 end
 
 group(:docgen) do

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,8 @@ group(:integration) do
   gem "knife-windows"
   gem "foodcritic"
 
-  gem "cucumber-core", "< 2.0.0"
+  # We pin this so nobody brings in a cucumber-core incompatible with cucumber latest
+  gem "cucumber", ">= 2.4.0"
   # We pin oc-chef-pedant to prevent it from updating out of lockstep with chef-zero
   gem "oc-chef-pedant", git: "https://github.com/chef/chef-server"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,8 +210,17 @@ GEM
       url
     coderay (1.1.1)
     colorize (0.8.1)
+    cucumber (2.4.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.5.0)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 4.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
+    cucumber-wire (0.0.1)
     debug_inspector (0.0.2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -332,6 +341,7 @@ GEM
       wmi-lite (~> 1.0)
     mixlib-versioning (1.1.0)
     multi_json (1.12.1)
+    multi_test (0.1.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
@@ -570,7 +580,7 @@ DEPENDENCIES
   cheffish
   chefspec
   chefstyle!
-  cucumber-core (< 2.0.0)
+  cucumber (>= 2.4.0)
   foodcritic
   github_changelog_generator
   halite

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/chef/chef-server
+  revision: dea545b10cbe209b89b30e782a58763407ba4526
+  specs:
+    oc-chef-pedant (2.2.0)
+      activesupport (~> 3.2)
+      erubis (~> 2.7)
+      mixlib-authentication (~> 1.4)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (>= 1.1)
+      net-http-spy (~> 0.2)
+      rest-client (>= 1.6)
+      rspec (~> 3.2)
+      rspec-rerun (~> 1.0)
+      rspec_junit_formatter (~> 0.2)
+
+GIT
   remote: https://github.com/chef/chefstyle.git
   revision: c36dcbd6c2c21d2e19db77d9fbdf2402d0bacccf
   branch: master
@@ -132,6 +148,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (3.2.22.4)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
     addressable (2.4.0)
     appbundler (0.9.0)
       mixlib-cli (~> 1.4)
@@ -198,6 +217,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.20160826)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
@@ -256,7 +277,10 @@ GEM
       thor
     hashie (3.4.4)
     highline (1.7.8)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     httpclient (2.8.2.3)
+    i18n (0.7.0)
     inifile (3.0.0)
     iniparse (1.4.2)
     ipaddress (0.8.3)
@@ -312,6 +336,7 @@ GEM
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
+    net-http-spy (0.2.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -382,6 +407,15 @@ GEM
     rainbow (2.1.0)
     rake (11.2.2)
     rb-readline (0.5.3)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rest-client (2.0.0-x86-mingw32)
+      ffi (~> 1.9)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retryable (2.0.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -398,6 +432,8 @@ GEM
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
+    rspec-rerun (1.1.0)
+      rspec (~> 3.0)
     rspec-support (3.5.0)
     rspec_junit_formatter (0.2.3)
       builder (< 4)
@@ -465,6 +501,10 @@ GEM
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
     ubuntu_ami (0.4.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.2-x86-mingw32)
     unicode-display_width (1.1.1)
     url (0.3.2)
     uuidtools (2.1.5)
@@ -537,6 +577,7 @@ DEPENDENCIES
   knife-windows
   netrc
   nokogiri
+  oc-chef-pedant!
   octokit
   poise
   poise-boiler!

--- a/version_policy.rb
+++ b/version_policy.rb
@@ -76,10 +76,9 @@ OMNIBUS_RUBYGEMS_AT_LATEST_VERSION = {
 #
 ACCEPTABLE_OUTDATED_GEMS = [
   "json",       # aws-sdk-v1 pins this because Ruby 2.0; chef-provisioning fix to abandon v1 TBD
-  "rack",       # chef-zero pins this because Ruby 2.0, will be fixed in 5.0
   "rubocop",    # chefstyle pins this, will often be somewhat behind
   "slop",       # expected to disappear with pry 0.11
-  "typhoeus",   # until https://github.com/travis-ci/travis.rb/pull/426 is fixed
+  "typhoeus",   # Until the travis gem updates to 1.0.
 ]
 
 #


### PR DESCRIPTION
Because chef-zero is pinned, oc-chef-pedant must be pinned too (as its test suite). They must move forward together or not at all. This difference caused a Travis breakage the other day.