### PR TITLE
Chef-13:  tweaks to rubygems source option for urls

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -240,3 +240,16 @@ mutable default value, define it inside a `lazy{}` helper like:
 ```ruby
 property :x, default: lazy { {} }
 ```
+
+### Rubygems provider sources behavior changed.
+
+The default behavior of the `gem_package` and `chef_gem` resources is now to inherit whatever settings are in the external environment
+that chef is running in.  Chef no longer forces `https://rubygems.org`.  The `Chef::Config[:rubygems_uri]` default has been changed to
+nil.  It can now be set to either a string URI or to an array of string URIs.  The behavior of setting the source on an individual
+resource now overrides the source setting completely and does not inherit the global setting.
+
+Users that previously relied on the source setting always being additive to "https://rubygmes.org" will find that they need to use
+the array form and explicitly add "https://rubygems.org" to their resources.  Users can now more easily remove "https://rubygems.org"
+either globally or on a resource case-by-case basis.
+
+The behavior of the `clear_sources` property is now to only add `--clear-sources` and has no side effects on the source options.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1050,7 +1050,8 @@ module ChefConfig
     # break Chef community cookbooks and is very highly discouraged.
     default :ruby_encoding, Encoding::UTF_8
 
-    default :rubygems_url, "https://rubygems.org"
+    # can be set to a string or array of strings for URIs to set as rubygems sources
+    default :rubygems_url, nil
 
     # If installed via an omnibus installer, this gives the path to the
     # "embedded" directory which contains all of the software packaged with

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2010-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,9 @@ class Chef
           begin
             Dir.mktmpdir("chef-gem-bundle") do |dir|
               File.open("#{dir}/Gemfile", "w+") do |tf|
-                tf.puts "source '#{Chef::Config[:rubygems_url]}'"
+                Array(Chef::Config[:rubygems_url] || "https://www.rubygems.org").each do |s|
+                  tf.puts "source '#{s}'"
+                end
                 cookbook_gems.each do |gem_name, args|
                   tf.puts "gem(*#{([gem_name] + args).inspect})"
                 end

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -423,6 +423,7 @@ class Chef
 
         def source_is_remote?
           return true if new_resource.source.nil?
+          return true if new_resource.source.is_a?(Array)
           scheme = URI.parse(new_resource.source).scheme
           # URI.parse gets confused by MS Windows paths with forward slashes.
           scheme = nil if scheme =~ /^[a-z]$/
@@ -469,7 +470,8 @@ class Chef
         end
 
         def gem_sources
-          new_resource.source ? Array(new_resource.source) : nil
+          srcs = new_resource.source || Chef::Config[:rubygems_url]
+          srcs ? Array(srcs) : nil
         end
 
         def load_current_resource

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,17 @@ class Chef
     class GemPackage < Chef::Resource::Package
       resource_name :gem_package
 
+      # the source can either be a path to a package source like:
+      #   source /var/tmp/mygem-1.2.3.4.gem
+      # or it can be a url rubygems source like:
+      #   https://www.rubygems.org
+      # the default has to be nil in order for the magical wiring up of the name property to
+      # the source pathname to work correctly.
+      #
+      # we don't do coercions here because its all a bit too complicated
+      #
+      # FIXME? the array form of installing paths most likely does not work?
+      #
       property :source, [ String, Array ]
       property :clear_sources, [ true, false ], default: false, desired_state: false
       # Sets a custom gem_binary to run for gem commands.

--- a/spec/unit/cookbook/gem_installer_spec.rb
+++ b/spec/unit/cookbook/gem_installer_spec.rb
@@ -67,4 +67,19 @@ describe Chef::Cookbook::GemInstaller do
 
     expect(bundler_dsl.dependencies.find { |d| d.name == "httpclient" }.requirements_list.length).to eql(2)
   end
+
+  it "generates a valid Gemfile when Chef::Config[:rubygems_url] is set to a String" do
+    Chef::Config[:rubygems_url] = "https://www.rubygems.org"
+    expect { gem_installer.install }.to_not raise_error
+
+    expect(bundler_dsl.dependencies.find { |d| d.name == "httpclient" }.requirements_list.length).to eql(2)
+  end
+
+  it "generates a valid Gemfile when Chef::Config[:rubygems_url] is set to an Array" do
+    Chef::Config[:rubygems_url] = [ "https://www.rubygems.org" ]
+
+    expect { gem_installer.install }.to_not raise_error
+
+    expect(bundler_dsl.dependencies.find { |d| d.name == "httpclient" }.requirements_list.length).to eql(2)
+  end
 end

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -638,7 +638,7 @@ describe Chef::Provider::Package::Rubygems do
           let(:gem_binary) { "/foo/bar" }
 
           it "installs the gem with rubygems.org as an added source" do
-            expected = "#{gem_binary} install rspec-core -q --no-rdoc --no-ri -v \"#{target_version}\" --source=#{source} --source=https://rubygems.org"
+            expected = "#{gem_binary} install rspec-core -q --no-rdoc --no-ri -v \"#{target_version}\" --source=#{source}"
             expect(provider).to receive(:shell_out!).with(expected, env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action


### PR DESCRIPTION
By default now we don't pass any --source option or set the
`Chef::Config[:rubygems_url]` to anything.  This is so that
if there is external config for rubygems sources we will simply
have rubygems pick it up and use it (the resource acts like
the command line).

There is also no more magic around `--clear-sources` and if you
set the property it sets the flag.

If the `Chef::Config[:rubygems_url]` setting is set then that
becomes the default `--source` flag sent to the command.  This
also supports Arrays now.

If the `source` option is set to a URI (it can also be set to a
filesystem path for poorly-designed-API reasons) then we do not
use the default values at all.  This may be an API break but this
much more clearly allows users to override individual resources
and is more declarative.  You get what you type.

