### PR TITLE
dnf_provider: be more specific when we provide `package`

### DIFF
--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -35,9 +35,11 @@ class Chef
         use_multipackage_api
         use_package_name_for_source
 
-        provides :package, platform_family: %w{rhel fedora amazon} do
+        provides :package, platform_family: %w{fedora amazon} do
           which("dnf") && shell_out("rpm -q dnf").stdout =~ /^dnf-[1-9]/
         end
+
+        provides :package, platform_family: %w{rhel}, platform_version: ">= 8"
 
         provides :dnf_package, os: "linux"
 


### PR DESCRIPTION
### Description

It is really bad to have Chef all of a sudden start using a different provider
on the same OS because you happen to install DNF to play with it.

For RHEL, we know 8 will default to DNF, and 7 defaults to yum, so we specify
that.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Issues Resolved

Unexpectedly switching package managers
