### PR TITLE
Improve version bumping 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group(:docgen) do
   gem "yard"
 end
 
-group(:maintenance) do
+group(:maintenance, :ci) do
   gem "tomlrb"
 
   # To sync maintainers with github
@@ -77,7 +77,7 @@ group(:development, :test) do
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
 end
 
-group(:changelog) do
+group(:ci) do
   gem "github_changelog_generator", git: "https://github.com/chef/github-changelog-generator"
   gem "mixlib-install"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -29,29 +29,11 @@ require_relative "tasks/cbgb"
 require_relative "tasks/dependencies"
 require_relative "tasks/changelog"
 require_relative "tasks/announce"
+require_relative "tasks/version"
 
 ChefConfig::PackageTask.new(File.expand_path("..", __FILE__), "Chef", "chef") do |package|
   package.component_paths = ["chef-config"]
   package.generate_version_class = true
-end
-# Add conservative dependency update to version:bump (which was created by PackageTask)
-task "version:bump" => %w{version:bump_patch version:update}
-task "version:bump" => %w{version:bump_patch version:update}
-
-task "version:bump_minor" do
-  Rake::Task["changelog:archive"].invoke
-  maj, min, _build = Chef::VERSION.split(".")
-  File.open("VERSION", "w+") { |f| f.write("#{maj}.#{min.to_i + 1}.0") }
-  Rake::Task["version"].invoke
-  Rake::Task["bundle:install"].invoke
-end
-
-task "version:bump_major" do
-  Rake::Task["changelog:archive"].invoke
-  maj, _min, _build = Chef::VERSION.split(".")
-  File.open("VERSION", "w+") { |f| f.write("#{maj.to_i + 1}.0.0") }
-  Rake::Task["version"].invoke
-  Rake::Task["bundle:install"].invoke
 end
 
 task :pedant, :chef_zero_spec

--- a/chef-config/lib/chef-config/package_task.rb
+++ b/chef-config/lib/chef-config/package_task.rb
@@ -182,6 +182,20 @@ module ChefConfig
           IO.write(version_file_path, new_version)
         end
 
+        task :bump_minor do
+          current_version = version
+          new_version = current_version.sub(/^(\d+)\.(\d+)\.(\d+)/) { "#{$1}.#{$2.to_i + 1}.0" }
+          puts "Updating version in #{version_rb_path} from #{current_version.chomp} to #{new_version.chomp}"
+          IO.write(version_file_path, new_version)
+        end
+
+        task :bump_major do
+          current_version = version
+          new_version = current_version.sub(/^(\d+)\.(\d+\.\d+)/) { "#{$1.to_i + 1}.0.0" }
+          puts "Updating version in #{version_rb_path} from #{current_version.chomp} to #{new_version.chomp}"
+          IO.write(version_file_path, new_version)
+        end
+
         def update_version_rb # rubocop:disable Lint/NestedMethodDefinition
           puts "Updating #{version_rb_path} to include version #{version} ..."
           contents = <<-VERSION_RB

--- a/ci/bundle_install.sh
+++ b/ci/bundle_install.sh
@@ -5,6 +5,6 @@ set -evx
 gem environment
 bundler_version=$(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
 gem install bundler -v $bundler_version --user-install --conservative
-# WITH: changelog (for version bumping and changelog creation)
+# WITH: ci (for version bumping and changelog creation)
 export BUNDLE_WITHOUT=omnibus_package:test:pry:integration:docgen:maintenance:travis:aix:bsd:linux:mac_os_x:solaris:windows:development:travis
 bundle _${bundler_version}_ install

--- a/ci/version_bump.sh
+++ b/ci/version_bump.sh
@@ -6,8 +6,6 @@ export LANG=en_US.UTF-8
 
 . ci/bundle_install.sh
 
-bundle exec rake version:bump
-bundle exec rake changelog || true
-bundle exec rake update_dockerfile
+bundle exec rake ci_version_bump
 
 git checkout .bundle/config

--- a/tasks/version.rb
+++ b/tasks/version.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+task :ci_version_bump do
+  begin
+    require "rake"
+
+    Rake::Task["version:bump_minor"].invoke
+    Rake::Task["version:update"].invoke
+
+    # We want to log errors that occur in the following tasks, but we don't
+    # want them to stop an otherwise valid version bump from progressing.
+    begin
+      Rake::Task["changelog:update"].invoke
+    rescue Exception => e
+      puts "There was an error updating the CHANGELOG"
+      puts e
+    end
+
+    begin
+      Rake::Task["update_dockerfile"].invoke
+    rescue Exception => e
+      puts "There was an error updating the Dockerfile"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR shifts some of the logic around, making it so that all the version bumping logic is together. It also adds a special helper that allows the entire version bump task to be tolerant of failure. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
