### PR TITLE
add a pointer from the run_context back to the runner

### DIFF
--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -111,6 +111,11 @@ class Chef
     attr_reader :audits
 
     #
+    # Pointer back to the Chef::Runner that created this
+    #
+    attr_accessor :runner
+
+    #
     # Notification handling
     #
 
@@ -646,6 +651,8 @@ ERROR_MESSAGE
         root_run_context
         resource_collection
         resource_collection=
+        runner
+        runner=
       }.map { |x| x.to_sym }
 
       # Verify that we didn't miss any methods

--- a/lib/chef/runner.rb
+++ b/lib/chef/runner.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@ class Chef
 
     def initialize(run_context)
       @run_context = run_context
+      run_context.runner = self
     end
 
     def delayed_actions

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -98,6 +98,10 @@ describe Chef::Runner do
     run_context.resource_collection << first_resource
   end
 
+  it "runner sets up a pointer back to itself in the run_context" do
+    expect(runner).to eql(run_context.runner)
+  end
+
   context "when we are doing dynamic provider resolution" do
 
     it "should pass each resource in the collection to a provider" do


### PR DESCRIPTION
because surfing through ObjectSpace makes kittens cry

