### PR TITLE
Fix manage_home provider inconsistency for Mac and FreeBSD User providers

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -210,6 +210,16 @@ class Chef
       def check_lock
         raise NotImplementedError
       end
+
+      def non_unique?
+        # XXX: THIS GOES AWAY IN CHEF-13 AND BECOMES JUST new_resource.non_unique
+        new_resource.non_unique || new_resource.supports[:non_unique]
+      end
+
+      def managing_home_dir?
+        # XXX: THIS GOES AWAY IN CHEF-13 AND BECOMES JUST new_resource.manage_home
+        new_resource.manage_home || new_resource.supports[:manage_home]
+      end
     end
   end
 end

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -292,7 +292,7 @@ user password using shadow hash.")
             return
           end
 
-          if new_resource.supports[:manage_home]
+          if managing_home_dir?
             validate_home_dir_specification!
 
             if (current_resource.home == new_resource.home) && !new_home_exists?
@@ -438,7 +438,7 @@ user password using shadow hash.")
         # and deleting home directory if needed.
         #
         def remove_user
-          if new_resource.supports[:manage_home]
+          if managing_home_dir?
             # Remove home directory
             FileUtils.rm_rf(current_resource.home)
           end

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -52,14 +52,14 @@ class Chef
           opts << "-s" << new_resource.shell if should_set?(:shell)
           opts << "-u" << new_resource.uid if should_set?(:uid)
           opts << "-d" << new_resource.home if updating_home?
-          opts << "-o" if non_unique
+          opts << "-o" if non_unique?
           opts
         end
 
         def usermod_options
           opts = []
           if updating_home?
-            if manage_home
+            if managing_home_dir?
               opts << "-m"
             end
           end
@@ -69,7 +69,7 @@ class Chef
         def useradd_options
           opts = []
           opts << "-r" if new_resource.system
-          if manage_home
+          if managing_home_dir?
             opts << "-m"
           else
             opts << "-M"
@@ -79,7 +79,7 @@ class Chef
 
         def userdel_options
           opts = []
-          opts << "-r" if manage_home
+          opts << "-r" if managing_home_dir?
           opts << "-f" if new_resource.force
           opts
         end
@@ -121,16 +121,6 @@ class Chef
 
           # FIXME: should probably go on the current_resource
           @locked
-        end
-
-        def non_unique
-          # XXX: THIS GOES AWAY IN CHEF-13 AND BECOMES JUST new_resource.non_unique
-          new_resource.non_unique || new_resource.supports[:non_unique]
-        end
-
-        def manage_home
-          # XXX: THIS GOES AWAY IN CHEF-13 AND BECOMES JUST new_resource.manage_home
-          new_resource.manage_home || new_resource.supports[:manage_home]
         end
       end
     end

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -46,7 +46,7 @@ class Chef
 
         def remove_user
           command = "pw userdel #{@new_resource.username}"
-          command << " -r" if @new_resource.supports[:manage_home]
+          command << " -r" if managing_home_dir?
           run_command(:command => command)
         end
 
@@ -87,7 +87,7 @@ class Chef
               end
             end
           end
-          if @new_resource.supports[:manage_home]
+          if managing_home_dir?
             Chef::Log.debug("#{@new_resource} is managing the users home directory")
             opts << " -m"
           end

--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -124,7 +124,7 @@ class Chef
                   Chef::Log.debug("#{new_resource} setting home to #{new_resource.home}")
                 end
               end
-              opts << "-o" if new_resource.non_unique
+              opts << "-o" if non_unique?
               opts
             end
         end
@@ -152,10 +152,6 @@ class Chef
           # ::File.expand_path("\\tmp") => "C:/tmp"
           return true if @current_resource.home.nil? && new_resource.home
           new_resource.home && Pathname.new(@current_resource.home).cleanpath != Pathname.new(new_resource.home).cleanpath
-        end
-
-        def managing_home_dir?
-          new_resource.manage_home || new_resource.supports[:manage_home]
         end
 
       end


### PR DESCRIPTION
on freebsd and mac we're now telling people to use `manage_home` instead
of `supports[:manage_home]` but it doesn't actually work.  fixes that so
that it works now.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>