### PR TITLE
Add the `--field-separator` flag to knife show commands

### DIFF
--- a/lib/chef/knife/core/generic_presenter.rb
+++ b/lib/chef/knife/core/generic_presenter.rb
@@ -28,12 +28,14 @@ class Chef
         # :nodoc:
         def self.included(includer)
           includer.class_eval do
-            @attrs_to_show = []
             option :attribute,
               :short => "-a ATTR1 [-a ATTR2]",
               :long => "--attribute ATTR1 [--attribute ATTR2] ",
-              :proc => lambda { |val| @attrs_to_show << val },
-              :description => "Show one or more attributes"
+              :description => "Show one or more attributes",
+              :proc => Proc.new { |a|
+                Chef::Config[:knife][:attribute] ||= []
+                Chef::Config[:knife][:attribute].push(a)
+              }
           end
         end
       end

--- a/lib/chef/knife/core/generic_presenter.rb
+++ b/lib/chef/knife/core/generic_presenter.rb
@@ -28,6 +28,11 @@ class Chef
         # :nodoc:
         def self.included(includer)
           includer.class_eval do
+            option :field_separator,
+              :short => "-S SEPARATOR",
+              :long => "--field-separator SEPARATOR",
+              :description => "Character separator used to delineate nesting in --attribute filters (default \".\")"
+
             option :attribute,
               :short => "-a ATTR1 [-a ATTR2]",
               :long => "--attribute ATTR1 [--attribute ATTR2] ",
@@ -175,8 +180,15 @@ class Chef
           config[:attribute] || config[:run_list]
         end
 
+        # GenericPresenter is used in contexts where MultiAttributeReturnOption
+        # is not, so we need to set the default value here rather than as part
+        # of the CLI option.
+        def attribute_field_separator
+          config[:field_separator] || "."
+        end
+
         def extract_nested_value(data, nested_value_spec)
-          nested_value_spec.split(".").each do |attr|
+          nested_value_spec.split(attribute_field_separator).each do |attr|
             data =
               if data.is_a?(Array)
                 data[attr.to_i]

--- a/lib/chef/knife/node_show.rb
+++ b/lib/chef/knife/node_show.rb
@@ -55,11 +55,6 @@ class Chef
 
         node = Chef::Node.load(@node_name)
         output(format_for_display(node))
-        self.class.attrs_to_show = []
-      end
-
-      def self.attrs_to_show=(attrs)
-        @attrs_to_show = attrs
       end
     end
   end

--- a/lib/chef/knife/osc_user_show.rb
+++ b/lib/chef/knife/osc_user_show.rb
@@ -48,7 +48,6 @@ class Chef
         user = Chef::User.load(@user_name)
         output(format_for_display(user))
       end
-
     end
   end
 end

--- a/spec/integration/knife/environment_show_spec.rb
+++ b/spec/integration/knife/environment_show_spec.rb
@@ -26,7 +26,7 @@ describe "knife environment show", :workstation do
   when_the_chef_server "has some environments" do
     before do
       environment "b", {
-        "default_attributes" => { "foo" => "bar" },
+        "default_attributes" => { "foo" => "bar", "baz" => { "raz.my" => "mataz" } },
       }
     end
 
@@ -36,6 +36,8 @@ describe "knife environment show", :workstation do
 chef_type:           environment
 cookbook_versions:
 default_attributes:
+  baz:
+    raz.my: mataz
   foo: bar
 description:         
 json_class:          Chef::Environment
@@ -46,11 +48,29 @@ EOM
     # rubocop:enable Style/TrailingWhitespace
 
     it "shows the requested attribute of an environment" do
-      pending "KnifeSupport doesn't appear to pass this through correctly"
-      knife("environment show b -a foo").should_succeed <<EOM
+      knife("environment show b -a default_attributes").should_succeed <<EOM
 b:
-  foo: bar
+  default_attributes:
+    baz:
+      raz.my: mataz
+    foo: bar
 EOM
+    end
+
+    it "shows the requested nested attribute of an environment" do
+      knife("environment show b -a default_attributes.baz").should_succeed <<EON
+b:
+  default_attributes.baz:
+    raz.my: mataz
+EON
+    end
+
+    it "shows the requested attribute of an environment with custom field separator" do
+      knife("environment show b -S: -a default_attributes:baz").should_succeed <<EOT
+b:
+  default_attributes:baz:
+    raz.my: mataz
+EOT
     end
   end
 end

--- a/spec/integration/knife/node_environment_set_spec.rb
+++ b/spec/integration/knife/node_environment_set_spec.rb
@@ -31,7 +31,10 @@ describe "knife node environment set", :workstation do
 
     it "sets an environment on a node" do
       knife("node environment set cons lisp").should_succeed /chef_environment:.*lisp/
-      knife("node show cons -a chef_environment").should_succeed /Environment:.*lisp/
+      knife("node show cons -a chef_environment").should_succeed <<EOM
+cons:
+  chef_environment: lisp
+EOM
     end
 
     it "with no environment" do

--- a/spec/support/shared/integration/knife_support.rb
+++ b/spec/support/shared/integration/knife_support.rb
@@ -64,8 +64,11 @@ module KnifeSupport
         subcommand_class.load_deps
         instance = subcommand_class.new(args)
 
+        # Load configs
+        instance.merge_configs
+
         # Capture stdout/stderr
-        instance.ui = Chef::Knife::UI.new(stdout, stderr, stdin, disable_editing: true)
+        instance.ui = Chef::Knife::UI.new(stdout, stderr, stdin, instance.config.merge(disable_editing: true))
 
         # Don't print stuff
         Chef::Config[:verbosity] = ( DEBUG ? 2 : 0 )

--- a/spec/unit/knife/core/ui_spec.rb
+++ b/spec/unit/knife/core/ui_spec.rb
@@ -28,6 +28,7 @@ describe Chef::Knife::UI do
       :verbosity => 0,
       :yes => nil,
       :format => "summary",
+      :field_separator => ".",
     }
     @ui = Chef::Knife::UI.new(@out, @err, @in, @config)
     Chef::Config[:treat_deprecation_warnings_as_errors] = false
@@ -409,6 +410,15 @@ EOM
         non_existing_path = "nope.nada.nothingtoseehere"
         @ui.config[:attribute] = non_existing_path
         expect(@ui.format_for_display(input)).to eq({ "sample-data-bag-item" => { non_existing_path => nil } })
+      end
+
+      describe "when --field-separator is passed" do
+        it "honors that separator" do
+          input = { "keys" => { "with spaces" => { "open" => { "doors" => { "with many.dots" => "when asked" } } } } }
+          @ui.config[:field_separator] = ";"
+          @ui.config[:attribute] = "keys;with spaces;open;doors;with many.dots"
+          expect(@ui.format_for_display(input)).to eq({ nil => { "keys;with spaces;open;doors;with many.dots" => "when asked" } })
+        end
       end
     end
 


### PR DESCRIPTION
### Description

For the commands that allow you to filter which attributes it shows you
using the `--attribute` flag, add the `--field-separator` flag to allow
the user to customize which character(s) they want to use to delineate the
attribute hierarchy.

``` shell
knife node show NODE -S: -a "packages:Chef Client v12.12.15"
```
### Issues Resolved
- Internal ticket COOL-599
### Check List
- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco
