### PR TITLE
Quiet the output of the zypper refresh and add force

### DIFF
--- a/lib/chef/provider/zypper_repository.rb
+++ b/lib/chef/provider/zypper_repository.rb
@@ -57,7 +57,7 @@ class Chef
       end
 
       action :refresh do
-        declare_resource(:execute, "zypper#{' --gpg-auto-import-keys' if new_resource.gpgautoimportkeys} refresh #{escaped_repo_name}") do
+        declare_resource(:execute, "zypper#{' --gpg-auto-import-keys' if new_resource.gpgautoimportkeys} --quiet --no-confirm refresh --force #{escaped_repo_name}") do
           only_if "zypper lr #{escaped_repo_name}"
         end
       end


### PR DESCRIPTION
This is probably the sane set of options for an automated refresh approach.

Signed-off-by: Tim Smith <tsmith@chef.io>