### PR TITLE
Use the full path to expand.exe for msu_package, raise exception if command fails

### DIFF
--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -125,9 +125,8 @@ class Chef
         end
 
         def extract_msu_contents(msu_file, destination)
-          shellout = Mixlib::ShellOut.new("expand -f:* #{msu_file} #{destination}", { :timeout => @new_resource.timeout })
           with_os_architecture(nil) do
-            shellout.run_command
+            shell_out_with_timeout!("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* #{msu_file} #{destination}")
           end
         end
 

--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -19,7 +19,7 @@
 require "spec_helper"
 require "chef/provider/package/cab"
 
-describe Chef::Resource::MsuPackage, :win2012r2_only, :appveyor_only do
+describe Chef::Resource::MsuPackage, :win2012r2_only do
 
   let(:package_name) { "Package_for_KB2959977" }
   let(:package_source) { "https://download.microsoft.com/download/3/B/3/3B320C07-B7B1-41E5-81F4-79EBC02DF7D3/Windows8.1-KB2959977-x64.msu" }

--- a/spec/unit/provider/package/msu_spec.rb
+++ b/spec/unit/provider/package/msu_spec.rb
@@ -243,8 +243,7 @@ The operation completed successfully.
 
   describe "#extract_msu_contents" do
     it "extracts the msu contents by using mixlib shellout" do
-      expect(Mixlib::ShellOut).to receive(:new).with("expand -f:* msu_file destination", { :timeout => new_resource.timeout })
-      expect(provider).to receive(:with_os_architecture)
+      expect(provider).to receive(:shell_out_with_timeout!).with("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* msu_file destination")
       provider.extract_msu_contents("msu_file", "destination")
     end
   end


### PR DESCRIPTION
### Description

Functional specs for msu_package failed pipeline with error:
```
1) Chef::Resource::MsuPackage installing package installs the package successfully
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: subject.run_action(:install)

          Chef::Exceptions::Package:
            msu_package[test msu package] (dynamically defined) had an error: Chef::Exceptions::Package: Corrupt MSU package: MSU package doesn't contain any xml file
          # ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'
          # ./lib/chef/provider/package/msu.rb:51:in `load_current_resource'
          # ./lib/chef/provider.rb:128:in `run_action'
          # ./lib/chef/resource.rb:622:in `run_action'
          # ./spec/functional/resource/msu_package_spec.rb:46:in `block (3 levels) in <top (required)>'
          # ------------------
          # --- Caused by: ---
          # Chef::Exceptions::Package:
          #   Corrupt MSU package: MSU package doesn't contain any xml file
          #   ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'

     1.2) Failure/Error: pkg_to_remove.run_action(:remove)

          Chef::Exceptions::Package:
            msu_package[Package_for_KB2959977] (dynamically defined) had an error: Chef::Exceptions::Package: Corrupt MSU package: MSU package doesn't contain any xml file
          # ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'
          # ./lib/chef/provider/package/msu.rb:51:in `load_current_resource'
          # ./lib/chef/provider.rb:128:in `run_action'
          # ./lib/chef/resource.rb:622:in `run_action'
          # ./spec/functional/resource/msu_package_spec.rb:82:in `remove_package'
          # ./spec/functional/resource/msu_package_spec.rb:43:in `block (3 levels) in <top (required)>'
          # ------------------
          # --- Caused by: ---
          # Chef::Exceptions::Package:
          #   Corrupt MSU package: MSU package doesn't contain any xml file
          #   ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'

  2) Chef::Resource::MsuPackage removing a package removes an installed package
     Failure/Error: subject.run_action(:install)

     Chef::Exceptions::Package:
       msu_package[test msu package] (dynamically defined) had an error: Chef::Exceptions::Package: Corrupt MSU package: MSU package doesn't contain any xml file
     # ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'
     # ./lib/chef/provider/package/msu.rb:51:in `load_current_resource'
     # ./lib/chef/provider.rb:128:in `run_action'
     # ./lib/chef/resource.rb:622:in `run_action'
     # ./spec/functional/resource/msu_package_spec.rb:54:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Chef::Exceptions::Package:
     #   Corrupt MSU package: MSU package doesn't contain any xml file
     #   ./lib/chef/provider/package/msu.rb:142:in `read_cab_files_from_xml'

Finished in 19 minutes 48 seconds (files took 36.23 seconds to load)
3596 examples, 2 failures, 70 pending
```

Seems like the msu package was not extracted successfully. Hence using `shell_out!`.