### PR TITLE
avoid mutation attempt of node['platform']

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -123,7 +123,7 @@ class Chef
             line_parts << run_list if run_list
 
             if node["platform"]
-              platform = node["platform"]
+              platform = node["platform"].dup
               if node["platform_version"]
                 platform << " #{node['platform_version']}"
               end

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -23,6 +23,8 @@ describe Chef::Knife::Status do
     node = Chef::Node.new.tap do |n|
       n.automatic_attrs["fqdn"] = "foobar"
       n.automatic_attrs["ohai_time"] = 1343845969
+      n.automatic_attrs["platform"] = "mac_os_x"
+      n.automatic_attrs["platform_version"] = "10.12.5"
     end
     allow(Time).to receive(:now).and_return(Time.at(1428573420))
     @query = double("Chef::Search::Query")


### PR DESCRIPTION
### Description 

Fixes https://github.com/chef/chef/issues/6277

Added `node['platform']` and `node['platform_version']` attributes in
the unit test to trigger the "can't modify frozen String" error which wasn't
being thrown in the unit tests before.

Fixed by doing shallow copy of `node['platform']` on assignment.

Signed-off-by: Jeremy J. Miller <jm@chef.io>

### Issues Resolved

https://github.com/chef/chef/issues/6277

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>