### PR TITLE
Pin nio4r gem to avoid install error

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,3 +14,8 @@ gem "berkshelf", "4.3.5"
 
 # until 2.0.0 is fixed for unstable packages
 gem "mixlib-install", "1.2.3"
+
+# nio4r 2.x was throwing a "could not install" error because of a Ruby version
+# conflict (that didn't actually exist). Since the only gem that really needs
+# it is celluloid, let's just pin it until it becomes a bigger problem.
+gem "nio4r", ">= 1.1.0", "< 2.0.0"

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -12,13 +12,13 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.5.1)
-    aws-sdk (2.6.48)
-      aws-sdk-resources (= 2.6.48)
-    aws-sdk-core (2.6.48)
+    aws-sdk (2.6.49)
+      aws-sdk-resources (= 2.6.49)
+    aws-sdk-core (2.6.49)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.48)
-      aws-sdk-core (= 2.6.48)
+    aws-sdk-resources (2.6.49)
+      aws-sdk-core (= 2.6.49)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -135,7 +135,7 @@ GEM
     net-ssh (4.0.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    nio4r (2.0.0)
+    nio4r (1.2.1)
     nori (2.6.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -249,6 +249,7 @@ DEPENDENCIES
   kitchen-inspec
   kitchen-vagrant
   mixlib-install (= 1.2.3)
+  nio4r (>= 1.1.0, < 2.0.0)
   test-kitchen
   windows_chef_zero
   winrm-elevated


### PR DESCRIPTION
### Description

The nio4r gem, which is a dep of celluloid, was having
some install problems. To avoid this we're just pinning it.

### Issues Resolved

* COOL-661 (Internal Ticket)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
