### PR TITLE
Clarify log messaging for required recipe feature

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -532,6 +532,7 @@ class Chef
     #
     def load_required_recipe(rest, run_context)
       required_recipe_contents = rest.get("required_recipe")
+      Chef::Log.info("Required Recipe found, loading it")
       Chef::FileCache.store("required_recipe", required_recipe_contents)
       required_recipe_file = Chef::FileCache.load("required_recipe", false)
 
@@ -552,7 +553,7 @@ class Chef
     rescue Net::HTTPServerException => e
       case e.response
       when Net::HTTPNotFound
-        Chef::Log.info("Required Recipe not found")
+        Chef::Log.debug("Required Recipe not configured on the server, skipping it")
       else
         raise
       end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -437,7 +437,7 @@ EOM
       end
 
       it "should log and continue on" do
-        expect(Chef::Log).to receive(:info)
+        expect(Chef::Log).to receive(:debug)
         client.load_required_recipe(rest, run_context)
       end
     end


### PR DESCRIPTION
The previous log message didn't have enough context and could sound
"scary" to users unfamiliar with the feature.

Signed-off-by: Daniel DeLeo <dan@chef.io>

### Description

Adds more context to the log message that's emitted when the 'required recipe' feature isn't enabled, to make it sound less scary.

Before: `[timestamp] INFO: Required Recipe not found`
Now: `[timestamp] DEBUG: Required Recipe not configured on the server, skipping it`

The message was also moved to debug as it unlikely to be useful information most of the time.

Additionally, an info message was added for the case that the required recipe is configured.

### Issues Resolved

Issue was reported in Chef's slack channel, no ticket.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>