### PR TITLE
Fix chef_platform_methods deprecation class name

### DIFF
--- a/lib/chef/platform/provider_mapping.rb
+++ b/lib/chef/platform/provider_mapping.rb
@@ -35,7 +35,7 @@ class Chef
       include Chef::Mixin::ParamsValidate
 
       def find(name, version)
-        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find is deprecated")
+        Chef.deprecated(:chef_platform_methods, "#{self.name}.find is deprecated")
         provider_map = platforms[:default].clone
 
         name_sym = name
@@ -91,7 +91,7 @@ class Chef
       end
 
       def provider_for_resource(resource, action = :nothing)
-        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.provider_for_resource is deprecated")
+        Chef.deprecated(:chef_platform_methods, "#{self.name}.provider_for_resource is deprecated")
         node = resource.run_context && resource.run_context.node
         raise ArgumentError, "Cannot find the provider for a resource with no run context set" unless node
         provider = find_provider_for_node(node, resource).new(resource, resource.run_context)
@@ -100,17 +100,17 @@ class Chef
       end
 
       def provider_for_node(node, resource_type)
-        raise NotImplementedError, "#{self.class.name} no longer supports #provider_for_node"
+        raise NotImplementedError, "#{self.name} no longer supports #provider_for_node"
       end
 
       def find_provider_for_node(node, resource_type)
-        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find_provider_for_node is deprecated")
+        Chef.deprecated(:chef_platform_methods, "#{self.name}.find_provider_for_node is deprecated")
         platform, version = find_platform_and_version(node)
         find_provider(platform, version, resource_type)
       end
 
       def set(args)
