### PR TITLE
Backport error info for Chef 12

### DIFF
--- a/lib/chef/formatters/error_description.rb
+++ b/lib/chef/formatters/error_description.rb
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 
-require 'chef/version'
-
+require "chef/version"
 
 class Chef
   module Formatters
@@ -68,7 +67,7 @@ class Chef
       end
 
       def error_context_info
-        context_info = {chef_version: Chef::VERSION}
+        context_info = { chef_version: Chef::VERSION }
         if Chef.node
           context_info[:platform] = Chef.node["platform"]
           context_info[:platform_version] = Chef.node["platform_version"]
@@ -79,7 +78,7 @@ class Chef
         context_info[:program_name] = $PROGRAM_NAME
         # This is kind of wonky but it's the only way to get the entry path script.
         context_info[:executable] = File.realpath(caller.last[/^(.*):\d+:in /, 1])
-        context_info.map {|k, v| "#{k}=#{v}"}.join("\n")
+        context_info.map { |k, v| "#{k}=#{v}" }.join("\n")
       end
 
     end

--- a/lib/chef/formatters/error_description.rb
+++ b/lib/chef/formatters/error_description.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+require 'chef/version'
+
+
 class Chef
   module Formatters
     # == Formatters::ErrorDescription
@@ -45,7 +48,7 @@ class Chef
             display_section(heading, text, out)
           end
         end
-        display_section("Platform:", RUBY_PLATFORM, out)
+        display_section("System Info:", error_context_info, out)
       end
 
       def for_json
@@ -62,6 +65,21 @@ class Chef
         out.puts "-" * heading.size
         out.puts text
         out.puts "\n"
+      end
+
+      def error_context_info
+        context_info = {chef_version: Chef::VERSION}
+        if Chef.node
+          context_info[:platform] = Chef.node["platform"]
+          context_info[:platform_version] = Chef.node["platform_version"]
+        end
+        # A string like "ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]"
+        context_info[:ruby] = RUBY_DESCRIPTION
+        # The argv[0] value.
+        context_info[:program_name] = $PROGRAM_NAME
+        # This is kind of wonky but it's the only way to get the entry path script.
+        context_info[:executable] = File.realpath(caller.last[/^(.*):\d+:in /, 1])
+        context_info.map {|k, v| "#{k}=#{v}"}.join("\n")
       end
 
     end

--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -53,13 +53,13 @@ describe Chef::Formatters::ErrorDescription do
       stub_const("RUBY_DESCRIPTION", "ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]")
       allow(subject).to receive(:caller) { Kernel.caller + ["/test/bin/chef-client:1:in `<main>'"] }
       allow(File).to receive(:realpath).and_call_original
-      allow(File).to receive(:realpath).with('/test/bin/chef-client').and_return('/test/bin/chef-client')
+      allow(File).to receive(:realpath).with("/test/bin/chef-client").and_return("/test/bin/chef-client")
     end
 
     around do |ex|
       old_program_name = $PROGRAM_NAME
       begin
-        $PROGRAM_NAME = 'chef-client'
+        $PROGRAM_NAME = "chef-client"
         ex.run
       ensure
         $PROGRAM_NAME = old_program_name
@@ -117,7 +117,7 @@ executable=/test/bin/chef-client
       it "should output the expected sections" do
         # This can't be in a before block because the spec-wide helper calls a
         # reset on global values.
-        Chef.set_node({"platform" => "openvms", "platform_version" => "8.4-2L1"})
+        Chef.set_node({ "platform" => "openvms", "platform_version" => "8.4-2L1" })
         subject.display(out)
         expect(out.out.string).to eq <<-END
 ================================================================================

--- a/spec/unit/formatters/error_description_spec.rb
+++ b/spec/unit/formatters/error_description_spec.rb
@@ -49,7 +49,21 @@ describe Chef::Formatters::ErrorDescription do
 
   describe "#display" do
     before do
-      stub_const("RUBY_PLATFORM", "ruby-foo-9000")
+      stub_const("Chef::VERSION", "1.2.3")
+      stub_const("RUBY_DESCRIPTION", "ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]")
+      allow(subject).to receive(:caller) { Kernel.caller + ["/test/bin/chef-client:1:in `<main>'"] }
+      allow(File).to receive(:realpath).and_call_original
+      allow(File).to receive(:realpath).with('/test/bin/chef-client').and_return('/test/bin/chef-client')
+    end
+
+    around do |ex|
+      old_program_name = $PROGRAM_NAME
+      begin
+        $PROGRAM_NAME = 'chef-client'
+        ex.run
+      ensure
+        $PROGRAM_NAME = old_program_name
+      end
     end
 
     context "when no sections have been added" do
@@ -60,9 +74,12 @@ describe Chef::Formatters::ErrorDescription do
 test title
 ================================================================================
 
-Platform:
----------
-ruby-foo-9000
+System Info:
+------------
+chef_version=1.2.3
+ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
+program_name=chef-client
+executable=/test/bin/chef-client
 
         END
       end
@@ -84,9 +101,37 @@ test heading
 ------------
 test text
 
-Platform:
----------
-ruby-foo-9000
+System Info:
+------------
+chef_version=1.2.3
+ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
+program_name=chef-client
+executable=/test/bin/chef-client
+
+        END
+      end
+
+    end
+
+    context "when node object is available" do
+      it "should output the expected sections" do
+        # This can't be in a before block because the spec-wide helper calls a
+        # reset on global values.
+        Chef.set_node({"platform" => "openvms", "platform_version" => "8.4-2L1"})
+        subject.display(out)
+        expect(out.out.string).to eq <<-END
+================================================================================
+test title
+================================================================================
+
+System Info:
+------------
+chef_version=1.2.3
+platform=openvms
+platform_version=8.4-2L1
+ruby=ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
+program_name=chef-client
+executable=/test/bin/chef-client
 
         END
       end


### PR DESCRIPTION
Backporting #5987 for the next Chef 12 release. Will maybe make support a little easier for people that end up stuck on 12 forever.