### PR TITLE
Modify `knife configure` example `chef_server_url`

### DIFF
--- a/distro/common/markdown/man1/knife-configure.mkd
+++ b/distro/common/markdown/man1/knife-configure.mkd
@@ -33,10 +33,11 @@ the specified _directory_.
   * On a freshly installed Chef Server, use _knife configure -i_ to
     create an administrator and knife configuration file. Leave the
     field blank to accept the default value. On most systems, the
-    default values are acceptable.
+    default values are acceptable (except for the chef server URL,
+    there you must add your organization name)
 
     user@host$ knife configure -i
-    Please enter the chef server URL: [http://localhost:4000]
+    Please enter the chef server URL: [http://localhost/organizations/myorg]
     Please enter a clientname for the new client: [username]
     Please enter the existing admin clientname: [chef-webui]
     Please enter the location of the existing admin client's private key: [/etc/chef/webui.pem]

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -133,7 +133,7 @@ EOH
 
       def ask_user_for_config
         server_name = guess_servername
-        @chef_server = config[:chef_server_url] || ask_question("Please enter the chef server URL: ", :default => "https://#{server_name}:443")
+        @chef_server = config[:chef_server_url] || ask_question("Please enter the chef server URL: ", :default => "https://#{server_name}/organizations/myorg")
         if config[:initial]
           @new_client_name        = config[:node_name] || ask_question("Please enter a name for the new user: ", :default => Etc.getlogin)
           @admin_client_name      = config[:admin_client_name] || ask_question("Please enter the existing admin name: ", :default => "admin")

--- a/spec/unit/knife/configure_spec.rb
+++ b/spec/unit/knife/configure_spec.rb
@@ -38,7 +38,7 @@ describe Chef::Knife::Configure do
   let(:default_validator_key) { "/etc/chef-server/chef-validator.pem" }
   let(:default_validator_key_win32) { File.expand_path(default_validator_key) }
 
-  let(:default_server_url) { "https://#{fqdn}:443" }
+  let(:default_server_url) { "https://#{fqdn}/organizations/myorg" }
 
   it "asks the user for the URL of the chef server" do
     @knife.ask_user_for_config


### PR DESCRIPTION
This modifies the example given for `chef_server_url` in `knife configure`. A proper `chef_server_url` in `knife.rb` must contain a path to an organization.