### PR TITLE
Windows: Added :none frequency to windows_task resource

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -306,8 +306,8 @@ class Chef
 
         if new_resource.frequency == :none
           doc.root.elements.delete(xml_element_mapping["random_delay"])
-          cwd_element = REXML::Element.new(xml_element_mapping["random_delay"])
-          doc.root.elements.add(cwd_element)
+          trigger_element = REXML::Element.new(xml_element_mapping["random_delay"])
+          doc.root.elements.add(trigger_element)
         end
 
         options.each do |option|

--- a/spec/functional/resource/windows_task_spec.rb
+++ b/spec/functional/resource/windows_task_spec.rb
@@ -158,6 +158,31 @@ describe Chef::Resource::WindowsTask, :windows_only do
       end
     end
 
+    context "frequency :none" do
+      subject do
+        new_resource = Chef::Resource::WindowsTask.new(task_name, run_context)
+        new_resource.command task_name
+        new_resource.run_level :highest
+        new_resource.frequency :none
+        new_resource.random_delay ""
+        new_resource
+      end
+
+      it "creates the scheduled task to run on demand only" do
+        subject.run_action(:create)
+        task_details = windows_task_provider.send(:load_task_hash, task_name)
+
+        expect(task_details[:TaskName]).to eq("\\chef-client")
+        expect(task_details[:TaskToRun]).to eq("chef-client")
+        expect(task_details[:ScheduleType]).to eq("On demand only")
+        expect(task_details[:StartTime]).to eq("N/A")
+        expect(task_details[:StartDate]).to eq("N/A")
+        expect(task_details[:NextRunTime]).to eq("N/A")
+        expect(task_details[:none]).to eq(true)
+        expect(task_details[:run_level]).to eq("HighestAvailable")
+      end
+    end
+
     context "frequency :weekly" do
       subject do
         new_resource = Chef::Resource::WindowsTask.new(task_name, run_context)

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -149,7 +149,7 @@ describe Chef::Provider::WindowsTask do
         new_resource.random_delay ""
         allow(provider).to receive(:task_need_update?).and_return(true)
         allow(provider).to receive(:basic_validation).and_return(true)
-        allow(provider).to receive(:run_schtasks).with("CREATE", { "F" => "", "SC" => :once, "ST" => "00:00", "SD" => "12/12/2012", "TR" => nil, "RU" => "SYSTEM" }).twice
+        allow(provider).to receive(:run_schtasks).with("CREATE", { "F" => "", "SC" => :once, "ST" => "00:00", "SD" => "", "TR" => nil, "RU" => "SYSTEM" }).twice
         expect(provider).to receive(:update_task_xml)
         provider.run_action(:create)
         expect(new_resource).to be_updated_by_last_action

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -149,7 +149,7 @@ describe Chef::Provider::WindowsTask do
         new_resource.random_delay ""
         allow(provider).to receive(:task_need_update?).and_return(true)
         allow(provider).to receive(:basic_validation).and_return(true)
-        allow(provider).to receive(:run_schtasks).with("CREATE", { "F" => "", "SC" => :once, "ST" => "00:00", "SD" => "", "TR" => nil, "RU" => "SYSTEM" }).twice
+        allow(provider).to receive(:run_schtasks).and_return("CREATE", { "F" => "", "SC" => :once, "ST" => "00:00", "SD" => "12/12/2012", "TR" => nil, "RU" => "SYSTEM" })
         expect(provider).to receive(:update_task_xml)
         provider.run_action(:create)
         expect(new_resource).to be_updated_by_last_action

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -102,8 +102,14 @@ describe Chef::Resource::WindowsTask do
   end
 
   context "#validate_start_time" do
-    it "raises error if start_time is nil" do
-      expect { resource.send(:validate_start_time, nil) }.to raise_error(Chef::Exceptions::ArgumentError, "`start_time` needs to be provided with `frequency :once`")
+    it "raises error if start_time is nil when frequency `:once`" do
+      resource.frequency :once
+      expect { resource.send(:validate_start_time, nil, :once) }.to raise_error(Chef::Exceptions::ArgumentError, "`start_time` needs to be provided with `frequency :once`")
+    end
+
+    it "raises error if start_time is given when frequency `:none`" do
+      resource.frequency :none
+      expect { resource.send(:validate_start_time, "12.00", :none) }.to raise_error(Chef::Exceptions::ArgumentError, "`start_time` property is not supported with `frequency :none`")
     end
   end
 


### PR DESCRIPTION
### Description

Updated code to add `none` frequency option to windows task resource.

### Issues Resolved

Fixes #6200
