### PR TITLE
Add InSpec to chef omnibus builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "cheffish", "~> 13" # required for rspec tests
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
+  gem "inspec"
   # nokogiri has no ruby-2.4 version for windows so it cannot go into our Gemfile.lock
   #  gem "nokogiri", ">= 1.7.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef-server
-  revision: b670bd5f2ed1f56a39ab0c211efd4204b6978422
+  revision: 07fea253ceea254af8fbd9c602a04017751cae21
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 6.0)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 21cc711810e860d9db378f39da88406eec48d878
+  revision: 6bb6e8cf30118b104dbcffaea17ffb1644aee2cc
   specs:
     ohai (13.0.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
@@ -205,17 +205,18 @@ GEM
       mixlib-cli (~> 1.4)
     artifactory (2.8.1)
     ast (2.3.0)
-    aws-sdk (2.9.2)
-      aws-sdk-resources (= 2.9.2)
-    aws-sdk-core (2.9.2)
+    aws-sdk (2.9.3)
+      aws-sdk-resources (= 2.9.3)
+    aws-sdk-core (2.9.3)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.2)
-      aws-sdk-core (= 2.9.2)
+    aws-sdk-resources (2.9.3)
+      aws-sdk-core (= 2.9.3)
     aws-sigv4 (1.0.0)
     backports (3.7.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    blankslate (2.1.2.4)
     builder (3.2.3)
     byebug (9.0.6)
     chef-api (0.7.0)
@@ -257,6 +258,9 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     docile (1.1.5)
+    docker-api (1.33.3)
+      excon (>= 0.38.0)
+      json
     domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
@@ -309,6 +313,23 @@ GEM
     httpclient (2.8.3)
     i18n (0.8.1)
     iniparse (1.4.2)
+    inspec (1.19.1)
+      addressable (~> 2.4)
+      faraday (>= 0.9.0)
+      hashie (~> 3.4)
+      json (>= 1.8, < 3.0)
+      method_source (~> 0.8)
+      mixlib-log
+      parallel (~> 1.9)
+      pry (~> 0)
+      rainbow (~> 2)
+      rspec (~> 3)
+      rspec-its (~> 1.2)
+      rubyzip (~> 1.1)
+      sslshake (~> 1)
+      thor (~> 0.19)
+      toml (~> 0.1)
+      train (>= 0.22.0, < 1.0)
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.0.3)
@@ -384,8 +405,11 @@ GEM
     nori (2.6.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.11.1)
     parser (2.4.0.0)
       ast (~> 2.2)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     plist (3.2.0)
     poise-profiler (1.0.1)
       halite (~> 1.0)
@@ -477,6 +501,7 @@ GEM
       net-ssh (>= 2.7, < 5.0)
       net-telnet
       sfl
+    sslshake (1.1.0)
     stove (5.1.0)
       chef-api (~> 0.5)
       logify (~> 0.2)
@@ -492,7 +517,17 @@ GEM
       thor (~> 0.19, < 0.19.2)
     thor (0.19.1)
     thread_safe (0.3.6)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
     tomlrb (1.2.4)
+    train (0.23.0)
+      docker-api (~> 1.26)
+      json (>= 1.8, < 3.0)
+      mixlib-shellout (~> 2.0)
+      net-scp (~> 1.2)
+      net-ssh (>= 2.9, < 5.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
     travis (1.8.8)
       backports
       faraday (~> 0.9)
@@ -578,6 +613,7 @@ DEPENDENCIES
   foodcritic
   github_changelog_generator!
   halite!
+  inspec
   knife-windows
   mixlib-install
   netrc

--- a/omnibus/config/software/chef-gem-inspec.rb
+++ b/omnibus/config/software/chef-gem-inspec.rb
@@ -1,0 +1,10 @@
+# gem installs this gem from the version specified in chef's Gemfile.lock
+# so we can take advantage of omnibus's caching. Just duplicate this file and
+# add the new software def to chef software def if you want to separate
+# another gem's installation.
+require_relative "../../files/chef-gem/build-chef-gem/gem-install-software-def"
+BuildChefGem::GemInstallSoftwareDef.define(self, __FILE__)
+
+license "Apache-2.0"
+license_file "https://raw.githubusercontent.com/chef/inspec/master/LICENSE"
+skip_transitive_dependency_licensing true

--- a/omnibus/config/software/chef.rb
+++ b/omnibus/config/software/chef.rb
@@ -44,6 +44,7 @@ dependency "chef-gem-ruby-prof"
 dependency "chef-gem-byebug"
 dependency "chef-gem-debug_inspector"
 dependency "chef-gem-binding_of_caller"
+dependency "chef-gem-inspec"
 unless ios_xr? || solaris?
   dependency "chef-gem-rbnacl-libsodium"
   dependency "chef-gem-bcrypt_pbkdf-ruby"


### PR DESCRIPTION
This change adds InSpec as a dependency of Chef, making it easier
for our community to use InSpec for testing without requiring
them to `chef_gem` install it prior to use.

This also helps our users who wish to use InSpec but are in an
air-gapped environment. Including our preferred testing library
in our Omnibus builds will make it much easier for those users
to use InSpec.