### PR TITLE
Update ohai resource to new style, stop overwriting name property

### DIFF
--- a/lib/chef/provider/ohai.rb
+++ b/lib/chef/provider/ohai.rb
@@ -21,6 +21,8 @@ require "ohai"
 class Chef
   class Provider
     class Ohai < Chef::Provider
+      use_inline_resources
+
       provides :ohai
 
       def whyrun_supported?
@@ -31,7 +33,7 @@ class Chef
         true
       end
 
-      def action_reload
+      action :reload do
         converge_by("re-run ohai and merge results into node attributes") do
           ohai = ::Ohai::System.new
 
@@ -39,9 +41,9 @@ class Chef
           # Otherwise it will only reload the specified plugin
           # Note that any changes to plugins, or new plugins placed on
           # the path are picked up by ohai.
-          ohai.all_plugins @new_resource.plugin
+          ohai.all_plugins new_resource.plugin
           node.automatic_attrs.merge! ohai.data
-          Chef::Log.info("#{@new_resource} reloaded")
+          Chef::Log.info("#{new_resource} reloaded")
         end
       end
     end

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -20,34 +20,14 @@
 class Chef
   class Resource
     class Ohai < Chef::Resource
+      resource_name :ohai
+      provides :ohai
 
-      identity_attr :name
-
-      state_attrs :plugin
+      property :ohai_name, name_property: true
+      property :plugin, [String]
 
       default_action :reload
-
-      def initialize(name, run_context = nil)
-        super
-        @name = name
-        @plugin = nil
-      end
-
-      def plugin(arg = nil)
-        set_or_return(
-          :plugin,
-          arg,
-          :kind_of => [ String ]
-        )
-      end
-
-      def name(arg = nil)
-        set_or_return(
-          :name,
-          arg,
-          :kind_of => [ String ]
-        )
-      end
+      allowed_actions :reload
     end
   end
 end

--- a/spec/unit/resource/ohai_spec.rb
+++ b/spec/unit/resource/ohai_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Resource::Ohai do
     expect(@resource.resource_name).to eql(:ohai)
   end
 
-  it "should have a default action of create" do
+  it "should have a default action of reload" do
     expect(@resource.action).to eql([:reload])
   end
 


### PR DESCRIPTION
If #5606 is approved, any resource that creates a property that is an
already-existing Ruby method on a Chef::Resource object will throw a
deprecation warning. The ohai resource currently creates a `name`
property which conflicts with the `name` property created in the base
Chef::Resource class.

This change updates the ohai resource and provider to the new style of
defining resources and stops overwriting the `name` method.

Signed-off-by: Adam Leff <adam@leff.co>