### PR TITLE
Link to the knife docs when the knife config file is missing

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -52,6 +52,12 @@ module ChefConfig
       configuration.inspect
     end
 
+    # given a *nix style config path return the platform specific path
+    # to that same config file
+    # @example client.pem path on Windows
+    #   platform_specific_path("/etc/chef/client.pem") #=> "C:\\chef\\client.pem"
+    # @param path [String] The unix path to convert to a platform specific path
+    # @return [String] a platform specific path
     def self.platform_specific_path(path)
       path = PathHelper.cleanpath(path)
       if ChefConfig.windows?
@@ -66,6 +72,11 @@ module ChefConfig
       path
     end
 
+    # the drive where Chef is installed on a windows host. This is determined
+    # either by the drive containing the current file or by the SYSTEMDRIVE ENV
+    # variable
+    #
+    # @return [String] the drive letter
     def self.windows_installation_drive
       if ChefConfig.windows?
         drive = File.expand_path(__FILE__).split("/", 2)[0]
@@ -249,7 +260,7 @@ module ChefConfig
     # Defaults to <chef_repo_path>/policies.
     default(:policy_path) { derive_path_from_chef_repo_path("policies") }
 
-    # Turn on "path sanity" by default. See also: http://wiki.opscode.com/display/chef/User+Environment+PATH+Sanity
+    # Turn on "path sanity" by default.
     default :enforce_path_sanity, false
 
     # Formatted Chef Client output is a beta feature, disabled by default:

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -182,7 +182,7 @@ class Chef
       config_loader.profile = profile
       config_loader.load
 
-      ui.warn("No knife configuration file found") if config_loader.no_config_found?
+      ui.warn("No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.") if config_loader.no_config_found?
 
       config_loader
     rescue Exceptions::ConfigurationError => e

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -242,7 +242,7 @@ EOM
         it "knife deps --tree prints each once" do
           knife("deps --tree /roles/foo.json /roles/self.json") do
             expect(stdout).to eq("/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n")
-            expect(stderr).to eq("WARNING: No knife configuration file found\n")
+            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.\n")
           end
         end
       end
@@ -580,7 +580,7 @@ EOM
         it "knife deps --tree prints each once" do
           knife("deps --remote --tree /roles/foo.json /roles/self.json") do
             expect(stdout).to eq("/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n")
-            expect(stderr).to eq("WARNING: No knife configuration file found\n")
+            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.\n")
           end
         end
       end


### PR DESCRIPTION
This is a pretty common first error message to experience with Chef. Let's point the users to a helpful location so they can quickly get up and running.

Signed-off-by: Tim Smith <tsmith@chef.io>