### PR TITLE
Mac: Ensure that launchd limit_load_to_session_type is properly handled

### DIFF
--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -73,7 +73,7 @@ class Chef
       property :ld_group, String
       property :limit_load_from_hosts, Array
       property :limit_load_to_hosts, Array
-      property :limit_load_to_session_type, String
+      property :limit_load_to_session_type, Array
       property :low_priority_io, [ TrueClass, FalseClass ]
       property :mach_services, Hash
       property :nice, Integer


### PR DESCRIPTION
The key `LimitLoadToSessionType` is actually an array and not a string. This causes chef to fail or create an incorrect launchd.
