### PR TITLE
Chef-13:  Chef::Resource cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: 5cdb74dc17a96cac30a6a4dc1381d3d3c7b2fb4f
+  revision: 4ec1d014c9a4945398c6baa550c71f7e3a7e69e0
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)
@@ -97,7 +97,7 @@ GIT
 
 GIT
   remote: https://github.com/poise/poise.git
-  revision: 62056469b3a19144f4bf4810abe14efa1c10463b
+  revision: 1aa3a6b7c5b3fe0c357e2f3fcc50080790772ccb
   specs:
     poise (2.7.3.pre)
       halite (~> 1.0)
@@ -205,13 +205,13 @@ GEM
       mixlib-cli (~> 1.4)
     artifactory (2.7.0)
     ast (2.3.0)
-    aws-sdk (2.8.1)
-      aws-sdk-resources (= 2.8.1)
-    aws-sdk-core (2.8.1)
+    aws-sdk (2.8.3)
+      aws-sdk-resources (= 2.8.3)
+    aws-sdk-core (2.8.3)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.1)
-      aws-sdk-core (= 2.8.1)
+    aws-sdk-resources (2.8.3)
+      aws-sdk-core (= 2.8.3)
     aws-sigv4 (1.0.0)
     backports (3.6.8)
     binding_of_caller (0.7.2)
@@ -222,7 +222,7 @@ GEM
       logify (~> 0.1)
       mime-types
     chef-sugar (3.4.0)
-    chef-zero (5.3.0)
+    chef-zero (5.3.1)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1478,6 +1478,13 @@ class Chef
 
     # @api private
     def lookup_provider_constant(name, action = :nothing)
+      # XXX: "name" is probably a poor choice of name here, ideally this would be nil, but we need to
+      # fix resources so that nil or empty names work (also solving the apt_update "doesn't matter one bit"
+      # problem).  WARNING: this string is not a public API and should not be referenced (e.g. in provides blocks)
+      # and may change at any time.  If you've found this comment you're also probably very lost and should maybe
+      # consider using `declare_resource :whatever` instead of trying to set `provider :whatever` on a resource, or in some
+      # other way reconsider what you're trying to do, since you're likely trying to force a bad design that we
+      # can't/won't support.
       self.class.resource_for_node(name, node).new("name", run_context).provider_for_action(action).class
     end
 

--- a/spec/data/lwrp/resources/buck_passer.rb
+++ b/spec/data/lwrp/resources/buck_passer.rb
@@ -1,0 +1,5 @@
+
+provides :buck_passer
+
+default_action :pass_buck
+actions :pass_buck

--- a/spec/data/lwrp/resources/buck_passer_2.rb
+++ b/spec/data/lwrp/resources/buck_passer_2.rb
@@ -1,0 +1,3 @@
+
+default_action :pass_buck
+actions :pass_buck

--- a/spec/data/lwrp/resources/embedded_resource_accesses_providers_scope.rb
+++ b/spec/data/lwrp/resources/embedded_resource_accesses_providers_scope.rb
@@ -1,0 +1,3 @@
+
+default_action :twiddle_thumbs
+actions :twiddle_thumbs

--- a/spec/data/lwrp/resources/inline_compiler.rb
+++ b/spec/data/lwrp/resources/inline_compiler.rb
@@ -1,0 +1,3 @@
+
+default_action :test
+actions :test, :no_updates

--- a/spec/data/lwrp/resources/monkey_name_printer.rb
+++ b/spec/data/lwrp/resources/monkey_name_printer.rb
@@ -1,0 +1,5 @@
+
+property :monkey
+
+default_action :twiddle_thumbs
+actions :twiddle_thumbs

--- a/spec/data/lwrp/resources/paint_drying_watcher.rb
+++ b/spec/data/lwrp/resources/paint_drying_watcher.rb
@@ -1,0 +1,3 @@
+
+default_action :prepare_eyes
+actions :prepare_eyes, :watch_paint_dry

--- a/spec/data/lwrp/resources/thumb_twiddler.rb
+++ b/spec/data/lwrp/resources/thumb_twiddler.rb
@@ -1,0 +1,3 @@
+
+default_action :prepare_thumbs
+actions :prepare_thumbs, :twiddle_thumbs

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -41,14 +41,11 @@ describe "LWRP" do
     Chef::ResourceResolver.resolve(name)
   end
 
