### PR TITLE
Chef-13: Support nameless resources and remove deprecated multi-arg resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -142,3 +142,18 @@ available in the [`poise-python`](https://github.com/poise/poise-python) cookboo
 
 We've upgraded to the latest stable release of the Ruby programming
 language.
+
+### Resource can now declare a default name
+
+The core `apt_update` resource can now be declared without any name argument, no need for `apt_update "this string doesn't matter but
+why do i have to type it?"`.
+
+This can be used by any other resource by just overriding the name property and supplying a default:
+
+```ruby
+  property :name, String, default: ""
+```
+
+Notifications to resources with empty strings as their name is also supported via either the bare resource name (`apt_update` --
+matches what the user types in the DSL) or with empty brackets (`apt_update[]` -- matches the resource notification pattern).
+

--- a/lib/chef/dsl/resources.rb
+++ b/lib/chef/dsl/resources.rb
@@ -34,11 +34,10 @@ class Chef
 
       def self.add_resource_dsl(dsl_name)
         module_eval(<<-EOM, __FILE__, __LINE__ + 1)
-            def #{dsl_name}(*args, &block)
-              Chef.deprecated(:internal_api, "Cannot create resource #{dsl_name} with more than one argument. All arguments except the name (\#{args[0].inspect}) will be ignored. This will cause an error in Chef 13. Arguments: \#{args}") if args.size > 1
-              declare_resource(#{dsl_name.inspect}, args[0], created_at: caller[0], &block)
-            end
-          EOM
+          def #{dsl_name}(arg = "", &block)
+            declare_resource(#{dsl_name.inspect}, arg, created_at: caller[0], &block)
+          end
+        EOM
       end
 
       def self.remove_resource_dsl(dsl_name)

--- a/lib/chef/dsl/resources.rb
+++ b/lib/chef/dsl/resources.rb
@@ -34,10 +34,10 @@ class Chef
 
       def self.add_resource_dsl(dsl_name)
         module_eval(<<-EOM, __FILE__, __LINE__ + 1)
-          def #{dsl_name}(arg = "", &block)
-            declare_resource(#{dsl_name.inspect}, arg, created_at: caller[0], &block)
-          end
-        EOM
+            def #{dsl_name}(args = nil, &block)
+              declare_resource(#{dsl_name.inspect}, args, created_at: caller[0], &block)
+            end
+          EOM
       end
 
       def self.remove_resource_dsl(dsl_name)

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -84,7 +84,7 @@ class Chef
     # @param name [Object] The name to set, typically a String or Array
     # @return [String] The name of this Resource.
     #
-    property :name, String, coerce: proc { |v| v.is_a?(Array) ? v.join(", ") : v.to_s }, desired_state: false
+    property :name, String, coerce: proc { |v| v.is_a?(Array) ? v.join(", ") : v.to_s }, desired_state: false, required: true
 
     #
     # The node the current Chef run is using.

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,8 @@ class Chef
       resource_name :apt_update
       provides :apt_update
 
+      # allow bare apt_update with no name
+      property :name, String, default: ""
       property :frequency, Integer, default: 86_400
 
       default_action :periodic

--- a/lib/chef/resource_builder.rb
+++ b/lib/chef/resource_builder.rb
@@ -43,8 +43,6 @@ class Chef
     end
 
     def build(&block)
-      raise ArgumentError, "You must supply a name when declaring a #{type} resource" if name.nil?
-
       @resource = resource_class.new(name, run_context)
       if resource.resource_name.nil?
         raise Chef::Exceptions::InvalidResourceSpecification, "#{resource}.resource_name is `nil`!  Did you forget to put `provides :blah` or `resource_name :blah` in your resource class?"

--- a/lib/chef/resource_collection/resource_set.rb
+++ b/lib/chef/resource_collection/resource_set.rb
@@ -46,7 +46,7 @@ class Chef
       def insert_as(resource, resource_type = nil, instance_name = nil)
         is_chef_resource!(resource)
         resource_type ||= resource.resource_name
-        instance_name ||= resource.name || ""
+        instance_name ||= resource.name
         key = create_key(resource_type, instance_name)
         @resources_by_key[key] = resource
       end
@@ -145,7 +145,7 @@ class Chef
 
       private
 
-      def create_key(resource_type, instance_name = "")
+      def create_key(resource_type, instance_name)
         "#{resource_type}[#{instance_name}]"
       end
 

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -8,6 +8,37 @@ describe "notifications" do
   let(:chef_dir) { File.expand_path("../../../../bin", __FILE__) }
   let(:chef_client) { "ruby '#{chef_dir}/chef-client' --minimal-ohai" }
 
+  when_the_repository "notifies a nameless resource" do
+    before do
+      directory "cookbooks/x" do
+        file "recipes/default.rb", <<-EOM
+          apt_update do
+            action :nothing
+          end
+          log "foo" do
+            notifies :nothing, 'apt_update', :delayed
+          end
+          log "bar" do
+            notifies :nothing, 'apt_update[]', :delayed
+          end
+        EOM
+      end
+    end
+
+    it "should complete with success" do
+      file "config/client.rb", <<EOM
+local_mode true
+cookbook_path "#{path_to('cookbooks')}"
+log_level :warn
+EOM
+
+      result = shell_out("#{chef_client} -c \"#{path_to('config/client.rb')}\" --no-color -F doc -o 'x::default'", :cwd => chef_dir)
+      # our delayed notification should run at the end of the parent run_context after the baz resource
+      expect(result.stdout).to match(/\* apt_update\[\] action nothing \(skipped due to action :nothing\)\s+\* log\[foo\] action write\s+\* log\[bar\] action write\s+\* apt_update\[\] action nothing \(skipped due to action :nothing\)/)
+      result.error!
+    end
+  end
+
   when_the_repository "notifies delayed one" do
     before do
       directory "cookbooks/x" do

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -59,20 +59,12 @@ describe "Recipe DSL methods" do
       expect(BaseThingy.created_resource).to eq BaseThingy
     end
 
-    it "errors out when you call base_thingy do ... end in a recipe" do
-      expect_converge do
-        base_thingy { ; }
-      end.to raise_error(ArgumentError, "You must supply a name when declaring a base_thingy resource")
-    end
-
-    it "emits a warning when you call base_thingy 'foo', 'bar' do ... end in a recipe" do
-      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+    it "does not errors  when you call base_thingy do ... end in a recipe" do
       recipe = converge do
-        base_thingy "foo", "bar" do
-        end
+        base_thingy { ; }
       end
-      expect(recipe.logged_warnings).to match(/Cannot create resource base_thingy with more than one argument. All arguments except the name \("foo"\) will be ignored. This will cause an error in Chef 13. Arguments: \["foo", "bar"\]/)
-      expect(BaseThingy.created_name).to eq "foo"
+      expect(recipe.logged_warnings).to eq ""
+      expect(BaseThingy.created_name).to eq ""
       expect(BaseThingy.created_resource).to eq BaseThingy
     end
 

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -59,13 +59,30 @@ describe "Recipe DSL methods" do
       expect(BaseThingy.created_resource).to eq BaseThingy
     end
 
-    it "does not errors  when you call base_thingy do ... end in a recipe" do
-      recipe = converge do
+    it "errors when you call base_thingy do ... end in a recipe" do
+      expect_converge do
         base_thingy { ; }
+      end.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+
+    context "nameless resources" do
+      before(:context) do
+        class NamelessThingy < BaseThingy
+          resource_name :nameless_thingy
+          provides :nameless_thingy
+
+          property :name, String, default: ""
+        end
       end
-      expect(recipe.logged_warnings).to eq ""
-      expect(BaseThingy.created_name).to eq ""
-      expect(BaseThingy.created_resource).to eq BaseThingy
+
+      it "does not error when not given a name" do
+        recipe = converge do
+          nameless_thingy {}
+        end
+        expect(recipe.logged_warnings).to eq ""
+        expect(BaseThingy.created_name).to eq ""
+        expect(BaseThingy.created_resource).to eq NamelessThingy
+      end
     end
 
     context "Deprecated automatic resource DSL" do

--- a/spec/unit/dsl/resources_spec.rb
+++ b/spec/unit/dsl/resources_spec.rb
@@ -80,6 +80,6 @@ describe Chef::DSL::Resources do
         test_resource {}
       end
     end
-    it { is_expected.to eq [[:test_resource, nil]] }
+    it { is_expected.to eq [[:test_resource, ""]] }
   end
 end

--- a/spec/unit/dsl/resources_spec.rb
+++ b/spec/unit/dsl/resources_spec.rb
@@ -80,6 +80,6 @@ describe Chef::DSL::Resources do
         test_resource {}
       end
     end
-    it { is_expected.to eq [[:test_resource, ""]] }
+    it { is_expected.to eq [[:test_resource, nil]] }
   end
 end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -301,7 +301,7 @@ describe "Chef::Resource.property" do
       expect(resource.property_is_set?(:name)).to be_truthy
       resource.reset_property(:name)
       expect(resource.property_is_set?(:name)).to be_falsey
-      expect(resource.name).to be_nil
+      expect { resource.name }.to raise_error Chef::Exceptions::ValidationFailed
     end
 
     it "when referencing an undefined property, reset_property(:x) raises an error" do

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -79,11 +79,6 @@ describe Chef::Recipe do
         expect(run_context.resource_collection.lookup("zen_master[]").name).to eql("")
       end
 
-      it "does not require a name argument and looks up with bare word" do
-        recipe.zen_master
-        expect(run_context.resource_collection.lookup("zen_master").name).to eql("")
-      end
-
       it "should allow regular errors (not NameErrors) to pass unchanged" do
         expect do
           recipe.cat("felix") { raise ArgumentError, "You Suck" }

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -74,10 +74,14 @@ describe Chef::Recipe do
         expect { recipe.not_home("not_home_resource") }.to raise_error(NameError)
       end
 
-      it "should require a name argument" do
-        expect do
-          recipe.cat
-        end.to raise_error(ArgumentError)
+      it "does not require a name argument and looks up with empty brackets" do
+        recipe.zen_master
+        expect(run_context.resource_collection.lookup("zen_master[]").name).to eql("")
+      end
+
+      it "does not require a name argument and looks up with bare word" do
+        recipe.zen_master
+        expect(run_context.resource_collection.lookup("zen_master").name).to eql("")
       end
 
       it "should allow regular errors (not NameErrors) to pass unchanged" do

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -74,11 +74,6 @@ describe Chef::Recipe do
         expect { recipe.not_home("not_home_resource") }.to raise_error(NameError)
       end
 
-      it "does not require a name argument and looks up with empty brackets" do
-        recipe.zen_master
-        expect(run_context.resource_collection.lookup("zen_master[]").name).to eql("")
-      end
-
       it "should allow regular errors (not NameErrors) to pass unchanged" do
         expect do
           recipe.cat("felix") { raise ArgumentError, "You Suck" }

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright 2011-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ describe Chef::Resource::Conditional do
     allow_any_instance_of(Mixlib::ShellOut).to receive(:run_command).and_return(nil)
     @status = OpenStruct.new(:success? => true)
     allow_any_instance_of(Mixlib::ShellOut).to receive(:status).and_return(@status)
-    @parent_resource = Chef::Resource.new(nil, Chef::Node.new)
+    @parent_resource = Chef::Resource.new("", Chef::Node.new)
   end
 
   it "raises an exception when neither a block or command is given" do

--- a/spec/unit/resource_collection/resource_set_spec.rb
+++ b/spec/unit/resource_collection/resource_set_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -161,6 +161,35 @@ describe Chef::ResourceCollection::ResourceSet do
 
     it "raises an error when attempting to find a resource that does not exist" do
       expect { collection.find("script[nonesuch]") }.to raise_error(Chef::Exceptions::ResourceNotFound)
+    end
+
+    context "nameless resources" do
+      let(:zen_master_name) { "" }
+
+      it "looks up nameless resources with find without brackets" do
+        collection.insert_as(zen_master)
+        expect(collection.find("zen_master")).to eq(zen_master)
+      end
+
+      it "looks up nameless resources with find with empty brackets" do
+        collection.insert_as(zen_master)
+        expect(collection.find("zen_master[]")).to eq(zen_master)
+      end
+
+      it "looks up nameless resources with find with empty string hash key" do
+        collection.insert_as(zen_master)
+        expect(collection.find(zen_master: "")).to eq(zen_master)
+      end
+
+      it "looks up nameless resources with lookup with empty brackets" do
+        collection.insert_as(zen_master)
+        expect(collection.lookup("zen_master[]")).to eq(zen_master)
+      end
+
+      it "looks up nameless resources with lookup with the resource" do
+        collection.insert_as(zen_master)
+        expect(collection.lookup(zen_master)).to eq(zen_master)
+      end
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -284,6 +284,23 @@ describe Chef::Resource do
       resource.notifies :reload, run_context.resource_collection.find(:zen_master => "coffee, tea")
       expect(resource.delayed_notifications.detect { |e| e.resource.name == "coffee, tea" && e.action == :reload }).not_to be_nil
     end
+
+    it "notifies a resource without a name via a string name with brackets" do
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("")
+      resource.notifies :reload, "zen_master[]"
+    end
+
+    it "notifies a resource without a name via a string name without brackets" do
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("")
+      resource.notifies :reload, "zen_master"
+      expect(resource.delayed_notifications.first.resource).to eql("zen_master")
+    end
+
+    it "notifies a resource without a name via a hash name with an empty string" do
+      run_context.resource_collection << Chef::Resource::ZenMaster.new("")
+      resource.notifies :reload, zen_master: ""
+      expect(resource.delayed_notifications.first.resource).to eql(zen_master: "")
+    end
   end
 
   describe "subscribes" do


### PR DESCRIPTION
This makes nameless resources work in the DSL:

```ruby
apt_update
```

It does it by giving it an empty-string name of ""

It also drops support for multi-arg resources, that has been deprecated
for some time:

```ruby
some_resource "foo", "bar", "baz"
```

Note that multipackage package resources do not use multiple args, but a
single argument which is an array:

```ruby
package [ "lsof", "strace", "tcpdump" ]
```

So this change does not affect that usage.  Multi-arg has been
deprecated for some time now and its not clear that it was ever used by
anyone.
