### PR TITLE
Fix apt_repository for latest os version 16.10

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -115,7 +115,7 @@ class Chef
         so = shell_out(cmd)
         so.run_command
         so.stdout.split(/\n/).map do |t|
-          if z = t.match(/^ +Key fingerprint = ([0-9A-F ]+)/)
+          if z = t.match(/^fpr:+([0-9A-F]+):/)
             z[1].split.join
           end
         end.compact
@@ -147,8 +147,10 @@ class Chef
       end
 
       def no_new_keys?(file)
-        installed_keys = extract_fingerprints_from_cmd("apt-key finger")
-        proposed_keys = extract_fingerprints_from_cmd("gpg --with-fingerprint #{file}")
+        # Now we are using the option --with-colons that works across old os versions
+        # as well as the latest (16.10). This for both `apt-key` and `gpg` commands
+        installed_keys = extract_fingerprints_from_cmd("apt-key adv --list-public-keys --with-fingerprint --with-colons")
+        proposed_keys = extract_fingerprints_from_cmd("gpg --with-fingerprint --with-colons #{file}")
         (installed_keys & proposed_keys).sort == proposed_keys.sort
       end
 

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -18,32 +18,30 @@
 
 require "spec_helper"
 
+# Now we are using the option --with-colons that works across old os versions
+# as well as the latest (16.10). This for both `apt-key` and `gpg` commands
+#
+# Output of the command:
+# => apt-key adv --list-public-keys --with-fingerprint --with-colons
 APT_KEY_FINGER = <<-EOF
-/etc/apt/trusted.gpg
---------------------
-pub   1024D/437D05B5 2004-09-12
-      Key fingerprint = 6302 39CC 130E 1A7F D81A  27B1 4097 6EAF 437D 05B5
-uid                  Ubuntu Archive Automatic Signing Key <ftpmaster@ubuntu.com>
-sub   2048g/79164387 2004-09-12
-
-pub   1024D/FBB75451 2004-12-30
-      Key fingerprint = C598 6B4F 1257 FFA8 6632  CBA7 4618 1433 FBB7 5451
-uid                  Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>
-
-pub   4096R/C0B21F32 2012-05-11
-      Key fingerprint = 790B C727 7767 219C 42C8  6F93 3B4F E6AC C0B2 1F32
-uid                  Ubuntu Archive Automatic Signing Key (2012) <ftpmaster@ubuntu.com>
-
-pub   4096R/EFE21092 2012-05-11
-      Key fingerprint = 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
-uid                  Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>
-
+tru:t:1:1488924856:0:3:1:5
+pub:-:1024:17:40976EAF437D05B5:2004-09-12:::-:Ubuntu Archive Automatic Signing Key <ftpmaster@ubuntu.com>::scESC:
+fpr:::::::::630239CC130E1A7FD81A27B140976EAF437D05B5:
+sub:-:2048:16:251BEFF479164387:2004-09-12::::::e:
+pub:-:1024:17:46181433FBB75451:2004-12-30:::-:Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>::scSC:
+fpr:::::::::C5986B4F1257FFA86632CBA746181433FBB75451:
+pub:-:4096:1:3B4FE6ACC0B21F32:2012-05-11:::-:Ubuntu Archive Automatic Signing Key (2012) <ftpmaster@ubuntu.com>::scSC:
+fpr:::::::::790BC7277767219C42C86F933B4FE6ACC0B21F32:
+pub:-:4096:1:D94AA3F0EFE21092:2012-05-11:::-:Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>::scSC:
+fpr:::::::::843938DF228D22F7B3742BC0D94AA3F0EFE21092:
 EOF
 
+# Output of the command:
+# => gpg --with-fingerprint --with-colons [FILE]
 GPG_FINGER = <<-EOF
-pub  1024D/02A818DD 2009-04-22 Cloudera Apt Repository
-      Key fingerprint = F36A 89E3 3CC1 BD0F 7107  9007 3275 74EE 02A8 18DD
-sub  2048g/D1CA74A1 2009-04-22
+pub:-:1024:17:327574EE02A818DD:2009-04-22:::-:Cloudera Apt Repository:
+fpr:::::::::F36A89E33CC1BD0F71079007327574EE02A818DD:
+sub:-:2048:16:84080586D1CA74A1:2009-04-22::::
 EOF
 
 describe Chef::Provider::AptRepository do
@@ -55,6 +53,10 @@ describe Chef::Provider::AptRepository do
     events = Chef::EventDispatch::Dispatcher.new
     run_context = Chef::RunContext.new(node, {}, events)
     Chef::Provider::AptRepository.new(new_resource, run_context)
+  end
+
+  let(:apt_key_finger_cmd) do
+    "apt-key adv --list-public-keys --with-fingerprint --with-colons"
   end
 
   let(:apt_key_finger) do
@@ -102,28 +104,32 @@ C5986B4F1257FFA86632CBA746181433FBB75451
 
     it "should run the desired command" do
       expect(apt_key_finger).to receive(:run_command)
-      provider.extract_fingerprints_from_cmd("apt-key finger")
+      provider.extract_fingerprints_from_cmd(apt_key_finger_cmd)
     end
 
     it "should return a list of key fingerprints" do
-      expect(provider.extract_fingerprints_from_cmd("apt-key finger")).to eql(apt_fingerprints)
+      expect(provider.extract_fingerprints_from_cmd(apt_key_finger_cmd)).to eql(apt_fingerprints)
     end
   end
 
   describe "#no_new_keys?" do
     before do
-      allow(provider).to receive(:extract_fingerprints_from_cmd).with("apt-key finger").and_return(apt_fingerprints)
+      allow(provider).to receive(:extract_fingerprints_from_cmd).with(apt_key_finger_cmd).and_return(apt_fingerprints)
     end
 
     let(:file) { "/tmp/remote-gpg-keyfile" }
 
     it "should match a set of keys" do
-      allow(provider).to receive(:extract_fingerprints_from_cmd).with("gpg --with-fingerprint #{file}").and_return(Array(apt_fingerprints.first))
+      allow(provider).to receive(:extract_fingerprints_from_cmd)
+        .with("gpg --with-fingerprint --with-colons #{file}")
+        .and_return(Array(apt_fingerprints.first))
       expect(provider.no_new_keys?(file)).to be_truthy
     end
 
     it "should notice missing keys" do
-      allow(provider).to receive(:extract_fingerprints_from_cmd).with("gpg --with-fingerprint #{file}").and_return(%w{ F36A89E33CC1BD0F71079007327574EE02A818DD })
+      allow(provider).to receive(:extract_fingerprints_from_cmd)
+        .with("gpg --with-fingerprint --with-colons #{file}")
+        .and_return(%w{ F36A89E33CC1BD0F71079007327574EE02A818DD })
       expect(provider.no_new_keys?(file)).to be_falsey
     end
   end


### PR DESCRIPTION
### Description
Great description and solution of the problem made by @jeremiahsnapp in
the below issue!

Closes https://github.com/chef/chef/issues/5831

I have validated this works fine for the following os:
* Ubuntu 14.04
* Ubuntu 16.04
* Ubuntu 16.10 (latest)
* Debian-6.0.10
* Debian-8.7 (latest)

Signed-off-by: Salim Afiune <afiune@chef.io>

### Issues Resolved

* COOL-685
* https://github.com/chef/chef/issues/5831

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
