### PR TITLE
[BEN-123] Fix IPS package must create symlinks to package commands

### DIFF
--- a/omnibus/resources/chef/ips/symlinks.erb
+++ b/omnibus/resources/chef/ips/symlinks.erb
@@ -1,0 +1,6 @@
+link path=usr/bin/chef-solo target=<%= projectdir %>/bin/chef-solo
+link path=usr/bin/chef-client target=<%= projectdir %>/bin/chef-client
+link path=usr/bin/chef-apply target=<%= projectdir %>/bin/chef-apply
+link path=usr/bin/chef-shell target=<%= projectdir %>/bin/chef-shell
+link path=usr/bin/knife target=<%= projectdir %>/bin/knife
+link path=usr/bin/ohai target=<%= projectdir %>/bin/ohai


### PR DESCRIPTION
### Description

Create symlinks.erb template resource for chef IPS package so it will install the symbolic links for the commands. These are the links added by post install scripts for other package types. But since IPS does not use post install scripts they need to be added here.

Resolves: https://github.com/chef/chef/issues/5458 after successful merge for this PR and https://github.com/chef/omnibus/pull/728 
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]
### Check List
- [y] New functionality includes tests
- [y] All tests pass
- [ ] RELEASE_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco

Create symlinks.erb template to exists in local project directory structure
to enable IPS package to create required symlinks for installed commands

Signed-off-by: Jaymala Sinha jsinha@chef.io
