### PR TITLE
Issue #5309 - allow timeout for service resource

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,4 @@
 ---
 BUNDLE_FROZEN: '1'
+BUNDLE_PATH: "/tmp/bundles/"
+BUNDLE_DISABLE_SHARED_GEMS: true

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,4 @@
 ---
 BUNDLE_FROZEN: '1'
-BUNDLE_PATH: "/tmp/bundles/"
+BUNDLE_PATH: "/tmp/bundleschef/"
 BUNDLE_DISABLE_SHARED_GEMS: true

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -26,6 +26,9 @@ class Chef
 
       include Chef::Mixin::Command
 
+      # depends on 'require mixlib' from above 'include mixin::command'
+      TIMEOUT = Mixlib::ShellOut::DEFAULT_READ_TIMEOUT
+
       def supports
         @supports ||= new_resource.supports.dup
       end
@@ -254,6 +257,12 @@ class Chef
         Chef.set_provider_priority_array :service, [ Systemd, Upstart, Insserv, Debian, Invokercd ], platform_family: "debian"
         Chef.set_provider_priority_array :service, [ Systemd, Insserv, Redhat ], platform_family: %w{rhel fedora suse}
       end
+
+      def timeout
+        _timeout = @new_resource.timeout.nil? ? TIMEOUT : @new_resource.timeout
+        {:timeout => _timeout}
+      end
+
     end
   end
 end

--- a/lib/chef/provider/service/aix.rb
+++ b/lib/chef/provider/service/aix.rb
@@ -49,17 +49,17 @@ class Chef
 
         def start_service
           if @is_resource_group
-            shell_out!("startsrc -g #{@new_resource.service_name}")
+            shell_out!("startsrc -g #{@new_resource.service_name}", timeout)
           else
-            shell_out!("startsrc -s #{@new_resource.service_name}")
+            shell_out!("startsrc -s #{@new_resource.service_name}", timeout)
           end
         end
 
         def stop_service
           if @is_resource_group
-            shell_out!("stopsrc -g #{@new_resource.service_name}")
+            shell_out!("stopsrc -g #{@new_resource.service_name}", timeout)
           else
-            shell_out!("stopsrc -s #{@new_resource.service_name}")
+            shell_out!("stopsrc -s #{@new_resource.service_name}", timeout)
           end
         end
 
@@ -70,9 +70,9 @@ class Chef
 
         def reload_service
           if @is_resource_group
-            shell_out!("refresh -g #{@new_resource.service_name}")
+            shell_out!("refresh -g #{@new_resource.service_name}", timeout)
           else
-            shell_out!("refresh -s #{@new_resource.service_name}")
+            shell_out!("refresh -s #{@new_resource.service_name}", timeout)
           end
         end
 

--- a/lib/chef/provider/service/init.rb
+++ b/lib/chef/provider/service/init.rb
@@ -57,7 +57,7 @@ class Chef
           if @new_resource.start_command
             super
           else
-            shell_out_with_systems_locale!("#{default_init_command} start")
+            shell_out_with_systems_locale!("#{default_init_command} start", timeout)
           end
         end
 
@@ -65,7 +65,7 @@ class Chef
           if @new_resource.stop_command
             super
           else
-            shell_out_with_systems_locale!("#{default_init_command} stop")
+            shell_out_with_systems_locale!("#{default_init_command} stop", timeout)
           end
         end
 
@@ -73,7 +73,7 @@ class Chef
           if @new_resource.restart_command
             super
           elsif supports[:restart]
-            shell_out_with_systems_locale!("#{default_init_command} restart")
+            shell_out_with_systems_locale!("#{default_init_command} restart", timeout)
           else
             stop_service
             sleep 1
@@ -85,7 +85,7 @@ class Chef
           if @new_resource.reload_command
             super
           elsif supports[:reload]
-            shell_out_with_systems_locale!("#{default_init_command} reload")
+            shell_out_with_systems_locale!("#{default_init_command} reload", timeout)
           end
         end
       end

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -88,16 +88,16 @@ class Chef
         end
 
         def start_service
