### PR TITLE
Enable zypper package options

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -103,7 +103,7 @@ class Chef
         end
 
         def install_package(name, version)
-          zypper_package("install", "--auto-agree-with-licenses", name, version)
+          zypper_package("install", *options, "--auto-agree-with-licenses", name, version)
         end
 
         def upgrade_package(name, version)
@@ -112,19 +112,19 @@ class Chef
         end
 
         def remove_package(name, version)
-          zypper_package("remove", name, version)
+          zypper_package("remove", *options, name, version)
         end
 
         def purge_package(name, version)
-          zypper_package("remove", "--clean-deps", name, version)
+          zypper_package("remove", *options, "--clean-deps", name, version)
         end
 
         def lock_package(name, version)
-          zypper_package("addlock", name, version)
+          zypper_package("addlock", *options, name, version)
         end
 
         def unlock_package(name, version)
-          zypper_package("removelock", name, version)
+          zypper_package("removelock", *options, name, version)
         end
 
         private

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -139,6 +139,14 @@ describe Chef::Provider::Package::Zypper do
       )
       provider.install_package(["emacs"], ["1.0"])
     end
+
+    it "should add user provided options to the command" do
+      new_resource.options "--user-provided"
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "emacs=1.0"
+      )
+      provider.install_package(["emacs"], ["1.0"])
+    end
   end
 
   describe "upgrade_package" do
@@ -159,6 +167,13 @@ describe Chef::Provider::Package::Zypper do
       Chef::Config[:zypper_check_gpg] = false
       shell_out_expectation!(
         "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "emacs=1.0"
+      )
+      provider.upgrade_package(["emacs"], ["1.0"])
+    end
+    it "should add user provided options to the command" do
+      new_resource.options "--user-provided"
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
@@ -196,6 +211,13 @@ describe Chef::Provider::Package::Zypper do
         )
         provider.remove_package(["emacs"], ["1.0"])
       end
+      it "should add user provided options to the command" do
+        new_resource.options "--user-provided"
+        shell_out_expectation!(
+          "zypper", "--non-interactive", "remove", "--user-provided", "emacs=1.0"
+        )
+        provider.remove_package(["emacs"], ["1.0"])
+      end
     end
   end
 
@@ -220,6 +242,13 @@ describe Chef::Provider::Package::Zypper do
       )
       provider.purge_package(["emacs"], ["1.0"])
     end
+    it "should add user provided options to the command" do
+      new_resource.options "--user-provided"
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "remove", "--user-provided", "--clean-deps", "emacs=1.0"
+      )
+      provider.purge_package(["emacs"], ["1.0"])
+    end
   end
 
   describe "lock_package" do
@@ -236,6 +265,13 @@ describe Chef::Provider::Package::Zypper do
       )
       provider.lock_package(["emacs"], [nil])
     end
+    it "should add user provided options to the command" do
+      new_resource.options "--user-provided"
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "addlock", "--user-provided", "emacs"
+      )
+      provider.lock_package(["emacs"], [nil])
+    end
   end
 
   describe "unlock_package" do
@@ -249,6 +285,13 @@ describe Chef::Provider::Package::Zypper do
       new_resource.gpg_check false
       shell_out_expectation!(
         "zypper", "--non-interactive", "--no-gpg-checks", "removelock", "emacs"
+      )
+      provider.unlock_package(["emacs"], [nil])
+    end
+    it "should add user provided options to the command" do
+      new_resource.options "--user-provided"
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "removelock", "--user-provided", "emacs"
       )
       provider.unlock_package(["emacs"], [nil])
     end


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

the `options` property was ignored on the `zypper` package resource. This adds it.
@chef/engineering-services 

### Issues Resolved

resolves https://github.com/chef/chef/issues/6011

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
