### PR TITLE
use ServerAliveInterval option if exists in ssh_config by `knife ssh`.

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -273,6 +273,10 @@ class Chef
             opts[:paranoid] = false
             opts[:user_known_hosts_file] = "/dev/null"
           end
+          if ssh_config[:keepalive]
+            opts[:keepalive] = true
+            opts[:keepalive_interval] = ssh_config[:keepalive_interval]
+          end
         end
       end
 

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -187,7 +187,7 @@ describe Chef::Knife::Ssh do
   describe "#session_from_list" do
     before :each do
       @knife.instance_variable_set(:@longest, 0)
-      ssh_config = { :timeout => 50, :user => "locutus", :port => 23 }
+      ssh_config = { :timeout => 50, :user => "locutus", :port => 23, :keepalive => true, :keepalive_interval => 60 }
       allow(Net::SSH).to receive(:configuration_for).with("the.b.org", true).and_return(ssh_config)
     end
 
@@ -222,6 +222,12 @@ describe Chef::Knife::Ssh do
     it "uses the user from an ssh config file" do
       @knife.session_from_list([["the.b.org", 123]])
       expect(@knife.session.servers[0].user).to eq("locutus")
+    end
+
+    it "uses keepalive settings from an ssh config file" do
+      @knife.session_from_list([["the.b.org", 123]])
+      expect(@knife.session.servers[0].options[:keepalive]).to be true
+      expect(@knife.session.servers[0].options[:keepalive_interval]).to eq 60
     end
   end
 


### PR DESCRIPTION
### Description

Depending on the setting of the server, the session times out when we run a long-time task with `knife ssh`.
This PR makes if ssh_config has ServerAliveInterval setting, change it so that it can be used.

### Issues Resolved

- https://forums.aws.amazon.com/thread.jspa?threadID=228154
- http://qiita.com/kackytw/items/49e2d10512b197089502

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>