### PR TITLE
Core: add delayed_action to the Chef::Resource API

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -181,6 +181,31 @@ class Chef
     alias_method :action=, :action
 
     #
+    # Force a delayed notification into this resource's run_context.
+    #
+    # This should most likely be paired with action :nothing
+    #
+    # @param arg [Array[Symbol], Symbol] A list of actions (e.g. `:create`)
+    # @return [Array[Symbol]] the list of actions.
+    #
+    def delayed_action(arg = nil)
+      if arg
+        arg = Array(arg).map(&:to_sym)
+        arg.each do |action|
+          validate(
+            { action: action },
+            { action: { kind_of: Symbol, equal_to: allowed_actions } }
+          )
+          # the resource effectively sends a delayed notification to itself
+          run_context.add_delayed_action(Notification.new(self, action, self))
+        end
+        @delayed_action = arg
+      else
+        @delayed_action
+      end
+    end
+
+    #
     # Sets up a notification that will run a particular action on another resource
     # if and when *this* resource is updated by an action.
     #

--- a/spec/integration/recipes/accumulator_spec.rb
+++ b/spec/integration/recipes/accumulator_spec.rb
@@ -46,10 +46,8 @@ describe "Accumulators" do
                 variables[:aliases][new_resource.address] ||= []
                 variables[:aliases][new_resource.address] += new_resource.recipients
                 action :nothing
+                delayed_action :create
               end
-            end
-            log "force delayed notification" do
-              notifies :create, "template[#{aliases_temppath}]", :delayed
             end
           end
         EOM
@@ -148,13 +146,11 @@ describe "Accumulators" do
                 source "aliases.erb"
                 variables[:aliases] = {}
                 action :nothing
+                delayed_action :create
               end
             end
             r.variables[:aliases][address] ||= []
             r.variables[:aliases][address] += new_resource.recipients
-            log "force delayed notification" do
-              notifies :create, "template[#{aliases_temppath}]", :delayed
-            end
           end
         EOM
 


### PR DESCRIPTION

effectively creates a resource which sends itself a delayed notification

useful to create a resource which runs exactly once at the end of a run:

```ruby
with_run_context :root do
  find_resource(:execute, "/bin/true") do
    action :nothing
    delayed_action :run
  end
end
```

avoids using a log resource to force a resource to update and force a
delayed notification which avoids the extra output from the log
resource, and avoids the resource updated count always being updated.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>