### PR TITLE
apply knife search node fuzzifier to knife ssh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -159,7 +159,7 @@ matches what the user types in the DSL) or with empty brackets (`apt_update[]` -
 
 ### The knife ssh command applies the same fuzzifier as knife search node
 
-A bare name to knife search node will search for the name in `tags`, `roles`, `fqdn`, `addresses`, `policy_name` or `policy_group` fields and wil
+A bare name to knife search node will search for the name in `tags`, `roles`, `fqdn`, `addresses`, `policy_name` or `policy_group` fields and will
 match when given partial strings.  The `knife ssh` search term has been similarly extended so that the search API matches in both cases.  The
 node search fuzzifier has also been extracted out to a `fuzz` option to Chef::Search::Query for re-use elsewhere.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -160,6 +160,7 @@ matches what the user types in the DSL) or with empty brackets (`apt_update[]` -
 ### The knife ssh command applies the same fuzzifier as knife search node
 
 A bare name to knife search node will search for the name in `tags`, `roles`, `fqdn`, `addresses`, `policy_name` or `policy_group` fields and will
-match when given partial strings.  The `knife ssh` search term has been similarly extended so that the search API matches in both cases.  The
-node search fuzzifier has also been extracted out to a `fuzz` option to Chef::Search::Query for re-use elsewhere.
+match when given partial strings (available since Chef 11).  The `knife ssh` search term has been similarly extended so that the
+search API matches in both cases.  The node search fuzzifier has also been extracted out to a `fuzz` option to Chef::Search::Query for re-use
+elsewhere.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -157,3 +157,9 @@ This can be used by any other resource by just overriding the name property and 
 Notifications to resources with empty strings as their name is also supported via either the bare resource name (`apt_update` --
 matches what the user types in the DSL) or with empty brackets (`apt_update[]` -- matches the resource notification pattern).
 
+### The knife ssh command applies the same fuzzifier as knife search node
+
+A bare name to knife search node will search for the name in `tags`, `roles`, `fqdn`, `addresses`, `policy_name` or `policy_group` fields and wil
+match when given partial strings.  The `knife ssh` search term has been similarly extended so that the search API matches in both cases.  The
+node search fuzzifier has also been extracted out to a `fuzz` option to Chef::Search::Query for re-use elsewhere.
+

--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,19 +73,18 @@ class Chef
 
       def run
         read_cli_args
-        fuzzify_query
 
         if @type == "node"
           ui.use_presenter Knife::Core::NodePresenter
         end
 
         q = Chef::Search::Query.new
-        escaped_query = Addressable::URI.encode_component(@query, Addressable::URI::CharacterClasses::QUERY)
 
         result_items = []
         result_count = 0
 
         search_args = Hash.new
+        search_args[:fuzz] = true
         search_args[:start] = config[:start] if config[:start]
         search_args[:rows] = config[:rows] if config[:rows]
         if config[:filter_result]
@@ -95,7 +94,7 @@ class Chef
         end
 
         begin
-          q.search(@type, escaped_query, search_args) do |item|
+          q.search(@type, @query, search_args) do |item|
             formatted_item = Hash.new
             if item.is_a?(Hash)
               # doing a little magic here to set the correct name
@@ -148,12 +147,6 @@ class Chef
             @type = name_args[0]
             @query = name_args[1]
           end
-        end
-      end
-
-      def fuzzify_query
-        if @query !~ /:/
-          @query = "tags:*#{@query}* OR roles:*#{@query}* OR fqdn:*#{@query}* OR addresses:*#{@query}* OR policy_name:*#{@query}* OR policy_group:*#{@query}*"
         end
       end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,7 +223,7 @@ class Chef
         end
 
         @search_count = 0
-        query.search(:node, @name_args[0], filter_result: required_attributes) do |item|
+        query.search(:node, @name_args[0], filter_result: required_attributes, fuzz: true) do |item|
           @search_count += 1
           # we should skip the loop to next iteration if the item
           # returned by the search is nil

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
         validate_type(type)
 
         args_h = hashify_args(*args)
-        if args_h.key?(:fuzz)
+        if args_h[:fuzz]
           if type == :node
             query = fuzzify_node_query(query)
           end

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -235,6 +235,27 @@ describe Chef::Search::Query do
       query.search(:node, "platform:rhel", rows: 4) do |r|
         nil
       end
+    end
+
+    it "fuzzifies node searches when fuzz is set" do
+      expect(rest).to receive(:get).with(
+        "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0"
+      ).and_return(response)
+      query.search(:node, "free.messi", fuzz: true)
+    end
+
+    it "does not fuzzify node searches when fuzz is not set" do
+      expect(rest).to receive(:get).with(
+        "search/node?q=free.messi&start=0"
+      ).and_return(response)
+      query.search(:node, "free.messi")
+    end
+
+    it "does not fuzzify client searches" do
+      expect(rest).to receive(:get).with(
+        "search/client?q=messi&start=0"
+      ).and_return(response)
+      query.search(:client, "messi", fuzz: true)
     end
 
     context "when :filter_result is provided as a result" do


### PR DESCRIPTION
extracts out a common 'fuzz' option to Chef::Search::Query so that anyone can
use it.

closes #3526