### PR TITLE
Use omnibus-toolchain on Windows platforms.

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "omnibus", git: "https://github.com/chef/omnibus", branch: "rhass/COOL-502_with_gcc_investigate"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "shain/ruby_windows_monster"
+gem "omnibus", git: "https://github.com/chef/omnibus"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software"
 gem "license_scout", git: "https://github.com/chef/license_scout"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: 585fed5d3948667466b3ea3ff9cf56a4f7f195c9
+  revision: 83f16f6bbf7f0f9ef94cf694aea2881e65ee034c
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,8 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: dce5283a85a44484a66a8a84991beba92e46fd12
-  branch: rhass/COOL-502_with_gcc_investigate
+  revision: 76d907f4fe92a28c5f7ab11779341e1d773c358d
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -25,8 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 086710002ec0054b3d240d14ca04d11163f528aa
-  branch: shain/ruby_windows_monster
+  revision: a6f5d260b34c5a19fb2ef873ab3216c7bab0ef6f
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -39,13 +37,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.7.0)
     awesome_print (1.7.0)
-    aws-sdk (2.8.0)
-      aws-sdk-resources (= 2.8.0)
-    aws-sdk-core (2.8.0)
+    aws-sdk (2.8.2)
+      aws-sdk-resources (= 2.8.2)
+    aws-sdk-core (2.8.2)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.0)
-      aws-sdk-core (= 2.8.0)
+    aws-sdk-resources (2.8.2)
+      aws-sdk-core (= 2.8.2)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -99,6 +97,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    ffi (1.9.18-x86-mingw32)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -215,15 +214,15 @@ GEM
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.15.0)
+    test-kitchen (1.16.0)
       mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.9, < 5.0)
       net-ssh-gateway (~> 1.2)
       safe_yaml (~> 1.0)
-      thor (~> 0.18)
-    thor (0.19.4)
+      thor (~> 0.19, < 0.19.2)
+    thor (0.19.1)
     timers (4.0.4)
       hitimes
     varia_model (0.4.1)
@@ -266,4 +265,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.13.6
+   1.12.5


### PR DESCRIPTION
### Description

This updates the branch pinnings to use the omnibus-toolchain enabled version of omnibus and omnibus-software and removes the no longer needed pinnings for the long-standing branches on omnibus and omnibus-software.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

/cc @chef/engineering-services 
/cc @chef/maintainers 