### PR TITLE
Remove debug write

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -481,7 +481,6 @@ class Chef
         if symbol == :to_ary
           merged_attributes.send(symbol, *args)
         elsif args.empty?
-          puts symbol
           Chef.log_deprecation %q{method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])}
           if key?(symbol)
             self[symbol]


### PR DESCRIPTION
### Description

Removes debug write introduced in previous commit: e57e29b96b75ff7fc04abb7f9db73920b2a5894a

### Issues Resolved

Removes erroneous output during compilation phase, eg:
```
Compiling Cookbooks...
python
platform
python
platform
platform
```

Obvious fix.