### PR TITLE
Update omnibus pinning to enable automated s3 omnibus cache population

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: e9c48c6773dec6fd718642194bfcb166d5685e03
+  revision: 75ffc87dd36b1be3b49a4a3dfe026734f48e146f
   specs:
     license_scout (0.1.3)
       ffi-yajl (~> 2.2)
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 0212438d74eb408791724d737afba83868e416ed
+  revision: f2f670e905f432a2d2c895650144b04ae4beffd2
   specs:
-    omnibus (5.5.0)
+    omnibus (5.6.1)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
@@ -37,15 +37,15 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.8.2)
-    awesome_print (1.7.0)
-    aws-sdk (2.9.41)
-      aws-sdk-resources (= 2.9.41)
-    aws-sdk-core (2.9.41)
+    awesome_print (1.8.0)
+    aws-sdk (2.10.10)
+      aws-sdk-resources (= 2.10.10)
+    aws-sdk-core (2.10.10)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.41)
-      aws-sdk-core (= 2.9.41)
-    aws-sigv4 (1.0.0)
+    aws-sdk-resources (2.10.10)
+      aws-sdk-core (= 2.10.10)
+    aws-sigv4 (1.0.1)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -85,12 +85,12 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (13.1.31)
+    chef-config (13.2.20)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-sugar (3.4.0)
+    chef-sugar (3.5.0)
     cleanroom (1.0.0)
     coderay (1.1.1)
     debug_inspector (0.0.3)
@@ -100,7 +100,7 @@ GEM
     ffi (1.9.18)
     ffi (1.9.18-x64-mingw32)
     ffi (1.9.18-x86-mingw32)
-    ffi-yajl (2.3.0)
+    ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.2.0)
@@ -153,7 +153,7 @@ GEM
     nori (2.6.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (8.24.0)
+    ohai (8.24.1)
       chef-config (>= 12.5.0.alpha.1, < 14)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

I ran `bundle update omnibus` - if that isn't the current way of updating, please fix as appropriate.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
