### PR TITLE
Revert "Verify systemd_unit file during create"

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -193,7 +193,6 @@ class Chef
           f.group "root"
           f.mode "0644"
           f.content new_resource.to_ini
-          f.verify systemd_analyze_cmd if systemd_analyze_path
         end.run_action(action)
       end
 
@@ -233,14 +232,6 @@ class Chef
           else
             {}
           end
-      end
-
-      def systemd_analyze_cmd
-        @systemd_analyze_cmd ||= "#{systemd_analyze_path} verify %{path}"
-      end
-
-      def systemd_analyze_path
-        @systemd_analyze_path ||= which("systemd-analyze")
       end
     end
   end


### PR DESCRIPTION
Reverts chef/chef#5210 since this appears to be a breaking change. See https://github.com/chef/chef/issues/5324