### PR TITLE
Use CIDR notation rather than netmask in route-eth0 file

### DIFF
--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -219,7 +219,7 @@ class Chef
         case action
         when :add
           content << (options[:target]).to_s
-          content << "/#{options[:netmask]}" if options[:netmask]
+          content << "/#{MASK[options[:netmask].to_s]}" if options[:netmask]
           content << " via #{options[:gateway]}" if options[:gateway]
           content << "\n"
         end

--- a/spec/unit/provider/route_spec.rb
+++ b/spec/unit/provider/route_spec.rb
@@ -230,13 +230,19 @@ describe Chef::Provider::Route do
       @run_context.resource_collection << Chef::Resource::Route.new("192.168.1.0/24 via 192.168.0.1")
       @run_context.resource_collection << Chef::Resource::Route.new("192.168.2.0/24 via 192.168.0.1")
       @run_context.resource_collection << Chef::Resource::Route.new("192.168.3.0/24 via 192.168.0.1")
+      @run_context.resource_collection << Chef::Resource::Route.new("Complex Route").tap do |r|
+        r.target "192.168.4.0"
+        r.gateway "192.168.0.1"
+        r.netmask "255.255.255.0"
+      end
 
       @provider.action = :add
       @provider.generate_config
-      expect(route_file.string.split("\n").size).to eq(3)
+      expect(route_file.string.split("\n").size).to eq(4)
       expect(route_file.string).to match(/^192\.168\.1\.0\/24 via 192\.168\.0\.1$/)
       expect(route_file.string).to match(/^192\.168\.2\.0\/24 via 192\.168\.0\.1$/)
       expect(route_file.string).to match(/^192\.168\.3\.0\/24 via 192\.168\.0\.1$/)
+      expect(route_file.string).to match(/^192\.168\.4\.0\/24 via 192\.168\.0\.1$/)
     end
   end
 end


### PR DESCRIPTION
### Description

Convert the netmask into it's CIDR block for the route-eth0 file.

Everything I've found in terms of documentation says that the CIDR block is perfectly acceptable in the route-eth0 file. Unless I missed something that's probably what we want to use as RHEL does not accept the netmask. 

### Issues Resolved

* Internal ZD-12741

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
