### PR TITLE
Add rake task for generator release annoucnements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ require_relative "tasks/maintainers"
 require_relative "tasks/cbgb"
 require_relative "tasks/dependencies"
 require_relative "tasks/changelog"
+require_relative "tasks/announce"
 
 ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "Chef", "chef") do |package|
   package.component_paths = ["chef-config"]

--- a/tasks/announce.rb
+++ b/tasks/announce.rb
@@ -1,0 +1,57 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'date'
+require 'erb'
+
+class ReleaseAnnouncement
+  include ERB::Util
+  attr_accessor :type, :version, :date, :release_notes
+
+  def initialize(version, date, type)
+    @version = version
+    @date = Date.parse(date) unless date.nil?
+    @release_notes = release_notes_from_file
+    @type = type
+  end
+
+  def render
+    puts "-" * 30
+    puts ERB.new(template_for(@type)).result(binding)
+    puts "-" * 30
+  end
+
+  def template_for(type)
+    File.read("tasks/templates/#{type}.md.erb")
+  end
+
+  def release_notes_from_file
+    File.read("RELEASE_NOTES.md").match(/^# Chef Client Release Notes 12.17:\n\n(.*)/m)[1]
+  end
+end
+
+namespace :announce do
+  desc "Generate the Prerelease Announcement (version: X.Y.Z, release_date: YYYY-MM-DD)"
+  task :prerelease, :version, :release_date do |t, args|
+    ReleaseAnnouncement.new(args[:version], args[:release_date], "prerelease").render
+  end
+
+  desc "Generate the Release Announcement (version: X.Y.Z)"
+  task :release, :version do |t, args|
+    ReleaseAnnouncement.new(args[:version], nil, "release").render
+  end
+end

--- a/tasks/announce.rb
+++ b/tasks/announce.rb
@@ -20,10 +20,11 @@ require 'erb'
 
 class ReleaseAnnouncement
   include ERB::Util
-  attr_accessor :type, :version, :date, :release_notes
+  attr_accessor :type, :version, :maj_minor, :date, :release_notes
 
   def initialize(version, date, type)
     @version = version
+    @maj_minor = version.split(".")[0..1].join(".")
     @date = Date.parse(date) unless date.nil?
     @release_notes = release_notes_from_file
     @type = type
@@ -40,7 +41,7 @@ class ReleaseAnnouncement
   end
 
   def release_notes_from_file
-    File.read("RELEASE_NOTES.md").match(/^# Chef Client Release Notes 12.17:\n\n(.*)/m)[1]
+    File.read("RELEASE_NOTES.md").match(/^# Chef Client Release Notes #{@maj_minor}:\n\n(.*)/m)[1]
   end
 end
 

--- a/tasks/announce.rb
+++ b/tasks/announce.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require 'date'
-require 'erb'
+require "date"
+require "erb"
 
 class ReleaseAnnouncement
   include ERB::Util

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -1,0 +1,35 @@
+Ohai Chefs!
+
+We have selected <%= @version %> as our Chef v<%= @version.split(".")[0..1].join(".") %> release candidate which is scheduled for release on <%= @date.strftime('%A %B %-d, %Y') %>.
+
+# Release Highlights
+
+<%= @release_notes %>
+
+Please see the [CHANGELOG](https://github.com/chef/chef/blob/master/CHANGELOG.md) for the complete list of changes.
+
+# Get the Build
+As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `milib-install` command line utility available in ChefDK 0.19.6 or greater.
+
+```shell
+$ mixlib-install download chef -v <%= @version %> -c current
+```
+
+Alternatively, you can install Chef using one of the following command options:
+
+```shell
+# In Shell
+$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v <%= @version %> -c current
+
+# In Windows Powershell
+. { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version <%= @version %> -channel current
+```
+
+If you want to give this version a spin in Test Kitchen, create or add the following to a `.kitchen.local.yml` file:
+
+```yaml
+provisioner:
+  product_name: chef
+  channel: current
+  product_version: <%= @version %>
+```

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -1,6 +1,6 @@
 Ohai Chefs!
 
-We have selected <%= @version %> as our Chef v<%= @version.split(".")[0..1].join(".") %> release candidate which is scheduled for release on <%= @date.strftime('%A %B %-d, %Y') %>.
+We have selected <%= @version %> as our Chef v<%= @maj_minor %> release candidate which is scheduled for release on <%= @date.strftime('%A %B %-d, %Y') %>.
 
 # Release Highlights
 

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -9,7 +9,7 @@ We have selected <%= @version %> as our Chef v<%= @maj_minor %> release candidat
 Please see the [CHANGELOG](https://github.com/chef/chef/blob/master/CHANGELOG.md) for the complete list of changes.
 
 # Get the Build
-As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `milib-install` command line utility available in ChefDK 0.19.6 or greater.
+As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `mixlib-install` command line utility available in ChefDK 0.19.6 or greater.
 
 ```shell
 $ mixlib-install download chef -v <%= @version %> -c current

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -1,6 +1,6 @@
 Ohai Chefs!
 
-We're happy to announce the release of Chef v<%= @version.split(".")[0..1].join(".") %>!
+We're happy to announce the release of Chef v<%= @maj_minor %>!
 
 # Release Highlights
 

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -1,0 +1,34 @@
+Ohai Chefs!
+
+We're happy to announce the release of Chef v<%= @version.split(".")[0..1].join(".") %>!
+
+# Release Highlights
+
+<%= @release_notes %>
+
+Please see the [CHANGELOG](https://github.com/chef/chef/blob/master/CHANGELOG.md) for the complete list of changes.
+
+# Get the Build
+As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `milib-install` command line utility available in ChefDK 0.19.6 or greater.
+
+```shell
+$ mixlib-install download chef -v <%= @version %>
+```
+
+Alternatively, you can install Chef using one of the following command options:
+
+```shell
+# In Shell
+$ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v <%= @version %>
+
+# In Windows Powershell
+. { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version <%= @version %>
+```
+
+If you want to give this version a spin in Test Kitchen, create or add the following to a `.kitchen.local.yml` file:
+
+```yaml
+provisioner:
+  product_name: chef
+  product_version: <%= @version %>
+```

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -9,7 +9,7 @@ We're happy to announce the release of Chef v<%= @maj_minor %>!
 Please see the [CHANGELOG](https://github.com/chef/chef/blob/master/CHANGELOG.md) for the complete list of changes.
 
 # Get the Build
-As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `milib-install` command line utility available in ChefDK 0.19.6 or greater.
+As always, you can download binaries directly from [downloads.chef.io](https://downloads.chef.io/chef-client) or by using the new `mixlib-install` command line utility available in ChefDK 0.19.6 or greater.
 
 ```shell
 $ mixlib-install download chef -v <%= @version %>


### PR DESCRIPTION
### Description

To ensure consistency, and to let users get the information they
want/need at a glance, we're introducing release announcement
templates. The Chef release team will use these tasks to generate the
release announcements before posting them to Discourse.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>


Signed-off-by: Tom Duffield <tom@chef.io>