### PR TITLE
CHEF-4538 - add an option for gateway_identity_file that will allow key-based authentication on the gateway.

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,2 @@
 ---
 BUNDLE_FROZEN: "1"
-BUNDLE_PATH: ".bundle"
-BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,4 @@
 ---
 BUNDLE_FROZEN: "1"
+BUNDLE_PATH: ".bundle"
+BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -714,6 +714,7 @@ module ChefConfig
       default :ssh_user, nil
       default :ssh_attribute, nil
       default :ssh_gateway, nil
+      default :ssh_gateway_identity, nil
       default :bootstrap_version, nil
       default :bootstrap_proxy, nil
       default :bootstrap_template, nil

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -67,6 +67,11 @@ class Chef
         :description => "The ssh gateway",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway] = key }
 
+      option :ssh_gateway_identity,
+        :long => "--ssh-gateway-identity SSH_GATEWAY_IDENTITY",
+        :description => "The SSH identity file used for gateway authentication",
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway_identity] = key }
+
       option :forward_agent,
         :short => "-A",
         :long => "--forward-agent",
@@ -438,6 +443,7 @@ class Chef
         ssh.config[:ssh_password] = config[:ssh_password]
         ssh.config[:ssh_port] = config[:ssh_port]
         ssh.config[:ssh_gateway] = config[:ssh_gateway]
+        ssh.config[:ssh_gateway_identity] = config[:ssh_gateway_identity]
         ssh.config[:forward_agent] = config[:forward_agent]
         ssh.config[:ssh_identity_file] = config[:ssh_identity_file] || config[:identity_file]
         ssh.config[:manual] = true

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -92,6 +92,11 @@ class Chef
         :description => "The ssh gateway",
         :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway] = key.strip }
 
+      option :ssh_gateway_identity,
+        :long => "--ssh-gateway-identity SSH_GATEWAY_IDENTITY",
+        :description => "The SSH identity file used for gateway authentication",
+        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway_identity] = key.strip }
+
       option :forward_agent,
         :short => "-A",
         :long => "--forward-agent",
@@ -250,7 +255,10 @@ class Chef
         {}.tap do |opts|
           # Chef::Config[:knife][:ssh_user] is parsed in #configure_user and written to config[:ssh_user]
           opts[:user] = user || config[:ssh_user] || ssh_config[:user]
-          if config[:ssh_identity_file]
+          if config[:ssh_gateway_identity]
+            opts[:keys] = File.expand_path(config[:ssh_gateway_identity])
+            opts[:keys_only] = true
+          elsif config[:ssh_identity_file]
             opts[:keys] = File.expand_path(config[:ssh_identity_file])
             opts[:keys_only] = true
           elsif config[:ssh_password]

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -554,7 +554,6 @@ class Chef
       end
 
       def configure_ssh_gateway_identity
-        # config[:identity_file] is DEPRECATED in favor of :ssh_identity_file
         config[:ssh_gateway_identity] = get_stripped_unfrozen_value(config[:ssh_gateway_identity] || Chef::Config[:knife][:ssh_gateway_identity])
       end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -94,8 +94,7 @@ class Chef
 
       option :ssh_gateway_identity,
         :long => "--ssh-gateway-identity SSH_GATEWAY_IDENTITY",
-        :description => "The SSH identity file used for gateway authentication",
-        :proc => Proc.new { |key| Chef::Config[:knife][:ssh_gateway_identity] = key.strip }
+        :description => "The SSH identity file used for gateway authentication"
 
       option :forward_agent,
         :short => "-A",
@@ -554,6 +553,11 @@ class Chef
         config[:ssh_identity_file] = get_stripped_unfrozen_value(config[:ssh_identity_file] || config[:identity_file] || Chef::Config[:knife][:ssh_identity_file])
       end
 
+      def configure_ssh_gateway_identity
+        # config[:identity_file] is DEPRECATED in favor of :ssh_identity_file
+        config[:ssh_gateway_identity] = get_stripped_unfrozen_value(config[:ssh_gateway_identity] || Chef::Config[:knife][:ssh_gateway_identity])
+      end
+
       def run
         @longest = 0
 
@@ -561,6 +565,7 @@ class Chef
         configure_password
         @password = config[:ssh_password] if config[:ssh_password]
         configure_ssh_identity_file
