### PR TITLE
Add UTF-8 environment var to version bumper

### DIFF
--- a/ci/version_bump.sh
+++ b/ci/version_bump.sh
@@ -2,6 +2,8 @@
 
 set -evx
 
+export LANG=en_US.UTF-8
+
 . ci/bundle_install.sh
 
 bundle exec rake version:bump


### PR DESCRIPTION
### Description

The Github Changelog Generator threw an error about invalid
encoding. This never happened locally, and indications are that its
because of this environment variable.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>