### PR TITLE
Remove Ruby 1.8/1.9 code from the specs

### DIFF
--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -218,7 +218,7 @@ EOM
           knife("list --local /roles").should_succeed "/roles/x.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
 {
@@ -281,7 +281,7 @@ EOM
           knife("list --local /roles").should_succeed "/roles/z.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
 {
@@ -489,7 +489,7 @@ EOM
           knife("list --local /users").should_succeed "/users/x.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", :skip => (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<EOM.strip
 {

--- a/spec/integration/knife/diff_spec.rb
+++ b/spec/integration/knife/diff_spec.rb
@@ -247,7 +247,7 @@ EOM
         end
         when_the_chef_server "has an environment with a different value" do
           before { environment "x", { "description" => "hi" } }
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x",
@@ -277,7 +277,7 @@ EOM
             environment "x", {}
           end
 
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x"
@@ -291,7 +291,7 @@ EOM
           before do
             environment "x", { "description" => "lo" }
           end
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
    "name": "x",
@@ -533,7 +533,7 @@ EOM
         end
         when_the_chef_server "has an environment with a different value" do
           before { environment "x", { "description" => "hi" } }
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x",
@@ -560,7 +560,7 @@ EOM
         end
         when_the_chef_server "has an environment with no value" do
           before { environment "x", {} }
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x"
@@ -574,7 +574,7 @@ EOM
           before do
             environment "x", { "description" => "lo" }
           end
-          it "knife diff reports the difference", :skip => (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
    "name": "x",

--- a/spec/integration/knife/raw_spec.rb
+++ b/spec/integration/knife/raw_spec.rb
@@ -38,7 +38,7 @@ describe "knife raw", :workstation do
       user "x", "{}"
     end
 
-    it "knife raw /nodes/x returns the node", :skip => (RUBY_VERSION < "1.9") do
+    it "knife raw /nodes/x returns the node" do
       knife("raw /nodes/x").should_succeed <<EOM
 {
   "name": "x",
@@ -70,7 +70,7 @@ EOM
       knife("raw /blarghle").should_fail(/ERROR: Server responded with error 404 "Not Found\s*"/)
     end
 
-    it "knife raw -m DELETE /roles/x succeeds", :skip => (RUBY_VERSION < "1.9") do
+    it "knife raw -m DELETE /roles/x succeeds" do
       knife("raw -m DELETE /roles/x").should_succeed <<EOM
 {
   "name": "x",
@@ -94,7 +94,7 @@ EOM
       knife("show /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
     end
 
-    it "knife raw -m PUT -i blah.txt /roles/x succeeds", :skip => (RUBY_VERSION < "1.9") do
+    it "knife raw -m PUT -i blah.txt /roles/x succeeds" do
       Tempfile.open("raw_put_input") do |file|
         file.write <<EOM
 {
@@ -148,7 +148,7 @@ EOM
       end
     end
 
-    it "knife raw -m POST -i blah.txt /roles succeeds", :skip => (RUBY_VERSION < "1.9") do
+    it "knife raw -m POST -i blah.txt /roles succeeds" do
       Tempfile.open("raw_put_input") do |file|
         file.write <<EOM
 {
@@ -198,7 +198,7 @@ EOM
         @raw_server_thread.kill if @raw_server_thread
       end
 
-      it "knife raw /blah returns the prettified json", :skip => (RUBY_VERSION < "1.9") do
+      it "knife raw /blah returns the prettified json" do
         knife("raw /blah").should_succeed <<EOM
 {
   "x": "y",

--- a/spec/integration/knife/show_spec.rb
+++ b/spec/integration/knife/show_spec.rb
@@ -76,7 +76,7 @@ EOM
 }
 EOM
       end
-      it "knife show /environments/x.json shows the remote version", :skip => (RUBY_VERSION < "1.9") do
+      it "knife show /environments/x.json shows the remote version" do
         knife("show /environments/x.json").should_succeed <<EOM
 /environments/x.json:
 {
@@ -92,7 +92,7 @@ EOM
 }
 EOM
       end
-      it "knife show /roles/x.json shows the remote version", :skip => (RUBY_VERSION < "1.9") do
+      it "knife show /roles/x.json shows the remote version" do
         knife("show /roles/x.json").should_succeed <<EOM
 /roles/x.json:
 {
@@ -135,7 +135,7 @@ EOM
         "name" => "x",
       }
     end
-    it "knife show shows the attributes in a predetermined order", :skip => (RUBY_VERSION < "1.9") do
+    it "knife show shows the attributes in a predetermined order" do
       knife("show /environments/x.json").should_succeed <<EOM
 /environments/x.json:
 {

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -29,26 +29,6 @@ def sha256_checksum(path)
   OpenSSL::Digest::SHA256.hexdigest(File.read(path))
 end
 
-# From Ruby 1.9.2+
-# Here for backwards compatibility with Ruby 1.8.7
-# http://rubydoc.info/stdlib/tmpdir/1.9.2/Dir/Tmpname
-def make_tmpname(prefix_suffix, n = nil)
-  case prefix_suffix
-  when String
-    prefix = prefix_suffix
-    suffix = ""
-  when Array
-    prefix = prefix_suffix[0]
-    suffix = prefix_suffix[1]
-  else
-    raise ArgumentError, "unexpected prefix_suffix: #{prefix_suffix.inspect}"
-  end
-  t = Time.now.strftime("%Y%m%d")
-  path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
-  path << "-#{n}" if n
-  path << suffix
-end
-
 # NOTE:
 # This is a temporary fix to get tests passing on systems that have no `diff`
 # until we can replace shelling out to `diff` with ruby diff-lcs


### PR DESCRIPTION
Removes a few legacy checks

Signed-off-by: Tim Smith <tsmith@chef.io>