### PR TITLE
Replace which apt-get check with simple debian check in apt resources

### DIFF
--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -19,17 +19,12 @@
 require "chef/provider"
 require "chef/dsl/declare_resource"
 require "chef/provider/noop"
-require "chef/mixin/which"
 require "chef/log"
 
 class Chef
   class Provider
     class AptPreference < Chef::Provider
-      extend Chef::Mixin::Which
-
-      provides :apt_preference do
-        which("apt-get")
-      end
+      provides :apt_preference, os: "linux", platform_family: [ "debian" ]
 
       APT_PREFERENCE_DIR = "/etc/apt/preferences.d".freeze
 

--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -24,7 +24,7 @@ require "chef/log"
 class Chef
   class Provider
     class AptPreference < Chef::Provider
-      provides :apt_preference, os: "linux", platform_family: [ "debian" ]
+      provides :apt_preference, os: "linux", platform_family: "debian"
 
       APT_PREFERENCE_DIR = "/etc/apt/preferences.d".freeze
 

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -27,7 +27,7 @@ class Chef
     class AptRepository < Chef::Provider
       include Chef::Mixin::ShellOut
 
-      provides :apt_repository, os: "linux", platform_family: [ "debian" ]
+      provides :apt_repository, os: "linux", platform_family: "debian"
 
       LIST_APT_KEYS = "apt-key list".freeze
       LIST_APT_KEY_FINGERPRINTS = "apt-key adv --list-public-keys --with-fingerprint --with-colons".freeze

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -19,7 +19,6 @@
 require "chef/resource"
 require "chef/dsl/declare_resource"
 require "chef/mixin/shell_out"
-require "chef/mixin/which"
 require "chef/http/simple"
 require "chef/provider/noop"
 
@@ -27,11 +26,8 @@ class Chef
   class Provider
     class AptRepository < Chef::Provider
       include Chef::Mixin::ShellOut
-      extend Chef::Mixin::Which
 
-      provides :apt_repository do
-        which("apt-get")
-      end
+      provides :apt_repository, os: "linux", platform_family: [ "debian" ]
 
       LIST_APT_KEYS = "apt-key list".freeze
       LIST_APT_KEY_FINGERPRINTS = "apt-key adv --list-public-keys --with-fingerprint --with-colons".freeze

--- a/lib/chef/provider/apt_update.rb
+++ b/lib/chef/provider/apt_update.rb
@@ -23,7 +23,7 @@ require "chef/dsl/declare_resource"
 class Chef
   class Provider
     class AptUpdate < Chef::Provider
-      provides :apt_update, os: "linux", platform_family: [ "debian" ]
+      provides :apt_update, os: "linux", platform_family: "debian"
 
       APT_CONF_DIR = "/etc/apt/apt.conf.d"
       STAMP_DIR = "/var/lib/apt/periodic"

--- a/lib/chef/provider/apt_update.rb
+++ b/lib/chef/provider/apt_update.rb
@@ -18,16 +18,12 @@
 
 require "chef/provider"
 require "chef/provider/noop"
-require "chef/mixin/which"
+require "chef/dsl/declare_resource"
 
 class Chef
   class Provider
     class AptUpdate < Chef::Provider
-      extend Chef::Mixin::Which
-
-      provides :apt_update do
-        which("apt-get")
-      end
+      provides :apt_update, os: "linux", platform_family: [ "debian" ]
 
       APT_CONF_DIR = "/etc/apt/apt.conf.d"
       STAMP_DIR = "/var/lib/apt/periodic"

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class AptPackage < Chef::Resource::Package
       resource_name :apt_package
-      provides :package, os: "linux", platform_family: [ "debian" ]
+      provides :package, os: "linux", platform_family: "debian"
 
       property :default_release, String, desired_state: false
 

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptPreference < Chef::Resource
       resource_name :apt_preference
-      provides :apt_preference
+      provides :apt_preference, os: "linux", platform_family: [ "debian" ]
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptPreference < Chef::Resource
       resource_name :apt_preference
-      provides :apt_preference, os: "linux", platform_family: [ "debian" ]
+      provides :apt_preference, os: "linux", platform_family: "debian"
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptRepository < Chef::Resource
       resource_name :apt_repository
-      provides :apt_repository
+      provides :apt_repository, os: "linux", platform_family: [ "debian" ]
 
       property :repo_name, String, name_property: true
       property :uri, String

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptRepository < Chef::Resource
       resource_name :apt_repository
-      provides :apt_repository, os: "linux", platform_family: [ "debian" ]
+      provides :apt_repository, os: "linux", platform_family: "debian"
 
       property :repo_name, String, name_property: true
       property :uri, String

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptUpdate < Chef::Resource
       resource_name :apt_update
