### PR TITLE
Adding support for rfc 62 exit code 213

### DIFF
--- a/lib/chef/application/exit_code.rb
+++ b/lib/chef/application/exit_code.rb
@@ -35,6 +35,7 @@ class Chef
         REBOOT_NEEDED: 37,
         REBOOT_FAILED: 41,
         AUDIT_MODE_FAILURE: 42,
+        CLIENT_UPGRADED: 213,
       }
 
       DEPRECATED_RFC_062_EXIT_CODES = {
@@ -127,6 +128,8 @@ class Chef
             VALID_RFC_062_EXIT_CODES[:REBOOT_FAILED]
           elsif audit_failure?(exception)
             VALID_RFC_062_EXIT_CODES[:AUDIT_MODE_FAILURE]
+          elsif client_upgraded?(exception)
+            VALID_RFC_062_EXIT_CODES[:CLIENT_UPGRADED]
           else
             VALID_RFC_062_EXIT_CODES[:GENERIC_FAILURE]
           end
@@ -159,6 +162,12 @@ class Chef
         def audit_failure?(exception)
           resolve_exception_array(exception).any? do |e|
             e.is_a? Chef::Exceptions::AuditError
+          end
+        end
+
+        def client_upgraded?(exception)
+          resolve_exception_array(exception).any? do |e|
+            e.is_a? Chef::Exceptions::ClientUpgraded
           end
         end
 

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -79,6 +79,7 @@ class Chef
     class Reboot < Exception; end
     class RebootPending < Exception; end
     class RebootFailed < Mixlib::ShellOut::ShellCommandFailed; end
+    class ClientUpgraded < Exception; end
     class PrivateKeyMissing < RuntimeError; end
     class CannotWritePrivateKey < RuntimeError; end
     class RoleNotFound < RuntimeError; end

--- a/spec/unit/application/exit_code_spec.rb
+++ b/spec/unit/application/exit_code_spec.rb
@@ -64,6 +64,10 @@ describe Chef::Application::ExitCode do
     it "validates a REBOOT_FAILED return code of 41" do
       expect(valid_rfc_exit_codes.include?(41)).to eq(true)
     end
+
+    it "validates a CLIENT_UPGRADED return code of 213" do
+      expect(valid_rfc_exit_codes.include?(213)).to eq(true)
+    end
   end
 
   context "when Chef::Config :exit_status is not configured" do
@@ -213,6 +217,12 @@ describe Chef::Application::ExitCode do
       reboot_error = Chef::Exceptions::RebootPending.new("BOOM")
       runtime_error = Chef::Exceptions::RunFailedWrappingError.new(reboot_error)
       expect(exit_codes.normalize_exit_code(runtime_error)).to eq(37)
+    end
+
+    it "returns CLIENT_UPGRADED when the client was upgraded during converge" do
+      client_upgraded_error = Chef::Exceptions::ClientUpgraded.new("BOOM")
+      runtime_error = Chef::Exceptions::RunFailedWrappingError.new(client_upgraded_error)
+      expect(exit_codes.normalize_exit_code(runtime_error)).to eq(213)
     end
 
     it "returns SIGINT_RECEIVED when a SIGINT is received." do


### PR DESCRIPTION
This adds support for the RFC062 exit code 213 "Chef has exited during a client upgrade"
One example implementation of a Chef Client upgrade is here: https://github.com/chef-cookbooks/omnibus_updater/pull/130