### PR TITLE
Support knife attribute filters with dots

### DIFF
--- a/spec/unit/knife/core/ui_spec.rb
+++ b/spec/unit/knife/core/ui_spec.rb
@@ -410,6 +410,20 @@ EOM
         @ui.config[:attribute] = non_existing_path
         expect(@ui.format_for_display(input)).to eq({ "sample-data-bag-item" => { non_existing_path => nil } })
       end
+
+      # ex: --attribute 'keys."with spaces".open.doors."with.dots"'
+      it "works with double-quoted strings that include spaces and dots" do
+        input = { "keys" => { "with spaces" => { "open" => { "doors" => { "with many.dots" => "when asked" } } } } }
+        @ui.config[:attribute] = "keys.\"with spaces\".open.doors.\"with many.dots\""
+        expect(@ui.format_for_display(input)).to eq({ nil => { "keys.\"with spaces\".open.doors.\"with many.dots\"" => "when asked" } })
+      end
+
+      # ex: --attribute "keys.'with spaces'.open.doors.'with.dots'"
+      it "works with single-quoted strings that include spaces and dots" do
+        input = { "keys" => { "with spaces" => { "open" => { "doors" => { "with many.dots" => "when asked" } } } } }
+        @ui.config[:attribute] = "keys.\'with spaces\'.open.doors.\'with many.dots\'"
+        expect(@ui.format_for_display(input)).to eq({ nil => { "keys.\'with spaces\'.open.doors.\'with many.dots\'" => "when asked" } })
+      end
     end
 
     describe "with --run-list passed" do


### PR DESCRIPTION
### Description

Some node attribute keys have dots in them, i.e. our current windows
package resolves to `packages.Chef Client v12.12.15`. Currently, when
parsing our `--attribute` flags we simply split on a `.` to indicate
nesting, which would result in the data not coming back to the user as
expected. This change adds support for quoted attributes in the filter
flags, so that you can specify keys that include special characters like
dots.

```shell
knife node show NODE --attribute 'packages."Chef Client v12.12.15"'
knife node show NODE --attribute "packages.'Chef Client v12.12.15'"
```

Because the shell processes the strings before we even get the chance to
see it, the user will need to make sure they escape or use a combination
of single or double quotes to preserve the quoting as appropriate.

### Issues Resolved

* Internal ticket COOL-599

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>