### PR TITLE
Chef 14: Remove deprecated bootstrap options

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -119,16 +119,6 @@ class Chef
         :description => "Do not proxy locations for the node being bootstrapped; this option is used internally by Opscode",
         :proc => Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
-      # DEPR: Remove this option in Chef 13
-      option :distro,
-        :short => "-d DISTRO",
-        :long => "--distro DISTRO",
-        :description => "Bootstrap a distro using a template. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-        :proc        => Proc.new { |v|
-          Chef::Log.warn("[DEPRECATED] -d / --distro option is deprecated. Use -t / --bootstrap-template option instead.")
-          v
-        }
-
       option :bootstrap_template,
         :short => "-t TEMPLATE",
         :long => "--bootstrap-template TEMPLATE",
@@ -148,15 +138,6 @@ class Chef
         :long => "--use-sudo-password",
         :description => "Execute the bootstrap via sudo with password",
         :boolean => false
-
-      # DEPR: Remove this option in Chef 13
-      option :template_file,
-        :long => "--template-file TEMPLATE",
-        :description => "Full path to location of template to use. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-        :proc        => Proc.new { |v|
-          Chef::Log.warn("[DEPRECATED] --template-file option is deprecated. Use -t / --bootstrap-template option instead.")
-          v
-        }
 
       option :run_list,
         :short => "-r RUN_LIST",
@@ -307,10 +288,9 @@ class Chef
       end
 
       def bootstrap_template
-        # The order here is important. We want to check if we have the new Chef 12 option is set first.
-        # Knife cloud plugins unfortunately all set a default option for the :distro so it should be at
-        # the end.
-        config[:bootstrap_template] || config[:template_file] || config[:distro] || default_bootstrap_template
+        #
+        # @return [String] The CLI specific bootstrap template or the default
+        config[:bootstrap_template] || default_bootstrap_template
       end
 
       def find_template

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -288,7 +288,7 @@ class Chef
       end
 
       def bootstrap_template
-        #
+        # Allow passing a bootstrap template or use the default
         # @return [String] The CLI specific bootstrap template or the default
         config[:bootstrap_template] || default_bootstrap_template
       end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -84,24 +84,8 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
-  context "with :distro and :bootstrap_template cli options" do
-    let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "--distro", "other-template" ] }
-
-    it "should select bootstrap template" do
-      expect(File.basename(knife.bootstrap_template)).to eq("my-template")
-    end
-  end
-
-  context "with :distro and :template_file cli options" do
-    let(:bootstrap_cli_options) { [ "--distro", "my-template", "--template-file", "other-template" ] }
-
-    it "should select bootstrap template" do
-      expect(File.basename(knife.bootstrap_template)).to eq("other-template")
-    end
-  end
-
   context "with :bootstrap_template and :template_file cli options" do
-    let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "--template-file", "other-template" ] }
+    let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "other-template" ] }
 
     it "should select bootstrap template" do
       expect(File.basename(knife.bootstrap_template)).to eq("my-template")
@@ -235,7 +219,7 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
-  ["-d", "--distro", "-t", "--bootstrap-template", "--template-file"].each do |t|
+  ["-t", "--bootstrap-template"].each do |t|
     context "when #{t} option is given in the command line" do
       it "sets the knife :bootstrap_template config" do
         knife.parse_options([t, "blahblah"])


### PR DESCRIPTION
We said we would remove these in Chef 13 in the code. Lets do it for 14 instead.

Signed-off-by: Tim Smith <tsmith@chef.io>