### PR TITLE
Chef-13: remove node_map back-compat

### DIFF
--- a/lib/chef/node_map.rb
+++ b/lib/chef/node_map.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,10 +31,7 @@ class Chef
     #
     # @return [NodeMap] Returns self for possible chaining
     #
-    def set(key, value, platform: nil, platform_version: nil, platform_family: nil, os: nil, on_platform: nil, on_platforms: nil, canonical: nil, override: nil, &block)
-      Chef.deprecated(:internal_api, "The on_platform option to node_map has been deprecated") if on_platform
-      Chef.deprecated(:internal_api, "The on_platforms option to node_map has been deprecated") if on_platforms
-      platform ||= on_platform || on_platforms
+    def set(key, value, platform: nil, platform_version: nil, platform_family: nil, os: nil, canonical: nil, override: nil, &block)
       filters = {}
       filters[:platform] = platform if platform
       filters[:platform_version] = platform_version if platform_version

--- a/spec/unit/node_map_spec.rb
+++ b/spec/unit/node_map_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -142,28 +142,6 @@ describe Chef::NodeMap do
         allow(node).to receive(:[]).with(:platform_version).and_return("7.0")
         expect(node_map.get(node, :thing)).to eql(:foo)
       end
-    end
-  end
-
-  describe "resource back-compat testing" do
-    before :each do
-      Chef::Config[:treat_deprecation_warnings_as_errors] = false
-    end
-
-    it "should handle :on_platforms => :all" do
-      node_map.set(:chef_gem, :foo, :on_platforms => :all)
-      allow(node).to receive(:[]).with(:platform).and_return("windows")
-      expect(node_map.get(node, :chef_gem)).to eql(:foo)
-    end
-    it "should handle :on_platforms => [ 'windows' ]" do
-      node_map.set(:dsc_script, :foo, :on_platforms => [ "windows" ])
-      allow(node).to receive(:[]).with(:platform).and_return("windows")
-      expect(node_map.get(node, :dsc_script)).to eql(:foo)
-    end
-    it "should handle :on_platform => :all" do
-      node_map.set(:link, :foo, :on_platform => :all)
-      allow(node).to receive(:[]).with(:platform).and_return("windows")
-      expect(node_map.get(node, :link)).to eql(:foo)
     end
   end
 


### PR DESCRIPTION
removes old Chef-10 era APIs that were not widely used.
