### PR TITLE
Chef-13:  remove magic from the logger/formatter settings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -270,9 +270,12 @@ The `use_inline_resources` provider mode is always enabled when using the
 `action :name do ... end` syntax. You can remove the `use_inline_resources`
 line.
 
-### Magic removed from logger and formatter settings
+### The logger and formatter settings are more predictable
 
-There is no more magic involved in the setting of the logger and the formatter, the default is now the formatter.
+The default now is the formatter.  There is no more automatic switching to the logger when logging or when output
+is sent to a pipe.  The logger needs to be specifically requested with `--force-logger` or it will not show up.
+
+The `--force-formatter` option does still exist, although it will probably be deprecated in the future.
 
 Setting the `log_location` in the config.rb now applies to both daemonized and command-line invocation and there is
 no magic which dups the logger in order to log to STDOUT on the command line in that case.
@@ -291,4 +294,3 @@ to the command line that invokes your daemon process.
 
 Redirecting output to a file with `chef-client > /tmp/chef.out` now captures the same output as invoking it directly on the command
 line with no redirection.
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -269,3 +269,26 @@ use `recipe.rb` in the root of the cookbook.
 The `use_inline_resources` provider mode is always enabled when using the
 `action :name do ... end` syntax. You can remove the `use_inline_resources`
 line.
+
+### Magic removed from logger and formatter settings
+
+There is no more magic involved in the setting of the logger and the formatter, the default is now the formatter.
+
+Setting the `log_location` in the config.rb now applies to both daemonized and command-line invocation and there is
+no magic which dups the logger in order to log to STDOUT on the command line in that case.
+
+Setting logger settings in config.rb is most likely no longer appropriate and those settings should be changed to
+command line flags on the config script or cronjob that invokes chef-client daemonized.  In other words:
+
+```
+chef-client -d -L /var/log/client.rb --force-logger
+```
+
+If your logfiles switch to the formatter, you need to include `--force-logger` for your daemonized runs.
+
+If your command line invocations have no output, delete the config.rb setting for the log_location and move that
+to the command line that invokes your daemon process.
+
+Redirecting output to a file with `chef-client > /tmp/chef.out` now captures the same output as invoking it directly on the command
+line with no redirection.
+

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -144,22 +144,12 @@ class Chef
     # unattended, the `force_formatter` option is provided.
     #
     # === Auto Log Level
-    # When `log_level` is set to `:auto` (default), the log level will be `:warn`
-    # when the primary output mode is an output formatter (see
-    # +using_output_formatter?+) and `:info` otherwise.
+    # The `log_level` of `:auto` means `:warn` in the formatter and `:info` in
+    # the logger.
     #
-    # === Automatic STDOUT Logging
-    # When `force_logger` is configured (e.g., Chef 10 mode), a second logger
-    # with output on STDOUT is added when running in a console (STDOUT is a tty)
-    # and the configured log_location isn't STDOUT. This accounts for the case
-    # that a user has configured a log_location in client.rb, but is running
-    # chef-client by hand to troubleshoot a problem.
     def configure_logging
       configure_log_location
       Chef::Log.init(MonoLogger.new(Chef::Config[:log_location]))
-      if want_additional_logger?
-        configure_stdout_logger
-      end
       Chef::Log.level = resolve_log_level
     rescue StandardError => error
       Chef::Log.fatal("Failed to open or create log file at #{Chef::Config[:log_location]}: #{error.class} (#{error.message})")
@@ -180,22 +170,9 @@ class Chef
         end
     end
 
-    def configure_stdout_logger
-      stdout_logger = MonoLogger.new(STDOUT)
-      stdout_logger.formatter = Chef::Log.logger.formatter
-      Chef::Log.loggers << stdout_logger
-    end
-
-    # Based on config and whether or not STDOUT is a tty, should we setup a
-    # secondary logger for stdout?
-    def want_additional_logger?
-      ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && (!Chef::Config[:daemonize]) && (Chef::Config[:force_logger])
-    end
-
-    # Use of output formatters is assumed if `force_formatter` is set or if
-    # `force_logger` is not set and STDOUT is to a console (tty)
+    # Use of output formatters is assumed if `force_formatter` is set or if `force_logger` is not set
     def using_output_formatter?
-      Chef::Config[:force_formatter] || (!Chef::Config[:force_logger] && STDOUT.tty?)
+      Chef::Config[:force_formatter] || !Chef::Config[:force_logger]
     end
 
     def auto_log_level?

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Maier (<maier@lambda.local>)
-# Copyright:: Copyright 2011-2016, Chef Software, Inc.
+# Copyright:: Copyright 2011-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -241,28 +241,13 @@ class Chef
 
       def configure_logging
         Chef::Log.init(MonoLogger.new(resolve_log_location))
-        if want_additional_logger?
-          configure_stdout_logger
-        end
         Chef::Log.level = resolve_log_level
