### PR TITLE
Remove lib-backcompat dir from require_path

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -57,6 +57,6 @@ Gem::Specification.new do |s|
   s.bindir       = "bin"
   s.executables  = %w{ chef-client chef-solo knife chef-shell chef-apply }
 
-  s.require_paths = %w{ lib lib-backcompat }
+  s.require_paths = %w{ lib }
   s.files = %w{Gemfile Rakefile LICENSE README.md CONTRIBUTING.md VERSION} + Dir.glob("{distro,lib,lib-backcompat,tasks,acceptance,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
 end


### PR DESCRIPTION
There is no such directory, no need to require it.