### PR TITLE
Chef-13:  Remove declare_resource create_if_missing API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,3 +59,9 @@ Previously, the syntax `node.foo.bar` could be used to mean `node["foo"]["bar"]`
 with the core ruby Object class (e.g. `node.class`) and where it collided with our own ability to extend the `Chef::Node` API.  This
 method access has been deprecated for some time, and has been removed in Chef-13.
 
+### Changed `declare_resource` API
+
+Dropped the `create_if_missing` parameter that was immediately supplanted by the `edit_resource` API (most likely nobody ever used
+this) and converted the `created_at` parameter from an optional positional parameter to a named parameter.  These changes are unlikely
+to affect any cookbook code.
+

--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters
-# Copyright:: Copyright 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,7 +117,7 @@ class Chef
       #     cookbook_name: cookbook_name
       #   end
       #
-      def edit_resource!(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
+      def edit_resource!(type, name, created_at: nil, run_context: self.run_context, &resource_attrs_block)
         resource = find_resource!(type, name, run_context: run_context)
         if resource_attrs_block
           if defined?(new_resource)
@@ -152,10 +152,10 @@ class Chef
       #   end
       #   resource.variables.merge!({ home: "/home/klowns"  })
       #
-      def edit_resource(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
-        edit_resource!(type, name, created_at, run_context: run_context, &resource_attrs_block)
+      def edit_resource(type, name, created_at: nil, run_context: self.run_context, &resource_attrs_block)
+        edit_resource!(type, name, created_at: created_at, run_context: run_context, &resource_attrs_block)
       rescue Chef::Exceptions::ResourceNotFound
-        declare_resource(type, name, created_at, run_context: run_context, &resource_attrs_block)
+        declare_resource(type, name, created_at: created_at, run_context: run_context, &resource_attrs_block)
       end
 
       # Lookup a resource in the resource collection by name.  If the resource is not
@@ -207,7 +207,7 @@ class Chef
         find_resource!(type, name, run_context: run_context)
       rescue Chef::Exceptions::ResourceNotFound
         if resource_attrs_block
-          declare_resource(type, name, created_at, run_context: run_context, &resource_attrs_block)
+          declare_resource(type, name, created_at: created_at, run_context: run_context, &resource_attrs_block)
         end # returns nil otherwise
       end
 
@@ -236,16 +236,10 @@ class Chef
       #     action :delete
       #   end
       #
-      def declare_resource(type, name, created_at = nil, run_context: self.run_context, create_if_missing: false, &resource_attrs_block)
+      def declare_resource(type, name, created_at: nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
 
-        if create_if_missing
-          Chef::Log.deprecation "build_resource with a create_if_missing flag is deprecated, use edit_resource instead"
-          # midly goofy since we call edit_resource only to re-call ourselves, but that's why its deprecated...
-          return edit_resource(type, name, created_at, run_context: run_context, &resource_attrs_block)
-        end
-
-        resource = build_resource(type, name, created_at, &resource_attrs_block)
+        resource = build_resource(type, name, created_at: created_at, &resource_attrs_block)
 
         run_context.resource_collection.insert(resource, resource_type: type, instance_name: name)
         resource
@@ -272,7 +266,7 @@ class Chef
       #     action :delete
       #   end
       #
-      def build_resource(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
+      def build_resource(type, name, created_at: nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
 
         # this needs to be lazy in order to avoid circular dependencies since ResourceBuilder

--- a/lib/chef/dsl/resources.rb
+++ b/lib/chef/dsl/resources.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser <jkeiser@chef.io>
-# Copyright:: Copyright 2015-2016, Chef Software, Inc.
+# Copyright:: Copyright 2015-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,14 +36,14 @@ class Chef
         module_eval(<<-EOM, __FILE__, __LINE__ + 1)
             def #{dsl_name}(*args, &block)
               Chef.deprecated(:internal_api, "Cannot create resource #{dsl_name} with more than one argument. All arguments except the name (\#{args[0].inspect}) will be ignored. This will cause an error in Chef 13. Arguments: \#{args}") if args.size > 1
-              declare_resource(#{dsl_name.inspect}, args[0], caller[0], &block)
+              declare_resource(#{dsl_name.inspect}, args[0], created_at: caller[0], &block)
             end
           EOM
       rescue SyntaxError
         # Handle the case where dsl_name has spaces, etc.
         define_method(dsl_name.to_sym) do |*args, &block|
           Chef.deprecated(:internal_api, "Cannot create resource #{dsl_name} with more than one argument. All arguments except the name (#{args[0].inspect}) will be ignored. This will cause an error in Chef 13. Arguments: #{args}") if args.size > 1
-          declare_resource(dsl_name, args[0], caller[0], &block)
+          declare_resource(dsl_name, args[0], created_at: caller[0], &block)
         end
       end
 

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -253,13 +253,6 @@ describe Chef::Recipe do
         expect(run_context.resource_collection.count).to eql(2)
       end
 
-      it "does not insert two resources if create_if_missing is used" do
-        zm_resource
-        Chef::Config[:treat_deprecation_warnings_as_errors] = false
-        recipe.declare_resource(:zen_master, "klopp", create_if_missing: true)
-        expect(run_context.resource_collection.count).to eql(1)
-      end
-
       context "injecting a different run_context" do
         let(:run_context2) do
           events = Chef::EventDispatch::Dispatcher.new


### PR DESCRIPTION
Likely nobody cares about this change, I added it and then a
release or two later introduced the better edit_resource style
of API.

I also changed "created_at" to be a proper named parameter, instead
of a positional parameter, which is a breaking change in an API that
has been around for quite some time -- makes the API consistent since
I added it as a named parameter to the new APIs when I wrote them.
(This one is very internal, though, so I suspect there's a shortlist of
things that muck about in chef internals that would be all that would break).
