### PR TITLE
Beginning of automatic API version detection

### DIFF
--- a/lib/chef/http/api_versions.rb
+++ b/lib/chef/http/api_versions.rb
@@ -1,0 +1,50 @@
+#--
+# Copyright:: Copyright 2017, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/server_api_versions"
+
+class Chef
+  class HTTP
+    # An HTTP middleware to retrieve and store the Chef Server's minimum
+    # and maximum supported API versions.
+    class APIVersions
+
+      def initialize(options = {})
+      end
+
+      def handle_request(method, url, headers = {}, data = false)
+        [method, url, headers, data]
+      end
+
+      def handle_response(http_response, rest_request, return_value)
+        if http_response.key?("x-ops-server-api-version")
+          ServerAPIVersions.instance.set_versions(http_response["x-ops-server-api-version"])
+        end
+        [http_response, rest_request, return_value]
+      end
+
+      def stream_response_handler(response)
+        nil
+      end
+
+      def handle_stream_complete(http_response, rest_request, return_value)
+        [http_response, rest_request, return_value]
+      end
+
+    end
+  end
+end

--- a/lib/chef/mixin/versioned_api.rb
+++ b/lib/chef/mixin/versioned_api.rb
@@ -1,0 +1,49 @@
+#--
+# Copyright:: Copyright 2017, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  module Mixin
+    module VersionedAPI
+
+      def self.included(base)
+        # When this file is mixed in, make sure we also add the class methods
+        base.send :extend, ClassMethods
+      end
+
+      module ClassMethods
+        def versioned_interfaces
+          @versioned_interfaces ||= []
+        end
+
+        def add_api_version(klass)
+          versioned_interfaces << klass
+        end
+      end
+
+      def select_api_version
+        self.class.versioned_interfaces.select do |klass|
+          version = klass.send(:supported_api_version)
+          # min and max versions will be nil if we've not made a request to the server yet,
+          # in which case we'll just start with the highest version and see what happens
+          ServerAPIVersions.instance.min_server_version.nil? || (version >= ServerAPIVersions.instance.min_server_version && version <= ServerAPIVersions.instance.max_server_version)
+        end
+          .sort { |a, b| a.send(:supported_api_version) <=> b.send(:supported_api_version) }
+          .last
+      end
+    end
+  end
+end

--- a/lib/chef/server_api.rb
+++ b/lib/chef/server_api.rb
@@ -24,6 +24,7 @@ require "chef/http/json_input"
 require "chef/http/json_output"
 require "chef/http/remote_request_id"
 require "chef/http/validate_content_length"
+require "chef/http/api_versions"
 
 class Chef
   class ServerAPI < Chef::HTTP
@@ -42,6 +43,7 @@ class Chef
     use Chef::HTTP::Decompressor
     use Chef::HTTP::Authenticator
     use Chef::HTTP::RemoteRequestID
+    use Chef::HTTP::APIVersions
 
     # ValidateContentLength should come after Decompressor
     # because the order of middlewares is reversed when handling

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -1,0 +1,36 @@
+#--
+# Copyright:: Copyright 2017, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "singleton"
+
+class Chef
+  class ServerAPIVersions
+    include Singleton
+
+    def set_versions(versions)
+      @versions ||= versions
+    end
+
+    def min_server_version
+      !@versions.nil? ? @versions["min_version"] : nil
+    end
+
+    def max_server_version
+      !@versions.nil? ? @versions["max_version"] : nil
+    end
+  end
+end

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -32,5 +32,9 @@ class Chef
     def max_server_version
       !@versions.nil? ? @versions["max_version"] : nil
     end
+
+    def reset!
+      @versions = nil
+    end
   end
 end

--- a/spec/unit/http/api_versions_spec.rb
+++ b/spec/unit/http/api_versions_spec.rb
@@ -1,0 +1,69 @@
+#
+# Copyright:: Copyright 2017, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::HTTP::APIVersions do
+  class TestVersionClient < Chef::HTTP
+    use Chef::HTTP::APIVersions
+  end
+
+  before do
+    Chef::ServerAPIVersions.instance.reset!
+  end
+
+  let(:method) { "GET" }
+  let(:url) { "http://dummy.com" }
+  let(:headers) { {} }
+  let(:data) { false }
+
+  let(:request) {}
+  let(:return_value) { "200" }
+
+  # Test Variables
+  let(:response_body) { "Thanks for checking in." }
+  let(:response_headers) do
+    {
+      "x-ops-server-api-version" => { "min_version" => 0, "max_version" => 2 },
+    }
+  end
+
+  let(:response) do
+    m = double("HttpResponse", :body => response_body)
+    allow(m).to receive(:key?).with("x-ops-server-api-version").and_return(true)
+    allow(m).to receive(:[]) do |key|
+      response_headers[key]
+    end
+
+    m
+  end
+
+  let(:middleware) do
+    client = TestVersionClient.new(url)
+    client.middlewares[0]
+  end
+
+  def run_api_version_handler
+    middleware.handle_request(method, url, headers, data)
+    middleware.handle_response(response, request, return_value)
+  end
+
+  it "correctly stores server api versions" do
+    run_api_version_handler
+    expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
+  end
+end

