### PR TITLE
fix yum regexp similarly to rpm regexp in #3985

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -197,7 +197,7 @@ class Chef
             Chef::Log.debug("#{@new_resource} checking rpm status")
             shell_out_with_timeout!("rpm -qp --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' #{@new_resource.source}", :timeout => Chef::Config[:yum_timeout]).stdout.each_line do |line|
               case line
-              when /([\w\d_.-]+)\s([\w\d_.-]+)/
+              when /^(\S+)\s(\S+)$/
                 @current_resource.package_name($1)
                 @new_resource.version($2)
               end


### PR DESCRIPTION

this is a "nope, aint got time to test this one" PR.

this affects a code path that is only for localinstalls and doesn't have
any existing tests.

i've already exceeded my 5 minute timebox for fixing the problem.

i'm more likely to rewrite the yum provider from scratch and shitcan the
unit tests in their entirety than to reuse any work that i do here so
any time spent on carefully testing this is likely to end up wasted.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>