### PR TITLE
remove non-working "from file" documentation

### DIFF
--- a/distro/common/html/knife_environment.html
+++ b/distro/common/html/knife_environment.html
@@ -200,11 +200,11 @@ windows            1.0.0    4.1.2
 </div>
 <div class="section" id="from-file">
 <h2>from file<a class="headerlink" href="#from-file" title="Permalink to this headline">¶</a></h2>
-<p>The <tt class="docutils literal"><span class="pre">from</span> <span class="pre">file</span></tt> argument is used to add or update an environment using a JSON or Ruby DSL description. It must be run with the <tt class="docutils literal"><span class="pre">create</span></tt> or <tt class="docutils literal"><span class="pre">edit</span></tt> arguments.</p>
+<p>The <tt class="docutils literal"><span class="pre">from</span> <span class="pre">file</span></tt> argument is used to add or update an environment using a JSON or Ruby DSL description.</p>
 <div class="section" id="id7">
 <h3>Syntax<a class="headerlink" href="#id7" title="Permalink to this headline">¶</a></h3>
 <p>This argument has the following syntax:</p>
-<div class="highlight-bash"><div class="highlight"><pre><span class="nv">$ </span>knife environment <span class="o">[</span>create | edit<span class="o">]</span> from file FILE <span class="o">(</span>options<span class="o">)</span>
+<div class="highlight-bash"><div class="highlight"><pre><span class="nv">$ </span>knife environment from file FILE <span class="o">(</span>options<span class="o">)</span>
 </pre></div>
 </div>
 </div>
@@ -221,11 +221,7 @@ windows            1.0.0    4.1.2
 <p>The following examples show how to use this knife subcommand:</p>
 <p><strong>Create an environment from a JSON file</strong></p>
 <p>To add an environment using data contained in a JSON file:</p>
-<div class="highlight-bash"><div class="highlight"><pre><span class="nv">$ </span>knife environment create devops from file <span class="s2">&quot;path to JSON file&quot;</span>
-</pre></div>
-</div>
-<p>or:</p>
-<div class="highlight-bash"><div class="highlight"><pre><span class="nv">$ </span>knife environment edit devops from file <span class="s2">&quot;path to JSON file&quot;</span>
+<div class="highlight-bash"><div class="highlight"><pre><span class="nv">$ </span>knife environment from file <span class="s2">&quot;path to JSON file&quot;</span>
 </pre></div>
 </div>
 </div>

--- a/distro/common/man/man1/knife-environment.1
+++ b/distro/common/man/man1/knife-environment.1
@@ -339,7 +339,7 @@ $ knife environment edit devops
 .UNINDENT
 .SH FROM FILE
 .sp
-The \fBfrom file\fP argument is used to add or update an environment using a JSON or Ruby DSL description. It must be run with the \fBcreate\fP or \fBedit\fP arguments.
+The \fBfrom file\fP argument is used to add or update an environment using a JSON or Ruby DSL description.
 .sp
 \fBSyntax\fP
 .sp
@@ -349,7 +349,7 @@ This argument has the following syntax:
 .sp
 .nf
 .ft C
-$ knife environment [create | edit] from file FILE (options)
+$ knife environment from file FILE (options)
 .ft P
 .fi
 .UNINDENT
@@ -366,25 +366,13 @@ Use to upload all environments found at the specified path.
 .sp
 \fBExamples\fP
 .sp
-To add an environment using data contained in a JSON file:
+To add or update an environment using data contained in a JSON file:
 .INDENT 0.0
 .INDENT 3.5
 .sp
 .nf
 .ft C
-$ knife environment create devops from file "path to JSON file"
-.ft P
-.fi
-.UNINDENT
-.UNINDENT
-.sp
-or:
-.INDENT 0.0
-.INDENT 3.5
-.sp
-.nf
-.ft C
-$ knife environment edit devops from file "path to JSON file"
+$ knife environment from file "path to JSON file"
 .ft P
 .fi
 .UNINDENT


### PR DESCRIPTION
### Description

Remove non-working (erroneous) from file documentation

### Issues Resolved

https://github.com/chef/chef/issues/5558

### Check List

- [X] New functionality includes tests
- [X ] All tests pass
- [X ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
