### PR TITLE
Add real support for rb files (at least roles) in knife-serve

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -768,7 +768,7 @@ class Chef
           end
 
         elsif path.length == 2 && path[0] != "cookbooks"
-          path[1] = path[1].gsub(/\.(rb|json)/, '')
+          path[1] = path[1].gsub(/\.(rb|json)/, "")
         end
 
         path

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -768,7 +768,7 @@ class Chef
           end
 
         elsif path.length == 2 && path[0] != "cookbooks"
-          path[1] = path[1][0..-6]
+          path[1] = path[1].gsub(/\.(rb|json)/, '')
         end
 
         path

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -55,7 +55,8 @@ describe "knife serve", :workstation do
   when_the_repository "also has one of each thing" do
     before do
       file "nodes/x.json", { "foo" => "bar" }
-      file "roles/a_role_with_a_name.json", { "foo" => "bar" }
+      file "roles/a_role_in_json.json", { "foo" => "bar" }
+      file "roles/a_role_in_ruby.rb", "name 'a_role_in_ruby'"
     end
 
     it "knife serve serves up /nodes/x" do
@@ -63,9 +64,19 @@ describe "knife serve", :workstation do
         expect(api.get("nodes/x")["name"]).to eq("x")
       end
     end
-    it "knife serve serves up /roles" do
-      with_knife_serve do |api|
-        expect(api.get("roles")).to have_key("a_role_with_a_name")
+
+    %w(a_role_in_json a_role_in_ruby).each do |file_type|
+      context file_type do
+        it "knife serve serves up /roles" do
+          with_knife_serve do |api|
+            expect(api.get("roles")).to have_key(file_type)
+          end
+        end
+        it "knife serve serves up /roles/#{file_type}" do
+          with_knife_serve do |api|
+            expect(api.get("roles/#{file_type}")['name']).to eq(file_type)
+          end
+        end
       end
     end
   end

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -53,11 +53,19 @@ describe "knife serve", :workstation do
   end
 
   when_the_repository "also has one of each thing" do
-    before { file "nodes/x.json", { "foo" => "bar" } }
+    before do
+      file "nodes/x.json", { "foo" => "bar" }
+      file "roles/a_role_with_a_name.json", { "foo" => "bar" }
+    end
 
     it "knife serve serves up /nodes/x" do
       with_knife_serve do |api|
         expect(api.get("nodes/x")["name"]).to eq("x")
+      end
+    end
+    it "knife serve serves up /roles" do
+      with_knife_serve do |api|
+        expect(api.get("roles")).to have_key("a_role_with_a_name")
       end
     end
   end

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -54,18 +54,28 @@ describe "knife serve", :workstation do
 
   when_the_repository "also has one of each thing" do
     before do
-      file "nodes/x.json", { "foo" => "bar" }
+      file "nodes/a_node_in_json.json", { "foo" => "bar" }
+      file "nodes/a_node_in_ruby.rb", "name 'a_node_in_ruby'"
       file "roles/a_role_in_json.json", { "foo" => "bar" }
       file "roles/a_role_in_ruby.rb", "name 'a_role_in_ruby'"
     end
 
-    it "knife serve serves up /nodes/x" do
-      with_knife_serve do |api|
-        expect(api.get("nodes/x")["name"]).to eq("x")
+    %w{a_node_in_json a_node_in_ruby}.each do |file_type|
+      context file_type do
+        it "knife serve serves up /nodes" do
+          with_knife_serve do |api|
+            expect(api.get("nodes")).to have_key(file_type)
+          end
+        end
+        it "knife serve serves up /nodes/#{file_type}" do
+          with_knife_serve do |api|
+            expect(api.get("nodes/#{file_type}")["name"]).to eq(file_type)
+          end
+        end
       end
     end
 
-    %w(a_role_in_json a_role_in_ruby).each do |file_type|
+    %w{a_role_in_json a_role_in_ruby}.each do |file_type|
       context file_type do
         it "knife serve serves up /roles" do
           with_knife_serve do |api|
@@ -74,7 +84,7 @@ describe "knife serve", :workstation do
         end
         it "knife serve serves up /roles/#{file_type}" do
           with_knife_serve do |api|
-            expect(api.get("roles/#{file_type}")['name']).to eq(file_type)
+            expect(api.get("roles/#{file_type}")["name"]).to eq(file_type)
           end
         end
       end


### PR DESCRIPTION
Add real support for rb files (at least roles) in knife-serve

### Issues Resolved

chef/chef-zero#107 claims knife-serve supports rb files.
It wasn't the case before this patch:
`knife serve & (sleep 5knife raw -s http://localhost:8889 /role)` shows truncated      names for rb roles.

This was due to the way filenames are transformed to object names.

This patch only tests behavior for roles.

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
