### PR TITLE
Conditional Guard Description

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -507,3 +507,11 @@ The implementation switched to `shell_out_with_systems_locale` to match `execute
 Chef Client will only exit with exit codes defined in RFC 062\. This allows other tooling to respond to how a Chef run completes. Attempting to exit Chef Client with an unsupported exit code (either via `Chef::Application.fatal!` or `Chef::Application.exit!`) will result in an exit code of 1 (GENERIC_FAILURE) and a warning in the event log.
 
 When Chef Client is running as a forked process on unix systems, the standardized exit codes are used by the child process. To actually have Chef Client return the standard exit code, `client_fork false` will need to be set in Chef Client's configuration file.
+
+## Guard clauses can now accept options without a shell command
+
+The only_if/not_if guards can be passed a single options hash with no command argument.
+
+### Guard clauses now accept :desc option
+
+Conditional guards can be passed a :desc option for better identification when a resource is skipped.

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -386,6 +386,10 @@ class Chef
     # @param block [Proc] A ruby block to run. Ignored if a command is given.
     #
     def only_if(command = nil, opts = {}, &block)
+      if command.is_a?(Hash) && opts.empty?
+        opts = command
+        command = nil
+      end
       if command || block_given?
         @only_if << Conditional.only_if(self, command, opts, &block)
       end
@@ -416,6 +420,10 @@ class Chef
     # @param block [Proc] A ruby block to run. Ignored if a command is given.
     #
     def not_if(command = nil, opts = {}, &block)
+      if command.is_a?(Hash) && opts.empty?
+        opts = command
+        command = nil
+      end
       if command || block_given?
         @not_if << Conditional.not_if(self, command, opts, &block)
       end

--- a/lib/chef/resource/conditional.rb
+++ b/lib/chef/resource/conditional.rb
@@ -69,7 +69,7 @@ class Chef
           end
 
           @guard_interpreter = nil
-          @command, @command_opts = nil, nil
+          @command = nil
         else
           # command was passed, but it wasn't a String
           raise ArgumentError, "Invalid only_if/not_if command, expected a string: #{command.inspect} (#{command.class})"
@@ -115,7 +115,7 @@ class Chef
       end
 
       def short_description
-        @positivity
+        @command_opts[:desc] ? "#{@positivity} (#{@command_opts[:desc]})" : @positivity
       end
 
       def description

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -38,6 +38,11 @@ describe Chef::Resource::Conditional do
     Chef::Resource::Conditional.only_if(@parent_resource, "true")
   end
 
+  it "uses a detailed short_description if a :desc is provided" do
+    @parent_resource_guard = Chef::Resource::Conditional.only_if(@parent_resource, "true", :desc => 'my guard desc')
+    expect(@parent_resource_guard.short_description).to be == 'only_if (my guard desc)'
+  end
+
   describe "configure" do
     it "raises an exception when a guard_interpreter is specified and a block is given" do
       @parent_resource.guard_interpreter :canadian_mounties
@@ -112,6 +117,7 @@ describe Chef::Resource::Conditional do
 
       it "indicates that resource convergence should continue" do
         expect(@conditional.continue?).to be_truthy
+        expect(@conditional.short_description).to be == @conditional.positivity
       end
     end
 

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -39,8 +39,8 @@ describe Chef::Resource::Conditional do
   end
 
   it "uses a detailed short_description if a :desc is provided" do
-    @parent_resource_guard = Chef::Resource::Conditional.only_if(@parent_resource, "true", :desc => 'my guard desc')
-    expect(@parent_resource_guard.short_description).to be == 'only_if (my guard desc)'
+    @parent_resource_guard = Chef::Resource::Conditional.only_if(@parent_resource, "true", :desc => "my guard desc")
+    expect(@parent_resource_guard.short_description).to be == "only_if (my guard desc)"
   end
 
   describe "configure" do

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -117,7 +117,6 @@ describe Chef::Resource::Conditional do
 
       it "indicates that resource convergence should continue" do
         expect(@conditional.continue?).to be_truthy
-        expect(@conditional.short_description).to be == @conditional.positivity
       end
     end
 


### PR DESCRIPTION
### Description

Custom description option (:desc) on only_if/not_if guards for better identification in output
```
log "hello" do
  not_if(:desc => 'randomly skip') { rand < 0.5 }
end
```

### Issues Resolved

https://github.com/chef/chef/issues/6322

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
