### PR TITLE
Ensure the service_name is always escaped when using systemd

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -20,6 +20,7 @@
 require "chef/resource/service"
 require "chef/provider/service/simple"
 require "chef/mixin/which"
+require "shellwords"
 
 class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
@@ -100,7 +101,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} start #{new_resource.service_name}", options)
+        shell_out_with_systems_locale!("#{systemctl_path} #{args} start #{Shellwords.escape(new_resource.service_name)}", options)
       end
     end
   end
@@ -113,7 +114,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} stop #{new_resource.service_name}", options)
+        shell_out_with_systems_locale!("#{systemctl_path} #{args} stop #{Shellwords.escape(new_resource.service_name)}", options)
       end
     end
   end
@@ -123,7 +124,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       super
     else
       options, args = get_systemctl_options_args
-      shell_out_with_systems_locale!("#{systemctl_path} #{args} restart #{new_resource.service_name}", options)
+      shell_out_with_systems_locale!("#{systemctl_path} #{args} restart #{Shellwords.escape(new_resource.service_name)}", options)
     end
   end
 
@@ -133,7 +134,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     else
       if current_resource.running
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} reload #{new_resource.service_name}", options)
+        shell_out_with_systems_locale!("#{systemctl_path} #{args} reload #{Shellwords.escape(new_resource.service_name)}", options)
       else
         start_service
       end
@@ -142,37 +143,37 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def enable_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} enable #{new_resource.service_name}", options)
+    shell_out!("#{systemctl_path} #{args} enable #{Shellwords.escape(new_resource.service_name)}", options)
   end
 
   def disable_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} disable #{new_resource.service_name}", options)
+    shell_out!("#{systemctl_path} #{args} disable #{Shellwords.escape(new_resource.service_name)}", options)
   end
 
   def mask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} mask #{new_resource.service_name}", options)
+    shell_out!("#{systemctl_path} #{args} mask #{Shellwords.escape(new_resource.service_name)}", options)
   end
 
   def unmask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} unmask #{new_resource.service_name}", options)
+    shell_out!("#{systemctl_path} #{args} unmask #{Shellwords.escape(new_resource.service_name)}", options)
   end
 
   def is_active?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-active #{new_resource.service_name} --quiet", options).exitstatus == 0
+    shell_out("#{systemctl_path} #{args} is-active #{Shellwords.escape(new_resource.service_name)} --quiet", options).exitstatus == 0
   end
 
   def is_enabled?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-enabled #{new_resource.service_name} --quiet", options).exitstatus == 0
+    shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)} --quiet", options).exitstatus == 0
   end
 
   def is_masked?
     options, args = get_systemctl_options_args
-    s = shell_out("#{systemctl_path} #{args} is-enabled #{new_resource.service_name}", options)
+    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", options)
     s.exitstatus != 0 && s.stdout.include?("masked")
   end
 

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -22,6 +22,7 @@ require "chef/mixin/shell_out"
 require "chef/resource/file"
 require "chef/resource/file/verification/systemd_unit"
 require "iniparse"
+require "shellwords"
 
 class Chef
   class Provider
@@ -203,11 +204,11 @@ class Chef
       end
 
       def systemctl_execute!(action, unit)
-        shell_out_with_systems_locale!("#{systemctl_cmd} #{action} #{unit}", systemctl_opts)
+        shell_out_with_systems_locale!("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", systemctl_opts)
       end
 
       def systemctl_execute(action, unit)
-        shell_out("#{systemctl_cmd} #{action} #{unit}", systemctl_opts)
+        shell_out("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", systemctl_opts)
       end
 
       def systemctl_cmd

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -36,7 +36,9 @@ describe Chef::Provider::Service::Systemd do
 
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
 
-  let(:service_name) { "rsyslog.service" }
+  let(:service_name) { "rsyslog\\x2d.service" }
+
+  let(:service_name_escaped) { "rsyslog\\\\x2d.service" }
 
   let(:new_resource) { Chef::Resource::Service.new(service_name) }
 
@@ -182,13 +184,13 @@ describe Chef::Provider::Service::Systemd do
 
         context "when a user is not specified" do
           it "should call '#{systemctl_path} --system start service_name' if no start command is specified" do
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name}", {}).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name_escaped}", {}).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --system start service_name' if it is already running" do
             current_resource.running(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name}", {})
