### PR TITLE
Use a fixed path to shutdown.exe on windows in Chef::Platform::Reboot…

### DIFF
--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -35,7 +35,9 @@ class Chef
 
           cmd = if Chef::Platform.windows?
                   # should this do /f as well? do we then need a minimum delay to let apps quit?
-                  "shutdown /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
+                  # Use explicit path to shutdown.exe, to protect against https://github.com/chef/chef/issues/5594
+                  windows_shutdown_path = "#{ENV['SYSTEMROOT']}/System32/shutdown.exe"
+                  "#{windows_shutdown_path} /r /t #{reboot_info[:delay_mins] * 60} /c \"#{reboot_info[:reason]}\""
                 else
                   # probably Linux-only.
                   "shutdown -r +#{reboot_info[:delay_mins]} \"#{reboot_info[:reason]}\""

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Platform::Rebooter do
 
   let(:expected) do
     {
-      :windows => 'shutdown /r /t 300 /c "rebooter spec test"',
+      :windows => "#{ENV['SYSTEMROOT']}/System32/shutdown.exe /r /t 300 /c \"rebooter spec test\"",
       :linux => 'shutdown -r +5 "rebooter spec test"',
     }
   end
@@ -80,7 +80,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot_if_needed!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows" do
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot_if_needed!, true, expected[:windows])
         end
 
@@ -92,7 +92,7 @@ describe Chef::Platform::Rebooter do
       describe "when using #reboot!" do
         include_context "test a reboot method"
 
-        it "should produce the correct string on Windows" do
+        it "should produce the correct string on Windows", :windows_only do
           test_rebooter_method(:reboot!, true, expected[:windows])
         end
 


### PR DESCRIPTION
 Use a fixed path to shutdown.exe on windows in Chef::Platform::Rebooter, fixes #5594, closes #5596