### PR TITLE
Bump mixlib-shellout for #6271

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: e6b966a18dc4a12b4dfa49ccb911dad7432ca4fd
+  revision: 5b59b5269cc0cf6c08fcc5e160bdc6363d194708
   branch: master
   specs:
     chefstyle (0.6.0)
@@ -21,9 +21,9 @@ GIT
 
 GIT
   remote: https://github.com/rubysec/bundler-audit.git
-  revision: 6eb5a81e9b184fbb8db03f3e57dc758c65dd7383
+  revision: 6e2e298aebb0707a1b62c08c005335ecd130aa66
   specs:
-    bundler-audit (0.5.0)
+    bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
 
@@ -122,7 +122,6 @@ GEM
     addressable (2.4.0)
     appbundler (0.10.0)
       mixlib-cli (~> 1.4)
-      mixlib-shellout (~> 2.0)
     ast (2.3.0)
     backports (3.8.0)
     binding_of_caller (0.7.2)
@@ -130,7 +129,7 @@ GEM
     blankslate (2.1.2.4)
     builder (3.2.3)
     byebug (9.0.6)
-    chef-zero (13.0.0)
+    chef-zero (13.1.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)
@@ -176,7 +175,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.5)
+    hashie (3.5.6)
     highline (1.7.8)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -220,13 +219,13 @@ GEM
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
-    mixlib-install (3.3.1)
+    mixlib-install (3.3.2)
       mixlib-shellout
       mixlib-versioning
       thor
     mixlib-log (1.7.1)
-    mixlib-shellout (2.2.7)
-    mixlib-shellout (2.2.7-universal-mingw32)
+    mixlib-shellout (2.3.1)
+    mixlib-shellout (2.3.1-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.1.0)
@@ -338,7 +337,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.1)
     slop (3.6.0)
-    specinfra (2.68.1)
+    specinfra (2.69.0)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet


### PR DESCRIPTION
#6271 requires mixlib-shellout 2.3 for elevated functionality merged in https://github.com/chef/mixlib-shellout/pull/149.