### PR TITLE
chef-rewind:  remove from integration gems (it was not in the testing matrix) as it is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ end
 group(:integration) do
   gem "chef-provisioning"
   gem "chef-provisioning-aws"
-  gem "chef-rewind"
   gem "chef-sugar"
   gem "chefspec"
   gem "halite"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,6 @@ GEM
       chef-provisioning (~> 2.0)
       retryable (~> 2.0, >= 2.0.1)
       ubuntu_ami (~> 0.4, >= 0.4.1)
-    chef-rewind (0.0.9)
     chef-sugar (3.4.0)
     chef-zero (5.1.0)
       ffi-yajl (~> 2.2)
@@ -575,7 +574,6 @@ DEPENDENCIES
   chef-config!
   chef-provisioning
   chef-provisioning-aws
-  chef-rewind
   chef-sugar
   cheffish
   chefspec


### PR DESCRIPTION
and its now officially deprecated in its README:

https://github.com/thommay/chef-rewind

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>