### PR TITLE
Add Dockerfile to root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM centos:5
+FROM busybox
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
 ARG CHANNEL=stable
 ARG VERSION=12.16.42
-ENV PATH=/opt/chef/bin:/opt/chef/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN yum install -y wget && \
-    wget --content-disposition --no-check-certificate "https://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/5/chef-${VERSION}-1.el5.x86_64.rpm" -O /tmp/chef-client.rpm && \
-    rpm -i /tmp/chef-client.rpm && \
+RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/5/chef-${VERSION}-1.el5.x86_64.rpm" -O /tmp/chef-client.rpm && \
+    rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \
     rm -rf /tmp/chef-client.rpm
 
 VOLUME [ "/opt/chef" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM ubuntu:16.04
+FROM centos:5
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
 ARG CHANNEL=stable
-ARG VERSION=latest
-ENV DEBIAN_FRONTEND=noninteractive
+ARG VERSION=12.16.42
 ENV PATH=/opt/chef/bin:/opt/chef/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN apt-get update && \
-    apt-get install -y wget ssh && \
-    wget --content-disposition "https://omnitruck.chef.io/${CHANNEL}/chef/download?p=ubuntu&pv=16.04&m=x86_64&v=${VERSION}" -O /tmp/chef-client.deb && \
-    dpkg -i /tmp/chef-client.deb && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN yum install -y wget && \
+    wget --content-disposition --no-check-certificate "https://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/5/chef-${VERSION}-1.el5.x86_64.rpm" -O /tmp/chef-client.rpm && \
+    rpm -i /tmp/chef-client.rpm && \
+    rm -rf /tmp/chef-client.rpm
+
+VOLUME [ "/opt/chef" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+MAINTAINER Chef Software, Inc. <docker@chef.io>
+
+ARG CHANNEL=stable
+ARG VERSION=latest
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/opt/chef/bin:/opt/chef/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update && \
+    apt-get install -y wget ssh && \
+    wget --content-disposition "https://omnitruck.chef.io/${CHANNEL}/chef/download?p=ubuntu&pv=16.04&m=x86_64&v=${VERSION}" -O /tmp/chef-client.deb && \
+    dpkg -i /tmp/chef-client.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
### Description

This Dockerfile will allow individuals, who wish to, to build Docker
images containing the latest Chef Client. Specifically, it can be used
inside testing frameworks like kitchen-dokken.

This Dockerfile will be used by internal Chef release engineering to
automatically post Docker images to the Docker Hub as part of our
standard artifact promotion pipeline.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>