### PR TITLE
Chef-13: remove iconv from the chef build

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -182,3 +182,14 @@ the first place (`some_resource "name_two" do ...`)
 
 All the APIs in chef/mixlib/command have been removed.  They were deprecated by mixlib-shellout and the shell_out mixin API.
 
+### Iconv has been removed from the ruby libraries and chef omnibus build
+
+The ruby Iconv library was replaced by the Encoding library in ruby 1.9.x and since the deprecation of ruby 1.8.7 there has been no need
+for the Iconv library but we have carried it forwards as a dependency since removing it might break some chef code out there which used
+this library.  It has now been removed from the ruby build.  This also removes LGPLv3 code from the omnibus build and reduces build
+headaches from porting iconv to every platform we ship chef-client on.
+
+This will also affect nokogiri, but that gem natively supports UTF-8, UTF-16LE/BE, ISO-8851-1(Latin-1), ASCII and "HTML" encodings.  Users
+who really need to write something like Shift-JIS inside of XML will need to either maintain their own nokogiri installs or will need to
+convert to using UTF-8.
+

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: bc08deef668865990bde3a0f0dc1ef3c3f5be735
+  revision: fee8dea479123a3b19b14244eeee0f8e36579107
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -38,13 +38,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.8.1)
     awesome_print (1.7.0)
-    aws-sdk (2.8.14)
-      aws-sdk-resources (= 2.8.14)
-    aws-sdk-core (2.8.14)
+    aws-sdk (2.9.1)
+      aws-sdk-resources (= 2.9.1)
+    aws-sdk-core (2.9.1)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.14)
-      aws-sdk-core (= 2.8.14)
+    aws-sdk-resources (2.9.1)
+      aws-sdk-core (= 2.9.1)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)

--- a/omnibus/config/software/chef.rb
+++ b/omnibus/config/software/chef.rb
@@ -26,7 +26,6 @@ end
 # For nokogiri
 dependency "libxml2"
 dependency "libxslt"
-dependency "libiconv"
 dependency "liblzma"
 dependency "zlib"
 

--- a/omnibus/files/chef-gem/build-chef-gem.rb
+++ b/omnibus/files/chef-gem/build-chef-gem.rb
@@ -99,7 +99,7 @@ module BuildChefGem
         --with-xml2-include=#{Shellwords.escape("#{install_dir}/embedded/include/libxml2")}
         --with-xslt-lib=#{Shellwords.escape("#{install_dir}/embedded/lib")}
         --with-xslt-include=#{Shellwords.escape("#{install_dir}/embedded/include/libxslt")}
-        --with-iconv-dir=#{Shellwords.escape("#{install_dir}/embedded")}
+        --without-iconv-dir
         --with-zlib-dir=#{Shellwords.escape("#{install_dir}/embedded")}
       }.join(" "),
     }


### PR DESCRIPTION
pulls in chef/omnibus-software#806 and removes iconv from both
nokogiri and ruby.

ruby hasn't needed iconv since 1.9.x and everyone should be using
the Encoding library by now.

nokogiri will lose support for things like Shift-JIS inside of XML
but UTF-8, UTF-16LE/BE, ISO-8851-1(Latin-1), ASCII and "HTML" encoding
are all supported by nokogiri natively.  if users need more they need
to be maintaining their own nokogiri installs and accept the
maintenance costs themselves.
