### PR TITLE
git provider: handle version numbers where the number is not the final word

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -104,7 +104,7 @@ class Chef
       end
 
       def git_minor_version
-        @git_minor_version ||= Gem::Version.new( git("--version").stdout.split.last )
+        @git_minor_version ||= Gem::Version.new( git("--version").stdout.match("[0-9]{1}\.[0-9]{1,2}((\.[0-9]+n?)?){1,2}").to_s )
       end
 
       def existing_git_clone?

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -724,4 +724,36 @@ SHAS
       end
     end
   end
+
+  context "parses git versions correctly" do
+    it "determines the correct version of normal git" do
+      @stdout = "git version 2.14.1\n"
+      expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider.git_minor_version).to eq Gem::Version.new("2.14.1")
+    end
+
+    it "determines the correct version of apple git" do
+      @stdout = "git version 2.11.0 (Apple Git-81)"
+      expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider.git_minor_version).to eq Gem::Version.new("2.11.0")
+    end
+
+    it "determines the correct version of git with a trailing n" do
+      @stdout = "git version 0.99.9n"
+      expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider.git_minor_version).to eq Gem::Version.new("0.99.9n")
+    end
+
+    it "determines the correct version of git with 2 numbers" do
+      @stdout = "git version 2.14"
+      expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider.git_minor_version).to eq Gem::Version.new("2.14")
+    end
+
+    it "determines the correct version of git with 4 numbers" do
+      @stdout = "git version 1.8.5.6"
+      expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
+      expect(@provider.git_minor_version).to eq Gem::Version.new("1.8.5.6")
+    end
+  end
 end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -733,25 +733,25 @@ SHAS
     end
 
     it "determines the correct version of apple git" do
-      @stdout = "git version 2.11.0 (Apple Git-81)"
+      @stdout = "git version 2.11.0 (Apple Git-81)\n"
       expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.git_minor_version).to eq Gem::Version.new("2.11.0")
     end
 
     it "determines the correct version of git with a trailing n" do
-      @stdout = "git version 0.99.9n"
+      @stdout = "git version 0.99.9n\n"
       expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.git_minor_version).to eq Gem::Version.new("0.99.9n")
     end
 
     it "determines the correct version of git with 2 numbers" do
-      @stdout = "git version 2.14"
+      @stdout = "git version 2.14\n"
       expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.git_minor_version).to eq Gem::Version.new("2.14")
     end
 
     it "determines the correct version of git with 4 numbers" do
-      @stdout = "git version 1.8.5.6"
+      @stdout = "git version 1.8.5.6\n"
       expect(@provider).to receive(:shell_out!).with("git --version", { :log_tag => "git[web2.0 app]" }).and_return(double("ShellOut result", :stdout => @stdout))
       expect(@provider.git_minor_version).to eq Gem::Version.new("1.8.5.6")
     end


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

Handles version strings like `git version 2.11.0 (Apple Git-81)`

### Issues Resolved

https://github.com/chef/chef/issues/6350

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>