### PR TITLE
server enforced required recipe

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -280,6 +280,8 @@ class Chef
 
         run_context = setup_run_context
 
+        load_required_recipe(@rest, run_context) unless Chef::Config[:solo_legacy_mode]
+
         if Chef::Config[:audit_mode] != :audit_only
           converge_error = converge_and_save(run_context)
         end
@@ -512,6 +514,51 @@ class Chef
       assert_cookbook_path_not_empty(run_context)
       run_status.run_context = run_context
       run_context
+    end
+
+    #
+    # Adds a required recipe as specified by the Chef Server
+    #
+    # @return The modified run context
+    #
+    # @api private
+    #
+    # TODO: @rest doesn't appear to be used anywhere outside
+    # of client.register except for here. If it's common practice
+    # to create your own rest client, perhaps we should do that
+    # here but it seems more appropriate to reuse one that we
+    # know is already created. for ease of testing, we'll pass
+    # the existing rest client in as a parameter
+    #
+    def load_required_recipe(rest, run_context)
+      begin
+        required_recipe_contents = rest.get("required_recipe")
+        Chef::FileCache.store("required_recipe", required_recipe_contents)
+        required_recipe_file = Chef::FileCache.load("required_recipe", false)
+
+        # TODO: add integration tests with resource reporting turned on
+        #       (presumably requires changes to chef-zero)
+        #
+        # Chef::Recipe.new takes a cookbook name and a recipe name along
+        # with the run context. These names are eventually used in the
+        # resource reporter, and if the cookbook name cannot be found in the
+        # cookbook collection then we will fail with an exception. Cases where
+        # we currently also fail:
+        #   - specific recipes
+        #   - chef-apply would fail if resource reporting was enabled
+        #
+        recipe = Chef::Recipe.new(nil, nil, run_context)
+        recipe.from_file(required_recipe_file)
+        run_context
+      rescue Net::HTTPServerException => e
+        case e.response
+        when Net::HTTPNotFound
+          Chef::Log.info("Required Recipe not found")
+        else
+          raise
+        end
+      end
+
     end
 
     #

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -531,34 +531,31 @@ class Chef
     # the existing rest client in as a parameter
     #
     def load_required_recipe(rest, run_context)
-      begin
-        required_recipe_contents = rest.get("required_recipe")
-        Chef::FileCache.store("required_recipe", required_recipe_contents)
-        required_recipe_file = Chef::FileCache.load("required_recipe", false)
+      required_recipe_contents = rest.get("required_recipe")
+      Chef::FileCache.store("required_recipe", required_recipe_contents)
+      required_recipe_file = Chef::FileCache.load("required_recipe", false)
 
-        # TODO: add integration tests with resource reporting turned on
-        #       (presumably requires changes to chef-zero)
-        #
-        # Chef::Recipe.new takes a cookbook name and a recipe name along
-        # with the run context. These names are eventually used in the
-        # resource reporter, and if the cookbook name cannot be found in the
-        # cookbook collection then we will fail with an exception. Cases where
-        # we currently also fail:
-        #   - specific recipes
-        #   - chef-apply would fail if resource reporting was enabled
-        #
-        recipe = Chef::Recipe.new(nil, nil, run_context)
-        recipe.from_file(required_recipe_file)
-        run_context
-      rescue Net::HTTPServerException => e
-        case e.response
-        when Net::HTTPNotFound
-          Chef::Log.info("Required Recipe not found")
-        else
-          raise
-        end
+      # TODO: add integration tests with resource reporting turned on
+      #       (presumably requires changes to chef-zero)
+      #
+      # Chef::Recipe.new takes a cookbook name and a recipe name along
+      # with the run context. These names are eventually used in the
+      # resource reporter, and if the cookbook name cannot be found in the
+      # cookbook collection then we will fail with an exception. Cases where
+      # we currently also fail:
+      #   - specific recipes
+      #   - chef-apply would fail if resource reporting was enabled
+      #
+      recipe = Chef::Recipe.new(nil, nil, run_context)
+      recipe.from_file(required_recipe_file)
+      run_context
+    rescue Net::HTTPServerException => e
+      case e.response
+      when Net::HTTPNotFound
+        Chef::Log.info("Required Recipe not found")
+      else
+        raise
       end
-
     end
 
     #

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -592,4 +592,27 @@ EOM
       expect(command.stdout).not_to include("INFO")
     end
   end
+
+  context "when connected to a Chef Server" do
+
+    let(:chef_client_cmd) { "#{chef_client} -c #{path_to('config/client.rb')}" }
+
+    before do
+      directory "config"
+      directory "cache"
+
+      file "config/client.rb", <<EOM
+chef_server_url "http://localhost:8900"
+cache_path "#{path_to("cache")}"
+client_key "#{path_to("config/client.pem")}"
+EOM
+    end
+
+    when_the_chef_server "is empty with a basic config" do
+      it "a chef-client run should succeed" do
+        result = shell_out(chef_client_cmd)
+        result.error!
+      end
+    end
+  end
 end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -592,27 +592,4 @@ EOM
       expect(command.stdout).not_to include("INFO")
     end
   end
