### PR TITLE
linux mount provider - skip device detection for zfs

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -193,7 +193,7 @@ class Chef
         def device_should_exist?
           ( @new_resource.device != "none" ) &&
             ( not network_device? ) &&
-            ( not %w{ cgroup tmpfs fuse vboxsf }.include? @new_resource.fstype )
+            ( not %w{ cgroup tmpfs fuse vboxsf zfs }.include? @new_resource.fstype )
         end
 
         private

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -107,7 +107,7 @@ describe Chef::Provider::Mount::Mount do
       expect { @provider.load_current_resource(); @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
-    %w{tmpfs fuse cgroup}.each do |fstype|
+    %w{tmpfs fuse cgroup vboxsf zfs}.each do |fstype|
       it "does not expect the device to exist for #{fstype}" do
         @new_resource.fstype(fstype)
         @new_resource.device("whatever")


### PR DESCRIPTION
### Description

linux mount provider - skip device detection for zfs

### Issues Resolved

#5597

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

