### PR TITLE
backport #6383 to 12

### DIFF
--- a/lib/chef/util/dsc/local_configuration_manager.rb
+++ b/lib/chef/util/dsc/local_configuration_manager.rb
@@ -73,7 +73,6 @@ class Chef::Util::DSC
     def lcm_command(apply_configuration)
       common_command_prefix = "$ProgressPreference = 'SilentlyContinue';"
       ps4_base_command = "#{common_command_prefix} Start-DscConfiguration -path #{@configuration_path} -wait -erroraction 'stop' -force"
-
       if apply_configuration
         ps4_base_command
       else


### PR DESCRIPTION
Backport #6383 to Chef 12, which adds support for using `dsc_script` on Powershell 5.