### PR TITLE
Fix for ifconfig resource's functional spec.

### DIFF
--- a/spec/functional/resource/ifconfig_spec.rb
+++ b/spec/functional/resource/ifconfig_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Resource::Ifconfig, :requires_root, :skip_travis, :external => in
     end
   end
 
-  def interface_name
+  def fetch_first_interface_name
     shell_out("ifconfig | grep Ethernet | head -1 | cut -d' ' -f1").stdout.strip
   end
 
@@ -61,7 +61,7 @@ describe Chef::Resource::Ifconfig, :requires_root, :skip_travis, :external => in
     when "aix"
       "en0"
     when "ubuntu"
-      interface_name
+      fetch_first_interface_name
     else
       "eth0"
     end

--- a/spec/functional/resource/ifconfig_spec.rb
+++ b/spec/functional/resource/ifconfig_spec.rb
@@ -51,11 +51,17 @@ describe Chef::Resource::Ifconfig, :requires_root, :skip_travis, :external => in
     end
   end
 
+  def interface_name
+    shell_out("ifconfig | grep Ethernet | head -1 | cut -d' ' -f1").stdout.strip
+  end
+
   # **Caution: any updates to core interfaces can be risky.
   def en0_interface_for_test
     case ohai[:platform]
     when "aix"
       "en0"
+    when "ubuntu"
+      interface_name
     else
       "eth0"
     end


### PR DESCRIPTION
Modified `ifconfig` resource's functional spec to handle `persistent stateless network interface names (deprecation of eth0)`, introduced in `Ubuntu 16.04` OS.