### PR TITLE
[knife] add order by and limit the number of cookbooks returned when listing

### DIFF
--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -36,13 +36,13 @@ class Chef
         :description => "Supermarket Site",
         :default => "https://supermarket.chef.io",
         :proc => Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-      
+
       option :order,
         :short => "-o ORDER_PREFERENCE",
         :long => "--order ORDER_PREFERENCE",
         :default => "name",
         :description => "Show cookbooks ordered by recently_updated, recently_added, most_downloaded, most_followed, or by name (DEFAULT)."
- 
+
       option :items,
         :short => "-n NUMBER_OF_ITEMS",
         :long => "--number NUMBER_OF_ITEMS",
@@ -50,7 +50,7 @@ class Chef
         :description => "Show number of cookbooks. Default 100."
 
       def run
-        if config[:with_uri]          
+        if config[:with_uri]
           ui.output(format_for_display(get_cookbook_list))
         else
           ui.msg(ui.list(get_cookbook_list.keys, :columns_down))

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -47,20 +47,6 @@ class Chef
           noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}/versions/#{name_args[1].tr('.', '_')}")
         end
       end
-
-      def get_cookbook_list(items = 10, start = 0, cookbook_collection = {})
-        cookbooks_url = "#{supermarket_uri}/cookbooks?items=#{items}&start=#{start}"
-        cr = noauth_rest.get(cookbooks_url)
-        cr["items"].each do |cookbook|
-          cookbook_collection[cookbook["cookbook_name"]] = cookbook
-        end
-        new_start = start + cr["items"].length
-        if new_start < cr["total"]
-          get_cookbook_list(items, new_start, cookbook_collection)
-        else
-          cookbook_collection
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
### Description

This updates knife cookbook site list to add order by and limit number functionality. It changes the default behavior from listing all cookbooks to 100. The refactor speeds up the response.

Additionally, code is removed from knife cookbook show list that isn't used. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
