### PR TITLE
CHEF-13:  remove supports API from Chef::Resource

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,7 +49,7 @@ PolicyFile users on Chef-13 should be using Chef Server 12.3 or higher.
 
 The remediation is removing the self-dependency `depends` line in the metadata.
 
-### Removed `supports` API from Chef::Resource, removed setting as array
+### Removed `supports` API from Chef::Resource
 
 Retained only for the service resource (where it makes some sense) and for the mount resource.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,3 +49,7 @@ PolicyFile users on Chef-13 should be using Chef Server 12.3 or higher.
 
 The remediation is removing the self-dependency `depends` line in the metadata.
 
+### Removed `supports` API from Chef::Resource, removed setting as array
+
+Retained only for the service resource (where it makes some sense) and for the mount resource.
+

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -138,7 +138,6 @@ class Chef
       @action = self.class.default_action
       @updated = false
       @updated_by_last_action = false
-      @supports = {}
       @ignore_failure = false
       @retries = 0
       @retry_delay = 2
@@ -952,29 +951,6 @@ class Chef
     #
     def resource_name
       @resource_name || self.class.resource_name
-    end
-
-    #
-    # Sets a list of capabilities of the real resource.  For example, `:remount`
-    # (for filesystems) and `:restart` (for services).
-    #
-    # TODO Calling resource.supports({}) will not set this to empty; it will do
-    # a get instead.  That's wrong.
-    #
-    # @param args Hash{Symbol=>Boolean} If non-empty, sets the capabilities of
-    #   this resource. Default: {}
-    # @return Hash{Symbol=>Boolean} An array of things this resource supports.
-    #
-    def supports(args = {})
-      if args.any?
-        @supports = args
-      else
-        @supports
-      end
-    end
-
-    def supports=(args)
-      supports(args)
     end
 
     #

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -31,7 +31,8 @@ class Chef
       allowed_actions :mount, :umount, :unmount, :remount, :enable, :disable
 
       # this is a poor API please do not re-use this pattern
-      property :supports, Hash, default: { remount: false }
+      property :supports, Hash, default: { remount: false },
+                                coerce: proc { |x| x.is_a?(Array) ? x.each_with_object({}) { |i, m| m[i] = true } : x }
 
       def initialize(name, run_context = nil)
         super

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,9 @@ class Chef
       default_action :mount
       allowed_actions :mount, :umount, :unmount, :remount, :enable, :disable
 
+      # this is a poor API please do not re-use this pattern
+      property :supports, Hash, default: { remount: false }
+
       def initialize(name, run_context = nil)
         super
         @mount_point = name
@@ -42,7 +45,6 @@ class Chef
         @pass = 2
         @mounted = false
         @enabled = false
-        @supports = { :remount => false }
         @username = nil
         @password = nil
         @domain = nil
@@ -138,16 +140,6 @@ class Chef
           arg,
           :kind_of => [ TrueClass, FalseClass ]
         )
-      end
-
-      def supports(args = {})
-        if args.is_a? Array
-          args.each { |arg| @supports[arg] = true }
-        elsif args.any?
-          @supports = args
-        else
-          @supports
-        end
       end
 
       def username(arg = nil)

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,8 @@ class Chef
       allowed_actions :enable, :disable, :start, :stop, :restart, :reload,
                       :mask, :unmask
 
+      property :supports, Hash, default: { restart: nil, reload: nil, status: nil }
+
       def initialize(name, run_context = nil)
         super
         @service_name = name
@@ -48,7 +50,6 @@ class Chef
         @timeout = nil
         @run_levels = nil
         @user = nil
-        @supports = { :restart => nil, :reload => nil, :status => nil }
       end
 
       def service_name(arg = nil)
@@ -201,17 +202,6 @@ class Chef
           :kind_of => [ String ]
         )
       end
