### PR TITLE
Data Collector debug log should output JSON

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -331,7 +331,7 @@ class Chef
       def send_to_data_collector(message)
         return unless data_collector_accessible?
 
-        Chef::Log.debug("data_collector_reporter: POSTing the following message to #{data_collector_server_url}: #{message}")
+        Chef::Log.debug("data_collector_reporter: POSTing the following message to #{data_collector_server_url}: #{Chef::JSONCompat.to_json(message)}")
         http.post(nil, message, headers)
       end
 


### PR DESCRIPTION
After changing Data Collector to use Chef::ServerAPI or
Chef::HTTP::SimpleJSON, the message output in the debug log is a ruby
inspect of the message hash rather than the JSON output that will be
sent to the data collector. Having this as JSON makes it easier to debug
and reproduce Data Collector-related issues.

Signed-off-by: Adam Leff <adam@leff.co>