### PR TITLE
Update Data Collector to use Chef::JSONCompat

### DIFF
--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -18,7 +18,6 @@
 # limitations under the License.
 #
 
-require "json"
 require "securerandom"
 require_relative "messages/helpers"
 

--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -142,14 +142,14 @@ class Chef
         # @return [Hash] DataCollector metadata for this node
         #
         def metadata
-          JSON.load(Chef::FileCache.load(metadata_filename))
+          Chef::JSONCompat.parse(Chef::FileCache.load(metadata_filename))
         rescue Chef::Exceptions::FileNotFound
           {}
         end
 
         def update_metadata(key, value)
           updated_metadata = metadata.tap { |x| x[key] = value }
-          Chef::FileCache.store(metadata_filename, updated_metadata.to_json, 0644)
+          Chef::FileCache.store(metadata_filename, Chef::JSONCompat.to_json(updated_metadata), 0644)
         end
 
         def metadata_filename


### PR DESCRIPTION
Data Collector uses the json gem to read/write the metadata file
in the file cache. Let's change that to use Chef::JSONCompat instead.