### PR TITLE
Add expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,0 +1,31 @@
+# The name of the product key for this product from mixlib-install
+product_key: chef
+
+# Slack channel in Chef Software slack to send notifications about build failures, etc
+slack:
+  notify_channel: chef-notify
+
+# When a version of ChefDK hits the current channel, build a corresponding Docker image
+# and publish that image to https://hub.docker.com/r/chef/chefdk
+docker:
+  enable: true
+  build_args:
+    CHANNEL: "{{channel}}"
+    VERSION: "{{version}}"
+
+github:
+  # The file where the MAJOR.MINOR.PATCH version is kept
+  version_file: "VERSION"
+
+  # When a PR is merged, bump the PATCH version
+  bump_version_on_merge: true
+
+  # After the PATCH version has been bumped, execute this script
+  # to distribute that version to other files in the repository.
+  update_version_script: ".expeditor/update_version.sh"
+
+  # The tag format Expeditor should use when tagging version commits
+  version_tag_format: "v{{version}}"
+
+  # After the version is bumped and the tag is pushed to Github, trigger a Jenkins build
+  trigger_build_on_bump: true

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# After a PR merge, Chef Expeditor will bump the PATCH version in the VERSION file.
+# It then executes this file to update any other files/components with that new version.
+#
+
+set -evx
+
+# The github-changelog-generator requires that LANG be set
+export LANG=en_US.UTF-8
+
+# Only install groups required to run the Rake command
+export BUNDLE_WITHOUT=omnibus_package:test:pry:integration:docgen:maintenance:travis:aix:bsd:linux:mac_os_x:solaris:windows:development
+
+# We need to run a bundle install so that our `bundle exec rake` command will work.
+gem environment
+omnibus_bundler=$(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+gem install bundler -v $omnibus_bundler --user-install --conservative
+bundle install
+
+# Run a rake command that will update various files in chef/chef-dk with the new VERSION
+bundle exec rake version:update
+
+# Run the following commands to update the changelog and dockerfile, but ignore errors.
+bundle exec rake changelog:update || true
+bundle exec rake update_dockerfile || true
+
+# Our `rake` command can sometimes modify this file, but we don't care about the
+# changes it makes. Reset it to HEAD.
+git checkout .bundle/config
+
+# Once Expeditor finshes executing this script, it will commit the changes and push
+# the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
### Description

Expeditor is the next-generation utility that we'll use for version bumping. It will include additional features that we don't currently have like the ability to not bump a version on a specific PR.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
