### PR TITLE
Fix makecache action name in yum_repository

### DIFF
--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -69,7 +69,7 @@ class Chef
       property :options, Hash
 
       default_action :create
-      allowed_actions :create, :remove, :make_cache, :add, :delete
+      allowed_actions :create, :remove, :makecache, :add, :delete
 
       # provide compatibility with the yum cookbook < 3.0 properties
       alias_method :url, :baseurl


### PR DESCRIPTION
Our allowed action in the resource doesn't match the action name in the provider. 

makecache is the correct action not make_cache:

https://github.com/chef-cookbooks/yum/blob/master/providers/repository.rb#L100

Signed-off-by: Tim Smith tsmith@chef.io