### PR TITLE
Add -u param to usermod in linux_user resource when using non_unique

### DIFF
--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -58,6 +58,7 @@ class Chef
 
         def usermod_options
           opts = []
+          opts += [ "-u", new_resource.uid ] if non_unique?
           if updating_home?
             if managing_home_dir?
               opts << "-m"


### PR DESCRIPTION
Signed-off-by: Maxime “pep” Buquet <pep@collabora.com>

### Description

`-u` (uid) parameter is required by usermod when using `-o` (non_unique). This patch adds the parameter if needed.

I don't have tests for it as apparently there is no test yet for usermod in the linux_spec. I can try to come up with some tests if somebody quickly guides me through it.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
