### PR TITLE
Add usage banner for knife client key create

### DIFF
--- a/lib/chef/knife/client_key_create.rb
+++ b/lib/chef/knife/client_key_create.rb
@@ -30,6 +30,8 @@ class Chef
     class ClientKeyCreate < Knife
       include Chef::Knife::KeyCreateBase
 
+      banner "knife client key create CLIENT (options)"
+
       attr_reader :actor
 
       def initialize(argv = [])


### PR DESCRIPTION
Signed-off-by: Daniel DeLeo <dan@chef.io>

### Description

The command didn't have a banner so `knife` showed the default one:

```
$ bundle exec bin/knife client key create -h
Usage: bin/knife (options)
...
```

### Issues Resolved

I'm not aware of a bug ticket.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>