### PR TITLE
MSYS-631 Added tests for Chef::Provider::Package::Windows::RegistryUninstallEntry.find_entries

### DIFF
--- a/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
+++ b/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
@@ -9,7 +9,7 @@ describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
   describe "when QuietUninstallString key not present" do
     let(:quiet_uninstall_string) { nil }
     let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
-    it "should return UninstallString key value" do
+    it "returns UninstallString key value" do
       expect(quiet_uninstall_string_key).to eql "UninstallStringPath"
     end
   end
@@ -17,9 +17,62 @@ describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
   describe "when QuietUninstallString key present" do
     let(:quiet_uninstall_string) { "QuietUninstallString" }
     let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
-
-    it "should return QuietUninstallString key value" do
+    it "returns QuietUninstallString key value" do
       expect(quiet_uninstall_string_key).to eql "QuietUninstallStringPath"
+    end
+  end
+
+  describe ".find_entries", :windows_only do
+    let (:registry_uninstall_entry) { Chef::Provider::Package::Windows::RegistryUninstallEntry }
+    before(:each) do
+      allow_any_instance_of(::Win32::Registry).to receive(:open).and_return("::Win32::Registry::HKEY_CURRENT_USER")
+    end
+
+    context "when passing nil" do
+      let(:package_name) { nil }
+      it "returns empty entries array" do
+        allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:read_registry_property).and_return(nil)
+        entries = Chef::Provider::Package::Windows::RegistryUninstallEntry.find_entries(package_name)
+        expect(entries.size).to eql 0
+      end
+    end
+
+    context "when passing empty string" do
+      let(:package_name) { " " }
+      it "returns no entries" do
+        allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:read_registry_property).and_return(nil)
+        entries = Chef::Provider::Package::Windows::RegistryUninstallEntry.find_entries(package_name)
+        expect(entries.size).to eql 0
+      end
+    end
+
+    context "when package is not found" do
+      let(:package_name) { "hive" }
+      it "returns no entries" do
+        allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:read_registry_property).and_return("Chef Client")
+        entries = Chef::Provider::Package::Windows::RegistryUninstallEntry.find_entries(package_name)
+        expect(entries).to eql []
+      end
+    end
+
+    context "when trailing spaces are given in display name" do
+      let(:package_name) { "Chef" }
+      let(:display_name_with_space) { "Chef      " }
+      it "removes the trailing spaces" do
+        allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:read_registry_property).and_return(display_name_with_space)
+        entries = registry_uninstall_entry.find_entries(package_name).first
+        expect(entries.display_name.rstrip).to eql package_name
+      end
+    end
+
+    context "When package found successfully" do
+      let(:package_name) { "Chef Client" }
+      let(:display_name) { "Chef Client" }
+      it "returns 'Chef Client' entries" do
+        allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:read_registry_property).and_return(display_name)
+        entries = registry_uninstall_entry.find_entries(package_name).first
+        expect(entries.display_name.rstrip).to eql package_name
+      end
     end
   end
 end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -224,7 +224,7 @@ describe Chef::Provider::Package::Windows, :windows_only do
         end
       end
 
-      context "eninstall entries is empty" do
+      context "uninstall entries is empty" do
         before { allow(Chef::Provider::Package::Windows::RegistryUninstallEntry).to receive(:find_entries).and_return([]) }
 
         it "returns nil" do


### PR DESCRIPTION
This adds missing test coverage for https://github.com/chef/chef/pull/6280.