### PR TITLE
bump omnibus gems and change protocol to https

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-gem "omnibus", github: "chef/omnibus", branch: "rhass/COOL-502_with_gcc_investigate"
-gem "omnibus-software", github: "chef/omnibus-software", branch: "shain/ruby_windows_monster"
-gem "license_scout", github: "chef/license_scout"
+gem "omnibus", git: "https://github.com/chef/omnibus", branch: "rhass/COOL-502_with_gcc_investigate"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "shain/ruby_windows_monster"
+gem "license_scout", git: "https://github.com/chef/license_scout"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,22 +1,5 @@
 GIT
-  remote: https://github.com/chef/license_scout.git
-  revision: 425b6f098224ddd9187d6a5bea73ebe6dffcb22a
-  specs:
-    license_scout (0.1.2)
-      ffi-yajl (~> 2.2)
-      mixlib-shellout (~> 2.2)
-
-GIT
-  remote: https://github.com/chef/omnibus-software.git
-  revision: 086710002ec0054b3d240d14ca04d11163f528aa
-  branch: shain/ruby_windows_monster
-  specs:
-    omnibus-software (4.0.0)
-      chef-sugar (>= 3.4.0)
-      omnibus (>= 5.5.0)
-
-GIT
-  remote: https://github.com/chef/omnibus.git
+  remote: http://github.com/chef/omnibus
   revision: dce5283a85a44484a66a8a84991beba92e46fd12
   branch: rhass/COOL-502_with_gcc_investigate
   specs:
@@ -32,6 +15,23 @@ GIT
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
 
+GIT
+  remote: https://github.com/chef/license_scout
+  revision: 585fed5d3948667466b3ea3ff9cf56a4f7f195c9
+  specs:
+    license_scout (0.1.2)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (~> 2.2)
+
+GIT
+  remote: https://github.com/chef/omnibus-software
+  revision: 086710002ec0054b3d240d14ca04d11163f528aa
+  branch: shain/ruby_windows_monster
+  specs:
+    omnibus-software (4.0.0)
+      chef-sugar (>= 3.4.0)
+      omnibus (>= 5.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -39,13 +39,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.7.0)
     awesome_print (1.7.0)
-    aws-sdk (2.7.13)
-      aws-sdk-resources (= 2.7.13)
-    aws-sdk-core (2.7.13)
+    aws-sdk (2.8.0)
+      aws-sdk-resources (= 2.8.0)
+    aws-sdk-core (2.8.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.13)
-      aws-sdk-core (= 2.7.13)
+    aws-sdk-resources (2.8.0)
+      aws-sdk-core (= 2.8.0)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -86,7 +86,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.19.33)
+    chef-config (12.19.36)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -98,8 +98,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.17)
-    ffi (1.9.17-x86-mingw32)
+    ffi (1.9.18)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -107,7 +106,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.4)
+    hashie (3.5.5)
     hitimes (1.2.4)
     hitimes (1.2.4-x86-mingw32)
     httpclient (2.7.2)
@@ -232,7 +231,7 @@ GEM
       hashie (>= 2.0.2, < 4.0.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    winrm (2.1.2)
+    winrm (2.1.3)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -267,4 +266,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.13.7
+   1.13.4


### PR DESCRIPTION
the `github:` argument gets translated to git:// urls, which are
insecure and i have a .gitconfig which translates those to
https:// urls, and the effect of that is that when _I_ bump the
Gemfile.lock the urls don't match and `bundle install` with
the `--deployment` flag gets all pissy and I break the build, and
since i don't habitually `bundle install --deployment` locally I
never see the failures.

