### PR TITLE
Set compile_time to false

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -825,12 +825,10 @@ module ChefConfig
     #
     default :no_lazy_load, true
 
-    # Default for the chef_gem compile_time attribute.  Nil is the same as true but will emit
-    # warnings on every use of chef_gem prompting the user to be explicit.  If the user sets this to
-    # true then the user will get backcompat behavior but with a single nag warning that cookbooks
-    # may break with this setting in the future.  The false setting is the recommended setting and
-    # will become the default.
-    default :chef_gem_compile_time, nil
+    # Default for the chef_gem compile_time attribute.
+    # If the user sets this to true then the user will get backcompat behavior
+    # Cookbooks may break with this set to true in the future.  
+    default :chef_gem_compile_time, false
 
     # A whitelisted array of attributes you want sent over the wire when node
     # data is saved.


### PR DESCRIPTION
### Description

Setting `compile_time: false` as per warnings. 

### Issues Resolved

https://github.com/chef/chef/issues/3377

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

https://github.com/chef/chef/issues/3377