-      provides :apt_update, os: "linux", platform_family: [ "debian" ]
+      provides :apt_update, os: "linux", platform_family: "debian"
 
       # allow bare apt_update with no name
       property :name, String, default: ""

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptUpdate < Chef::Resource
       resource_name :apt_update
-      provides :apt_update
+      provides :apt_update, os: "linux", platform_family: [ "debian" ]
 
       # allow bare apt_update with no name
       property :name, String, default: ""

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/resource/apt_preference_spec.rb
+++ b/spec/unit/resource/apt_preference_spec.rb
@@ -24,18 +24,26 @@ describe Chef::Resource::AptPreference do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptPreference.new("libmysqlclient16", run_context) }
 
-  it "should create a new Chef::Resource::AptPreference" do
+  it "creates a new Chef::Resource::AptPreference" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::AptPreference)
   end
 
-  it "should resolve to a Noop class when apt-get is not found" do
-    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(false)
+  it "resolves to a Noop class when on non-linux OS" do
+    node.automatic[:os] = "windows"
+    node.automatic[:platform_family] = "windows"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
   end
 
-  it "should resolve to a AptPreference class when apt-get is found" do
-    expect(Chef::Provider::AptPreference).to receive(:which).with("apt-get").and_return(true)
+  it "resolves to a Noop class when on non-debian linux" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "gentoo"
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "resolves to a AptUpdate class when on a debian platform_family" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "debian"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptPreference)
   end
 end

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,27 +24,35 @@ describe Chef::Resource::AptRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptRepository.new("multiverse", run_context) }
 
-  it "should create a new Chef::Resource::AptRepository" do
+  it "creates a new Chef::Resource::AptRepository" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::AptRepository)
   end
 
-  it "the default keyserver should be keyserver.ubuntu.com" do
+  it "uses keyserver.ubuntu.com as the keyserver" do
     expect(resource.keyserver).to eql("keyserver.ubuntu.com")
   end
 
-  it "the default distribution should be nillable" do
+  it "default distribution is nillable" do
     expect(resource.distribution(nil)).to eql(nil)
     expect(resource.distribution).to eql(nil)
   end
 
-  it "should resolve to a Noop class when apt-get is not found" do
-    expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(false)
+  it "resolves to a Noop class when on non-linux OS" do
+    node.automatic[:os] = "windows"
+    node.automatic[:platform_family] = "windows"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
   end
 
-  it "should resolve to a AptRepository class when apt-get is found" do
-    expect(Chef::Provider::AptRepository).to receive(:which).with("apt-get").and_return(true)
+  it "resolves to a Noop class when on non-debian linux" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "gentoo"
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "resolves to a AptUpdate class when on a debian platform_family" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "debian"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptRepository)
   end
 end

--- a/spec/unit/resource/apt_update_spec.rb
+++ b/spec/unit/resource/apt_update_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,27 +24,35 @@ describe Chef::Resource::AptUpdate do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptUpdate.new("update", run_context) }
 
-  it "should create a new Chef::Resource::AptUpdate" do
+  it "creates a new Chef::Resource::AptUpdate" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::AptUpdate)
   end
 
-  it "the default frequency should be 1 day" do
+  it "default frequency is set to be 1 day" do
     expect(resource.frequency).to eql(86_400)
   end
 
-  it "the frequency should accept integers" do
+  it "frequency accepts integers" do
     resource.frequency(400)
     expect(resource.frequency).to eql(400)
   end
 
-  it "should resolve to a Noop class when apt-get is not found" do
-    expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(false)
+  it "resolves to a Noop class when on non-linux OS" do
+    node.automatic[:os] = "windows"
+    node.automatic[:platform_family] = "windows"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
   end
 
-  it "should resolve to a AptUpdate class when apt-get is found" do
-    expect(Chef::Provider::AptUpdate).to receive(:which).with("apt-get").and_return(true)
+  it "resolves to a Noop class when on non-debian linux" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "gentoo"
+    expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
+  end
+
+  it "resolves to a AptUpdate class when on a debian platform_family" do
+    node.automatic[:os] = "linux"
+    node.automatic[:platform_family] = "debian"
     expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::AptUpdate)
   end
 end


### PR DESCRIPTION
apt-get is a link to yast2 in suse so these resources fire there when someone wouldn't expect them to. Looking back we probably should have skipped the whole platform based no-op thing, but that ship sailed. This makes it behave the way a user would expect it to. What happens if you have apt compiled on your gentoo box? Well it's going to break. We'll just have to live with fixing it for 99.99% of users instead of the current 95%. Also: This is faster.

Signed-off-by: Tim Smith <tsmith@chef.io>