### PR TITLE
Pass json configuration to ShellSession class

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -138,6 +138,7 @@ module Shell
   def self.session
     unless client_type.instance.node_built?
       puts "Session type: #{client_type.session_type}"
+      client_type.instance.json_configuration = @json_attribs
       client_type.instance.reset!
     end
     client_type.instance

--- a/lib/chef/shell/shell_session.rb
+++ b/lib/chef/shell/shell_session.rb
@@ -38,7 +38,7 @@ module Shell
       @session_type
     end
 
-    attr_accessor :node, :compile, :recipe, :run_context
+    attr_accessor :node, :compile, :recipe, :run_context, :json_configuration
     attr_reader :node_attributes, :client
     def initialize
       @node_built = false
@@ -151,7 +151,7 @@ module Shell
 
     def rebuild_node
       Chef::Config[:solo_legacy_mode] = true
-      @client = Chef::Client.new(nil, Chef::Config[:shell_config])
+      @client = Chef::Client.new(json_configuration, Chef::Config[:shell_config])
       @client.run_ohai
       @client.load_node
       @client.build_node
@@ -183,7 +183,7 @@ module Shell
     def rebuild_node
       # Tell the client we're chef solo so it won't try to contact the server
       Chef::Config[:solo_legacy_mode] = true
-      @client = Chef::Client.new(nil, Chef::Config[:shell_config])
+      @client = Chef::Client.new(json_configuration, Chef::Config[:shell_config])
       @client.run_ohai
       @client.load_node
       @client.build_node
@@ -218,7 +218,7 @@ module Shell
     def rebuild_node
       # Make sure the client knows this is not chef solo
       Chef::Config[:solo_legacy_mode] = false
-      @client = Chef::Client.new(nil, Chef::Config[:shell_config])
+      @client = Chef::Client.new(json_configuration, Chef::Config[:shell_config])
       @client.run_ohai
       @client.register
       @client.load_node


### PR DESCRIPTION
This commit passes json configuration to ShellSession class and thusly into ChefClient object created by the ShellSession. 

### Description

This commit fixes an issue in chef-shell whereby runlists passed in via a json file using the -j flag would not be loaded when running chef-shell in client mode using the -z flag.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
