### PR TITLE
Ensure we quote ETHTOOL/BONDING_OPTS

### DIFF
--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -38,8 +38,8 @@ class Chef
 <% if new_resource.hwaddr %>HWADDR=<%= new_resource.hwaddr %><% end %>
 <% if new_resource.metric %>METRIC=<%= new_resource.metric %><% end %>
 <% if new_resource.mtu %>MTU=<%= new_resource.mtu %><% end %>
-<% if new_resource.ethtool_opts %>ETHTOOL_OPTS=<%= new_resource.ethtool_opts %><% end %>
-<% if new_resource.bonding_opts %>BONDING_OPTS=<%= new_resource.bonding_opts %><% end %>
+<% if new_resource.ethtool_opts %>ETHTOOL_OPTS="<%= new_resource.ethtool_opts %>"<% end %>
+<% if new_resource.bonding_opts %>BONDING_OPTS="<%= new_resource.bonding_opts %>"<% end %>
 <% if new_resource.master %>MASTER=<%= new_resource.master %><% end %>
 <% if new_resource.slave %>SLAVE=<%= new_resource.slave %><% end %>
           }

--- a/spec/unit/provider/ifconfig/redhat_spec.rb
+++ b/spec/unit/provider/ifconfig/redhat_spec.rb
@@ -56,8 +56,8 @@ describe Chef::Provider::Ifconfig::Redhat do
         expect(arg).to match(/^\s*DEVICE=eth0\s*$/)
         expect(arg).to match(/^\s*IPADDR=10\.0\.0\.1\s*$/)
         expect(arg).to match(/^\s*NETMASK=255\.255\.254\.0\s*$/)
-        expect(arg).to match(/^\s*ETHTOOL_OPTS=-A eth0 autoneg off\s*$/)
-        expect(arg).to match(/^\s*BONDING_OPTS=mode=active-backup miimon=100\s*$/)
+        expect(arg).to match(/^\s*ETHTOOL_OPTS="-A eth0 autoneg off"\s*$/)
+        expect(arg).to match(/^\s*BONDING_OPTS="mode=active-backup miimon=100"\s*$/)
         expect(arg).to match(/^\s*MASTER=bond0\s*$/)
         expect(arg).to match(/^\s*SLAVE=yes\s*$/)
       end


### PR DESCRIPTION
Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

### Description

Quote ETHTOOL_OPTS and BONDING_OPTS so ifcfg-if changes from

BONDING_OPTS=mode=active-backup miimon=100 # invalid

to

BONDING_OPTS="mode=active-backup miimon=100" # valid

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
