### PR TITLE
Chef-13: restore log_location in client.rb

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -280,20 +280,7 @@ is sent to a pipe.  The logger needs to be specifically requested with `--force-
 
 The `--force-formatter` option does still exist, although it will probably be deprecated in the future.
 
-Setting the `log_location` in the config.rb now applies to both daemonized and command-line invocation and there is
-no magic which dups the logger in order to log to STDOUT on the command line in that case.
-
-Setting logger settings in config.rb is most likely no longer appropriate and those settings should be changed to
-command line flags on the config script or cronjob that invokes chef-client daemonized.  In other words:
-
-```
-chef-client -d -L /var/log/client.rb --force-logger
-```
-
 If your logfiles switch to the formatter, you need to include `--force-logger` for your daemonized runs.
-
-If your command line invocations have no output, delete the config.rb setting for the log_location and move that
-to the command line that invokes your daemon process.
 
 Redirecting output to a file with `chef-client > /tmp/chef.out` now captures the same output as invoking it directly on the command
 line with no redirection.

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -241,11 +241,26 @@ class Chef
 
       def configure_logging
         Chef::Log.init(MonoLogger.new(resolve_log_location))
+        if want_additional_logger?
+          configure_stdout_logger
+        end
         Chef::Log.level = resolve_log_level
       end
 
+      def configure_stdout_logger
+        stdout_logger = MonoLogger.new(STDOUT)
+        stdout_logger.formatter = Chef::Log.logger.formatter
+        Chef::Log.loggers << stdout_logger
+      end
+
+      # Based on config and whether or not STDOUT is a tty, should we setup a
+      # secondary logger for stdout?
+      def want_additional_logger?
+        ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && !Chef::Config[:daemonize]
+      end
+
       # Use of output formatters is assumed if `force_formatter` is set or if
-      # `force_logger` is not set and STDOUT is to a console (tty)
+      # `force_logger` is not set
       def using_output_formatter?
         Chef::Config[:force_formatter] || !Chef::Config[:force_logger]
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -188,7 +188,7 @@ describe Chef::Application do
         @monologger = double("Monologger")
         expect(MonoLogger).to receive(:new).with(Chef::Config[:log_location]).and_return(@monologger)
         allow(MonoLogger).to receive(:new).with(STDOUT).and_return(@monologger)
-        expect(@monologger).to receive(:formatter=).with(Chef::Log.logger.formatter)
+        allow(@monologger).to receive(:formatter=).with(Chef::Log.logger.formatter)
         expect(Chef::Log).to receive(:init).with(@monologger)
         @app.configure_logging
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -187,7 +187,7 @@ describe Chef::Application do
         allow(Chef::Log).to receive(:level=)
         @monologger = double("Monologger")
         expect(MonoLogger).to receive(:new).with(Chef::Config[:log_location]).and_return(@monologger)
-        expect(MonoLogger).to receive(:new).with(STDOUT).and_return(@monologger)
+        allow(MonoLogger).to receive(:new).with(STDOUT).and_return(@monologger)
         expect(@monologger).to receive(:formatter=).with(Chef::Log.logger.formatter)
         expect(Chef::Log).to receive(:init).with(@monologger)
         @app.configure_logging

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -187,6 +187,8 @@ describe Chef::Application do
         allow(Chef::Log).to receive(:level=)
         @monologger = double("Monologger")
         expect(MonoLogger).to receive(:new).with(Chef::Config[:log_location]).and_return(@monologger)
+        expect(MonoLogger).to receive(:new).with(STDOUT).and_return(@monologger)
+        expect(@monologger).to receive(:formatter=).with(Chef::Log.logger.formatter)
         expect(Chef::Log).to receive(:init).with(@monologger)
         @app.configure_logging
       end


### PR DESCRIPTION
This backs out a bit of #5851 that was probably too aggressive.