### PR TITLE
Use shellsplit for apt_package options

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -23,6 +23,7 @@ require "chef/log"
 require "chef/file_cache"
 require "chef/platform"
 require "chef/decorator/lazy_array"
+require "shellwords"
 
 class Chef
   class Provider
@@ -54,10 +55,7 @@ class Chef
 
       def options
         if new_resource.options.is_a?(String)
-          # XXX: needs to handle double quotes, single quotes, nested quotes, etc and probably act
-          # more like a space-separated "C"SV file -- although users can fix this just by passing in
-          # a correctly pre-split Array.
-          new_resource.options.split(" ")
+          new_resource.options.shellsplit
         else
           new_resource.options
         end

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -291,6 +291,16 @@ mpg123 1.12.1-0ubuntu1
 
             @provider.install_package(["irssi"], ["0.8.12-7"])
           end
+
+          it "should run apt-get install with the package name and quotes options if specified" do
+            expect(@provider).to receive(:shell_out!).with(
+              "apt-get", "-q", "-y", "--force-yes", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confnew", "install", "irssi=0.8.12-7",
+              :env => { "DEBIAN_FRONTEND" => "noninteractive" },
+              :timeout => @timeout
+            )
+            @new_resource.options('--force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew"')
+            @provider.install_package(["irssi"], ["0.8.12-7"])
+          end
         end
 
         describe resource_klass, "upgrade_package" do


### PR DESCRIPTION
### Description

This correctly deals with quotes and so on in package options to apt_package.

### Issues Resolved

#5836 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
