### PR TITLE
Make gem_installer generate a valid Gemfile

### DIFF
--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -43,7 +43,7 @@ class Chef
             if cookbook_gems[args.first].last.is_a?(Hash)
               args << {} unless args.last.is_a?(Hash)
               args.last.merge!(cookbook_gems[args.first].pop) do |key, v1, v2|
-                Chef::Log.warn "Conflicting requirements for gem '#{args.first}', will use #{key.inspect} => #{v2.inspect}" if v1 != v2
+                raise Chef::Exceptions::GemRequirementConflict.new(args.first, key, v1, v2) if v1 != v2
                 v2
               end
             end

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -40,6 +40,13 @@ class Chef
 
         cookbook_collection.each do |cookbook_name, cookbook_version|
           cookbook_version.metadata.gems.each do |args|
+            if cookbook_gems[args.first].last.is_a?(Hash)
+              args << {} unless args.last.is_a?(Hash)
+              args.last.merge!(cookbook_gems[args.first].pop) do |key, v1, v2|
+                Chef::Log.warn "Conflicting requirements for gem '#{args.first}', will use #{key.inspect} => #{v2.inspect}" if v1 != v2
+                v2
+              end
+            end
             cookbook_gems[args.first] += args[1..-1]
           end
         end

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -521,5 +521,11 @@ This error is most often caused by network issues (proxies, etc) outside of chef
 
     # exception specific to invalid usage of 'dsc_resource' resource
     class DSCModuleNameMissing < ArgumentError; end
+
+    class GemRequirementConflict < RuntimeError
+      def initialize(gem_name, option, value1, value2)
+        super "Conflicting requirements for gem '#{gem_name}': Both #{value1.inspect} and #{value2.inspect} given for option #{option.inspect}"
+      end
+    end
   end
 end

--- a/spec/unit/cookbook/gem_installer_spec.rb
+++ b/spec/unit/cookbook/gem_installer_spec.rb
@@ -22,7 +22,14 @@ describe Chef::Cookbook::GemInstaller do
         :cookbook,
         metadata: double(
           :metadata,
-          gems: [["httpclient", ">= 1.0"]]
+          gems: [["httpclient", ">= 1.0", { "git" => "https://github.com/nahi/httpclient" }]]
+        )
+      ),
+      test4: double(
+        :cookbook,
+        metadata: double(
+          :metadata,
+          gems: [["httpclient", { "path" => "./gems/httpclient" }]]
         )
       ),
     }


### PR DESCRIPTION
### Description

When multiple cookbooks in the run list require the same gem from the gem_installer, and these gem declarations include keyword arguments (e.g. to install the gem from a git repository), the gem_installer will generate an invalid Gemfile.

This should fix this by handling keyword arguments separately and merging them together when necessary. This may still result in unwanted behaviour, if the cookbooks specify different arguments that do not play well together, but at least we will have a valid Gemfile in all cases.

### Issues Resolved

None?

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
