### PR TITLE
Use property vs. attribute in yum_repository

### DIFF
--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -57,7 +57,7 @@ class Chef
       property :password, String, regex: /.*/
       property :repo_gpgcheck, [TrueClass, FalseClass]
       property :report_instanceid, [TrueClass, FalseClass]
-      property :repositoryid, String, regex: /.*/, name_attribute: true
+      property :repositoryid, String, regex: /.*/, name_property: true
       property :sensitive, [TrueClass, FalseClass], default: false
       property :skip_if_unavailable, [TrueClass, FalseClass]
       property :source, String, regex: /.*/


### PR DESCRIPTION
We're using the legacy name instead of the new name here. The result is the same, but we should clean this up.