### PR TITLE
Add run_command deprecation to the release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,9 +18,14 @@ _This file holds "in progress" release notes for the current release under devel
 
 ## New deprecations introduced in this release:
 
-### Chef Platform Methods
+### Chef Platform Helper Methods
 
 - **Deprecation ID**: 13
 - **Remediation Docs**: <https://docs.chef.io/chef_platform_methods.html>
 - **Expected Removal**: Chef 13 (April 2017)
 
+### run_command Helper Method
+
+- **Deprecation ID**: 14
+- **Remediation Docs**: <https://docs.chef.io/run_command.html>
+- **Expected Removal**: Chef 13 (April 2017)


### PR DESCRIPTION
Pretty straight forward. This needs to go in prior to our release