### PR TITLE
Core: Ensure chef-solo creates node files w/ correct permissions

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -44,6 +44,7 @@ require "chef/chef_fs/data_handler/role_data_handler"
 require "chef/chef_fs/data_handler/user_data_handler"
 require "chef/chef_fs/data_handler/group_data_handler"
 require "chef/chef_fs/data_handler/container_data_handler"
+require "chef/win32/security" if Chef::Platform.windows?
 
 class Chef
   module ChefFS
@@ -109,7 +110,17 @@ class Chef
             else
               child_paths[name].each do |path|
                 begin
-                  Dir.mkdir(path)
+                  Dir.mkdir(path, 0700)
+                  if Chef::Platform.windows?
+                    all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
+                    owner = Chef::ReservedNames::Win32::Security::SID.current_user
+                    dacl = Chef::ReservedNames::Win32::Security::ACL.create([
+                      Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, all_mask),
+                    ])
+                    so = Chef::ReservedNames::Win32::Security::SecurableObject.new(path)
+                    so.owner = owner
+                    so.set_dacl(dacl, false)
+                  end
                 rescue Errno::EEXIST
                 end
               end

--- a/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
@@ -20,6 +20,7 @@
 require "chef/chef_fs/file_system/repository/node"
 require "chef/chef_fs/file_system/repository/directory"
 require "chef/chef_fs/file_system/exceptions"
+require "chef/win32/security" if Chef::Platform.windows?
 
 class Chef
   module ChefFS
@@ -29,6 +30,24 @@ class Chef
 
           def make_child_entry(child_name)
             Node.new(child_name, self)
+          end
+
+          def create_child(child_name, file_contents = nil)
+            child = super
+            File.chmod(0600, child.file_path)
+            if Chef::Platform.windows?
+              read_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_READ
+              write_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_WRITE
+              owner = Chef::ReservedNames::Win32::Security::SID.current_user
+              dacl = Chef::ReservedNames::Win32::Security::ACL.create([
+                Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, read_mask),
+                Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, write_mask),
+              ])
+              so = Chef::ReservedNames::Win32::Security::SecurableObject.new(child.file_path)
+              so.owner = owner
+              so.set_dacl(dacl, false)
+            end
+            child
           end
         end
       end


### PR DESCRIPTION
### Description

This commit ensures that the `nodes` dir and the node files within
it are created with the correct permissions by chef-solo.

### Issues Resolved

Internal ticket

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

cc @chef/client-core @chef/client-windows 