### PR TITLE
HTTP: add debug long for non-JSON response

### DIFF
--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -61,7 +61,9 @@ class Chef
           [http_response, rest_request, return_value]
         else
           Chef::Log.debug("Expected JSON response, but got content-type '#{http_response['content-type']}'")
-          Chef::Log.debug("Response body contains:\n#{http_response.body.length < 256 ? http_response.body : http_response.body[0..256] + " [...truncated...]"}")
+          if http_response.body
+            Chef::Log.debug("Response body contains:\n#{http_response.body.length < 256 ? http_response.body : http_response.body[0..256] + " [...truncated...]"}")
+          end
           return [http_response, rest_request, http_response.body.to_s]
         end
       end

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -61,7 +61,7 @@ class Chef
           [http_response, rest_request, return_value]
         else
           Chef::Log.debug("Expected JSON response, but got content-type '#{http_response['content-type']}'")
-          Chef::Log.debug("Response body contains:\n#{http_response.body}")
+          Chef::Log.debug("Response body contains:\n#{http_response.body.length < 256 ? http_response.body : http_response.body[0..256] + " [...truncated...]"}")
           return [http_response, rest_request, http_response.body.to_s]
         end
       end

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Daniel DeLeo (<dan@chef.io>)
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,7 @@ class Chef
           [http_response, rest_request, return_value]
         else
           Chef::Log.debug("Expected JSON response, but got content-type '#{http_response['content-type']}'")
+          Chef::Log.debug("Response body contains:\n#{http_response.body}")
           return [http_response, rest_request, http_response.body.to_s]
         end
       end


### PR DESCRIPTION
we should probably raise (?) but this at least helps us debug.

This is just a little bit of help for bugs like this one:  https://github.com/chef/chef-dk/issues/1184