### PR TITLE
Swap rbx testing in Travis for Ruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
     bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-  - rvm: rbx
+  - rvm: ruby-head
     sudo: true
     script: sudo -E $(which bundle) exec rake spec;
     # also remove integration / external tests
@@ -329,7 +329,7 @@ matrix:
       - sudo cat /var/log/squid3/access.log
 
   allow_failures:
-    - rvm: rbx
+    - rvm: ruby-head
 
 notifications:
   on_change: true


### PR DESCRIPTION
Rbx was failing as it wasn't a valid rbenv name. Ruby 2.4 comes out this month so we should add it to the test matrix.