### PR TITLE
User Provider:  Fix home folder comparison

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -113,15 +113,13 @@ class Chef
       # <true>:: If a change is required
       # <false>:: If the users are identical
       def compare_user
-        changed = [ :comment, :home, :shell, :password ].select do |user_attrib|
-          !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib) != @current_resource.send(user_attrib)
+        return true if !@new_resource.home.nil? && Pathname.new(@new_resource.home).cleanpath != Pathname.new(@current_resource.home).cleanpath
+
+        [ :comment, :shell, :password, :uid, :gid ].each do |user_attrib|
+          return true if !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib).to_s != @current_resource.send(user_attrib).to_s
         end
 
-        changed += [ :uid, :gid ].select do |user_attrib|
-          !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib).to_s != @current_resource.send(user_attrib).to_s
-        end
-
-        changed.any?
+        false
       end
 
       def action_create

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -221,6 +221,12 @@ describe Chef::Provider::User do
     it "should return false if the objects are identical" do
       expect(@provider.compare_user).to eql(false)
     end
+
+    it "should ignore differences in trailing slash in home paths" do
+      @new_resource.home "/home/adam"
+      @current_resource.home "/home/adam/"
+      expect(@provider.compare_user).to eql(false)
+    end
   end
 
   describe "action_create" do


### PR DESCRIPTION
### Description

This fixes the `Chef::Provider::User#compare_user` method for comparing the home folder by ignoring trailing slashes.

### Issues Resolved

 Fixes #5444 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Documentation, especially RELEASE\_NOTES.md, has been updated if
  required
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>