### PR TITLE
Use rubygems_url config option in default case

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -540,7 +540,8 @@ class Chef
             src = " --clear-sources"
             src << (new_resource.source && " --source=#{new_resource.source}" || "")
           else
-            src = new_resource.source && " --source=#{new_resource.source} --source=#{Chef::Config[:rubygems_url]}"
+            src = new_resource.source && " --source=#{new_resource.source}" || ""
+            src << (Chef::Config[:rubygems_url] && " --source=#{Chef::Config[:rubygems_url]}" || "")
           end
           if !version.nil? && !version.empty?
             shell_out_with_timeout!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src}#{opts}", env: nil)


### PR DESCRIPTION
### Description

The (undocumented) `Chef::Config` option `rubygems_url` does not work in the default case where `source` is not specified for the `chef_gem` or `gem_package` resource.  Since this config option is undocumented (chef/chef-web-docs#206), this seems like the expected behavior.

### Issues Resolved

 - No open issues, but with out this, setting `rubygems_url` does not work for me

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] This commit includes same level of test and documentation as original commit adding the feature (chef/chef@1d063284f755b996a6563d7210496afd716a9f2d)

### Example

Recipe:
```ruby
chef_gem 'net-ldap' do
  compile_time true
  action :install
end
```

Command:
```
chef-client --local-mode --config-option rubygems_url=http://localhost/ -o test
```