### PR TITLE
Ensure the gem binary is installed on windows

### DIFF
--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/destroy.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/destroy.rb
@@ -1,1 +1,1 @@
-#kitchen "destroy"
+kitchen "destroy"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/provision.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/provision.rb
@@ -1,1 +1,1 @@
-#kitchen "converge"
+kitchen "converge"

--- a/acceptance/fips/.acceptance/acceptance-cookbook/recipes/verify.rb
+++ b/acceptance/fips/.acceptance/acceptance-cookbook/recipes/verify.rb
@@ -1,1 +1,1 @@
-#kitchen "verify"
+kitchen "verify"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "tm/copy_ruby_bins"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software"
 gem "license_scout", git: "https://github.com/chef/license_scout"
 
 gem "pedump"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "tm/copy_ruby_bins"
 gem "license_scout", git: "https://github.com/chef/license_scout"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -25,8 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 23d2dd83dd55b6d0260b1a48160b018157db7cd9
-  branch: tm/copy_ruby_bins
+  revision: cae44c1a3ebf7207516813ba15b372231c253954
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: 2cf81860f92d4f2df4444341048b8aeec2da0cfa
+  revision: ff3cb28159e72414d63008f9a0d42e85d4aec4ba
   specs:
-    license_scout (0.1.2)
+    license_scout (0.1.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: dae5821c972ad37716f852767bc8ec7919730600
+  revision: ffbda9ad7d37ddb485342505ff4407c6ff23d95f
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -25,7 +25,8 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 7a9182b313ca767a0d286e0db337cc61a6e621a3
+  revision: 23d2dd83dd55b6d0260b1a48160b018157db7cd9
+  branch: tm/copy_ruby_bins
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -38,13 +39,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.8.1)
     awesome_print (1.7.0)
-    aws-sdk (2.9.3)
-      aws-sdk-resources (= 2.9.3)
-    aws-sdk-core (2.9.3)
+    aws-sdk (2.9.7)
+      aws-sdk-resources (= 2.9.7)
+    aws-sdk-core (2.9.7)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.3)
-      aws-sdk-core (= 2.9.3)
+    aws-sdk-resources (2.9.7)
+      aws-sdk-core (= 2.9.7)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -113,12 +114,12 @@ GEM
     iostruct (0.0.4)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.0.3)
+    json (2.0.4)
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     little-plugger (1.1.4)
-    logging (2.2.0)
+    logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.8.2)
@@ -150,7 +151,7 @@ GEM
       net-ssh (>= 2.6.5)
     nio4r (2.0.0)
     nori (2.6.0)
-    octokit (4.6.2)
+    octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (8.23.0)
       chef-config (>= 12.5.0.alpha.1, < 13)


### PR DESCRIPTION
`gem` has mysteriously disappeared on Windows. Our hero is venturing on to the dark paths to hunt down the missing command, and coax it lovingly in to returning to the light of a chef release.

Bug #6049 has the gory details