### PR TITLE
Load yaml files via command knife from file

### DIFF
--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -95,6 +95,14 @@ class Chef
             else
               @klass.from_hash(r)
             end
+          when /\.(yaml|yml)$/
+            r = YAML.load(IO.read(filename))
+            # Chef::DataBagItem doesn't work well with the json_create method
+            if @klass == Chef::DataBagItem
+              r
+            else
+              @klass.from_hash(r)
+            end
           when /\.rb$/
             r = klass.new
             r.from_file(filename)

--- a/spec/integration/knife/environment_from_file_spec.rb
+++ b/spec/integration/knife/environment_from_file_spec.rb
@@ -83,6 +83,15 @@ EOM
 }
 EOM
 
+        file "environments/lore.yaml", <<EOM
+name: lore
+description: "An environment for last nodes"
+cookbook_versions: {}
+default_attributes:
+  hole: "Amigos!"
+override_attributes: {}
+EOM
+
       end
 
       it "uploads a single file" do
@@ -92,10 +101,11 @@ EOM
       end
 
       it "uploads many files" do
-        knife("environment from file #{env_dir}/cons.json #{env_dir}/car.json #{env_dir}/cdr.json").should_succeed stderr: <<EOM
+        knife("environment from file #{env_dir}/cons.json #{env_dir}/car.json #{env_dir}/cdr.json #{env_dir}/lore.yaml").should_succeed stderr: <<EOM
 Updated Environment cons
 Updated Environment car
 Updated Environment cdr
+Updated Environment lore
 EOM
       end
 

--- a/spec/integration/knife/role_from_file_spec.rb
+++ b/spec/integration/knife/role_from_file_spec.rb
@@ -74,6 +74,14 @@ EOM
 }
 EOM
 
+        file "roles/lore.yaml", <<EOM
+name: lore
+description: "A role for list nodes"
+default_attributes:
+  hola: "Amigos!"
+override_attributes: {}
+EOM
+
       end
 
       it "uploads a single file" do
@@ -83,10 +91,11 @@ EOM
       end
 
       it "uploads many files" do
-        knife("role from file #{role_dir}/cons.json #{role_dir}/car.json #{role_dir}/cdr.json").should_succeed stderr: <<EOM
+        knife("role from file #{role_dir}/cons.json #{role_dir}/car.json #{role_dir}/cdr.json #{role_dir}/lore.yaml").should_succeed stderr: <<EOM
 Updated Role cons
 Updated Role car
 Updated Role cdr
+Updated Role lore
 EOM
       end
 


### PR DESCRIPTION
### Description

It will allow to use yaml language as definition role and enviroments files.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Dmitry Vasiliev <vadv.mkn@gmail.com>