### PR TITLE
Remove deprecated --distro option.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -119,16 +119,6 @@ class Chef
         :description => "Do not proxy locations for the node being bootstrapped; this option is used internally by Opscode",
         :proc => Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
-      # DEPR: Remove this option in Chef 13
-      option :distro,
-        :short => "-d DISTRO",
-        :long => "--distro DISTRO",
-        :description => "Bootstrap a distro using a template. [DEPRECATED] Use -t / --bootstrap-template option instead.",
-        :proc        => Proc.new { |v|
-          Chef::Log.warn("[DEPRECATED] -d / --distro option is deprecated. Use -t / --bootstrap-template option instead.")
-          v
-        }
-
       option :bootstrap_template,
         :short => "-t TEMPLATE",
         :long => "--bootstrap-template TEMPLATE",
@@ -310,7 +300,7 @@ class Chef
         # The order here is important. We want to check if we have the new Chef 12 option is set first.
         # Knife cloud plugins unfortunately all set a default option for the :distro so it should be at
         # the end.
-        config[:bootstrap_template] || config[:template_file] || config[:distro] || default_bootstrap_template
+        config[:bootstrap_template] || config[:template_file] || default_bootstrap_template
       end
 
       def find_template

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -84,22 +84,6 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
-  context "with :distro and :bootstrap_template cli options" do
-    let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "--distro", "other-template" ] }
-
-    it "should select bootstrap template" do
-      expect(File.basename(knife.bootstrap_template)).to eq("my-template")
-    end
-  end
-
-  context "with :distro and :template_file cli options" do
-    let(:bootstrap_cli_options) { [ "--distro", "my-template", "--template-file", "other-template" ] }
-
-    it "should select bootstrap template" do
-      expect(File.basename(knife.bootstrap_template)).to eq("other-template")
-    end
-  end
-
   context "with :bootstrap_template and :template_file cli options" do
     let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "--template-file", "other-template" ] }
 
@@ -235,7 +219,7 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
-  ["-d", "--distro", "-t", "--bootstrap-template", "--template-file"].each do |t|
+  ["-t", "--bootstrap-template", "--template-file"].each do |t|
     context "when #{t} option is given in the command line" do
       it "sets the knife :bootstrap_template config" do
         knife.parse_options([t, "blahblah"])


### PR DESCRIPTION
### Description

Removes the --distro bootstrap option which, per the comment, was supposed to be deleted for Chef 13.

### Issues Resolved

None

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
