### PR TITLE
fix knife list_commands()

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -236,6 +236,20 @@ class Chef
     OFFICIAL_PLUGINS = %w{ec2 rackspace windows openstack terremark bluebox}
 
     class << self
+      def list_commands(preferred_category = nil)
+        category_desc = preferred_category ? preferred_category + " " : ""
+        msg "Available #{category_desc}subcommands: (for details, knife SUB-COMMAND --help)\n\n"
+        subcommand_loader.list_commands(preferred_category).sort.each do |category, commands|
+          next if category =~ /deprecated/i
+          msg "** #{category.upcase} COMMANDS **"
+          commands.sort.each do |command|
+            subcommand_loader.load_command(command)
+            msg subcommands[command].banner if subcommands[command]
+          end
+          msg
+        end
+      end
+
       private
 
       # @api private
@@ -267,21 +281,6 @@ class Chef
         end
 
         exit 10
-      end
-
-      # @api private
-      def list_commands(preferred_category = nil)
-        category_desc = preferred_category ? preferred_category + " " : ""
-        msg "Available #{category_desc}subcommands: (for details, knife SUB-COMMAND --help)\n\n"
-        subcommand_loader.list_commands(preferred_category).sort.each do |category, commands|
-          next if category =~ /deprecated/i
-          msg "** #{category.upcase} COMMANDS **"
-          commands.sort.each do |command|
-            subcommand_loader.load_command(command)
-            msg subcommands[command].banner if subcommands[command]
-          end
-          msg
-        end
       end
 
       # @api private


### PR DESCRIPTION
this was not supposed to be private

Fixes this:

```
/Users/lamont/.rvm/gems/ruby-2.3.1/gems/chef-12.14.77/lib/chef/application/knife.rb:212:in `print_help_and_exit': private method `list_commands' called for Chef::Knife:Class (NoMethodError)
Did you mean?  subcommands
	from /Users/lamont/.rvm/gems/ruby-2.3.1/gems/chef-12.14.77/lib/chef/application/knife.rb:176:in `validate_and_parse_options'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/gems/chef-12.14.77/lib/chef/application/knife.rb:154:in `run'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/gems/chef-12.14.77/bin/knife:25:in `<top (required)>'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/bin/knife:23:in `load'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/bin/knife:23:in `<main>'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
	from /Users/lamont/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'
```

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>