-          shell_out_with_systems_locale!(@new_resource.start_command)
+          shell_out_with_systems_locale!(@new_resource.start_command, timeout)
         end
 
         def stop_service
-          shell_out_with_systems_locale!(@new_resource.stop_command)
+          shell_out_with_systems_locale!(@new_resource.stop_command, timeout)
         end
 
         def restart_service
           if @new_resource.restart_command
-            shell_out_with_systems_locale!(@new_resource.restart_command)
+            shell_out_with_systems_locale!(@new_resource.restart_command, timeout)
           else
             stop_service
             sleep 1
@@ -106,7 +106,7 @@ class Chef
         end
 
         def reload_service
-          shell_out_with_systems_locale!(@new_resource.reload_command)
+          shell_out_with_systems_locale!(@new_resource.reload_command, timeout)
         end
 
         protected
@@ -170,6 +170,7 @@ class Chef
         def ps_cmd
           @run_context.node[:command] && @run_context.node[:command][:ps]
         end
+
       end
     end
   end

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -100,6 +100,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
+        options = options.merge(timeout)
         shell_out_with_systems_locale!("#{systemctl_path} #{args} start #{new_resource.service_name}", options)
       end
     end
@@ -113,6 +114,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
+        options = options.merge(timeout)
         shell_out_with_systems_locale!("#{systemctl_path} #{args} stop #{new_resource.service_name}", options)
       end
     end
@@ -123,6 +125,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       super
     else
       options, args = get_systemctl_options_args
+      options = options.merge(timeout)
       shell_out_with_systems_locale!("#{systemctl_path} #{args} restart #{new_resource.service_name}", options)
     end
   end
@@ -133,6 +136,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     else
       if current_resource.running
         options, args = get_systemctl_options_args
+        options = options.merge(timeout)
         shell_out_with_systems_locale!("#{systemctl_path} #{args} reload #{new_resource.service_name}", options)
       else
         start_service

--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -165,7 +165,7 @@ class Chef
             if @new_resource.start_command
               super
             else
-              shell_out_with_systems_locale!("/sbin/start #{@job}")
+              shell_out_with_systems_locale!("/sbin/start #{@job}", timeout)
             end
           end
         end
@@ -179,7 +179,7 @@ class Chef
             if @new_resource.stop_command
               super
             else
-              shell_out_with_systems_locale!("/sbin/stop #{@job}")
+              shell_out_with_systems_locale!("/sbin/stop #{@job}", timeout)
             end
           end
         end
@@ -191,7 +191,7 @@ class Chef
           # Older versions of upstart would fail on restart if the service was currently stopped, check for that. LP:430883
           else
             if @current_resource.running
-              shell_out_with_systems_locale!("/sbin/restart #{@job}")
+              shell_out_with_systems_locale!("/sbin/restart #{@job}", timeout)
             else
               start_service
             end
@@ -203,7 +203,7 @@ class Chef
             super
           else
             # upstart >= 0.6.3-4 supports reload (HUP)
-            shell_out_with_systems_locale!("/sbin/reload #{@job}")
+            shell_out_with_systems_locale!("/sbin/reload #{@job}", timeout)
           end
         end
 

--- a/spec/unit/provider/service/aix_service_spec.rb
+++ b/spec/unit/provider/service/aix_service_spec.rb
@@ -29,6 +29,10 @@ describe Chef::Provider::Service::Aix do
 
     @provider = Chef::Provider::Service::Aix.new(@new_resource, @run_context)
     allow(Chef::Resource::Service).to receive(:new).and_return(@current_resource)
+
+    @timeout = {:timeout => 600}
+    @timeout_user_value = 1
+    @timeout_user = {:timeout => @timeout_user_value}
   end
 
   describe "load current resource" do
@@ -134,13 +138,13 @@ describe Chef::Provider::Service::Aix do
 
     it "should call the start command for groups" do
       @provider.instance_eval("@is_resource_group = true")
