### PR TITLE
Chef-13: better solution to gem_package source issues

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -243,16 +243,19 @@ property :x, default: lazy { {} }
 
 ### Rubygems provider sources behavior changed.
 
-The default behavior of the `gem_package` and `chef_gem` resources is now to inherit whatever settings are in the external environment
-that chef is running in.  Chef no longer forces `https://rubygems.org`.  The `Chef::Config[:rubygems_uri]` default has been changed to
-nil.  It can now be set to either a string URI or to an array of string URIs.  The behavior of setting the source on an individual
-resource now overrides the source setting completely and does not inherit the global setting.
+The behavior of `gem_package` and `chef_gem` is now to always apply the `Chef::Config[:rubygems_uri]` sources, which may be a
+String uri or an Array of Strings.  If additional sources are put on the resource with the `source` property those are added
+to the configured `:rubygems_uri` sources.
 
-Users that previously relied on the source setting always being additive to "https://rubygmes.org" will find that they need to use
-the array form and explicitly add "https://rubygems.org" to their resources.  Users can now more easily remove "https://rubygems.org"
-either globally or on a resource case-by-case basis.
+This should enable easier setup of rubygems mirrors particularly in "airgapped" environments through the use of the global config
+variable.  It also means that an admin may force all rubygems.org traffic to an internal mirror, while still being able to
+consume external cookbooks which have resources which add other mirrors unchanged (in a non-airgapped environment).
 
-The behavior of the `clear_sources` property is now to only add `--clear-sources` and has no side effects on the source options.
+In the case where a resource must force the use of only the specified source(s), then the `include_default_source` property
+has been added -- setting it to false will remove the `Chef::Config[:rubygems_url]` setting from the list of sources for
+that resource.
+
+The behavior of the `clear_sources` property is now to only add `--clear-sources` and has no magic side effects on the source options.
 
 ### `knife cookbook site vendor` has been removed
 

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1055,7 +1055,7 @@ module ChefConfig
     default :ruby_encoding, Encoding::UTF_8
 
     # can be set to a string or array of strings for URIs to set as rubygems sources
-    default :rubygems_url, nil
+    default :rubygems_url, "https://www.rubygems.org"
 
     # If installed via an omnibus installer, this gives the path to the
     # "embedded" directory which contains all of the software packaged with

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -470,8 +470,9 @@ class Chef
         end
 
         def gem_sources
-          srcs = new_resource.source || Chef::Config[:rubygems_url]
-          srcs ? Array(srcs) : nil
+          srcs = [ new_resource.source ]
+          srcs << Chef::Config[:rubygems_url] if new_resource.include_default_source
+          srcs.flatten.compact
         end
 
         def load_current_resource
@@ -540,10 +541,7 @@ class Chef
             name = new_resource.source
           else
             src << "--clear-sources" if new_resource.clear_sources
-            srcarry = [ new_resource.source || Chef::Config[:rubygems_url] ].flatten.compact
-            srcarry.each do |s|
-              src << "--source=#{s}"
-            end
+            src += gem_sources.map { |s| "--source=#{s}" }
           end
           src_str = src.empty? ? "" : " #{src.join(" ")}"
           if !version.nil? && !version.empty?

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -39,6 +39,9 @@ class Chef
       # Sets a custom gem_binary to run for gem commands.
       property :gem_binary, String, desired_state: false
 
+      # set to false to avoid including Chef::Config[:rubygems_url] in the sources
+      property :include_default_source, [ TrueClass, FalseClass ], default: true
+
       ##
       # Options for the gem install, either a Hash or a String. When a hash is
       # given, the options are passed to Gem::DependencyInstaller.new, and the


### PR DESCRIPTION
I think this is better

- Chef::Config[:rubygems_uri] is nearly always applied (but
  could be set to nil if someone really wanted to opt-out)
- the per-resources sources are additive on top of the
  global config (lets cookbooks be additive to global config
  rather than override it by default).
- there's a new flag for if you want to opt-out of the global
  config completely on a per-resource basis.

So I think this gets the most commmon and the next most common
use cases correct, while still allow people with arbitrarily
crazy needs to write resources that do it.

The RELEASE_NOTES also have somewhat better user stories in them,
which I think suggests that I'm on the right track here.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>
