### PR TITLE
node attributes: remove useless dup in merge_all

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -536,10 +536,6 @@ class Chef
           apply_path(@automatic, path),
         ]
 
-        components.map! do |component|
-          safe_dup(component)
-        end
-
         return nil if components.compact.empty?
 
         components.inject(ImmutableMash.new({}, self, __node__, :merged)) do |merged, component|


### PR DESCRIPTION
since immutablize now does dup + freeze of everything this
is definitively unnecessary, and appears to have been
unnecessary even in Chef-12 (at last does not break any
specs there either).
