### PR TITLE
Ensures correct version of shutdown is called when using the reboot resource on Windows

### DIFF
--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -36,7 +36,7 @@ class Chef
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
                   # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
-                  windows_shutdown_path = "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe"
+                  windows_shutdown_path = "#{ENV['SYSTEMROOT']}/System32/shutdown.exe"
                   "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.

--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -36,7 +36,7 @@ class Chef
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
                   # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
-                  windows_shutdown_path = 'C:/Windows/System32/shutdown.exe'
+                  windows_shutdown_path = "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe"
                   "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.

--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -35,7 +35,9 @@ class Chef
 
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
-                  "shutdown /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
+                  # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
+                  windows_shutdown_path = 'C:/Windows/System32/shutdown.exe'
+                  "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.
                   "shutdown -r +#{reboot_info[:delay_mins]} \"#{reboot_info[:reason]}\""

--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -36,7 +36,7 @@ class Chef
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
                   # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
-                  windows_shutdown_path = "#{ENV['SYSTEMROOT']}/System32/shutdown.exe"
+                  windows_shutdown_path = "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe"
                   "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.

--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -36,7 +36,7 @@ class Chef
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
                   # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
-                  windows_shutdown_path = "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe"
+                  windows_shutdown_path = 'C:/Windows/System32/shutdown.exe'
                   "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
+      :windows => 'C:/Windows/System32/shutdown.exe /r /t 300 /c "rebooter spec test"',
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => 'C:/Windows/System32/shutdown.exe /r /t 300 /c "rebooter spec test"',
+      :windows => "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
+      :windows => "#{ENV['SYSTEMROOT']}/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end
@@ -80,7 +80,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot_if_needed!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows" do
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot_if_needed!, true, expected[:windows])
         end
 
@@ -91,8 +91,8 @@ describe Chef::Platform::Rebooter do
 
       describe "when using #reboot!" do
         include_context "test a reboot method"
-
-        it "should produce the correct string on Windows" do
+        
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot!, true, expected[:windows])
         end
 

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => 'shutdown /r /t 300 /c "rebooter spec test"',
+      :windows => 'C:/Windows/System32/shutdown.exe /r /t 300 /c "rebooter spec test"',
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
+      :windows => "#{ENV['SYSTEMROOT']}/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end
@@ -80,7 +80,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot_if_needed!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows" do
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot_if_needed!, true, expected[:windows])
         end
 
@@ -92,7 +92,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows" do
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot!, true, expected[:windows])
         end
 

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => "#{ENV['SYSTEMROOT']}/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
+      :windows => "#{ENV['SystemDrive']}/Windows/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end
@@ -80,7 +80,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot_if_needed!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows", :windows_only do
+        it "should produce the correct string on Windows" do
           test_rebooter_method(:reboot_if_needed!, true, expected[:windows])
         end
 
@@ -91,8 +91,8 @@ describe Chef::Platform::Rebooter do
 
       describe "when using #reboot!" do
         include_context "test a reboot method"
-        
-        it "should produce the correct string on Windows", :windows_only do
+
+        it "should produce the correct string on Windows" do
           test_rebooter_method(:reboot!, true, expected[:windows])
         end
 


### PR DESCRIPTION
### Description

Use 'C:/Windows/System32/shutdown.exe...' instead of 'shutdown...' when rebooting.

### Issues Resolved

https://github.com/chef/chef/issues/5594

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [N/A] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
