### PR TITLE
Add deprecations to Data Collector competion message

### DIFF
--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -66,7 +66,7 @@ class Chef
           "entity_uuid"            => node_uuid,
           "expanded_run_list"      => reporter_data[:expanded_run_list],
           "id"                     => run_status.run_id,
-          "message_version"        => "1.0.0",
+          "message_version"        => "1.1.0",
           "message_type"           => "run_converge",
           "node"                   => run_status.node,
           "node_name"              => run_status.node.name,
@@ -80,6 +80,7 @@ class Chef
           "status"                 => reporter_data[:status],
           "total_resource_count"   => reporter_data[:resources].count,
           "updated_resource_count" => reporter_data[:resources].select { |r| r.report_data["status"] == "updated" }.count,
+          "deprecations"           => reporter_data[:deprecations],
         }
 
         message["error"] = {

--- a/spec/unit/data_collector/messages_spec.rb
+++ b/spec/unit/data_collector/messages_spec.rb
@@ -113,6 +113,7 @@ describe Chef::DataCollector::Messages do
           status
           total_resource_count
           updated_resource_count
+          deprecations
         }
       end
       let(:optional_fields) { %w{error} }
@@ -164,6 +165,7 @@ describe Chef::DataCollector::Messages do
           status
           total_resource_count
           updated_resource_count
+          deprecations
         }
       end
       let(:optional_fields) { [] }


### PR DESCRIPTION
By adding deprecation warnings to Data Collector, receivers of
Data Collector messages can easily identify nodes that would need
attention to their versions/cookbooks before a major version Chef
upgrade would be successful.
