### PR TITLE
Update 12.16 release notes with package locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Knife: Add the `--field-separator` flag to knife show commands [\#5489](https://github.com/chef/chef/pull/5489) ([tduffield](https://github.com/tduffield))
 - Core: Enable Signed Header Auth for Data Collector, and Configure the Data Collector Automatically [\#5487](https://github.com/chef/chef/pull/5487) ([danielsdeleo](https://github.com/danielsdeleo))
 - Core: set use\_inline\_resources in package superclass [\#5483](https://github.com/chef/chef/pull/5483) ([lamont-granquist](https://github.com/lamont-granquist))
+- Package: Add new "lock" action for apt, yum and zypper packages [\#5395](https://github.com/chef/chef/pull/5395) ([yeoldegrove](https://github.com/yeoldegrove))
 
 **Fixed bugs:**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 - Knife: Add the `--field-separator` flag to knife show commands [\#5489](https://github.com/chef/chef/pull/5489) ([tduffield](https://github.com/tduffield))
 - Core: Enable Signed Header Auth for Data Collector, and Configure the Data Collector Automatically [\#5487](https://github.com/chef/chef/pull/5487) ([danielsdeleo](https://github.com/danielsdeleo))
 - Core: set use\_inline\_resources in package superclass [\#5483](https://github.com/chef/chef/pull/5483) ([lamont-granquist](https://github.com/lamont-granquist))
+- Package: Add new "lock" action for apt, yum and zypper packages [\#5395](https://github.com/chef/chef/pull/5395) ([yeoldegrove](https://github.com/yeoldegrove))
 
 **Fixed bugs:**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -86,4 +86,19 @@ webapp:
   alpha:beta: omega
 ```
 
+### Package locking for Apt, Yum, and Zypper
+
+To allow for more fine grained control of package installation the `apt_package`,
+`yum_package`, and `zypper_package` resources now support the `:lock` and `:unlock` actions.
+
+```ruby
+package "httpd" do
+  action :lock
+end
+
+package "httpd" do
+  action :unlock
+end
+```
+
 ## Highlighted bug fixes for this release:


### PR DESCRIPTION
### Description

We forgot to mention a really cool contribution that made it into the last release! This must be corrected!

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>