### PR TITLE
fix non-utf8 filename issues in the file provider (again)

### DIFF
--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -7,6 +7,14 @@
 
 hostname "chef-travis-ci.chef.io"
 
+file "/tmp/chef-test-ümlauts" do
+  content "testing UTF-8 char in the filename"
+end
+
+file "/tmp/chef-test-\xFDmlaut" do
+  content "testing illegal UTF-8 char in the filename"
+end
+
 if node["platform_family"] == "debian"
   include_recipe "ubuntu"
   apt_update "packages"
@@ -28,7 +36,7 @@ end
 
 include_recipe "build-essential"
 
-include_recipe "#{cookbook_name}::packages"
+include_recipe "::packages"
 
 include_recipe "ntp"
 
@@ -50,3 +58,5 @@ include_recipe "openssh"
 include_recipe "nscd"
 
 include_recipe "logrotate"
+
+include_recipe "::tests"

--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -7,14 +7,6 @@
 
 hostname "chef-travis-ci.chef.io"
 
-file "/tmp/chef-test-ümlauts" do
-  content "testing UTF-8 char in the filename"
-end
-
-file "/tmp/chef-test-\xFDmlaut" do
-  content "testing illegal UTF-8 char in the filename"
-end
-
 if node["platform_family"] == "debian"
   include_recipe "ubuntu"
   apt_update "packages"

--- a/kitchen-tests/cookbooks/base/recipes/tests.rb
+++ b/kitchen-tests/cookbooks/base/recipes/tests.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: webapp
+# Recipe:: default
+#
+# Copyright (C) 2014
+#
+
+#
+# this file is for random tests to check specific chef-client internal functionality
+#
+
+file "/tmp/chef-test-ümlauts" do
+  content "testing UTF-8 char in the filename"
+end
+
+# this caught a regression in 12.14.70 before it was released when i
+# ran it in lamont-ci, so added the test here so everyone else other than
+# me gets coverage for this as well.
+file "/tmp/chef-test-\xFDmlaut" do
+  content "testing illegal UTF-8 char in the filename"
+end

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -41,7 +41,9 @@ class Chef
         tempfile_dirnames.each do |tempfile_dirname|
           begin
             # preserving the file extension of the target filename should be considered a public API
+            puts "HERE"
             tf = ::Tempfile.open([tempfile_basename, tempfile_extension], tempfile_dirname)
+            puts "THERE"
             break
           rescue SystemCallError => e
             message = "Creating temp file under '#{tempfile_dirname}' failed with: '#{e.message}'"
@@ -64,18 +66,25 @@ class Chef
       # as the arguments to Tempfile.new() consistently.
       #
       def tempfile_basename
+        puts "FOO"
         basename = ::File.basename(@new_resource.path, tempfile_extension)
+        puts "BAR"
         # the leading "[.]chef-" here should be considered a public API and should not be changed
         basename.insert 0, "chef-"
+        puts "BAZ"
         basename.insert 0, "." unless Chef::Platform.windows? # dotfile if we're not on windows
+        puts "QUX"
         basename
       end
 
       # this is similar to File.extname() but greedy about the extension (from the first dot, not the last dot)
       def tempfile_extension
         # complexity here is due to supporting mangling non-UTF8 strings (e.g. latin-1 filenames with characters that are illegal in UTF-8)
+        puts "ONE"
         b = File.basename(@new_resource.path)
+        puts "TWO"
         i = b.index(".")
+        puts "THREE"
         i.nil? ? "" : b[i..-1]
       end
 

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -73,7 +73,10 @@ class Chef
 
       # this is similar to File.extname() but greedy about the extension (from the first dot, not the last dot)
       def tempfile_extension
-        File.basename(@new_resource.path)[/\..*/] || ""
+        # complexity here is due to supporting mangling non-UTF8 strings (e.g. latin-1 filenames with characters that are illegal in UTF-8)
+        b = File.basename(@new_resource.path)
+        i = b.index(".")
+        i.nil? ? "" : b[i..-1]
       end
 
       # Returns the possible directories for the tempfile to be created in.

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -41,9 +41,7 @@ class Chef
         tempfile_dirnames.each do |tempfile_dirname|
           begin
             # preserving the file extension of the target filename should be considered a public API
-            puts "HERE"
             tf = ::Tempfile.open([tempfile_basename, tempfile_extension], tempfile_dirname)
-            puts "THERE"
             break
           rescue SystemCallError => e
             message = "Creating temp file under '#{tempfile_dirname}' failed with: '#{e.message}'"
@@ -66,25 +64,18 @@ class Chef
       # as the arguments to Tempfile.new() consistently.
       #
       def tempfile_basename
-        puts "FOO"
         basename = ::File.basename(@new_resource.path, tempfile_extension)
-        puts "BAR"
         # the leading "[.]chef-" here should be considered a public API and should not be changed
         basename.insert 0, "chef-"
-        puts "BAZ"
         basename.insert 0, "." unless Chef::Platform.windows? # dotfile if we're not on windows
-        puts "QUX"
         basename
       end
 
       # this is similar to File.extname() but greedy about the extension (from the first dot, not the last dot)
       def tempfile_extension
         # complexity here is due to supporting mangling non-UTF8 strings (e.g. latin-1 filenames with characters that are illegal in UTF-8)
-        puts "ONE"
         b = File.basename(@new_resource.path)
-        puts "TWO"
         i = b.index(".")
-        puts "THREE"
         i.nil? ? "" : b[i..-1]
       end
 

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -81,7 +81,7 @@ class Chef
       end
 
       def special_docker_files?(file)
-        %w{/etc/hosts /etc/hostname /etc/resolv.conf}.include?(Pathname(file).cleanpath.to_path)
+        %w{/etc/hosts /etc/hostname /etc/resolv.conf}.include?(Pathname(file.scrub).cleanpath.to_path)
       end
     end
   end


### PR DESCRIPTION
it looks like we broke this awhile back with the docker specific check in the file provider (but only broke it in docker containers)

and the tempfile fix that went into master just broke this as well for everyone, but that version was never released.

adds a test (which conveniently runs in a docker container) so that hopefully we don't regress again.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>