### PR TITLE
check for a set home property before testing file existence (fixes #5777)

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -318,7 +318,7 @@ user password using shadow hash.")
         end
 
         def current_home_exists?
-          ::File.exist?(current_resource.home)
+          current_resource.home && ::File.exist?(current_resource.home)
         end
 
         def new_home_exists?


### PR DESCRIPTION
### Description

`::File.exist?('')` returns false, but is non-obvious, which is how this got broken in the first place; rather than casting back to a string to resolve, make the check for a truthy home property explicit.

### Issues Resolved

#5777 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
