### PR TITLE
Use badge in CHANGELOG

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -23,7 +23,7 @@ begin
       config.enhancement_labels = "enhancement,Enhancement,New Feature,Feature".split(",")
       config.bug_labels = "bug,Bug,Improvement,Upstream Bug".split(",")
       config.exclude_labels = "duplicate,question,invalid,wontfix,no_changelog,Exclude From Changelog,Question,Discussion".split(",")
-      config.header = "This changelog reflects the current state of chef's master branch on github and may not reflect the current released version of chef, which is **#{latest_stable_version}**."
+      config.header = "This changelog reflects the current state of chef's master branch on github and may not reflect the current released version of chef, which is [![Gem Version](https://badge.fury.io/rb/chef.svg)](https://badge.fury.io/rb/chef)."
     end
   end
 


### PR DESCRIPTION
### Description

Use the badge in the changelog so the current stable version is shown
regardless of when the CHANGELOG is viewed.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>