### PR TITLE
switch to using trusty on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 sudo: false
 cache: bundler
+dist: trusty
 
 # Early warning system to catch if Rubygems breaks something
 before_install:
   - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
   - gem --version
-  - gem uninstall bundler -a -x
   - rvm @global do gem uninstall bundler -a -x
   - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
   - bundle --version
@@ -274,7 +274,6 @@ matrix:
 #    ### END TEST KITCHEN ONLY ###
   - rvm: 2.4.1
     sudo: required
-    dist: trusty
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)


### PR DESCRIPTION
the travis precise openssl libs appears to hate rubygems and we should
do this anyway.
