### PR TITLE
pass true as 2nd args for Net::SSH.configuration_for by default.

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -232,7 +232,7 @@ class Chef
       # @param user [String] Optional username for this session.
       # @return [Hash<Symbol, Object>]
       def session_options(host, port, user = nil)
-        ssh_config = Net::SSH.configuration_for(host)
+        ssh_config = Net::SSH.configuration_for(host, true)
         {}.tap do |opts|
           # Chef::Config[:knife][:ssh_user] is parsed in #configure_user and written to config[:ssh_user]
           opts[:user] = user || config[:ssh_user] || ssh_config[:user]

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -190,7 +190,7 @@ describe Chef::Knife::Ssh do
     before :each do
       @knife.instance_variable_set(:@longest, 0)
       ssh_config = { :timeout => 50, :user => "locutus", :port => 23 }
-      allow(Net::SSH).to receive(:configuration_for).with("the.b.org").and_return(ssh_config)
+      allow(Net::SSH).to receive(:configuration_for).with("the.b.org", true).and_return(ssh_config)
     end
 
     it "uses the port from an ssh config file" do


### PR DESCRIPTION
### Description

Net-ssh 4.0 is incompatible with configration_for.

https://github.com/chef/chef/pull/5687#issuecomment-272775751

- add true to 2nd arg. It has not changed the behavior. 

### Issues Resolved

- #5461

### Check List

- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
