### PR TITLE
Windows: search for config on same drive as executable location

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -67,7 +67,11 @@ module ChefConfig
     end
 
     def self.windows_installation_drive
-      File.expand_path(__FILE__).split('/', 2)[0] if ChefConfig.windows?
+      if ChefConfig.windows?
+        drive = File.expand_path(__FILE__).split('/', 2)[0]
+        drive = ENV["SYSTEMDRIVE"] if drive.to_s == ''
+        drive
+      end
     end
 
     def self.add_formatter(name, file_path = nil)

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -56,11 +56,18 @@ module ChefConfig
       path = PathHelper.cleanpath(path)
       if ChefConfig.windows?
         # turns \etc\chef\client.rb and \var\chef\client.rb into C:/chef/client.rb
-        if env["SYSTEMDRIVE"] && path[0] == '\\' && path.split('\\')[2] == "chef"
-          path = PathHelper.join(env["SYSTEMDRIVE"], path.split('\\', 3)[2])
+        # Some installations will be on different drives so use the drive that
+        # the expanded path to __FILE__ is found.
+        drive = windows_installation_drive
+        if drive && path[0] == '\\' && path.split('\\')[2] == "chef"
+          path = PathHelper.join(drive, path.split('\\', 3)[2])
         end
       end
       path
+    end
+
+    def self.windows_installation_drive
+      File.expand_path(__FILE__).split('/', 2)[0] if ChefConfig.windows?
     end
 
     def self.add_formatter(name, file_path = nil)

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -68,8 +68,8 @@ module ChefConfig
 
     def self.windows_installation_drive
       if ChefConfig.windows?
-        drive = File.expand_path(__FILE__).split('/', 2)[0]
-        drive = ENV["SYSTEMDRIVE"] if drive.to_s == ''
+        drive = File.expand_path(__FILE__).split("/", 2)[0]
+        drive = ENV["SYSTEMDRIVE"] if drive.to_s == ""
         drive
       end
     end

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ChefConfig::Config do
         end
         if is_windows
           path = "/etc/chef/cookbooks"
-          describe "a windows system with chef installed on C: drive" do
+          context "a windows system with chef installed on C: drive" do
             before do
               allow(ChefConfig::Config).to receive(:windows_installation_drive).and_return("C:")
             end
@@ -231,7 +231,7 @@ RSpec.describe ChefConfig::Config do
               expect(ChefConfig::Config.platform_specific_path(path)).to eq("C:\\chef\\cookbooks")
             end
           end
-          describe "a windows system with chef installed on D: drive" do
+          context "a windows system with chef installed on D: drive" do
             before do
               allow(ChefConfig::Config).to receive(:windows_installation_drive).and_return("D:")
             end
@@ -370,6 +370,11 @@ RSpec.describe ChefConfig::Config do
         end
 
         describe "ChefConfig::Config[:cache_path]" do
+          before do
+            if is_windows
+              allow(File).to receive(:expand_path).and_return("#{ChefConfig::Config.env["SYSTEMDRIVE"]}/Path/To/Executable")
+            end
+          end
           context "when /var/chef exists and is accessible" do
             it "defaults to /var/chef" do
               allow(ChefConfig::Config).to receive(:path_accessible?).with(to_platform("/var/chef")).and_return(true)

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -203,16 +203,41 @@ RSpec.describe ChefConfig::Config do
       before :each do
         allow(ChefConfig).to receive(:windows?).and_return(is_windows)
       end
-
-      describe "class method: platform_specific_path" do
+      describe "class method: windows_installation_drive" do
+        before do
+          allow(File).to receive(:expand_path).and_return("D:/Path/To/Executable")
+        end
         if is_windows
-          it "should return a windows path on windows systems" do
-            path = "/etc/chef/cookbooks"
-            allow(ChefConfig::Config).to receive(:env).and_return({ "SYSTEMDRIVE" => "C:" })
-            # match on a regex that looks for the base path with an optional
-            # system drive at the beginning (c:)
-            # system drive is not hardcoded b/c it can change and b/c it is not present on linux systems
-            expect(ChefConfig::Config.platform_specific_path(path)).to eq("C:\\chef\\cookbooks")
+          it "should return D: on a windows system" do
+            expect(ChefConfig::Config.windows_installation_drive).to eq("D:")
+          end
+        else
+          it "should return nil on a non-windows system" do
+            expect(ChefConfig::Config.windows_installation_drive).to eq(nil)
+          end
+        end
+      end
+      describe "class method: platform_specific_path" do
+        before do
+          allow(ChefConfig::Config).to receive(:env).and_return({ "SYSTEMDRIVE" => "C:" })
+        end
+        if is_windows
+          path = "/etc/chef/cookbooks"
+          describe "a windows system with chef installed on C: drive" do
+            before do
+              allow(ChefConfig::Config).to receive(:windows_installation_drive).and_return("C:")
+            end
+            it "should return a windows path rooted in C:" do
+              expect(ChefConfig::Config.platform_specific_path(path)).to eq("C:\\chef\\cookbooks")
+            end
+          end
+          describe "a windows system with chef installed on D: drive" do
+            before do
+              allow(ChefConfig::Config).to receive(:windows_installation_drive).and_return("D:")
+            end
+            it "should return a windows path rooted in D:" do
+              expect(ChefConfig::Config.platform_specific_path(path)).to eq("D:\\chef\\cookbooks")
+            end
           end
         else
           it "should return given path on non-windows systems" do


### PR DESCRIPTION
### Description

This change causes the platform_specific_path function to root its's path in the drive `__FILE__` is found in. This is arguably more accurate than $env:SystemDrive since in some security contexts a chef-client installation on a drive other than the OS is preferred. 

### Issues Resolved

fixes #5477
### Check List
- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco
