### PR TITLE
Alias older :makecache rather than new :make_cache only.

### DIFF
--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -24,6 +24,7 @@ yum_repository "epel" do
   gpgcheck true
   mirrorlist "https://mirrors.fedoraproject.org/metalink?repo=epel-#{node['platform_version'].to_i}&arch=$basearch"
   only_if { node["platform_family"] == "rhel" }
+  action [ :add, :makecache ]
 end
 
 include_recipe "build-essential"

--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -109,6 +109,7 @@ class Chef
 
       alias_method :action_add, :action_create
       alias_method :action_remove, :action_delete
+      alias_method :action_make_cache, :action_makecache
 
       def template_available?(path)
         !path.nil? && run_context.has_template_in_cookbook?(new_resource.cookbook_name, path)

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -69,7 +69,7 @@ class Chef
       property :options, Hash
 
       default_action :create
-      allowed_actions :create, :remove, :make_cache, :add, :delete
+      allowed_actions :create, :remove, :make_cache, :add, :delete, :makecache
 
       # provide compatibility with the yum cookbook < 3.0 properties
       alias_method :url, :baseurl


### PR DESCRIPTION
## Problem
The recent port of the yum_repository resource into chef 12.14.60 has caused issues with the make cache action on a repo. yum@4.0.0 [appears to use](https://github.com/chef-cookbooks/yum/blob/master/resources/repository.rb#L21) `:makecache` as the action, however the new port is using `:make_cache`. This appears to be breaking cookbooks that utilize the older resource from the yum Cookbook when the newer core cookbook takes precedence.

## Solution
This adds in `:makecache` as an alias to the `:make_cache` action in the new chef core resource.