### PR TITLE
Apt: Add apt_preference resource from apt cookbooks

### DIFF
--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -1,0 +1,106 @@
+#
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/resource"
+require "chef/dsl/declare_resource"
+require "chef/mixin/which"
+require "chef/provider/noop"
+require "chef/log"
+
+class Chef
+  class Provider
+    class AptPreference < Chef::Provider
+      use_inline_resources
+
+      extend Chef::Mixin::Which
+
+      provides :apt_preference do
+        which("apt-get")
+      end
+
+      def whyrun_supported?
+        true
+      end
+
+      def load_current_resource
+      end
+
+      action :add do
+        preference = build_pref(
+          new_resource.glob || new_resource.package_name,
+          new_resource.pin,
+          new_resource.pin_priority
+        )
+
+        declare_resource(:directory, "/etc/apt/preferences.d") do
+          owner "root"
+          group "root"
+          mode "0755"
+          recursive true
+          action :create
+        end
+
+        name = safe_name(new_resource.name)
+
+        declare_resource(:file, "/etc/apt/preferences.d/#{new_resource.name}.pref") do
+          action :delete
+          if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}.pref")
+            Chef::Log.warn "Replacing #{new_resource.name}.pref with #{name}.pref in /etc/apt/preferences.d/"
+          end
+          only_if { name != new_resource.name }
+        end
+
+        declare_resource(:file, "/etc/apt/preferences.d/#{new_resource.name}") do
+          action :delete
+          if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}")
+            Chef::Log.warn "Replacing #{new_resource.name} with #{new_resource.name}.pref in /etc/apt/preferences.d/"
+          end
+        end
+
+        declare_resource(:file, "/etc/apt/preferences.d/#{name}.pref") do
+          owner "root"
+          group "root"
+          mode "0644"
+          content preference
+          action :create
+        end
+      end
+
+      action :delete do
+        name = safe_name(new_resource.name)
+        if ::File.exist?("/etc/apt/preferences.d/#{name}.pref")
+          Chef::Log.info "Un-pinning #{name} from /etc/apt/preferences.d/"
+          declare_resource(:file, "/etc/apt/preferences.d/#{name}.pref") do
+            action :delete
+          end
+        end
+      end
+    end
+
+    # Build preferences.d file contents
+    def build_pref(package_name, pin, pin_priority)
+      "Package: #{package_name}\nPin: #{pin}\nPin-Priority: #{pin_priority}\n"
+    end
+
+    def safe_name(name)
+      name.tr(".", "_").gsub("*", "wildcard")
+    end
+  end
+end
+
+Chef::Provider::Noop.provides :apt_preference

--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -33,10 +33,6 @@ class Chef
         which("apt-get")
       end
 
-      def whyrun_supported?
-        true
-      end
-
       def load_current_resource
       end
 

--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -45,7 +45,6 @@ class Chef
 
         declare_resource(:directory, APT_PREFERENCE_DIR) do
           mode "0755"
-          recursive true
           action :create
         end
 

--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -83,15 +83,15 @@ class Chef
           end
         end
       end
-    end
 
-    # Build preferences.d file contents
-    def build_pref(package_name, pin, pin_priority)
-      "Package: #{package_name}\nPin: #{pin}\nPin-Priority: #{pin_priority}\n"
-    end
+      # Build preferences.d file contents
+      def build_pref(package_name, pin, pin_priority)
+        "Package: #{package_name}\nPin: #{pin}\nPin-Priority: #{pin_priority}\n"
+      end
 
-    def safe_name(name)
-      name.tr(".", "_").gsub("*", "wildcard")
+      def safe_name(name)
+        name.tr(".", "_").gsub("*", "wildcard")
+      end
     end
   end
 end

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/provider/apt_update"
+require "chef/provider/apt_preference"
 require "chef/provider/apt_repository"
 require "chef/provider/batch"
 require "chef/provider/breakpoint"

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -1,0 +1,36 @@
+#
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/resource"
+
+class Chef
+  class Resource
+    class AptPreference < Chef::Resource
+      resource_name :apt_repository
+      provides :apt_preference
+
+      property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
+      property :glob, String
+      property :pin, String
+      property :pin_priority, String
+
+      default_action :add
+      allowed_actions :add, :remove
+    end
+  end
+end

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -27,7 +27,7 @@ class Chef
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String
       property :pin, String, required: true
