### PR TITLE
Fix error thrown by solo when run on Windows as SYSTEM

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -113,7 +113,7 @@ class Chef
                   Dir.mkdir(path, 0700)
                   if Chef::Platform.windows?
                     all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
-                    owner = Chef::ReservedNames::Win32::Security::SID.current_user
+                    owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
                     dacl = Chef::ReservedNames::Win32::Security::ACL.create([
                       Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, all_mask),
                     ])

--- a/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
@@ -38,7 +38,7 @@ class Chef
             if Chef::Platform.windows?
               read_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_READ
               write_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_WRITE
-              owner = Chef::ReservedNames::Win32::Security::SID.current_user
+              owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
               dacl = Chef::ReservedNames::Win32::Security::ACL.create([
                 Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, read_mask),
                 Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, write_mask),


### PR DESCRIPTION
`Chef::ReservedNames::Win32::Security::SID.current_user` throws an error when `chef-solo` is being run as a `SYSTEM` user:

```
================================================================================
Chef encountered an error attempting to load the node data for "WIN-00P0BGAA4IV"
================================================================================
Unknown Server Error:
---------------------
The server had a fatal error attempting to load the node data.
Server Response:
----------------
Exception raised! #<Chef::Exceptions::Win32APIError: No mapping between account names and security IDs was done.
---- Begin Win32 API output ----
System Error Code: 1332
System Error Message: No mapping between account names and security IDs was done.
---- End Win32 API output ----
>
c:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/win32/error.rb:81:in `raise!'
c:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/win32/security.rb:383:in `lookup_account_name'
c:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/win32/security/sid.rb:44:in `from_account'
c:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/win32/security/sid.rb:241:in `current_user'
c:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-12.17.44-universal-mingw32/lib/chef/chef_fs/file_system/repository/nodes_dir.rb:41:in `create_child'
```

This commit modfies these calls to use `SID.default_security_object_owner` instead which will return `SID.Administrators` for users such as `SYSTEM` and then returns `SID.current_user` for everyone else.