### PR TITLE
[In-progress] Calling reconfigure outside trap('HUP')

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -72,11 +72,6 @@ class Chef
         trap("QUIT") do
           Chef::Log.info("SIGQUIT received, call stack:\n  " + caller.join("\n  "))
         end
-
-        trap("HUP") do
-          Chef::Log.info("SIGHUP received, reconfiguring")
-          reconfigure
-        end
       end
     end
 

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -412,6 +412,11 @@ class Chef::Application::Client < Chef::Application
         Chef::Log.info("SIGUSR1 received, waking up")
         SELF_PIPE[1].putc(IMMEDIATE_RUN_SIGNAL) # wakeup master process from select
       end
+
+      trap("HUP") do
+        Chef::Log.info("SIGHUP received, reconfiguring")
+        $reconfigure = true
+      end
     end
   end
 
@@ -438,6 +443,7 @@ class Chef::Application::Client < Chef::Application
   private
 
   def interval_run_chef_client
+    reconfigure if $reconfigure
     if Chef::Config[:daemonize]
       Chef::Daemon.daemonize("chef-client")
 


### PR DESCRIPTION
### Description

Ruby 2.0+ prevents you from performing a lot of actions inside a trap. Previously it would allow it but risked deadlocking if the trap interfered with resources the main thread was using.
Hence calling `reconfigure` from trap raises error if any `require` statement is given in `client.rb` file.

### Issues Resolved

https://github.com/chef/chef/issues/4578

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
