### PR TITLE
Launchd should not load launchagents as root.

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -85,7 +85,12 @@ class Chef
         manage_service(:disable)
       end
 
+      def action_restart
+        manage_service(:restart)
+      end
+
       def manage_plist(action)
+        return unless manage_agent?(action)
         if source
           res = cookbook_file_resource
         else
@@ -97,9 +102,28 @@ class Chef
       end
 
       def manage_service(action)
+        return unless manage_agent?(action)
         res = service_resource
         res.run_action(action)
         new_resource.updated_by_last_action(true) if res.updated?
+      end
+
+      def manage_agent?(action)
+        # Gets UID of console_user and converts to string.
+        console_user = Etc.getpwuid(::File.stat("/dev/console").uid).name
+        root = console_user == "root"
+        agent = type == "agent"
+        invalid_action = [:delete, :disable, :enable, :restart].include?(action)
+        lltstype = ""
+        if new_resource.limit_load_to_session_type
+          lltstype = new_resource.limit_load_to_session_type
+        end
+        invalid_type = lltstype != "LoginWindow"
+        if root && agent && invalid_action && invalid_type
+          Chef::Log.debug("#{label}: Aqua LaunchAgents shouldn't be loaded as root")
+          return false
+        end
+        true
       end
 
       def service_resource

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -52,17 +52,18 @@ class Chef
           @plist_size = 0
           @plist = @new_resource.plist ? @new_resource.plist : find_service_plist
           @service_label = find_service_label
-          # LauchAgents should be loaded as the console user.
+          # LaunchAgents should be loaded as the console user.
           @console_user = @plist ? @plist.include?("LaunchAgents") : false
           @session_type = @new_resource.session_type
 
           if @console_user
-            @console_user = Etc.getlogin
+            @console_user = Etc.getpwuid(::File.stat("/dev/console").uid).name
             Chef::Log.debug("#{new_resource} console_user: '#{@console_user}'")
             cmd = "su "
             param = this_version_or_newer?("10.10") ? "" : "-l "
+            param = "-l " if this_version_or_newer?("10.12")
             @base_user_cmd = cmd + param + "#{@console_user} -c"
-            # Default LauchAgent session should be Aqua
+            # Default LaunchAgent session should be Aqua
             @session_type = "Aqua" if @session_type.nil?
           end
 

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -76,7 +76,7 @@ XML
             allow(Dir).to receive(:glob).and_return([plist], [])
             @stat = double("File::Stat", { :uid => 501 })
             allow(File).to receive(:stat).and_return(@stat)
-            @getpwuid = double("Etc::Passwd", { :name => 'mikedodge04' })
+            @getpwuid = double("Etc::Passwd", { :name => "mikedodge04" })
             allow(Etc).to receive(:getpwuid).and_return(@getpwuid)
             allow(node).to receive(:[]).with("platform_version").and_return(platform_version)
             cmd = "launchctl list #{service_label}"

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -74,7 +74,10 @@ XML
           let(:service_label) { "io.redis.redis-server" }
           before do
             allow(Dir).to receive(:glob).and_return([plist], [])
-            allow(Etc).to receive(:getlogin).and_return("igor")
+            @stat = double("File::Stat", { :uid => 501 })
+            allow(File).to receive(:stat).and_return(@stat)
+            @getpwuid = double("Etc::Passwd", { :name => 'mikedodge04' })
+            allow(Etc).to receive(:getpwuid).and_return(@getpwuid)
             allow(node).to receive(:[]).with("platform_version").and_return(platform_version)
             cmd = "launchctl list #{service_label}"
             allow(provider).to receive(:shell_out_with_systems_locale).


### PR DESCRIPTION
The Launchd resource will load launchagents as root when the mac is
sitting on the login window. This is never a desired outcome and is hard
to recover from. This change now will now check to see if a user is
logged in before loading launchagents.

Signed-off-by: Mike Dodge <mikedodge04@gmail.com>