### PR TITLE
Fix --no-fips on chef-client

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -289,7 +289,7 @@ class Chef::Application::Client < Chef::Application
     :boolean        => true
 
   option :fips,
-    :long         => "--fips",
+    :long         => "--[no-]fips",
     :description  => "Enable fips mode",
     :boolean      => true
 


### PR DESCRIPTION
Somewhat unintuitively, mixlib-cli needs both `boolean => true` as well as
`long => "--[no-]option"` for the boolean feature to work.
