### PR TITLE
Fix an issue where DeepMerge overwrites nil values

### DIFF
--- a/lib/chef/mixin/deep_merge.rb
+++ b/lib/chef/mixin/deep_merge.rb
@@ -64,7 +64,7 @@ class Chef
         when Hash
           if dest.kind_of?(Hash)
             source.each do |src_key, src_value|
-              if dest[src_key]
+              if dest.key?(src_key)
                 dest[src_key] = deep_merge!(src_value, dest[src_key])
               else # dest[src_key] doesn't exist so we take whatever source has
                 dest[src_key] = src_value

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -340,7 +340,7 @@ describe Chef::Node do
 
       it "consume_attributes does not exhibit chef/chef/issues/6302 bug" do
         node.normal["a"]["r1"] = nil
-        node.consume_attributes({"a" => { "r2" => nil}})
+        node.consume_attributes({ "a" => { "r2" => nil } })
         expect(node["a"]["r1"]).to be_nil
         expect(node["a"]["r2"]).to be_nil
       end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -337,6 +337,13 @@ describe Chef::Node do
         node.override_unless[:decontamination] = "foo"
         expect(node.override[:decontamination]).to eql("foo")
       end
+
+      it "consume_attributes does not exhibit chef/chef/issues/6302 bug" do
+        node.normal["a"]["r1"] = nil
+        node.consume_attributes({"a" => { "r2" => nil}})
+        expect(node["a"]["r1"]).to be_nil
+        expect(node["a"]["r2"]).to be_nil
+      end
     end
 
     describe "default attributes" do


### PR DESCRIPTION

### Description

Fix an issue where DeepMerge overwrites nil values when run against a VividMash.

Call .key? instead of [] when checking if a key exists for a VividMash
Otherwise the VividMash will return an empty object instead of nil for
that key.


### Issues Resolved

Fixes https://github.com/chef/chef/issues/6302

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