+            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system start #{service_name_escaped}", {})
             provider.start_service
           end
         end
@@ -196,14 +198,14 @@ describe Chef::Provider::Service::Systemd do
         context "when a user is specified" do
           it "should call '#{systemctl_path} --user start service_name' if no start command is specified" do
             current_resource.user("joe")
-            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" }).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name_escaped}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" }).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --user start service_name' if it is already running" do
             current_resource.running(true)
             current_resource.user("joe")
-            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" })
+            expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --user start #{service_name_escaped}", { :environment => { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, :user => "joe" })
             provider.start_service
           end
         end
@@ -217,7 +219,7 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} --system restart service_name' if no restart command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system restart #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system restart #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.restart_service
         end
 
@@ -234,7 +236,7 @@ describe Chef::Provider::Service::Systemd do
           context "when a reload command is not specified" do
             it "should call '#{systemctl_path} --system reload service_name' if the service is running" do
               current_resource.running(true)
-              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system reload #{service_name}", {}).and_return(shell_out_success)
+              expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system reload #{service_name_escaped}", {}).and_return(shell_out_success)
               provider.reload_service
             end
 
@@ -255,13 +257,13 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} --system stop service_name' if no stop command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.stop_service
         end
 
         it "should not call '#{systemctl_path} --system stop service_name' if it is already stopped" do
           current_resource.running(false)
-          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name}", {})
+          expect(provider).not_to receive(:shell_out_with_systems_locale!).with("#{systemctl_path} --system stop #{service_name_escaped}", {})
           provider.stop_service
         end
       end
@@ -274,12 +276,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} --system enable service_name' to enable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system enable #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system enable #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.enable_service
         end
 
         it "should call '#{systemctl_path} --system disable service_name' to disable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system disable #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system disable #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.disable_service
         end
       end
@@ -292,12 +294,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} --system mask service_name' to mask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system mask #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system mask #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.mask_service
         end
 
         it "should call '#{systemctl_path} --system unmask service_name' to unmask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system unmask #{service_name}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system unmask #{service_name_escaped}", {}).and_return(shell_out_success)
           provider.unmask_service
         end
       end
@@ -310,12 +312,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-active service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name} --quiet", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name_escaped} --quiet", {}).and_return(shell_out_success)
           expect(provider.is_active?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-active service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name} --quiet", {}).and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name_escaped} --quiet", {}).and_return(shell_out_failure)
           expect(provider.is_active?).to be false
         end
       end
@@ -328,12 +330,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name} --quiet", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped} --quiet", {}).and_return(shell_out_success)
           expect(provider.is_enabled?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name} --quiet", {}).and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped} --quiet", {}).and_return(shell_out_failure)
           expect(provider.is_enabled?).to be false
         end
       end
@@ -346,22 +348,22 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 'masked' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "masked", :exitstatus => shell_out_failure))
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(:stdout => "masked", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' outputs 'masked-runtime' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "masked-runtime", :exitstatus => shell_out_failure))
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(:stdout => "masked-runtime", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "enabled", :exitstatus => shell_out_success))
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(:stdout => "enabled", :exitstatus => shell_out_success))
           expect(provider.is_masked?).to be false
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0 and outputs an error'" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name}", {}).and_return(double(:stdout => "Failed to get unit file state for #{service_name}: No such file or directory", :exitstatus => shell_out_failure))
+          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(:stdout => "Failed to get unit file state for #{service_name}: No such file or directory", :exitstatus => shell_out_failure))
           expect(provider.is_masked?).to be false
         end
       end

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -32,13 +32,14 @@ describe Chef::Provider::SystemdUnit do
 
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
-  let(:unit_name) { "sysstat-collect.timer" }
+  let(:unit_name) { "sysstat-collect\\x2d.timer" }
+  let(:unit_name_escaped) { "sysstat-collect\\\\x2d.timer" }
   let(:user_name) { "joe" }
   let(:current_resource) { Chef::Resource::SystemdUnit.new(unit_name) }
   let(:new_resource) { Chef::Resource::SystemdUnit.new(unit_name) }
   let(:provider) { Chef::Provider::SystemdUnit.new(new_resource, run_context) }
