### PR TITLE
Add trailing newline to generated 15update-stamp

### DIFF
--- a/lib/chef/provider/apt_update.rb
+++ b/lib/chef/provider/apt_update.rb
@@ -73,7 +73,7 @@ class Chef
         end
 
         declare_resource(:file, "#{APT_CONF_DIR}/15update-stamp") do
-          content "APT::Update::Post-Invoke-Success {\"touch #{STAMP_DIR}/update-success-stamp 2>/dev/null || true\";};"
+          content "APT::Update::Post-Invoke-Success {\"touch #{STAMP_DIR}/update-success-stamp 2>/dev/null || true\";};\n"
           action :create_if_missing
         end
 


### PR DESCRIPTION
The `apt_update` resource generates a file at `/etc/apt/apt.conf.d/15update-stamp` that conflicts with the system-provided `update-notifier-common` package on Ubuntu. Because the file dropped by Chef differs from the system-provided file, `apt-get` requires user interaction to install `update-notifier-common`. This creates a problem if you're trying to install `update-notifier-common` via a Chef `package` resource... Adding a trailing newline makes the file identical to the one provided by `update-notifier-common`, and allows the package install to proceed without interaction.

A debatable shortcoming of my fix is that if someone installs `update-notifier-common` and then later removes it, `/etc/apt/apt.conf.d/15update-stamp` will be removed. However, within the `apt_update` update interval, the file will be re-created by Chef.