+        configure_ssh_gateway_identity
         configure_gateway
         configure_session
 

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -254,7 +254,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "~/.ssh/aws-gateway.rsa", :keys_only => true })
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "#{ENV['HOME']}/.ssh/aws-gateway.rsa", :keys_only => true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end
@@ -268,7 +268,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "~/.ssh/aws-gateway.rsa", :keys_only => true })
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "#{ENV['HOME']}/.ssh/aws-gateway.rsa", :keys_only => true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -248,13 +248,13 @@ describe Chef::Knife::Ssh do
 
     context "when knife[:ssh_gateway_identity] is set" do
       before do
-        setup_knife(['*:*','uptime'])
+        setup_knife(["*:*", "uptime"])
         Chef::Config[:knife][:ssh_gateway] = "user@ec2.public_hostname"
         Chef::Config[:knife][:ssh_gateway_identity] = "~/.ssh/aws-gateway.rsa"
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user",{:keys=>"~/.ssh/aws-gateway.rsa"})
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "~/.ssh/aws-gateway.rsa", :keys_only => true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end
@@ -262,18 +262,17 @@ describe Chef::Knife::Ssh do
 
     context "when -ssh-gateway-identity is provided and knife[:ssh_gateway] is set" do
       before do
-        setup_knife(['--ssh-gateway-identity','~/.ssh/aws-gateway.rsa','*:*','uptime'])
+        setup_knife(["--ssh-gateway-identity", "~/.ssh/aws-gateway.rsa", "*:*", "uptime"])
         Chef::Config[:knife][:ssh_gateway] = "user@ec2.public_hostname"
         Chef::Config[:knife][:ssh_gateway_identity] = nil
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user",{:keys=>"~/.ssh/aws-gateway.rsa"})
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { :keys => "~/.ssh/aws-gateway.rsa", :keys_only => true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end
     end
-
 
     context "when the gateway requires a password" do
       before do

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -246,6 +246,35 @@ describe Chef::Knife::Ssh do
       end
     end
 
+    context "when knife[:ssh_gateway_identity] is set" do
+      before do
+        setup_knife(['*:*','uptime'])
+        Chef::Config[:knife][:ssh_gateway] = "user@ec2.public_hostname"
+        Chef::Config[:knife][:ssh_gateway_identity] = "~/.ssh/aws-gateway.rsa"
+      end
+
+      it "uses the ssh_gateway_identity file" do
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user",{:keys=>"~/.ssh/aws-gateway.rsa"})
+        @knife.run
+        expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
+      end
+    end
+
+    context "when -ssh-gateway-identity is provided and knife[:ssh_gateway] is set" do
+      before do
+        setup_knife(['--ssh-gateway-identity','~/.ssh/aws-gateway.rsa','*:*','uptime'])
+        Chef::Config[:knife][:ssh_gateway] = "user@ec2.public_hostname"
+        Chef::Config[:knife][:ssh_gateway_identity] = nil
+      end
+
+      it "uses the ssh_gateway_identity file" do
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user",{:keys=>"~/.ssh/aws-gateway.rsa"})
+        @knife.run
+        expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
+      end
+    end
+
+
     context "when the gateway requires a password" do
       before do
         setup_knife(["-G user@ec2.public_hostname", "*:*", "uptime"])

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -649,6 +649,7 @@ describe Chef::Knife::Bootstrap do
         Chef::Config[:knife][:forward_agent] = true
         Chef::Config[:knife][:ssh_identity_file] = "~/.ssh/you.rsa"
         Chef::Config[:knife][:ssh_gateway] = "towel.blinkenlights.nl"
+        Chef::Config[:knife][:ssh_gateway_identity] = "~/.ssh/gateway.rsa"
         Chef::Config[:knife][:host_key_verify] = true
         allow(knife).to receive(:render_template).and_return("")
         knife.config = {}
@@ -674,6 +675,10 @@ describe Chef::Knife::Bootstrap do
 
       it "configures the ssh gateway" do
         expect(knife_ssh.config[:ssh_gateway]).to eq("towel.blinkenlights.nl")
+      end
+
+      it "configures the ssh gateway identity" do
+        expect(knife_ssh.config[:ssh_gateway_identity]).to eq('~/.ssh/gateway.rsa')
       end
 
       it "configures the host key verify mode" do

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -678,7 +678,7 @@ describe Chef::Knife::Bootstrap do
       end
 
       it "configures the ssh gateway identity" do
-        expect(knife_ssh.config[:ssh_gateway_identity]).to eq('~/.ssh/gateway.rsa')
+        expect(knife_ssh.config[:ssh_gateway_identity]).to eq("~/.ssh/gateway.rsa")
       end
 
       it "configures the host key verify mode" do


### PR DESCRIPTION
Add an option for gateway_identity_file that will allow key-based authentication on the gateway.

### Description

Rebase of https://github.com/chef/chef/pull/1651

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
