### PR TITLE
Support an array of keys for apt_repository

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -33,7 +33,7 @@ class Chef
       # whether or not to add the repository as a source repo, too
       property :deb_src, [TrueClass, FalseClass], default: false
       property :keyserver, [String, nil, false], default: "keyserver.ubuntu.com", nillable: true, coerce: proc { |x| x ? x : nil }
-      property :key, [String, Array, nil, false], default: [], coerce: proc { |x| x ? [x].flatten : nil }
+      property :key, [String, Array, nil, false], default: [], coerce: proc { |x| x ? Array(x) : nil }
       property :key_proxy, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
 
       property :cookbook, [String, nil, false], default: nil, desired_state: false, nillable: true, coerce: proc { |x| x ? x : nil }

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -33,7 +33,7 @@ class Chef
       # whether or not to add the repository as a source repo, too
       property :deb_src, [TrueClass, FalseClass], default: false
       property :keyserver, [String, nil, false], default: "keyserver.ubuntu.com", nillable: true, coerce: proc { |x| x ? x : nil }
-      property :key, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
+      property :key, [String, Array, nil, false], default: [], coerce: proc { |x| x ? [x].flatten : nil }
       property :key_proxy, [String, nil, false], default: nil, nillable: true, coerce: proc { |x| x ? x : nil }
 
       property :cookbook, [String, nil, false], default: nil, desired_state: false, nillable: true, coerce: proc { |x| x ? x : nil }


### PR DESCRIPTION
### Description

Amends `apt_repository` key property to accept an array of keys to install, in the case of authenticating packages from repos signed by multiple keys.

### Issues Resolved

Fix #6369