### PR TITLE
Rebuild HTTP headers on each retried request

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -329,10 +329,9 @@ class Chef
     # Runs a synchronous HTTP request, with no middleware applied (use #request
     # to have the middleware applied). The entire response will be loaded into memory.
     # @api private
-    def send_http_request(method, url, headers, body, &response_handler)
-      headers = build_headers(method, url, headers, body)
-
+    def send_http_request(method, url, base_headers, body, &response_handler)
       retrying_http_errors(url) do
+        headers = build_headers(method, url, base_headers, body)
         client = http_client(url)
         return_value = nil
         if block_given?


### PR DESCRIPTION
### Description

Depending on how you configure your Chef client, it's possible that a
later retry would have an authentication timestamp header
(`X-OPS-TIMESTAMP`) that was more than 900 seconds old. Since the Chef
server treats timestamps older than this threshold as unauthorized
requests, you would potentially get seemingly spurious "401
Unauthorized" responses from the server.

A solution is to generate the headers on each retry so that we have a
new authentication timestamp for each retried request.

I'm not sure if this change of behavior requires additional thought. Hoping someone with more context can weigh in here.

### Issues Resolved

- [Intermittent "401 Unauthorized" failures from Chef server using Chef client](https://github.com/chef/chef-server/issues/968)

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>