### PR TITLE
ideas for the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ Larger product enhancement and feedback should go through either the feedback si
 * [Chef RFCs](https://github.com/chef/chef-rfc)
 * [Chef Community Slack Meetings](https://github.com/chef/chef-rfc/blob/master/rfc001-slack-meetings.md)
 
-Bugs in other products should go to their specific repos, this is not a catch-all repo for all products:
+Bugs in other products should go to their specific repos, this is not a catch-all or default repo for all products, examples:
 
 * [Chef Server issues](https://github.com/chef/chef-server/issues/new)
 * [ChefDK issues](https://github.com/chef/chef-dk/issues/new)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,36 +1,51 @@
-## Description
+## NOTE: Actionable Chef Client Bugs Only
 
-Briefly describe the issue
+The issues opened against this repository must be relevant to chef-client and the code contained within this repository
+(knife, chef-apply, chef-solo, etc).
 
-## Chef Version
+This issue tracker is for software development, support questions are better handled through Slack, the Chef Mailing List,
+Stack Overflow or your support contact:
 
-Tell us which version of chef-client you are using (see below for Server+ChefDK bugs).
+* [Chef Mailing List](https://discourse.chef.io/)
+* [Chef Community Slack](https://community-slack.chef.io/)
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/chef) - tag questions with 'chef'
 
-## Platform Version
+Larger product enhancement and feedback should go through either the feedback site or go through the RFC process:
 
-Tell us which Operating System distribution and version chef-client is running on.
+* [feedback.chef.io](https://feedback.chef.io/forums/301644-chef-product-feedback/category/110832-chef-client)
+* [Chef RFCs](https://github.com/chef/chef-rfc)
+* [Chef Community Slack Meetings](https://github.com/chef/chef-rfc/blob/master/rfc001-slack-meetings.md)
 
-## Replication Case
+Bugs in other products should go to their specific repos, this is not a catch-all repo for all products:
 
-Tell us what steps to take to replicate your problem.  See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
-for information on how to create a good replication case.
-
-## Client Output
-
-The relevant output of the chef-client run or a link to a gist of the entire run, if there is one.
-
-The debug output (chef-client -l debug) may be useful, but please link to a gist, or truncate it.
-
-## Stacktrace
-
-Please include the stacktrace.out output or link to a gist of it, if there is one.
-
-### NOTE: CHEF CLIENT BUGS ONLY
-
-This issue tracker is for the code contained within this repo -- `chef-client`, base `knife` functionality (not
-plugins), `chef-apply`, `chef-solo`, `chef-client -z`, etc.
-
-* Requests for new or alternative functionality should be made to [feedback.chef.io](https://feedback.chef.io/forums/301644-chef-product-feedback/category/110832-chef-client)
 * [Chef Server issues](https://github.com/chef/chef-server/issues/new)
 * [ChefDK issues](https://github.com/chef/chef-dk/issues/new)
 * Cookbook Issues (see the https://github.com/chef-cookbooks repos or search [Supermarket](https://supermarket.chef.io) or GitHub/Google)
+
+## Description
+
+< Briefly describe the issue. >
+
+## Chef Version
+
+< Tell us which version of chef-client you are using. >
+
+## Platform Version
+
+< Tell us which Operating System distribution and version chef-client is running on. >
+
+## Replication Case
+
+< Tell us what steps to take to replicate your problem.  See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
+for information on how to create a good replication case. >
+
+## Client Output
+
+< The relevant output of the chef-client run or a link to a gist of the entire run, if there is one. >
+
+< The debug output (chef-client -l debug) may be useful, but please link to a gist, or truncate it. >
+
+## Stacktrace
+
+< Please include the stacktrace.out output or link to a gist of it, if there is one. >
+


### PR DESCRIPTION
maybe try this?

- directly put the purpose of the issue tracker directly in front of users
- use direct links instead of dereferenced links to links to links
- also tried putting the "form test" inside of <>'s to see if more people will delete it that way.  i suspect that with the changes we'll get the big splash notice at the top of every submission, but i can suffer through deleting that for users as long as it improves the correct usage of the tracker and filters users towards the correct resources...