-      expect(@provider).to receive(:shell_out!).with("startsrc -g #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("startsrc -g #{@new_resource.service_name}", @timeout)
 
       @provider.start_service
     end
 
     it "should call the start command for subsystem" do
-      expect(@provider).to receive(:shell_out!).with("startsrc -s #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("startsrc -s #{@new_resource.service_name}", @timeout)
 
       @provider.start_service
     end
@@ -153,13 +157,13 @@ describe Chef::Provider::Service::Aix do
 
     it "should call the stop command for groups" do
       @provider.instance_eval("@is_resource_group = true")
-      expect(@provider).to receive(:shell_out!).with("stopsrc -g #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("stopsrc -g #{@new_resource.service_name}", @timeout)
 
       @provider.stop_service
     end
 
     it "should call the stop command for subsystem" do
-      expect(@provider).to receive(:shell_out!).with("stopsrc -s #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("stopsrc -s #{@new_resource.service_name}", @timeout)
 
       @provider.stop_service
     end
@@ -172,13 +176,20 @@ describe Chef::Provider::Service::Aix do
 
     it "should call the reload command for groups" do
       @provider.instance_eval("@is_resource_group = true")
-      expect(@provider).to receive(:shell_out!).with("refresh -g #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("refresh -g #{@new_resource.service_name}", @timeout)
 
       @provider.reload_service
     end
 
     it "should call the reload command for subsystem" do
-      expect(@provider).to receive(:shell_out!).with("refresh -s #{@new_resource.service_name}")
+      expect(@provider).to receive(:shell_out!).with("refresh -s #{@new_resource.service_name}", @timeout)
+
+      @provider.reload_service
+    end
+
+    it "should call the reload command for subsystem with user defined timeout" do
+      @provider.timeout(@timeout_user_value)
+      expect(@provider).to receive(:shell_out!).with("refresh -s #{@new_resource.service_name}", @timeout_user)
 
       @provider.reload_service
     end

--- a/spec/unit/provider/service/init_service_spec.rb
+++ b/spec/unit/provider/service/init_service_spec.rb
@@ -39,6 +39,9 @@ aj        8119  6041  0 21:34 pts/3    00:00:03 vi init_service_spec.rb
 PS
     @status = double("Status", :exitstatus => 0, :stdout => @stdout)
     allow(@provider).to receive(:shell_out!).and_return(@status)
+    @timeout = {:timeout => 600}
+    @timeout_user_value = 1
+    @timeout_user = {:timeout => @timeout_user_value}
   end
 
   it "should create a current resource with the name of the new resource" do
@@ -100,7 +103,7 @@ PS
     end
 
     it "should use the init_command if one has been specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/opt/chef-server/service/erchef start")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/opt/chef-server/service/erchef start", @timeout)
       @provider.start_service
     end
 
@@ -164,12 +167,12 @@ RUNNING_PS
   describe "when starting the service" do
     it "should call the start command if one is specified" do
       @new_resource.start_command("/etc/init.d/chef startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally", @timeout)
       @provider.start_service()
     end
 
     it "should call '/etc/init.d/service_name start' if no start command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} start")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} start", @timeout)
       @provider.start_service()
     end
   end
@@ -177,12 +180,12 @@ RUNNING_PS
   describe Chef::Provider::Service::Init, "stop_service" do
     it "should call the stop command if one is specified" do
       @new_resource.stop_command("/etc/init.d/chef itoldyoutostop")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef itoldyoutostop")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef itoldyoutostop", @timeout)
       @provider.stop_service()
     end
 
     it "should call '/etc/init.d/service_name stop' if no stop command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} stop")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} stop", @timeout)
       @provider.stop_service()
     end
   end
@@ -190,13 +193,13 @@ RUNNING_PS
   describe "when restarting a service" do
     it "should call 'restart' on the service_name if the resource supports it" do
       @new_resource.supports({ :restart => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restart")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restart", @timeout)
       @provider.restart_service()
     end
 
     it "should call the restart_command if one has been specified" do
       @new_resource.restart_command("/etc/init.d/chef restartinafire")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restartinafire")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restartinafire", @timeout)
       @provider.restart_service()
     end
 
