### PR TITLE
Bump minimum required ruby version to 2.2.2

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
   s.author = "Adam Jacob"
   s.email = "adam@chef.io"
-  s.homepage = "http://www.chef.io"
+  s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
 


### PR DESCRIPTION
Ruby 2.2 is still not compatible with the latest rack. We need to actually specify 2.2.2+ which is what rack and others now require. We dep on rack via chef-zero.

Signed-off-by: Tim Smith <tsmith@chef.io>