### PR TITLE
Revert "updating dependencies"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: 277ec8d3df77dde70b8a3a3423c9fe55318a0384
+  revision: 53b28425d56005a92b0e3bb153f95b505168354a
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: b2bf89dd11270e169fd2315495c98095d4a19090
+  revision: 7e47afd6141d3c44a11322916e3fc85c89aa9b59
   branch: master
   specs:
     chefstyle (0.5.0)
@@ -138,13 +138,13 @@ GEM
       mixlib-cli (~> 1.4)
     artifactory (2.6.0)
     ast (2.3.0)
-    aws-sdk (2.7.8)
-      aws-sdk-resources (= 2.7.8)
-    aws-sdk-core (2.7.8)
+    aws-sdk (2.7.7)
+      aws-sdk-resources (= 2.7.7)
+    aws-sdk-core (2.7.7)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.8)
-      aws-sdk-core (= 2.7.8)
+    aws-sdk-resources (2.7.7)
+      aws-sdk-core (= 2.7.7)
     aws-sigv4 (1.0.0)
     backports (3.6.8)
     binding_of_caller (0.7.2)
@@ -154,14 +154,13 @@ GEM
     chef-api (0.7.0)
       logify (~> 0.1)
       mime-types
-    chef-provisioning (2.1.1)
+    chef-provisioning (2.1.0)
       cheffish (~> 4.0)
       inifile (>= 2.0.2)
       mixlib-install (>= 1.0, < 3.0)
       net-scp (~> 1.0)
       net-ssh (>= 2.9, < 5.0)
       net-ssh-gateway (~> 1.2)
-      winrm (~> 2.0)
       winrm-fs (~> 1.0)
     chef-sugar (3.4.0)
     chef-zero (5.3.0)
@@ -271,7 +270,7 @@ GEM
     kitchen-sync (2.1.2)
       net-sftp
       test-kitchen (>= 1.0.0)
-    kitchen-vagrant (1.0.2)
+    kitchen-vagrant (1.0.1)
       test-kitchen (~> 1.4)
     knife-windows (1.9.0)
       winrm (~> 2.1)
@@ -462,7 +461,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    specinfra (2.67.0)
+    specinfra (2.66.9)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -591,4 +590,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.7
+   1.12.5

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
-  remote: https://github.com/chef/license_scout.git
-  revision: aac23c63c0906d3dad7d3472d62843d04178e5c4
+  remote: git://github.com/chef/license_scout.git
+  revision: f90293a9753652fb64994a14de4108e503c06632
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
 
 GIT
-  remote: https://github.com/chef/omnibus-software.git
+  remote: git://github.com/chef/omnibus-software.git
   revision: 086710002ec0054b3d240d14ca04d11163f528aa
   branch: shain/ruby_windows_monster
   specs:
@@ -16,7 +16,7 @@ GIT
       omnibus (>= 5.5.0)
 
 GIT
-  remote: https://github.com/chef/omnibus.git
+  remote: git://github.com/chef/omnibus.git
   revision: dce5283a85a44484a66a8a84991beba92e46fd12
   branch: rhass/COOL-502_with_gcc_investigate
   specs:
@@ -39,13 +39,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.6.0)
     awesome_print (1.7.0)
-    aws-sdk (2.7.8)
-      aws-sdk-resources (= 2.7.8)
-    aws-sdk-core (2.7.8)
+    aws-sdk (2.7.5)
+      aws-sdk-resources (= 2.7.5)
+    aws-sdk-core (2.7.5)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.8)
-      aws-sdk-core (= 2.7.8)
+    aws-sdk-resources (2.7.5)
+      aws-sdk-core (= 2.7.5)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -107,7 +107,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.3)
+    hashie (3.5.1)
     hitimes (1.2.4)
     hitimes (1.2.4-x86-mingw32)
     httpclient (2.7.2)
@@ -267,4 +267,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.13.7
+   1.12.5


### PR DESCRIPTION
This reverts commit bd45e8360cf233cbadba17c4ee9870d450a610f8.

Seems to have caused some chaos building omnibus in manhattan for reasons that I don't understand right now and the shortest path to getting back to green (and isolating the fact that the dep bumping broke the build) is just to revert this change.