### PR TITLE
Clean up more stubbed properties in tests

### DIFF
--- a/lib/chef/resource/env.rb
+++ b/lib/chef/resource/env.rb
@@ -20,46 +20,14 @@
 class Chef
   class Resource
     class Env < Chef::Resource
-
-      identity_attr :key_name
-
-      state_attrs :value
-
       provides :env, os: "windows"
 
       default_action :create
       allowed_actions :create, :delete, :modify
 
-      def initialize(name, run_context = nil)
-        super
-        @key_name = name
-        @value = nil
-        @delim = nil
-      end
-
-      def key_name(arg = nil)
-        set_or_return(
-          :key_name,
-          arg,
-          :kind_of => [ String ]
-        )
-      end
-
-      def value(arg = nil)
-        set_or_return(
-          :value,
-          arg,
-          :kind_of => [ String ]
-        )
-      end
-
-      def delim(arg = nil)
-        set_or_return(
-          :delim,
-          arg,
-          :kind_of => [ String ]
-        )
-      end
+      property :key_name, String, identity: true, name_property: true
+      property :value, String, required: true
+      property :delim, [ String, nil, false ], desired_state: false
     end
   end
 end

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -22,116 +22,22 @@ require "chef/resource"
 class Chef
   class Resource
     class Route < Chef::Resource
-      identity_attr :target
-
-      state_attrs :netmask, :gateway
-
       default_action :add
       allowed_actions :add, :delete
 
-      def initialize(name, run_context = nil)
-        super
-        @target = name
-        @netmask = nil
-        @gateway = nil
-        @metric = nil
-        @device = nil
-        @route_type = :host
-        @networking = nil
-        @networking_ipv6 = nil
-        @hostname = nil
-        @domainname = nil
-        @domain = nil
-      end
+      property :target, String, identity: true, name_property: true
+      property :netmask, [String, nil]
+      property :gateway, [String, nil]
+      property :device, [String, nil], desired_state: false # Has a partial default in the provider of eth0.
+      property :route_type, [:host, :net], default: :host, coerce: proc { |x| x.to_sym }, desired_state: false
 
