### PR TITLE
Update Gemfile.lock without attempting to install Gems

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_FROZEN: "1"

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -10,7 +10,7 @@ sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" chef-config
 sed -i -r "s/VersionString\.new\(\".+\"\)/VersionString.new(\"$(cat VERSION)\")/" lib/chef/version.rb
 
 # Update the version inside Gemfile.lock
-bundle update chef chef-config
+bundle lock --update chef chef-config
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
### Description

Fix the auto-bumping by removing the bundle lock that was preventing us from updating the Gemfile.lock.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
