### PR TITLE
Pass authentication for chocolatey_package

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -228,8 +228,7 @@ EOS
         def available_packages
           @available_packages ||=
             begin
-              cmd = [ "list -r #{package_name_array.join ' '}" ]
-              cmd.push( "-source #{new_resource.source}" ) if new_resource.source
+              cmd = [ "list -r #{package_name_array.join ' '}", cmd_args ]
               raw = parse_list_output(*cmd)
               raw.keys.each_with_object({}) do |name, available|
                 available[name] = desired_name_versions[name] || raw[name]


### PR DESCRIPTION
Signed-off-by: Andrew Stoltz <astoltz@gmx.com>

### Description

```ruby
chocolatey_package 'private-package' do
  source 'https://custom/nuget'
  options '-u username -p password'
end
```
Before PR, the authentication parameters don't get passed along to the "choco list" command causing failed authentication. The PR causes these parameters to be passed along.

I'm not sure if there are options that should be passed during "choco install" but not "choco list". If there are, we may need a separate property for this purpose.