### PR TITLE
Depth Enhancements

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -162,7 +162,7 @@ class Chef
             current_depth = 1
             last_depth = 0
             depth = new_resource.depth
-            while (exit_code != 0 && current_depth < 50)
+            while exit_code != 0 && current_depth < 50
               git_fetch_result = git("fetch", new_resource.remote, "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_fetch_tags_result = git("fetch", new_resource.remote, "--tags", "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_force_branch_result = git("branch", "-f", new_resource.checkout_branch, sha_ref, cwd: cwd, returns: [0, 128])
@@ -206,7 +206,7 @@ class Chef
             current_depth = 1
             last_depth = 0
             depth = new_resource.depth
-            while (exit_code != 0 && current_depth < 50)
+            while exit_code != 0 && current_depth < 50
               git_fetch_specific_ref_result = git("fetch", new_resource.remote, target_revision, cwd: cwd, returns: [0, 1])
               git_fetch_with_depth_result = git("fetch", new_resource.remote, "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_fetch_tags_result = git("fetch", new_resource.remote, "--tags", "--depth", depth.to_s, cwd: cwd, returns: [0, 1])

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -162,7 +162,7 @@ class Chef
             current_depth = 1
             last_depth = 0
             depth = new_resource.depth
-            while(exit_code != 0 && current_depth < 50)
+            while (exit_code != 0 && current_depth < 50)
               git_fetch_result = git("fetch", new_resource.remote, "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_fetch_tags_result = git("fetch", new_resource.remote, "--tags", "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_force_branch_result = git("branch", "-f", new_resource.checkout_branch, sha_ref, cwd: cwd, returns: [0, 128])
@@ -206,7 +206,7 @@ class Chef
             current_depth = 1
             last_depth = 0
             depth = new_resource.depth
-            while(exit_code != 0 && current_depth < 50)
+            while (exit_code != 0 && current_depth < 50)
               git_fetch_specific_ref_result = git("fetch", new_resource.remote, target_revision, cwd: cwd, returns: [0, 1])
               git_fetch_with_depth_result = git("fetch", new_resource.remote, "--depth", depth.to_s, cwd: cwd, returns: [0, 1])
               git_fetch_tags_result = git("fetch", new_resource.remote, "--tags", "--depth", depth.to_s, cwd: cwd, returns: [0, 1])


### PR DESCRIPTION
**Depth Enhancements**

**Abstract**
Git resource only honors 'depth' attribute when performing an initial clone.
Git resource is unable to recover gracefully when depth is specified, but the target ref is outside the depth.

**Summary**
This PR adds support for shallow fetches, and automatically increasing the depth when the ref is outside the specified depth.

If the requested ref is outside the specified depth the client will deepen the shallow clone/fetch until enough histroy is avaiable to complete the requested operation.
There is a hard limit on the additional depth allowed (50) in order to prevent situtations involving infinite looops or overflows.

The deep is increased using a fibonacci scale:
[User specified depth] + [1, 2, 3, 5, 8, 13, 21, ... ]

**Example**
If we specify a depth of 1 on the resource:

```
git 'my stuff' do
  depth 1
  action :sync
end
```

and are unable to complete the checkout, we will see depth increase as follows up to the limit:

(initial run) 1
(initial run) 1 + 1 = 2
(initial run) 1 + 2 = 3
(initial run) 1 + 3 = 4
(initial run) 1 + 5 = 6
(initial run) 1 + 8 = 9
(initial run) 1 + 13 = 14
(initial run) 1 + 21 = 22
...

