### PR TITLE
Special case for the supports pseudo-property for Chef 12.

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -657,6 +657,10 @@ class Chef
       # as needed.
       return if Chef::Resource.properties.keys.include?(name)
 
+      # Special case for `supports` as it was moved in Chef 13 and this is causing
+      # some user confusion in cookbooks that need to support both 12 and 13.
+      return if name.to_s == 'supports'
+
       # Emit the deprecation.
       resource_name = declared_in.respond_to?(:resource_name) ? declared_in.resource_name : declared_in
       Chef.deprecated(:property_name_collision, "Property `#{name}` of resource `#{resource_name}` overwrites an existing method. " \


### PR DESCRIPTION
We could (and probably should) fix this in each cookbook but this has been the cause of enough issue spam that a special case seems warranted, especially since it is only needed on the 12.x branch and won't live on in 13.