### PR TITLE
add support QuietUninstallString for windows packages

### DIFF
--- a/lib/chef/provider/package/windows/registry_uninstall_entry.rb
+++ b/lib/chef/provider/package/windows/registry_uninstall_entry.rb
@@ -41,11 +41,11 @@ class Chef
                       entry = reg.open(key, desired)
                       display_name = read_registry_property(entry, "DisplayName")
                       if display_name == package_name
-                        quiet_uninstall_string = RegistryUninstallEntry.read_registry_property(entry, 'QuietUninstallString')
+                        quiet_uninstall_string = RegistryUninstallEntry.read_registry_property(entry, "QuietUninstallString")
                         if quiet_uninstall_string.nil?
                           entries.push(RegistryUninstallEntry.new(hkey, key, entry))
                         else
-                          entries.push(RegistryUninstallEntry.new(hkey, key, entry, 'QuietUninstallString'))
+                          entries.push(RegistryUninstallEntry.new(hkey, key, entry, "QuietUninstallString"))
                         end
                       end
                     rescue ::Win32::Registry::Error => ex
@@ -67,7 +67,7 @@ class Chef
             nil
           end
 
-          def initialize(hive, key, registry_data, uninstall_key = 'UninstallString')
+          def initialize(hive, key, registry_data, uninstall_key = "UninstallString")
             Chef::Log.debug("Creating uninstall entry for #{hive}::#{key}")
             @hive = hive
             @key = key

--- a/lib/chef/provider/package/windows/registry_uninstall_entry.rb
+++ b/lib/chef/provider/package/windows/registry_uninstall_entry.rb
@@ -18,7 +18,6 @@
 #
 
 require "win32/registry" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-require "pry"
 
 class Chef
   class Provider

--- a/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
+++ b/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "chef/provider/package/windows/registry_uninstall_entry"
+
+describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
+  
+  let(:hkey) { :hkey } # mock all the methods
+  let(:key) { :key }
+  let(:entry) { {"UninstallString" => "UninstallStringPath", "QuietUninstallString" => "QuietUninstallStringPath"} }
+  
+  describe "when 'QuietUninstallString' key not present" do
+   	  let(:quiet_uninstall_string) { nil }
+      let (:quiet_uninstall_string_key){Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string}
+    it "should return 'UninstallString' key value" do
+    	expect(quiet_uninstall_string_key).to eql "UninstallStringPath"
+    end
+  end  
+
+  describe "when 'QuietUninstallString' key present" do
+   	  let(:quiet_uninstall_string) { "QuietUninstallString" }
+      let (:quiet_uninstall_string_key){Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string}
+
+    it "should return 'QuietUninstallString' key value" do
+    	expect(quiet_uninstall_string_key).to eql "QuietUninstallStringPath"
+    end
+  end  
+end

--- a/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
+++ b/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
@@ -2,25 +2,24 @@ require "spec_helper"
 require "chef/provider/package/windows/registry_uninstall_entry"
 
 describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
-  
   let(:hkey) { :hkey } # mock all the methods
   let(:key) { :key }
-  let(:entry) { {"UninstallString" => "UninstallStringPath", "QuietUninstallString" => "QuietUninstallStringPath"} }
-  
-  describe "when 'QuietUninstallString' key not present" do
-   	  let(:quiet_uninstall_string) { nil }
-      let (:quiet_uninstall_string_key){Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string}
-    it "should return 'UninstallString' key value" do
-    	expect(quiet_uninstall_string_key).to eql "UninstallStringPath"
-    end
-  end  
+  let(:entry) { { "UninstallString" => "UninstallStringPath", "QuietUninstallString" => "QuietUninstallStringPath" } }
 
-  describe "when 'QuietUninstallString' key present" do
-   	  let(:quiet_uninstall_string) { "QuietUninstallString" }
-      let (:quiet_uninstall_string_key){Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string}
-
-    it "should return 'QuietUninstallString' key value" do
-    	expect(quiet_uninstall_string_key).to eql "QuietUninstallStringPath"
+  describe "when QuietUninstallString key not present" do
+    let(:quiet_uninstall_string) { nil }
+    let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
+    it "should return UninstallString key value" do
+      expect(quiet_uninstall_string_key).to eql "UninstallStringPath"
     end
-  end  
+  end
+
+  describe "when QuietUninstallString key present" do
+    let(:quiet_uninstall_string) { "QuietUninstallString" }
+    let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
+
+    it "should return QuietUninstallString key value" do
+      expect(quiet_uninstall_string_key).to eql "QuietUninstallStringPath"
+    end
+  end
 end


### PR DESCRIPTION
#
### Description In progress PR
Some Windows packages apparently create a separate uninstall string under the key QuietUninstallString. We should search for that and use it if it exists.
### Issues Resolved
https://github.com/chef/chef/issues/5580

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
