### PR TITLE
Discard caches for files not in the manifest

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -202,7 +202,7 @@ class Chef
         ( cookbook_name, segment, file ) = md[1..3]
         if have_cookbook?(cookbook_name)
           manifest_segment = cookbook_segment(cookbook_name, segment)
-          if manifest_segment.select { |manifest_record| manifest_record["path"] == "#{segment}/#{file}" }.empty?
+          if manifest_segment.nil? || manifest_segment.select { |manifest_record| manifest_record["path"] == "#{segment}/#{file}" }.empty?
             Chef::Log.info("Removing #{cache_file} from the cache; its is no longer in the cookbook manifest.")
             cache.delete(cache_file)
             @events.removed_cookbook_file(cache_file)

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -191,6 +191,18 @@ describe Chef::CookbookSynchronizer do
       allow(synchronizer).to receive(:cache).and_return(file_cache)
       synchronizer.remove_deleted_files
     end
+
+    it "removes files not in the manifest" do
+      not_in_manifest_cb_file = %w{cookbooks/valid1/test/deleted.rb cookbooks/valid1/spec/deleted.rb}
+      expect(file_cache).to receive(:find).with(File.join(%w{cookbooks ** {*,.*}})).and_return(not_in_manifest_cb_file)
+      expect(synchronizer).to receive(:have_cookbook?).with("valid1").at_least(:once).and_return(true)
+      expect(file_cache).to receive(:delete).with("cookbooks/valid1/test/deleted.rb")
+      expect(file_cache).to receive(:delete).with("cookbooks/valid1/spec/deleted.rb")
+      expect(synchronizer).to receive(:cookbook_segment).with("valid1", "test").at_least(:once).and_return(nil)
+      expect(synchronizer).to receive(:cookbook_segment).with("valid1", "spec").at_least(:once).and_return(nil)
+      allow(synchronizer).to receive(:cache).and_return(file_cache)
+      synchronizer.remove_deleted_files
+    end
   end
 
   let(:cookbook_a_default_recipe_tempfile) do


### PR DESCRIPTION
### Description

cookbook_segment returns nil if the cache is not found in the manifest.
This can happen when chef client 12 runs on a node where chef client 13
generated cookbook cache files.

Currently, chef client fails in this case. This patch fixes it.

It should be safe to remove those cache files because they are not
cached in Chef 12, after all.

### Issues Resolved

https://github.com/chef/chef/issues/6128

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
