### PR TITLE
Auto import gpg keys in zypper_repository

### DIFF
--- a/lib/chef/provider/zypper_repository.rb
+++ b/lib/chef/provider/zypper_repository.rb
@@ -57,7 +57,7 @@ class Chef
       end
 
       action :refresh do
-        declare_resource(:execute, "zypper refresh #{escaped_repo_name}") do
+        declare_resource(:execute, "zypper#{' --gpg-auto-import-keys' if new_resource.gpgautoimportkeys} refresh #{escaped_repo_name}") do
           only_if "zypper lr #{escaped_repo_name}"
         end
       end

--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -39,6 +39,7 @@ class Chef
       property :mode, default: "0644"
       property :refresh_cache, [true, false], default: true
       property :source, String, regex: /.*/
+      property :gpgautoimportkeys, [true, false], default: true
 
       default_action :create
       allowed_actions :create, :remove, :add, :refresh


### PR DESCRIPTION
Without this anything that's gpg signed will fail waiting for the user to accept or deny the key. If users don't want this I've provided a new property to disable it.

Signed-off-by: Tim Smith <tsmith@chef.io>