### PR TITLE
update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,5 @@ StackOverflow discussion that's relevant]
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
-- [ ] Documentation, especially RELEASE\_NOTES.md, has been updated if
-  required
+- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
 - [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>


### PR DESCRIPTION
users don't understand what we mean by "all documentation", so
clarify that what we mean to be RELEASE_NOTES.md and that's it, they
need to stay away from CHANGELOG.md

i believe we've dropped DOC_CHANGES.md in favor of RELEASE_NOTES.md

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>