### PR TITLE
Use chef/chef image instead of downloading from packages.chef.io

### DIFF
--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -2,7 +2,8 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: latest
+  chef_image: chef/chef
+  chef_version: current
 
 transport:
   name: dokken
@@ -10,9 +11,6 @@ transport:
 provisioner:
   name: chef_github
   root_path: /opt/kitchen
-  require_chef_omnibus: latest
-  chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
-  chef_omnibus_install_options: "-c current"
   github_owner: "chef"
   github_repo: "chef"
   refname: <%= ENV['TRAVIS_COMMIT'] %>


### PR DESCRIPTION
### Description

Since we use kitchen-dokken, we are downloading the chef Docker image. To avoid downloading the Chef binary from packages.chef.io as well, use the chef/chef:current image available on the Docker Hub instead. 

### Issues Resolved

* Excess bandwidth spent downloading duplicate Chef packages

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>