### PR TITLE
Fixed 5459 - Purge yum cache before deleting repo config

### DIFF
--- a/lib/chef/provider/yum_repository.rb
+++ b/lib/chef/provider/yum_repository.rb
@@ -76,16 +76,15 @@ class Chef
       end
 
       action :delete do
-        declare_resource(:file, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
-          action :delete
-          notifies :run, "execute[yum clean all #{new_resource.repositoryid}]", :immediately
-          notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
-        end
-
+        # clean the repo cache first
         declare_resource(:execute, "yum clean all #{new_resource.repositoryid}") do
           command "yum clean all --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
-          only_if "yum repolist | grep -P '^#{new_resource.repositoryid}([ \t]|$)'"
-          action :nothing
+          only_if "yum repolist all | grep -P '^#{new_resource.repositoryid}([ \t]|$)'"
+        end
+
+        declare_resource(:file, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
+          action :delete
+          notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
         end
 
         declare_resource(:ruby_block, "yum-cache-reload-#{new_resource.repositoryid}") do


### PR DESCRIPTION
### Description

This fixes #5459: Purge the yum cache and metadata before deleting the yum repository config.

### Issues Resolved

Fixes #5459. See also https://github.com/chef-cookbooks/yum/pull/166.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

