### PR TITLE
turn off fips unit-functional tests on windows acceptance

### DIFF
--- a/acceptance/fips/.kitchen.yml
+++ b/acceptance/fips/.kitchen.yml
@@ -1,6 +1,6 @@
 suites:
   - name: fips-unit-functional
-    includes: [centos-6, windows-2012r2]
+    includes: [centos-6]
     run_list:
 
   - name: fips-integration


### PR DESCRIPTION
This "turns off" the FIPS acceptance tests on windows that are breaking with the latest winrm bug fix. A bit of history here:

* Early this year we turned off the windows fips acceptance tests because they were failing and it was not obvioous why and we needed to get the pipeline green for the other 99.9% of users.
* Early July of this year we started using winrm v2 for acceptance tests. This had a bug that would swallow some exit codes.
* Mid July - turned acceptance/fips/windows tests back on and everything seemed fine
* Last week fixed winrmv2 bug and now the error in fips is surfacing

We do need to root cause fips but not hold everything else up.