### PR TITLE
require the event_dispatch dsl since it's used in chef_class

### DIFF
--- a/lib/chef/chef_class.rb
+++ b/lib/chef/chef_class.rb
@@ -30,6 +30,7 @@ require "chef/platform/provider_priority_map"
 require "chef/platform/resource_priority_map"
 require "chef/platform/provider_handler_map"
 require "chef/platform/resource_handler_map"
+require "chef/event_dispatch/dsl"
 
 class Chef
   class << self


### PR DESCRIPTION
### Description

According to the documentation at https://docs.chef.io/dsl_handler.html you can use `Chef.event_handler` in a recipe. However, when you do so and run chefspec you get the following error:
```
Failure/Error: expect { chef_run }.not_to raise_error

       expected no Exception, got #<NameError: uninitialized constant Chef::EventDispatch::DSL
       Did you mean?  Chef::DSL> with backtrace:
         # /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.14.89/lib/chef/chef_class.rb:59:in `event_handler'
```
We worked around the problem by requiring 'chef/event_dispatch/dsl' in our spec file but I believe the true fix is to require the class where it is being used. With this fix in place we can remove our workaround.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Documentation, especially RELEASE\_NOTES.md, has been updated if
  required
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Thiago Oliveira <thiagoo@yahoo-inc.com>