-      property :pin_priority, [String,Integer], required: true
+      property :pin_priority, [String, Integer], required: true
 
       default_action :add
       allowed_actions :add, :remove

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,8 +26,8 @@ class Chef
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String
-      property :pin, String
-      property :pin_priority, String
+      property :pin, String, required: true
+      property :pin_priority, String, required: true
 
       default_action :add
       allowed_actions :add, :remove

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -27,7 +27,7 @@ class Chef
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String
       property :pin, String, required: true
-      property :pin_priority, String, required: true
+      property :pin_priority, [String,Integer], required: true
 
       default_action :add
       allowed_actions :add, :remove

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -21,7 +21,7 @@ require "chef/resource"
 class Chef
   class Resource
     class AptPreference < Chef::Resource
-      resource_name :apt_repository
+      resource_name :apt_preference
       provides :apt_preference
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]

--- a/lib/chef/resources.rb
+++ b/lib/chef/resources.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource/apt_package"
+require "chef/resource/apt_preference"
 require "chef/resource/apt_repository"
 require "chef/resource/apt_update"
 require "chef/resource/bash"

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -1,0 +1,53 @@
+#
+# Author:: Thom May (<thom@chef.io>)
+# Author:: Tim Smith (<tim@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Provider::AptPreference do
+  let(:new_resource) { Chef::Resource::AptPreference.new("libmysqlclient16") }
+  let(:provider) do
+    node = Chef::Node.new
+    events = Chef::EventDispatch::Dispatcher.new
+    run_context = Chef::RunContext.new(node, {}, events)
+    Chef::Provider::AptPreference.new(new_resource, run_context)
+  end
+
+  it "responds to load_current_resource" do
+    expect(provider).to respond_to(:load_current_resource)
+  end
+
+  it "creates apt preferences directory if it does not exist" do
+    provider.run_action(:update)
+    expect(new_resource).to be_updated_by_last_action
+    expect(File.exist?('/etc/apt/preferences.d')).to be true
+    expect(File.directory?('/etc/apt/preferences.d')).to be true
+  end
+
+  it "cleans up legacy non-sanitized name files" do
+    # something
+  end
+
+  it "creates an apt .pref file" do
+    # something
+  end
+
+  it "creates an apt .pref file with a sanitized filename" do
+    # something
+  end
+end

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Thom May (<thom@chef.io>)
 # Author:: Tim Smith (<tim@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -20,7 +20,7 @@
 require "spec_helper"
 
 describe Chef::Provider::AptPreference do
-  let(:new_resource) { Chef::Resource::AptPreference.new("libmysqlclient16") }
+  let(:new_resource) { Chef::Resource::AptPreference.new("libmysqlclient16.1*") }
   let(:pref_dir) { Dir.mktmpdir("apt_pref_d") }
 
   before do
@@ -53,12 +53,10 @@ describe Chef::Provider::AptPreference do
       expect(File.directory?(pref_dir)).to be true
     end
 
-    it "creates an apt .pref file" do
-      # something
-    end
-
-    it "creates an apt .pref file with a sanitized filename" do
-      # something
+    it "creates a sanitized .pref file" do
+      provider.run_action(:add)
+      expect(new_resource).to be_updated_by_last_action
+      expect(File.exist?(::File.join(pref_dir,'libmysqlclient16_1wildcard.pref'))).to be true
     end
   end
 end

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Provider::AptPreference do
 
   before do
     stub_const("Chef::Provider::AptPreference::APT_PREFERENCE_DIR", pref_dir)
-    new_resource.pin = '1.0.1'
+    new_resource.pin = "1.0.1"
     new_resource.pin_priority 1001
   end
 
@@ -56,7 +56,7 @@ describe Chef::Provider::AptPreference do
     it "creates a sanitized .pref file" do
       provider.run_action(:add)
       expect(new_resource).to be_updated_by_last_action
-      expect(File.read(::File.join(pref_dir,'libmysqlclient16_1wildcard.pref'))).to match(/Package: libmysqlclient16.1*.*Pin: 1.0.1.*Pin-Priority: 1001/m)
+      expect(File.read(::File.join(pref_dir, "libmysqlclient16_1wildcard.pref"))).to match(/Package: libmysqlclient16.1*.*Pin: 1.0.1.*Pin-Priority: 1001/m)
 
     end
   end

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -56,7 +56,8 @@ describe Chef::Provider::AptPreference do
     it "creates a sanitized .pref file" do
       provider.run_action(:add)
       expect(new_resource).to be_updated_by_last_action