-  let(:unit_path_system) { "/etc/systemd/system/sysstat-collect.timer" }
-  let(:unit_path_user) { "/etc/systemd/user/sysstat-collect.timer" }
+  let(:unit_path_system) { "/etc/systemd/system/sysstat-collect\\x2d.timer" }
+  let(:unit_path_user) { "/etc/systemd/user/sysstat-collect\\x2d.timer" }
   let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
   let(:malformed_content_string) { "derp" }
 
@@ -384,7 +385,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.enabled(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user enable #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user enable #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_enable
           end
@@ -407,7 +408,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.enabled(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user disable #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user disable #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_disable
           end
@@ -431,7 +432,7 @@ describe Chef::Provider::SystemdUnit do
           it "enables the unit when it is disabled" do
             current_resource.enabled(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system enable #{unit_name}", {})
+                                  .with("#{systemctl_path} --system enable #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_enable
           end
@@ -451,7 +452,7 @@ describe Chef::Provider::SystemdUnit do
           it "disables the unit when it is enabled" do
             current_resource.enabled(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system disable #{unit_name}", {})
+                                  .with("#{systemctl_path} --system disable #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_disable
           end
@@ -477,7 +478,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.masked(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user mask #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user mask #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_mask
           end
@@ -493,7 +494,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.masked(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user unmask #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user unmask #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_unmask
           end
@@ -510,7 +511,7 @@ describe Chef::Provider::SystemdUnit do
           it "masks the unit when it is unmasked" do
             current_resource.masked(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system mask #{unit_name}", {})
+                                  .with("#{systemctl_path} --system mask #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_mask
           end
@@ -524,7 +525,7 @@ describe Chef::Provider::SystemdUnit do
           it "unmasks the unit when it is masked" do
             current_resource.masked(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system unmask #{unit_name}", {})
+                                  .with("#{systemctl_path} --system unmask #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_unmask
           end
@@ -543,7 +544,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.active(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user start #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user start #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_start
           end
@@ -559,7 +560,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.active(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user stop #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user stop #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_stop
           end
@@ -576,7 +577,7 @@ describe Chef::Provider::SystemdUnit do
           it "starts the unit when it is inactive" do
             current_resource.active(false)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system start #{unit_name}", {})
+                                  .with("#{systemctl_path} --system start #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_start
           end
@@ -590,7 +591,7 @@ describe Chef::Provider::SystemdUnit do
           it "stops the unit when it is active" do
             current_resource.active(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system stop #{unit_name}", {})
+                                  .with("#{systemctl_path} --system stop #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_stop
           end
@@ -608,7 +609,7 @@ describe Chef::Provider::SystemdUnit do
           it "restarts the unit" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user restart #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user restart #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_restart
           end
@@ -617,7 +618,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             current_resource.active(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user reload #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_reload
           end
@@ -633,7 +634,7 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "restarts the unit" do
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system restart #{unit_name}", {})
+                                  .with("#{systemctl_path} --system restart #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_restart
           end
@@ -641,7 +642,7 @@ describe Chef::Provider::SystemdUnit do
           it "reloads the unit if active" do
             current_resource.active(true)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload #{unit_name}", {})
+                                  .with("#{systemctl_path} --system reload #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_reload
           end
@@ -659,7 +660,7 @@ describe Chef::Provider::SystemdUnit do
           it "try-restarts the unit" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user try-restart #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user try-restart #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_try_restart
           end
@@ -668,7 +669,7 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "try-restarts the unit" do
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system try-restart #{unit_name}", {})
+                                  .with("#{systemctl_path} --system try-restart #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_try_restart
           end
@@ -680,7 +681,7 @@ describe Chef::Provider::SystemdUnit do
           it "reload-or-restarts the unit" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload-or-restart #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user reload-or-restart #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_reload_or_restart
           end
@@ -689,7 +690,7 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "reload-or-restarts the unit" do
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload-or-restart #{unit_name}", {})
+                                  .with("#{systemctl_path} --system reload-or-restart #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_reload_or_restart
           end
@@ -701,7 +702,7 @@ describe Chef::Provider::SystemdUnit do
           it "reload-or-try-restarts the unit" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload-or-try-restart #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user reload-or-try-restart #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             provider.action_reload_or_try_restart
           end
@@ -710,7 +711,7 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "reload-or-try-restarts the unit" do
             expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload-or-try-restart #{unit_name}", {})
+                                  .with("#{systemctl_path} --system reload-or-try-restart #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             provider.action_reload_or_try_restart
           end
@@ -727,7 +728,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns true when unit is active" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-active #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-active #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             expect(provider.active?).to be true
           end
@@ -735,7 +736,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns false when unit is inactive" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-active #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-active #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_failure)
             expect(provider.active?).to be false
           end
@@ -744,14 +745,14 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "returns true when unit is active" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-active #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-active #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             expect(provider.active?).to be true
           end
 
           it "returns false when unit is not active" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-active #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-active #{unit_name_escaped}", {})
                                   .and_return(shell_out_failure)
             expect(provider.active?).to be false
           end
@@ -768,7 +769,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns true when unit is enabled" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-enabled #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-enabled #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_success)
             expect(provider.enabled?).to be true
           end
@@ -776,7 +777,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns false when unit is not enabled" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-enabled #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-enabled #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_failure)
             expect(provider.enabled?).to be false
           end
@@ -785,14 +786,14 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "returns true when unit is enabled" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-enabled #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-enabled #{unit_name_escaped}", {})
                                   .and_return(shell_out_success)
             expect(provider.enabled?).to be true
           end
 
           it "returns false when unit is not enabled" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-enabled #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-enabled #{unit_name_escaped}", {})
                                   .and_return(shell_out_failure)
             expect(provider.enabled?).to be false
           end
@@ -809,7 +810,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns true when the unit is masked" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user status #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user status #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_masked)
             expect(provider.masked?).to be true
           end
@@ -817,7 +818,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns false when the unit is not masked" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user status #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user status #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_static)
             expect(provider.masked?).to be false
           end
@@ -826,14 +827,14 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "returns true when the unit is masked" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system status #{unit_name}", {})
+                                  .with("#{systemctl_path} --system status #{unit_name_escaped}", {})
                                   .and_return(shell_out_masked)
             expect(provider.masked?).to be true
           end
 
           it "returns false when the unit is not masked" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system status #{unit_name}", {})
+                                  .with("#{systemctl_path} --system status #{unit_name_escaped}", {})
                                   .and_return(shell_out_static)
             expect(provider.masked?).to be false
           end
@@ -850,7 +851,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns true when the unit is static" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-enabled #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-enabled #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_static)
             expect(provider.static?).to be true
           end
@@ -858,7 +859,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns false when the unit is not static" do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --user is-enabled #{unit_name}", user_cmd_opts)
+                                  .with("#{systemctl_path} --user is-enabled #{unit_name_escaped}", user_cmd_opts)
                                   .and_return(shell_out_masked)
             expect(provider.static?).to be false
           end
@@ -867,14 +868,14 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "returns true when the unit is static" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-enabled #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-enabled #{unit_name_escaped}", {})
                                   .and_return(shell_out_static)
             expect(provider.static?).to be true
           end
 
           it "returns false when the unit is not static" do
             expect(provider).to receive(:shell_out)
-                                  .with("#{systemctl_path} --system is-enabled #{unit_name}", {})
+                                  .with("#{systemctl_path} --system is-enabled #{unit_name_escaped}", {})
                                   .and_return(shell_out_masked)
             expect(provider.static?).to be false
           end


### PR DESCRIPTION
### Description

Chef currently passes the string representing the name of a service (i.e. of the unit in systemd land) directly on the `systemctl` command line when shelling out. This causes issues for units containing escape sequences (e.g. autogenerated units like `dev-dm\x2d1.swap`), which will result in Chef calling `systemctl start dev-dm\x2d1.swap`, which doesn't work as the shell reads the `\` as a control character. This PR fixes the problem by always calling `.shellescape` when using the service name in a command line for the systemd `service` provider and the `systemd_unit` provider.

### Issues Resolved

N/A

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
