### PR TITLE
surface default guard interpreter errors

### DIFF
--- a/lib/chef/guard_interpreter/default_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/default_guard_interpreter.rb
@@ -33,7 +33,9 @@ class Chef
       public
 
       def evaluate
-        shell_out_with_systems_locale(@command, @command_opts).status.success?
+        result = shell_out_with_systems_locale(@command, @command_opts)
+        Chef::Log.debug "Command failed: #{result.stderr}" unless result.status.success?
+        result.status.success?
       # Timeout fails command rather than chef-client run, see:
       #   https://tickets.opscode.com/browse/CHEF-2690
       rescue Chef::Exceptions::CommandTimeout


### PR DESCRIPTION
surface command stderr when guard interpreter command is unsuccessful. helps with showing why file/systemd_unit verify commands may fail.

surfacing the error in the converge output is important for debugging since the temporary files used during verification are not available for inspection after the verification command is run.

### Description

aids in debugging when guard interpreter fails

### Issues Resolved

#5931 

### Check List

- [x] New functionality includes tests (N/A)
- [x] All tests pass (N/A)
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes) (N/A)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
