### PR TITLE
Have a sensible default for old chef servers

### DIFF
--- a/lib/chef/http/api_versions.rb
+++ b/lib/chef/http/api_versions.rb
@@ -37,6 +37,8 @@ class Chef
         end
         if http_response.key?("x-ops-server-api-version")
           ServerAPIVersions.instance.set_versions(JSONCompat.parse(http_response["x-ops-server-api-version"]))
+        else
+          ServerAPIVersions.instance.unversioned!
         end
         [http_response, rest_request, return_value]
       end

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -26,15 +26,34 @@ class Chef
     end
 
     def min_server_version
-      !@versions.nil? ? Integer(@versions["min_version"]) : nil
+      # If we're working with a pre-api-versioning server, always claim to be zero
+      if @versions.nil?
+        unversioned? ? 0 : nil
+      else
+        Integer(@versions["min_version"])
+      end
     end
 
     def max_server_version
-      !@versions.nil? ? Integer(@versions["max_version"]) : nil
+      # If we're working with a pre-api-versioning server, always claim to be zero
+      if @versions.nil?
+        unversioned? ? 0 : nil
+      else
+        Integer(@versions["max_version"])
+      end
+    end
+
+    def unversioned!
+      @unversioned = true
+    end
+
+    def unversioned?
+      @unversioned
     end
 
     def reset!
       @versions = nil
+      @unversioned = false
     end
   end
 end

--- a/spec/unit/server_api_versions_spec.rb
+++ b/spec/unit/server_api_versions_spec.rb
@@ -22,9 +22,27 @@ describe Chef::ServerAPIVersions do
     Chef::ServerAPIVersions.instance.reset!
   end
 
+  describe "#reset!" do
+    it "resets the version information" do
+      Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
+      Chef::ServerAPIVersions.instance.reset!
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to be_nil
+    end
+
+    it "resets the unversioned flag" do
+      Chef::ServerAPIVersions.instance.unversioned!
+      Chef::ServerAPIVersions.instance.reset!
+      expect(Chef::ServerAPIVersions.instance.unversioned?).to be false
+    end
+  end
+
   describe "#min_server_version" do
     it "returns nil if no versions have been recorded" do
       expect(Chef::ServerAPIVersions.instance.min_server_version).to be_nil
+    end
+    it "returns 0 if unversioned" do
+      Chef::ServerAPIVersions.instance.unversioned!
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
     end
     it "returns the correct value" do
       Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })
@@ -35,6 +53,10 @@ describe Chef::ServerAPIVersions do
   describe "#max_server_version" do
     it "returns nil if no versions have been recorded" do
       expect(Chef::ServerAPIVersions.instance.max_server_version).to be_nil
+    end
+    it "returns 0 if unversioned" do
+      Chef::ServerAPIVersions.instance.unversioned!
+      expect(Chef::ServerAPIVersions.instance.min_server_version).to eq(0)
     end
     it "returns the correct value" do
       Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 0, "max_version" => 2 })


### PR DESCRIPTION
If we don't see a version header, we should default to only supporting
API version 0, and if we can't support that, then we should die as usual