### PR TITLE
Update to a 'newer' omnibus-software branch

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", github: "chef/omnibus", branch: "rhass/COOL-502_with_gcc_investigate"
-gem "omnibus-software", github: "chef/omnibus-software", branch: "lcg/ruby23"
+gem "omnibus-software", github: "chef/omnibus-software", branch: "shain/ruby_windows_monster"
 gem "license_scout", github: "chef/license_scout"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: 37e75fd9372a5c69280258ef9d6c00ac27625c1e
+  revision: 4fd26d99d0617d6336ae372f026c190617800e6b
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: f0f4bb4beab18a9b6adbc0a34bcd2f0caf10be5c
-  branch: lcg/ruby23
+  revision: 4ce91af05b8be7d46feac765d0fc24eb28e62c68
+  branch: shain/ruby_windows_monster
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -38,12 +38,12 @@ GEM
     addressable (2.4.0)
     artifactory (2.5.0)
     awesome_print (1.7.0)
-    aws-sdk (2.6.2)
-      aws-sdk-resources (= 2.6.2)
-    aws-sdk-core (2.6.2)
+    aws-sdk (2.6.3)
+      aws-sdk-resources (= 2.6.3)
+    aws-sdk-core (2.6.3)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.2)
-      aws-sdk-core (= 2.6.2)
+    aws-sdk-resources (2.6.3)
+      aws-sdk-core (= 2.6.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -83,7 +83,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.14.77)
+    chef-config (12.14.89)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -262,4 +262,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.1


### PR DESCRIPTION
This updates to a branch that was based on the lcg/ruby23 branch.

https://github.com/chef/omnibus-software/compare/lcg/ruby23...shain/ruby_windows_monster