### PR TITLE
Revert --local filter for gems installed from  paths

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -536,7 +536,6 @@ class Chef
         def install_via_gem_command(name, version)
           if @new_resource.source =~ /\.gem$/i
             name = @new_resource.source
-            src = " --local" unless source_is_remote?
           elsif @new_resource.clear_sources
             src = " --clear-sources"
             src << (@new_resource.source && " --source=#{@new_resource.source}" || "")

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -735,10 +735,9 @@ describe Chef::Provider::Package::Rubygems do
         context "when source is a path" do
           let(:source) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
           let(:target_version) { ">= 0" }
-          let(:domain) { " --local" }
 
           it "installs the gem by shelling out to gem install" do
-            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{source} -q --no-rdoc --no-ri -v \"#{target_version}\"#{domain}", env: nil, timeout: 900)
+            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{source} -q --no-rdoc --no-ri -v \"#{target_version}\"", env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end
@@ -747,11 +746,10 @@ describe Chef::Provider::Package::Rubygems do
         context "when the package is a path and source is nil" do
           let(:gem_name) { CHEF_SPEC_DATA + "/gems/chef-integration-test-0.1.0.gem" }
           let(:target_version) { ">= 0" }
-          let(:domain) { " --local" }
 
           it "installs the gem from file by shelling out to gem install when the package is a path and the source is nil" do
             expect(new_resource.source).to eq(gem_name)
-            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{gem_name} -q --no-rdoc --no-ri -v \"#{target_version}\"#{domain}", env: nil, timeout: 900)
+            expect(provider).to receive(:shell_out!).with("#{gem_binary} install #{gem_name} -q --no-rdoc --no-ri -v \"#{target_version}\"", env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
           end


### PR DESCRIPTION
pr #5098 was intended tom revert #4847 however that revert left behind the addition of the `--local` argument when installing gems from a local path. So from what I can tell, the original bug reported in #4955 remains. If I try to install a gem locally that has remote dependencies, the converge fails.

This essentially completes the revert and allows remote dependencies to to be installed.