### PR TITLE
Allow specifying default gateway on RHEL/Centos

### DIFF
--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -87,14 +87,13 @@ class Chef
 
         # cidr or quad dot mask
         new_ip = if new_resource.target == "default"
-                   nil
+                   IPAddr.new(new_resource.gateway)
                  elsif new_resource.netmask
                    IPAddr.new("#{new_resource.target}/#{new_resource.netmask}")
                  else
                    IPAddr.new(new_resource.target)
                  end
 
-        return unless new_ip
         # For linux, we use /proc/net/route file to read proc table info
         return if node[:os] != "linux"
 
@@ -208,14 +207,9 @@ class Chef
 
         case action
         when :add
-          if target == "default"
-            command = [ "ip", "route", "replace", target ]
-            command += [ "via", new_resource.gateway ] if new_resource.gateway
-          else
-            command = [ "ip", "route", "replace", target ]
-            command += [ "via", new_resource.gateway ] if new_resource.gateway
-            command += [ "dev", new_resource.device ] if new_resource.device
-          end
+          command = [ "ip", "route", "replace", target ]
+          command += [ "via", new_resource.gateway ] if new_resource.gateway
+          command += [ "dev", new_resource.device ] if new_resource.device
         when :delete
           command = [ "ip", "route", "delete", target ]
           command += [ "via", new_resource.gateway ] if new_resource.gateway

--- a/spec/unit/provider/route_spec.rb
+++ b/spec/unit/provider/route_spec.rb
@@ -29,9 +29,14 @@ describe Chef::Provider::Route do
     @new_resource.gateway "10.0.0.9"
     @current_resource = Chef::Resource::Route.new("10.0.0.10")
     @current_resource.gateway "10.0.0.9"
+    @default_resource = Chef::Resource::Route.new("default")
+    @default_resource.gateway "10.0.0.9"
 
     @provider = Chef::Provider::Route.new(@new_resource, @run_context)
     @provider.current_resource = @current_resource
+
+    @default_provider = Chef::Provider::Route.new(@default_resource, @run_context)
+    @default_provider.current_resource = @default_resource
   end
 
   describe Chef::Provider::Route, "hex2ip" do
@@ -160,6 +165,11 @@ describe Chef::Provider::Route do
     it "should not include ' via $gateway ' when a gateway is not specified" do
       @new_resource.gateway(nil)
       expect(@provider.generate_command(:add).join(" ")).not_to match(/\svia\s#{Regexp.escape(@new_resource.gateway.to_s)}/)
+    end
+
+    it "should use the gatway when target is default" do
+      @default_resource.gateway("10.0.0.10")
+      expect(@default_provider.generate_command(:add).join(" ")).to match(/10.0.0.10/)
     end
   end
 

--- a/spec/unit/provider/route_spec.rb
+++ b/spec/unit/provider/route_spec.rb
@@ -226,9 +226,19 @@ describe Chef::Provider::Route do
 
         route_file = StringIO.new
         expect(File).to receive(:new).with("/etc/sysconfig/network-scripts/route-eth0", "w").and_return(route_file)
-        # Chef::Log.should_receive(:debug).with("route[10.0.0.10] writing route.eth0\n10.0.0.10 via 10.0.0.9\n")
         @run_context.resource_collection << @new_resource
         @provider.generate_config
+      end
+
+    end
+    %w{ centos redhat fedora }.each do |platform|
+      it "should write a default route file on #{platform} platform" do
+        @node.automatic_attrs[:platform] = platform
+
+        route_file = StringIO.new
+        expect(File).to receive(:new).with("/etc/sysconfig/network", "w").and_return(route_file)
+        @run_context.resource_collection << @default_resource
+        @default_provider.generate_config
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

### Description

Allow specifying default gateway on RHEL/Centos

### Issues Resolved

https://github.com/chef/chef/issues/2243

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
