### PR TITLE
Fix a typo in the apt_repository spec

### DIFF
--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::AptRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptRepository.new("multiverse", run_context) }
 
-  it "should create a new Chef::Resource::AptUpdate" do
+  it "should create a new Chef::Resource::AptRepository" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::AptRepository)
   end


### PR DESCRIPTION
This was copied and the name of the resource we're testing wasn't updated.