### PR TITLE
[MSYS-586] Allow windows_task create action to update tasks.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Previous Visual Studio 2013
+os: Windows Server 2012 R2
 platform:
   - x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Windows Server 2012 R2
+os: Previous Visual Studio 2013
 platform:
   - x64
 


### PR DESCRIPTION
Signed-off-by: MSys <harikesh.kolekar@msystechnologies.com>

### Description
Since `windows_task` moved into core, the expectation is that the `:create` action can take the place of the old `:change` action (since it has the same attributes).  In fact, the plan sounds like that `:change` action can just be aliased to `:create` to prevent legacy breakage.  However, the `:create` action will break if the `command` attribute is not specified (like it would be in a preexisting `:change` action): ` undefined method `tr' for nil:NilClass`
*Expected Results*:  The windows_task resource can be modified by resource name without having to specify the command



### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
