### PR TITLE
Use socketless local mode by default

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,23 @@
 _This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes._
 
-# Chef Client Release Notes 13.0-13.1:
+# Chef Client Release Notes
+
+# 13.2
+
+## Socketless local mode by default
+
+For security reasons we are switching Local Mode to use socketless connections
+by default. This prevents potential attacks where an unprivileged user or process
+connects to the internal Zero server for the converge and changes data.
+
+If you use Chef Provisioning with Local Mode, you may need to pass `--listen` to
+`chef-client`.
+
+# 13.1
+
+No new major features.
+
+# 13.0
 
 ## Rubygems provider sources behavior changed.
 

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -286,7 +286,7 @@ class Chef::Application::Client < Chef::Application
   option :listen,
     :long           => "--[no-]listen",
     :description    => "Whether a local mode (-z) server binds to a port",
-    :boolean        => true
+    :boolean        => false
 
   option :fips,
     :long         => "--[no-]fips",

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -132,7 +132,7 @@ class Chef::Application::Knife < Chef::Application
   option :listen,
     :long           => "--[no-]listen",
     :description    => "Whether a local mode (-z) server binds to a port",
-    :boolean        => true
+    :boolean        => false
 
   option :version,
     :short        => "-v",

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -238,6 +238,16 @@ class Chef
       end
     end
 
+    class LocalListen < Base
+      def id
+        18
+      end
+
+      def target
+        "local_listen.html"
+      end
+    end
+
     # id 3694 was deleted
 
     class Generic < Base

--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -73,6 +73,7 @@ class Chef
         @chef_zero_server = ChefZero::Server.new(server_options)
 
         if Chef::Config[:listen]
+          Chef.deprecated(:local_listen, "Starting local-mode server in deprecated socket mode")
           @chef_zero_server.start_background
         else
           @chef_zero_server.start_socketless


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/6088, docs in https://github.com/chef/chef-web-docs/pull/687.

The only case where this is likely to matter is the chef-provisioning stuff mentioned in #6088, which is few enough people that I'm calling this a security fix.