### PR TITLE
Handle display names with trailing spaces

### DIFF
--- a/lib/chef/provider/package/windows/registry_uninstall_entry.rb
+++ b/lib/chef/provider/package/windows/registry_uninstall_entry.rb
@@ -40,7 +40,7 @@ class Chef
                     begin
                       entry = reg.open(key, desired)
                       display_name = read_registry_property(entry, "DisplayName")
-                      if display_name == package_name
+                      if display_name.to_s.rstrip == package_name
                         quiet_uninstall_string = RegistryUninstallEntry.read_registry_property(entry, "QuietUninstallString")
                         entries.push(quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry))
                       end


### PR DESCRIPTION
Closes #6217.

The reason why we do `to_s.rstrip` is to handle the (potentially weird case of) `display_name` being `nil`, in which case we will otherwise get an unfriendly Ruby error message.

### Check List

- [ ] New functionality includes tests (negative: if this is a requirement, please tell me where to add them)
- [x] All tests pass
- [ ] ~RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)~ Should not be required in this case
- [ ] ~All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>~ (should not be needed for the trivial change, let me know if you want me to amend to include this)
