### PR TITLE
Core: Ensure paths are correctly escaped when syntax checking

### DIFF
--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -110,7 +110,7 @@ class Chef
       end
 
       def remove_uninteresting_ruby_files(file_list)
-        file_list.reject { |f| f =~ %r{#{Chef::Util::PathHelper.escape_glob_dir(cookbook_path)}/(files|templates)/} }
+        file_list.reject { |f| f =~ %r{#{Regexp.quote(cookbook_path)}/(files|templates)/} }
       end
 
       def ruby_files

--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -110,7 +110,7 @@ class Chef
       end
 
       def remove_uninteresting_ruby_files(file_list)
-        file_list.reject { |f| f =~ %r{#{cookbook_path}/(files|templates)/} }
+        file_list.reject { |f| f =~ %r{#{Chef::Util::PathHelper.escape_glob_dir(cookbook_path)}/(files|templates)/} }
       end
 
       def ruby_files

--- a/spec/unit/cookbook/syntax_check_spec.rb
+++ b/spec/unit/cookbook/syntax_check_spec.rb
@@ -25,6 +25,7 @@ describe Chef::Cookbook::SyntaxCheck do
   end
 
   let(:cookbook_path) { File.join(CHEF_SPEC_DATA, "cookbooks", "openldap") }
+  let(:unsafe_cookbook_path) { 'C:\AGENT-HOME\xml-data\build-dir\76808194-76906499\artifact\cookbooks/java' }
   let(:syntax_check) { Chef::Cookbook::SyntaxCheck.new(cookbook_path) }
 
   let(:open_ldap_cookbook_files) do
@@ -53,7 +54,7 @@ describe Chef::Cookbook::SyntaxCheck do
     @recipes = %w{default.rb gigantor.rb one.rb return.rb}.map { |f| File.join(cookbook_path, "recipes", f) }
     @spec_files = [ File.join(cookbook_path, "spec", "spec_helper.rb") ]
     @ruby_files = @attr_files + @libr_files + @defn_files + @recipes + @spec_files + [File.join(cookbook_path, "metadata.rb")]
-    basenames = %w{ helpers_via_partial_test.erb
+    @basenames = %w{ helpers_via_partial_test.erb
                     helper_test.erb
                     helpers.erb
                     openldap_stuff.conf.erb
@@ -64,7 +65,7 @@ describe Chef::Cookbook::SyntaxCheck do
                     some_windows_line_endings.erb
                     all_windows_line_endings.erb
                     no_windows_line_endings.erb }
-    @template_files = basenames.map { |f| File.join(cookbook_path, "templates", "default", f) }
+    @template_files = @basenames.map { |f| File.join(cookbook_path, "templates", "default", f) }
   end
 
   after do
@@ -92,6 +93,11 @@ describe Chef::Cookbook::SyntaxCheck do
       expect(syntax_check.cookbook_path).to eq(cookbook_path)
       expect(syntax_check.ruby_files).to eq([File.join(cookbook_path, "recipes/default.rb")])
     end
+  end
+
+  it "safely handles a path containing control characters" do
+    syntax_check = Chef::Cookbook::SyntaxCheck.new(unsafe_cookbook_path)
+    expect { syntax_check.remove_uninteresting_ruby_files(@basenames) }.not_to raise_error
   end
 
   describe "when first created" do


### PR DESCRIPTION
### Description

Fixed 'too short control escape' on knfie upload.

### Issues Resolved

#5702

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>