### PR TITLE
Grant Administrators group permissions to nodes directory under chef-solo

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -113,9 +113,11 @@ class Chef
                   Dir.mkdir(path, 0700)
                   if Chef::Platform.windows?
                     all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
+                    administrators = Chef::ReservedNames::Win32::Security::SID.Administrators
                     owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
                     dacl = Chef::ReservedNames::Win32::Security::ACL.create([
                       Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, all_mask),
+                      Chef::ReservedNames::Win32::Security::ACE.access_allowed(administrators, all_mask),
                     ])
                     so = Chef::ReservedNames::Win32::Security::SecurableObject.new(path)
                     so.owner = owner

--- a/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/nodes_dir.rb
@@ -38,10 +38,13 @@ class Chef
             if Chef::Platform.windows?
               read_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_READ
               write_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_WRITE
+              administrators = Chef::ReservedNames::Win32::Security::SID.Administrators
               owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
               dacl = Chef::ReservedNames::Win32::Security::ACL.create([
                 Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, read_mask),
                 Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, write_mask),
+                Chef::ReservedNames::Win32::Security::ACE.access_allowed(administrators, read_mask),
+                Chef::ReservedNames::Win32::Security::ACE.access_allowed(administrators, write_mask),
               ])
               so = Chef::ReservedNames::Win32::Security::SecurableObject.new(child.file_path)
               so.owner = owner


### PR DESCRIPTION
### Description

In addition to the creating user, grant the Administrators group permission to the nodes directory created when chef-solo executes. 

### Issues Resolved

* Fixes #5768 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
