### PR TITLE
Bump net-ssh to v4, add dependencies for ed25519

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: '1'
+BUNDLE_FROZEN: "1"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: "1"
+BUNDLE_FROZEN: '1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -260,7 +260,7 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test webapp-amazonlinux
+      - travis_wait bundle exec kitchen test webapp-amazonlinux
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -248,24 +248,25 @@ matrix:
 #    env:
 #      - FEDORA=latest
 #      - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.3.3
-    services: docker
-    sudo: required
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
-    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-    before_script:
-      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      - cd kitchen-tests
-    script:
-      - travis_wait bundle exec kitchen test webapp-amazonlinux
-    after_failure:
-      - cat .kitchen/logs/kitchen.log
-    env:
-      - AMAZONLINUX=LATEST
-      - KITCHEN_YAML=.kitchen.travis.yml
+# can re-enable amazonlinux when we get a build in current that contains the crypto libs added in #5687
+#  - rvm: 2.3.3
+#    services: docker
+#    sudo: required
+#    gemfile: kitchen-tests/Gemfile
+#    before_install:
+#      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+#      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+#    bundler_args: --without changelog development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
+#    before_script:
+#      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+#      - cd kitchen-tests
+#    script:
+#      - travis_wait bundle exec kitchen test webapp-amazonlinux
+#    after_failure:
+#      - cat .kitchen/logs/kitchen.log
+#    env:
+#      - AMAZONLINUX=LATEST
+#      - KITCHEN_YAML=.kitchen.travis.yml
   - rvm: 2.3.3
     services: docker
     sudo: required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: b69e9df027c99ed37aae1e3fd8468a5c6496ced1
+  revision: 2d06ce7ef5976e2a410906f60152142bf90a17fb
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: 2d06ce7ef5976e2a410906f60152142bf90a17fb
+  revision: b69e9df027c99ed37aae1e3fd8468a5c6496ced1
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: c2076d117ff4307faf755ecc23eb2892aa20807a
+  revision: f3bc51612667e069f736f8ff18cf0bc0c18098fb
   branch: master
   specs:
     chefstyle (0.4.0)
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/rubysec/bundler-audit.git
-  revision: 044d056961dbc4b70d236a354a9cc86af54e0ae2
+  revision: 80ae638e72df4c218da0e7a485ea2ee73aa257f2
   specs:
     bundler-audit (0.5.0)
       bundler (~> 1.2)
@@ -49,6 +49,7 @@ PATH
   specs:
     chef (12.18.31)
       addressable
+      bcrypt_pbkdf (~> 1.0.0)
       bundler (>= 1.10)
       chef-config (= 12.18.31)
       chef-zero (>= 4.8)
@@ -63,11 +64,13 @@ PATH
       mixlib-log (~> 1.3)
       mixlib-shellout (~> 2.0)
       net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (>= 2.9, < 4.0)
+      net-ssh (>= 2.9, < 5.0)
       net-ssh-multi (~> 1.1)
       ohai (>= 8.6.0.alpha.1, < 9)
       plist (~> 3.2)
       proxifier (~> 1.0)
+      rbnacl (~> 4.0.0)
+      rbnacl-libsodium (~> 1.0.0)
       rspec-core (~> 3.5)
       rspec-expectations (~> 3.5)
       rspec-mocks (~> 3.5)
@@ -78,6 +81,7 @@ PATH
       uuidtools (~> 2.1.5)
     chef (12.18.31-universal-mingw32)
       addressable
+      bcrypt_pbkdf (~> 1.0.0)
       bundler (>= 1.10)
       chef-config (= 12.18.31)
       chef-zero (>= 4.8)
@@ -93,11 +97,13 @@ PATH
       mixlib-log (~> 1.3)
       mixlib-shellout (~> 2.0)
       net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (>= 2.9, < 4.0)
+      net-ssh (>= 2.9, < 5.0)
       net-ssh-multi (~> 1.1)
       ohai (>= 8.6.0.alpha.1, < 9)
       plist (~> 3.2)
       proxifier (~> 1.0)
+      rbnacl (~> 4.0.0)
+      rbnacl-libsodium (~> 1.0.0)
       rspec-core (~> 3.5)
       rspec-expectations (~> 3.5)
       rspec-mocks (~> 3.5)
@@ -129,7 +135,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -139,15 +145,17 @@ GEM
       mixlib-cli (~> 1.4)
     artifactory (2.5.1)
     ast (2.3.0)
