### PR TITLE
RFC 59: Load Ohai plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,12 +12,12 @@ source "https://rubygems.org"
 gem "chef", path: "."
 
 # tracking master of ohai for chef-13.0 development, this should be able to be deleted after release
-gem "ohai", git: "https://github.com/chef/ohai.git"
+gem "ohai", git: "https://github.com/chef/ohai.git", branch: "tm/load_additional_plugins"
 
 gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.exist?(File.expand_path("../chef-config", __FILE__))
 gem "rake"
 gem "bundler"
-gem "cheffish", "~> 13" # required for rspec tests
+gem "cheffish", "~> 13", git: "https://github.com/chef/cheffish.git", branch: "tm/ohai_run_context"# required for rspec tests
 
 group(:omnibus_package) do
   gem "appbundler"

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "tm/load_additional
 gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.exist?(File.expand_path("../chef-config", __FILE__))
 gem "rake"
 gem "bundler"
-gem "cheffish", "~> 13", git: "https://github.com/chef/cheffish.git", branch: "tm/ohai_run_context"# required for rspec tests
+gem "cheffish", "~> 13", git: "https://github.com/chef/cheffish.git", branch: "tm/ohai_run_context" # required for rspec tests
 
 group(:omnibus_package) do
   gem "appbundler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,15 @@ GIT
       rspec_junit_formatter (~> 0.2)
 
 GIT
+  remote: https://github.com/chef/cheffish.git
+  revision: d088e7a10b4289cfb1410b92388e8bc5972a6be2
+  branch: tm/ohai_run_context
+  specs:
+    cheffish (13.0.0)
+      chef-zero (~> 13.0)
+      net-ssh
+
+GIT
   remote: https://github.com/chef/chefstyle.git
   revision: b2bf89dd11270e169fd2315495c98095d4a19090
   branch: master
