### PR TITLE
remove dependency on Chef.run_context global state

### DIFF
--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -47,7 +47,7 @@ class Chef
           when Chef::RunContext
             rc
           when :root
-            Chef.run_context
+            run_context.root_run_context
           when :parent
             run_context.parent_run_context
           else

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -91,9 +91,7 @@ class Chef
     #
     def root_run_context
       rc = self
-      until rc.parent_run_context.nil?
-        rc = rc.parent_run_context
-      end
+      rc = rc.parent_run_context until rc.parent_run_context.nil?
       rc
     end
 

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -85,6 +85,19 @@ class Chef
     attr_reader :parent_run_context
 
     #
+    # The root run context.
+    #
+    # @return [Chef::RunContext] The root run context.
+    #
+    def root_run_context
+      rc = self
+      until rc.parent_run_context.nil?
+        rc = rc.parent_run_context
+      end
+      rc
+    end
+
+    #
     # The collection of resources intended to be converged (and able to be
     # notified).
     #

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -666,6 +666,7 @@ ERROR_MESSAGE
         notifies_immediately
         notifies_delayed
         parent_run_context
+        root_run_context
         resource_collection
         resource_collection=
       }.map { |x| x.to_sym }


### PR DESCRIPTION
introduce run_context.root_run_context that avoids global state

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>