### PR TITLE
Prefer Systemd with sysvinit script over Upstart for service provider

### DIFF
--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -69,7 +69,7 @@ class Chef
           configs = []
 
           if ::File.exist?(Chef.path_to("/etc/init.d/#{service_name}"))
-            configs << :initd
+            configs += [ :initd, :systemd ]
           end
 
           if ::File.exist?(Chef.path_to("/etc/init/#{service_name}.conf"))

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -192,34 +192,34 @@ describe Chef::ProviderResolver do
           stub_service_providers(:debian, :invokercd, :upstart, :systemd)
         end
 
-        it "when only the SysV init script exists, it returns a Service::Debian provider" do
+        it "when both the SysV init and Systemd script exists, it returns a Service::Debian provider" do
           stub_service_configs(:initd, :systemd)
           expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
-        it "when both SysV and Upstart scripts exist, it returns a Service::Upstart provider" do
+        it "when SysV, Upstart, and Systemd scripts exist, it returns a Service::Systemd provider" do
           stub_service_configs(:initd, :upstart, :systemd)
           expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
-        it "when only the Upstart script exists, it returns a Service::Upstart provider" do
+        it "when both the Upstart and Systemd scripts exists, it returns a Service::Systemd provider" do
           stub_service_configs(:upstart, :systemd)
           expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
-        it "when both do not exist, it calls the old style provider resolver and returns a Debian Provider" do
+        it "when both do not exist, it calls the old style provider resolver and returns a Systemd Provider" do
           stub_service_configs(:systemd)
           expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
-        it "when only the SysV init script exists, it returns a Service::Debian provider" do
+        it "when only the SysV init script exists, it returns a Service::Systemd provider" do
           stub_service_configs(:initd)
-          expect(resolved_provider).to eql(Chef::Provider::Service::Debian)
+          expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
-        it "when both SysV and Upstart scripts exist, it returns a Service::Upstart provider" do
+        it "when both SysV and Upstart scripts exist, it returns a Service::Systemd provider" do
           stub_service_configs(:initd, :upstart)
-          expect(resolved_provider).to eql(Chef::Provider::Service::Upstart)
+          expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
 
         it "when only the Upstart script exists, it returns a Service::Upstart provider" do
@@ -227,7 +227,7 @@ describe Chef::ProviderResolver do
           expect(resolved_provider).to eql(Chef::Provider::Service::Upstart)
         end
 
-        it "when both do not exist, it calls the old style provider resolver and returns a Debian Provider" do
+        it "when both do not exist, it calls the old style provider resolver and returns a Systemd Provider" do
           stub_service_configs
           expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
@@ -410,7 +410,7 @@ describe Chef::ProviderResolver do
           stub_service_providers(:debian, :invokercd, :upstart, :systemd)
           stub_service_configs(:initd, :upstart)
           mock_shellout_command("/bin/systemctl list-unit-files", exitstatus: 1)
-          expect(resolved_provider).to eql(Chef::Provider::Service::Upstart)
+          expect(resolved_provider).to eql(Chef::Provider::Service::Systemd)
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Grant Ridder <shortdudey123@gmail.com>

### Description

On newer Debian based systems that use systemd to have a package install a SysV init and Upstart script.  Systemd can use systemd service files or SysV init scripts.  However, on the Chef serivce provider side, this is not reflected.  So in this case, Upstart will be prefered even if Upstart itself is not installed on the system.

### Issues Resolved

Service resource failing to modify a service on a systemd based host that has SysV init and Upstart scripts.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

closes #6076