### PR TITLE
Verify data bag exists before trying to create it

### DIFF
--- a/lib/chef/knife/data_bag_create.rb
+++ b/lib/chef/knife/data_bag_create.rb
@@ -49,13 +49,15 @@ class Chef
           exit(1)
         end
 
-        # create the data bag
+        # Verify if the data bag exists
         begin
+          rest.get("data/#{@data_bag_name}")
+          ui.info("Data bag #{@data_bag_name} already exists")
+        rescue Net::HTTPServerException => e
+          raise unless e.to_s =~ /^404/
+          # if it doesn't exists, try to create it
           rest.post("data", { "name" => @data_bag_name })
           ui.info("Created data_bag[#{@data_bag_name}]")
-        rescue Net::HTTPServerException => e
-          raise unless e.to_s =~ /^409/
-          ui.info("Data bag #{@data_bag_name} already exists")
         end
 
         # if an item is specified, create it, as well


### PR DESCRIPTION
### Description
[ZD-12613]
There are users who want to customize permissions to prevent a group of
users from creating new data bags but want to allow the group of users
to create data bag items within an existing data bag.

If the user doesn't have permission to create data bags then the current
API request sequence will prevent the user from creating a data bag item
even if the data bag already exists.

This commit fixes the above problem by verifying (not trying to create)
if the data bag exist through a GET request, if it doesn't the it tries
to generate it, then it proceeds to create the data bag item.

Signed-off-by: Salim Afiune <afiune@chef.io>

### Issues Resolved

ZD-12613

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
