### PR TITLE
Fix functional tests for alternate user support

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,6 +152,7 @@ RSpec.configure do |config|
   config.filter_run_excluding :windows_powershell_no_dsc_only => true unless ! windows_powershell_dsc?
   config.filter_run_excluding :windows_domain_joined_only => true unless windows_domain_joined?
   config.filter_run_excluding :windows_not_domain_joined_only => true if windows_domain_joined?
+  config.filter_run_excluding :windows_service_requires_assign_token => true if !STDOUT.isatty && !windows_user_right?("SeAssignPrimaryTokenPrivilege")
   config.filter_run_excluding :solaris_only => true unless solaris?
   config.filter_run_excluding :system_windows_service_gem_only => true unless system_windows_service_gem?
   config.filter_run_excluding :unix_only => true unless unix?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -92,6 +92,12 @@ def windows_nano_server?
   Chef::Platform.windows_nano_server?
 end
 
+def windows_user_right?(right)
+  return false unless windows?
+  require 'chef/win32/security'
+  Chef::ReservedNames::Win32::Security.get_account_right(ENV["USERNAME"]).include?(right)
+end
+
 def mac_osx_106?
   if File.exists? "/usr/bin/sw_vers"
     result = ShellHelpers.shell_out("/usr/bin/sw_vers")

--- a/spec/support/shared/functional/execute_resource.rb
+++ b/spec/support/shared/functional/execute_resource.rb
@@ -68,7 +68,7 @@ shared_context "a command that can be executed as an alternate user" do
 end
 
 shared_examples_for "an execute resource that supports alternate user identity" do
-  context "when running on Windows", :windows_only do
+  context "when running on Windows", :windows_only, :windows_service_requires_assign_token do
 
     include_context "a command that can be executed as an alternate user"
 
@@ -102,7 +102,7 @@ shared_examples_for "an execute resource that supports alternate user identity" 
 end
 
 shared_examples_for "a resource with a guard specifying an alternate user identity" do
-  context "when running on Windows", :windows_only do
+  context "when running on Windows", :windows_only, :windows_service_requires_assign_token do
     include_context "alternate user identity"
 
     let(:resource_command_property) { :command }

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -178,11 +178,11 @@ shared_context Chef::Resource::WindowsScript do
         resource.run_action(:run)
       end
 
-      context "the script is executed with the identity of the current user" do
+      context "the script is executed with the identity of the current user", :windows_service_requires_assign_token do
         it_behaves_like "a script that cannot be accessed by other users if they are not administrators"
       end
 
-      context "the script is executed with an alternate non-admin identity" do
+      context "the script is executed with an alternate non-admin identity", :windows_service_requires_assign_token do
         include_context "alternate user identity"
 
         before do


### PR DESCRIPTION
On Windows you need the SeAssignPrimaryTokenPrivilege right to use
CreateProcessAsUser when running under a service, even if you're an
Administrator. This makes these functional tests not run under Jenkins if
the jenkins user does not have this right.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>
