### PR TITLE
removing option -r for solaris machines

### DIFF
--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -126,7 +126,7 @@ class Chef
 
         def groupadd_options
           opts = ""
-          opts << " -r" if @new_resource.system
+          opts << " -r" if @new_resource.system && !node['platform'] == 'solaris2'
           opts << " -o" if @new_resource.non_unique
           opts
         end

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -126,7 +126,7 @@ class Chef
 
         def groupadd_options
           opts = ""
-          opts << " -r" if @new_resource.system && !node['platform'] == 'solaris2'
+          opts << " -r" if @new_resource.system && node['platform'] != 'solaris2'
           opts << " -o" if @new_resource.non_unique
           opts
         end

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -126,7 +126,7 @@ class Chef
 
         def groupadd_options
           opts = ""
-          opts << " -r" if @new_resource.system && node['platform'] != 'solaris2'
+          opts << " -r" if @new_resource.system && node["platform"] != "solaris2"
           opts << " -o" if @new_resource.non_unique
           opts
         end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -69,8 +69,9 @@ describe Chef::Provider::Group::Groupadd, "set_options" do
       expect(@provider.groupadd_options).not_to match(/-r/)
     end
 
-    it "should set groupadd -r if system is true" do
-      @new_resource.system(true)
+    it "should set groupadd -r if system is true and platform is not solaris" do
+      allow(@new_resource).to receive(:system).and_return(true)
+      allow(Chef::Platform).to receive(:solaris?).and_return(false)
       expect(@provider.groupadd_options).to eq(" -r")
     end
   end


### PR DESCRIPTION
disabling opt -r from being passed if the host is a solaris machine. 