### PR TITLE
Fix chef-shell option name and help message

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -338,7 +338,7 @@ FOOTER
         Chef::Config.platform_specific_path("/etc/chef/solo.rb")
       elsif config[:client]
         Chef::Config.platform_specific_path("/etc/chef/client.rb")
-      elsif config[:solo]
+      elsif config[:solo_shell]
         Chef::WorkstationConfigLoader.new(nil, Chef::Log).config_location
       else
         nil

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -211,8 +211,10 @@ module Shell
 When no CONFIG is specified, chef-shell attempts to load a default configuration file:
 * If a NAMED_CONF is given, chef-shell will load ~/.chef/NAMED_CONF/chef_shell.rb
 * If no NAMED_CONF is given chef-shell will load ~/.chef/chef_shell.rb if it exists
-* chef-shell falls back to loading /etc/chef/client.rb or /etc/chef/solo.rb if -z or
-  -s options are given and no chef_shell.rb can be found.
+* If no chef_shell.rb can be found, chef-shell falls back to load:
+      /etc/chef/client.rb if -z option is given.
+      /etc/chef/solo.rb   if --solo-legacy-mode option is given.
+      .chef/knife.rb      if -s option is given.
 FOOTER
 
     option :config_file,


### PR DESCRIPTION
### Description

There is a little mistake that we didn't catch. This will fix the option name and help message.

### Issues Resolved

None

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
