### PR TITLE
Require chef/version when trying to read it

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -161,13 +161,14 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
           end
 
           if Chef::Config[:fips]
-            client_rb << <<-CONFIG
-fips true
-chef_version = ::Chef::VERSION.split(".")
-unless chef_version[0].to_i > 12 || (chef_version[0].to_i == 12 && chef_version[1].to_i >= 8)
-  raise "FIPS Mode requested but not supported by this client"
-end
-CONFIG
+            client_rb << <<-CONFIG.gsub(/^ {14}/, "")
+              fips true
+              require "chef/version"
+              chef_version = ::Chef::VERSION.split(".")
+              unless chef_version[0].to_i > 12 || (chef_version[0].to_i == 12 && chef_version[1].to_i >= 8)
+                raise "FIPS Mode requested but not supported by this client"
+              end
+            CONFIG
           end
 
           client_rb

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -213,6 +213,23 @@ EXPECTED
     end
   end
 
+  describe "fips mode" do
+    before do
+      Chef::Config[:fips] = true
+    end
+
+    it "adds the chef version check" do
+      expect(bootstrap_context.config_content).to include <<-CONFIG.gsub(/^ {8}/, "")
+        fips true
+        require "chef/version"
+        chef_version = ::Chef::VERSION.split(".")
+        unless chef_version[0].to_i > 12 || (chef_version[0].to_i == 12 && chef_version[1].to_i >= 8)
+          raise "FIPS Mode requested but not supported by this client"
+        end
+      CONFIG
+    end
+  end
+
   describe "verify_api_cert" do
     it "isn't set in the config_content by default" do
       expect(bootstrap_context.config_content).not_to include("verify_api_cert")


### PR DESCRIPTION
### Description

When a node is bootstrapped in FIPS mode and then tries to run a
chef-client run it gets the following error:

```
STDERR: /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/chef-config-12.18.31/lib/chef-config/workstation_config_loader.rb:163:in `rescue in apply_config': You have an error in your config file /var/opt/delivery/workspace/.chef/knife.rb (ChefConfig::ConfigurationError)

NameError: uninitialized constant Chef
  /var/opt/delivery/workspace/.chef/knife.rb:2:in `eval'
  /var/opt/delivery/workspace/.chef/knife.rb:2:in `eval'
  /var/opt/delivery/workspace/.chef/knife.rb:2:in `from_string'
```

### Issues Resolved

ER-478 in Jira

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
