### PR TITLE
chef server rejects metadata with nil maintainer

### DIFF
--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -100,8 +100,8 @@ class Chef
         @long_description = ""
         @license = "All rights reserved"
 
-        @maintainer = nil
-        @maintainer_email = nil
+        @maintainer = ""
+        @maintainer_email = ""
 
         @platforms = Mash.new
         @dependencies = Mash.new

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Falcon (<seth@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,11 +98,11 @@ describe Chef::Cookbook::Metadata do
     end
 
     it "has an empty maintainer field" do
-      expect(metadata.maintainer).to eq(nil)
+      expect(metadata.maintainer).to eq("")
     end
 
     it "has an empty maintainer_email field" do
-      expect(metadata.maintainer).to eq(nil)
+      expect(metadata.maintainer_email).to eq("")
     end
 
     it "has an empty platforms list" do

--- a/spec/unit/knife/cookbook_show_spec.rb
+++ b/spec/unit/knife/cookbook_show_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2017, Chef Software Inc.
 # License:: Apache License, eersion 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,8 +110,8 @@ describe Chef::Knife::CookbookShow do
             "name" => nil,
             "description" => "",
             "long_description" => "",
-            "maintainer" => nil,
-            "maintainer_email" => nil,
+            "maintainer" => "",
+            "maintainer_email" => "",
             "license" => "All rights reserved",
             "platforms" => {},
             "dependencies" => {},


### PR DESCRIPTION
chef server returns a 400.  we could prune nil values out of the
JSON but then it'd be difficult to specify a "null" JSON value if we
really needed one.  seems better to follow the pattern of using
empty string here (which i tested against Hosted and works).

