### PR TITLE
check to see if a unit is-active after starting

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -115,6 +115,8 @@ class Chef
         unless current_resource.active
           converge_by("starting unit: #{new_resource.name}") do
             systemctl_execute!(:start, new_resource.name)
+            sleep 0.5
+            systemctl_execute!("is-active", new_resource.name)
           end
         end
       end
@@ -130,6 +132,8 @@ class Chef
       def action_restart
         converge_by("restarting unit: #{new_resource.name}") do
           systemctl_execute!(:restart, new_resource.name)
+          sleep 0.5
+          systemctl_execute!("is-active", new_resource.name)
         end
       end
 


### PR DESCRIPTION
With certain types of systemd units we cannot depend systemctl's
exit code to determine if the unit is active.

Use systemctl is-active to explicitly check if the unit has started