### PR TITLE
[MSYS-646]Working on fix for minimum package versioning bug

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -445,12 +445,26 @@ class Chef
           end
 
           unless packages.empty?
-            new_package_name = packages.first.name
-            new_package_version = packages.first.version.to_s
-            debug_msg = "#{name}: Unable to match package '#{name}' but matched #{packages.size} "
-            debug_msg << (packages.size == 1 ? "package" : "packages")
-            debug_msg << ", selected '#{new_package_name}' version '#{new_package_version}'"
-            Chef::Log.debug(debug_msg)
+            installed_package = packages.find {|p| p.installed == true }
+
+            if installed_package
+              packages.each do |pkg|
+                if pkg.version.evr > installed_package.version.evr
+                  new_package_name = pkg.name
+                  new_package_version = pkg.version.to_s
+                else
+                  new_package_name = installed_package.name
+                  new_package_version = installed_package.version
+                end
+              end
+            else
+              new_package_name = packages.first.name
+              new_package_version = packages.first.version.to_s
+              debug_msg = "#{name}: Unable to match package '#{name}' but matched #{packages.size} "
+              debug_msg << (packages.size == 1 ? "package" : "packages")
+              debug_msg << ", selected '#{new_package_name}' version '#{new_package_version}'"
+              Chef::Log.debug(debug_msg)
+            end
 
             # Ensure it's not the same package under a different architecture
             unique_names = []


### PR DESCRIPTION
In progress

### Description
When running 
package 'binutils >= 2.20.51.0.2-5.11' 

chef client fails with exception 
`installed package binutils-2.23.52.0.1-55.el7 is newer than candidate package binutils-2.23.52.0.1-30.el7_1.2`

Though 2.23.52.0.1-55.el7 being the latest version on the system, client run is trying to update it to version 2.23.52.0.1-30.el7_1.2 lower than currently installed 2.23.52.0.1-55.el7.
### Issues Resolved

https://getchef.zendesk.com/agent/#/tickets/15964

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
