### PR TITLE
[Do Not Merge - On Hold] Calling the shell_out! method to raise errors in powershell_out code flow.

### DIFF
--- a/lib/chef/mixin/powershell_out.rb
+++ b/lib/chef/mixin/powershell_out.rb
@@ -64,7 +64,7 @@ class Chef
         arch = options.delete(:architecture)
 
         with_os_architecture(nil, architecture: arch) do
-          shell_out(
+          shell_out!(
             build_powershell_command(script),
             options
           )


### PR DESCRIPTION
In-progress.

Issue Ref: https://github.com/chef/chef/issues/4803