### PR TITLE
moved 'purge is off' msg to correct location

### DIFF
--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -291,10 +291,11 @@ class Chef
                     end
                   end
                 else
-                  ui.output ("Not deleting extra entry #{dest_path} (purge is off)") if ui
+                  ui.output "Skipping #{dest_path}" if ui
                 end
+              else
+                ui.output "Skipping #{dest_path} (purge is off)" if ui
               end
-
             elsif !dest_entry.exists?
               if new_dest_parent.can_have_child?(src_entry.name, src_entry.dir?)
                 # If the entry can do a copy directly from filesystem, do that.

--- a/lib/chef/chef_fs/file_system.rb
+++ b/lib/chef/chef_fs/file_system.rb
@@ -290,11 +290,9 @@ class Chef
                       ui.output "Entry #{dest_path} does not exist. Nothing to do. (purge is on)" if ui
                     end
                   end
-                else
-                  ui.output "Skipping #{dest_path}" if ui
                 end
               else
-                ui.output "Skipping #{dest_path} (purge is off)" if ui
+                ui.output "Not deleting extra entry #{dest_path} (purge is off)" if ui
               end
             elsif !dest_entry.exists?
               if new_dest_parent.can_have_child?(src_entry.name, src_entry.dir?)


### PR DESCRIPTION
Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Description

The original ui message `ui.output ("Not deleting extra entry #{dest_path} (purge is off)") if ui` was being output under the wrong condition since it was nested under the incorrect `if/else` block, confusing the user.

This commit changes it to be associated with the `if options[:purge]` condition, not the `if src_entry.parent.can_have_child?(dest_entry.name, dest_entry.dir?)`:

```
              if options[:purge]
                # If we would not have uploaded it, we will not purge it.
                if src_entry.parent.can_have_child?(dest_entry.name, dest_entry.dir?)
```

Tested and validated works as expected.

### Issues Resolved

n/a

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>