-
-      def supports(args = {})
-        if args.is_a? Array
-          args.each { |arg| @supports[arg] = true }
-        elsif args.any?
-          @supports = args
-        else
-          @supports
-        end
-      end
-
     end
   end
 end

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -30,7 +30,9 @@ class Chef
       allowed_actions :enable, :disable, :start, :stop, :restart, :reload,
                       :mask, :unmask
 
-      property :supports, Hash, default: { restart: nil, reload: nil, status: nil }
+      # this is a poor API please do not re-use this pattern
+      property :supports, Hash, default: { restart: nil, reload: nil, status: nil },
+                                coerce: proc { |x| x.is_a?(Array) ? x.each_with_object({}) { |i, m| m[i] = true } : x }
 
       def initialize(name, run_context = nil)
         super

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -151,10 +151,6 @@ class Chef
           :kind_of => [ TrueClass, FalseClass ]
         )
       end
-
-      def supports(args = {})
-        raise Chef::Exceptions::User, "calling supports on a user resource is no longer supported in Chef-13, you probably need to use the manage_home or non_unique properties directly"
-      end
     end
   end
 end

--- a/spec/unit/provider/user/linux_spec.rb
+++ b/spec/unit/provider/user/linux_spec.rb
@@ -46,11 +46,11 @@ describe Chef::Provider::User::Linux do
     end
 
     it "throws an error when trying to set supports manage_home: true" do
-      expect { @new_resource.supports( manage_home: true ) }.to raise_error(Chef::Exceptions::User)
+      expect { @new_resource.supports( manage_home: true ) }.to raise_error(NoMethodError)
     end
 
     it "throws an error when trying to set supports non_unique: true" do
-      expect { @new_resource.supports( non_unique: true ) }.to raise_error(Chef::Exceptions::User)
+      expect { @new_resource.supports( non_unique: true ) }.to raise_error(NoMethodError)
     end
 
     it "defaults manage_home to false" do

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,11 +87,6 @@ describe Chef::Resource::Mount do
     expect(@resource.options).to be_a_kind_of(Array)
   end
 
-  it "should allow options attribute as an array" do
-    @resource.options %w{ro nosuid}
-    expect(@resource.options).to be_a_kind_of(Array)
-  end
-
   it "should allow options to be sent as a delayed evaluator" do
     @resource.options Chef::DelayedEvaluator.new { %w{rw noexec} }
     expect(@resource.options).to eql(%w{rw noexec})
@@ -141,13 +136,6 @@ describe Chef::Resource::Mount do
 
   it "should default all feature support to false" do
     support_hash = { :remount => false }
-    expect(@resource.supports).to eq(support_hash)
-  end
-
-  it "should allow you to set feature support as an array" do
-    support_array = [ :remount ]
-    support_hash = { :remount => true }
-    @resource.supports(support_array)
     expect(@resource.supports).to eq(support_hash)
   end
 

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2009-2017, Chef Software Inc.
+# Copyright:: Copyright 2009-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,6 +87,11 @@ describe Chef::Resource::Mount do
     expect(@resource.options).to be_a_kind_of(Array)
   end
 
+  it "should allow options attribute as an array" do
+    @resource.options %w{ro nosuid}
+    expect(@resource.options).to be_a_kind_of(Array)
+  end
+
   it "should allow options to be sent as a delayed evaluator" do
     @resource.options Chef::DelayedEvaluator.new { %w{rw noexec} }
     expect(@resource.options).to eql(%w{rw noexec})
@@ -136,6 +141,13 @@ describe Chef::Resource::Mount do
 
   it "should default all feature support to false" do
     support_hash = { :remount => false }
+    expect(@resource.supports).to eq(support_hash)
+  end
+
+  it "should allow you to set feature support as an array" do
+    support_array = [ :remount ]
+    support_hash = { :remount => true }
+    @resource.supports(support_array)
     expect(@resource.supports).to eq(support_hash)
   end
 

