### PR TITLE
Jeremymv2/cheffs optimizations

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -165,6 +165,9 @@ class Chef
           end
 
           def write(file_contents)
+            # free up cache - it will be hydrated on next check for exists?
+            @this_object_cache = nil
+
             begin
               object = Chef::JSONCompat.parse(file_contents)
             rescue Chef::Exceptions::JSON::ParseError => e

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -98,11 +98,11 @@ class Chef
           end
 
           def read
+            # Minimize the value (get rid of defaults) so the results don't look terrible
             Chef::JSONCompat.to_json_pretty(minimize_value(_read_json))
           end
 
           def _read_json
-            # Minimize the value (get rid of defaults) so the results don't look terrible
             @target_object ? JSON.parse(@target_object) : root.get_json(api_path)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "Timeout reading: #{e}")

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -101,8 +101,9 @@ class Chef
           end
 
           def _read_json
-              # Minimize the value (get rid of defaults) so the results don't look terrible
-            root.get_json(api_path)
+            # Minimize the value (get rid of defaults) so the results don't look terrible
+            # For node objects, just assume they differ - too expensive to fetch and compare
+            parent.api_path == 'nodes' ? JSON.parse('{}') : root.get_json(api_path)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "Timeout reading: #{e}")
           rescue Net::HTTPServerException => e

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -86,6 +86,8 @@ class Chef
           end
 
           def delete(recurse)
+            # free up cache - it will be hydrated on next check for exists?
+            @target_object = nil
             rest.delete(api_path)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:delete, self, e, "Timeout deleting: #{e}")

--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -30,7 +30,7 @@ class Chef
           def initialize(name, parent, exists = nil)
             super(name, parent)
             @exists = exists
-            @target_object = nil
+            @this_object_cache = nil
           end
 
           def data_handler
@@ -70,7 +70,7 @@ class Chef
           def exists?
             if @exists.nil?
               begin
-                @target_object = rest.get(api_path)
+                @this_object_cache = rest.get(api_path)
                 @exists = true
               rescue Net::HTTPServerException => e
                 if e.response.code == "404"
@@ -87,7 +87,7 @@ class Chef
 
           def delete(recurse)
             # free up cache - it will be hydrated on next check for exists?
-            @target_object = nil
+            @this_object_cache = nil
             rest.delete(api_path)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:delete, self, e, "Timeout deleting: #{e}")
@@ -105,7 +105,7 @@ class Chef
           end
 
           def _read_json
-            @target_object ? JSON.parse(@target_object) : root.get_json(api_path)
+            @this_object_cache ? JSON.parse(@this_object_cache) : root.get_json(api_path)
           rescue Timeout::Error => e
             raise Chef::ChefFS::FileSystem::OperationFailedError.new(:read, self, e, "Timeout reading: #{e}")
           rescue Net::HTTPServerException => e
@@ -155,7 +155,7 @@ class Chef
             other_value_json = Chef::JSONCompat.to_json_pretty(other_value)
 
             # free up cache - it will be hydrated on next check for exists?
-            @target_object = nil
+            @this_object_cache = nil
 
             [ value == other_value, value_json, other_value_json ]
           end


### PR DESCRIPTION
### Description

During the course of a backup/restore operation, initially two `GET` requests are made: the first for establishing whether the objects exists, the second for comparing the object for determining whether to copy it or not.  Both requests result in the entire object being retrieved.  This is very inefficient when dealing with thousands of objects.

This change eliminates one of those `GET` requests by caching the first and using it for later comparison.
It has been tested and validated for both backup and restore operations.

### Issues Resolved

n/a

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
