### PR TITLE
Report a dummy resource if sensitive is enabled

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ _This file holds "in progress" release notes for the current release under devel
   compromise any sensitive data.
 
   _Note: Old data that was already sent to Reporting marked as sensitive will continue to be
-  displayed. Apologize._
+  displayed. Apologies._
 
 ## New deprecations introduced in this release:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ _This file holds "in progress" release notes for the current release under devel
 
 - You can now enable chef-client to run as a scheduled task directly from the client MSI on Windows hosts.
 
+## Highlighted bug fixes for this release:
+
+- Fixed exposure of sensitive data of resources marked as sensitive inside Reporting. Before you
+  were able to see the sensitive data on the Run History tab in the Chef Manage Console. Now we
+  are sending a new blank resource if the resource is marked as sensitive, this way we will not
+  compromise any sensitive data.
+
+  _Note: Old data that was already sent to Reporting marked as sensitive will continue to be
+  displayed. Apologize._
+
 ## New deprecations introduced in this release:
 
 ### Chef Platform Methods
@@ -13,3 +23,4 @@ _This file holds "in progress" release notes for the current release under devel
 - **Deprecation ID**: 13
 - **Remediation Docs**: <https://docs.chef.io/chef_platform_methods.html>
 - **Expected Removal**: Chef 13 (April 2017)
+

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -200,28 +200,18 @@ class Chef
         @pending_update.finish
 
         # Verify if the resource has sensitive data
+        # and create a new blank resource with only
+        # the name so we can report it back without
+        # sensitive data
         if @pending_update.new_resource.sensitive
-          sensitive_resource = transform_sensitive_resource(@pending_update.new_resource)
-          @pending_update.new_resource = sensitive_resource
+          klass = @pending_update.new_resource.class
+          resource_name = @pending_update.new_resource.name
+          @pending_update.new_resource = klass.new(resource_name)
         end
+
         @updated_resources << @pending_update
         @pending_update = nil
       end
-    end
-
-    def transform_sensitive_resource(resource)
-      mock_display = '*sensitive*'
-
-      # Every resource has a name
-      resource.name(mock_display)
-      # For Execute Resources
-      resource.command(mock_display) if defined? resource.command
-      # For File Resources
-      resource.content(mock_display) if defined? resource.content
-      # For Template Resources
-      resource.variables({'data' => mock_display}) if defined? resource.variables
-
-      resource
     end
 
     def run_completed(node)

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -265,6 +265,30 @@ describe Chef::ResourceReporter do
       @resource_reporter.run_started(@run_status)
     end
 
+    context "when the new_resource is sensitive" do
+      before do
+        @execute_resource = Chef::Resource::Execute.new("my sensitive execute block")
+        @execute_resource.name('sensitive-resource')
+        @execute_resource.command('echo "password: SECRET"')
+        @execute_resource.sensitive(true)
+        @resource_reporter.resource_action_start(@execute_resource, :run)
+        @resource_reporter.resource_current_state_loaded(@execute_resource, :run, @current_resource)
+        @resource_reporter.resource_updated(@execute_resource, :run)
+        @resource_reporter.resource_completed(@execute_resource)
+        @run_status.stop_clock
+        @report = @resource_reporter.prepare_run_data
+        @first_update_report = @report["resources"].first
+      end
+
+      it "resource_name in prepared_run_data should be transformed" do
+        expect(@first_update_report["name"]).to eq('*sensitive*')
+      end
+
+      it "resource_command in prepared_run_data should be transformed" do
+        expect(@first_update_report["after"]).to eq({:command=>"*sensitive*"})
+      end
+    end
+
     context "when the new_resource does not have a string for name and identity" do
       context "the new_resource name and id are nil" do
         before do

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -267,8 +267,8 @@ describe Chef::ResourceReporter do
 
     context "when the new_resource is sensitive" do
       before do
-        @execute_resource = Chef::Resource::Execute.new("my sensitive execute block")
-        @execute_resource.name('sensitive-resource')
+        @execute_resource = Chef::Resource::Execute.new("sensitive-resource")
+        @execute_resource.name("sensitive-resource")
         @execute_resource.command('echo "password: SECRET"')
         @execute_resource.sensitive(true)
         @resource_reporter.resource_action_start(@execute_resource, :run)
@@ -280,12 +280,12 @@ describe Chef::ResourceReporter do
         @first_update_report = @report["resources"].first
       end
 
-      it "resource_name in prepared_run_data should be transformed" do
-        expect(@first_update_report["name"]).to eq('*sensitive*')
+      it "resource_name in prepared_run_data should be the same" do
+        expect(@first_update_report["name"]).to eq("sensitive-resource")
       end
 
-      it "resource_command in prepared_run_data should be transformed" do
-        expect(@first_update_report["after"]).to eq({:command=>"*sensitive*"})
+      it "resource_command in prepared_run_data should be blank" do
+        expect(@first_update_report["after"]).to eq({ :command => "sensitive-resource" })
       end
     end
 


### PR DESCRIPTION
### Description

Before this commit we were sending sensitive resource information to
Reporting and therefor you were able to see the sensitive data on the
Run History in the Chef Manage Console.

This commit is fixing this problem and now it is transforming any
sensitive resource to display the word `*sensitive*` instead of the
actual data. As we are inserting this values directly to the data base,
it means that this change will cascade all the way to the front-end.

Catch: Old data that was already reported and is displaying sensitive
data will contineu to be displayed. Apologize.

Signed-off-by: Salim Afiune <afiune@chef.io>

### Issues Resolved

COOL-642/ZD 12936 - Chef Manage Run History compromises sensitive data

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
