### PR TITLE
Newly creating uninstall string using the product code value retrieved from the uninstall_string of the Windows registry to avoid using invalid uninstall_string.

### DIFF
--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -79,9 +79,10 @@ class Chef
               uninstall_version = new_resource.version || installed_version
               uninstall_entries.select { |entry| [uninstall_version].flatten.include?(entry.display_version) }
                 .map { |version| version.uninstall_string }.uniq.each do |uninstall_string|
-                Chef::Log.debug("#{new_resource} removing MSI package version using '#{uninstall_string}'")
+                uninstall_string = "msiexec /x #{uninstall_string.match(/{.*}/)}"
                 uninstall_string += expand_options(new_resource.options)
-                uninstall_string += " /Q" unless uninstall_string =~ / \/Q\b/
+                uninstall_string += " /q" unless uninstall_string.downcase =~ / \/q/
+                Chef::Log.debug("#{new_resource} removing MSI package version using '#{uninstall_string}'")
                 shell_out!(uninstall_string, { :timeout => new_resource.timeout, :returns => new_resource.returns })
               end
             end

--- a/spec/unit/provider/package/windows/msi_spec.rb
+++ b/spec/unit/provider/package/windows/msi_spec.rb
@@ -121,7 +121,7 @@ describe Chef::Provider::Package::Windows::MSI do
       end
 
       it "removes installed package" do
-        expect(provider).to receive(:shell_out!).with(/MsiExec.exe \/X{guid} \/Q/, kind_of(Hash))
+        expect(provider).to receive(:shell_out!).with(/msiexec \/x {guid} \/q/, kind_of(Hash))
         provider.remove_package
       end
 
@@ -140,8 +140,8 @@ describe Chef::Provider::Package::Windows::MSI do
         end
 
         it "removes both installed package" do
-          expect(provider).to receive(:shell_out!).with(/MsiExec.exe \/X{guid} \/Q/, kind_of(Hash))
-          expect(provider).to receive(:shell_out!).with(/MsiExec.exe \/X{guid2} \/Q/, kind_of(Hash))
+          expect(provider).to receive(:shell_out!).with(/msiexec \/x {guid} \/q/, kind_of(Hash))
+          expect(provider).to receive(:shell_out!).with(/msiexec \/x {guid2} \/q/, kind_of(Hash))
           provider.remove_package
         end
       end
@@ -150,7 +150,16 @@ describe Chef::Provider::Package::Windows::MSI do
         before { new_resource.options("/Q") }
 
         it "does not duplicate quiet switch" do
-          expect(provider).to receive(:shell_out!).with(/MsiExec.exe \/X{guid} \/Q/, kind_of(Hash))
+          expect(provider).to receive(:shell_out!).with(/msiexec \/x {guid} \/Q/, kind_of(Hash))
+          provider.remove_package
+        end
+      end
+
+      context "custom options includes /qn" do
+        before { new_resource.options("/qn") }
+
+        it "does not duplicate quiet switch" do
+          expect(provider).to receive(:shell_out!).with(/msiexec \/x {guid} \/qn/, kind_of(Hash))
           provider.remove_package
         end
       end


### PR DESCRIPTION
w.r.t. https://github.com/chef/chef/issues/5274
In-progress.