### PR TITLE
[CHEF-3775] Converting recipe loading to recursive.

### DIFF
--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -86,7 +86,7 @@ class Chef
 
         load_as(:attribute_filenames, "attributes", "*.rb")
         load_as(:definition_filenames, "definitions", "*.rb")
-        load_as(:recipe_filenames, "recipes", "*.rb")
+        load_recursively_as(:recipe_filenames, "recipes", "*.rb")
         load_recursively_as(:library_filenames, "libraries", "*")
         load_recursively_as(:template_filenames, "templates", "*")
         load_recursively_as(:file_filenames, "files", "*")

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -201,7 +201,7 @@ class Chef
     def fully_qualified_recipe_names
       results = Array.new
       recipe_filenames_by_name.each_key do |rname|
-        results << "#{name}::#{rname.gsub(/[\\\/]/, '::')}"
+        results << "#{name}::#{rname.to_s.gsub(/[\\\/]/, '::')}"
       end
       results
     end

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -201,7 +201,7 @@ class Chef
     def fully_qualified_recipe_names
       results = Array.new
       recipe_filenames_by_name.each_key do |rname|
-        results << "#{name}::#{rname}"
+        results << "#{name}::#{rname.gsub(/[\\\/]/, '::')}"
       end
       results
     end

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -208,7 +208,11 @@ class Chef
 
     def recipe_filenames=(*filenames)
       @recipe_filenames = filenames.flatten
-      @recipe_filenames_by_name = filenames_by_name(recipe_filenames)
+      recipes_dir = Pathname(@root_paths[0]).join('recipes')
+      @recipe_filenames_by_name = recipe_filenames.select { |filename| filename =~ /\.rb$/ }.inject({}) { |memo, filename|
+        memo[Pathname(filename).dirname.relative_path_from(recipes_dir).join(File.basename(filename, ".rb")).to_s] = filename
+        next memo
+      }
       recipe_filenames
     end
 

--- a/spec/unit/cookbook_spec.rb
+++ b/spec/unit/cookbook_spec.rb
@@ -52,6 +52,15 @@ describe Chef::CookbookVersion do
     expect(@cookbook.recipe_filenames_by_name["two"]).to eq("recipes/two.rb")
   end
 
+  it "should be able to understand nested recipe paths" do
+    @cookbook.recipe_filenames = [ "recipes/one.rb", "recipes/group/two.rb", "recipes/one/three.rb" ]
+    expect(@cookbook.recipe_filenames).to.eq([ "recipes/one.rb", "recipes/group/two.rb", "recipes/one/three.rb" ])
+    expect(@cookbook.recipe_filenames_by_name.keys.sort).to eql(%w{group/two one one/three})
+    expect(@cookbook.recipe_filenames_by_name["one"]).to eq("recipes/one.rb")
+    expect(@cookbook.recipe_filenames_by_name["group/two"]).to eq("recipes/group/two.rb")
+    expect(@cookbook.recipe_filenames_by_name["one/three"]).to eq("recipes/one/three.rb")
+  end
+
   it "should generate a list of recipes by fully-qualified name" do
     @cookbook.recipe_filenames = [ "recipes/one.rb", "/recipes/two.rb", "three.rb" ]
     expect(@cookbook.fully_qualified_recipe_names.include?("openldap::one")).to eq(true)

--- a/spec/unit/cookbook_spec.rb
+++ b/spec/unit/cookbook_spec.rb
@@ -62,10 +62,11 @@ describe Chef::CookbookVersion do
   end
 
   it "should generate a list of recipes by fully-qualified name" do
-    @cookbook.recipe_filenames = [ "recipes/one.rb", "/recipes/two.rb", "three.rb" ]
+    @cookbook.recipe_filenames = [ "recipes/one.rb", "/recipes/two.rb", "three.rb", "recipes/two/four.rb" ]
     expect(@cookbook.fully_qualified_recipe_names.include?("openldap::one")).to eq(true)
     expect(@cookbook.fully_qualified_recipe_names.include?("openldap::two")).to eq(true)
     expect(@cookbook.fully_qualified_recipe_names.include?("openldap::three")).to eq(true)
+    expect(@cookbook.fully_qualified_recipe_names.include?("openldap::two::four")).to eq(true)
   end
 
   it "should raise an ArgumentException if you try to load a bad recipe name" do


### PR DESCRIPTION
This _should_ fix the issue raised on the jira a while back where recipes couldn't be referenced if they were in subfolders. The format I went for was simply recipe[cookbook::folder/recipe], though if desired I can alter it to be recipe[cookbook::folder::recipe].