-      def networking(arg = nil)
-        set_or_return(
-          :networking,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def networking_ipv6(arg = nil)
-        set_or_return(
-          :networking_ipv6,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def hostname(arg = nil)
-        set_or_return(
-          :hostname,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def domainname(arg = nil)
-        set_or_return(
-          :domainname,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def domain(arg = nil)
-        set_or_return(
-          :domain,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def target(arg = nil)
-        set_or_return(
-          :target,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def netmask(arg = nil)
-        set_or_return(
-          :netmask,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def gateway(arg = nil)
-        set_or_return(
-          :gateway,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def metric(arg = nil)
-        set_or_return(
-          :metric,
-          arg,
-          :kind_of => Integer
-        )
-      end
-
-      def device(arg = nil)
-        set_or_return(
-          :device,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def route_type(arg = nil)
-        real_arg = arg.kind_of?(String) ? arg.to_sym : arg
-        set_or_return(
-          :route_type,
-          real_arg,
-          :equal_to => [ :host, :net ]
-        )
-      end
+      # I can find no evidence of these properties actually being used by Chef. NK 2017-04-11
+      property :networking, [String, nil], desired_state: false
+      property :networking_ipv6, [String, nil], desired_state: false
+      property :hostname, [String, nil], desired_state: false
+      property :domainname, [String, nil], desired_state: false
+      property :domain, [String, nil], desired_state: false
+      property :metric, [Integer, nil], desired_state: false
     end
   end
 end

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -78,7 +78,7 @@ class Chef
         set_or_return(
           :start_command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, NilClass, FalseClass ]
         )
       end
 
@@ -87,7 +87,7 @@ class Chef
         set_or_return(
           :stop_command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, NilClass, FalseClass ]
         )
       end
 
@@ -96,7 +96,7 @@ class Chef
         set_or_return(
           :status_command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, NilClass, FalseClass ]
         )
       end
 
@@ -105,7 +105,7 @@ class Chef
         set_or_return(
           :restart_command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, NilClass, FalseClass ]
         )
       end
 
@@ -113,7 +113,7 @@ class Chef
         set_or_return(
           :reload_command,
           arg,
-          :kind_of => [ String ]
+          :kind_of => [ String, NilClass, FalseClass ]
         )
       end
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -62,19 +62,21 @@ class Chef
         )
       end
 
-      def uid(arg = nil)
+      def uid(arg = Chef::NOT_PASSED)
         set_or_return(
           :uid,
           arg,
-          :kind_of => [ String, Integer ]
+          :kind_of => [ String, Integer, NilClass ],
+          :coerce => proc {|x| x || nil }
         )
       end
 
-      def gid(arg = nil)
+      def gid(arg = Chef::NOT_PASSED)
         set_or_return(
           :gid,
           arg,
-          :kind_of => [ String, Integer ]
+          :kind_of => [ String, Integer, NilClass ],
+          :coerce => proc {|x| x || nil }
         )
       end
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -67,7 +67,7 @@ class Chef
           :uid,
           arg,
           :kind_of => [ String, Integer, NilClass ],
-          :coerce => proc {|x| x || nil }
+          :coerce => proc { |x| x || nil }
         )
       end
 
@@ -76,7 +76,7 @@ class Chef
           :gid,
           arg,
           :kind_of => [ String, Integer, NilClass ],
-          :coerce => proc {|x| x || nil }
+          :coerce => proc { |x| x || nil }
         )
       end
 

--- a/spec/functional/resource/registry_spec.rb
+++ b/spec/functional/resource/registry_spec.rb
@@ -124,7 +124,7 @@ describe Chef::Resource::RegistryKey, :windows_only, :broken => true do
 
     @new_resource.cookbook_name = "monkey"
     @cookbook_version = double("Cookbook::Version", :version => "1.2.3")
-    allow(@new_resource).to receive(:cookbook_version).and_return(@cookbook_version)
+    @new_resource.cookbook_version(@cookbook_version)
   end
 
   after (:all) do

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -75,9 +75,9 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       end
 
       it "should set the option for #{attribute} if the new resources #{attribute} is not nil, without homedir management (using real attributes)" do
-        allow(@new_resource).to receive(:manage_home).and_return(false)
-        allow(@new_resource).to receive(:non_unique).and_return(false)
-        allow(@new_resource).to receive(:non_unique).and_return(false)
+        @new_resource.manage_home(false)
+        @new_resource.non_unique(false)
+        @new_resource.non_unique(false)
         allow(@new_resource).to receive(attribute).and_return("hola")
         expect(provider.universal_options).to eql([option, "hola"])
       end

--- a/spec/unit/provider/env_spec.rb
+++ b/spec/unit/provider/env_spec.rb
@@ -183,12 +183,12 @@ describe Chef::Provider::Env do
     end
 
     it "should return true if the element is not found" do
-      allow(@new_resource).to receive(:value).and_return("C:/baz/bin")
+      @new_resource.value("C:/baz/bin")
       expect(@provider.delete_element).to eql(true)
     end
 
     it "should return false if the delim not defined" do
-      allow(@new_resource).to receive(:delim).and_return(nil)
+      @new_resource.delim(nil)
       expect(@provider.delete_element).to eql(false)
     end
 

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -182,8 +182,8 @@ describe Chef::Provider::Group::Dscl do
 
     describe "with existing members in the current resource and append set to false in the new resource" do
       before do
-        allow(@new_resource).to receive(:members).and_return([])
-        allow(@new_resource).to receive(:append).and_return(false)
+        @new_resource.members([])
+        @new_resource.append(false)
         allow(@current_resource).to receive(:members).and_return(%w{all your base})
       end
 

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -77,7 +77,7 @@ describe Chef::Provider::Group::Pw do
 
     describe "with an empty members array in both the new and current resource" do
       before do
-        allow(@new_resource).to receive(:members).and_return([])
+        @new_resource.members([])
         allow(@current_resource).to receive(:members).and_return([])
       end
 
@@ -88,7 +88,7 @@ describe Chef::Provider::Group::Pw do
 
     describe "with an empty members array in the new resource and existing members in the current resource" do
       before do
-        allow(@new_resource).to receive(:members).and_return([])
+        @new_resource.members([])
         allow(@current_resource).to receive(:members).and_return(%w{all your base})
       end
 
@@ -104,7 +104,7 @@ describe Chef::Provider::Group::Pw do
 
     describe "with supplied members array in the new resource and an empty members array in the current resource" do
       before do
-        allow(@new_resource).to receive(:members).and_return(%w{all your base})
+        @new_resource.members(%w{all your base})
         allow(@current_resource).to receive(:members).and_return([])
       end
 

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -34,8 +34,8 @@ describe Chef::Provider::Group::Usermod do
 
     describe "with an empty members array" do
       before do
-        allow(@new_resource).to receive(:append).and_return(true)
-        allow(@new_resource).to receive(:members).and_return([])
+        @new_resource.append(true)
+        @new_resource.members([])
       end
 
       it "should log an appropriate message" do
@@ -56,7 +56,7 @@ describe Chef::Provider::Group::Usermod do
       }
 
       before do
-        allow(@new_resource).to receive(:members).and_return(%w{all your base})
+        @new_resource.members(%w{all your base})
         allow(File).to receive(:exist?).and_return(true)
       end
 
@@ -73,8 +73,8 @@ describe Chef::Provider::Group::Usermod do
         @provider.load_current_resource
         @provider.instance_variable_set("@group_exists", true)
         @provider.action = :modify
-        allow(@new_resource).to receive(:append).and_return(true)
-        allow(@new_resource).to receive(:excluded_members).and_return(["someone"])
+        @new_resource.append(true)
+        @new_resource.excluded_members(["someone"])
         expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "excluded_members is not supported by #{@provider}")
       end
 
