### PR TITLE
Revert "Handling double quotes in powershell_out"

### DIFF
--- a/lib/chef/mixin/powershell_out.rb
+++ b/lib/chef/mixin/powershell_out.rb
@@ -34,14 +34,7 @@ class Chef
         script = command_args.first
         options = command_args.last.is_a?(Hash) ? command_args.last : nil
 
-        result = run_command_with_os_architecture(script, options)
-
-        if result.stderr.include? "A positional parameter cannot be found that accepts argument"
-          raise Mixlib::ShellOut::ShellCommandFailed, "Please use single escape for special characters in powershell_out. \n #{result.stderr}"
-        elsif result.stderr != ""
-          raise Mixlib::ShellOut::ShellCommandFailed, result.stderr
-        end
-        result
+        run_command_with_os_architecture(script, options)
       end
 
       # Run a command under powershell with the same API as shell_out!
@@ -98,8 +91,7 @@ class Chef
           "-InputFormat None",
         ]
 
-        # without gsub user has to add double escape for double quotes in the recipe
-        "powershell.exe #{flags.join(' ')} -Command \"#{script.gsub('"', '\"')}\""
+        "powershell.exe #{flags.join(' ')} -Command \"#{script}\""
       end
     end
   end

--- a/spec/functional/mixin/powershell_out_spec.rb
+++ b/spec/functional/mixin/powershell_out_spec.rb
@@ -25,6 +25,10 @@ describe Chef::Mixin::PowershellOut, windows_only: true do
     it "runs a powershell command and collects stdout" do
       expect(powershell_out("get-process").run_command.stdout).to match /Handles\s+NPM\(K\)\s+PM\(K\)\s+WS\(K\)\s+VM\(M\)\s+CPU\(s\)\s+Id\s+/
     end
+
+    it "does not raise exceptions when the command is invalid" do
+      powershell_out("this-is-not-a-valid-command").run_command
+    end
   end
 
   describe "#powershell_out!" do
@@ -33,7 +37,7 @@ describe Chef::Mixin::PowershellOut, windows_only: true do
     end
 
     it "raises exceptions when the command is invalid" do
-      expect { powershell_out!("this-is-not-a-valid-command").run_command }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
+      expect { powershell_out!("this-is-not-a-valid-command").run_command }.to raise_exception(Mixlib::ShellOut::ShellCommandFailed)
     end
   end
 end

--- a/spec/unit/mixin/powershell_out_spec.rb
+++ b/spec/unit/mixin/powershell_out_spec.rb
@@ -18,7 +18,7 @@
 require "spec_helper"
 require "chef/mixin/powershell_out"
 
-describe Chef::Mixin::PowershellOut, :windows_only do
+describe Chef::Mixin::PowershellOut do
   let(:shell_out_class) { Class.new { include Chef::Mixin::PowershellOut } }
   subject(:object) { shell_out_class.new }
   let(:architecture) { "something" }
@@ -28,24 +28,43 @@ describe Chef::Mixin::PowershellOut, :windows_only do
 
   describe "#powershell_out" do
     it "runs a command and returns the shell_out object" do
-      result = object.powershell_out("Get-Process")
-      expect(result.stderr).to be == ""
+      ret = double("Mixlib::ShellOut")
+      expect(object).to receive(:shell_out).with(
+        "powershell.exe #{flags} -Command \"Get-Process\"",
+        {}
+      ).and_return(ret)
+      expect(object.powershell_out("Get-Process")).to eql(ret)
     end
 
     it "passes options" do
-      result = object.powershell_out("Get-Process", timeout: 600)
-      expect(result.stderr).to be == ""
+      ret = double("Mixlib::ShellOut")
+      expect(object).to receive(:shell_out).with(
+        "powershell.exe #{flags} -Command \"Get-Process\"",
+        timeout: 600
+      ).and_return(ret)
+      expect(object.powershell_out("Get-Process", timeout: 600)).to eql(ret)
+    end
+  end
+
+  describe "#powershell_out!" do
+    it "runs a command and returns the shell_out object" do
+      mixlib_shellout = double("Mixlib::ShellOut")
+      expect(object).to receive(:shell_out).with(
+        "powershell.exe #{flags} -Command \"Get-Process\"",
+        {}
+      ).and_return(mixlib_shellout)
+      expect(mixlib_shellout).to receive(:error!)
+      expect(object.powershell_out!("Get-Process")).to eql(mixlib_shellout)
     end
 
-    context "when double quote is passed in the powershell command" do
-      it "passes if double quote is appended with single escape" do
-        result = object.powershell_out("Write-Verbose \"Some String\" -Verbose")
-        expect(result.stderr).to be == ""
-      end
-
-      it "raises error if double quote is passed with double escape characters" do
-        expect { object.powershell_out("Write-Verbose \\\"Some String\\\" -Verbose") }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
-      end
+    it "passes options" do
+      mixlib_shellout = double("Mixlib::ShellOut")
+      expect(object).to receive(:shell_out).with(
+        "powershell.exe #{flags} -Command \"Get-Process\"",
+        timeout: 600
+      ).and_return(mixlib_shellout)
+      expect(mixlib_shellout).to receive(:error!)
+      expect(object.powershell_out!("Get-Process", timeout: 600)).to eql(mixlib_shellout)
     end
   end
 end


### PR DESCRIPTION
Reverts chef/chef#5381

I had to revert this because its causing the chocolatey functional tests to fail on Jenkins 2008R2 testers. 

The above failure is partly the fault of something in the chocolatey tests which I will get to in a bit. The key problem with this PR is that it bubbles up exceptions from stderr in `powershell_out` but the bubbling of exceptions should only happen automatically from `powershell_out!`. Any error conditions are meant to be  suppressed in `powershell_out` so that the caller can examine them and act as it sees fit.

So it ends up that on 2008R2, the chocolatey installer fails and that failure causes `powershell_out` to raise an exception where it previously suppressed it. This was not a problem since chocolatey is already installed. We do need to investigate that problem separately. However we need to move the exception logic added by this PR to `powershell_out!`.