### PR TITLE
Do not modify File's new_resource during why-run

### DIFF
--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -138,7 +138,7 @@ class Chef
         end
         do_acl_changes
         do_selinux(true)
-        load_resource_attributes_from_file(@new_resource)
+        load_resource_attributes_from_file(@new_resource) unless Chef::Config[:why_run]
       end
 
       def action_delete

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -154,7 +154,7 @@ class Chef
         do_contents_changes
         do_acl_changes
         do_selinux
-        load_resource_attributes_from_file(@new_resource)
+        load_resource_attributes_from_file(@new_resource) unless Chef::Config[:why_run]
       end
 
       def action_create_if_missing

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -683,6 +683,16 @@ shared_examples_for Chef::Provider::File do
       end
     end
 
+    context "in why run mode" do
+      before { Chef::Config[:why_run] = true }
+      after { Chef::Config[:why_run] = false }
+
+      it "does not modify new_resource" do
+        setup_missing_file
+        expect(provider).not_to receive(:load_resource_attributes_from_file).with(provider.new_resource)
+        provider.run_action(:create)
+      end
+    end
   end
 
   context "action delete" do

--- a/spec/unit/provider/directory_spec.rb
+++ b/spec/unit/provider/directory_spec.rb
@@ -148,6 +148,16 @@ describe Chef::Provider::Directory do
         directory.run_action(:create)
         expect(new_resource).not_to be_updated
       end
+
+      context "in why run mode" do
+        before { Chef::Config[:why_run] = true }
+        after { Chef::Config[:why_run] = false }
+
+        it "does not modify new_resource" do
+          expect(directory).not_to receive(:load_resource_attributes_from_file).with(new_resource)
+          directory.run_action(:create)
+        end
+      end
     end
 
     describe "when the directory does not exist" do


### PR DESCRIPTION
### Description

The `File` provider's `action_create` method would modify the `new_resource` object during a
`why-run`. This was problematic when a `File` resource was configured with a `notifies :before`
because resources with `before` timers have their actions executed twice. [Once](https://github.com/chef/chef/blob/a2e1d1d4edb74a968b416517fdbdf35740686467/lib/chef/runner.rb#L54-L57) in `why-run` mode to
see if the other resources need to be notified, and then executed [once again](https://github.com/chef/chef/blob/a2e1d1d4edb74a968b416517fdbdf35740686467/lib/chef/runner.rb#L68-L69) after the `before`
notifications are resolved. This behavior would result in existing File resources not getting their
ownership and permissions updated properly during a converge.

### Issues Resolved

Internal ticket

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
