### PR TITLE
Properly use chef-shell in SoloSession by deprecating old behavior into SoloLegacySession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ kitchen-tests/nodes/*
 
 # Temporary files present during spec runs
 spec/data/test-dir
+spec/data/nodes
 /config/
 
 # acceptance binstubs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -100,3 +100,8 @@ confusion.  A simple example is `property :hash` which overrides the Object#hash
 is placed into the Chef::ResourceCollection which uses a Hash internally which expects to call Object#hash to get a unique id for the
 object.  Attempting to create `property :action` would also override the Chef::Resource#action method which is unlikely to end well for
 the user.  Overriding inherited properties is still supported.
+
+### `chef-shell` now supports solo and legacy solo modes
+
+Running `chef-shell -s` or `chef-shell --solo` will give you an experience consistent with `chef-solo`. `chef-shell --solo-legacy-mode`
+will give you an experience consistent with `chef-solo --legacy-mode`.

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -239,6 +239,12 @@ FOOTER
       :description  => "chef-client session",
       :boolean      => true
 
+    option :solo_legacy_mode,
+      :long         => "--solo-legacy-mode",
+      :description  => "chef-solo legacy session",
+      :boolean      => true,
+      :proc         => proc { Chef::Config[:solo_legacy_mode] = true }
+
     option :json_attribs,
       :short => "-j JSON_ATTRIBS",
       :long => "--json-attributes JSON_ATTRIBS",
@@ -313,7 +319,7 @@ FOOTER
         config_file_to_try
       elsif dot_chef_dir && ::File.exist?(File.join(dot_chef_dir, "chef_shell.rb"))
         File.join(dot_chef_dir, "chef_shell.rb")
-      elsif config[:solo]
+      elsif config[:solo_legacy_mode]
         Chef::Config.platform_specific_path("/etc/chef/solo.rb")
       elsif config[:client]
         Chef::Config.platform_specific_path("/etc/chef/client.rb")

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -27,6 +27,7 @@ require "chef/config"
 require "chef/config_fetcher"
 
 require "chef/shell/shell_session"
+require "chef/workstation_config_loader"
 require "chef/shell/ext"
 require "chef/json_compat"
 require "chef/util/path_helper"
@@ -62,6 +63,12 @@ module Shell
 
     irb = IRB::Irb.new
 
+    if solo_mode?
+      # Setup the mocked ChefServer
+      Chef::Config.local_mode = true
+      Chef::LocalMode.setup_server_connectivity
+    end
+
     init(irb.context.main)
 
     irb_conf[:IRB_RC].call(irb.context) if irb_conf[:IRB_RC]
@@ -74,6 +81,13 @@ module Shell
     catch(:IRB_EXIT) do
       irb.eval_input
     end
+  ensure
+    # We destroy the mocked ChefServer
+    Chef::LocalMode.destroy_server_connectivity if solo_mode?
+  end
+
+  def self.solo_mode?
+    Chef::Config[:solo]
   end
 
   def self.setup_logger
@@ -167,8 +181,9 @@ module Shell
 
   def self.client_type
     type = Shell::StandAloneSession
-    type = Shell::SoloSession   if Chef::Config[:shell_solo]
-    type = Shell::ClientSession if Chef::Config[:client]
+    type = Shell::SoloSession         if solo_mode?
+    type = Shell::SoloLegacySession   if Chef::Config[:solo_legacy_shell]
+    type = Shell::ClientSession       if Chef::Config[:client]
     type = Shell::DoppelGangerSession if Chef::Config[:doppelganger]
     type
   end
@@ -226,7 +241,7 @@ FOOTER
       :default      => true,
       :boolean      => true
 
-    option :shell_solo,
+    option :solo_shell,
       :short        => "-s",
       :long         => "--solo",
       :description  => "chef-solo session",
@@ -239,7 +254,7 @@ FOOTER
       :description  => "chef-client session",
       :boolean      => true
 
-    option :solo_legacy_mode,
+    option :solo_legacy_shell,
       :long         => "--solo-legacy-mode",
       :description  => "chef-solo legacy session",
       :boolean      => true,
@@ -319,10 +334,12 @@ FOOTER
         config_file_to_try
       elsif dot_chef_dir && ::File.exist?(File.join(dot_chef_dir, "chef_shell.rb"))
         File.join(dot_chef_dir, "chef_shell.rb")
-      elsif config[:solo_legacy_mode]
+      elsif config[:solo_legacy_shell]
         Chef::Config.platform_specific_path("/etc/chef/solo.rb")
       elsif config[:client]
         Chef::Config.platform_specific_path("/etc/chef/client.rb")
+      elsif config[:solo]
+        Chef::WorkstationConfigLoader.new(nil, Chef::Log).config_location
       else
         nil
       end

--- a/lib/chef/shell/shell_session.rb
+++ b/lib/chef/shell/shell_session.rb
@@ -227,6 +227,12 @@ module Shell
 
   end
 
+  class SoloSession < ClientSession
+
+    session_type :solo
+
+  end
+
   class DoppelGangerClient < Chef::Client
 
     attr_reader :node_name

--- a/lib/chef/shell/shell_session.rb
+++ b/lib/chef/shell/shell_session.rb
@@ -159,9 +159,9 @@ module Shell
 
   end
 
-  class SoloSession < ShellSession
+  class SoloLegacySession < ShellSession
 
-    session_type :solo
+    session_type :solo_legacy_mode
 
     def definitions
       @run_context.definitions
@@ -191,9 +191,13 @@ module Shell
 
   end
 
-  class ClientSession < SoloSession
+  class ClientSession < ShellSession
 
     session_type :client
+
+    def definitions
+      @run_context.definitions
+    end
 
     def save_node
       @client.save_node

--- a/spec/data/shef-config.rb
+++ b/spec/data/shef-config.rb
@@ -7,3 +7,5 @@ ohai[:disabled_plugins] << "solaris2::cpu" << "solaris2::dmi" << "solaris2::file
 ohai[:disabled_plugins] << "solaris2::virtualization" << "solaris2::zpools"
 ohai[:disabled_plugins] << "c" << "php" << "mono" << "groovy" << "lua" << "erlang"
 ohai[:disabled_plugins] << "kernel" << "linux::filesystem" << "ruby"
+chef_repo_path File.dirname(__FILE__)
+cookbook_path  "#{chef_repo_path}/cookbooks"

--- a/spec/functional/shell_spec.rb
+++ b/spec/functional/shell_spec.rb
@@ -135,6 +135,24 @@ describe Shell do
       expect(exitstatus).to eq(0)
     end
 
+    context "on solo mode" do
+      it "starts correctly" do
+        output, exitstatus = run_chef_shell_with("--solo")
+        expect(output).to include("done")
+        expect(exitstatus).to eq(0)
+      end
+
+      it "should be able to use the API" do
+        output, exitstatus = run_chef_shell_with("-s") do |out, keyboard|
+          simple_api_get = "api.get('data')"
+          keyboard.puts(simple_api_get)
+          read_until(out, simple_api_get)
+        end
+        expect(output).to include("{}")
+        expect(exitstatus).to eq(0)
+      end
+    end
+
     it "sets the override_runlist from the command line" do
       output, exitstatus = run_chef_shell_with("-o 'override::foo,override::bar'") do |out, keyboard|
         show_recipes_code = %q[puts "#{node["recipes"].inspect}"]


### PR DESCRIPTION
### Description

As a person who debugs chef cookbooks with chef-shell, I should be able to connect to a local chef-zero instance with chef-shell, so that I can more easily debug my cookbooks in server mode.

### Issues Resolved

https://feedback.chef.io/forums/301644-chef-product-feedback/suggestions/8783605-chef-shell-with-chef-zero-local-client-mode-supp

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
