### PR TITLE
Fixed knife download cookbooks issue which used to corrupt the certificate files each time the command was fired.

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -39,17 +39,13 @@ class Chef
           def read
             begin
               tmpfile = rest.streaming_request(file[:url])
+              File.open(tmpfile, "rb") { |f| f.read }
             rescue Timeout::Error => e
               raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "Timeout reading #{file[:url]}: #{e}")
             rescue Net::HTTPServerException => e
               raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "#{e.message} retrieving #{file[:url]}")
-            end
-
-            begin
-              tmpfile.open
-              tmpfile.read
-            ensure
-              tmpfile.close!
+            rescue Errno::ENOENT
+              raise Chef::ChefFS::FileSystem::NotFoundError.new(self, $!)
             end
           end
 


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/5363
Signed-off-by: aliasgar16 aliasgar.batterywala@msystechnologies.com