-    aws-sdk (2.6.40)
-      aws-sdk-resources (= 2.6.40)
-    aws-sdk-core (2.6.40)
+    aws-sdk (2.6.44)
+      aws-sdk-resources (= 2.6.44)
+    aws-sdk-core (2.6.44)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.40)
-      aws-sdk-core (= 2.6.40)
+    aws-sdk-resources (2.6.44)
+      aws-sdk-core (= 2.6.44)
     aws-sigv4 (1.0.0)
     backports (3.6.8)
+    bcrypt_pbkdf (1.0.0)
+    bcrypt_pbkdf (1.0.0-x86-mingw32)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -155,13 +163,13 @@ GEM
     chef-api (0.7.0)
       logify (~> 0.1)
       mime-types
-    chef-provisioning (2.0.2)
+    chef-provisioning (2.1.0)
       cheffish (~> 4.0)
       inifile (>= 2.0.2)
       mixlib-install (>= 1.0, < 3.0)
       net-scp (~> 1.0)
-      net-ssh (>= 2.9, < 4.0)
-      net-ssh-gateway (~> 1.2.0)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
       winrm-fs (~> 1.0)
     chef-sugar (3.4.0)
     chef-zero (5.1.1)
@@ -184,7 +192,7 @@ GEM
       simplecov
       url
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -205,7 +213,7 @@ GEM
     ethon (0.10.1)
       ffi (>= 1.3.0)
     excon (0.54.0)
-    faraday (0.10.0)
+    faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
@@ -219,7 +227,7 @@ GEM
       ffi
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
-    foodcritic (8.1.0)
+    foodcritic (8.2.0)
       cucumber-core (>= 1.3)
       erubis
       nokogiri (>= 1.5, < 2.0)
@@ -259,7 +267,7 @@ GEM
     iniparse (1.4.2)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.0.2)
+    json (2.0.3)
     kitchen-docker (2.6.0)
       test-kitchen (>= 1.0.0)
     kitchen-ec2 (1.2.0)
@@ -273,7 +281,7 @@ GEM
       test-kitchen (>= 1.0.0)
     kitchen-vagrant (0.21.1)
       test-kitchen (~> 1.4)
-    knife-windows (1.7.1)
+    knife-windows (1.8.0)
       winrm (~> 2.1)
       winrm-elevated (~> 1.0)
     launchy (2.4.3)
@@ -325,9 +333,9 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    nokogiri (1.6.8.1-x86-mingw32)
+    nokogiri (1.7.0.1-x86-mingw32)
       mini_portile2 (~> 2.1.0)
     nori (2.6.0)
     octokit (4.6.2)
@@ -399,9 +407,13 @@ GEM
       json
       websocket (~> 1.0)
     rack (2.0.1)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     rake (11.3.0)
     rb-readline (0.5.3)
+    rbnacl (4.0.1)
+      ffi
+    rbnacl-libsodium (1.0.11)
+      rbnacl (>= 3.0.1)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -411,7 +423,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retriable (2.1.0)
+    retriable (3.0.0)
     retryable (2.0.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -462,7 +474,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.66.2)
+    specinfra (2.66.3)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -546,7 +558,7 @@ GEM
       winrm (~> 2.0)
     wmi-lite (1.0.0)
     yajl-ruby (1.3.0)
-    yard (0.9.5)
+    yard (0.9.7)
     yard-classmethods (1.0.0)
       yard
 
@@ -591,4 +603,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -603,4 +603,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.7
+   1.12.5

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -25,7 +25,10 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9"
 
   s.add_dependency "ffi-yajl", "~> 2.2"
-  s.add_dependency "net-ssh", ">= 2.9", "< 4.0"
+  s.add_dependency "net-ssh", "~> 4.0"
+  s.add_dependency "rbnacl-libsodium", "~> 1.0.0"
+  s.add_dependency "rbnacl", "~> 4.0.0"
+  s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
   s.add_dependency "net-ssh-multi", "~> 1.1"
   s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
   s.add_dependency "highline", "~> 1.6", ">= 1.6.9"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ohai", ">= 8.6.0.alpha.1", "< 9"
 
   s.add_dependency "ffi-yajl", "~> 2.2"
-  s.add_dependency "net-ssh", "~> 4.0"
+  s.add_dependency "net-ssh", ">= 2.9", "< 5.0"
   s.add_dependency "rbnacl-libsodium", "~> 1.0.0"
   s.add_dependency "rbnacl", "~> 4.0.0"
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"


### PR DESCRIPTION
### Description

Bump net-ssh to 4.0.0 and add dependencies for ed25519 support

### Issues Resolved

https://github.com/chef/chef/issues/5461

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