@@ -84,7 +84,7 @@ describe Chef::Provider::Group::Usermod do
           current_resource.members([ ])
           @provider.current_resource = current_resource
           @node.automatic_attrs[:platform] = platform
-          allow(@new_resource).to receive(:append).and_return(true)
+          @new_resource.append(true)
           expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "all")
           expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "your")
           expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "base")

--- a/spec/unit/provider/group/windows_spec.rb
+++ b/spec/unit/provider/group/windows_spec.rb
@@ -62,19 +62,19 @@ describe Chef::Provider::Group::Windows do
     end
 
     it "should call @net_group.local_set_members" do
-      allow(@new_resource).to receive(:append).and_return(false)
+      @new_resource.append(false)
       expect(@net_group).to receive(:local_set_members).with(@new_resource.members)
       @provider.manage_group
     end
 
     it "should call @net_group.local_add_members" do
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       expect(@net_group).to receive(:local_add_members).with(@new_resource.members)
       @provider.manage_group
     end
 
     it "should call @net_group.local_delete_members" do
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       allow(@provider).to receive(:lookup_account_name).with("all").and_return("all")
       expect(@net_group).to receive(:local_delete_members).with(@new_resource.excluded_members)
       @provider.manage_group

--- a/spec/unit/provider/group_spec.rb
+++ b/spec/unit/provider/group_spec.rb
@@ -103,26 +103,26 @@ describe Chef::Provider::User do
 
     it "should return false if append is true and the group member(s) already exists" do
       @current_resource.members << "extra_user"
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       expect(@provider.compare_group).to be_falsey
     end
 
     it "should return true if append is true and the group member(s) do not already exist" do
       @new_resource.members << "extra_user"
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       expect(@provider.compare_group).to be_truthy
     end
 
     it "should return false if append is true and excluded_members include a non existing member" do
       @new_resource.excluded_members << "extra_user"
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       expect(@provider.compare_group).to be_falsey
     end
 
     it "should return true if the append is true and excluded_members include an existing user" do
       @new_resource.members.each { |m| @new_resource.excluded_members << m }
       @new_resource.members.clear
-      allow(@new_resource).to receive(:append).and_return(true)
+      @new_resource.append(true)
       expect(@provider.compare_group).to be_truthy
     end
 

