### PR TITLE
use the HA pool for the docker acceptance test

### DIFF
--- a/acceptance/top-cookbooks/.kitchen.docker.yml
+++ b/acceptance/top-cookbooks/.kitchen.docker.yml
@@ -1,6 +1,10 @@
 suites:
   - name: docker-default
     attributes:
+      apt-docker:
+        repos:
+          docker-main:
+            keyserver: hkp://ha.pool.sks-keyservers.net
       docker:
         version: 1.10.0
     run_list:


### PR DESCRIPTION
the port 80 keyservers pool is really unreliable