-      end
-
-      def configure_stdout_logger
-        stdout_logger = MonoLogger.new(STDOUT)
-        stdout_logger.formatter = Chef::Log.logger.formatter
-        Chef::Log.loggers << stdout_logger
-      end
-
-      # Based on config and whether or not STDOUT is a tty, should we setup a
-      # secondary logger for stdout?
-      def want_additional_logger?
-        ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && (!Chef::Config[:daemonize]) && (Chef::Config[:force_logger])
       end
 
       # Use of output formatters is assumed if `force_formatter` is set or if
       # `force_logger` is not set and STDOUT is to a console (tty)
       def using_output_formatter?
-        Chef::Config[:force_formatter] || (!Chef::Config[:force_logger] && STDOUT.tty?)
+        Chef::Config[:force_formatter] || !Chef::Config[:force_logger]
       end
 
       def auto_log_level?

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -372,7 +372,7 @@ class Chef
 
     # @api private
     def default_formatter
-      if (STDOUT.tty? && !Chef::Config[:force_logger]) || Chef::Config[:force_formatter]
+      if !Chef::Config[:force_logger] || Chef::Config[:force_formatter]
         [:doc]
       else
         [:null]

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,8 +75,6 @@ class Chef
 
         ::File.open(config[:config_file], "w") do |f|
           f.puts <<-EOH
-log_level                :info
-log_location             STDOUT
 node_name                '#{new_client_name}'
 client_key               '#{new_client_key}'
 validation_client_name   '#{validation_client_name}'

--- a/lib/chef/knife/configure_client.rb
+++ b/lib/chef/knife/configure_client.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +34,6 @@ class Chef
         FileUtils.mkdir_p(@config_dir)
         ui.info("Writing client.rb")
         File.open(File.join(@config_dir, "client.rb"), "w") do |file|
-          file.puts("log_level        :info")
-          file.puts("log_location     STDOUT")
           file.puts("chef_server_url  '#{Chef::Config[:chef_server_url]}'")
           file.puts("validation_client_name '#{Chef::Config[:validation_client_name]}'")
         end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -554,4 +554,42 @@ EOM
       command.error!
     end
   end
+
+  when_the_repository "has a cookbook that logs at the info level" do
+    before do
+      file "cookbooks/x/recipes/default.rb", <<EOM
+      log "info level" do
+        level :info
+      end
+EOM
+      file "config/client.rb", <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+EOM
+    end
+
+    it "a chef client run should not log to info by default" do
+      command = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default' --no-fork", :cwd => chef_dir)
+      command.error!
+      expect(command.stdout).not_to include("INFO")
+    end
+
+    it "a chef client run to a pipe should not log to info by default" do
+      command = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'x::default' --no-fork | tee #{path_to('chefrun.out')}", :cwd => chef_dir)
+      command.error!
+      expect(command.stdout).not_to include("INFO")
+    end
+
+    it "a chef solo run should not log to info by default" do
+      command = shell_out("#{chef_solo} -c \"#{path_to('config/client.rb')}\" -o 'x::default' --no-fork", :cwd => chef_dir)
+      command.error!
+      expect(command.stdout).not_to include("INFO")
+    end
+
+    it "a chef solo run to a pipe should not log to info by default" do
+      command = shell_out("#{chef_solo} -c \"#{path_to('config/client.rb')}\" -o 'x::default' --no-fork | tee #{path_to('chefrun.out')}", :cwd => chef_dir)
+      command.error!
+      expect(command.stdout).not_to include("INFO")
+    end
+  end
 end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -294,10 +294,9 @@ chef_server_url 'http://omg.com/blah'
 cookbook_path "#{path_to('cookbooks')}"
 EOM
 
-      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -r 'x::default' -z", :cwd => chef_dir)
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -r 'x::default' -z -l info", :cwd => chef_dir)
       expect(result.stdout).not_to include("Overridden Run List")
       expect(result.stdout).to include("Run List is [recipe[x::default]]")
-      #puts result.stdout
       result.error!
     end
 
@@ -445,7 +444,7 @@ control_group "control group without top level control" do
 end
       RECIPE
 
-      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'audit_test::succeed'", :cwd => chef_dir)
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" -o 'audit_test::succeed' -l info", :cwd => chef_dir)
       expect(result.error?).to be_falsey
       expect(result.stdout).to include("Successfully executed all `control_group` blocks and contained examples")
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@junglist.gen.nz>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -192,48 +192,49 @@ describe Chef::Application do
       end
 
       shared_examples_for "log_level_is_auto" do
-        context "when STDOUT is to a tty" do
+        before do
+          allow(STDOUT).to receive(:tty?).and_return(true)
+        end
+
+        it "configures the log level to :warn" do
+          @app.configure_logging
+          expect(Chef::Log.level).to eq(:warn)
+        end
+
+        context "when force_formater is configured" do
           before do
-            allow(STDOUT).to receive(:tty?).and_return(true)
+            Chef::Config[:force_formatter] = true
           end
 
-          it "configures the log level to :warn" do
+          it "configures the log level to warn" do
             @app.configure_logging
             expect(Chef::Log.level).to eq(:warn)
           end