--- a/spec/unit/mixin/versioned_api_spec.rb
+++ b/spec/unit/mixin/versioned_api_spec.rb
@@ -1,0 +1,107 @@
+#
+# Copyright:: Copyright 2015-2017, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef/mixin/versioned_api"
+
+describe Chef::Mixin::VersionedAPI do
+  let(:dummy_class) { Class.new { extend Chef::Mixin::VersionedAPI } }
+
+  it "allows a class to declare the minimum supported API version" do
+    dummy_class.minimum_api_version 3
+    expect(dummy_class.minimum_api_version).to eq(3)
+  end
+end
+
+describe Chef::Mixin::VersionedAPIFactory do
+  class V1Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 1; end
+  class V2Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 2; end
+  class V3Class; extend Chef::Mixin::VersionedAPI; minimum_api_version 3; end
+
+  let(:factory_class) { Class.new { extend Chef::Mixin::VersionedAPIFactory } }
+
+  before do
+    Chef::ServerAPIVersions.instance.reset!
+  end
+
+  describe "#add_versioned_api_class" do
+    it "adds a target class" do
+      factory_class.add_versioned_api_class V1Class
+      expect(factory_class.versioned_interfaces).to eq([V1Class])
+    end
+
+    it "can be called many times" do
+      factory_class.add_versioned_api_class V1Class
+      factory_class.add_versioned_api_class V2Class
+      expect(factory_class.versioned_interfaces).to eq([V1Class, V2Class])
+    end
+  end
+
+  describe "#versioned_api_class" do
+    describe "with no known versions" do
+      it "with one class it returns that class" do
+        factory_class.add_versioned_api_class V2Class
+        expect(factory_class.versioned_api_class.minimum_api_version).to eq(2)
+      end
+
+      it "with many classes it returns the highest minimum version" do
+        factory_class.add_versioned_api_class V1Class
+        factory_class.add_versioned_api_class V2Class
+        factory_class.add_versioned_api_class V3Class
+        expect(factory_class.versioned_api_class.minimum_api_version).to eq(3)
+      end
+    end
+
+    describe "with a known version" do
+      it "with one class it returns that class" do
+        Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
+        factory_class.add_versioned_api_class V2Class
+        expect(factory_class.versioned_api_class.minimum_api_version).to eq(2)
+      end
+
+      it "with a maximum version it returns the highest possible versioned class" do
+        Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
+        factory_class.add_versioned_api_class V1Class
+        factory_class.add_versioned_api_class V2Class
+        factory_class.add_versioned_api_class V3Class
+        expect(factory_class.versioned_api_class.minimum_api_version).to eq(2)
+      end
+    end
+
+    it "with no classes it returns nil" do
+      expect(factory_class.versioned_api_class).to be_nil
+    end
+  end
+
+  describe "#new" do
+    it "creates an instance of the versioned class" do
+      factory_class.add_versioned_api_class V2Class
+      expect { factory_class.new }.to_not raise_error
+      expect(factory_class.new.class).to eq(V2Class)
+    end
+  end
+
+  describe "#def_versioned_delegator" do
+    it "delegates the method to the correct class" do
+      factory_class.add_versioned_api_class V2Class
+      factory_class.def_versioned_delegator("test_method")
+      expect(V2Class).to receive(:test_method).with("test message").and_return(true)
+
+      factory_class.test_method("test message")
+    end
+  end
+end

--- a/spec/unit/server_api_versions_spec.rb
+++ b/spec/unit/server_api_versions_spec.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: Copyright 2017, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::ServerAPIVersions do
+  before do
+    Chef::ServerAPIVersions.instance.reset!
+  end
+
+  describe "#min_server_version" do
+    it "returns nil if no versions have been recorded" do
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to be_nil
+    end
+    it "returns the correct value" do
+      Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
+    end
+  end
+
+  describe "#max_server_version" do
+    it "returns nil if no versions have been recorded" do
+      expect(Chef::ServerAPIVersions.instance.max_server_version).to be_nil
+    end
+    it "returns the correct value" do
+      Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
+      expect(Chef::ServerAPIVersions.instance.max_server_version).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
When we make a request to a chef server, we capture the minimum and
maximum support API versions and allow them to be queried.
We then provide some infrastructure for making decisions on which class
should be used, in a middleware-ish mechanism.