### PR TITLE
RFC 59 - Load ohai plugins

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 6bb6e8cf30118b104dbcffaea17ffb1644aee2cc
+  revision: daeb73c1089d8b611bc5fde3bfddddad28f304eb
   specs:
     ohai (13.0.0)
       chef-config (>= 12.5.0.alpha.1, < 14)

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -450,6 +450,10 @@ module ChefConfig
     # most of our testing scenarios)
     default :minimal_ohai, false
 
+    # When consuming Ohai plugins from cookbook segments, we place those plugins in this directory.
+    # Subsequent chef client runs will wipe and re-populate the directory to ensure cleanliness
+    default(:ohai_segment_plugin_path) { PathHelper.join(config_dir, "ohai", "cookbook_plugins") }
+
     ###
     # Policyfile Settings
     #

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -195,6 +195,22 @@ class Chef
       def lwrp_load_complete
       end
 
+      # Called when an ohai plugin file loading starts
+      def ohai_plugin_load_start(file_count)
+      end
+
+      # Called when an ohai plugin file has been loaded
+      def ohai_plugin_file_loaded(path)
+      end
+
+      # Called when an ohai plugin file has an error on load.
+      def ohai_plugin_file_load_failed(path, exception)
+      end
+
+      # Called when an ohai plugin file loading has finished
+      def ohai_plugin_load_complete
+      end
+
       # Called before attribute files are loaded
       def attribute_load_start(attribute_file_count)
       end

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -338,6 +338,10 @@ class Chef
       automatic[:platform_version] = version
     end
 
+    def consume_ohai_data(ohai_data)
+      self.automatic_attrs = Chef::Mixin::DeepMerge.merge(automatic_attrs, ohai_data)
+    end
+
     # Consumes the combined run_list and other attributes in +attrs+
     def consume_attributes(attrs)
       normal_attrs_to_merge = consume_run_list(attrs)


### PR DESCRIPTION
RFC 59 - Load ohai plugins, take 2. This just uses a new ohai system context to run all the plugins.

replaces #6007