### PR TITLE
remove chef-provisioning-aws from travis

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: '1'
+BUNDLE_FROZEN: "1"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: "1"
+BUNDLE_FROZEN: '1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,6 @@ matrix:
     script: tasks/bin/run_external_test $TEST_GEM rake spec
     rvm: 2.3.1
   - env:
-      TEST_GEM: chef-provisioning-aws
-    script: tasks/bin/run_external_test $TEST_GEM rake spec
-    rvm: 2.3.1
-  - env:
       TEST_GEM: chef-sugar
     script: tasks/bin/run_external_test $TEST_GEM rake
     rvm: 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ end
 # These are used for external tests
 group(:integration) do
   gem "chef-provisioning"
-  gem "chef-provisioning-aws"
   gem "chef-sugar"
   gem "chefspec"
   gem "halite"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: d6d1d3791a1b71cf22af7438d1d7a8f1b44ccac7
+  revision: 2d06ce7ef5976e2a410906f60152142bf90a17fb
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.0.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -184,7 +184,7 @@ GEM
       simplecov
       url
     coderay (1.1.1)
-    concurrent-ruby (1.0.3)
+    concurrent-ruby (1.0.2)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -462,7 +462,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.66.3)
+    specinfra (2.66.2)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -591,4 +591,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: 2d06ce7ef5976e2a410906f60152142bf90a17fb
+  revision: d6d1d3791a1b71cf22af7438d1d7a8f1b44ccac7
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)
@@ -129,7 +129,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -139,16 +139,13 @@ GEM
       mixlib-cli (~> 1.4)
     artifactory (2.5.1)
     ast (2.3.0)
-    aws-sdk (2.6.35)
-      aws-sdk-resources (= 2.6.35)
-    aws-sdk-core (2.6.35)
+    aws-sdk (2.6.40)
+      aws-sdk-resources (= 2.6.40)
+    aws-sdk-core (2.6.40)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.35)
-      aws-sdk-core (= 2.6.35)
-    aws-sdk-v1 (1.66.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
+    aws-sdk-resources (2.6.40)
+      aws-sdk-core (= 2.6.40)
     aws-sigv4 (1.0.0)
     backports (3.6.8)
     binding_of_caller (0.7.2)
@@ -166,12 +163,6 @@ GEM
       net-ssh (>= 2.9, < 4.0)
       net-ssh-gateway (~> 1.2.0)
       winrm-fs (~> 1.0)
-    chef-provisioning-aws (2.1.0)
-      aws-sdk (>= 2.1.26, < 3.0)
-      aws-sdk-v1 (>= 1.59.0)
-      chef-provisioning (>= 1.0, < 3.0)
-      retryable (~> 2.0, >= 2.0.1)
-      ubuntu_ami (~> 0.4, >= 0.4.1)
     chef-sugar (3.4.0)
     chef-zero (5.1.1)
       ffi-yajl (~> 2.2)
@@ -193,7 +184,7 @@ GEM
       simplecov
       url
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -268,7 +259,7 @@ GEM
     iniparse (1.4.2)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (2.0.2)
     kitchen-docker (2.6.0)
       test-kitchen (>= 1.0.0)
     kitchen-ec2 (1.2.0)
@@ -471,7 +462,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.66.2)
+    specinfra (2.66.3)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -507,7 +498,6 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    ubuntu_ami (0.4.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -537,7 +527,7 @@ GEM
       ffi-win32-extensions
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
-    winrm (2.1.0)
+    winrm (2.1.1)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -571,7 +561,6 @@ DEPENDENCIES
   chef!
   chef-config!
   chef-provisioning
-  chef-provisioning-aws
   chef-sugar
   cheffish
   chefspec
@@ -602,4 +591,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
blocks testing on ruby 2.4

