### PR TITLE
Chef 12 Attribute Regression

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -452,9 +452,7 @@ class Chef
        #
 
       def merged_attributes(*path)
-        # immutablize(
-        merge_all(path)
-        # )
+        immutablize(merge_all(path))
       end
 
       def combined_override(*path)

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -73,6 +73,7 @@ class Chef
       def initialize(root, data)
         @root = root
         super(data)
+        map! { |e| convert_value(e) }
       end
 
       # For elements like Fixnums, true, nil...
@@ -84,6 +85,23 @@ class Chef
 
       def dup
         Array.new(map { |e| safe_dup(e) })
+      end
+
+      private
+
+      def convert_value(value)
+        case value
+        when VividMash
+          value
+        when AttrArray
+          value
+        when Hash
+          VividMash.new(root, value)
+        when Array
+          AttrArray.new(root, value)
+        else
+          value
+        end
       end
 
     end
@@ -184,10 +202,12 @@ class Chef
         case value
         when VividMash
           value
+        when AttrArray
+          value
         when Hash
           VividMash.new(root, value)
         when Array
-          AttrArray.new(root, value.map { |e| convert_value(e) })
+          AttrArray.new(root, value)
         else
           value
         end

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -187,7 +187,7 @@ class Chef
         when Hash
           VividMash.new(root, value)
         when Array
-          AttrArray.new(root, value)
+          AttrArray.new(root, value.map { |e| convert_value(e) })
         else
           value
         end

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1171,7 +1171,29 @@ describe Chef::Node::Attribute do
       Chef::Config[:treat_deprecation_warnings_as_errors] = false
       expect { @attributes.new_key = "new value" }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
     end
-
   end
 
+  describe "deeply converting values" do
+    it "converts values through an array" do
+      @attributes.default[:foo] = [ { bar: true } ]
+      expect(@attributes["foo"].class).to eql(Chef::Node::ImmutableArray)
+      expect(@attributes["foo"][0].class).to eql(Chef::Node::ImmutableMash)
+      expect(@attributes["foo"][0]["bar"]).to be true
+    end
+
+    it "converts values through nested arrays" do
+      @attributes.default[:foo] = [ [ { bar: true } ] ]
+      expect(@attributes["foo"].class).to eql(Chef::Node::ImmutableArray)
+      expect(@attributes["foo"][0].class).to eql(Chef::Node::ImmutableArray)
+      expect(@attributes["foo"][0][0].class).to eql(Chef::Node::ImmutableMash)
+      expect(@attributes["foo"][0][0]["bar"]).to be true
+    end
+
+    it "converts values through nested hashes" do
+      @attributes.default[:foo] = { baz: { bar: true } }
+      expect(@attributes["foo"].class).to eql(Chef::Node::ImmutableMash)
+      expect(@attributes["foo"]["baz"].class).to eql(Chef::Node::ImmutableMash)
+      expect(@attributes["foo"]["baz"]["bar"]).to be true
+    end
+  end
 end

--- a/spec/unit/node/vivid_mash_spec.rb
+++ b/spec/unit/node/vivid_mash_spec.rb
@@ -37,6 +37,33 @@ describe Chef::Node::VividMash do
     expect(root).to receive(:top_level_breadcrumb=).with(key).at_least(:once).and_call_original
   end
 
+  context "#[]=" do
+    it "deep converts values through arrays" do
+      allow(root).to receive(:reset_cache)
+      vivid[:foo] = [ { :bar => true } ]
+      expect(vivid["foo"].class).to eql(Chef::Node::AttrArray)
+      expect(vivid["foo"][0].class).to eql(Chef::Node::VividMash)
+      expect(vivid["foo"][0]["bar"]).to be true
+    end
+
+    it "deep converts values through nested arrays" do
+      allow(root).to receive(:reset_cache)
+      vivid[:foo] = [ [ { :bar => true } ] ]
+      expect(vivid["foo"].class).to eql(Chef::Node::AttrArray)
+      expect(vivid["foo"][0].class).to eql(Chef::Node::AttrArray)
+      expect(vivid["foo"][0][0].class).to eql(Chef::Node::VividMash)
+      expect(vivid["foo"][0][0]["bar"]).to be true
+    end
+
+    it "deep converts values through hashes" do
+      allow(root).to receive(:reset_cache)
+      vivid[:foo] = { baz: { :bar => true } }
+      expect(vivid["foo"]).to be_an_instance_of(Chef::Node::VividMash)
+      expect(vivid["foo"]["baz"]).to be_an_instance_of(Chef::Node::VividMash)
+      expect(vivid["foo"]["baz"]["bar"]).to be true
+    end
+  end
+
   context "#read" do
     before do
       # vivify the vividmash, then we're read-only so the cache should never be cleared afterwards

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -784,6 +784,50 @@ describe Chef::Node do
         expect(node["passenger"]["root_path_2"]).to eql("passenger-4.0.57")
         expect(node[:passenger]["root_path_2"]).to eql("passenger-4.0.57")
       end
