### PR TITLE
Suppress sensitive properties from resource log and reporting output

### DIFF
--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -354,6 +354,24 @@ describe Chef::Resource do
     end
   end
 
+  describe "to_text" do
+    it "prints nice message" do
+      resource_class = Class.new(Chef::Resource) { property :foo, String }
+      resource = resource_class.new("sensitive_property_tests")
+      resource.foo = "some value"
+      expect(resource.to_text).to match(/foo "some value"/)
+    end
+
+    context "when property is sensitive" do
+      it "supresses that properties value" do
+        resource_class = Class.new(Chef::Resource) { property :foo, String, sensitive: true }
+        resource = resource_class.new("sensitive_property_tests")
+        resource.foo = "some value"
+        expect(resource.to_text).to match(/foo "\*sensitive value suppressed\*"/)
+      end
+    end
+  end
+
   describe "self.resource_name" do
     context "When resource_name is not set" do
       it "and there are no provides lines, resource_name is nil" do


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

When a property is marked sensitive, suppress it when printing a text representation of the resource for logging purposes. 

### Issues Resolved

* ZD-13635 (internal ticket)
* COOL-680 (internal ticket)
* Fixes #5473 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