@@ -211,13 +214,27 @@ RUNNING_PS
   describe "when reloading a service" do
     it "should call 'reload' on the service if it supports it" do
       @new_resource.supports({ :reload => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef reload")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef reload", @timeout)
       @provider.reload_service()
     end
 
-    it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
+    it "should run the user specified reload command if one is specified and the service doesn't support reload" do
       @new_resource.reload_command("/etc/init.d/chef lollerpants")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef lollerpants")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef lollerpants", @timeout)
+      @provider.reload_service()
+    end
+
+    it "should call 'reload' on the service with user defined timeout"
+      @new_resource.supports({ :reload => true })
+      @new_resource.timeout(@timeout_user_value)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef reload", @timeout_user)
+      @provider.reload_service() 
+    end
+
+    it "should run the user specified reload command if one is specified and the service doesn't support reload and use user defined timeout" do
+      @new_resource.reload_command("/etc/init.d/chef lollerpants")
+      @new_resource.timeout(@timeout_user_value)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef lollerpants", @timeout_user)
       @provider.reload_service()
     end
   end
@@ -225,7 +242,7 @@ RUNNING_PS
   describe "when a custom command has been specified" do
     before do
       @new_resource.start_command("/etc/init.d/chef startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally", @timeout)
     end
 
     it "should still pass all why run assertions" do

--- a/spec/unit/provider/service/init_service_spec.rb
+++ b/spec/unit/provider/service/init_service_spec.rb
@@ -224,7 +224,7 @@ RUNNING_PS
       @provider.reload_service()
     end
 
-    it "should call 'reload' on the service with user defined timeout"
+    it "should call 'reload' on the service with user defined timeout" do
       @new_resource.supports({ :reload => true })
       @new_resource.timeout(@timeout_user_value)
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef reload", @timeout_user)

--- a/spec/unit/provider/service/simple_service_spec.rb
+++ b/spec/unit/provider/service/simple_service_spec.rb
@@ -38,6 +38,9 @@ aj        8119  6041  0 21:34 pts/3    00:00:03 vi simple_service_spec.rb
 NOMOCKINGSTRINGSPLZ
     @status = double("Status", :exitstatus => 0, :stdout => @stdout)
     allow(@provider).to receive(:shell_out!).and_return(@status)
+    @timeout = {:timeout => 600}
+    @timeout_user_value = 1
+    @timeout_user = {:timeout => @timeout_user_value}
   end
 
   it "should create a current resource with the name of the new resource" do
@@ -107,7 +110,7 @@ NOMOCKINGSTRINGSPLZ
   describe "when starting the service" do
     it "should call the start command if one is specified" do
       allow(@new_resource).to receive(:start_command).and_return("#{@new_resource.start_command}")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("#{@new_resource.start_command}")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("#{@new_resource.start_command}", @timeout)
       @provider.start_service()
     end
 
@@ -121,7 +124,7 @@ NOMOCKINGSTRINGSPLZ
   describe "when stopping a service" do
     it "should call the stop command if one is specified" do
       @new_resource.stop_command("/etc/init.d/themadness stop")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/themadness stop")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/themadness stop", @timeout)
       @provider.stop_service()
     end
 
@@ -135,7 +138,7 @@ NOMOCKINGSTRINGSPLZ
   describe Chef::Provider::Service::Simple, "restart_service" do
     it "should call the restart command if one has been specified" do
       @new_resource.restart_command("/etc/init.d/foo restart")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/foo restart")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/foo restart", @timeout)
       @provider.restart_service()
     end
 
@@ -163,6 +166,13 @@ NOMOCKINGSTRINGSPLZ
     it "should should run the user specified reload command if one is specified" do
       @new_resource.reload_command("kill -9 1")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("kill -9 1")
