### PR TITLE
Update Release Announcements; Keep Dockerfile up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ If you just want to use Chef, check out these resources:
 
 * [learnchef](https://learn.chef.io): Getting started guide
 * [docs.chef.io](https://docs.chef.io): Comprehensive User Docs
-* [Installer Downloads](https://downloads.chef.io/chef-client/): Install Chef as a complete package
+* [Installer Downloads](https://downloads.chef.io/chef/): Install Chef as a complete package
 
 ## Installing From Git
 
 **NOTE:** Unless you have a specific reason to install from source (to
 try a new feature, contribute a patch, or run chef on an OS for which no
-package is available), you should head to the [downloads page](https://downloads.chef.io/chef-client/)
+package is available), you should head to the [downloads page](https://downloads.chef.io/chef/)
 to get a prebuilt package.
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you just want to use Chef, check out these resources:
 * [learnchef](https://learn.chef.io): Getting started guide
 * [docs.chef.io](https://docs.chef.io): Comprehensive User Docs
 * [Installer Downloads](https://downloads.chef.io/chef/): Install Chef as a complete package
+* [chef/chef](https://hub.docker.com/r/chef/chef): Docker image for use with [kitchen-dokken](https://github.com/someara/kitchen-dokken)
 
 ## Installing From Git
 

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,15 @@ task :register_eventlog do
   end
 end
 
+desc "Keep the Dockerfile up-to-date"
+task :update_dockerfile do
+  require "mixlib/install"
+  latest_stable_version = Mixlib::Install.available_versions("chef", "stable").last
+  text = File.read("Dockerfile")
+  new_text = text.gsub(/^ARG VERSION=[\d\.]+$/, "ARG VERSION=#{latest_stable_version}")
+  File.open("Dockerfile", "w+") { |f| f.write(new_text) }
+end
+
 begin
   require "chefstyle"
   require "rubocop/rake_task"

--- a/ci/version_bump.sh
+++ b/ci/version_bump.sh
@@ -8,5 +8,6 @@ export LANG=en_US.UTF-8
 
 bundle exec rake version:bump
 bundle exec rake changelog
+bundle exec rake update_dockerfile
 
 git checkout .bundle/config

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -24,21 +24,3 @@ $ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v <%= @ve
 # In Windows Powershell
 . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version <%= @version %> -channel current
 ```
-
-If you want to give this version a spin in Test Kitchen, create or add the following to a `.kitchen.local.yml` file:
-
-```yaml
-provisioner:
-  product_name: chef
-  channel: current
-  product_version: <%= @version %>
-```
-
-If you use [kitchen-dokken](https://github.com/someara/kitchen-dokken), you can use the following configuration:
-
-```yaml
-driver:
-  name: dokken
-  chef_image: chef/chef
-  chef_version: <%= @version %> # use "current" to always use the latest build from the current channel
-```

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -33,3 +33,12 @@ provisioner:
   channel: current
   product_version: <%= @version %>
 ```
+
+If you use [kitchen-dokken](https://github.com/someara/kitchen-dokken), you can use the following configuration:
+
+```yaml
+driver:
+  name: dokken
+  chef_image: chef/chef
+  chef_version: <%= @version %> # use "current" to always use the latest build from the current channel
+```

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -24,20 +24,3 @@ $ curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v <%= @ve
 # In Windows Powershell
 . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version <%= @version %>
 ```
-
-If you want to give this version a spin in Test Kitchen, create or add the following to a `.kitchen.local.yml` file:
-
-```yaml
-provisioner:
-  product_name: chef
-  product_version: <%= @version %>
-```
-
-If you use [kitchen-dokken](https://github.com/someara/kitchen-dokken), you can use the following configuration:
-
-```yaml
-driver:
-  name: dokken
-  chef_image: chef/chef
-  chef_version: <%= @version %> # use "latest" to always use the latest stable release
-```

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -32,3 +32,12 @@ provisioner:
   product_name: chef
   product_version: <%= @version %>
 ```
+
+If you use [kitchen-dokken](https://github.com/someara/kitchen-dokken), you can use the following configuration:
+
+```yaml
+driver:
+  name: dokken
+  chef_image: chef/chef
+  chef_version: <%= @version %> # use "latest" to always use the latest stable release
+```


### PR DESCRIPTION
### Description

* Update the release announcement templates to remove kitchen language.
* Make sure that the default version in the Dockerfile is kept up to date with the latest stable release.
* Update the download URL for chef in the README.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
