### PR TITLE
reconfigure between runs when running in a loop

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -72,6 +72,11 @@ class Chef
         trap("QUIT") do
           Chef::Log.info("SIGQUIT received, call stack:\n  " + caller.join("\n  "))
         end
+
+        trap("HUP") do
+          Chef::Log.info("SIGHUP received, reconfiguring")
+          reconfigure
+        end
       end
     end
 

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -72,11 +72,6 @@ class Chef
         trap("QUIT") do
           Chef::Log.info("SIGQUIT received, call stack:\n  " + caller.join("\n  "))
         end
-
-        trap("HUP") do
-          Chef::Log.info("SIGHUP received, reconfiguring")
-          reconfigure
-        end
       end
     end
 

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -412,6 +412,11 @@ class Chef::Application::Client < Chef::Application
         Chef::Log.info("SIGUSR1 received, waking up")
         SELF_PIPE[1].putc(IMMEDIATE_RUN_SIGNAL) # wakeup master process from select
       end
+
+      trap("HUP") do
+        Chef::Log.info("SIGHUP received, reconfiguring")
+        $reconfigure = true
+      end
     end
   end
 
@@ -438,6 +443,7 @@ class Chef::Application::Client < Chef::Application
   private
 
   def interval_run_chef_client
+    reconfigure if $reconfigure
     if Chef::Config[:daemonize]
       Chef::Daemon.daemonize("chef-client")
 

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -257,6 +257,7 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
       before do
         allow(@app).to receive(:interval_sleep).with(wait_secs).and_return true
         allow(@app).to receive(:interval_sleep).with(0).and_call_original
+        allow(@app).to receive(:time_to_sleep).and_return(1)
       end
 
       it "sleeps for the amount of time passed" do
@@ -519,6 +520,7 @@ describe Chef::Application::Client, "run_application", :unix_only do
     end
 
     it "shouldn't sleep when sent USR1" do
+      allow(@app).to receive(:interval_sleep).and_return true
       allow(@app).to receive(:interval_sleep).with(0).and_call_original
       pid = fork do
         @app.run_application


### PR DESCRIPTION
We can't reconfigure in a trap context because we might open files or another activity that could cause a deadlock. Ruby 2.0+ now prevents this by raising a ThreadError.

Fixes #4578, Replaces #6119.