### PR TITLE
Robmul/attribute blacklist

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -835,6 +835,15 @@ module ChefConfig
     default :normal_attribute_whitelist, nil
     default :override_attribute_whitelist, nil
 
+    # A blacklisted array of attributes you do not want to send over the
+    # wire when node data is saved
+    # The default setting is nil, which collects all data. Setting to [] will
+    # still collect all data for save
+    default :automatic_attribute_blacklist, nil
+    default :default_attribute_blacklist, nil
+    default :normal_attribute_blacklist, nil
+    default :override_attribute_blacklist, nil
+    
     # Pull down all the rubygems versions from rubygems and cache them the first time we do a gem_package or
     # chef_gem install.  This is memory-expensive and will grow without bounds, but will reduce network
     # round trips.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -843,7 +843,7 @@ module ChefConfig
     default :default_attribute_blacklist, nil
     default :normal_attribute_blacklist, nil
     default :override_attribute_blacklist, nil
-    
+
     # Pull down all the rubygems versions from rubygems and cache them the first time we do a gem_package or
     # chef_gem install.  This is memory-expensive and will grow without bounds, but will reduce network
     # round trips.

--- a/lib/chef/blacklist.rb
+++ b/lib/chef/blacklist.rb
@@ -1,0 +1,81 @@
+
+require "chef/exceptions"
+
+class Chef
+  class Blacklist
+
+    # filter takes two arguments - the data you want to filter, and a blacklisted array
+    # of keys you want discluded. You can capture a subtree of the data to filter by
+    # providing a "/"-delimited string of keys. If some key includes "/"-characters,
+    # you must provide an array of keys instead.
+    #
+    # Blacklist.filter(
+    #   { "filesystem" => {
+    #       "/dev/disk" => {
+    #         "size" => "10mb"
+    #       },
+    #       "map - autohome" => {
+    #         "size" => "10mb"
+    #       }
+    #     },
+    #     "network" => {
+    #       "interfaces" => {
+    #         "eth0" => {...},
+    #         "eth1" => {...}
+    #       }
+    #     }
+    #   },
+    #   ["network/interfaces/eth0", ["filesystem", "/dev/disk"]])
+    # will exclude the eth0 and /dev/disk subtrees.
+    def self.filter(data, blacklist = nil)
+      return data if blacklist.nil?
+
+      blacklist.each do |item|
+	Chef::Log.warn("Removing item #{item}")
+        remove_data(data, item)
+      end
+      data
+    end
+
+    # Walk the data according to the keys provided by the blacklisted item
+    # and add the data to the whitelisting result.
+    def self.remove_data(data, item)
+      parts = to_array(item)
+
+      item_ref = data
+      parts[0..-2].each do |part|
+        unless item_ref[part]
+          Chef::Log.warn("Could not find blacklist attribute #{item}.")
+          return nil
+        end
+
+        item_ref = item_ref[part]
+      end
+
+      unless item_ref.key?(parts[-1])
+        Chef::Log.warn("Could not find blacklist attribute #{item}.")
+        return nil
+      end
+
+      item_ref[parts[-1]] = nil
+      data
+    end
+
+    private_class_method :remove_data
+
+    # Accepts a String or an Array, and returns an Array of String keys that
+    # are used to traverse the data hash. Strings are split on "/", Arrays are
+    # assumed to contain exact keys (that is, Array elements will not be split
+    # by "/").
+    def self.to_array(item)
+      return item if item.kind_of? Array
+
+      parts = item.split("/")
+      parts.shift if !parts.empty? && parts[0].empty?
+      parts
+    end
+
+    private_class_method :to_array
+
+  end
+end

--- a/lib/chef/blacklist.rb
+++ b/lib/chef/blacklist.rb
@@ -38,7 +38,7 @@ class Chef
     end
 
     # Walk the data according to the keys provided by the blacklisted item
-    # and add the data to the whitelisting result.
+    # to get a reference to the item that will be removed.
     def self.remove_data(data, item)
       parts = to_array(item)
 
@@ -57,7 +57,7 @@ class Chef
         return nil
       end
 
-      item_ref[parts[-1]] = nil
+      item_ref.del(parts[-1])
       data
     end
 

--- a/lib/chef/blacklist.rb
+++ b/lib/chef/blacklist.rb
@@ -57,7 +57,7 @@ class Chef
         return nil
       end
 
-      item_ref.del(parts[-1])
+      item_ref.delete(parts[-1])
       data
     end
 

--- a/lib/chef/blacklist.rb
+++ b/lib/chef/blacklist.rb
@@ -31,7 +31,7 @@ class Chef
       return data if blacklist.nil?
 
       blacklist.each do |item|
-	Chef::Log.warn("Removing item #{item}")
+        Chef::Log.warn("Removing item #{item}")
         remove_data(data, item)
       end
       data

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -34,6 +34,7 @@ require "chef/mash"
 require "chef/json_compat"
 require "chef/search/query"
 require "chef/whitelist"
+require "chef/blacklist"
 
 class Chef
   class Node
@@ -663,6 +664,13 @@ class Chef
         unless whitelist.nil? # nil => save everything
           Chef::Log.info("Whitelisting #{level} node attributes for save.")
           data[level] = Chef::Whitelist.filter(data[level], whitelist)
+        end
+
+        blacklist_config_option = "#{level}_attribute_blacklist".to_sym
+        blacklist = Chef::Config[blacklist_config_option]
+        unless blacklist.nil? # nil => remove nothing
+          Chef::Log.info("Blacklisting #{level} node attributes for save")
+          data[level] = Chef::Blacklist.filter(data[level], blacklist)
         end
       end
       data

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1635,12 +1635,10 @@ describe Chef::Node do
           selected_data = {
             "automatic" => {
               "filesystem" => {
-                "/dev/disk0s2"   => nil,
                 "map - autohome" => { "size" => "10mb" },
               },
               "network" => {
                 "interfaces" => {
-                  "eth0" => nil,
                   "eth1" => {},
                 },
               },

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1681,7 +1681,6 @@ describe Chef::Node do
         end
       end
 
-
       context "when policyfile attributes are present" do
 
         before do


### PR DESCRIPTION
### Description

Adds the ability to blacklist attributes from being saved to the chef server. It is a slight modification of an existing feature that allows you to whitelist attributes.

Adds the blacklist.rb to handle the blacklisting logic.
Modifies node_spec.rb to add tests for the blacklisting functionality.
Modifies node.rb to update the save function to include the blacklisting feature in the save.
Modifies config.rb to include blacklist config options into the set of configuration options available.


### Issues Resolved


### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
