### PR TITLE
Link to the knife docs in both places where we error on editor

### DIFF
--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -172,7 +172,7 @@ class Chef
             tf.sync = true
             tf.puts output
             tf.close
-            raise "Please set EDITOR environment variable" unless system("#{config[:editor]} #{tf.path}")
+            raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_using.html for details." unless system("#{config[:editor]} #{tf.path}")
 
             output = IO.read(tf.path)
           end


### PR DESCRIPTION
We're already doing this same thing in the other location where we throw the editor error.

Signed-off-by: Tim Smith <tsmith@chef.io>