### PR TITLE
Knife Bootstrap: Passing config_log_level and config_log_location from config.rb

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -69,7 +69,8 @@ class Chef
 
         def config_content
           client_rb = <<-CONFIG
-log_location     STDOUT
+log_level        :#{@chef_config[:config_log_level]}
+log_location     "#{@chef_config[:config_log_location]}"
 chef_server_url  "#{@chef_config[:chef_server_url]}"
 validation_client_name "#{@chef_config[:validation_client_name]}"
           CONFIG

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -67,13 +67,38 @@ class Chef
           @trusted_certs ||= trusted_certs_content
         end
 
+        def get_log_location
+          if (@chef_config[:config_log_location].nil? || @chef_config[:config_log_location].empty?)
+            "STDOUT"
+          elsif @chef_config[:config_log_location].equal?(:win_evt)
+            raise "The value \:win_evt is not supported for config_log_location on Linux Platforms \n"
+          elsif @chef_config[:config_log_location].equal?(:syslog)
+            ":syslog"
+          elsif (@chef_config[:config_log_location].equal?(STDOUT))
+            "STDOUT"
+          elsif (@chef_config[:config_log_location].equal?(STDERR))
+            "STDERR"
+          elsif @chef_config[:config_log_location]
+             %Q{"#{@chef_config[:config_log_location]}"}
+          else
+            "STDOUT"
+          end
+        end
+
+
+
         def config_content
           client_rb = <<-CONFIG
-log_level        :#{@chef_config[:config_log_level]}
-log_location     "#{@chef_config[:config_log_location]}"
 chef_server_url  "#{@chef_config[:chef_server_url]}"
 validation_client_name "#{@chef_config[:validation_client_name]}"
           CONFIG
+
+          if !(@chef_config[:config_log_level].nil? || @chef_config[:config_log_level].empty?)
+            client_rb << %Q{log_level   :#{@chef_config[:config_log_level]}\n}
+          end
+
+          client_rb << "log_location   #{get_log_location}\n"
+
           if @config[:chef_node_name]
             client_rb << %Q{node_name "#{@config[:chef_node_name]}"\n}
           else

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -68,24 +68,22 @@ class Chef
         end
 
         def get_log_location
-          if (@chef_config[:config_log_location].nil? || @chef_config[:config_log_location].empty?)
+          if !(@chef_config[:config_log_location].class == IO ) && (@chef_config[:config_log_location].nil? || @chef_config[:config_log_location].to_s.empty?)
             "STDOUT"
           elsif @chef_config[:config_log_location].equal?(:win_evt)
-            raise "The value \:win_evt is not supported for config_log_location on Linux Platforms \n"
+            raise "The value :win_evt is not supported for config_log_location on Linux Platforms \n"
           elsif @chef_config[:config_log_location].equal?(:syslog)
             ":syslog"
-          elsif (@chef_config[:config_log_location].equal?(STDOUT))
+          elsif @chef_config[:config_log_location].equal?(STDOUT)
             "STDOUT"
-          elsif (@chef_config[:config_log_location].equal?(STDERR))
+          elsif @chef_config[:config_log_location].equal?(STDERR)
             "STDERR"
           elsif @chef_config[:config_log_location]
-             %Q{"#{@chef_config[:config_log_location]}"}
+            %Q{"#{@chef_config[:config_log_location]}"}
           else
             "STDOUT"
           end
         end
-
-
 
         def config_content
           client_rb = <<-CONFIG

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -70,10 +70,10 @@ describe Chef::Knife::Core::BootstrapContext do
 
   it "generates the config file data" do
     expected = <<-EXPECTED
-log_level        :info
-log_location     "/tmp/log"
 chef_server_url  "http://chef.example.com:4444"
 validation_client_name "chef-validator-testing"
+log_level   :info
+log_location   "/tmp/log"
 # Using default node name (fqdn)
 EXPECTED
     expect(bootstrap_context.config_content).to eq expected
@@ -253,4 +253,55 @@ EXPECTED
     end
   end
 
+  describe "#config_log_location" do
+    context "when config_log_location is nil" do
+      let(:chef_config) { { :config_log_location => nil } }
+      it "sets the default config_log_location  in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq "STDOUT"
+      end
+    end
+
+    context "when config_log_location is empty" do
+      let(:chef_config) { { :config_log_location => "" } }
+      it "sets the default config_log_location  in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq "STDOUT"
+      end
+    end
+
+    context "when config_log_location is :win_evt" do
+      let(:chef_config) { { :config_log_location => :win_evt } }
+      it "raise error when config_log_location is :win_evt " do
+        expect { bootstrap_context.get_log_location }.to raise_error("The value :win_evt is not supported for config_log_location on Linux Platforms \n")
+      end
+    end
+
+    context "when config_log_location is :syslog" do
+      let(:chef_config) { { :config_log_location => :syslog } }
+      it "sets the config_log_location value as :syslog in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq ":syslog"
+      end
+    end
+
+    context "When config_log_location is STDOUT" do
+      let(:chef_config) { { :config_log_location => STDOUT } }
+      it "Sets the config_log_location value as STDOUT in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq "STDOUT"
+      end
+    end
+
+    context "when config_log_location is STDERR" do
+      let(:chef_config) { { :config_log_location => STDERR } }
+      it "sets the config_log_location value as STDERR  in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq "STDERR"
+      end
+    end
+
+    context "when config_log_location is a path" do
+      let(:chef_config) { { :config_log_location => "/tmp/ChefLogFile" } }
+      it "sets the config_log_location path in the client.rb" do
+        expect(bootstrap_context.get_log_location).to eq "\"/tmp/ChefLogFile\""
+      end
+    end
+
+  end
 end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -30,6 +30,8 @@ describe Chef::Knife::Core::BootstrapContext do
   let(:run_list) { Chef::RunList.new("recipe[tmux]", "role[base]") }
   let(:chef_config) do
     {
+      :config_log_level => "info",
+      :config_log_location => "/tmp/log",
       :validation_key => File.join(CHEF_SPEC_DATA, "ssl", "private_key.pem"),
       :chef_server_url => "http://chef.example.com:4444",
       :validation_client_name => "chef-validator-testing",
@@ -68,16 +70,13 @@ describe Chef::Knife::Core::BootstrapContext do
 
   it "generates the config file data" do
     expected = <<-EXPECTED
-log_location     STDOUT
+log_level        :info
+log_location     "/tmp/log"
 chef_server_url  "http://chef.example.com:4444"
 validation_client_name "chef-validator-testing"
 # Using default node name (fqdn)
 EXPECTED
     expect(bootstrap_context.config_content).to eq expected
-  end
-
-  it "does not set a default log_level" do
-    expect(bootstrap_context.config_content).not_to match(/log_level/)
   end
 
   describe "alternate chef-client path" do


### PR DESCRIPTION
### In Progress

### Description

Passing config_log_level and config_log_location from config.rb

### Issues Resolved
https://github.com/chef/chef/issues/1452

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
