### PR TITLE
pinning chef-config in acceptance to rubygems version

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -15,4 +15,5 @@ gem "berkshelf"
 # packages are not always immediately available via the omnitruck API.
 gem "mixlib-install", "1.2.3"
 
-gem "chef-config", path: "../chef-config"
+# for chef-13 development - pin to the released rubygems version
+gem "chef-config", "< 13.0"

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -6,15 +6,6 @@ GIT
       mixlib-shellout (~> 2.0)
       thor (~> 0.19)
 
-PATH
-  remote: ../chef-config
-  specs:
-    chef-config (13.0.15)
-      addressable
-      fuzzyurl
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -64,6 +55,11 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    chef-config (12.19.36)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
     cleanroom (1.0.0)
     coderay (1.1.1)
     diff-lcs (1.3)
@@ -254,7 +250,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf
   chef-acceptance!
-  chef-config!
+  chef-config (< 13.0)
   inspec
   kitchen-ec2
   kitchen-inspec


### PR DESCRIPTION
jenkins barfed pretty hard on the prior attempt to fix.  this
should work better.

can obviously be backed out once chef-13 is released.
