### PR TITLE
Deprecate Cisco platforms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,6 +83,10 @@ end
 - Ensure that the Windows Administrator group can access the chef-solo nodes directory
 - When loading a cookbook in Chef Solo, use `metadata.json` in preference to `metadata.rb`
 
+## Deprecation Notice
+
+- As of version 12.19, chef client will no longer be build or tested on the Cisco NX-OS and IOS XR platforms.
+
 # Ohai Release Notes 8.23:
 
 ## Cumulus Linux Platform


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

Chef Client will no longer be built or tested on Cisco platforms.

@chef/engineering-services 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
