### PR TITLE
WIP: Handle non-root usage of cron resource and basic test.

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -35,10 +35,26 @@ class Chef
       SPECIAL_PATTERN = /\A(@(#{SPECIAL_TIME_VALUES.join('|')}))\s(.*)/
       ENV_PATTERN = /\A(\S+)=(\S*)/
 
+      def can_modify_cron?
+        unless Process.euid == 0
+          begin
+            nuid = Etc.getpwnam(@new_resource.user).uid
+          rescue ArgumentError
+            raise Chef::Exceptions::Cron,
+              "Error in #{@new_resource.name}, #{@new_resource.user} does not exists on this system."
+          end
+          unless nuid == Process.euid
+            raise Chef::Exceptions::Cron,
+              "Error in #{@new_resource.name}, Chef can't modify another user crontab when not running as root."
+          end
+        end
+      end
+
       def initialize(new_resource, run_context)
         super(new_resource, run_context)
         @cron_exists = false
         @cron_empty = false
+        @specify_user = ""
       end
       attr_accessor :cron_exists, :cron_empty
 
@@ -51,6 +67,10 @@ class Chef
         @current_resource = Chef::Resource::Cron.new(@new_resource.name)
         @current_resource.user(@new_resource.user)
         @cron_exists = false
+        
+        # Raise an execption if Chef can't read or update the crontab.
+        can_modify_cron?
+
         if crontab = read_crontab
           cron_found = false
           crontab.each_line do |line|
@@ -207,7 +227,8 @@ class Chef
 
       def read_crontab
         crontab = nil
-        status = popen4("crontab -l -u #{@new_resource.user}") do |pid, stdin, stdout, stderr|
+        @specify_user="-u #{@new_resource.user}" if Process.euid === 0
+        status = popen4("crontab -l #{@specify_user}") do |pid, stdin, stdout, stderr|
           crontab = stdout.read
         end
         if status.exitstatus > 1
@@ -218,7 +239,8 @@ class Chef
 
       def write_crontab(crontab)
         write_exception = false
-        status = popen4("crontab -u #{@new_resource.user} -", :waitlast => true) do |pid, stdin, stdout, stderr|
+        @specify_user="-u #{@new_resource.user}" if Process.euid === 0
+        status = popen4("crontab #{@specify_user} -", :waitlast => true) do |pid, stdin, stdout, stderr|
           begin
             stdin.write crontab
           rescue Errno::EPIPE => e

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -67,7 +67,6 @@ class Chef
         @current_resource = Chef::Resource::Cron.new(@new_resource.name)
         @current_resource.user(@new_resource.user)
         @cron_exists = false
-        
         # Raise an execption if Chef can't read or update the crontab.
         can_modify_cron?
 
@@ -227,7 +226,7 @@ class Chef
 
       def read_crontab
         crontab = nil
-        @specify_user="-u #{@new_resource.user}" if Process.euid === 0
+        @specify_user = "-u #{@new_resource.user}" if Process.euid === 0
         status = popen4("crontab -l #{@specify_user}") do |pid, stdin, stdout, stderr|
           crontab = stdout.read
         end
@@ -239,7 +238,7 @@ class Chef
 
       def write_crontab(crontab)
         write_exception = false
-        @specify_user="-u #{@new_resource.user}" if Process.euid === 0
+        @specify_user = "-u #{@new_resource.user}" if Process.euid === 0
         status = popen4("crontab #{@specify_user} -", :waitlast => true) do |pid, stdin, stdout, stderr|
           begin
             stdin.write crontab

--- a/spec/unit/provider/cron_spec.rb
+++ b/spec/unit/provider/cron_spec.rb
@@ -156,14 +156,13 @@ CRONTAB
   describe "when examining the current system state" do
     context "when run as non root" do
       before do
-	mock_struct = OpenStruct.new(:uid => 0)
+        mock_struct = OpenStruct.new(:uid => 0)
         allow(Process).to receive(:euid).and_return(42)
-	allow(Etc).to receive(:getpwnam).with("root").and_return(mock_struct)
+        allow(Etc).to receive(:getpwnam).with("root").and_return(mock_struct)
       end
+
       it "should raise exception" do
-        expect do
-          @provider.load_current_resource
-        end.to raise_error(Chef::Exceptions::Cron)
+        expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Cron)
       end
     end
     context "with no crontab for the user" do

--- a/spec/unit/provider/cron_spec.rb
+++ b/spec/unit/provider/cron_spec.rb
@@ -154,6 +154,18 @@ CRONTAB
   end
 
   describe "when examining the current system state" do
+    context "when run as non root" do
+      before do
+	mock_struct = OpenStruct.new(:uid => 0)
+        allow(Process).to receive(:euid).and_return(42)
+	allow(Etc).to receive(:getpwnam).with("root").and_return(mock_struct)
+      end
+      it "should raise exception" do
+        expect do
+          @provider.load_current_resource
+        end.to raise_error(Chef::Exceptions::Cron)
+      end
+    end
     context "with no crontab for the user" do
       before :each do
         allow(@provider).to receive(:read_crontab).and_return(nil)


### PR DESCRIPTION
### Description

Ensure the crontab command line used doesn't use `-u` if not run as root, fail if non-root and trying to set someone else crontab.

### Issues Resolved

- Issue 2491
- StackOverflow Q/A: [Unable to run Chef cron recipe as non-root user](http://stackoverflow.com/questions/40470685/unable-to-run-chef-cron-recipe-as-non-root-user/40475768#40475768)

### Check List

- [x] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

### TODO: 

It should have more tests for the cases:

- [x] Non-root user editing its own crontab should not raise an error.
- [x] Non-root user editing someone else crontab should raise an error.