### PR TITLE
Chef-13: coerce package options property to an Array

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -52,11 +52,7 @@ class Chef
       end
 
       def options
-        if new_resource.options.is_a?(String)
-          new_resource.options.shellsplit
-        else
-          new_resource.options
-        end
+        new_resource.options
       end
 
       def check_resource_semantics!

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,9 @@ class Chef
         super
         @resource_name = :chocolatey_package
       end
+
+      # windows can't take Array options yet
+      property :options, String
 
       property :package_name, [String, Array], coerce: proc { |x| [x].flatten }
 

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -36,7 +36,7 @@ class Chef
       property :package_name, [ String, Array ], identity: true
 
       property :version, [ String, Array ]
-      property :options, [ String, Array ]
+      property :options, [ String, Array ], coerce: proc { |x| x.is_a?(String) ? x.shellsplit : x }
       property :response_file, String, desired_state: false
       property :response_file_variables, Hash, default: lazy { {} }, desired_state: false
       property :source, String, desired_state: false

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,9 @@ class Chef
         super
         @source ||= source(@package_name) if @package_name.downcase.end_with?(".msi")
       end
+
+      # windows can't take array options yet
+      property :options, String
 
       # Unique to this resource
       property :installer_type, Symbol

--- a/spec/unit/provider/package/windows/msi_spec.rb
+++ b/spec/unit/provider/package/windows/msi_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -61,7 +61,12 @@ describe Chef::Resource::Package do
 
   it "should accept a string for the options" do
     @resource.options "something"
-    expect(@resource.options).to eql("something")
+    expect(@resource.options).to eql(["something"])
+  end
+
+  it "should split options" do
+    @resource.options "-a -b 'arg with spaces' -b \"and quotes\""
+    expect(@resource.options).to eql(["-a", "-b", "arg with spaces", "-b", "and quotes"])
   end
 
   describe "when it has a package_name and version" do
@@ -74,7 +79,7 @@ describe Chef::Resource::Package do
     it "describes its state" do
       state = @resource.state_for_resource_reporter
       expect(state[:version]).to eq("10.9.8")
-      expect(state[:options]).to eq("-al")
+      expect(state[:options]).to eq(["-al"])
     end
 
     it "returns the file path as its identity" do


### PR DESCRIPTION
Windows side we still can't support this kind of API, this
is for Unix-ey stuff.

closes #5763 