-        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.set is deprecated")
+        Chef.deprecated(:chef_platform_methods, "#{self.name}.set is deprecated")
         validate(
           args,
           {
@@ -176,7 +176,7 @@ class Chef
       end
 
       def find_provider(platform, version, resource_type)
-        Chef.deprecated(:chef_platform_methods, "#{self.class.name}.find_provider is deprecated")
+        Chef.deprecated(:chef_platform_methods, "#{self.name}.find_provider is deprecated")
         provider_klass = explicit_provider(platform, version, resource_type) ||
           platform_provider(platform, version, resource_type) ||
           resource_matching_provider(platform, version, resource_type)

--- a/spec/unit/platform_spec.rb
+++ b/spec/unit/platform_spec.rb
@@ -21,6 +21,14 @@ require "spec_helper"
 describe Chef::Platform do
 
   context "while testing with fake data" do
+    def expect_platform_warning(method_name, times: 1, recurse: true)
+      expect(Chef).to receive(:deprecated).with(:chef_platform_methods, "Chef::Platform.#{method_name} is deprecated").exactly(times).times
+      return unless recurse
+
+      expect_platform_warning(:find_provider_for_node, times: times) if method_name == :provider_for_resource
+      expect_platform_warning(:find_provider, times: times) if method_name == :find_provider_for_node
+      expect_platform_warning(:find, times: times) if method_name == :find_provider
+    end
 
     before :all do
       @original_platform_map = Chef::Platform.platforms
@@ -31,7 +39,6 @@ describe Chef::Platform do
     end
 
     before(:each) do
-      Chef::Config[:treat_deprecation_warnings_as_errors] = false
       Chef::Platform.platforms = {
         :darwin => {
           ">= 10.11" => {
@@ -58,57 +65,67 @@ describe Chef::Platform do
     end
 
     it "should allow you to look up a platform by name and version, returning the provider map for it" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("Darwin", "9.2.2")
       expect(pmap).to be_a_kind_of(Hash)
       expect(pmap[:file]).to eql("darwinian")
     end
 
     it "should allow you to look up a platform by name and version using \"greater than\" style operators" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("Darwin", "11.1.0")
       expect(pmap).to be_a_kind_of(Hash)
       expect(pmap[:file]).to eql("new_darwinian")
     end
 
     it "should use the default providers for an os if the specific version does not exist" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("Darwin", "1")
       expect(pmap).to be_a_kind_of(Hash)
       expect(pmap[:file]).to eql("old school")
     end
 
     it "should use the default providers if the os doesn't give me a default, but does exist" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("mars_volta", "1")
       expect(pmap).to be_a_kind_of(Hash)
       expect(pmap[:file]).to eql(Chef::Provider::File)
     end
 
     it "should use the default provider if the os does not exist" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("AIX", "1")
       expect(pmap).to be_a_kind_of(Hash)
       expect(pmap[:file]).to eql(Chef::Provider::File)
     end
 
     it "should merge the defaults for an os with the specific version" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("Darwin", "9.2.2")
       expect(pmap[:file]).to eql("darwinian")
       expect(pmap[:snicker]).to eql("snack")
     end
 
     it "should merge the defaults for an os with the universal defaults" do
+      expect_platform_warning(:find)
       pmap = Chef::Platform.find("Darwin", "9.2.2")
       expect(pmap[:file]).to eql("darwinian")
       expect(pmap[:pax]).to eql("brittania")
     end
 
     it "should allow you to look up a provider for a platform directly by symbol" do
+      expect_platform_warning(:find_provider)
       expect(Chef::Platform.find_provider("Darwin", "9.2.2", :file)).to eql("darwinian")
     end
 
     it "should raise an exception if a provider cannot be found for a resource type" do
+      expect_platform_warning(:find_provider)
       expect { Chef::Platform.find_provider("Darwin", "9.2.2", :coffee) }.to raise_error(Chef::Exceptions::ProviderNotFound)
     end
 
     it "should look up a provider for a resource with a Chef::Resource object" do
       kitty = Chef::Resource::Cat.new("loulou")
+      expect_platform_warning(:find_provider)
       expect(Chef::Platform.find_provider("Darwin", "9.2.2", kitty)).to eql("nice")
     end
 
@@ -118,10 +135,12 @@ describe Chef::Platform do
       node.name("Intel")
       node.automatic_attrs[:platform] = "mac_os_x"
       node.automatic_attrs[:platform_version] = "9.2.2"
+      expect_platform_warning(:find_provider_for_node)
       expect(Chef::Platform.find_provider_for_node(node, kitty)).to eql("nice")
     end
 
     it "should not throw an exception when the platform version has an unknown format" do
+      expect_platform_warning(:find_provider)
       expect(Chef::Platform.find_provider(:darwin, "bad-version", :file)).to eql("old school")
     end
 
@@ -132,6 +151,8 @@ describe Chef::Platform do
       node.name("Intel")
       node.automatic_attrs[:platform] = "mac_os_x"
       node.automatic_attrs[:platform_version] = "9.2.2"
+      expect_platform_warning(:find_provider_for_node, recurse: false)
+      expect_platform_warning(:find_provider, recurse: false)
       expect(Chef::Platform.find_provider_for_node(node, kitty)).to eql(Chef::Provider::File)
     end
 
@@ -143,6 +164,7 @@ describe Chef::Platform do
       node.name("Intel")
       node.automatic_attrs[:platform] = "mac_os_x"
       node.automatic_attrs[:platform_version] = "8.5"
+      expect_platform_warning(:find_provider_for_node)
       expect(Chef::Platform.find_provider_for_node(node, kitty)).to eql(Chef::Provider::Cat)
     end
 
@@ -156,6 +178,7 @@ describe Chef::Platform do
 
     it "returns a provider object given a Chef::Resource object which has a valid run context and an action" do
       file, run_context = setup_file_resource
+      expect_platform_warning(:provider_for_resource)
       provider = Chef::Platform.provider_for_resource(file, :foo)
       expect(provider).to be_an_instance_of(Chef::Provider::File)
       expect(provider.new_resource).to equal(file)
@@ -164,6 +187,7 @@ describe Chef::Platform do
 
     it "returns a provider object given a Chef::Resource object which has a valid run context without an action" do
       file, run_context = setup_file_resource
+      expect_platform_warning(:provider_for_resource)
       provider = Chef::Platform.provider_for_resource(file)
       expect(provider).to be_an_instance_of(Chef::Provider::File)
       expect(provider.new_resource).to equal(file)
@@ -172,6 +196,7 @@ describe Chef::Platform do
 
     it "raises an error when trying to find the provider for a resource with no run context" do
       file = Chef::Resource::File.new("whateva")
+      expect_platform_warning(:provider_for_resource, recurse: false)
       expect { Chef::Platform.provider_for_resource(file) }.to raise_error(ArgumentError)
     end
 
@@ -180,6 +205,7 @@ describe Chef::Platform do
     end
 
     it "should update the provider map with map" do
+      expect_platform_warning(:set, times: 7)
       Chef::Platform.set(
            :platform => :darwin,
            :version => "9.2.2",
@@ -228,6 +254,7 @@ describe Chef::Platform do
     end
 
     it "does not overwrite the platform map when using :default platform" do
+      expect_platform_warning(:set)
       Chef::Platform.set(
         :resource => :file,
         :platform => :default,


### PR DESCRIPTION
Deprecation warnings for Chef::Platform methods introduced in #5631 were
logged as e.g. `"Class.set is deprecated"` instead of `"Chef::Platform.set is
deprecated"`

This gets correct class name for message and adds unit specs to cover
the expected deprecation messages.

Unfortunately for these specs, some of these methods use each other,
resulting in multiple warnings. I have put an expectation for each of
these to avoid masking any other deprecations.

Signed-off-by: Bill Ruddock <bill.ruddock@gmail.com>