### PR TITLE
Compress debs and rpms with xz

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -53,6 +53,16 @@ dependency "chef-complete"
 
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
+
+  unless rhel? && platform_version.satisfies?("< 6")
+    compression_level 1
+    compression_type :xz
+  end
+end
+
+package :deb do
+  compression_level 1
+  compression_type :xz
 end
 
 proj_to_work_around_cleanroom = self


### PR DESCRIPTION
This gives considerable size benefits, at a cost of slightly slower decompression. xz compression has been available in dpkg and rpm since 2009 so we shouldn't see any platforms that don't support this.