### PR TITLE
Remove the Dev Tools component

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -45,6 +45,9 @@ To mention the team, use @chef/client-core
 * [Tyler Ball](https://github.com/tyler-ball)
 * [Ranjib Dey](https://github.com/ranjib)
 * [Matt Wrock](https://github.com/mwrock)
+* [Joshua Timberman](https://github.com/jtimberman)
+* [Steven Danna](https://github.com/stevendanna)
+
 
 ## Ohai
 
@@ -58,19 +61,6 @@ To mention the team, use @chef/ohai
 
 * [Bryan McLellan](https://github.com/btm)
 * [Tim Smith](https://github.com/tas50)
-
-## Dev Tools
-
-ChefDK, Chef Zero, Knife, Chef Apply and Chef Shell.
-To mention the team, use @chef/client-dev-tools
-
-### Maintainers
-
-* [Daniel DeLeo](https://github.com/danielsdeleo)
-* [John Keiser](https://github.com/jkeiser)
-* [Joshua Timberman](https://github.com/jtimberman)
-* [Lamont Granquist](https://github.com/lamont-granquist)
-* [Steven Danna](https://github.com/stevendanna)
 
 ## Test Tools
 
@@ -293,4 +283,3 @@ To mention the team, use @chef/client-archlinux
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
 * [Ryan Cragun](https://github.com/ryancragun)
-


### PR DESCRIPTION
This PR removes the Dev Tools component. All responsibilities of Dev
Tools would thus be handled by the Core Maintainers.  As part of this
change, I propose that

  Steven Danna, and
  Joshua Timberman

be added as Core Maintainers. All other members of Dev Tools are already
core maintainers. This move simplifies the MAINTAINER list and makes it
easier to find reviewers for the components previously handled by Dev
Tools.

To add the new core maintainers this PR requires approval from a
majority of @chef/client-core and @thommay.

No procedure is specified to remove a component. I recommend that we
require a super-majority of 80% (4/5ths) of existing Dev
Tools (@chef/client-dev-tools) maintainers to approve with no vetos.

Signed-off-by: Steven Danna <steve@chef.io>