-
-          context "when force_logger is configured" do
-            before do
-              Chef::Config[:force_logger] = true
-            end
-
-            it "configures the log level to info" do
-              @app.configure_logging
-              expect(Chef::Log.level).to eq(:info)
-            end
-          end
         end
 
-        context "when STDOUT is not to a tty" do
+        context "when force_logger is configured" do
           before do
-            allow(STDOUT).to receive(:tty?).and_return(false)
+            Chef::Config[:force_logger] = true
           end
 
-          it "configures the log level to :info" do
+          it "configures the log level to info" do
             @app.configure_logging
             expect(Chef::Log.level).to eq(:info)
           end
+        end
 
-          context "when force_formatter is configured" do
-            before do
-              Chef::Config[:force_formatter] = true
-            end
-            it "sets the log level to :warn" do
-              @app.configure_logging
-              expect(Chef::Log.level).to eq(:warn)
-            end
+        context "when both are is configured" do
+          before do
+            Chef::Config[:force_logger] = true
+            Chef::Config[:force_formatter] = true
+          end
+
+          it "configures the log level to warn" do
+            @app.configure_logging
+            expect(Chef::Log.level).to eq(:warn)
           end
         end
+
       end
 
       context "when log_level is not set" do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,48 +71,40 @@ describe Chef::Client do
 
   describe "configuring output formatters" do
     context "when no formatter has been configured" do
-      context "and STDOUT is a TTY" do
-        before do
-          allow(STDOUT).to receive(:tty?).and_return(true)
-        end
-
-        it "configures the :doc formatter" do
-          expect(client.formatters_for_run).to eq([[:doc]])
-        end
-
-        context "and force_logger is set" do
-          before do
-            Chef::Config[:force_logger] = true
-          end
-
-          it "configures the :null formatter" do
-            expect(Chef::Config[:force_logger]).to be_truthy
-            expect(client.formatters_for_run).to eq([[:null]])
-          end
-
-        end
-
+      it "configures the :doc formatter" do
+        expect(client.formatters_for_run).to eq([[:doc]])
       end
 
-      context "and STDOUT is not a TTY" do
+      context "and force_logger is set" do
         before do
-          allow(STDOUT).to receive(:tty?).and_return(false)
+          Chef::Config[:force_logger] = true
         end
 
         it "configures the :null formatter" do
           expect(client.formatters_for_run).to eq([[:null]])
         end
+      end
 
-        context "and force_formatter is set" do
-          before do
-            Chef::Config[:force_formatter] = true
-          end
-          it "it configures the :doc formatter" do
-            expect(client.formatters_for_run).to eq([[:doc]])
-          end
+      context "and force_formatter is set" do
+        before do
+          Chef::Config[:force_formatter] = true
+        end
+
+        it "configures the :doc formatter" do
+          expect(client.formatters_for_run).to eq([[:doc]])
         end
       end
 
+      context "both are set" do
+        before do
+          Chef::Config[:force_formatter] = true
+          Chef::Config[:force_logger] = true
+        end
+
+        it "configures the :doc formatter" do
+          expect(client.formatters_for_run).to eq([[:doc]])
+        end
+      end
     end
 
     context "when a formatter is configured" do

--- a/spec/unit/knife/configure_client_spec.rb
+++ b/spec/unit/knife/configure_client_spec.rb
@@ -58,8 +58,6 @@ describe Chef::Knife::ConfigureClient do
       it "should write out the config file" do
         allow(FileUtils).to receive(:mkdir_p)
         @knife.run
-        expect(@client_file.string).to match /log_level\s+\:info/
-        expect(@client_file.string).to match /log_location\s+STDOUT/
         expect(@client_file.string).to match /chef_server_url\s+'https\:\/\/chef\.example\.com'/
         expect(@client_file.string).to match /validation_client_name\s+'chef-validator'/
       end


### PR DESCRIPTION

This should remove all of the magic.

This makes `chef-client > /tmp/client.out` log with the formatter.

It also makes the default log format the formatter.

It also eliminates the magical addition of a STDOUT formatter when a log formatter is configured in client.rb

closes #2514

There may be a little bit of overrreach here in that someone might be using the magic additional logger to capture logs of all command line invocations of chef-client, which will now be removed.  I tend to feel like that's a better use case for event handlers, the data collector, etc.  Its a very poor-mans solution and i think it had fairly poor features since i think it would switch log formats based on how you invoked it.  At any rate, if people show up who really want that kind of behavior back, I'd say we engineer a knob for them for config.rb which ensures that even on the command line that output goes to a specified log location in addition to STDOUT -- the magical solution was a poor solution.

Note that if people have a `log_location` set in config.rb that now we will read that and when chef-client is invoked on the command line we will send all the output to the log file and the tty will get no output.  IMO, that is simply chef-client doing precisely what you tell it to.  The right way to fix that is to delete that line from config.rb and to pass the `-L` option on the command line to the daemon process or cronjob -- because you want different behavior in those two cases and so you should have to configure it differently.