### PR TITLE
Add `--allow-downgrades` to all `apt-get` commands

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -86,7 +86,7 @@ class Chef
           package_name = name.zip(version).map do |n, v|
             package_data[n][:virtual] ? n : "#{n}=#{v}"
           end
-          run_noninteractive("apt-get", "-q", "-y", default_release_options, options, "install", package_name)
+          run_noninteractive("apt-get", "-q", "-y", "--allow-downgrades", default_release_options, options, "install", package_name)
         end
 
         def upgrade_package(name, version)
@@ -97,14 +97,14 @@ class Chef
           package_name = name.map do |n|
             package_data[n][:virtual] ? resolve_virtual_package_name(n) : n
           end
-          run_noninteractive("apt-get", "-q", "-y", options, "remove", package_name)
+          run_noninteractive("apt-get", "-q", "-y", "--allow-downgrades", options, "remove", package_name)
         end
 
         def purge_package(name, version)
           package_name = name.map do |n|
             package_data[n][:virtual] ? resolve_virtual_package_name(n) : n
           end
-          run_noninteractive("apt-get", "-q", "-y", options, "purge", package_name)
+          run_noninteractive("apt-get", "-q", "-y", "--allow-downgrades", options, "purge", package_name)
         end
 
         def preseed_package(preseed_file)

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -259,7 +259,7 @@ mpg123 1.12.1-0ubuntu1
         describe "install_package" do
           it "should run apt-get install with the package name and version" do
             expect(@provider).to receive(:shell_out!). with(
-              "apt-get", "-q", "-y", "install", "irssi=0.8.12-7",
+              "apt-get", "-q", "-y", "--allow-downgrades", "install", "irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -268,7 +268,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get install with the package name and version and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "--force-yes", "install", "irssi=0.8.12-7",
+              "apt-get", "-q", "-y", "--allow-downgrades", "--force-yes", "install", "irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -284,7 +284,7 @@ mpg123 1.12.1-0ubuntu1
             @provider.new_resource = @new_resource
 
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "-o", "APT::Default-Release=lenny-backports", "install", "irssi=0.8.12-7",
+              "apt-get", "-q", "-y", "--allow-downgrades", "-o", "APT::Default-Release=lenny-backports", "install", "irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -294,7 +294,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get install with the package name and quotes options if specified" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "--force-yes", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confnew", "install", "irssi=0.8.12-7",
+              "apt-get", "-q", "-y", "--allow-downgrades", "--force-yes", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confnew", "install", "irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -315,7 +315,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get remove with the package name" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "remove", "irssi",
+              "apt-get", "-q", "-y", "--allow-downgrades", "remove", "irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -324,7 +324,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get remove with the package name and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "--force-yes", "remove", "irssi",
+              "apt-get", "-q", "-y", "--allow-downgrades", "--force-yes", "remove", "irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -338,7 +338,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get purge with the package name" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "purge", "irssi",
+              "apt-get", "-q", "-y", "--allow-downgrades", "purge", "irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -347,7 +347,7 @@ mpg123 1.12.1-0ubuntu1
 
           it "should run apt-get purge with the package name and options if specified" do
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "--force-yes", "purge", "irssi",
+              "apt-get", "-q", "-y", "--allow-downgrades", "--force-yes", "purge", "irssi",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -431,7 +431,7 @@ mpg123 1.12.1-0ubuntu1
           it "should install the package without specifying a version" do
             @provider.package_data["libmysqlclient15-dev"][:virtual] = true
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "install", "libmysqlclient15-dev",
+              "apt-get", "-q", "-y", "--allow-downgrades", "install", "libmysqlclient15-dev",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -443,7 +443,7 @@ mpg123 1.12.1-0ubuntu1
           it "should remove the resolved name instead of the virtual package name" do
             expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "remove", "libmysqlclient-dev",
+              "apt-get", "-q", "-y", "--allow-downgrades", "remove", "libmysqlclient-dev",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -455,7 +455,7 @@ mpg123 1.12.1-0ubuntu1
           it "should purge the resolved name instead of the virtual package name" do
             expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "purge", "libmysqlclient-dev",
+              "apt-get", "-q", "-y", "--allow-downgrades", "purge", "libmysqlclient-dev",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )
@@ -467,7 +467,7 @@ mpg123 1.12.1-0ubuntu1
           it "can install a virtual package followed by a non-virtual package" do
             # https://github.com/chef/chef/issues/2914
             expect(@provider).to receive(:shell_out!).with(
-              "apt-get", "-q", "-y", "install", "libmysqlclient15-dev", "irssi=0.8.12-7",
+              "apt-get", "-q", "-y", "--allow-downgrades", "install", "libmysqlclient15-dev", "irssi=0.8.12-7",
               :env => { "DEBIAN_FRONTEND" => "noninteractive" },
               :timeout => @timeout
             )


### PR DESCRIPTION
### Description

Adds `--allow-downgrades` to every apt command, as discussed in #6095.

Caution, `man apt-get` says this:

       --allow-downgrades
           This is a dangerous option that will cause apt to continue without prompting if it is doing downgrades. It should not be used except in very special situations.
           Using it can potentially destroy your system! Configuration Item: APT::Get::allow-downgrades. Introduced in APT 1.1.

Let me know what you think.

### Issues Resolved

resolves #6095