### PR TITLE
Add the policyfile revision_id as an automatic attribute.

### DIFF
--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -173,6 +173,7 @@ class Chef
         CookbookCacheCleaner.instance.skip_removal = true if named_run_list_requested?
 
         node.run_list(run_list)
+        node.automatic_attrs[:policy_revision] = revision_id
         node.automatic_attrs[:roles] = []
         node.automatic_attrs[:recipes] = run_list_expansion_ish.recipes
         run_list_expansion_ish


### PR DESCRIPTION
/cc @coderanger @danielsdeleo

We have been looking for an easy way to get this value into our error
reporting application and it surprised me that it isn't already
captured. If there's a better way to do this totally open for thoughts!