-  def get_lwrp_provider(name)
-    old_treat_deprecation_warnings_as_errors = Chef::Config[:treat_deprecation_warnings_as_errors]
-    Chef::Config[:treat_deprecation_warnings_as_errors] = false
-    begin
-      Chef::Provider.const_get(convert_to_class_name(name.to_s))
-    ensure
-      Chef::Config[:treat_deprecation_warnings_as_errors] = old_treat_deprecation_warnings_as_errors
-    end
+  def get_dynamic_lwrp_provider(name)
+    # need a node to do dynamic lookup, so also need a run_context and a resource instance
+    node = Chef::Node.new
+    run_context = Chef::RunContext.new(node, {}, nil)
+    Chef::Resource.new("name", run_context).lookup_provider_constant(name)
   end
 
   describe "when overriding an existing class" do
@@ -386,7 +383,7 @@ describe "LWRP" do
 
     let(:runner) { Chef::Runner.new(run_context) }
 
-    let(:lwrp_cookbok_name) { "lwrp" }
+    let(:lwrp_cookbook_name) { "lwrp" }
 
     before do
       Chef::Provider::LWRPBase.class_eval { @loaded_lwrps = {} }
@@ -394,18 +391,18 @@ describe "LWRP" do
 
     before(:each) do
       Dir[File.expand_path(File.expand_path("../../data/lwrp/resources/*", __FILE__))].each do |file|
-        Chef::Resource::LWRPBase.build_from_file(lwrp_cookbok_name, file, run_context)
+        Chef::Resource::LWRPBase.build_from_file(lwrp_cookbook_name, file, run_context)
       end
 
       Dir[File.expand_path(File.expand_path("../../data/lwrp/providers/*", __FILE__))].each do |file|
-        Chef::Provider::LWRPBase.build_from_file(lwrp_cookbok_name, file, run_context)
+        Chef::Provider::LWRPBase.build_from_file(lwrp_cookbook_name, file, run_context)
       end
     end
 
     it "should properly handle a new_resource reference" do
       resource = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       resource.monkey("bob")
-      resource.provider(get_lwrp_provider(:lwrp_monkey_name_printer))
+      resource.provider(get_dynamic_lwrp_provider(:lwrp_monkey_name_printer))
       provider = resource.provider_for_action(:twiddle_thumbs)
       provider.action_twiddle_thumbs
     end
@@ -426,8 +423,8 @@ describe "LWRP" do
       end
 
       it "should create a method for each action" do
-        expect(get_lwrp_provider(:lwrp_buck_passer).instance_methods).to include(:action_pass_buck)
-        expect(get_lwrp_provider(:lwrp_thumb_twiddler).instance_methods).to include(:action_twiddle_thumbs)
+        expect(get_dynamic_lwrp_provider(:lwrp_buck_passer).instance_methods).to include(:action_pass_buck)
+        expect(get_dynamic_lwrp_provider(:lwrp_thumb_twiddler).instance_methods).to include(:action_twiddle_thumbs)
       end
 
       it "sets itself as a provider for a resource of the same name" do
@@ -435,30 +432,30 @@ describe "LWRP" do
         # we bypass the per-file loading to get the file to load each time,
         # which creates the LWRP class repeatedly. New things get prepended to
         # the list of providers.
-        expect(found_providers.first).to eq(get_lwrp_provider(:lwrp_buck_passer))
+        expect(found_providers.first).to eq(get_dynamic_lwrp_provider(:lwrp_buck_passer))
       end
 
       context "with a cookbook with an underscore in the name" do
 
-        let(:lwrp_cookbok_name) { "l_w_r_p" }
+        let(:lwrp_cookbook_name) { "l_w_r_p" }
 
         it "sets itself as a provider for a resource of the same name" do
           found_providers = Chef::Platform::ProviderHandlerMap.instance.list(node, :l_w_r_p_buck_passer)
           expect(found_providers.size).to eq(1)
-          expect(found_providers.last).to eq(get_lwrp_provider(:l_w_r_p_buck_passer))
+          expect(found_providers.last).to eq(get_dynamic_lwrp_provider(:l_w_r_p_buck_passer))
         end
       end
 
       context "with a cookbook with a hypen in the name" do
 
