### PR TITLE
Enable data collector w/o token for solo, but require explicit URL

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -857,7 +857,13 @@ module ChefConfig
       # Full URL to the endpoint that will receive our data. If nil, the
       # data collector will not run.
       # Ex: http://my-data-collector.mycompany.com/ingest
-      default(:server_url) { File.join(config_parent.chef_server_url, "/data-collector") }
+      default(:server_url) do
+        if config_parent.solo || config_parent.local_mode
+          nil
+        else
+          File.join(config_parent.chef_server_url, "/data-collector")
+        end
+      end
 
       # An optional pre-shared token to pass as an HTTP header (x-data-collector-token)
       # that can be used to determine whether or not the poster of this

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -1131,9 +1131,25 @@ RSpec.describe ChefConfig::Config do
 
     context "when using default settings" do
 
-      it "configures the data collector URL as a relative path to the Chef Server URL" do
-        ChefConfig::Config[:chef_server_url] = "https://chef.example/organizations/myorg"
-        expect(ChefConfig::Config[:data_collector][:server_url]).to eq("https://chef.example/organizations/myorg/data-collector")
+      context "for Chef Client" do
+
+        it "configures the data collector URL as a relative path to the Chef Server URL" do
+          ChefConfig::Config[:chef_server_url] = "https://chef.example/organizations/myorg"
+          expect(ChefConfig::Config[:data_collector][:server_url]).to eq("https://chef.example/organizations/myorg/data-collector")
+        end
+
+      end
+
+      context "for Chef Solo" do
+
+        before do
+          ChefConfig::Config[:solo] = true
+        end
+
+        it "sets the data collector server URL to nil" do
+          ChefConfig::Config[:chef_server_url] = "https://chef.example/organizations/myorg"
+          expect(ChefConfig::Config[:data_collector][:server_url]).to be_nil
+        end
 
       end
 

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -55,8 +55,7 @@ class Chef
         return false
       end
       if solo? && !token_auth_configured?
-        Chef::Log.debug("Data collector token must be configured in solo mode, disabling data collector")
-        return false
+        Chef::Log.debug("Data collector token must be configured to use Chef Automate data collector with Chef Solo")
       end
       if !solo? && token_auth_configured?
         Chef::Log.warn("Data collector token authentication is not recommended for client-server mode" \

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -91,8 +91,8 @@ describe Chef::DataCollector do
                 Chef::Config[:solo] = true
               end
 
-              it "returns false" do
-                expect(Chef::DataCollector.register_reporter?).to be_falsey
+              it "returns true" do
+                expect(Chef::DataCollector.register_reporter?).to be(true)
               end
 
             end
@@ -104,7 +104,7 @@ describe Chef::DataCollector do
               end
 
               it "returns false" do
-                expect(Chef::DataCollector.register_reporter?).to be_falsey
+                expect(Chef::DataCollector.register_reporter?).to be(true)
               end
             end
 


### PR DESCRIPTION
### Description

Third-party data collector implementations are supported and may not
require a token for authentication. Therefore we must allow the case
where the token is nil in Chef Solo mode. To reduce the chance that the
data collector is accidentally enabled, only set the data collector URL
to a default value in Chef Client mode.

### Issues Resolved

Acceptance is failing in the pipeline because it tests this exact case

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>


Signed-off-by: Daniel DeLeo <dan@chef.io>