### PR TITLE
Fix unit tests while running on a machine that has FIPS enabled.

### DIFF
--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -420,7 +420,7 @@ describe Chef::Application::Client, "configure_chef" do
   before do
     @original_argv = ARGV.dup
     ARGV.clear
-    allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_return("0")
+    allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_call_original
     allow(::File).to receive(:read).with(Chef::Config.platform_specific_path("/etc/chef/client.rb")).and_return("")
     app.configure_chef
   end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -420,6 +420,7 @@ describe Chef::Application::Client, "configure_chef" do
   before do
     @original_argv = ARGV.dup
     ARGV.clear
+    allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_return("0")
     allow(::File).to receive(:read).with(Chef::Config.platform_specific_path("/etc/chef/client.rb")).and_return("")
     app.configure_chef
   end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -420,7 +420,7 @@ describe Chef::Application::Client, "configure_chef" do
   before do
     @original_argv = ARGV.dup
     ARGV.clear
-    allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_call_original
+    allow(::File).to receive(:read).with("/proc/sys/crypto/fips_enabled").and_call_original
     allow(::File).to receive(:read).with(Chef::Config.platform_specific_path("/etc/chef/client.rb")).and_return("")
     app.configure_chef
   end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -101,6 +101,7 @@ describe Chef::Application do
 
         @app = Chef::Application.new
         allow(@app).to receive(:parse_options).and_return(true)
+        allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_return("0")
         expect(Chef::Config).to receive(:export_proxies).and_return(true)
       end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -101,7 +101,7 @@ describe Chef::Application do
 
         @app = Chef::Application.new
         allow(@app).to receive(:parse_options).and_return(true)
-        allow(::File).to receive(:read).with('/proc/sys/crypto/fips_enabled').and_return("0")
+        allow(::File).to receive(:read).with("/proc/sys/crypto/fips_enabled").and_call_original
         expect(Chef::Config).to receive(:export_proxies).and_return(true)
       end
 


### PR DESCRIPTION
### Description

This is a first pass at fixing a couple failing unit tests when running them on a system that has FIPS enabled. I think for the purposes of these tests, it's fine to assume FIPS is _disabled_, but if folks disagree, I could just pass through the actual value of a `File::read` of `/proc/sys/crypto/fips_enabled`.

### Issues Resolved

Fixes #5533 
