### PR TITLE
Fix git command in DCO sign-off example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ The DCO requires a sign-off message in the following format appear on each commi
 Signed-off-by: Julia Child <juliachild@chef.io>
 ```
 
-The DCO text can either be manually added to your commit body, or you can add either **-s** or **--signoff** to your usual git commit commands. If you forget to add the sign-off you can also amend a previous commit with the sign-off by running **git commit –-amend -s**. If you've pushed your changes to Github already you'll need to force push your branch after this with **git push -f**.
+The DCO text can either be manually added to your commit body, or you can add either **-s** or **--signoff** to your usual git commit commands. If you forget to add the sign-off you can also amend a previous commit with the sign-off by running **git commit --amend -s**. If you've pushed your changes to Github already you'll need to force push your branch after this with **git push -f**.
 
 ### Chef Obvious Fix Policy
 


### PR DESCRIPTION
Previously the first dash in `--amend` was a unicode en dash (U+2013) rather than a hyphen, which results in the confusing:
```
$ git commit –-amend -s
error: pathspec '–-amend' did not match any file(s) known to git.
```
