### PR TITLE
Use new `fips_mode` variable to define whether to build with FIPS

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -39,11 +39,6 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-# Global FIPS override flag.
-if windows? || rhel?
-  override :fips, enabled: true
-end
-
 # Load dynamically updated overrides
 overrides_path = File.expand_path("../../../../omnibus_overrides.rb", current_file)
 instance_eval(IO.read(overrides_path), overrides_path)

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -52,3 +52,4 @@ fetcher_read_timeout 120
 # local_software_dirs ['/path/to/local/software']
 
 fatal_transitive_dependency_licensing_warnings true
+fips_mode (ENV["OMNIBUS_FIPS_MODE"] || "").casecmp?("true")


### PR DESCRIPTION
### Description

Use the new `fips_mode` variable added in https://github.com/chef/omnibus/commit/7fc5529b89327c7b1df457f3ac1f60cd2a9d8f64 to manage FIPS compilation. 

cc @tyler-ball 

### Issues Resolved

Internal ticket COOL-663

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
