### PR TITLE
Swap Ubuntu 12.04 testing for openSUSE Leap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
 branches:
   only:
   - master
-  - 11-stable
 
 env:
   global:
@@ -108,24 +107,6 @@ matrix:
     rvm: 2.3.3
   ### START TEST KITCHEN ONLY ###
   #
-  - rvm: 2.3.3
-    services: docker
-    sudo: required
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
-    bundler_args: --without ci development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
-    before_script:
-      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      - cd kitchen-tests
-    script:
-      - bundle exec kitchen test webapp-ubuntu-1204
-    after_failure:
-      - cat .kitchen/logs/kitchen.log
-    env:
-      - UBUNTU=12.04
-      - KITCHEN_YAML=.kitchen.travis.yml
   - rvm: 2.3.3
     services: docker
     sudo: required
@@ -269,6 +250,24 @@ matrix:
       - cat .kitchen/logs/kitchen.log
     env:
       - AMAZONLINUX=LATEST
+      - KITCHEN_YAML=.kitchen.travis.yml
+  - rvm: 2.3.3
+    services: docker
+    sudo: required
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+    bundler_args: --without ci development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
+      - travis_wait bundle exec kitchen test webapp-opensuse-422
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+      - OPENSUSE=42.2
       - KITCHEN_YAML=.kitchen.travis.yml
 #  - rvm: 2.3.3
 #    services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,6 @@ matrix:
       - cd kitchen-tests
     script:
       - bundle exec kitchen test webapp-debian-8
-    bundler_args: --without ci development docgen guard integration maintenance omnibus_package tools aix bsd mac_os_x solaris windows --frozen
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:

--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -2,7 +2,6 @@
 driver:
   name: dokken
   privileged: true
-  chef_image: chef/chef
   chef_version: current
 
 transport:
@@ -43,16 +42,6 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get -y install zlib1g-dev sudo net-tools wget ca-certificates
 
-- name: centos-5
-  driver:
-    image: centos:5
-    platform: rhel
-    run_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum clean all
-      - RUN yum install -y which initscripts net-tools sudo wget
-      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
-
 - name: centos-6
   driver:
     image: centos:6
@@ -83,14 +72,6 @@ platforms:
       - RUN yum makecache
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: ubuntu-12.04
-  driver:
-    image: ubuntu-upstart:12.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install zlib1g-dev sudo net-tools wget ca-certificates
-
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04
@@ -107,9 +88,9 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get -y install zlib1g-dev sudo net-tools wget ca-certificates
 
-- name: opensuse-13.2
+- name: opensuse-42.2
   driver:
-    image: opensuse:13.2
+    image: opensuse:42.2
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper refresh

--- a/kitchen-tests/.kitchen.yml
+++ b/kitchen-tests/.kitchen.yml
@@ -22,13 +22,11 @@ provisioner:
     diff_disabled: true
 
 platforms:
-  - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: centos-7.2
-  - name: centos-6.7
-  # needs fixing for 5.11
-  # - name: centos-5.11
+  - name: centos-7.3
+  - name: centos-6.8
+  - name: opensuse-leap-42.2
 
 suites:
   - name: webapp


### PR DESCRIPTION
    Swap Ubuntu 12.04 testing for openSUSE Leap

    Ubuntu 12.04 is going end of life so lets swap testing for another OS we should check.

    While we’re in here lets update a few other things
    -  There’s no longer a reason to hold back dokken to the 1.0 release.
    - Remove a dupe travis config
    - Remove centos 5 from the kitchen config since it’s going into the mostly EOL phase
    - Update platforms in the local kitchen config

    Signed-off-by: Tim Smith <tsmith@chef.io>