### PR TITLE
Style/NumericPredicate comparison style

### DIFF
--- a/lib/chef/http/json_input.rb
+++ b/lib/chef/http/json_input.rb
@@ -33,7 +33,7 @@ class Chef
 
       def handle_request(method, url, headers = {}, data = false)
         if data && should_encode_as_json?(headers)
-          headers.delete_if { |key, _value| key.casecmp("content-type").zero? }
+          headers.delete_if { |key, _value| key.casecmp("content-type") == 0 }
           headers["Content-Type"] = "application/json"
           json_opts = {}
           json_opts[:validate_utf8] = opts[:validate_utf8] if opts.has_key?(:validate_utf8)
@@ -64,7 +64,7 @@ class Chef
         # ruby/Net::HTTP don't enforce capitalized headers (it normalizes them
         # for you before sending the request), so we have to account for all
         # the variations we might find
-        requested_content_type = headers.find { |k, v| k.casecmp("content-type").zero? }
+        requested_content_type = headers.find { |k, v| k.casecmp("content-type") == 0 }
         requested_content_type.nil? || requested_content_type.last.include?("json")
       end
 

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -145,7 +145,7 @@ class Chef
     end
 
     def self.subcommand_class_from(args)
-      if args.size == 1 && args[0].strip.casecmp("rehash").zero?
+      if args.size == 1 && args[0].strip.casecmp("rehash") == 0
         # To prevent issues with the rehash file not pointing to the correct plugins,
         # we always use the glob loader when regenerating the rehash file
         @subcommand_loader = Chef::Knife::SubcommandLoader.gem_glob_loader(chef_config_dir)

--- a/lib/chef/provider/env/windows.rb
+++ b/lib/chef/provider/env/windows.rb
@@ -36,7 +36,7 @@ class Chef
           obj.variablevalue = @new_resource.value
           obj.put_
           value = @new_resource.value
-          value = expand_path(value) if @new_resource.key_name.casecmp("PATH").zero?
+          value = expand_path(value) if @new_resource.key_name.casecmp("PATH") == 0
           ENV[@new_resource.key_name] = value
           broadcast_env_change
         end

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -58,7 +58,7 @@ class Chef
           def makefile_variable_value(variable, dir = nil)
             options = dir ? { :cwd => dir } : {}
             make_v = shell_out_with_timeout!("make -V #{variable}", options.merge!(:env => nil, :returns => [0, 1]))
-            make_v.exitstatus.zero? ? make_v.stdout.strip.split($\).first : nil # $\ is the line separator, i.e. newline.
+            make_v.exitstatus == 0 ? make_v.stdout.strip.split($\).first : nil # $\ is the line separator, i.e. newline.
           end
         end
 

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -64,7 +64,7 @@ class Chef
             end
 
             pkg_query = shell_out_with_timeout!("pkg rquery#{expand_options(options)} '%v' #{@new_resource.package_name}", :env => nil)
-            pkg_query.exitstatus.zero? ? pkg_query.stdout.strip.split(/\n/).last : nil
+            pkg_query.exitstatus == 0 ? pkg_query.stdout.strip.split(/\n/).last : nil
           end
 
           def repo_regex

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -262,7 +262,7 @@ class Chef
           if source_location.nil?
             inferred_registry_type == :msi
           else
-            ::File.extname(source_location).casecmp(".msi").zero?
+            ::File.extname(source_location).casecmp(".msi") == 0
           end
         end
       end

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -197,7 +197,7 @@ class Chef
               case line.downcase
               when /\s+\"pid\"\s+=\s+(\d+).*/
                 pid = $1
-                @current_resource.running(!pid.to_i.zero?)
+                @current_resource.running(!pid.to_i == 0)
                 Chef::Log.debug("Current PID for #{@service_label} is #{pid}")
               end
             end


### PR DESCRIPTION
Apparently rubocop thinks the default behavior should be that we have to
rewrite every use of `foo == 0` into `foo.zero?` which is a big pile of
NOPE for me.  After discovering that `.zero?` is actually slower, I'd
prefer to go the other direction.  Same for `positive?` and
`negative?`.

These are the only uses of `zero?` in the chef/chef codebase, while I'm
pretty sure the inverse rule would touch nearly every file.

