### PR TITLE
Resolve a bunch of YARD parsing issues

### DIFF
--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -47,7 +47,7 @@ class Chef
 
     # Gets or sets the client name.
     #
-    # @params [Optional String] The name must be alpha-numeric plus - and _.
+    # @param [Optional String] The name must be alpha-numeric plus - and _.
     # @return [String] The current value of the name.
     def name(arg = nil)
       set_or_return(
@@ -59,7 +59,7 @@ class Chef
 
     # Gets or sets whether this client is an admin.
     #
-    # @params [Optional True/False] Should be true or false - default is false.
+    # @param [Optional True/False] Should be true or false - default is false.
     # @return [True/False] The current value
     def admin(arg = nil)
       set_or_return(
@@ -71,7 +71,7 @@ class Chef
 
     # Gets or sets the public key.
     #
-    # @params [Optional String] The string representation of the public key.
+    # @param [Optional String] The string representation of the public key.
     # @return [String] The current value.
     def public_key(arg = nil)
       set_or_return(
@@ -83,7 +83,7 @@ class Chef
 
     # Gets or sets whether this client is a validator.
     #
-    # @params [Boolean] whether or not the client is a validator.  If
+    # @param [Boolean] whether or not the client is a validator.  If
     #   `nil`, retrieves the already-set value.
     # @return [Boolean] The current value
     def validator(arg = nil)
@@ -96,7 +96,7 @@ class Chef
 
     # Gets or sets the private key.
     #
-    # @params [Optional String] The string representation of the private key.
+    # @param [Optional String] The string representation of the private key.
     # @return [String] The current value.
     def private_key(arg = nil)
       set_or_return(

--- a/lib/chef/api_client_v1.rb
+++ b/lib/chef/api_client_v1.rb
@@ -70,7 +70,7 @@ class Chef
 
     # Gets or sets the client name.
     #
-    # @params [Optional String] The name must be alpha-numeric plus - and _.
+    # @param [Optional String] The name must be alpha-numeric plus - and _.
     # @return [String] The current value of the name.
     def name(arg = nil)
       set_or_return(
@@ -82,7 +82,7 @@ class Chef
 
     # Gets or sets whether this client is an admin.
     #
-    # @params [Optional True/False] Should be true or false - default is false.
+    # @param [Optional True/False] Should be true or false - default is false.
     # @return [True/False] The current value
     def admin(arg = nil)
       set_or_return(
@@ -94,7 +94,7 @@ class Chef
 
     # Gets or sets the public key.
     #
-    # @params [Optional String] The string representation of the public key.
+    # @param [Optional String] The string representation of the public key.
     # @return [String] The current value.
     def public_key(arg = nil)
       set_or_return(
@@ -106,7 +106,7 @@ class Chef
 
     # Gets or sets whether this client is a validator.
     #
-    # @params [Boolean] whether or not the client is a validator.  If
+    # @param [Boolean] whether or not the client is a validator.  If
     #   `nil`, retrieves the already-set value.
     # @return [Boolean] The current value
     def validator(arg = nil)
@@ -120,7 +120,7 @@ class Chef
     # Private key. The server will return it as a string.
     # Set to true under API V0 to have the server regenerate the default key.
     #
-    # @params [Optional String] The string representation of the private key.
+    # @param [Optional String] The string representation of the private key.
     # @return [String] The current value.
     def private_key(arg = nil)
       set_or_return(
@@ -132,7 +132,7 @@ class Chef
 
     # Used to ask server to generate key pair under api V1
     #
-    # @params [Optional True/False] Should be true or false - default is false.
+    # @param [Optional True/False] Should be true or false - default is false.
     # @return [True/False] The current value
     def create_key(arg = nil)
       set_or_return(

--- a/lib/chef/chef_class.rb
+++ b/lib/chef/chef_class.rb
@@ -65,7 +65,7 @@ class Chef
 
     # Get the array of providers associated with a resource_name for the current node
     #
-    # @param resource_name [Symbol] name of the resource as a symbol
+    # @param [Symbol] resource_name the name of the resource as a symbol
     #
     # @return [Array<Class>] Priority Array of Provider Classes to use for the resource_name on the node
     #
@@ -78,7 +78,7 @@ class Chef
     #
     # Get the array of resources associated with a resource_name for the current node
     #
-    # @param resource_name [Symbol] name of the resource as a symbol
+    # @param [Symbol] resource_name the name of the resource as a symbol
     #
     # @return [Array<Class>] Priority Array of Resource Classes to use for the resource_name on the node
     #
@@ -91,9 +91,9 @@ class Chef
     #
     # Set the array of providers associated with a resource_name for the current node
     #
-    # @param resource_name [Symbol] name of the resource as a symbol
-    # @param priority_array [Class, Array<Class>] Class or Array of Classes to set as the priority for resource_name on the node
-    # @param filter [Hash] Chef::Nodearray-style filter
+    # @param [Symbol] resource_name the name of the resource as a symbol
+    # @param [Class, Array<Class>] priority_array the Class or Array of Classes to set as the priority for resource_name on the node
+    # @param [Hash] filter the Chef::Nodearray-style filter
     #
     # @return [Array<Class>] Modified Priority Array of Provider Classes to use for the resource_name on the node
     #
@@ -106,9 +106,9 @@ class Chef
     #
     # Get the array of resources associated with a resource_name for the current node
     #
-    # @param resource_name [Symbol] name of the resource as a symbol
-    # @param priority_array [Class, Array<Class>] Class or Array of Classes to set as the priority for resource_name on the node
-    # @param filter [Hash] Chef::Nodearray-style filter
+    # @param [Symbol] resource_name the name of the resource as a symbol
+    # @param [Class, Array<Class>] priority_array the Class or Array of Classes to set as the priority for resource_name on the node
+    # @param [Hash] filter the Chef::Nodearray-style filter
     #
     # @return [Array<Class>] Modified Priority Array of Resource Classes to use for the resource_name on the node
     #
@@ -127,7 +127,7 @@ class Chef
     #
     # Sets the resource_priority_map
     #
-    # @param resource_priority_map [Chef::Platform::ResourcePriorityMap]
+    # @param [Chef::Platform::ResourcePriorityMap] resource_priority_map
     #
     # @api private
     def set_resource_priority_map(resource_priority_map)
@@ -137,7 +137,7 @@ class Chef
     #
     # Sets the provider_priority_map
     #
-    # @param provider_priority_map [Chef::Platform::providerPriorityMap]
+    # @param [Chef::Platform::providerPriorityMap] provider_priority_map
     #
     # @api private
     def set_provider_priority_map(provider_priority_map)
@@ -148,7 +148,7 @@ class Chef
     # Sets the node object
     #
     # @api private
-    # @param node [Chef::Node]
+    # @param [Chef::Node] node
     def set_node(node)
       @node = node
     end
@@ -156,7 +156,7 @@ class Chef
     #
     # Sets the run_context object
     #
-    # @param run_context [Chef::RunContext]
+    # @param [Chef::RunContext] run_context
     #
     # @api private
     def set_run_context(run_context)
@@ -200,8 +200,8 @@ class Chef
     #
     # Emit a deprecation message.
     #
-    # @param type The message to send. This should be a symbol, referring to
-    #   a class defined in Chef::Deprecated
+    # @param [Symbol] type The message to send. This should refer to a class
+    #   defined in Chef::Deprecated
     # @param message  An explicit message to display, rather than the generic one
     #   associated with the deprecation.
     # @param location The location. Defaults to the caller who called you (since

--- a/lib/chef/chef_fs/data_handler/container_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/container_data_handler.rb
@@ -17,8 +17,8 @@ class Chef
 
         # Verify that the JSON hash for this type has a key that matches its name.
         #
-        # @param object [Object] JSON hash of the object
-        # @param entry [Chef::ChefFS::FileSystem::BaseFSObject] filesystem object we are verifying
+        # @param [Object] object the JSON hash of the object
+        # @param [Chef::ChefFS::FileSystem::BaseFSObject] entry the filesystem object we are verifying
         # @yield  [s] callback to handle errors
         # @yieldparam [s<string>] error message
         def verify_integrity(object, entry)

--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -44,8 +44,8 @@ class Chef
 
         # Verify that the JSON hash for this type has a key that matches its name.
         #
-        # @param object [Object] JSON hash of the object
-        # @param entry [Chef::ChefFS::FileSystem::BaseFSObject] filesystem object we are verifying
+        # @param [Object] object the JSON hash of the object
+        # @param [Chef::ChefFS::FileSystem::BaseFSObject] entry the filesystem object we are verifying
         # @yield  [s] callback to handle errors
         # @yieldparam [s<string>] error message
         def verify_integrity(object, entry)

--- a/lib/chef/chef_fs/data_handler/data_handler_base.rb
+++ b/lib/chef/chef_fs/data_handler/data_handler_base.rb
@@ -56,8 +56,7 @@ class Chef
         # 2. Put the actual values in the order of the defaults
         # 3. Move any other values to the end
         #
-        # == Example
-        #
+        # @example
         #   normalize_hash({x: 100, c: 2, a: 1}, { a: 10, b: 20, c: 30})
         #   -> { a: 1, b: 20, c: 2, x: 100}
         #
@@ -140,8 +139,7 @@ class Chef
         # the keys specified in "keys"; anything else must be emitted by the
         # caller.
         #
-        # == Example
-        #
+        # @example
         #   to_ruby_keys({"name" => "foo", "environment" => "desert", "foo": "bar"}, [ "name", "environment" ])
         #   ->
         #   'name "foo"
@@ -188,8 +186,8 @@ class Chef
 
         # Verify that the JSON hash for this type has a key that matches its name.
         #
-        # @param object [Object] JSON hash of the object
-        # @param entry [Chef::ChefFS::FileSystem::BaseFSObject] filesystem object we are verifying
+        # @param [Object] object the JSON hash of the object
+        # @param [Chef::ChefFS::FileSystem::BaseFSObject] entry the filesystem object we are verifying
         # @yield  [s] callback to handle errors
         # @yieldparam [s<string>] error message
         def verify_integrity(object, entry)

--- a/lib/chef/chef_fs/data_handler/policy_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/policy_data_handler.rb
@@ -28,8 +28,8 @@ class Chef
 
         # Verify that the JSON hash for this type has a key that matches its name.
         #
-        # @param object [Object] JSON hash of the object
-        # @param entry [Chef::ChefFS::FileSystem::BaseFSObject] filesystem object we are verifying
+        # @param [Object] object the JSON hash of the object
+        # @param [Chef::ChefFS::FileSystem::BaseFSObject] entry the filesystem object we are verifying
         # @yield  [s] callback to handle errors
         # @yieldparam [s<string>] error message
         def verify_integrity(object_data, entry)

--- a/lib/chef/cookbook/chefignore.rb
+++ b/lib/chef/cookbook/chefignore.rb
@@ -33,12 +33,16 @@ class Chef
         @ignores = parse_ignore_file
       end
 
+      # @param [Array] list the list of cookbook files
+      # @return [Array] list of cookbook files with chefignore files removed
       def remove_ignores_from(file_list)
         Array(file_list).inject([]) do |unignored, file|
           ignored?(file) ? unignored : unignored << file
         end
       end
 
+      # @param [String] file_name the file name to check ignored status for
+      # @return [Boolean] is the file ignored or not
       def ignored?(file_name)
         @ignores.any? { |glob| File.fnmatch?(glob, file_name) }
       end

--- a/lib/chef/cookbook/cookbook_collection.rb
+++ b/lib/chef/cookbook/cookbook_collection.rb
@@ -47,8 +47,8 @@ class Chef
     # Currently checks chef_version and ohai_version in the cookbook metadata
     # against the running Chef::VERSION and Ohai::VERSION.
     #
-    # @raises [Chef::Exceptions::CookbookChefVersionMismatch] if the Chef::VERSION fails validation
-    # @raises [Chef::Exceptions::CookbookOhaiVersionMismatch] if the Ohai::VERSION fails validation
+    # @raise [Chef::Exceptions::CookbookChefVersionMismatch] if the Chef::VERSION fails validation
+    # @raise [Chef::Exceptions::CookbookOhaiVersionMismatch] if the Ohai::VERSION fails validation
     def validate!
       each do |cookbook_name, cookbook_version|
         cookbook_version.metadata.validate_chef_version!

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -320,7 +320,7 @@ class Chef
       # with the result being 'OR'd such that if any statements match, the version
       # is considered supported.  Uses Gem::Requirement for its implementation.
       #
-      # @param version_args [Array<String>] Version constraint in String form
+      # @param [Array<String>] version_args the version constraint in String form
       # @return [Array<Gem::Dependency>] Current chef_versions array
       def chef_version(*version_args)
         @chef_versions << Gem::Dependency.new("chef", *version_args) unless version_args.empty?
@@ -596,7 +596,7 @@ class Chef
       # Validates that the Ohai::VERSION of the running chef-client matches one of the
       # configured ohai_version statements in this cookbooks metadata.
       #
-      # @raises [Chef::Exceptions::CookbookOhaiVersionMismatch] if the cookbook fails validation
+      # @raise [Chef::Exceptions::CookbookOhaiVersionMismatch] if the cookbook fails validation
       def validate_ohai_version!
         unless gem_dep_matches?("ohai", Gem::Version.new(Ohai::VERSION), *ohai_versions)
           raise Exceptions::CookbookOhaiVersionMismatch.new(Ohai::VERSION, name, version, *ohai_versions)
@@ -606,7 +606,7 @@ class Chef
       # Validates that the Chef::VERSION of the running chef-client matches one of the
       # configured chef_version statements in this cookbooks metadata.
       #
-      # @raises [Chef::Exceptions::CookbookChefVersionMismatch] if the cookbook fails validation
+      # @raise [Chef::Exceptions::CookbookChefVersionMismatch] if the cookbook fails validation
       def validate_chef_version!
         unless gem_dep_matches?("chef", Gem::Version.new(Chef::VERSION), *chef_versions)
           raise Exceptions::CookbookChefVersionMismatch.new(Chef::VERSION, name, version, *chef_versions)

--- a/lib/chef/key.rb
+++ b/lib/chef/key.rb
@@ -35,7 +35,7 @@ class Chef
   # @attr [String] rest            Chef::ServerAPI object, initialized and cached via chef_rest method
   # @attr [string] api_base        either "users" or "clients", initialized and cached via api_base method
   #
-  # @attr_reader [String] actor_field_name must be either 'client' or 'user'
+  # @!attribute [r] [String] actor_field_name must be either 'client' or 'user'
   class Key
 
     include Chef::Mixin::ParamsValidate

--- a/lib/chef/knife/bootstrap/chef_vault_handler.rb
+++ b/lib/chef/knife/bootstrap/chef_vault_handler.rb
@@ -31,8 +31,8 @@ class Chef
         # @return [Chef::ApiClient] vault client
         attr_reader :client
 
-        # @param knife_config [Hash] knife merged config, typically @config
-        # @param ui [Chef::Knife::UI] ui object for output
+        # @param [Hash] knife_config the knife merged config, typically @config
+        # @param [Chef::Knife::UI] ui the ui object for output
         def initialize(knife_config: {}, ui: nil)
           @knife_config = knife_config
           @ui           = ui
@@ -118,8 +118,8 @@ class Chef
 
         # Update an individual vault item and save it
         #
-        # @param vault [String] name of the chef-vault encrypted data bag
-        # @param item [String] name of the chef-vault encrypted item
+        # @param [String] vault the name of the chef-vault encrypted data bag
+        # @param [String] item the name of the chef-vault encrypted item
         def update_vault(vault, item)
           require_chef_vault!
           bootstrap_vault_item = load_chef_bootstrap_vault_item(vault, item)
@@ -129,9 +129,9 @@ class Chef
 
         # Hook to stub out ChefVault
         #
-        # @param vault [String] name of the chef-vault encrypted data bag
-        # @param item [String] name of the chef-vault encrypted item
-        # @returns [ChefVault::Item] ChefVault::Item object
+        # @param [String] vault the name of the chef-vault encrypted data bag
+        # @param [String] item the name of the chef-vault encrypted item
+        # @return [ChefVault::Item] ChefVault::Item object
         def load_chef_bootstrap_vault_item(vault, item)
           ChefVault::Item.load(vault, item)
         end

--- a/lib/chef/knife/client_key_create.rb
+++ b/lib/chef/knife/client_key_create.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class ClientKeyCreate < Knife
       include Chef::Knife::KeyCreateBase
 

--- a/lib/chef/knife/client_key_delete.rb
+++ b/lib/chef/knife/client_key_delete.rb
@@ -26,7 +26,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class ClientKeyDelete < Knife
       banner "knife client key delete CLIENT KEYNAME (options)"
 

--- a/lib/chef/knife/client_key_edit.rb
+++ b/lib/chef/knife/client_key_edit.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class ClientKeyEdit < Knife
       include Chef::Knife::KeyEditBase
 

--- a/lib/chef/knife/client_key_list.rb
+++ b/lib/chef/knife/client_key_list.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class ClientKeyList < Knife
       include Chef::Knife::KeyListBase
 

--- a/lib/chef/knife/client_key_show.rb
+++ b/lib/chef/knife/client_key_show.rb
@@ -26,7 +26,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class ClientKeyShow < Knife
       banner "knife client key show CLIENT KEYNAME (options)"
 

--- a/lib/chef/knife/core/generic_presenter.rb
+++ b/lib/chef/knife/core/generic_presenter.rb
@@ -23,7 +23,7 @@ class Chef
     module Core
 
       # Allows includer knife commands to  return multiple attributes
-      # @brief knife node show NAME -a ATTR1 -a ATTR2
+      # @example knife node show NAME -a ATTR1 -a ATTR2
       module MultiAttributeReturnOption
         # :nodoc:
         def self.included(includer)

--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -95,7 +95,7 @@ class Chef
 
       ##
       # Determine if the user has specified an appropriate secret for encrypting data bag items.
-      # @returns boolean
+      # @return boolean
       def base_encryption_secret_provided?(need_encrypt_flag = true)
         validate_secrets
 

--- a/lib/chef/knife/key_create.rb
+++ b/lib/chef/knife/key_create.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_accessor [Hash] cli input, see UserKeyCreate and ClientKeyCreate for what could populate it
+    # @!attribute [rw] [Hash] cli input, see UserKeyCreate and ClientKeyCreate for what could populate it
     class KeyCreate
 
       attr_accessor :config

--- a/lib/chef/knife/key_delete.rb
+++ b/lib/chef/knife/key_delete.rb
@@ -25,7 +25,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_accessor [Hash] cli input, see UserKeyDelete and ClientKeyDelete for what could populate it
+    # @!attribute [rw] [Hash] cli input, see UserKeyDelete and ClientKeyDelete for what could populate it
     class KeyDelete
       def initialize(name, actor, actor_field_name, ui)
         @name = name

--- a/lib/chef/knife/key_edit.rb
+++ b/lib/chef/knife/key_edit.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_accessor [Hash] cli input, see UserKeyEdit and ClientKeyEdit for what could populate it
+    # @!attribute [rw] [Hash] cli input, see UserKeyEdit and ClientKeyEdit for what could populate it
     class KeyEdit
 
       attr_accessor :config

--- a/lib/chef/knife/key_list.rb
+++ b/lib/chef/knife/key_list.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_accessor [Hash] cli input, see UserKeyList and ClientKeyList for what could populate it
+    # @!attribute [rw] [Hash] cli input, see UserKeyList and ClientKeyList for what could populate it
     class KeyList
 
       attr_accessor :config

--- a/lib/chef/knife/key_show.rb
+++ b/lib/chef/knife/key_show.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_accessor [Hash] cli input, see UserKeyShow and ClientKeyShow for what could populate it
+    # @!attribute [rw] [Hash] cli input, see UserKeyShow and ClientKeyShow for what could populate it
     class KeyShow
 
       attr_accessor :config

--- a/lib/chef/knife/user_key_create.rb
+++ b/lib/chef/knife/user_key_create.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the user that this key is for
+    # @!attribute [r] [String] actor the name of the user that this key is for
     class UserKeyCreate < Knife
       include Chef::Knife::KeyCreateBase
 

--- a/lib/chef/knife/user_key_delete.rb
+++ b/lib/chef/knife/user_key_delete.rb
@@ -26,7 +26,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class UserKeyDelete < Knife
       banner "knife user key delete USER KEYNAME (options)"
 

--- a/lib/chef/knife/user_key_edit.rb
+++ b/lib/chef/knife/user_key_edit.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the user that this key is for
+    # @!attribute [r] [String] actor the name of the user that this key is for
     class UserKeyEdit < Knife
       include Chef::Knife::KeyEditBase
 

--- a/lib/chef/knife/user_key_list.rb
+++ b/lib/chef/knife/user_key_list.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class UserKeyList < Knife
       include Chef::Knife::KeyListBase
 

--- a/lib/chef/knife/user_key_show.rb
+++ b/lib/chef/knife/user_key_show.rb
@@ -26,7 +26,7 @@ class Chef
     #
     # @author Tyler Cloke
     #
-    # @attr_reader [String] actor the name of the client that this key is for
+    # @!attribute [r] [String] actor the name of the client that this key is for
     class UserKeyShow < Knife
       banner "knife user key show USER KEYNAME (options)"
 

--- a/lib/chef/mash.rb
+++ b/lib/chef/mash.rb
@@ -50,8 +50,8 @@
 # params[:key] instead of params['key'].
 class Mash < Hash
 
-  # @param constructor<Object>
-  #   The default value for the mash. Defaults to an empty hash.
+  # @param <Object>
+  #   constructor the default value for the mash. Defaults to an empty hash.
   #
   # @details [Alternatives]
   #   If constructor is a Hash, a new mash will be created based on the keys of
@@ -65,7 +65,7 @@ class Mash < Hash
     end
   end
 
-  # @param orig<Object> Mash being copied
+  # @param <Object> orig the Mash being copied
   #
   # @return [Object] A new copied Mash
   def initialize_copy(orig)
@@ -79,7 +79,7 @@ class Mash < Hash
     self
   end
 
-  # @param key<Object> The default value for the mash. Defaults to nil.
+  # @param <Object> key the default value for the mash. Defaults to nil.
   #
   # @details [Alternatives]
   #   If key is a Symbol and it is a key in the mash, then the default value will
@@ -95,9 +95,8 @@ class Mash < Hash
   alias_method :regular_writer, :[]= unless method_defined?(:regular_writer)
   alias_method :regular_update, :update unless method_defined?(:regular_update)
 
-  # @param key<Object> The key to set.
-  # @param value<Object>
-  #   The value to set the key to.
+  # @param <Object> key the key to set.
+  # @param <Object> value the value to set the key to.
   #
   # @see Mash#convert_key
   # @see Mash#convert_value

--- a/lib/chef/mixin/powershell_out.rb
+++ b/lib/chef/mixin/powershell_out.rb
@@ -74,7 +74,7 @@ class Chef
       # Helper to build a powershell command around the script to run.
       #
       # @param script [String] script to run
-      # @retrurn [String] powershell command to execute
+      # @return [String] powershell command to execute
       def build_powershell_command(script)
         flags = [
           # Hides the copyright banner at startup.

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -124,7 +124,7 @@ class Chef
           end
         end
 
-        # @returns Array<Version>
+        # @return [Array<Version>]
         def available_version(index)
           @available_version ||= []
 
@@ -137,7 +137,7 @@ class Chef
           @available_version[index]
         end
 
-        # @returns Array<Version>
+        # @return [Array<Version>]
         def installed_version(index)
           @installed_version ||= []
           @installed_version[index] ||= if new_resource.source

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -61,7 +61,7 @@ class Chef
             start if stdin.nil?
           end
 
-          # @returns Array<Version>
+          # @return [Array<Version>]
           def query(action, provides, version = nil, arch = nil)
             with_helper do
               json = build_query(action, provides, version, arch)

--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -153,7 +153,7 @@ class Chef
       #
       # FIXME: it should do breadth-first, see CHEF-5080 (please use a performant sort)
       #
-      # @return Array<String> The list of files to transfer
+      # @return [Array<String>] The list of files to transfer
       # @api private
       #
       def files_to_transfer

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -43,7 +43,7 @@ class Chef
       # mutate the new_resource.checksum which would change the
       # user intent in the new_resource if the resource is reused.
       #
-      # @returns [String] Checksum of the file we actually rendered
+      # @return [String] Checksum of the file we actually rendered
       attr_accessor :final_checksum
 
       default_action :create

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -29,7 +29,6 @@ require "forwardable"
 
 class Chef
 
-  # == Chef::RunContext
   # Value object that loads and tracks the context of a Chef run
   class RunContext
     #
@@ -157,8 +156,8 @@ class Chef
     # Creates a new Chef::RunContext object and populates its fields. This object gets
     # used by the Chef Server to generate a fully compiled recipe list for a node.
     #
-    # @param node [Chef::Node] The node to run against.
-    # @param cookbook_collection [Chef::CookbookCollection] The cookbooks
+    # @param [Chef::Node] node the node to run against.
+    # @param [Chef::CookbookCollection] cookbook_collection the cookbooks
     #   involved in this run.
     # @param events [EventDispatch::Dispatcher] The event dispatcher for this
     #   run.
@@ -184,7 +183,7 @@ class Chef
     #
     # Triggers the compile phase of the chef run.
     #
-    # @param run_list_expansion [Chef::RunList::RunListExpansion] The run list.
+    # @param [Chef::RunList::RunListExpansion] run_list_expansion the run list.
     # @see Chef::RunContext::CookbookCompiler
     #
     def load(run_list_expansion)
@@ -207,7 +206,7 @@ class Chef
     #
     # Adds an before notification to the +before_notification_collection+.
     #
-    # @param [Chef::Resource::Notification] The notification to add.
+    # @param [Chef::Resource::Notification] notification the notification to add.
     #
     def notifies_before(notification)
       # Note for the future, notification.notifying_resource may be an instance
@@ -219,7 +218,7 @@ class Chef
     #
     # Adds an immediate notification to the +immediate_notification_collection+.
     #
-    # @param [Chef::Resource::Notification] The notification to add.
+    # @param [Chef::Resource::Notification] notification the notification to add.
     #
     def notifies_immediately(notification)
       # Note for the future, notification.notifying_resource may be an instance
@@ -231,7 +230,7 @@ class Chef
     #
     # Adds a delayed notification to the +delayed_notification_collection+.
     #
-    # @param [Chef::Resource::Notification] The notification to add.
+    # @param [Chef::Resource::Notification] notification the notification to add.
     #
     def notifies_delayed(notification)
       # Note for the future, notification.notifying_resource may be an instance
@@ -306,13 +305,13 @@ class Chef
     #
     # Evaluates the recipe +recipe_name+. Used by DSL::IncludeRecipe
     #
-    # TODO I am sort of confused why we have both this and include_recipe ...
+    # @todo I am sort of confused why we have both this and include_recipe ...
     #      I don't see anything different beyond accepting and returning an
     #      array of recipes.
     #
-    # @param recipe_names [Array[String]] The recipe name (e.g 'my_cookbook' or
+    # @param [Array[String]] recipe_names the recipe name (e.g 'my_cookbook' or
     #   'my_cookbook::my_resource').
-    # @param current_cookbook The cookbook we are currently running in.
+    # @param [String] current_cookbook the cookbook we are currently running in.
     #
     # @return A truthy value if the load occurred; `false` if already loaded.
     #
@@ -347,7 +346,7 @@ ERROR_MESSAGE
     #
     # Load the given recipe from a filename.
     #
-    # @param recipe_file [String] The recipe filename.
+    # @param [String] recipe_file the recipe filename.
     #
     # @return [Chef::Recipe] The loaded recipe.
     #
@@ -367,8 +366,8 @@ ERROR_MESSAGE
     #
     # Look up an attribute filename.
     #
-    # @param cookbook_name [String] The cookbook name of the attribute file.
-    # @param attr_file_name [String] The attribute file's name (not path).
+    # @param [String] cookbook_name the cookbook name of the attribute file.
+    # @param [String] attr_file_name the attribute file's name (not path).
     #
     # @return [String] The filename.
     #
@@ -420,8 +419,8 @@ ERROR_MESSAGE
     #
     # Find out if a given recipe has been loaded.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param recipe [String] Recipe name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] recipe the recipe name.
     #
     # @return [Boolean] `true` if the recipe has been loaded, `false` otherwise.
     #
@@ -432,7 +431,7 @@ ERROR_MESSAGE
     #
     # Find out if a given recipe has been loaded.
     #
-    # @param recipe [String] Recipe name.  "nginx" and "nginx::default" yield
+    # @param [String] recipe the recipe name.  "nginx" and "nginx::default" yield
     #   the same results.
     #
     # @return [Boolean] `true` if the recipe has been loaded, `false` otherwise.
@@ -445,8 +444,8 @@ ERROR_MESSAGE
     #
     # Mark a given recipe as having been loaded.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param recipe [String] Recipe name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] recipe the recipe name.
     #
     def loaded_recipe(cookbook, recipe)
       loaded_recipes_hash["#{cookbook}::#{recipe}"] = true
@@ -455,8 +454,8 @@ ERROR_MESSAGE
     #
     # Find out if a given attribute file has been loaded.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param attribute_file [String] Attribute file name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] attribute_file the attribute file name.
     #
     # @return [Boolean] `true` if the recipe has been loaded, `false` otherwise.
     #
@@ -467,8 +466,8 @@ ERROR_MESSAGE
     #
     # Mark a given attribute file as having been loaded.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param attribute_file [String] Attribute file name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] attribute_file the attribute file name.
     #
     def loaded_attribute(cookbook, attribute_file)
       loaded_attributes_hash["#{cookbook}::#{attribute_file}"] = true
@@ -480,8 +479,8 @@ ERROR_MESSAGE
     #
     # Find out if the cookbook has the given template.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param template_name [String] Template name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] template_name the template name.
     #
     # @return [Boolean] `true` if the template is in the cookbook, `false`
     #   otherwise.
@@ -495,8 +494,8 @@ ERROR_MESSAGE
     #
     # Find out if the cookbook has the given file.
     #
-    # @param cookbook [String] Cookbook name.
-    # @param cb_file_name [String] File name.
+    # @param [String] cookbook the cookbook name.
+    # @param [String] cb_file_name the file name.
     #
     # @return [Boolean] `true` if the file is in the cookbook, `false`
     #   otherwise.
@@ -510,7 +509,7 @@ ERROR_MESSAGE
     #
     # Find out whether the given cookbook is in the cookbook dependency graph.
     #
-    # @param cookbook_name [String] Cookbook name.
+    # @param [String] cookbook_name the cookbook name.
     #
     # @return [Boolean] `true` if the cookbook is reachable, `false` otherwise.
     #
@@ -522,8 +521,8 @@ ERROR_MESSAGE
     #
     # Open a stream object that can be printed into and will dispatch to events
     #
-    # @param name [String] The name of the stream.
-    # @param options [Hash] Other options for the stream.
+    # @param [String] name the name of the stream.
+    # @param [Hash] options the other options for the stream.
     #
     # @return [EventDispatch::EventsOutputStream] The created stream.
     #
@@ -556,11 +555,18 @@ ERROR_MESSAGE
       @reboot_info = reboot_info
     end
 
+    #
+    # Cancels a pending reboot
+    #
     def cancel_reboot
       Chef::Log.info "Changing reboot status from #{reboot_info.inspect} to {}"
       @reboot_info = {}
     end
 
+    #
+    # Checks to see if a reboot has been requested
+    # @return [Boolean]
+    #
     def reboot_requested?
       reboot_info.size > 0
     end

--- a/lib/chef/version_string.rb
+++ b/lib/chef/version_string.rb
@@ -25,7 +25,7 @@ class Chef
 
     # Create a new VersionString from an input String.
     #
-    # @param val [String] Version string to parse.
+    # @param [String] val the version string to parse.
     def initialize(val)
       super
       @parsed_version = ::Gem::Version.create(self)
@@ -35,7 +35,7 @@ class Chef
 
     # Compat wrapper for + to behave like a normal String.
     #
-    # @param other [String]
+    # @param [String] other
     # @return [String]
     def +(other)
       to_s + other
@@ -43,7 +43,7 @@ class Chef
 
     # Compat wrapper for * to behave like a normal String.
     #
-    # @param other [Integer]
+    # @param [Integer] other
     # @return [String]
     def *(other)
       to_s * other
@@ -55,7 +55,7 @@ class Chef
     # then sort like `Gem::Version`, otherwise try to treat the other object as
     # a version but fall back to normal string comparison.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Integer]
     def <=>(other)
       other_ver = case other
@@ -74,7 +74,7 @@ class Chef
 
     # Compat wrapper for == based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def ==(other)
       (self <=> other) == 0
@@ -82,7 +82,7 @@ class Chef
 
     # Compat wrapper for != based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def !=(other)
       (self <=> other) != 0
@@ -90,7 +90,7 @@ class Chef
 
     # Compat wrapper for < based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def <(other)
       (self <=> other) < 0
@@ -98,7 +98,7 @@ class Chef
 
     # Compat wrapper for <= based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def <=(other)
       (self <=> other) < 1
@@ -106,7 +106,7 @@ class Chef
 
     # Compat wrapper for > based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def >(other)
       (self <=> other) > 0
@@ -114,7 +114,7 @@ class Chef
 
     # Compat wrapper for >= based on <=>.
     #
-    # @param other [Object]
+    # @param [Object] other
     # @return [Boolean]
     def >=(other)
       (self <=> other) > -1
@@ -124,7 +124,7 @@ class Chef
 
     # Matching operator to support checking against a requirement string.
     #
-    # @param other [Regexp, String]
+    # @param [Regexp, String] other
     # @return [Boolean]
     # @example Match against a Regexp
     #   Chef::VersionString.new('1.0.0') =~ /^1/


### PR DESCRIPTION
We were using the wrong tags and incorrectly placing the param name before the type field. We still have a whole bunch of those to fix, but this clears up about 1/2 the warnings.

Signed-off-by: Tim Smith <tsmith@chef.io>