### PR TITLE
move nokogiri config to omnibus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "inspec"
-  gem "nokogiri", ">= 1.8"
 end
 
 group(:omnibus_package, :pry) do

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -48,6 +48,9 @@ instance_eval(IO.read(overrides_path), overrides_path)
 dependency "preparation"
 dependency "chef"
 
+# Nokogiri is an addon-extra we bundle and not a direct dep of chef itself
+dependency "nokogiri"
+
 # FIXME?: might make sense to move dependencies below into the omnibus-software chef
 #  definition or into a chef-complete definition added to omnibus-software.
 dependency "gem-permissions"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,6 +3,7 @@
 # try to keep it machine-parsable.
 override :rubygems, version: "2.6.11"
 override :bundler, version: "1.14.6"
+override "nokogiri", version: "1.8.0"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.14"
 override "liblzma", version: "5.2.3"


### PR DESCRIPTION
this hand-builds it with the software dep, and its not a direct dep of
chef itself and shouldn't be in the Gemfile.lock anyway, plus we need
to pin via omnibus_overrides.rb and double-pinning in the Gemfile.lock
is just added fussiness
