### PR TITLE
Fix failing useradd test for rhel6 on s390x platform

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -645,6 +645,15 @@ describe Chef::Provider::User::Useradd, metadata do
             expect(@error).to be_a(Mixlib::ShellOut::ShellCommandFailed)
             expect(@error.message).to include("Cannot unlock the password")
           end
+        elsif %w{rhel}.include?(OHAI_SYSTEM["platform_family"]) &&
+            OHAI_SYSTEM["platform_version"].to_f == 6.8
+          # usermod -U returns following message for rhel68 on s390x platforms
+          # usermod: unlocking the user's password would result in a passwordless account.
+          #You should set a password with usermod -p to unlock this user's password.
+          it "errors out trying to unlock the user" do
+            expect(@error).to be_a(Mixlib::ShellOut::ShellCommandFailed)
+            expect(@error.message).to include("You should set a password")
+          end
         else
 
           # borked on all other platforms:


### PR DESCRIPTION
usermod -U for user with blank password on Rhel6 zlinux systems
exits with error message.  Updating the test for this behavior

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

@chef/engineering-services 

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