--- a/spec/unit/provider/http_request_spec.rb
+++ b/spec/unit/provider/http_request_spec.rb
@@ -73,7 +73,7 @@ describe Chef::Provider::HttpRequest do
       end
 
       it "should inflate a message block at runtime" do
-        allow(@new_resource).to receive(:message).and_return(lambda { "return" })
+        @new_resource.message(lambda { "return" })
         expect(@http).to receive(:put).with("http://www.opscode.com/", "return", {})
         @provider.run_action(:put)
         expect(@new_resource).to be_updated

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -163,7 +163,7 @@ describe Chef::Provider::Package::Aix do
     end
 
     it "should run installp with -eLogfile option." do
-      allow(@new_resource).to receive(:options).and_return("-e/tmp/installp.log")
+      @new_resource.options("-e/tmp/installp.log")
       expect(@provider).to receive(:shell_out!).with("installp", "-aYF", "-e/tmp/installp.log", "-d", "/tmp/samba.base", "samba.base", timeout: 900)
       @provider.install_package("samba.base", "3.3.12.0")
     end
@@ -176,7 +176,7 @@ describe Chef::Provider::Package::Aix do
     end
 
     it "should run installp -u -e/tmp/installp.log  with options -e/tmp/installp.log" do
-      allow(@new_resource).to receive(:options).and_return("-e/tmp/installp.log")
+      @new_resource.options("-e/tmp/installp.log")
       expect(@provider).to receive(:shell_out!).with("installp", "-u", "-e/tmp/installp.log", "samba.base", timeout: 900)
       @provider.remove_package("samba.base", "3.3.12.0")
     end

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -217,8 +217,8 @@ mpg123 1.12.1-0ubuntu1
           @new_resource = Chef::Resource::AptPackage.new("irssi", @run_context)
           @provider = Chef::Provider::Package::Apt.new(@new_resource, @run_context)
 
