### PR TITLE
Fix for creating users in non english windows machines

### DIFF
--- a/lib/chef/util/windows/net_user.rb
+++ b/lib/chef/util/windows/net_user.rb
@@ -116,7 +116,7 @@ class Chef::Util::Windows::NetUser < Chef::Util::Windows
   def add(args)
     transformed_args = transform_usri3(args)
     NetUser.net_user_add_l3(nil, transformed_args)
-    NetUser.net_local_group_add_member(nil, "Users", args[:name])
+    NetUser.net_local_group_add_member(nil, Chef::ReservedNames::Win32::Security::SID.BuiltinUsers.account_simple_name, args[:name])
   end
 
   # FIXME: yard with @yield

--- a/lib/chef/win32/security/sid.rb
+++ b/lib/chef/win32/security/sid.rb
@@ -59,6 +59,11 @@ class Chef
           Chef::ReservedNames::Win32::Security.lookup_account_sid(self)
         end
 
+        def account_simple_name
+          domain, name, use = account
+          name
+        end
+
         def account_name
           domain, name, use = account
           (!domain.nil? && domain.length > 0) ? "#{domain}\\#{name}" : name


### PR DESCRIPTION
### Description

Get Users group name based on SID

### Issues Resolved

In some languages, windows translates the name of the Users group. This causes a group does not exist error. The SID is supposed to be the same across different languages, so getting the name based on the SID fixes the problem.

The only gotcha is that account_name returns something like BUILTIN\Users, and that also fails with a group does not exist error. Only the group name must be sent, and not the domain.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
