### PR TITLE
fix chef-solo spec timeouts

### DIFF
--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -112,7 +112,7 @@ EOM
       file "cookbooks/x/recipes/default.rb", <<EOM
 ruby_block "sleeping" do
   block do
-    retries = 200000
+    retries = 200
     while IO.read(Chef::Config[:log_location]) !~ /Chef client .* is running, will wait for it to finish and then run./
       sleep 0.1
       raise "we ran out of retries" if ( retries -= 1 ) <= 0
@@ -138,17 +138,13 @@ EOM
           # Instantiate the first chef-solo run
           threads << Thread.new do
             s1 = Process.spawn("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default'  -l debug -L #{path_to('logs/runs.log')}", :chdir => chef_dir)
-            puts "before waitpid1"
             Process.waitpid(s1)
-            puts "after waitpid1"
           end
 
           # Instantiate the second chef-solo run
           threads << Thread.new do
             s2 = Process.spawn("#{chef_solo} -c \"#{path_to('config/solo.rb')}\" -o 'x::default'  -l debug -L #{path_to('logs/runs.log')}", :chdir => chef_dir)
-            puts "before waitpid2"
             Process.waitpid(s2)
-            puts "after waitpid2"
           end
 
           threads.each(&:join)


### PR DESCRIPTION
caused by a race condition (not actually fixed) where the pid
can be read by the process which lost the race to lock it before the
pid has been written by the process which got the lock.

the result is a message like:

"WARN: Chef client  is running, will wait for it to finish and then run."

without any numerical pid.

i'm not super concerned with fixing the race, this will unbreak a lot
of red travis failures though.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>