-      expect(File.exist?(::File.join(pref_dir,'libmysqlclient16_1wildcard.pref'))).to be true
+      expect(File.read(::File.join(pref_dir,'libmysqlclient16_1wildcard.pref'))).to match(/Package: libmysqlclient16.1*.*Pin: 1.0.1.*Pin-Priority: 1001/m)
+
     end
   end
 end

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -21,6 +21,14 @@ require "spec_helper"
 
 describe Chef::Provider::AptPreference do
   let(:new_resource) { Chef::Resource::AptPreference.new("libmysqlclient16") }
+  let(:pref_dir) { Dir.mktmpdir("apt_pref_d") }
+
+  before do
+    stub_const("Chef::Provider::AptPreference::APT_PREFERENCE_DIR", pref_dir)
+    new_resource.pin = '1.0.1'
+    new_resource.pin_priority 1001
+  end
+
   let(:provider) do
     node = Chef::Node.new
     events = Chef::EventDispatch::Dispatcher.new
@@ -32,22 +40,25 @@ describe Chef::Provider::AptPreference do
     expect(provider).to respond_to(:load_current_resource)
   end
 
-  it "creates apt preferences directory if it does not exist" do
-    provider.run_action(:update)
-    expect(new_resource).to be_updated_by_last_action
-    expect(File.exist?('/etc/apt/preferences.d')).to be true
-    expect(File.directory?('/etc/apt/preferences.d')).to be true
-  end
+  context "when the preferences.d directory does not exist" do
+    before do
+      FileUtils.rmdir pref_dir
+      expect(File.exist?(pref_dir)).to be false
+    end
 
-  it "cleans up legacy non-sanitized name files" do
-    # something
-  end
+    it "should create the preferences.d directory" do
+      provider.run_action(:add)
+      expect(new_resource).to be_updated_by_last_action
+      expect(File.exist?(pref_dir)).to be true
+      expect(File.directory?(pref_dir)).to be true
+    end
 
-  it "creates an apt .pref file" do
-    # something
-  end
+    it "creates an apt .pref file" do
+      # something
+    end
 
-  it "creates an apt .pref file with a sanitized filename" do
-    # something
+    it "creates an apt .pref file with a sanitized filename" do
+      # something
+    end
   end
 end

--- a/spec/unit/provider/apt_preference_spec.rb
+++ b/spec/unit/provider/apt_preference_spec.rb
@@ -61,7 +61,8 @@ describe Chef::Provider::AptPreference do
         FileUtils.touch("#{pref_dir}/libmysqlclient16.1*")
       end
 
-      it "creates a sanitized .pref file and removes the legacy cookbook files" do
+      # FileUtils.touch throws "Invalid argument @ utime_failed" in appveyer
+      it "creates a sanitized .pref file and removes the legacy cookbook files", :unix_only do
         provider.run_action(:add)
         expect(new_resource).to be_updated_by_last_action
         expect(File).not_to exist("#{pref_dir}/libmysqlclient16.1*.pref")

--- a/spec/unit/resource/apt_preference_spec.rb
+++ b/spec/unit/resource/apt_preference_spec.rb
@@ -1,0 +1,45 @@
+#
+# Author:: Tim Smith (<tsmith@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::AptPreference do
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::AptPreference.new("libmysqlclient16", run_context) }
+
+  it "should create a new Chef::Resource::AptPreference" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::AptPreference)
+  end
+
+  it "should resolve to a AptPreference class class when apt-get is found" do
+    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(true)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptPreference)
+  end
+
+  it "should resolve to a Noop class when apt-get is not found" do
+    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(false)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "should resolve to a NoOp provider" do
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+end

--- a/spec/unit/resource/apt_preference_spec.rb
+++ b/spec/unit/resource/apt_preference_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/resource/apt_preference_spec.rb
+++ b/spec/unit/resource/apt_preference_spec.rb
@@ -29,17 +29,13 @@ describe Chef::Resource::AptPreference do
     expect(resource).to be_a_kind_of(Chef::Resource::AptPreference)
   end
 
-  it "should resolve to a AptPreference class class when apt-get is found" do
-    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(true)
-    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptPreference)
-  end
-
   it "should resolve to a Noop class when apt-get is not found" do
     expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(false)
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
   end
 
-  it "should resolve to a NoOp provider" do
-    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  it "should resolve to a AptPreference class when apt-get is found" do
+    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(true)
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptPreference)
   end
 end


### PR DESCRIPTION
### Description

Pull in the apt_preference provider from the apt cookbook. This fully deprecates the apt cookbook.

### Issues Resolved
N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Specs are a placeholder on the provider side

Signed-off-by: Tim Smith <tsmith@chef.io>