### PR TITLE
Attributes: add tests for regression in 12.0 fixed recently

### DIFF
--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -243,6 +243,34 @@ describe Chef::Node do
       expect { node.sunshine = "is bright" }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
     end
 
+    it "does not allow modification of node attributes via hash methods" do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+      node.default["h4sh"] = { foo: "bar" }
+      expect { node["h4sh"].delete("foo") }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
+      expect { node.h4sh.delete("foo") }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
+    end
+
+    it "does not allow modification of node attributes via array methods" do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+      node.default["array"] = []
+      expect { node["array"] << "boom" }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
+      expect { node.array << "boom" }.to raise_error(Chef::Exceptions::ImmutableAttributeModification)
+    end
+
+    it "returns merged immutable attributes for arrays" do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+      node.default["array"] = []
+      expect( node["array"].class ).to eql(Chef::Node::ImmutableArray)
+      expect( node.array.class ).to eql(Chef::Node::ImmutableArray)
+    end
+
+    it "returns merged immutable attributes for hashes" do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+      node.default["h4sh"] = {}
+      expect( node["h4sh"].class ).to eql(Chef::Node::ImmutableMash)
+      expect( node.h4sh.class ).to eql(Chef::Node::ImmutableMash)
+    end
+
     it "should allow you get get an attribute via method_missing" do
       Chef::Config[:treat_deprecation_warnings_as_errors] = false
       node.default.sunshine = "is bright"


### PR DESCRIPTION

Tests for the issue that led up to

https://github.com/chef/chef/issues/5447

The Hash tests actually pass against 12.13.37 so it appears that we
only broke the ImmutableArray objects in 12.0.  This both explains
why we didn't have any existing tests that caught it, and why it went
uncaught for so long.  It also adds some ammunition to the argument
that fixing this in 12.14.x was not a major breaking change to users
that had been relying on the buggy 12.0 behavior, since Hash behavior
has been correct all along.
