### PR TITLE
Removing Cisco from Maintainers files

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -157,30 +157,6 @@ To mention the team, use @chef/client-debian
 * [Lamont Granquist](https://github.com/lamont-granquist)
 * [Tim Smith](https://github.com/tas50)
 
-## Cisco NX-OS
-
-To mention the team, use @chef/client-nxos
-
-### Lieutenant
-
-* [Adam Leff](https://github.com/adamleff)
-
-### Maintainers
-
-* [Adam Leff](https://github.com/adamleff)
-
-## Cisco IOS XR
-
-To mention the team, use @chef/client-iosxr
-
-### Lieutenant
-
-* [Adam Leff](https://github.com/adamleff)
-
-### Maintainers
-
-* [Adam Leff](https://github.com/adamleff)
-
 ## Fedora
 
 To mention the team, use @chef/client-fedora

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -150,26 +150,6 @@ The specific components of Chef related to a given platform - including (but not
           "tas50"
         ]
 
-      [Org.Components.Subsystems.CiscoNXOS]
-        title = "Cisco NX-OS"
-        team = "client-nxos"
-
-        lieutenant = "adamleff"
-
-        maintainers = [
-          "adamleff"
-        ]
-
-      [Org.Components.Subsystems.CiscoIOSXR]
-        title = "Cisco IOS XR"
-        team = "client-iosxr"
-
-        lieutenant = "adamleff"
-
-        maintainers = [
-          "adamleff"
-        ]
-
     [Org.Components.Subsystems.Fedora]
         title = "Fedora"
         team = "client-fedora"
@@ -242,10 +222,6 @@ The specific components of Chef related to a given platform - including (but not
   [people.adamhjk]
     Name = "Adam Jacob"
     GitHub = "adamhjk"
-
-  [people.adamleff]
-    Name = "Adam Leff"
-    GitHub = "adamleff"
 
   [people.Aevin1387]
     Name = "Cory Stephenson"


### PR DESCRIPTION
Chef is no longer built on the Cisco platforms, so there is no need
for lieutenants and maintainers any longer.

Signed-off-by: Adam Leff <adam@leff.co>