### PR TITLE
Provide release_branch as an array instead of a hash

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,10 +30,10 @@ github:
   # (as determined by the value in the VERSION file) those branches are responsible
   # for building.
   release_branch:
-    master:
-      version_constraint: ~> 13.0
-    chef-12:
-      version_constraint: ~> 12.0
+    - master:
+        version_constraint: ~> 13.0
+    - chef-12:
+        version_constraint: ~> 12.0
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