-          allow(@new_resource).to receive(:default_release).and_return("lenny-backports")
-          allow(@new_resource).to receive(:provider).and_return(nil)
+          @new_resource.default_release("lenny-backports")
+          @new_resource.provider(nil)
           expect(@provider).to receive(:shell_out!).with(
             "apt-cache", "-o", "APT::Default-Release=lenny-backports", "policy", "irssi",
             :env => { "DEBIAN_FRONTEND" => "noninteractive" },

--- a/spec/unit/provider/package/ips_spec.rb
+++ b/spec/unit/provider/package/ips_spec.rb
@@ -134,7 +134,7 @@ INSTALLED
 
     it "raises an error if package fails to install" do
       expect(@provider).to receive(:shell_out!).with("pkg", "--no-refresh", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
-      allow(@new_resource).to receive(:options).and_return("--no-refresh")
+      @new_resource.options("--no-refresh")
       expect { @provider.install_package("crypto/gnupg", "2.0.17") }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 

--- a/spec/unit/provider/package/ips_spec.rb
+++ b/spec/unit/provider/package/ips_spec.rb
@@ -201,7 +201,7 @@ REMOTE
 
     context "when accept_license is true" do
       before do
-        allow(@new_resource).to receive(:accept_license).and_return(true)
+        @new_resource.accept_license(true)
       end
 
       it "should run pkg install with the --accept flag" do

--- a/spec/unit/provider/package/macports_spec.rb
+++ b/spec/unit/provider/package/macports_spec.rb
@@ -121,7 +121,7 @@ EOF
     it "should add options to the port command when specified" do
       expect(@current_resource).to receive(:version).and_return("4.1.6")
       @provider.current_resource = @current_resource
-      allow(@new_resource).to receive(:options).and_return("-f")
+      @new_resource.options("-f")
       expect(@provider).to receive(:shell_out!).with("port", "-f", "install", "zsh", "@4.2.7", timeout: 900)
 
       @provider.install_package("zsh", "4.2.7")
@@ -140,7 +140,7 @@ EOF
     end
 
     it "should add options to the port command when specified" do
-      allow(@new_resource).to receive(:options).and_return("-f")
+      @new_resource.options("-f")
       expect(@provider).to receive(:shell_out!).with("port", "-f", "uninstall", "zsh", "@4.2.7", timeout: 900)
       @provider.purge_package("zsh", "4.2.7")
     end
@@ -158,7 +158,7 @@ EOF
     end
 
     it "should add options to the port command when specified" do
-      allow(@new_resource).to receive(:options).and_return("-f")
+      @new_resource.options("-f")
       expect(@provider).to receive(:shell_out!).with("port", "-f", "deactivate", "zsh", "@4.2.7", timeout: 900)
       @provider.remove_package("zsh", "4.2.7")
     end
@@ -191,7 +191,7 @@ EOF
     end
 
     it "should add options to the port command when specified" do
-      allow(@new_resource).to receive(:options).and_return("-f")
+      @new_resource.options("-f")
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.1.6")
       @provider.current_resource = @current_resource
 

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -157,7 +157,7 @@ PACMAN_CONF
 
     it "should run pacman install with the package name and version and options if specified" do
       expect(@provider).to receive(:shell_out!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
-      allow(@new_resource).to receive(:options).and_return("--debug")
+      @new_resource.options("--debug")
 
       @provider.install_package("nano", "1.0")
     end
@@ -178,7 +178,7 @@ PACMAN_CONF
 
     it "should run pacman remove with the package name and options if specified" do
       expect(@provider).to receive(:shell_out!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
-      allow(@new_resource).to receive(:options).and_return("--debug")
+      @new_resource.options("--debug")
 
       @provider.remove_package("nano", "1.0")
     end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -527,7 +527,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum localinstall if given a path to an rpm" do
-      allow(@new_resource).to receive(:source).and_return("/tmp/emacs-21.4-20.el5.i386.rpm")
+      @new_resource.source("/tmp/emacs-21.4-20.el5.i386.rpm")
       expect(@provider).to receive(:yum_command).with(
         "-d0 -e0 -y localinstall /tmp/emacs-21.4-20.el5.i386.rpm"
       )
@@ -546,7 +546,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum install with the package name, version and arch" do
-      allow(@new_resource).to receive(:arch).and_return("i386")
+      @new_resource.arch("i386")
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       @provider.load_current_resource
       expect(@provider).to receive(:yum_command).with(
@@ -584,7 +584,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should raise an exception if candidate version is older than the installed version and allow_downgrade is false" do
-      allow(@new_resource).to receive(:allow_downgrade).and_return(false)
+      @new_resource.allow_downgrade(false)
       @yum_cache = double(
         "Chef::Provider::Yum::YumCache",
         :reload_installed => true,
@@ -627,7 +627,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum downgrade if candidate version is older than the installed version and allow_downgrade is true" do
-      allow(@new_resource).to receive(:allow_downgrade).and_return(true)
+      @new_resource.allow_downgrade(true)
       @yum_cache = double(
         "Chef::Provider::Yum::YumCache",
         :reload_installed => true,
@@ -651,7 +651,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum install then flush the cache if :after is true" do
-      allow(@new_resource).to receive(:flush_cache).and_return({ :after => true, :before => false })
+      @new_resource.flush_cache({ :after => true, :before => false })
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
@@ -662,7 +662,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum install then not flush the cache if :after is false" do
-      allow(@new_resource).to receive(:flush_cache).and_return({ :after => false, :before => false })
+      @new_resource.flush_cache({ :after => false, :before => false })
       @provider.load_current_resource
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
@@ -758,7 +758,7 @@ describe Chef::Provider::Package::Yum do
     end
 
     it "should run yum remove with the package name and arch" do
-      allow(@new_resource).to receive(:arch).and_return("x86_64")
+      @new_resource.arch("x86_64")
       expect(@provider).to receive(:yum_command).with(
         "-d0 -e0 -y remove emacs-1.0.x86_64"
       )
@@ -2145,8 +2145,8 @@ describe "Chef::Provider::Package::Yum - Multi" do
 
   describe "when evaluating the correctness of the resource" do
     it "raises an error if the array lengths of package name, arch, and version do not match up" do
-      allow(@new_resource).to receive(:version).and_return(["1.1"])
-      allow(@new_resource).to receive(:arch).and_return(%w{x86_64 i386 i686})
+      @new_resource.version(["1.1"])
+      @new_resource.arch(%w{x86_64 i386 i686})
       expect { @provider.check_resource_semantics! }.to raise_error(Chef::Exceptions::InvalidResourceSpecification)
     end
   end
@@ -2245,7 +2245,7 @@ describe "Chef::Provider::Package::Yum - Multi" do
 
     it "should run yum install with the package name, version and arch" do
       @provider.load_current_resource
-      allow(@new_resource).to receive(:arch).and_return(%w{i386 i386})
+      @new_resource.arch(%w{i386 i386})
       allow(Chef::Provider::Package::Yum::RPMUtils).to receive(:rpmvercmp).and_return(-1)
       expect(@provider).to receive(:yum_command).with(
         "-d0 -e0 -y install cups-1.2.4-11.19.el5.i386 vim-1.0.i386"

--- a/spec/unit/provider/route_spec.rb
+++ b/spec/unit/provider/route_spec.rb
@@ -144,12 +144,12 @@ describe Chef::Provider::Route do
 
   describe Chef::Provider::Route, "generate_command for action_add" do
     it "should include a netmask when a one is specified" do
-      allow(@new_resource).to receive(:netmask).and_return("255.255.0.0")
+      @new_resource.netmask("255.255.0.0")
       expect(@provider.generate_command(:add).join(" ")).to match(/\/\d{1,2}/)
     end
 
     it "should not include a netmask when a one is specified" do
-      allow(@new_resource).to receive(:netmask).and_return(nil)
+      @new_resource.netmask(nil)
       expect(@provider.generate_command(:add).join(" ")).not_to match(/\/\d{1,2}/)
     end
 
@@ -158,19 +158,19 @@ describe Chef::Provider::Route do
     end
 
     it "should not include ' via $gateway ' when a gateway is not specified" do
-      allow(@new_resource).to receive(:gateway).and_return(nil)
+      @new_resource.gateway(nil)
       expect(@provider.generate_command(:add).join(" ")).not_to match(/\svia\s#{Regexp.escape(@new_resource.gateway.to_s)}/)
     end
   end
 
   describe Chef::Provider::Route, "generate_command for action_delete" do
     it "should include a netmask when a one is specified" do
-      allow(@new_resource).to receive(:netmask).and_return("255.255.0.0")
+      @new_resource.netmask("255.255.0.0")
       expect(@provider.generate_command(:delete).join(" ")).to match(/\/\d{1,2}/)
     end
 
     it "should not include a netmask when a one is specified" do
-      allow(@new_resource).to receive(:netmask).and_return(nil)
+      @new_resource.netmask(nil)
       expect(@provider.generate_command(:delete).join(" ")).not_to match(/\/\d{1,2}/)
     end
 
@@ -179,14 +179,14 @@ describe Chef::Provider::Route do
     end
 
     it "should not include ' via $gateway ' when a gateway is not specified" do
-      allow(@new_resource).to receive(:gateway).and_return(nil)
+      @new_resource.gateway(nil)
       expect(@provider.generate_command(:delete).join(" ")).not_to match(/\svia\s#{Regexp.escape(@new_resource.gateway.to_s)}/)
     end
   end
 
   describe Chef::Provider::Route, "config_file_contents for action_add" do
     it "should include a netmask when a one is specified" do
-      allow(@new_resource).to receive(:netmask).and_return("255.255.0.0")
+      @new_resource.netmask("255.255.0.0")
       expect(@provider.config_file_contents(:add, target: @new_resource.target, netmask: @new_resource.netmask)).to match(/\/\d{1,2}.*\n$/)
     end
 

--- a/spec/unit/provider/service/arch_service_spec.rb
+++ b/spec/unit/provider/service/arch_service_spec.rb
@@ -221,7 +221,7 @@ RUNNING_PS
       # end
 
       it "should call the start command if one is specified" do
-        allow(@new_resource).to receive(:start_command).and_return("/etc/rc.d/chef startyousillysally")
+        @new_resource.start_command("/etc/rc.d/chef startyousillysally")
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef startyousillysally")
         @provider.start_service()
       end
@@ -247,7 +247,7 @@ RUNNING_PS
       # end
 
       it "should call the stop command if one is specified" do
-        allow(@new_resource).to receive(:stop_command).and_return("/etc/rc.d/chef itoldyoutostop")
+        @new_resource.stop_command("/etc/rc.d/chef itoldyoutostop")
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef itoldyoutostop")
         @provider.stop_service()
       end
@@ -274,13 +274,13 @@ RUNNING_PS
       # end
 
       it "should call 'restart' on the service_name if the resource supports it" do
-        allow(@new_resource).to receive(:supports).and_return({ :restart => true })
+        @new_resource.supports({ :restart => true })
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} restart")
         @provider.restart_service()
       end
 
       it "should call the restart_command if one has been specified" do
-        allow(@new_resource).to receive(:restart_command).and_return("/etc/rc.d/chef restartinafire")
+        @new_resource.restart_command("/etc/rc.d/chef restartinafire")
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} restartinafire")
         @provider.restart_service()
       end
@@ -309,13 +309,13 @@ RUNNING_PS
       # end
 
       it "should call 'reload' on the service if it supports it" do
-        allow(@new_resource).to receive(:supports).and_return({ :reload => true })
+        @new_resource.supports({ :reload => true })
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} reload")
         @provider.reload_service()
       end
 
       it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
-        allow(@new_resource).to receive(:reload_command).and_return("/etc/rc.d/chef lollerpants")
+        @new_resource.reload_command("/etc/rc.d/chef lollerpants")
         expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} lollerpants")
         @provider.reload_service()
       end

--- a/spec/unit/provider/service/init_service_spec.rb
+++ b/spec/unit/provider/service/init_service_spec.rb
@@ -83,7 +83,7 @@ PS
 
   describe "when a status command has been specified" do
     before do
-      allow(@new_resource).to receive(:status_command).and_return("/etc/init.d/chefhasmonkeypants status")
+      @new_resource.status_command("/etc/init.d/chefhasmonkeypants status")
     end
 
     it "should run the services status command if one has been specified" do
@@ -95,7 +95,7 @@ PS
 
   describe "when an init command has been specified" do
     before do
-      allow(@new_resource).to receive(:init_command).and_return("/opt/chef-server/service/erchef")
+      @new_resource.init_command("/opt/chef-server/service/erchef")
       @provider = Chef::Provider::Service::Init.new(@new_resource, @run_context)
     end
 

--- a/spec/unit/provider/service/invokercd_service_spec.rb
+++ b/spec/unit/provider/service/invokercd_service_spec.rb
@@ -83,7 +83,7 @@ PS
 
   describe "when a status command has been specified" do
     before do
-      allow(@new_resource).to receive(:status_command).and_return("/usr/sbin/invoke-rc.d chefhasmonkeypants status")
+      @new_resource.status_command("/usr/sbin/invoke-rc.d chefhasmonkeypants status")
     end
 
     it "should run the services status command if one has been specified" do

--- a/spec/unit/provider/service/simple_service_spec.rb
+++ b/spec/unit/provider/service/simple_service_spec.rb
@@ -106,7 +106,7 @@ NOMOCKINGSTRINGSPLZ
 
   describe "when starting the service" do
     it "should call the start command if one is specified" do
-      allow(@new_resource).to receive(:start_command).and_return("#{@new_resource.start_command}")
+      @new_resource.start_command("#{@new_resource.start_command}")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("#{@new_resource.start_command}")
       @provider.start_service()
     end

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -194,7 +194,7 @@ describe Chef::Provider::Service::Upstart do
 
     describe "when a status command has been specified" do
       before do
-        allow(@new_resource).to receive(:status_command).and_return("/bin/chefhasmonkeypants status")
+        @new_resource.status_command("/bin/chefhasmonkeypants status")
       end
 
       it "should run the services status command if one has been specified" do
@@ -266,7 +266,7 @@ describe Chef::Provider::Service::Upstart do
 
     it "should call the start command if one is specified" do
       @provider.upstart_service_running = false
-      allow(@new_resource).to receive(:start_command).and_return("/sbin/rsyslog startyousillysally")
+      @new_resource.start_command("/sbin/rsyslog startyousillysally")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog startyousillysally")
       @provider.start_service()
     end
@@ -294,7 +294,7 @@ describe Chef::Provider::Service::Upstart do
 
     it "should call the restart command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      allow(@new_resource).to receive(:restart_command).and_return("/sbin/rsyslog restartyousillysally")
+      @new_resource.restart_command("/sbin/rsyslog restartyousillysally")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog restartyousillysally")
       @provider.restart_service()
     end
@@ -316,7 +316,7 @@ describe Chef::Provider::Service::Upstart do
 
     it "should call the reload command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      allow(@new_resource).to receive(:reload_command).and_return("/sbin/rsyslog reloadyousillysally")
+      @new_resource.reload_command("/sbin/rsyslog reloadyousillysally")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog reloadyousillysally")
       @provider.reload_service()
     end
@@ -329,7 +329,7 @@ describe Chef::Provider::Service::Upstart do
 
     it "should call the stop command if one is specified" do
       @provider.upstart_service_running = true
-      allow(@new_resource).to receive(:stop_command).and_return("/sbin/rsyslog stopyousillysally")
+      @new_resource.stop_command("/sbin/rsyslog stopyousillysally")
       expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog stopyousillysally")
       @provider.stop_service()
     end

--- a/spec/unit/provider/service_spec.rb
+++ b/spec/unit/provider/service_spec.rb
@@ -123,7 +123,7 @@ describe Chef::Provider::Service do
 
     it "should raise an exception if reload isn't supported" do
       @new_resource.supports(:reload => false)
-      allow(@new_resource).to receive(:reload_command).and_return(false)
+      @new_resource.reload_command(false)
       expect { @provider.run_action(:reload) }.to raise_error(Chef::Exceptions::UnsupportedAction)
     end
 

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -160,7 +160,7 @@ describe Chef::Provider::User::Pw do
 
     describe "and the new password has not been specified" do
       before(:each) do
-        allow(@new_resource).to receive(:password).and_return(nil)
+        @new_resource.password(nil)
       end
 
       it "logs an appropriate message" do
@@ -170,19 +170,19 @@ describe Chef::Provider::User::Pw do
 
     describe "and the new password has been specified" do
       before(:each) do
-        allow(@new_resource).to receive(:password).and_return("abracadabra")
+        @new_resource.password("abracadabra")
       end
 
       it "should check for differences in password between the new and current resources" do
         expect(@current_resource).to receive(:password)
-        expect(@new_resource).to receive(:password)
+        expect(@new_resource).to receive(:password).and_call_original.at_least(:once)
         @provider.modify_password
       end
     end
 
     describe "and the passwords are identical" do
       before(:each) do
-        allow(@new_resource).to receive(:password).and_return("abracadabra")
+        @new_resource.password("abracadabra")
         allow(@current_resource).to receive(:password).and_return("abracadabra")
       end
 
@@ -193,7 +193,7 @@ describe Chef::Provider::User::Pw do
 
     describe "and the passwords are different" do
       before(:each) do
-        allow(@new_resource).to receive(:password).and_return("abracadabra")
+        @new_resource.password("abracadabra")
         allow(@current_resource).to receive(:password).and_return("sesame")
       end
 

--- a/spec/unit/provider/user_spec.rb
+++ b/spec/unit/provider/user_spec.rb
@@ -129,7 +129,7 @@ describe Chef::Provider::User do
     end
 
     it "shouldn't try and convert the group gid if none has been supplied" do
-      allow(@new_resource).to receive(:gid).and_return(nil)
+      @new_resource.gid(false)
       expect(@provider).not_to receive(:convert_group_name)
       @provider.load_current_resource
     end


### PR DESCRIPTION
This kind of got away from me as it turns out a whole bunch of tests were assuming nillable properties. I converted the two easy ones (`env` and `route`) so that's just done, for the others I could either revert the test changes or we can live with annoying hacks for nillable stuff for the few cases where it was breaking tests.