### PR TITLE
Cron Provider: Eliminate crontab rewrite that happens with every chef-client run

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -199,7 +199,7 @@ class Chef
 
       def set_environment_var(attr_name, attr_value)
         if %w{MAILTO PATH SHELL HOME}.include?(attr_name)
-          @current_resource.send(attr_name.downcase.to_sym, attr_value.gsub(/^"|"$/, ''))
+          @current_resource.send(attr_name.downcase.to_sym, attr_value.gsub(/^"|"$/, ""))
         else
           @current_resource.environment(@current_resource.environment.merge(attr_name => attr_value))
         end

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -199,7 +199,7 @@ class Chef
 
       def set_environment_var(attr_name, attr_value)
         if %w{MAILTO PATH SHELL HOME}.include?(attr_name)
-          @current_resource.send(attr_name.downcase.to_sym, attr_value)
+          @current_resource.send(attr_name.downcase.to_sym, attr_value.gsub(/^"|"$/, ''))
         else
           @current_resource.environment(@current_resource.environment.merge(attr_name => attr_value))
         end


### PR DESCRIPTION
### Description

#5127, which I admittedly advocated for via #4900, implemented the ability to set certain environment variables (`MAILTO`, `PATH`, `SHELL`, `HOME`) to an empty string. A side effect of that fix is that if a `cron` resource uses one of those variables (empty or not), the crontab file gets rewritten with every chef-client run. This is because the desired state of the resource uses unquoted strings for those variables, while the current state of the resource uses quoted strings.

This PR fixes the problem by stripping leading and trailing double quotes from those four variables when parsing the current crontab. There are definitely other ways this could be fixed (for example, by forcing all environment variables to be quoted) - I only chose this approach because it seems like the least intrusive way to do it.

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
