### PR TITLE
Core: fix node attribute "unless" API methods

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -1,4 +1,4 @@
-#--
+#la--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
 # Copyright:: Copyright 2008-2016, Chef Software, Inc.
@@ -416,23 +416,22 @@ class Chef
 
       def normal_unless(*args)
         return Decorator::Unchain.new(self, :normal_unless) unless args.length > 0
-        write(:normal, *args) if read(*args[0...-1]).nil?
+        write(:normal, *args) if normal.read(*args[0...-1]).nil?
       end
 
       def default_unless(*args)
         return Decorator::Unchain.new(self, :default_unless) unless args.length > 0
-        write(:default, *args) if read(*args[0...-1]).nil?
+        write(:default, *args) if default.read(*args[0...-1]).nil?
       end
 
       def override_unless(*args)
         return Decorator::Unchain.new(self, :override_unless) unless args.length > 0
-        write(:override, *args) if read(*args[0...-1]).nil?
+        write(:override, *args) if override.read(*args[0...-1]).nil?
       end
 
       def set_unless(*args)
         Chef.deprecated(:attributes, "node.set_unless is deprecated and will be removed in Chef 14, please use node.default_unless/node.override_unless (or node.normal_unless if you really need persistence)")
-        return Decorator::Unchain.new(self, :default_unless) unless args.length > 0
-        write(:normal, *args) if read(*args[0...-1]).nil?
+        normal_unless(*args)
       end
 
       def has_key?(key)

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -1,4 +1,4 @@
-#la--
+#--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
 # Copyright:: Copyright 2008-2016, Chef Software, Inc.

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -337,14 +337,35 @@ describe Chef::Node do
         Chef::Config[:treat_deprecation_warnings_as_errors] = false
         expect(Chef).to receive(:deprecated).with(:attributes, /set is deprecated/)
         node.set[:snoopy][:is_a_puppy] = true
-        expect(node[:snoopy][:is_a_puppy]).to eq(true)
+        expect(node.normal[:snoopy][:is_a_puppy]).to eq(true)
       end
 
       it "set_unless is a deprecated alias for normal_unless" do
         Chef::Config[:treat_deprecation_warnings_as_errors] = false
         expect(Chef).to receive(:deprecated).with(:attributes, /set_unless is deprecated/)
         node.set_unless[:snoopy][:is_a_puppy] = false
-        expect(node[:snoopy][:is_a_puppy]).to eq(false)
+        expect(node.normal[:snoopy][:is_a_puppy]).to eq(false)
+      end
+
+      it "normal_unless sets a value even if default or override attrs are set" do
+        node.default[:decontamination] = true
+        node.override[:decontamination] = false
+        node.normal_unless[:decontamination] = "foo"
+        expect(node.normal[:decontamination]).to eql("foo")
+      end
+
+      it "default_unless sets a value even if normal or override attrs are set" do
+        node.normal[:decontamination] = true
+        node.override[:decontamination] = false
+        node.default_unless[:decontamination] = "foo"
+        expect(node.default[:decontamination]).to eql("foo")
+      end
+
+      it "override_unless sets a value even if default or normal attrs are set" do
+        node.default[:decontamination] = true
+        node.normal[:decontamination] = false
+        node.override_unless[:decontamination] = "foo"
+        expect(node.override[:decontamination]).to eql("foo")
       end
     end
 


### PR DESCRIPTION
closes #5556

corrects behavior to 12.11.x behavior which was lost in the refactor

may address #5715

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>

