### PR TITLE
Only run the Chocolatey tests if Chocolatey is installed

### DIFF
--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -18,7 +18,7 @@
 require "spec_helper"
 require "chef/mixin/powershell_out"
 
-describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed,  do
+describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
   include Chef::Mixin::PowershellOut
 
   let(:package_name) { "test-A" }

--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -18,7 +18,7 @@
 require "spec_helper"
 require "chef/mixin/powershell_out"
 
-describe Chef::Resource::ChocolateyPackage, :windows_only, :win2012r2_only do
+describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed,  do
   include Chef::Mixin::PowershellOut
 
   let(:package_name) { "test-A" }


### PR DESCRIPTION
This is a bit of a workaround for now. We need to get Chocolatey back on the windows jenkins builders so we can get green tests. This gets us green for the 13.1 release though.

Signed-off-by: Tim Smith <tsmith@chef.io>