### PR TITLE
Have knife cookbook generate use SPDX standard license strings

### DIFF
--- a/acceptance/data-collector/.acceptance/data-collector-test/metadata.rb
+++ b/acceptance/data-collector/.acceptance/data-collector-test/metadata.rb
@@ -1,7 +1,7 @@
 name 'data-collector-test'
 maintainer 'Adam Leff'
 maintainer_email 'adamleff@chef.io'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs/Configures data-collector-test'
 long_description 'Installs/Configures data-collector-test'
 version '0.1.0'

--- a/lib/chef/knife/cookbook_create.rb
+++ b/lib/chef/knife/cookbook_create.rb
@@ -418,11 +418,11 @@ EOH
 
         license_name = case license
                        when "apachev2"
-                         "Apache 2.0"
+                         "Apache-2.0"
                        when "gplv2"
-                         "GNU Public License 2.0"
+                         "GPL-2.0"
                        when "gplv3"
-                         "GNU Public License 3.0"
+                         "GPL-3.0"
                        when "mit"
                          "MIT"
                        when "none"


### PR DESCRIPTION
We’re trying to get everything to use these so we can have standardized values in Supermarket. All Rights Reserved is clearly not a standard license and that’s just life.

Signed-off-by: Tim Smith <tsmith@chef.io>