+
+      it "should deep merge array attributes defined as literals" do
+        node.default["attr_literal_hash"] = { "key" => { "inner" => "value" } }
+        expect(node[:attr_literal_hash][:key]).not_to be_nil
+        expect(node[:attr_literal_hash][:key]).to be_a_kind_of(Mash)
+        expect(node[:attr_literal_hash]["key"]).not_to be_nil
+        expect(node["attr_literal_hash"]["key"]).not_to be_nil
+        expect(node["attr_literal_hash"][:key]).not_to be_nil
+        expect(node[:attr_literal_hash][:key][:inner]).to eql("value")
+        expect(node[:attr_literal_hash]["key"][:inner]).to eql("value")
+        expect(node[:attr_literal_hash]["key"]["inner"]).to eql("value")
+        expect(node[:attr_literal_hash][:key]["inner"]).to eql("value")
+        expect(node["attr_literal_hash"][:key][:inner]).to eql("value")
+        expect(node["attr_literal_hash"]["key"][:inner]).to eql("value")
+        expect(node["attr_literal_hash"]["key"]["inner"]).to eql("value")
+        expect(node["attr_literal_hash"][:key]["inner"]).to eql("value")
+        expect(node["attr_literal_hash"][:key]["not_existing"]).to be_nil
+
+        node.default["attr_literal_array"] = [{ "key" => { "inner" => "value" } }]
+        expect(node[:attr_literal_array]).to be_a_kind_of(Array)
+        expect(node[:attr_literal_array].first[:key]).not_to be_nil
+        expect(node[:attr_literal_array].first["key"]).not_to be_nil
+        expect(node["attr_literal_array"].first["key"]).not_to be_nil
+        expect(node["attr_literal_array"].first[:key]).not_to be_nil
+        expect(node[:attr_literal_array].first[:key][:inner]).to eql("value")
+        expect(node[:attr_literal_array].first["key"][:inner]).to eql("value")
+        expect(node[:attr_literal_array].first["key"]["inner"]).to eql("value")
+        expect(node[:attr_literal_array].first[:key]["inner"]).to eql("value")
+        expect(node["attr_literal_array"].first[:key][:inner]).to eql("value")
+        expect(node["attr_literal_array"].first["key"][:inner]).to eql("value")
+        expect(node["attr_literal_array"].first["key"]["inner"]).to eql("value")
+        expect(node["attr_literal_array"].first[:key]["inner"]).to eql("value")
+        expect(node["attr_literal_array"].first[:key]["not_existing"]).to be_nil
+
+        node.default["nested_array_literal"] = [[ { "key" => "value" } ], [ { "key" => "value" } ]]
+        expect(node[:nested_array_literal]).to be_a_kind_of(Array)
+        expect(node[:nested_array_literal].first).to be_a_kind_of(Array)
+        expect(node[:nested_array_literal].last).to be_a_kind_of(Array)
+        expect(node[:nested_array_literal].first.first[:key]).not_to be_nil
+        expect(node[:nested_array_literal].first.first["key"]).to eql("value")
+        expect(node[:nested_array_literal].first.last[:key]).not_to be_nil
+        expect(node[:nested_array_literal].first.last["key"]).to eql("value")
+        expect(node[:nested_array_literal].first.last[:key]["not_existing"]).to be_nil
+      end
     end
 
     it "should raise an ArgumentError if you ask for an attribute that doesn't exist via method_missing" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -784,50 +784,6 @@ describe Chef::Node do
         expect(node["passenger"]["root_path_2"]).to eql("passenger-4.0.57")
         expect(node[:passenger]["root_path_2"]).to eql("passenger-4.0.57")
       end
