### PR TITLE
Added :elevated option for powershell_script resource

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Previous Visual Studio 2013
+os: Previous Visual Studio 2015
 platform:
   - x64
 

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -27,7 +27,7 @@ class Chef
 
       provides :execute
 
-      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates
+      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated
 
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
@@ -102,6 +102,7 @@ class Chef
             opts[:live_stream] = STDOUT
           end
         end
+        opts[:elevated] = elevated if elevated
         opts
       end
 

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -59,9 +59,9 @@ describe Chef::Resource::PowershellScript do
       allow(resource).to receive(:updated).and_return(true)
     end
 
-    it "inherits exactly the :cwd, :environment, :group, :path, :user, :umask, and :architecture attributes from a parent resource class" do
+    it "inherits exactly the :cwd, :environment, :group, :path, :user, :umask, :architecture, :elevated attributes from a parent resource class" do
       inherited_difference = Chef::Resource::PowershellScript.guard_inherited_attributes -
-        [:cwd, :environment, :group, :path, :user, :umask, :architecture ]
+        [:cwd, :environment, :group, :path, :user, :umask, :architecture, :elevated ]
 
       expect(inherited_difference).to eq([])
     end


### PR DESCRIPTION
### Description

Added :elevated option for powershell_script resource. This should be merged after https://github.com/chef/mixlib-shellout/pull/148

### Issues Resolved
fixes https://github.com/chef/chef/issues/6086

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
