### PR TITLE
Maintain backwards compatibility with apt_preference

### DIFF
--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -37,6 +37,10 @@ class Chef
       end
 
       action :add do
+        # raise within the action vs. requiring the resource so :remove doesn't fail w/o pin & pin_priority
+        raise "pin property required for apt_preference when using the :add action" if new_resource.pin.nil?
+        raise "pin property required for apt_preference when using the :add action" if new_resource.pin_priority.nil?
+
         preference = build_pref(
           new_resource.glob || new_resource.package_name,
           new_resource.pin,

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -26,8 +26,8 @@ class Chef
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String
-      property :pin, String, required: true
-      property :pin_priority, [String, Integer], required: true
+      property :pin, String
+      property :pin_priority, [String, Integer]
 
       default_action :add
       allowed_actions :add, :remove


### PR DESCRIPTION
Remove did not previously require the pin and pin_priority. Also it doesn't make sense to require those for a remove action.

Signed-off-by: Tim Smith <tsmith@chef.io>