### PR TITLE
Retry API requests if using an unsupported version

### DIFF
--- a/lib/chef/http/api_versions.rb
+++ b/lib/chef/http/api_versions.rb
@@ -16,6 +16,7 @@
 #
 
 require "chef/server_api_versions"
+require "chef/json_compat"
 
 class Chef
   class HTTP
@@ -32,7 +33,7 @@ class Chef
 
       def handle_response(http_response, rest_request, return_value)
         if http_response.key?("x-ops-server-api-version")
-          ServerAPIVersions.instance.set_versions(http_response["x-ops-server-api-version"])
+          ServerAPIVersions.instance.set_versions(JSONCompat.parse(http_response["x-ops-server-api-version"]))
         end
         [http_response, rest_request, return_value]
       end

--- a/lib/chef/http/api_versions.rb
+++ b/lib/chef/http/api_versions.rb
@@ -32,6 +32,9 @@ class Chef
       end
 
       def handle_response(http_response, rest_request, return_value)
+        if http_response.code == "406"
+          ServerAPIVersions.instance.reset!
+        end
         if http_response.key?("x-ops-server-api-version")
           ServerAPIVersions.instance.set_versions(JSONCompat.parse(http_response["x-ops-server-api-version"]))
         end

--- a/lib/chef/mixin/versioned_api.rb
+++ b/lib/chef/mixin/versioned_api.rb
@@ -40,11 +40,15 @@ class Chef
       end
 
       def versioned_api_class
+        get_class_for(:max_server_version)
+      end
+
+      def get_class_for(type)
         versioned_interfaces.select do |klass|
           version = klass.send(:minimum_api_version)
           # min and max versions will be nil if we've not made a request to the server yet,
           # in which case we'll just start with the highest version and see what happens
-          ServerAPIVersions.instance.min_server_version.nil? || (version >= ServerAPIVersions.instance.min_server_version && version <= ServerAPIVersions.instance.max_server_version)
+          ServerAPIVersions.instance.min_server_version.nil? || (version >= ServerAPIVersions.instance.min_server_version && version <= ServerAPIVersions.instance.send(type))
         end
           .sort { |a, b| a.send(:minimum_api_version) <=> b.send(:minimum_api_version) }
           .last
@@ -57,6 +61,13 @@ class Chef
           end
         }
         module_eval(str, __FILE__, line_no)
+      end
+
+      # When teeing up an HTTP request, we need to be able to ask which API version we should use.
+      # Something in Net::HTTP seems to expect to strip headers, so we return this as a string.
+      def best_request_version
+        klass = get_class_for(:max_server_version)
+        klass.minimum_api_version.to_s
       end
 
       def new(*args)

--- a/lib/chef/mixin/versioned_api.rb
+++ b/lib/chef/mixin/versioned_api.rb
@@ -70,6 +70,10 @@ class Chef
         klass.minimum_api_version.to_s
       end
 
+      def possible_requests
+        versioned_interfaces.length
+      end
+
       def new(*args)
         object = versioned_api_class.allocate
         object.send(:initialize, *args)

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -26,11 +26,11 @@ class Chef
     end
 
     def min_server_version
-      !@versions.nil? ? @versions["min_version"] : nil
+      !@versions.nil? ? Integer(@versions["min_version"]) : nil
     end
 
     def max_server_version
-      !@versions.nil? ? @versions["max_version"] : nil
+      !@versions.nil? ? Integer(@versions["max_version"]) : nil
     end
 
     def reset!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,9 @@ require "chef/chef_fs/file_system_cache"
 
 require "chef/api_client_v1"
 
+require "chef/mixin/versioned_api"
+require "chef/server_api_versions"
+
 if ENV["CHEF_FIPS"] == "1"
   Chef::Config.init_openssl
 end

--- a/spec/unit/http/api_versions_spec.rb
+++ b/spec/unit/http/api_versions_spec.rb
@@ -38,7 +38,7 @@ describe Chef::HTTP::APIVersions do
   let(:response_body) { "Thanks for checking in." }
   let(:response_headers) do
     {
-      "x-ops-server-api-version" => { "min_version" => 0, "max_version" => 2 },
+      "x-ops-server-api-version" => { "min_version" => 0, "max_version" => 2 }.to_json,
     }
   end
 

--- a/spec/unit/http/api_versions_spec.rb
+++ b/spec/unit/http/api_versions_spec.rb
@@ -45,6 +45,7 @@ describe Chef::HTTP::APIVersions do
   let(:response) do
     m = double("HttpResponse", :body => response_body)
     allow(m).to receive(:key?).with("x-ops-server-api-version").and_return(true)
+    allow(m).to receive(:code).and_return(return_value)
     allow(m).to receive(:[]) do |key|
       response_headers[key]
     end
@@ -65,5 +66,14 @@ describe Chef::HTTP::APIVersions do
   it "correctly stores server api versions" do
     run_api_version_handler
     expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
+  end
+
+  context "with an unacceptable api version" do
+    let (:return_value) { "406" }
+    it "resets the list of supported versions" do
+      Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 1, "max_version" => 3 })
+      run_api_version_handler
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
+    end
   end
 end

--- a/spec/unit/mixin/versioned_api_spec.rb
+++ b/spec/unit/mixin/versioned_api_spec.rb
@@ -87,6 +87,19 @@ describe Chef::Mixin::VersionedAPIFactory do
     end
   end
 
+  describe "#best_request_version" do
+    it "returns a String" do
+      factory_class.add_versioned_api_class V2Class
+      expect(factory_class.best_request_version).to be_a(String)
+    end
+
+    it "returns the most relevant version" do
+      factory_class.add_versioned_api_class V2Class
+      factory_class.add_versioned_api_class V3Class
+      expect(factory_class.best_request_version).to eq("3")
+    end
+  end
+
   describe "#new" do
     it "creates an instance of the versioned class" do
       factory_class.add_versioned_api_class V2Class

--- a/spec/unit/mixin/versioned_api_spec.rb
+++ b/spec/unit/mixin/versioned_api_spec.rb
@@ -100,6 +100,14 @@ describe Chef::Mixin::VersionedAPIFactory do
     end
   end
 
+  describe "#possible_requests" do
+    it "returns the number of registered classes" do
+      factory_class.add_versioned_api_class V2Class
+      factory_class.add_versioned_api_class V3Class
+      expect(factory_class.possible_requests).to eq(2)
+    end
+  end
+
   describe "#new" do
     it "creates an instance of the versioned class" do
       factory_class.add_versioned_api_class V2Class


### PR DESCRIPTION
If we've not made a request to the server previously, we start by
trying the best possible version we know about; this means that in the case of a fresh connection to an old server we in general should only make two requests at worst.

cc @chef/maintainers