### PR TITLE
Add .dockerignore to reduce size of resulting images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# We don't want/need anything from the local system, so ignore everything.
+*


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Our container image does not require any files from the local path. This PR adds a `.dockerignore` file that will ensure none of the local system files get copied over to the container image when it is built. This should reduce the size of the resulting container image. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
