### PR TITLE
Chef-13: turn on zypper gpg checks by default

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -644,11 +644,10 @@ module ChefConfig
     # generation (server generates client keys).
     default(:local_key_generation) { true }
 
-    # Zypper package provider gpg checks. Set to true to enable package
-    # gpg signature checking. This will be default in the
-    # future. Setting to false disables the warnings.
-    # Leaving this set to nil or false is a security hazard!
-    default :zypper_check_gpg, nil
+    # Zypper package provider gpg checks. Set to false to disable package
+    # gpg signature checking globally.  This will warn you that it is a
+    # bad thing to do.
+    default :zypper_check_gpg, true
 
     # Report Handlers
     default :report_handlers, []

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -48,6 +48,7 @@ class Chef
       configure_chef
       configure_logging
       configure_encoding
+      emit_warnings
     end
 
     # Get this party started
@@ -77,6 +78,10 @@ class Chef
           reconfigure
         end
       end
+    end
+
+    def emit_warnings
+      Chef::Log.warn "Chef::Config[:zypper_check_gpg] is set to false which disables security checking on zypper packages" unless Chef::Config[:zypper_check_gpg]
     end
 
     # Parse configuration (options and config file)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -2,7 +2,7 @@
 #
 # Authors:: Adam Jacob (<adam@chef.io>)
 #           Ionuț Arțăriși (<iartarisi@suse.cz>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 #             Copyright 2013-2016, SUSE Linux GmbH
 # License:: Apache License, Version 2.0
 #
@@ -145,17 +145,7 @@ class Chef
         end
 
         def gpg_checks
-          case Chef::Config[:zypper_check_gpg]
-          when true
-            nil
-          when false
-            "--no-gpg-checks"
-          when nil
-            Chef::Log.warn("Chef::Config[:zypper_check_gpg] was not set. " \
-              "All packages will be installed without gpg signature checks. " \
-              "This is a security hazard.")
-            "--no-gpg-checks"
-          end
+          "--no-gpg-checks" unless new_resource.gpg_check
         end
       end
     end

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -23,6 +23,8 @@ class Chef
     class ZypperPackage < Chef::Resource::Package
       resource_name :zypper_package
       provides :package, platform_family: "suse"
+
+      property :gpg_check, [ TrueClass, FalseClass ], default: lazy { Chef::Config[:zypper_check_gpg] }
     end
   end
 end


### PR DESCRIPTION
Adds a gpg_check property to the resource to turn them off on a
per-resource basis.  The global config is also preserved.  The
global config will warn once if you have it set to turn off
gpg checks.  The per-resource property will not warn (presumably
you know you're doing something bad when you turn it off).

closes #2339 

