### PR TITLE
If we don't have a run_list, don't send it

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -223,6 +223,7 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
               attributes[:run_list] = @run_list
             end
 
+            attributes.delete(:run_list) if attributes[:policy_name] && !attributes[:policy_name].empty?
             attributes.merge!(:tags => @config[:tags]) if @config[:tags] && !@config[:tags].empty?
           end
         end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -586,6 +586,10 @@ describe Chef::Knife::Bootstrap do
         expect(knife.bootstrap_context.first_boot).to have_key(:policy_group)
       end
 
+      it "ensures that run_list is not set in the bootstrap context" do
+        expect(knife.bootstrap_context.first_boot).to_not have_key(:run_list)
+      end
+
     end
 
     # https://github.com/chef/chef/issues/4131


### PR DESCRIPTION
This should help bootstrapping with policies

Fixes: #5353