### PR TITLE
Updated to fix day validation with monthly frequency

### DIFF
--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -161,8 +161,8 @@ class Chef
       end
 
       def validate_create_day(day, frequency)
-        unless [:weekly].include?(frequency)
-          raise "day attribute is only valid for tasks that run weekly"
+        unless [:weekly, :monthly].include?(frequency)
+          raise "day attribute is only valid for tasks that run monthly or weekly"
         end
         if day.is_a?(String) && day.to_i.to_s != day
           days = day.split(",")

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -166,12 +166,16 @@ describe Chef::Resource::WindowsTask do
   end
 
   context "#validate_create_day" do
-    it "raises error if frequency is not :weekly" do
-      expect  { resource.send(:validate_create_day, "Mon", :monthly) }.to raise_error("day attribute is only valid for tasks that run weekly")
+    it "raises error if frequency is not :weekly or :monthly" do
+      expect  { resource.send(:validate_create_day, "Mon", :daily) }.to raise_error("day attribute is only valid for tasks that run weekly of monthly")
+    end
+    
+    it "accepts a valid day range" do
+      expect  { resource.send(:validate_create_day, "Mon-Fri", :weekly) }.not_to raise_error
     end
 
     it "accepts a valid single day" do
-      expect  { resource.send(:validate_create_day, "Mon", :weekly) }.not_to raise_error
+      expect  { resource.send(:validate_create_day, "Mon", :monthly) }.not_to raise_error
     end
 
     it "accepts a comma separated list of valid days" do

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -167,15 +167,11 @@ describe Chef::Resource::WindowsTask do
 
   context "#validate_create_day" do
     it "raises error if frequency is not :weekly or :monthly" do
-      expect  { resource.send(:validate_create_day, "Mon", :daily) }.to raise_error("day attribute is only valid for tasks that run weekly of monthly")
-    end
-    
-    it "accepts a valid day range" do
-      expect  { resource.send(:validate_create_day, "Mon-Fri", :weekly) }.not_to raise_error
+      expect  { resource.send(:validate_create_day, "Mon", :once) }.to raise_error("day attribute is only valid for tasks that run monthly or weekly")
     end
 
     it "accepts a valid single day" do
-      expect  { resource.send(:validate_create_day, "Mon", :monthly) }.not_to raise_error
+      expect  { resource.send(:validate_create_day, "Mon", :weekly) }.not_to raise_error
     end
 
     it "accepts a comma separated list of valid days" do


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <corey.hemminger@nativex.com>

### Description

allows day option for windows_task with monthly frequency. 

### Issues Resolved

This should fix issue #6104

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
