### PR TITLE
Updated location for latest release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 *This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team.
-Please see `https://docs.chef.io/release/<major>-<minor>/release_notes.html` for the official Chef release notes.*
+Please see [https://docs.chef.io/release_notes.html](https://docs.chef.io/release_notes.html) for the official Chef release notes.*
 
 # Chef Client Release Notes 12.14:
 


### PR DESCRIPTION
Release notes are now aggregated for all minor releases, so changing the docs.chef.io location to reflect that change.