### PR TITLE
Only run msu_package functional tests on Appveyor

### DIFF
--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -19,7 +19,7 @@
 require "spec_helper"
 require "chef/provider/package/cab"
 
-describe Chef::Resource::MsuPackage, :win2012r2_only do
+describe Chef::Resource::MsuPackage, :win2012r2_only, :appveyor_only do
 
   let(:package_name) { "Package_for_KB2959977" }
   let(:package_source) { "https://download.microsoft.com/download/3/B/3/3B320C07-B7B1-41E5-81F4-79EBC02DF7D3/Windows8.1-KB2959977-x64.msu" }


### PR DESCRIPTION
### Description

Sets the msu_package functional tests to only run on appveyor.

### Issues Resolved

Unblocks chef-test in Jenkins where these tests fail

### Other Words

Choosing an MSU that works on a system but shouldn't be installed is hard / impossible.

These tests work on appveyor but break the build in Jenkins. For now, let them just run on
appveyor.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>