### PR TITLE
Test on the latest fedora and fix yum failures in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -246,11 +246,11 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test webapp-fedora-23
+      - bundle exec kitchen test webapp-fedora-latest
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
-      - FEDORA=23
+      - FEDORA=latest
       - KITCHEN_YAML=.kitchen.travis.yml
   - rvm: 2.3.1
     services: docker

--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -75,12 +75,13 @@ platforms:
       - RUN yum -y install which initscripts net-tools sudo wget
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: fedora-23
+- name: fedora-latest
   driver:
-    image: fedora:23
+    image: fedora:latest
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN dnf -y install yum which initscripts rpm-build zlib-devel net-tools sudo wget
+      - RUN yum makecache
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: ubuntu-12.04


### PR DESCRIPTION
Use the latest fedora to avoid having to bump things every X months

We need to make the cache afterwards. I ran into this same issue in the cron cookbook and I’ve updated the dnf_compat recipe in yum to do the same.