### PR TITLE
Fix Data Collector organization parsing regex

### DIFF
--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -76,7 +76,7 @@ class Chef
         def chef_server_organization
           return "unknown_organization" unless Chef::Config[:chef_server_url]
 
-          Chef::Config[:chef_server_url].match(%r{/+organizations/+([\w-]+)}).nil? ? "unknown_organization" : $1
+          Chef::Config[:chef_server_url].match(%r{/+organizations/+([a-z0-9][a-z0-9_-]{0,254})}).nil? ? "unknown_organization" : $1
         end
 
         #

--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -76,7 +76,7 @@ class Chef
         def chef_server_organization
           return "unknown_organization" unless Chef::Config[:chef_server_url]
 
-          Chef::Config[:chef_server_url].match(%r{/+organizations/+(\w+)}).nil? ? "unknown_organization" : $1
+          Chef::Config[:chef_server_url].match(%r{/+organizations/+([\w-]+)}).nil? ? "unknown_organization" : $1
         end
 
         #

--- a/spec/unit/data_collector/messages/helpers_spec.rb
+++ b/spec/unit/data_collector/messages/helpers_spec.rb
@@ -72,6 +72,13 @@ describe Chef::DataCollector::Messages::Helpers do
         expect(TestMessage.chef_server_organization).to eq("unknown_organization")
       end
     end
+
+    context "when the organization in the URL contains hyphens" do
+      it "returns the full org name" do
+        Chef::Config[:chef_server_url] = "http://mycompany.com/organizations/myorg-test"
+        expect(TestMessage.chef_server_organization).to eq("myorg-test")
+      end
+    end
   end
 
   describe "#collector_source" do


### PR DESCRIPTION
The regex used to pluck the Chef Server Organization from the
chef_server_url config value did not permit hyphens in org names
even though they are allowed by Chef Server. This caused org names
to get incorrectly truncated when sending the payload to Data
Collector servers.

Re: Chef bug IPO-500

Signed-off-by: Adam Leff <adam@leff.co>