### PR TITLE
set default guard_interpreter to powershell_script

### DIFF
--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -23,7 +23,7 @@ class Chef
       provides :powershell_script, os: "windows"
 
       def initialize(name, run_context = nil)
-        super(name, run_context, nil, "powershell.exe")
+        super(name, run_context, :powershell_script, "powershell.exe")
         @convert_boolean_return = false
       end
 


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

Sets the default `guard_interpreter` of `powershell_script` back to `:powershell_script`

### Issues Resolved

https://github.com/chef/chef/issues/5953

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
