### PR TITLE
Use `all?` instead of `any?` to check for SUSE users

### DIFF
--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -41,7 +41,7 @@ class Chef
           requirements.assert(:create, :manage, :modify) do |a|
             a.assertion do
               begin
-                to_add(@new_resource.members).any? { |member| Etc.getpwnam(member) }
+                to_add(@new_resource.members).all? { |member| Etc.getpwnam(member) }
               rescue
                 false
               end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -425,6 +425,7 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" end
       end
 
       it "does not raise an error on manage" do
+        allow(Etc).to receive(:getpwnam).and_return(double("User"))
         expect { group_resource.run_action(:manage) }.not_to raise_error
       end
     end


### PR DESCRIPTION
### Description

Fixes suse spec test. Using `all?` will return `false` when the array is empty, thus causing the resource to raise an error incorrectly.

### Issues Resolved

COOL-597

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>