### PR TITLE
Chef-13: Remove deprecated Chef::ResourceResolver.resource API

### DIFF
--- a/lib/chef/resource_resolver.rb
+++ b/lib/chef/resource_resolver.rb
@@ -54,11 +54,6 @@ class Chef
     # @api private
     attr_reader :resource_name
     # @api private
-    def resource
-      Chef.deprecated(:custom_resource, "Chef::ResourceResolver.resource deprecated.  Use resource_name instead.")
-      resource_name
-    end
-    # @api private
     attr_reader :action
     # @api private
     attr_reader :canonical


### PR DESCRIPTION
Removes an alias to Chef::ResourceResolver.resource_name

