### PR TITLE
Implement `--config-option` CLI opt for knife

### DIFF
--- a/chef-config/lib/chef-config/exceptions.rb
+++ b/chef-config/lib/chef-config/exceptions.rb
@@ -22,5 +22,6 @@ module ChefConfig
 
   class ConfigurationError < ArgumentError; end
   class InvalidPath < StandardError; end
+  class UnparsableConfigOption < StandardError; end
 
 end


### PR DESCRIPTION
### Description

The `--config-option` CLI option allows setting any `Chef::Config`
setting on the command line, which allows applications to be used
without a configuration file even if a desired config option does not
have a corresponding CLI option. This CLI option was present in the help
output for knife but was not actually implemented. Moving the behavior
into chef-config allows us to use it for both `chef-client` and `knife`.

### Issues Resolved

Internal issue for a Chef Software customer.

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Daniel DeLeo <dan@chef.io>