### PR TITLE
yum_repository: Allow baseurl to be an array & allow fastestmirror_enabled false

### DIFF
--- a/lib/chef/provider/support/yum_repo.erb
+++ b/lib/chef/provider/support/yum_repo.erb
@@ -4,8 +4,13 @@
 [<%= @config.repositoryid %>]
 name=<%= @config.description %>
 <% if @config.baseurl %>
-baseurl=<%= @config.baseurl %>
-<% end %>
+baseurl=<%= case @config.baseurl
+     when Array
+       @config.baseurl.join("\n")
+     else
+       @config.baseurl
+     end %>
+<% end -%>
 <% if @config.cost %>
 cost=<%= @config.cost %>
 <% end %>
@@ -24,7 +29,9 @@ exclude=<%= @config.exclude %>
 failovermethod=<%= @config.failovermethod %>
 <% end %>
 <% if @config.fastestmirror_enabled %>
-fastestmirror_enabled=<%= @config.fastestmirror_enabled %>
+fastestmirror_enabled=1
+<% else %>
+fastestmirror_enabled=0
 <% end %>
 <% if @config.gpgcheck %>
 gpgcheck=1

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -25,7 +25,7 @@ class Chef
       provides :yum_repository
 
       # http://linux.die.net/man/5/yum.conf
-      property :baseurl, String, regex: /.*/
+      property :baseurl, [String, Array], regex: /.*/
       property :cost, String, regex: /^\d+$/
       property :clean_headers, [TrueClass, FalseClass], default: false # deprecated
       property :clean_metadata, [TrueClass, FalseClass], default: true


### PR DESCRIPTION
Port two fixes that were made the yum cookbook yum_repository provider.

https://github.com/chef-cookbooks/yum/pull/165
https://github.com/chef-cookbooks/yum/pull/162

Signed-off-by: Tim Smith <tsmith@chef.io>