### PR TITLE
Properly check lock status of user on solaris2

### DIFF
--- a/lib/chef/provider/user/solaris.rb
+++ b/lib/chef/provider/user/solaris.rb
@@ -53,7 +53,7 @@ class Chef
 
           raise Chef::Exceptions::User, "Cannot determine if #{@new_resource} is locked!" if user.nil?
 
-          @locked = !!(user[1] =~ /^\*?LK\*?/)
+          @locked = user[1].start_with?("*LK*")
         end
 
         def lock_user

--- a/spec/unit/provider/user/solaris_spec.rb
+++ b/spec/unit/provider/user/solaris_spec.rb
@@ -123,11 +123,11 @@ describe Chef::Provider::User::Solaris do
 
       # locked shadow lines
       [
-        "adam:LK:::::::",
         "adam:*LK*:::::::",
         "adam:*LK*foobar:::::::",
         "adam:*LK*bahamas10:::::::",
         "adam:*LK*goonawaLK:::::::",
+        "adam:*LK*LKgir:::::::",
         "adam:*LK*L....:::::::",
       ].each do |shadow|
         context "for user 'adam' with entry '#{shadow}'" do
@@ -146,6 +146,7 @@ describe Chef::Provider::User::Solaris do
         "adam:foobar:::::::",
         "adam:bahamas10:::::::",
         "adam:goonawaLK:::::::",
+        "adam:LKgir:::::::",
         "adam:L...:::::::",
       ].each do |shadow|
         context "for user 'adam' with entry '#{shadow}'" do

--- a/spec/unit/provider/user/solaris_spec.rb
+++ b/spec/unit/provider/user/solaris_spec.rb
@@ -99,7 +99,27 @@ describe Chef::Provider::User::Solaris do
   end
 
   describe "when managing user locked status" do
+    let(:user_lock) { "adam:FOO:::::::" }
+    let(:shadow_file_contents) do
+      %W{
+        user1:LK:::::::
+        #{user_lock}
+        user2:NP:::::::
+      }
+    end
+
     describe "when determining if the user is locked" do
+      before do
+        allow(IO).to receive(:read).and_return(shadow_file_contents.join("\n"))
+      end
+
+      context "when user does not exist" do
+        let(:user_lock) { "other_user:FOO:::::::" }
+
+        it "should raise a sensible error" do
+          expect { provider.check_lock }.to raise_error(Chef::Exceptions::User)
+        end
+      end
 
       # locked shadow lines
       [
@@ -107,12 +127,15 @@ describe Chef::Provider::User::Solaris do
         "adam:*LK*:::::::",
         "adam:*LK*foobar:::::::",
         "adam:*LK*bahamas10:::::::",
+        "adam:*LK*goonawaLK:::::::",
         "adam:*LK*L....:::::::",
       ].each do |shadow|
-        it "should return true if user is locked with #{shadow}" do
-          shell_return = shellcmdresult.new(shadow + "\n", "", 0)
-          expect(provider).to receive(:shell_out!).with("getent", "shadow", "adam").and_return(shell_return)
-          expect(provider.check_lock).to eql(true)
+        context "for user 'adam' with entry '#{shadow}'" do
+          let(:user_lock) { shadow }
+
+          it "should return true" do
+            expect(provider.check_lock).to eql(true)
+          end
         end
       end
 
@@ -122,12 +145,15 @@ describe Chef::Provider::User::Solaris do
         "adam:*NP*:::::::",
         "adam:foobar:::::::",
         "adam:bahamas10:::::::",
+        "adam:goonawaLK:::::::",
         "adam:L...:::::::",
       ].each do |shadow|
-        it "should return false if user is unlocked with #{shadow}" do
-          shell_return = shellcmdresult.new(shadow + "\n", "", 0)
-          expect(provider).to receive(:shell_out!).with("getent", "shadow", "adam").and_return(shell_return)
-          expect(provider.check_lock).to eql(false)
+        context "for user 'adam' with entry '#{shadow}'" do
+          let(:user_lock) { shadow }
+
+          it "should return false" do
+            expect(provider.check_lock).to eql(false)
+          end
         end
       end
     end


### PR DESCRIPTION
### Description

On Solaris, the 'shadow' database does not exist within `getent`, so the
checking for the username there won't return accurate results. As the
Solaris provider assumes user management via /etc/shadow, we can very
easily parse the contents of the file directly

``` shell
tduffield@chef-solaris-11-i86pc:~$ getent shadow tduffield
Unknown database: shadow
usage: getent database [ key ... ]
```
### Issues Resolved
- Internal ticket COOL-413
### Check List
- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco
