### PR TITLE
Use the previous VS 2015 image in appveyor instead of 2013

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Previous Visual Studio 2013
+os: Previous Visual Studio 2015
 platform:
   - x64
 


### PR DESCRIPTION
@harikesh-kolekar believes we'll have better luck on the 'Previous' 2015 image rather than 2013.