### PR TITLE
Update package resource with default for timeout.

### DIFF
--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -40,7 +40,7 @@ class Chef
       property :response_file, String, desired_state: false
       property :response_file_variables, Hash, default: lazy { {} }, desired_state: false
       property :source, String, desired_state: false
-      property :timeout, [ String, Integer ], desired_state: false
+      property :timeout, [ String, Integer ], desired_state: false, default: 600
 
     end
   end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -42,7 +42,6 @@ class Chef
 
       # Unique to this resource
       property :installer_type, Symbol
-      property :timeout, [ String, Integer ], default: 600
       # In the past we accepted return code 127 for an unknown reason and 42 because of a bug
       property :returns, [ String, Integer, Array ], default: [ 0 ], desired_state: false
       property :source, String,


### PR DESCRIPTION
### Description

Currently the timeout attribute is inconsistent in behavior between windows and non-windows platforms. This was initially observed in chef-ingredient with allowing the resource to be of type NilClass. Converges would fail on Windows but succeed on other platforms. This PR moves the default value to the package superclass and removes the attribute from windows_package.

### Issues Resolved

https://github.com/chef-cookbooks/chef-ingredient/issues/155

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
