### PR TITLE
convert svn_password to property + make sensitive

### DIFF
--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -89,7 +89,7 @@ class Chef
         )
       end
 
-      property :svn_password, String, sensitive: true
+      property :svn_password, String, sensitive: true, desired_state: false
 
       def svn_arguments(arg = nil)
         @svn_arguments, arg = nil, nil if arg == false

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -89,13 +89,7 @@ class Chef
         )
       end
 
-      def svn_password(arg = nil)
-        set_or_return(
-          :svn_password,
-          arg,
-          :kind_of => String
-        )
-      end
+      property :svn_password, String, sensitive: true
 
       def svn_arguments(arg = nil)
         @svn_arguments, arg = nil, nil if arg == false


### PR DESCRIPTION
should always suppress the password output by default since typically nobody wants to see that in their logs when we crash.