### PR TITLE
Chef-13: Simplify DSL creation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,3 +122,8 @@ This was deprecated and replaced a long time ago with mixlib-shellout and the sh
 
 The core of chef hasn't used this to implement the Recipe DSL since 12.5.1 and its unlikely that any external code depended upon it.
 
+### Simplify Recipe DSL wiring
+
+Support for actions with spaces and hyphens in the action name has been dropped.  Resources and property names with spaces and hyphens
+most likely never worked in Chef-12.  UTF-8 characters have always been supported and still are.
+

--- a/lib/chef/dsl/resources.rb
+++ b/lib/chef/dsl/resources.rb
@@ -39,12 +39,6 @@ class Chef
               declare_resource(#{dsl_name.inspect}, args[0], created_at: caller[0], &block)
             end
           EOM
-      rescue SyntaxError
-        # Handle the case where dsl_name has spaces, etc.
-        define_method(dsl_name.to_sym) do |*args, &block|
-          Chef.deprecated(:internal_api, "Cannot create resource #{dsl_name} with more than one argument. All arguments except the name (#{args[0].inspect}) will be ignored. This will cause an error in Chef 13. Arguments: #{args}") if args.size > 1
-          declare_resource(dsl_name, args[0], created_at: caller[0], &block)
-        end
       end
 
       def self.remove_resource_dsl(dsl_name)

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -515,16 +515,6 @@ class Chef
           self.class.properties[#{name.inspect}].set(self, value)
         end
       EOM
-    rescue SyntaxError
-      # If the name is not a valid ruby name, we use define_method.
-      declared_in.define_method(name) do |value = NOT_PASSED, &block|
-        raise "Property `#{name}` of `#{self}` was incorrectly passed a block!  Possible property-resource collision.  To call a resource named `#{name}` either rename the property or else use `declare_resource(:#{name}, ...)`" if block
-        self.class.properties[name].call(self, value)
-      end
-      declared_in.define_method("#{name}=") do |value, &block|
-        raise "Property `#{name}` of `#{self}` was incorrectly passed a block!  Possible property-resource collision.  To call a resource named `#{name}` either rename the property or else use `declare_resource(:#{name}, ...)`" if block
-        self.class.properties[name].set(self, value)
-      end
     end
 
     #

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -379,16 +379,11 @@ class Chef
         def action(name, &block)
           # We need the block directly in a method so that `super` works
           define_method("compile_action_#{name}", &block)
-          # We try hard to use `def` because define_method doesn't show the method name in the stack.
-          begin
-            class_eval <<-EOM
-              def action_#{name}
-                compile_and_converge_action { compile_action_#{name} }
-              end
-            EOM
-          rescue SyntaxError
-            define_method("action_#{name}") { send("compile_action_#{name}") }
-          end
+          class_eval <<-EOM
+            def action_#{name}
+              compile_and_converge_action { compile_action_#{name} }
+            end
+          EOM
         end
       end
     end

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -1373,6 +1373,23 @@ describe "Recipe DSL methods" do
         end
       end
     end
+
+    context "with UTF-8 provides" do
+      before(:context) do
+        class UTF8Thingy < BaseThingy
+          resource_name :Straße
+          provides :Straße
+        end
+      end
+
+      it "utf-8 dsl names work" do
+        recipe = converge do
+          Straße("blah") {}
+        end
+        expect(recipe.logged_warnings).to eq ""
+        expect(BaseThingy.created_resource).to eq(UTF8Thingy)
+      end
+    end
   end
 
   before(:all) { Namer.current_index = 0 }
@@ -1418,4 +1435,5 @@ describe "Recipe DSL methods" do
       end
     end
   end
+
 end

--- a/spec/integration/recipes/resource_action_spec.rb
+++ b/spec/integration/recipes/resource_action_spec.rb
@@ -357,7 +357,7 @@ module ResourceActionSpec
       end
     end
 
-    context "With a resource with action a-b-c d" do
+    context "With a resource with a UTF-8 action" do
       class WeirdActionJackson < Chef::Resource
         use_automatic_resource_name
 
@@ -365,7 +365,7 @@ module ResourceActionSpec
           attr_accessor :action_was
         end
 
-        action "a-b-c d" do
+        action :Straße do
           WeirdActionJackson.action_was = action
         end
       end
@@ -374,7 +374,7 @@ module ResourceActionSpec
         expect_recipe do
           weird_action_jackson "hi"
         end.to be_up_to_date
-        expect(WeirdActionJackson.action_was).to eq :"a-b-c d"
+        expect(WeirdActionJackson.action_was).to eq :Straße
       end
     end
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -108,6 +108,16 @@ describe "Chef::Resource.property" do
     end
   end
 
+  with_property ":Straße" do
+    it "properties with UTF-8 in their name work" do
+      expect(resource.Straße).to eql(nil)
+      expect(resource.Straße "foo").to eql("foo")
+      expect(resource.Straße).to eql("foo")
+      expect(resource.Straße = "bar").to eql("bar")
+      expect(resource.Straße).to eql("bar")
+    end
+  end
+
   with_property ":x, name_property: true" do
     context "and subclass" do
       let(:subresource_class) do


### PR DESCRIPTION
we did actually have tests around creating actions with spaces and
hyphens in their names.  we had fallback code for properties, but it
was broken and threw a "private method define_resource called" and then
it created a closure and didn't have the `name` in the binding so it
called itself and blew up the stack.

this change walks that back.  it does prove that we still support
UTF-8 in property names, actions and DSL names, which i'd argue is
more than enough.
