### PR TITLE
Bumps Bundler version to 1.15.4

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -2,7 +2,7 @@
 # .travis.yml and appveyor.yml consume this,
 # try to keep it machine-parsable.
 override :rubygems, version: "2.6.11"
-override :bundler, version: "1.14.6"
+override :bundler, version: "1.15.4"
 override "nokogiri", version: "1.8.0"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.14"


### PR DESCRIPTION
### Description

Bumps Bundler version to 1.15.4

### Issues Resolved

https://github.com/bundler/bundler/issues/5781 was included in Bundler 1.15.2 that fixes `no_proxy` environment variable support. Without it, we are unable to contact an internally hosted Artifactory instance proxying RubyGems when utilizing `http_proxy`,  `https_proxy`, and `no_proxy` as `no_proxy` was not being respected and it was attempting to send the traffic through the proxy.

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