@@ -37,7 +46,8 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 58296dc0035e4f94a7b7cdc1db01887a3c3c1e30
+  revision: 0b4cab6d491a5b1e52995a65e0039c6fa1ba8e9f
+  branch: tm/load_additional_plugins
   specs:
     ohai (13.0.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
@@ -228,9 +238,6 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    cheffish (13.0.0)
-      chef-zero (~> 13.0)
-      net-ssh
     chefspec (5.4.0)
       chef (>= 12.0)
       fauxhai (~> 3.6)
@@ -571,7 +578,7 @@ DEPENDENCIES
   chef!
   chef-config!
   chef-sugar
-  cheffish (~> 13)
+  cheffish (~> 13)!
   chefspec
   chefstyle!
   cucumber (>= 2.4.0)

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -450,6 +450,10 @@ module ChefConfig
     # most of our testing scenarios)
     default :minimal_ohai, false
 
+    # When consuming Ohai plugins from cookbook segments, we place those plugins in this directory.
+    # Subsequent chef client runs will wipe and re-populate the directory to ensure cleanliness
+    default(:ohai_segment_plugin_path) { PathHelper.join(config_dir, "ohai", "cookbook_plugins") }
+
     ###
     # Policyfile Settings
     #

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -522,7 +522,7 @@ class Chef
     # @api private
     #
     def policy_builder
-      @policy_builder ||= Chef::PolicyBuilder::Dynamic.new(node_name, ohai.data, json_attribs, override_runlist, events)
+      @policy_builder ||= Chef::PolicyBuilder::Dynamic.new(node_name, ohai, json_attribs, override_runlist, events)
     end
 
     #

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -179,6 +179,22 @@ class Chef
       def library_load_complete
       end
 
+      # Called when an ohai plugin file loading starts
+      def ohai_plugin_load_start(file_count)
+      end
+
+      # Called when an ohai plugin file has been loaded
+      def ohai_plugin_file_loaded(path)
+      end
+
+      # Called when an ohai plugin file has an error on load.
+      def ohai_plugin_file_load_failed(path, exception)
+      end
+
+      # Called when an ohai plugin file loading has finished
+      def ohai_plugin_load_complete
+      end
+
       # Called when LWRP loading starts
       def lwrp_load_start(lwrp_file_count)
       end

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -329,13 +329,16 @@ class Chef
     def consume_external_attrs(ohai_data, json_cli_attrs)
       Chef::Log.debug("Extracting run list from JSON attributes provided on command line")
       consume_attributes(json_cli_attrs)
-
       self.automatic_attrs = ohai_data
 
       platform, version = Chef::Platform.find_platform_and_version(self)
       Chef::Log.debug("Platform is #{platform} version #{version}")
       automatic[:platform] = platform
       automatic[:platform_version] = version
+    end
+
+    def consume_ohai_data(ohai_data)
+      self.automatic_attrs = Chef::Mixin::DeepMerge.merge(automatic_attrs, ohai_data)
     end
 
     # Consumes the combined run_list and other attributes in +attrs+

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -35,16 +35,16 @@ class Chef
 
       attr_reader :node
       attr_reader :node_name
-      attr_reader :ohai_data
+      attr_reader :ohai
       attr_reader :json_attribs
       attr_reader :override_runlist
       attr_reader :events
 
-      def initialize(node_name, ohai_data, json_attribs, override_runlist, events)
+      def initialize(node_name, ohai, json_attribs, override_runlist, events)
         @implementation = nil
 
+        @ohai = ohai
         @node_name = node_name
-        @ohai_data = ohai_data
         @json_attribs = json_attribs
         @override_runlist = override_runlist
         @events = events
@@ -152,9 +152,9 @@ class Chef
             policyfile_attribs_in_node_json? ||
             node_has_policyfile_attrs?(node) ||
             policyfile_compat_mode_config?
-          @implementation = Policyfile.new(node_name, ohai_data, json_attribs, override_runlist, events)
+          @implementation = Policyfile.new(node_name, ohai, json_attribs, override_runlist, events)
         else
-          @implementation = ExpandNodeObject.new(node_name, ohai_data, json_attribs, override_runlist, events)
+          @implementation = ExpandNodeObject.new(node_name, ohai, json_attribs, override_runlist, events)
         end
       end
 

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -68,6 +68,10 @@ class Chef
         Chef.set_run_context(run_context)
       end
 
+      def ohai_data
+        @ohai.data
+      end
+
       def setup_run_context(specific_recipes = nil)
         if Chef::Config[:solo_legacy_mode]
           Chef::Cookbook::FileVendor.fetch_from_disk(Chef::Config[:cookbook_path])

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -41,15 +41,15 @@ class Chef
       attr_reader :events
       attr_reader :node
       attr_reader :node_name
-      attr_reader :ohai_data
+      attr_reader :ohai
       attr_reader :json_attribs
       attr_reader :override_runlist
       attr_reader :run_context
       attr_reader :run_list_expansion
 
-      def initialize(node_name, ohai_data, json_attribs, override_runlist, events)
+      def initialize(node_name, ohai, json_attribs, override_runlist, events)
         @node_name = node_name
-        @ohai_data = ohai_data
+        @ohai = ohai
         @json_attribs = json_attribs
         @override_runlist = override_runlist
         @events = events
@@ -77,7 +77,7 @@ class Chef
           cookbook_collection.validate!
           cookbook_collection.install_gems(events)
 
-          run_context = Chef::RunContext.new(node, cookbook_collection, @events)
+          run_context = Chef::RunContext.new(node, cookbook_collection, @events, ohai)
         else
           Chef::Cookbook::FileVendor.fetch_from_remote(api_service)
           cookbook_hash = sync_cookbooks
@@ -85,7 +85,7 @@ class Chef
           cookbook_collection.validate!
           cookbook_collection.install_gems(events)
 
-          run_context = Chef::RunContext.new(node, cookbook_collection, @events)
+          run_context = Chef::RunContext.new(node, cookbook_collection, @events, ohai)
         end
 
         # TODO: this is really obviously not the place for this

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -98,6 +98,10 @@ class Chef
         nil
       end
 
+      def ohai_data
+        @ohai.data
+      end
+
       # Policyfile gives you the run_list already expanded, but users of this
       # class may expect to get a run_list expansion compatible object by
       # calling this method.

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -56,13 +56,13 @@ class Chef
       attr_reader :events
       attr_reader :node
       attr_reader :node_name
-      attr_reader :ohai_data
+      attr_reader :ohai
       attr_reader :json_attribs
       attr_reader :run_context
 
-      def initialize(node_name, ohai_data, json_attribs, override_runlist, events)
+      def initialize(node_name, ohai, json_attribs, override_runlist, events)
         @node_name = node_name
-        @ohai_data = ohai_data
+        @ohai = ohai
         @json_attribs = json_attribs
         @events = events
 
@@ -128,7 +128,7 @@ class Chef
         # determine which versions of cookbooks to use.
         node.reset_defaults_and_overrides
 
-        node.consume_external_attrs(ohai_data, json_attribs)
+        node.consume_external_attrs(ohai.data, json_attribs)
 
         expand_run_list
         apply_policyfile_attributes
@@ -155,7 +155,7 @@ class Chef
         cookbook_collection.validate!
         cookbook_collection.install_gems(events)
 
-        run_context = Chef::RunContext.new(node, cookbook_collection, events)
+        run_context = Chef::RunContext.new(node, cookbook_collection, events, ohai)
 
         setup_chef_class(run_context)
 

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -149,6 +149,7 @@ class Chef
     #
     attr_reader :delayed_actions
 
+    attr_reader :ohai
     # Creates a new Chef::RunContext object and populates its fields. This object gets
     # used by the Chef Server to generate a fully compiled recipe list for a node.
     #
@@ -158,10 +159,11 @@ class Chef
     # @param events [EventDispatch::Dispatcher] The event dispatcher for this
     #   run.
     #
-    def initialize(node, cookbook_collection, events)
+    def initialize(node, cookbook_collection, events, ohai)
       @node = node
       @cookbook_collection = cookbook_collection
       @events = events
+      @ohai = ohai
 
       node.run_context = self
       node.set_cookbook_attribute
@@ -603,6 +605,7 @@ ERROR_MESSAGE
         loaded_recipes
         loaded_recipes_hash
         node
+        ohai
         open_stream
         reboot_info
         reboot_info=

--- a/spec/functional/resource/base.rb
+++ b/spec/functional/resource/base.rb
@@ -23,6 +23,6 @@ def run_context
     node.default[:platform_version] = ohai[:platform_version]
     node.default[:os] = ohai[:os]
     events = Chef::EventDispatch::Dispatcher.new
-    Chef::RunContext.new(node, {}, events)
+    Chef::RunContext.new(node, {}, events, Ohai::System.new)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -196,7 +196,7 @@ RSpec.configure do |config|
     node = TEST_NODE.dup
     resource_class = Chef::ResourceResolver.resolve(type, node: node)
     if resource_class
-      resource = resource_class.new("test", Chef::RunContext.new(node, nil, nil))
+      resource = resource_class.new("test", Chef::RunContext.new(node, nil, nil, Ohai::System.new))
       begin
         provider = resource.provider_for_action(Array(resource_class.default_action).first)
         provider.class != target_provider


### PR DESCRIPTION
*Minimum Viable Ohai Plugins*

This adds a new phase in the compilation of the run context, and bubbles
up the ohai object from the client to the run_context.

We definitely need some discussion about the changes to the run context
and having the full ohai object in so many places, and
`consume_ohai_data` also would benefit from careful review.

cc @chef/maintainers