--- a/spec/unit/resource/service_spec.rb
+++ b/spec/unit/resource/service_spec.rb
@@ -144,8 +144,15 @@ describe Chef::Resource::Service do
       expect(@resource.supports).to eq(support_hash)
     end
 
+    it "should allow you to set what features this resource supports as a array" do
+      support_array = [ :status, :restart ]
+      support_hash = { :status => true, :restart => true }
+      @resource.supports(support_array)
+      expect(@resource.supports).to eq(support_hash)
+    end
+
     it "should allow you to set what features this resource supports as a hash" do
-      support_hash = { :status => true, :restart => true, :reload => false }
+      support_hash = { :status => true, :restart => true }
       @resource.supports(support_hash)
       expect(@resource.supports).to eq(support_hash)
     end

--- a/spec/unit/resource/service_spec.rb
+++ b/spec/unit/resource/service_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -141,13 +141,6 @@ describe Chef::Resource::Service do
 
     it "should default all the feature support to nil" do
       support_hash = { :status => nil, :restart => nil, :reload => nil }
-      expect(@resource.supports).to eq(support_hash)
-    end
-
-    it "should allow you to set what features this resource supports as a array" do
-      support_array = [ :status, :restart ]
-      support_hash = { :status => true, :restart => true, :reload => nil }
-      @resource.supports(support_array)
       expect(@resource.supports).to eq(support_hash)
     end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -192,7 +192,6 @@ describe Chef::Resource do
   describe "load_from" do
     let(:prior_resource) do
       prior_resource = Chef::Resource.new("funk")
-      prior_resource.supports(:funky => true)
       prior_resource.source_line
       prior_resource.allowed_actions << :funkytown
       prior_resource.action(:funkytown)
@@ -205,7 +204,6 @@ describe Chef::Resource do
 
     it "should load the attributes of a prior resource" do
       resource.load_from(prior_resource)
-      expect(resource.supports).to eq({ :funky => true })
     end
 
     it "should not inherit the action from the prior resource" do
@@ -481,7 +479,7 @@ describe Chef::Resource do
       let(:resource_class) { Class.new(Chef::Resource) { property :a, default: 1 } }
       it "should include the default in the hash" do
         expect(resource.to_hash.keys.sort).to eq([:a, :allowed_actions, :params, :provider, :updated,
-          :updated_by_last_action, :before, :supports,
+          :updated_by_last_action, :before,
           :noop, :ignore_failure, :name, :source_line,
           :action, :retries, :retry_delay, :elapsed_time,
           :default_guard_interpreter, :guard_interpreter, :sensitive].sort)
@@ -493,7 +491,7 @@ describe Chef::Resource do
     it "should convert to a hash" do
       hash = resource.to_hash
       expected_keys = [ :allowed_actions, :params, :provider, :updated,
-        :updated_by_last_action, :before, :supports,
+        :updated_by_last_action, :before,
         :noop, :ignore_failure, :name, :source_line,
         :action, :retries, :retry_delay, :elapsed_time,
         :default_guard_interpreter, :guard_interpreter, :sensitive ]
@@ -509,18 +507,6 @@ describe Chef::Resource do
       serialized_node = Chef::JSONCompat.from_json(json)
       expect(serialized_node).to be_a_kind_of(Chef::Resource)
       expect(serialized_node.name).to eql(resource.name)
-    end
-  end
-
-  describe "supports" do
-    it "should allow you to set what features this resource supports" do
-      support_hash = { :one => :two }
-      resource.supports(support_hash)
-      expect(resource.supports).to eql(support_hash)
-    end
-
-    it "should return the current value of supports" do
-      expect(resource.supports).to eq({})
     end
   end
 


### PR DESCRIPTION
still there on service (where it makes some sense)

also still on mount (because i have no idea if that is actively being
used or if it makes any sense at all).

converts it to a property on mount + service as well.

bonus bug fix:  the old array-style code was mutating the default values, which it should not do now.