### PR TITLE
fix knife ssh --exit-on-error

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -332,7 +332,9 @@ class Chef
         command.force_encoding("binary") if command.respond_to?(:force_encoding)
         subsession.open_channel do |chan|
           if config[:on_error] && exit_status != 0
-            chan.close()
+            chan.exec "true" do |ch, success|
+              raise ArgumentError, "Cannot execute #{command}" unless success
+            end
           else
             chan.request_pty
             chan.exec command do |ch, success|


### PR DESCRIPTION
With enhancement #5978 `knife ssh` hang on some occasions.

```
root@test:/# knife ssh 'name:test.wwwpp*' "echo 'toto'; true" … -C 1 --exit-on-error
test.wwwpp-01   toto
test.wwwpp-02   toto

→ OK

root@test:/# knife ssh 'name:test.wwwpp*' "echo 'toto'; false" … -C 1 --exit-on-error
test.www-01   toto

→ OK

root@test:/# knife ssh 'name:test.www*' "echo 'toto'; true" … -C 1 --exit-on-error
test.www-01   toto
test.www-02   toto
test.wwwpp-02 toto
test.wwwpp-01 toto

→ OK

root@test:/# knife ssh 'name:test.www*' "echo 'toto'; false" … -C 1 --exit-on-error
test.www-01   toto
^C

→ FAIL, `knife ssh` hang
```

This patch fix this issue :

```
root@test:/# knife ssh 'name:test.wwwpp*' "echo 'toto'; true" … -C 1 --exit-on-error
test.wwwpp-01   toto
test.wwwpp-02   toto

→ OK

root@test:/# knife ssh 'name:test.wwwpp*' "echo 'toto'; false" … -C 1 --exit-on-error
test.www-01   toto

→ OK

root@test:/# knife ssh 'name:test.www*' "echo 'toto'; true" … -C 1 --exit-on-error
test.www-01   toto
test.www-02   toto
test.wwwpp-02 toto
test.wwwpp-01 toto

→ OK

root@test:/# knife ssh 'name:test.www*' "echo 'toto'; false" … -C 1 --exit-on-error
test.www-01   toto

→ OK

```

With -C 2 :

```
root@test:/# knife ssh 'name:test.www* OR name:test.api*' "echo 'toto'; true" … -C 2 --exit-on-error
test.api-02   toto
test.apipp-02 toto
test.www-02   toto
test.api-04   toto
test.www-01   toto
test.api-01   toto
test.wwwpp-01 toto
test.apipp-01 toto
test.api-03   toto
test.wwwpp-02 toto

→ OK

root@test:/# knife ssh 'name:test.www* OR name:test.api*' "echo 'toto'; false" … -C 2 --exit-on-error
test.apipp-02 toto
test.api-02   toto

→ OK

```

### Description

`knife ssh … --exit-on-error` ; end sessions loop in case of error.

### Issues Resolved

* #5978
* #5399

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>