-
-  context "when connected to a Chef Server" do
-
-    let(:chef_client_cmd) { "#{chef_client} -c #{path_to('config/client.rb')}" }
-
-    before do
-      directory "config"
-      directory "cache"
-
-      file "config/client.rb", <<EOM
-chef_server_url "http://localhost:8900"
-cache_path "#{path_to("cache")}"
-client_key "#{path_to("config/client.pem")}"
-EOM
-    end
-
-    when_the_chef_server "is empty with a basic config" do
-      it "a chef-client run should succeed" do
-        result = shell_out(chef_client_cmd)
-        result.error!
-      end
-    end
-  end
 end

--- a/spec/support/shared/context/client.rb
+++ b/spec/support/shared/context/client.rb
@@ -135,6 +135,12 @@ shared_context "a client run" do
       and_return({})
   end
 
+  def stub_for_required_recipe
+    response = Net::HTTPNotFound.new("1.1", "404", "Not Found")
+    exception = Net::HTTPServerException.new('404 "Not Found"', response)
+    expect(http_node_load).to receive(:get).with("required_recipe").and_raise(exception)
+  end
+
   def stub_for_converge
     # define me
   end
@@ -165,6 +171,7 @@ shared_context "a client run" do
     stub_for_data_collector_init
     stub_for_node_load
     stub_for_sync_cookbooks
+    stub_for_required_recipe
     stub_for_converge
     stub_for_audit
     stub_for_node_save

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -398,11 +398,11 @@ describe Chef::Client do
     let(:rest)        { double("Chef::ServerAPI (required recipe)") }
     let(:run_context) { double("Chef::RunContext") }
     let(:recipe)      { double("Chef::Recipe (required recipe)") }
-    let(:required_recipe) {
+    let(:required_recipe) do
       <<EOM
 fake_recipe_variable = "for reals"
 EOM
-    }
+    end
 
     context "when required_recipe is configured" do
 
@@ -417,11 +417,11 @@ EOM
       end
 
       context "when the required_recipe has bad contents" do
-        let(:required_recipe) {
+        let(:required_recipe) do
           <<EOM
 this is not a recipe
 EOM
-        }
+        end
         it "should not raise an error" do
           expect { client.load_required_recipe(rest, run_context) }.not_to raise_error()
         end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -394,6 +394,55 @@ describe Chef::Client do
     end
   end
 
+  describe "load_required_recipe" do
+    let(:rest)        { double("Chef::ServerAPI (required recipe)") }
+    let(:run_context) { double("Chef::RunContext") }
+    let(:recipe)      { double("Chef::Recipe (required recipe)") }
+    let(:required_recipe) {
+      <<EOM
+fake_recipe_variable = "for reals"
+EOM
+    }
+
+    context "when required_recipe is configured" do
+
+      before(:each) do
+        expect(rest).to receive(:get).with("required_recipe").and_return(required_recipe)
+        expect(Chef::Recipe).to receive(:new).with(nil, nil, run_context).and_return(recipe)
+        expect(recipe).to receive(:from_file)
+      end
+
+      it "fetches the recipe and adds it to the run context" do
+        client.load_required_recipe(rest, run_context)
+      end
+
+      context "when the required_recipe has bad contents" do
+        let(:required_recipe) {
+          <<EOM
+this is not a recipe
+EOM
+        }
+        it "should not raise an error" do
+          expect { client.load_required_recipe(rest, run_context) }.not_to raise_error()
+        end
+      end
+    end
+
+    context "when required_recipe returns 404" do
+      let(:http_response) { Net::HTTPNotFound.new("1.1", "404", "Not Found") }
+      let(:http_exception) { Net::HTTPServerException.new('404 "Not Found"', http_response) }
+
+      before(:each) do
+        expect(rest).to receive(:get).with("required_recipe").and_raise(http_exception)
+      end
+
+      it "should log and continue on" do
+        expect(Chef::Log).to receive(:info)
+        client.load_required_recipe(rest, run_context)
+      end
+    end
+  end
+
   describe "windows_admin_check" do
     context "platform is not windows" do
       before do


### PR DESCRIPTION
when the chef-server is configured to serve a requried recipe,
chef-client shall load the recipe into the run context and
execute it as part of the converge phase.

if the chef-server is NOT configured, it will return a 404 and
chef-client will continue normally.

Signed-off-by: Stephen Delano <stephen@chef.io>

### Description

See above.

See also:
* https://github.com/chef/chef-rfc/pull/258
* https://github.com/chef/chef-server/pull/1214

### Issues Resolved

* https://github.com/chef/chef-rfc/pull/258

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
