### PR TITLE
use pkg.path variable to reference path to self

### DIFF
--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,5 +1,5 @@
 #!/bin/sh
-export GEM_HOME="$(hab pkg path chef/chef-client)/ruby/2.3.0"
+export GEM_HOME="{{pkg.path}}/ruby/2.3.0"
 export GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.3.0:$(hab pkg path core/bundler):$GEM_HOME"
 export APPBUNDLER_ALLOW_RVM=true
 


### PR DESCRIPTION
### Description

This will resolve an error that appears if this Habitat package is built and run for development or personal use under a different origin.

Paired with @ubergeekgirl on this change.

### Issues Resolved

No open issues related. This change was first posited on [a comment](https://github.com/chef/chef/pull/5677#discussion_r94259175) on the PR adding a Habitat plan to this repo.

Error that appears when the package is built with my origin is:
```
hab-sup(MN): Starting robbkidd/chef-client
hab-sup(MR): Butterfly Member ID f4f32fe7c7d14bd98dbf0f2788f43afe
chef-client.default(SR): Process will run as user=root, group=hab
hab-sup(MR): Starting butterfly on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
chef-client.default(SR): Initializing
chef-client.default(SV): Starting
chef-client.default(O): /hab/pkgs/core/ruby/2.3.1/20161214031900/lib/ruby/site_ruby/2.3.0/rubygems/dependency.rb:308:in `to_specs': Could not find 'addressable' (= 2.4.0) among 14 total gem(s) (Gem::MissingSpecError)
chef-client.default(O): Checked in 'GEM_PATH=/hab/pkgs/core/ruby/2.3.1/20161214031900/lib/ruby/gems/2.3.0:/hab/pkgs/core/bundler/1.13.7/20170104000124:/ruby/2.3.0', execute `gem env` for more information
```

Note, it could not find a gem on the `GEM_PATH`: 

```
/hab/pkgs/core/ruby/2.3.1/20161214031900/lib/ruby/gems/2.3.0:
/hab/pkgs/core/bundler/1.13.7/20170104000124:
/ruby/2.3.0
```

The last entry is shortened because having built and started `robbkidd/chef-client` there is no `chef/chef-client` on the system.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
