### PR TITLE
Prevent apt_update failures on non-Linux platforms

### DIFF
--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptUpdate < Chef::Resource
       resource_name :apt_update
-      provides :apt_update, os: "linux"
+      provides :apt_update
 
       property :frequency, Integer, default: 86_400
 

--- a/spec/unit/resource/apt_update_spec.rb
+++ b/spec/unit/resource/apt_update_spec.rb
@@ -24,35 +24,27 @@ describe Chef::Resource::AptUpdate do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptUpdate.new("update", run_context) }
 
-  context "on linux", :linux_only do
-    it "should create a new Chef::Resource::AptUpdate" do
-      expect(resource).to be_a_kind_of(Chef::Resource)
-      expect(resource).to be_a_kind_of(Chef::Resource::AptUpdate)
-    end
-
-    it "the default frequency should be 1 day" do
-      expect(resource.frequency).to eql(86_400)
-    end
-
-    it "the frequency should accept integers" do
-      resource.frequency(400)
-      expect(resource.frequency).to eql(400)
-    end
-
-    it "should resolve to a Noop class when apt-get is not found" do
-      expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(false)
-      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
-    end
-
-    it "should resolve to a AptUpdate class when apt-get is found" do
-      expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(true)
-      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptUpdate)
-    end
+  it "should create a new Chef::Resource::AptUpdate" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::AptUpdate)
   end
 
-  context "on windows", :windows_only do
-    it "should resolve to a NoOp provider" do
-      expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
-    end
+  it "the default frequency should be 1 day" do
+    expect(resource.frequency).to eql(86_400)
+  end
+
+  it "the frequency should accept integers" do
+    resource.frequency(400)
+    expect(resource.frequency).to eql(400)
+  end
+
+  it "should resolve to a Noop class when apt-get is not found" do
+    expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(false)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "should resolve to a AptUpdate class when apt-get is found" do
+    expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(true)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptUpdate)
   end
 end


### PR DESCRIPTION
Prevent apt_update failures on non-Linux platforms

We 1/2 wired up the noop functionality, but specifying that we only provided the resource on Linux caused that code to never run.

This prevents this sort of error on non-Linux platforms:

```
Cannot find a resource for apt_update on windows version 6.3.9600
```