### PR TITLE
use master of chef-config we're tesing in acceptance tests

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,3 +14,5 @@ gem "berkshelf"
 # Pin to 1.2.3 because current mixlib-install has a problem where unstable
 # packages are not always immediately available via the omnitruck API.
 gem "mixlib-install", "1.2.3"
+
+gem "chef-config", path: "../chef-config"

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -6,6 +6,15 @@ GIT
       mixlib-shellout (~> 2.0)
       thor (~> 0.19)
 
+PATH
+  remote: ../chef-config
+  specs:
+    chef-config (13.0.15)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -55,11 +64,6 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (13.0.1)
-      addressable
-      fuzzyurl
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
     cleanroom (1.0.0)
     coderay (1.1.1)
     diff-lcs (1.3)
@@ -250,6 +254,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf
   chef-acceptance!
+  chef-config!
   inspec
   kitchen-ec2
   kitchen-inspec


### PR DESCRIPTION
i guess this makes this also an integration test of
chef-config against berkshelf and ridley.

i considered going the other way and pinning to < 13 in order
to get the rubygems version, but decided to go this direction
since it feels like we get more 'coverage' this way.