### PR TITLE
(chore)fetch latest stable version only if its required

### DIFF
--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -4,7 +4,9 @@ begin
 
   namespace :changelog do
     # Fetch the latest version from mixlib-install
-    latest_stable_version = Mixlib::Install.available_versions("chef", "stable").last
+    def latest_stable_version
+      Mixlib::Install.available_versions("chef", "stable").last
+    end
 
     # Take the changelog from the latest stable release and put it into history.
     task :archive do


### PR DESCRIPTION
### Description

Allow running specs offline. Done fetch latest version information unless required

### Issues Resolved
Changelog related rake task always attempt to obtain latest version information.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
