### PR TITLE
Alias unmount to umount for mount resource

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,4 +29,13 @@ _This file holds "in progress" release notes for the current release under devel
   end
   ```
 
+- Alias `unmount` to `umount` for mount resource
+Example:
+
+  ```ruby
+  mount '/mount/tmp' do
+    action :unmount
+  end
+  ```
+
 ## Highlighted bug fixes for this release:

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -108,6 +108,8 @@ class Chef
         end
       end
 
+      alias :action_unmount :action_umount
+
       #
       # Abstract Methods to be implemented by subclasses
       #

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -28,7 +28,7 @@ class Chef
       state_attrs :mount_point, :device_type, :fstype, :username, :password, :domain
 
       default_action :mount
-      allowed_actions :mount, :umount, :remount, :enable, :disable
+      allowed_actions :mount, :umount, :unmount, :remount, :enable, :disable
 
       def initialize(name, run_context = nil)
         super

--- a/spec/unit/provider/mount_spec.rb
+++ b/spec/unit/provider/mount_spec.rb
@@ -70,6 +70,13 @@ describe Chef::Provider::Mount do
       expect(new_resource).to be_updated_by_last_action
     end
 
+    it "should unmount the filesystem if it is mounted" do
+      allow(current_resource).to receive(:mounted).and_return(true)
+      expect(provider).to receive(:umount_fs).and_return(true)
+      provider.run_action(:unmount)
+      expect(new_resource).to be_updated_by_last_action
+    end
+
     it "should not umount the filesystem if it is not mounted" do
       allow(current_resource).to receive(:mounted).and_return(false)
       expect(provider).not_to receive(:umount_fs)

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -41,9 +41,10 @@ describe Chef::Resource::Mount do
     expect(@resource.action).to eql([:mount])
   end
 
-  it "should accept mount, umount and remount as actions" do
+  it "should accept mount, umount, unmount and remount as actions" do
     expect { @resource.action :mount }.not_to raise_error
     expect { @resource.action :umount }.not_to raise_error
+    expect { @resource.action :unmount }.not_to raise_error
     expect { @resource.action :remount }.not_to raise_error
     expect { @resource.action :brooklyn }.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
### Description

Allows the usage of `action :unmount` to `umount` a mount point

### Issues Resolved

Closes https://github.com/chef/chef/issues/5595

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Grant Ridder <shortdudey123@gmail.com>