### PR TITLE
include chef/chef_class for method log_deprecation

### DIFF
--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -37,6 +37,7 @@ require "chef/config"
 require "chef/exceptions"
 require "chef/platform/query_helpers"
 require "chef/http/remote_request_id"
+require "chef/chef_class"
 
 class Chef
 


### PR DESCRIPTION
### Description

The rest.rb [**add the deprecation warnings**](https://github.com/chef/chef/commit/0ef0ab07531ae78cb4052242037227b0fb5365dc), but the method log_deprecation is undefined, it need to require "chef/chef_class" first.

### Issues Resolved

If user follow [**official document**](https://docs.chef.io/auth.html#ruby) to request Chef server API in ruby, there is exception showing ...

```
/opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.15.19/lib/chef/rest.rb:62:in `initialize': undefined method `log_deprecation' for Chef:Class (NoMethodError)
```

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