-        let(:lwrp_cookbok_name) { "l-w-r-p" }
+        let(:lwrp_cookbook_name) { "l-w-r-p" }
 
         it "sets itself as a provider for a resource of the same name" do
           incorrect_providers = Chef::Platform::ProviderHandlerMap.instance.list(node, :'l-w-r-p_buck_passer')
           expect(incorrect_providers).to eq([])
 
           found_providers = Chef::Platform::ProviderHandlerMap.instance.list(node, :l_w_r_p_buck_passer)
-          expect(found_providers.first).to eq(get_lwrp_provider(:l_w_r_p_buck_passer))
+          expect(found_providers.first).to eq(get_dynamic_lwrp_provider(:l_w_r_p_buck_passer))
         end
       end
     end
@@ -466,7 +463,7 @@ describe "LWRP" do
     it "should insert resources embedded in the provider into the middle of the resource collection" do
       injector = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       injector.action(:pass_buck)
-      injector.provider(get_lwrp_provider(:lwrp_buck_passer))
+      injector.provider(get_dynamic_lwrp_provider(:lwrp_buck_passer))
       dummy = Chef::Resource::ZenMaster.new("keanu reeves", run_context)
       dummy.provider(Chef::Provider::Easy)
       run_context.resource_collection.insert(injector)
@@ -483,11 +480,11 @@ describe "LWRP" do
     it "should insert embedded resources from multiple providers, including from the last position, properly into the resource collection" do
       injector = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       injector.action(:pass_buck)
-      injector.provider(get_lwrp_provider(:lwrp_buck_passer))
+      injector.provider(get_dynamic_lwrp_provider(:lwrp_buck_passer))
 
       injector2 = get_lwrp(:lwrp_bar).new("tank", run_context)
       injector2.action(:pass_buck)
-      injector2.provider(get_lwrp_provider(:lwrp_buck_passer_2))
+      injector2.provider(get_dynamic_lwrp_provider(:lwrp_buck_passer_2))
 
       dummy = Chef::Resource::ZenMaster.new("keanu reeves", run_context)
       dummy.provider(Chef::Provider::Easy)
@@ -510,7 +507,7 @@ describe "LWRP" do
     it "should properly handle a new_resource reference" do
       resource = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       resource.monkey("bob")
-      resource.provider(get_lwrp_provider(:lwrp_monkey_name_printer))
+      resource.provider(get_dynamic_lwrp_provider(:lwrp_monkey_name_printer))
 
       provider = resource.provider_for_action(:twiddle_thumbs)
       provider.action_twiddle_thumbs
@@ -521,7 +518,7 @@ describe "LWRP" do
     it "should properly handle an embedded Resource accessing the enclosing Provider's scope" do
       resource = get_lwrp(:lwrp_foo).new("morpheus", run_context)
       resource.monkey("bob")
-      resource.provider(get_lwrp_provider(:lwrp_embedded_resource_accesses_providers_scope))
+      resource.provider(get_dynamic_lwrp_provider(:lwrp_embedded_resource_accesses_providers_scope))
 
       provider = resource.provider_for_action(:twiddle_thumbs)
       #provider = @runner.build_provider(resource)
@@ -541,7 +538,7 @@ describe "LWRP" do
         @resource = get_lwrp(:lwrp_foo).new("morpheus", run_context)
         @resource.allowed_actions << :test
         @resource.action(:test)
-        @resource.provider(get_lwrp_provider(:lwrp_inline_compiler))
+        @resource.provider(get_dynamic_lwrp_provider(:lwrp_inline_compiler))
       end
 
       it "does not add interior resources to the exterior resource collection" do

--- a/spec/unit/resource/deploy_spec.rb
+++ b/spec/unit/resource/deploy_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -216,12 +216,12 @@ describe Chef::Resource::Deploy do
   end
 
   it "allows deploy providers to be set via symbol" do
-    @resource.provider :revision
+    @resource.provider :deploy_revision
     expect(@resource.provider).to eq(Chef::Provider::Deploy::Revision)
   end
 
   it "allows deploy providers to be set via string" do
-    @resource.provider "revision"
+    @resource.provider "deploy_revision"
     expect(@resource.provider).to eq(Chef::Provider::Deploy::Revision)
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -231,14 +231,6 @@ describe Chef::Resource do
     end
   end
 
