### PR TITLE
Switch to current VS 2015 Appveyor Image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Previous Visual Studio 2015
+os: Visual Studio 2015
 platform:
   - x64
 


### PR DESCRIPTION
@FeodorFitsner reports that https://github.com/appveyor/ci/issues/1657 has been fixed for the VS 2015 images.