-
-      it "should deep merge array attributes defined as literals" do
-        node.default["attr_literal_hash"] = { "key" => { "inner" => "value" } }
-        expect(node[:attr_literal_hash][:key]).not_to be_nil
-        expect(node[:attr_literal_hash][:key]).to be_a_kind_of(Mash)
-        expect(node[:attr_literal_hash]["key"]).not_to be_nil
-        expect(node["attr_literal_hash"]["key"]).not_to be_nil
-        expect(node["attr_literal_hash"][:key]).not_to be_nil
-        expect(node[:attr_literal_hash][:key][:inner]).to eql("value")
-        expect(node[:attr_literal_hash]["key"][:inner]).to eql("value")
-        expect(node[:attr_literal_hash]["key"]["inner"]).to eql("value")
-        expect(node[:attr_literal_hash][:key]["inner"]).to eql("value")
-        expect(node["attr_literal_hash"][:key][:inner]).to eql("value")
-        expect(node["attr_literal_hash"]["key"][:inner]).to eql("value")
-        expect(node["attr_literal_hash"]["key"]["inner"]).to eql("value")
-        expect(node["attr_literal_hash"][:key]["inner"]).to eql("value")
-        expect(node["attr_literal_hash"][:key]["not_existing"]).to be_nil
-
-        node.default["attr_literal_array"] = [{ "key" => { "inner" => "value" } }]
-        expect(node[:attr_literal_array]).to be_a_kind_of(Array)
-        expect(node[:attr_literal_array].first[:key]).not_to be_nil
-        expect(node[:attr_literal_array].first["key"]).not_to be_nil
-        expect(node["attr_literal_array"].first["key"]).not_to be_nil
-        expect(node["attr_literal_array"].first[:key]).not_to be_nil
-        expect(node[:attr_literal_array].first[:key][:inner]).to eql("value")
-        expect(node[:attr_literal_array].first["key"][:inner]).to eql("value")
-        expect(node[:attr_literal_array].first["key"]["inner"]).to eql("value")
-        expect(node[:attr_literal_array].first[:key]["inner"]).to eql("value")
-        expect(node["attr_literal_array"].first[:key][:inner]).to eql("value")
-        expect(node["attr_literal_array"].first["key"][:inner]).to eql("value")
-        expect(node["attr_literal_array"].first["key"]["inner"]).to eql("value")
-        expect(node["attr_literal_array"].first[:key]["inner"]).to eql("value")
-        expect(node["attr_literal_array"].first[:key]["not_existing"]).to be_nil
-
-        node.default["nested_array_literal"] = [[ { "key" => "value" } ], [ { "key" => "value" } ]]
-        expect(node[:nested_array_literal]).to be_a_kind_of(Array)
-        expect(node[:nested_array_literal].first).to be_a_kind_of(Array)
-        expect(node[:nested_array_literal].last).to be_a_kind_of(Array)
-        expect(node[:nested_array_literal].first.first[:key]).not_to be_nil
-        expect(node[:nested_array_literal].first.first["key"]).to eql("value")
-        expect(node[:nested_array_literal].first.last[:key]).not_to be_nil
-        expect(node[:nested_array_literal].first.last["key"]).to eql("value")
-        expect(node[:nested_array_literal].first.last[:key]["not_existing"]).to be_nil
-      end
     end
 
     it "should raise an ArgumentError if you ask for an attribute that doesn't exist via method_missing" do


### PR DESCRIPTION
## Summary

Chef-12 changes the behaviour of how attributes that are defined as literal arrays are handled, such as they do not longer work as they did in Chef-11

given an attributed defined as an array of hashes

```
node['foo'] = [ {'key' => 'value'} ]
```

in Chef-11 accessing using symbols or strings works seamlessly, while in Chef-12 yields different results, i.e.

```
node['foo'].first['key'] == node['foo'].first[:key]  

```
returns `true` in Chef-11 and `false` in Chef 12, as in the latter `node['foo'].first[:key]` is `nil`

I created [a gist with a really basic cookbook](https://gist.github.com/gbagnoli/7fc007c3f67869faf8081f9f584268b4) that shows the problem -- `result_unpatched.txt` is the rendered template using code from master and `result_patched.txt` contains the same template rendered with the patched code from this PR

## To replicate

Simply add the spec from this PR to master and see it fail.
Add the same spec to `11-stable` branch and it passes :)

## Explanation

`VividMash`, unlike `Mash`, does not recursively convert values inside
arrays, just the array itself.
As such, hashes inside arrays are not converted to *Mash, introducing
a behaviour that differs from Chef 11

This PR fixes `VividMash` so arrays are recursively converted and the
behaviour restored, plus it `immutablize` `merge_all` return value, so to be sure that hashes contained in Arrays are properly immutablized as well, ensuring that non-existing attributes
are **not** automatically vivified (which would make them return an empty `VividMash`
instead of `nil`)

This problem was first reported in chef/chef#2871.

Signed-off-by: Giacomo Bagnoli <gbagnoli@gmail.com>

closes #4368