### PR TITLE
systemd_unit verifier escape hatch

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -194,7 +194,7 @@ class Chef
           f.group "root"
           f.mode "0644"
           f.content new_resource.to_ini
-          f.verify :systemd_unit
+          f.verify :systemd_unit if new_resource.verify
         end.run_action(action)
       end
 

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -33,14 +33,19 @@ class Chef
                       :try_restart, :reload_or_restart,
                       :reload_or_try_restart
 
+      # Internal provider-managed properties
       property :enabled, [TrueClass, FalseClass]
       property :active, [TrueClass, FalseClass]
       property :masked, [TrueClass, FalseClass]
       property :static, [TrueClass, FalseClass]
+
+      # User-provided properties
       property :user, String, desired_state: false
       property :content, [String, Hash]
       property :triggers_reload, [TrueClass, FalseClass],
                                  default: true, desired_state: false
+      property :verify, [TrueClass, FalseClass],
+                        default: true, desired_state: false
 
       def to_ini
         case content


### PR DESCRIPTION
systemd's pretty strict with the verification rules. it's usually possible to make it work, but this adds an escape hatch for if the verifier is too strict, or for use in debugging, since verifier output isn't surfaced right now.

### Description

permits users to opt out of resource verification

### Issues Resolved

helps with situations like #5931 and #5909. a full fix for #5931 that actually surfaces err output is incoming, but as a separate PR (#5972) since it touches more than just the systemd_unit resource.

### Check List

- [x] New functionality includes tests (N/A)
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes) (N/A)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