-  describe "noop" do
-    it "should accept true or false for noop" do
-      expect { resource.noop true }.not_to raise_error
-      expect { resource.noop false }.not_to raise_error
-      expect { resource.noop "eat it" }.to raise_error(ArgumentError)
-    end
-  end
-
   describe "notifies" do
     it "should make notified resources appear in the actions hash" do
       run_context.resource_collection << Chef::Resource::ZenMaster.new("coffee")
@@ -450,18 +442,6 @@ describe Chef::Resource do
     end
   end
 
-  describe "is" do
-    it "should return the arguments passed with 'is'" do
-      zm = Chef::Resource::ZenMaster.new("coffee")
-      expect(zm.is("one", "two", "three")).to eq(%w{one two three})
-    end
-
-    it "should allow arguments preceded by is to methods" do
-      resource.noop(resource.is(true))
-      expect(resource.noop).to eql(true)
-    end
-  end
-
   describe "to_json" do
     it "should serialize to json" do
       json = resource.to_json
@@ -480,7 +460,7 @@ describe Chef::Resource do
       it "should include the default in the hash" do
         expect(resource.to_hash.keys.sort).to eq([:a, :allowed_actions, :params, :provider, :updated,
           :updated_by_last_action, :before,
-          :noop, :name, :source_line,
+          :name, :source_line,
           :action, :elapsed_time,
           :default_guard_interpreter, :guard_interpreter].sort)
         expect(resource.to_hash[:name]).to eq "funk"
@@ -492,7 +472,7 @@ describe Chef::Resource do
       hash = resource.to_hash
       expected_keys = [ :allowed_actions, :params, :provider, :updated,
         :updated_by_last_action, :before,
-        :noop, :name, :source_line,
+        :name, :source_line,
         :action, :elapsed_time,
         :default_guard_interpreter, :guard_interpreter ]
       expect(hash.keys - expected_keys).to eq([])
@@ -569,31 +549,6 @@ describe Chef::Resource do
       expect { retriable_resource.run_action(:purr) }.to raise_error(RuntimeError)
       expect(retriable_resource.retries).to eq(3)
     end
-  end
-
-  describe "setting the base provider class for the resource" do
-
-    it "defaults to Chef::Provider for the base class" do
-      expect(Chef::Resource.provider_base).to eq(Chef::Provider)
-    end
-
-    it "allows the base provider to be overridden" do
-      Chef::Config.treat_deprecation_warnings_as_errors(false)
-      class OverrideProviderBaseTest < Chef::Resource
-        provider_base Chef::Provider::Package
-      end
-
-      expect(OverrideProviderBaseTest.provider_base).to eq(Chef::Provider::Package)
-    end
-
-    it "warns when setting provider_base" do
-      expect do
-        class OverrideProviderBaseTest2 < Chef::Resource
-          provider_base Chef::Provider::Package
-        end
-      end.to raise_error(Chef::Exceptions::DeprecatedFeatureError)
-    end
-
   end
 
   it "runs an action by finding its provider, loading the current resource and then running the action" do


### PR DESCRIPTION
most of this deletes useless old code.

the change to lookup_provider_constant changes to more strictly
stop using class name based lookups and to go through the resource
resolver and provider resolver.

as a result in order to find the provider class for a given dsl name
you have to go through the resource resolver to find the resource in
order to be able to pass a resource instance through the provider
resolver.  since the provider resolver api passes resources into blocks
passed into provides api you must construct a resource instance.

that means that providers need to be associated with resources in order
to be looked up (which makes sense in Real Life(tm) use of Chef, but
breaks quite a few lazy tests we had where we constructed providers
without doing the work of wrapping them in a resource.

note that as the deploy resource shows this filters into a changed
behavior of the `provider` syntax where before `provider :revision`
would look up Chef::Provider::Deploy::Revision via class-name based
magic.  this breaks that API so that `provider :deploy_revision` is
used instead -- the symbol (or string) there is turned into a resource
first via the Chef::ResourceResolver and then looked up via the
Chef::ProviderResolver into Chef::Provider::Deploy::Revision.  this
is a breaking change but is also a bug fix so that the symbol here
goes through the same lookup that you get when you type it in the DSL.

i had considered implementing a lookup from a resource_name symbol to
a provider, but in looking at how to implement that in the
ProviderResolver the issue is that we really need to have a resource
instance order to pass to the ProviderResolver.