### PR TITLE
Add gem release badge to the readme / changelog header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Code Climate](https://codeclimate.com/github/chef/chef.svg)](https://codeclimate.com/github/chef/chef)
 [![Build Status Master](https://travis-ci.org/chef/chef.svg?branch=master)](https://travis-ci.org/chef/chef)
 [![Build Status Master](https://ci.appveyor.com/api/projects/status/github/chef/chef?branch=master&svg=true&passingText=master%20-%20Ok&pendingText=master%20-%20Pending&failingText=master%20-%20Failing)](https://ci.appveyor.com/project/Chef/chef/branch/master)
+[![Gem Version](https://badge.fury.io/rb/chef.svg)](https://badge.fury.io/rb/chef)
 
 Want to try Chef? Get started with [learnchef](https://learn.chef.io)
 
@@ -76,7 +77,7 @@ The general development process is:
    master.
 
 Once your repository is set up, you can start working on the code. We do utilize
-RSpec for test driven development, so you'll need to get a development 
+RSpec for test driven development, so you'll need to get a development
 environment running. Follow the above procedure ("Installing from Git") to get
 your local copy of the source running.
 

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -19,6 +19,7 @@ begin
     config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
     config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
     config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion".split(",")
+    config.header = "This changelog reflects the current state of chef's master branch on github and may not reflect the current released version of chef, which is [![Gem Version](https://badge.fury.io/rb/chef.svg)](https://badge.fury.io/rb/chef)"
   end
 
   task :changelog do


### PR DESCRIPTION
Add gem release badge to the readme / changelog header

When we update our changelog it’s a bit confusing since multiple days go by before we ship the new release. Adding a header and a readme gem release badge should help clear up what our current release is.