+      @provider.reload_service()
+    end
+
+    it "should should run the user specified reload command if one is specified with user defined timeout" do
+      @new_resource.reload_command("kill -9 1")
+      @new_resource.timeout(@timeout_user_value)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("kill -9 1", @timeout_user)
       @provider.reload_service()
     end
   end

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -34,6 +34,10 @@ describe Chef::Provider::Service::Upstart do
 
     @new_resource = Chef::Resource::Service.new("rsyslog")
     @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
+
+    @timeout = {:timeout => 600}
+    @timeout_user_value = 1
+    @timeout_user = {:timeout => @timeout_user_value}
   end
 
   describe "when first created" do
@@ -279,12 +283,12 @@ describe Chef::Provider::Service::Upstart do
 
     it "should call the start command if one is specified" do
       allow(@new_resource).to receive(:start_command).and_return("/sbin/rsyslog startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog startyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog startyousillysally", @timeout)
       @provider.start_service()
     end
 
     it "should call '/sbin/start service_name' if no start command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}", @timeout).and_return(shell_out_success)
       @provider.start_service()
     end
 
@@ -299,52 +303,60 @@ describe Chef::Provider::Service::Upstart do
       @new_resource.parameters({ "OSD_ID" => "2" })
       @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
       @provider.current_resource = @current_resource
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start rsyslog OSD_ID=2").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start rsyslog OSD_ID=2", @timeout).and_return(shell_out_success)
       @provider.start_service()
     end
 
     it "should call the restart command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
       allow(@new_resource).to receive(:restart_command).and_return("/sbin/rsyslog restartyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog restartyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog restartyousillysally", @timeout)
       @provider.restart_service()
     end
 
     it "should call '/sbin/restart service_name' if no restart command is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/restart #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/restart #{@new_resource.service_name}", @timeout).and_return(shell_out_success)
       @provider.restart_service()
     end
 
     it "should call '/sbin/start service_name' if restart_service is called for a stopped service" do
       allow(@current_resource).to receive(:running).and_return(false)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}", @timeout).and_return(shell_out_success)
       @provider.restart_service()
     end
 
     it "should call the reload command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
       allow(@new_resource).to receive(:reload_command).and_return("/sbin/rsyslog reloadyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog reloadyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog reloadyousillysally", @timeout)
       @provider.reload_service()
     end
 
     it "should call '/sbin/reload service_name' if no reload command is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/reload #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/reload #{@new_resource.service_name}",@timeout).and_return(shell_out_success)
+      @provider.reload_service()
+    end
+
+    it "should call the reload command and set suer defined timeout if specified" do
+      allow(@current_resource).to receive(:running).and_return(true)
+      allow(@new_resource).to receive(:reload_command).and_return("/sbin/rsyslog reloadyousillysally")
+      allow(@new_resource).to receive(:timeout).and_return(@timeout_user_value)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog reloadyousillysally", @timeout_user)
       @provider.reload_service()
     end
 
     it "should call the stop command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
       allow(@new_resource).to receive(:stop_command).and_return("/sbin/rsyslog stopyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog stopyousillysally")
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog stopyousillysally", @timeout)
       @provider.stop_service()
     end
 
     it "should call '/sbin/stop service_name' if no stop command is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/stop #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/stop #{@new_resource.service_name}", @timeout).and_return(shell_out_success)
       @provider.stop_service()
     end
 

--- a/spec/unit/provider/service_spec.rb
+++ b/spec/unit/provider/service_spec.rb
@@ -165,4 +165,5 @@ describe Chef::Provider::Service do
   it "delegates reload_service to subclasses" do
     expect { @provider.reload_service }.to raise_error(Chef::Exceptions::UnsupportedAction)
   end
+ 
 end


### PR DESCRIPTION
this pr is to allow timeout to be set for service resource

test:
create a service resource and set 'timeout 1' and 'restart_command 'sleep 10''
notify this service to restart

test will fail due to timeout ... which is 1 and not 600 as by default (mixlib::shellout)
