### PR TITLE
throw readable errors if multiple dsc resources are found

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -515,7 +515,7 @@ This error is most often caused by network issues (proxies, etc) outside of chef
             "Resource #{r['Name']} is a binary resource"
           end
         end
-        super "Found multiple matching resources. #{matches_info.join("\n")}"
+        super "Found multiple matching resources of #{matches_info[0]["Module"]["Name"]}:\n#{(matches_info.map { |f| f["Module"]["Version"] }).uniq.join("\n")}"
       end
     end
 

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -515,7 +515,7 @@ This error is most often caused by network issues (proxies, etc) outside of chef
             "Resource #{r['Name']} is a binary resource"
           end
         end
-        super "Found multiple matching resources of #{matches_info[0]["Module"]["Name"]}:\n#{(matches_info.map { |f| f["Module"]["Version"] }).uniq.join("\n")}"
+        super "Found multiple resources matching #{matches_info[0]["Module"]["Name"]}:\n#{(matches_info.map { |f| f["Module"]["Version"] }).uniq.join("\n")}"
       end
     end
 

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -155,8 +155,8 @@ describe Chef::Provider::DscResource do
       context "multiple resource are found" do
         let (:resource_records) do
           [
-          { "Module" => { "Name" => "ModuleName1" } },
-          { "Module" => { "Name" => "ModuleName2" } },
+          { "Module" => { "Name" => "ModuleName1", "Version" => "1.0.0.0" } },
+          { "Module" => { "Name" => "ModuleName1", "Version" => "2.0.0.0" } },
         ] end
 
         it "raises MultipleDscResourcesFound" do


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

Currently, MultipleDscResourcesFound errors are unreadable due to the (usually) large object which is returned. This change adresses this by printing only the name and discovered versions of the dsc resources.

### Issues Resolved

Talked to @thommay in the chef community slack #chef-dev channel.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>