### PR TITLE
Update omnibus/Gemfile.lock for Chef 12.

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: 83f16f6bbf7f0f9ef94cf694aea2881e65ee034c
+  revision: 462e731f92ce168e2d0ba407cb9b1ebcfb2e4d9d
   specs:
-    license_scout (0.1.2)
+    license_scout (0.1.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 76d907f4fe92a28c5f7ab11779341e1d773c358d
+  revision: ffbda9ad7d37ddb485342505ff4407c6ff23d95f
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -19,11 +19,13 @@ GIT
       mixlib-shellout (~> 2.0)
       mixlib-versioning
       ohai (~> 8.0)
+      pedump
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
 
+GIT
   remote: https://github.com/chef/omnibus-software
-  revision: a6f5d260b34c5a19fb2ef873ab3216c7bab0ef6f
+  revision: 3df02fce13992dcdef6ae083856cb62544cb7e23
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -32,17 +34,17 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    artifactory (2.6.0)
+    artifactory (2.8.1)
     awesome_print (1.7.0)
-    aws-sdk (2.8.2)
-      aws-sdk-resources (= 2.8.2)
-    aws-sdk-core (2.8.2)
+    aws-sdk (2.9.13)
+      aws-sdk-resources (= 2.9.13)
+    aws-sdk-core (2.9.13)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.2)
-      aws-sdk-core (= 2.8.2)
+    aws-sdk-resources (2.9.13)
+      aws-sdk-core (= 2.9.13)
     aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -83,7 +85,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.18.31)
+    chef-config (12.19.36)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -104,19 +106,19 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.1)
+    hashie (3.5.5)
     hitimes (1.2.4)
     hitimes (1.2.4-x86-mingw32)
     httpclient (2.7.2)
     iostruct (0.0.4)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.0.3)
+    json (2.1.0)
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     little-plugger (1.1.4)
-    logging (2.1.0)
+    logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.8.2)
@@ -143,12 +145,12 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (4.0.1)
+    net-ssh (4.1.0)
     net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
     nio4r (2.0.0)
     nori (2.6.0)
-    octokit (4.6.2)
+    octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (8.23.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
@@ -168,7 +170,7 @@ GEM
       multipart-post (~> 2.0.0)
       progressbar
       zhexdump (>= 0.0.2)
-    plist (3.2.0)
+    plist (3.3.0)
     progressbar (1.8.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -201,7 +203,7 @@ GEM
       semverse (~> 1.1)
       varia_model (~> 0.4.0)
     ruby-progressbar (1.8.1)
-    rubyntlm (0.6.1)
+    rubyntlm (0.6.2)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sawyer (0.8.1)
@@ -229,7 +231,7 @@ GEM
       hashie (>= 2.0.2, < 4.0.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    winrm (2.1.2)
+    winrm (2.2.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)


### PR DESCRIPTION
### Description

This updates the Gemfile.lock so that Chef 12 can build successfully.

### Issues Resolved

Fixes building since the version of omnibus which was previously pinned was broken.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

/cc @sdelano 
