### PR TITLE
Install apt-transport-https when needed in apt_repository

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -54,9 +54,13 @@ class Chef
         # make sure we have apt-transport-https installed before we try to
         # apt-get update with a https repo defined
         if new_resource.uri =~ /^https/
+          declare_resource(:apt_update, new_resource.name) do
+            ignore_failure true
+            action :periodic
+          end
+
           declare_resource(:package, "apt-transport-https") do
             action :install
-            notifies :update, "apt_update[#{new_resource.name}]", :before
           end
         end
 

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -51,6 +51,15 @@ class Chef
           end
         end
 
+        # make sure we have apt-transport-https installed before we try to
+        # apt-get update with a https repo defined
+        if new_resource.uri =~ /^https/
+          declare_resource(:package, "apt-transport-https") do
+            action :install
+            notifies :update, "apt_update[#{new_resource.name}]", :before
+          end
+        end
+
         declare_resource(:execute, "apt-cache gencaches") do
           ignore_failure true
           action :nothing

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptRepository < Chef::Resource
       resource_name :apt_repository
-      provides :apt_repository
+      provides :apt_repository, os: "linux"
 
       property :repo_name, String, name_property: true
       property :uri, String
@@ -35,7 +35,6 @@ class Chef
       property :keyserver, [String, nil, false], default: "keyserver.ubuntu.com", nillable: true, coerce: proc { |x| x ? x : nil }
       property :key, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
       property :key_proxy, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
-
       property :cookbook, [String, nil, false], default: nil, desired_state: false, nillable: true, coerce: proc { |x| x ? x : nil }
       property :cache_rebuild, [TrueClass, FalseClass], default: true, desired_state: false
       property :sensitive, [TrueClass, FalseClass], default: false, desired_state: false

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -24,27 +24,35 @@ describe Chef::Resource::AptRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptRepository.new("multiverse", run_context) }
 
-  it "should create a new Chef::Resource::AptUpdate" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::AptRepository)
+  context "on linux", :linux_only do
+    it "should create a new Chef::Resource::AptUpdate" do
+      expect(resource).to be_a_kind_of(Chef::Resource)
+      expect(resource).to be_a_kind_of(Chef::Resource::AptRepository)
+    end
+
+    it "the default keyserver should be keyserver.ubuntu.com" do
+      expect(resource.keyserver).to eql("keyserver.ubuntu.com")
+    end
+
+    it "the default distribution should be nillable" do
+      expect(resource.distribution(nil)).to eql(nil)
+      expect(resource.distribution).to eql(nil)
+    end
+
+    it "should resolve to a Noop class when apt-get is not found" do
+      expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(false)
+      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+    end
+
+    it "should resolve to a AptRepository class when apt-get is found" do
+      expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(true)
+      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptRepository)
+    end
   end
 
-  it "the default keyserver should be keyserver.ubuntu.com" do
-    expect(resource.keyserver).to eql("keyserver.ubuntu.com")
-  end
-
-  it "the default distribution should be nillable" do
-    expect(resource.distribution(nil)).to eql(nil)
-    expect(resource.distribution).to eql(nil)
-  end
-
-  it "should resolve to a Noop class when apt-get is not found" do
-    expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(false)
-    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
-  end
-
-  it "should resolve to a AptRepository class when apt-get is found" do
-    expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(true)
-    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptRepository)
+  context "on windows", :windows_only do
+    it "should resolve to a NoOp provider" do
+      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+    end
   end
 end


### PR DESCRIPTION
Right now a system lacking apt-transport-https will fail if you define a
https repo. We should run apt-get update and then install
apt-transport-https before defining anything with https in the URI

This is a scenario we should get into acceptance testing. If someone wants to point me in the right direction there I can make sure we test out a few apt scenarios. The apt cookbook had a healthy set of tests in it.

Signed-off-by: Tim Smith tsmith@chef.io
