### PR TITLE
Chef-13: remove more deprecated method_missing access

### DIFF
--- a/lib/chef/decorator/unchain.rb
+++ b/lib/chef/decorator/unchain.rb
@@ -38,22 +38,6 @@ class Chef
         __path__.push(key)
         @delegate_sd_obj.public_send(__method__, *__path__, value)
       end
-
-      # unfortunately we have to support method_missing for node.set_unless.foo.bar = 'baz' notation
-      def method_missing(symbol, *args)
-        if symbol == :to_ary
-          merged_attributes.send(symbol, *args)
-        elsif args.empty?
-          Chef.deprecated :attributes, %q{method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])}
-          self[symbol]
-        elsif symbol.to_s =~ /=$/
-          Chef.deprecated :attributes, %q{method setting of node attributes (node.foo="bar") is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]="bar")}
-          key_to_set = symbol.to_s[/^(.+)=$/, 1]
-          self[key_to_set] = (args.length == 1 ? args[0] : args)
-        else
-          raise NoMethodError, "Undefined node attribute or method `#{symbol}' on `node'"
-        end
-      end
     end
   end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -265,12 +265,6 @@ describe Chef::Node do
         expect(node[:snoopy][:is_a_puppy]).to eq(true)
       end
 
-      it "should allow you to set an attribute with set_unless with method_missing but emit a deprecation warning" do
-        Chef::Config[:treat_deprecation_warnings_as_errors] = false
-        node.normal_unless.snoopy.is_a_puppy = false
-        expect(node[:snoopy][:is_a_puppy]).to eq(false)
-      end
-
       it "should allow you to set an attribute with set_unless" do
         node.normal_unless[:snoopy][:is_a_puppy] = false
         expect(node[:snoopy][:is_a_puppy]).to eq(false)


### PR DESCRIPTION
removes the `node.set_unless.foo.bar.baz` case