### PR TITLE
Properly deprecate old Chef::Platform methods

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -156,6 +156,16 @@ class Chef
       end
     end
 
+    class ChefPlatformMethods < Base
+      def id
+        13
+      end
+
+      def target
+        "chef_platform_methods.html"
+      end
+    end
+
     class ResourceCloning < Base
       def id
         3694

--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -35,6 +35,7 @@ class Chef
       include Chef::Mixin::ParamsValidate
 
       def find(name, version)
+        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find is deprecated")
         provider_map = platforms[:default].clone
 
         name_sym = name
@@ -90,6 +91,7 @@ class Chef
       end
 
       def provider_for_resource(resource, action = :nothing)
+        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.provider_for_resource is deprecated")
         node = resource.run_context && resource.run_context.node
         raise ArgumentError, "Cannot find the provider for a resource with no run context set" unless node
         provider = find_provider_for_node(node, resource).new(resource, resource.run_context)
@@ -102,11 +104,13 @@ class Chef
       end
 
       def find_provider_for_node(node, resource_type)
+        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find_provider_for_node is deprecated")
         platform, version = find_platform_and_version(node)
         find_provider(platform, version, resource_type)
       end
 
       def set(args)
+        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.set is deprecated")
         validate(
           args,
           {
@@ -172,6 +176,7 @@ class Chef
       end
 
       def find_provider(platform, version, resource_type)
+        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find_provider is deprecated")
         provider_klass = explicit_provider(platform, version, resource_type) ||
           platform_provider(platform, version, resource_type) ||
           resource_matching_provider(platform, version, resource_type)

--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -76,6 +76,7 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only do
   let(:env_value2) { "value2" }
   let(:dsc_test_run_context) do
     node = Chef::Node.new
+    node.automatic["os"] = "windows"
     node.automatic["platform"] = "windows"
     node.automatic["platform_version"] = "6.1"
     node.automatic["kernel"][:machine] = :x86_64 # Only 64-bit architecture is supported

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -1425,6 +1425,7 @@ describe "Recipe DSL methods" do
               end
 
               it "my_resource fails to find a provider (and calls provides)" do
+                Chef::Config[:treat_deprecation_warnings_as_errors] = false
                 my_resource = self.my_resource
                 expect_converge do
                   instance_eval("#{my_resource} 'foo'")
@@ -1435,6 +1436,7 @@ describe "Recipe DSL methods" do
 
             context "that does not provide :my_resource" do
               it "my_resource fails to find a provider (and calls provides)" do
+                Chef::Config[:treat_deprecation_warnings_as_errors] = false
                 my_resource = self.my_resource
                 expect_converge do
                   instance_eval("#{my_resource} 'foo'")
@@ -1510,6 +1512,7 @@ describe "Recipe DSL methods" do
     end
 
     it "looks up the provider in Chef::Provider converting the resource name from snake case to camel case" do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
       resource = nil
       recipe = converge do
         resource = lw_resource_with_hw_provider_test_case("blah") {}

--- a/spec/support/lib/chef/provider/snakeoil.rb
+++ b/spec/support/lib/chef/provider/snakeoil.rb
@@ -19,6 +19,7 @@
 class Chef
   class Provider
     class SnakeOil < Chef::Provider
+      provides :cat
 
       def load_current_resource
         true

--- a/spec/support/lib/chef/resource/cat.rb
+++ b/spec/support/lib/chef/resource/cat.rb
@@ -19,6 +19,7 @@
 class Chef
   class Resource
     class Cat < Chef::Resource
+      provides :cat
 
       attr_accessor :action
 

--- a/spec/support/lib/chef/resource/one_two_three_four.rb
+++ b/spec/support/lib/chef/resource/one_two_three_four.rb
@@ -19,6 +19,7 @@
 class Chef
   class Resource
     class OneTwoThreeFour < Chef::Resource
+      provides :one_two_three_four
 
       attr_reader :i_can_count
 

--- a/spec/support/lib/chef/resource/openldap_includer.rb
+++ b/spec/support/lib/chef/resource/openldap_includer.rb
@@ -19,6 +19,8 @@
 class Chef
   class Resource
     class OpenldapIncluder < Chef::Resource::LWRPBase
+      provides :openldap_includer
+
       allowed_actions :run
       default_action :run
     end

--- a/spec/support/lib/chef/resource/with_state.rb
+++ b/spec/support/lib/chef/resource/with_state.rb
@@ -22,6 +22,8 @@ require "chef/json_compat"
 class Chef
   class Resource
     class WithState < Chef::Resource
+      provides :with_state
+
       attr_accessor :state
     end
   end

--- a/spec/support/lib/chef/resource/zen_master.rb
+++ b/spec/support/lib/chef/resource/zen_master.rb
@@ -22,6 +22,7 @@ require "chef/json_compat"
 class Chef
   class Resource
     class ZenMaster < Chef::Resource
+      provides :zen_master
       allowed_actions :win, :score
 
       attr_reader :peace

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -413,8 +413,7 @@ describe "LWRP" do
       resource = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       resource.monkey("bob")
       resource.provider(get_lwrp_provider(:lwrp_monkey_name_printer))
-
-      provider = Chef::Platform.provider_for_resource(resource, :twiddle_thumbs)
+      provider = resource.provider_for_action(:twiddle_thumbs)
       provider.action_twiddle_thumbs
     end
 
@@ -520,7 +519,7 @@ describe "LWRP" do
       resource.monkey("bob")
       resource.provider(get_lwrp_provider(:lwrp_monkey_name_printer))
 
-      provider = Chef::Platform.provider_for_resource(resource, :twiddle_thumbs)
+      provider = resource.provider_for_action(:twiddle_thumbs)
       provider.action_twiddle_thumbs
 
       expect(provider.monkey_name).to eq("my monkey's name is 'bob'")
@@ -531,7 +530,7 @@ describe "LWRP" do
       resource.monkey("bob")
       resource.provider(get_lwrp_provider(:lwrp_embedded_resource_accesses_providers_scope))
 
-      provider = Chef::Platform.provider_for_resource(resource, :twiddle_thumbs)
+      provider = resource.provider_for_action(:twiddle_thumbs)
       #provider = @runner.build_provider(resource)
       provider.action_twiddle_thumbs
 

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -31,6 +31,7 @@ describe Chef::Platform do
     end
 
     before(:each) do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
       Chef::Platform.platforms = {
         :darwin => {
           ">= 10.11" => {

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -135,6 +135,7 @@ describe Chef::ProviderResolver do
             end
           else
             it "'#{name}' fails to resolve (since #{name.inspect} is unsupported on #{platform} #{platform_version})", *tags do
+              Chef::Config[:treat_deprecation_warnings_as_errors] = false
               expect(resolved_provider).to be_nil
             end
           end

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -36,13 +36,13 @@ describe Chef::Resource::RemoteFile do
   it "says its provider is RemoteFile when the source is an absolute URI" do
     @resource.source("http://www.google.com/robots.txt")
     expect(@resource.provider).to eq(Chef::Provider::RemoteFile)
-    expect(Chef::Platform.find_provider(:noplatform, "noversion", @resource)).to eq(Chef::Provider::RemoteFile)
+    expect(@resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 
   it "says its provider is RemoteFile when the source is a network share" do
     @resource.source("\\\\fakey\\fakerton\\fake.txt")
     expect(@resource.provider).to eq(Chef::Provider::RemoteFile)
-    expect(Chef::Platform.find_provider(:noplatform, "noversion", @resource)).to eq(Chef::Provider::RemoteFile)
+    expect(@resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 
   describe "source" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -838,6 +838,8 @@ describe Chef::Resource do
     it "should run only_if/not_if conditionals when notified to run another action (CHEF-972)" do
       snitch_var1 = snitch_var2 = 0
       runner = Chef::Runner.new(run_context)
+
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
       Chef::Platform.set(
         :resource => :cat,
         :provider => Chef::Provider::SnakeOil

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -101,6 +101,7 @@ describe Chef::Runner do
   context "when we fall through to old Chef::Platform resolution" do
     let(:provider_resolver) { Chef::ProviderResolver.new(node, first_resource, nil) }
     before do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
       # set up old Chef::Platform resolution instead of provider_resolver
       Chef::Platform.set(
         :resource => :cat,


### PR DESCRIPTION

These should have been deprecated formally in 12.5.1 after the
Dynamic Provider-Resolver'ing of the internal chef resources
was completed.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>