### PR TITLE
Add support for HTTP PATCH requests

### DIFF
--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -49,6 +49,7 @@ class Chef
       ENCODING_GZIP_DEFLATE = "gzip;q=1.0,deflate;q=0.6,identity;q=0.3".freeze
 
       GET     = "get".freeze
+      PATCH   = "patch".freeze
       PUT     = "put".freeze
       POST    = "post".freeze
       DELETE  = "delete".freeze
@@ -161,6 +162,8 @@ class Chef
                           Net::HTTP::Post.new(req_path, headers)
                         when PUT
                           Net::HTTP::Put.new(req_path, headers)
+                        when PATCH
+                          Net::HTTP::Patch.new(req_path, headers)
                         when DELETE
                           Net::HTTP::Delete.new(req_path, headers)
                         when HEAD

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -62,6 +62,20 @@ class Chef
         end
       end
 
+      # Send a PATCH request to new_resource.url, with the message as the payload
+      def action_patch
+        converge_by("#{new_resource} PATCH to #{new_resource.url}") do
+          message = check_message(new_resource.message)
+          body = @http.patch(
+            "#{new_resource.url}",
+            message,
+            new_resource.headers
+          )
+          Chef::Log.info("#{new_resource} PATCH to #{new_resource.url} successful")
+          Chef::Log.debug("#{new_resource} PATCH request response: #{body}")
+        end
+      end
+
       # Send a PUT request to new_resource.url, with the message as the payload
       def action_put
         converge_by("#{new_resource} PUT to #{new_resource.url}") do

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -27,7 +27,7 @@ class Chef
       identity_attr :url
 
       default_action :get
-      allowed_actions :get, :put, :post, :delete, :head, :options
+      allowed_actions :get, :patch, :put, :post, :delete, :head, :options
 
       def initialize(name, run_context = nil)
         super


### PR DESCRIPTION
### Description
Add support for HTTP PATCH requests 

### Issues Resolved

http_request cannot send PATCH requests - limiting usefulness when working with APIs which require them 

### Check List
- [x] New functionality includes tests (skipped)
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
