### PR TITLE
ignore unknown metadata fields in metadata.rb

### DIFF
--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -726,7 +726,7 @@ class Chef
         if block_given?
           super
         else
-          Chef::Log.warn "ignoring method #{method} on cookbook with name #{name}, possible typo or future metdata?"
+          Chef::Log.debug "ignoring method #{method} on cookbook with name #{name}, possible typo or future metadata?"
         end
       end
 

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -722,6 +722,14 @@ class Chef
         end
       end
 
+      def method_missing(method, *args, &block)
+        if block_given?
+          super
+        else
+          Chef::Log.warn "ignoring method #{method} on cookbook with name #{name}, possible typo or future metdata?"
+        end
+      end
+
       private
 
       # Helper to match a gem style version (ohai_version/chef_version) against a set of

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -948,5 +948,24 @@ describe Chef::Cookbook::Metadata do
       end
     end
 
+    describe "from_file" do
+      it "ignores unknown metadata fields in metadata.rb files" do
+        expect(Chef::Log).to receive(:warn).with(/ignoring method some_spiffy_new_metadata_field/)
+        Tempfile.open("metadata.rb") do |f|
+          f.write <<-EOF
+            some_spiffy_new_metadata_field "stuff its set to"
+          EOF
+          f.close
+          metadata.from_file(f.path)
+        end
+      end
+    end
+
+    describe "from_json" do
+      it "ignores unknown metadata fields in metdata.json files" do
+        json = %q{{ "some_spiffy_new_metadata_field": "stuff its set to" }}
+        metadata.from_json(json)
+      end
+    end
   end
 end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -950,7 +950,7 @@ describe Chef::Cookbook::Metadata do
 
     describe "from_file" do
       it "ignores unknown metadata fields in metadata.rb files" do
-        expect(Chef::Log).to receive(:warn).with(/ignoring method some_spiffy_new_metadata_field/)
+        expect(Chef::Log).to receive(:debug).with(/ignoring method some_spiffy_new_metadata_field/)
         Tempfile.open("metadata.rb") do |f|
           f.write <<-EOF
             some_spiffy_new_metadata_field "stuff its set to"


### PR DESCRIPTION
if we're just using chef-zero there's no metadata.json file so
chef-client doesn't do json parsing (which ignores unknown metadata
fields already) but parses metadata.json which explodes.

i believe since TK goes through berks it renders the rb to json before
copying to the virt so we don't see this in TK or in running chef-client
from a real server.

this only affects the chef-client -z or chef-zolo mode of operation (and
probably legacy chef-solo)

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>