### PR TITLE
added gateway attribute to ifconfig resource on debian

### DIFF
--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -48,6 +48,7 @@ iface <%= new_resource.device %> inet static
     <% if new_resource.metric %>metric <%= new_resource.metric %><% end %>
     <% if new_resource.hwaddr %>hwaddress <%= new_resource.hwaddr %><% end %>
     <% if new_resource.mtu %>mtu <%= new_resource.mtu %><% end %>
+    <% if new_resource.gateway %>gateway <%= new_resource.gateway %><% end %>
 <% end %>
 <% end %>
           }

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -36,6 +36,7 @@ class Chef
         @hwaddr = nil
         @mask = nil
         @inet_addr = nil
+        @gateway = nil
         @bcast = nil
         @mtu = nil
         @metric = nil
@@ -73,6 +74,14 @@ class Chef
       def inet_addr(arg = nil)
         set_or_return(
           :inet_addr,
+          arg,
+          :kind_of => String
+        )
+      end
+
+      def gateway(arg = nil)
+        set_or_return(
+          :gateway,
           arg,
           :kind_of => String
         )


### PR DESCRIPTION
### Description

I noticed that the ifconfig resource does not implement the "gateway" option for network interfaces. I tried some local changes to see if some copy pasting and name changing from existing attributes will do the trick. It did! Using gateway "ipaddress" will now put that ip address in the interface file.
### Issues Resolved

I did not find a relevant issue for that subject.

### Check List

NOTE: I ran into multiple issues trying to get rspec to run. something with cheffish requiring version 2.3.3 of ruby (which I've installed). Either way, I have no way to run the existing specs on my machine.
If there is a docker image with all the requirements for the tests to run please let me know and I'll be happy to run and write tests for this pull request. But as of now I've been trying to get rspec to work for more than an hour.

- [ no ] New functionality includes tests
- [ don't know ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
