### PR TITLE
Ignore validation errors in Resource#to_text

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -641,7 +641,11 @@ class Chef
 
       all_props = {}
       self.class.state_properties.map do |p|
-        all_props[p.name.to_s] = p.sensitive? ? '"*sensitive value suppressed*"' : value_to_text(p.get(self))
+        begin
+          all_props[p.name.to_s] = p.sensitive? ? '"*sensitive value suppressed*"' : value_to_text(p.get(self))
+        rescue Chef::Exceptions::ValidationFailed
+          # This space left intentionally blank, the property was probably required or had an invalid default.
+        end
       end
 
       ivars = instance_variables.map { |ivar| ivar.to_sym } - HIDDEN_IVARS

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -377,6 +377,14 @@ describe Chef::Resource do
         expect(resource.to_text).to match(/foo "\*sensitive value suppressed\*"/)
       end
     end
+
+    context "when property is required" do
+      it "supresses that properties value" do
+        resource_class = Class.new(Chef::Resource) { property :foo, String, required: true }
+        resource = resource_class.new("sensitive_property_tests")
+        expect { resource.to_text }.to_not raise_error Chef::Exceptions::ValidationFailed
+      end
+    end
   end
 
   describe "self.resource_name" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -381,7 +381,7 @@ describe Chef::Resource do
     context "when property is required" do
       it "does not propagate vailidation errors" do
         resource_class = Class.new(Chef::Resource) { property :foo, String, required: true }
-        resource = resource_class.new("sensitive_property_tests")
+        resource = resource_class.new("required_property_tests")
         expect { resource.to_text }.to_not raise_error Chef::Exceptions::ValidationFailed
       end
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -379,7 +379,7 @@ describe Chef::Resource do
     end
 
     context "when property is required" do
-      it "supresses that properties value" do
+      it "does not propagate vailidation errors" do
         resource_class = Class.new(Chef::Resource) { property :foo, String, required: true }
         resource = resource_class.new("sensitive_property_tests")
         expect { resource.to_text }.to_not raise_error Chef::Exceptions::ValidationFailed


### PR DESCRIPTION
Fixes #6320, which can cause all kinds of fun cascade errors since we invoke to_text as part of the error display.