### PR TITLE
Don't catch SIGCHLD from dnf_helper.py

### DIFF
--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -72,7 +72,6 @@ def exit_handler(signal, frame):
 signal.signal(signal.SIGINT, exit_handler)
 signal.signal(signal.SIGHUP, exit_handler)
 signal.signal(signal.SIGPIPE, exit_handler)
-signal.signal(signal.SIGCHLD, exit_handler)
 
 while 1:
     # kill self if we get orphaned (tragic)


### PR DESCRIPTION
### Description

dnf_helper.py was configured to catch the SIGCHLD signal and quit if it
was received.  In Fedora26 I have found that the fill_sack call in the
dnf python package may shell out causing a SIHCHLD call.  This results
in no information as the helper just exits before finding a package.

This removes the helper restoring the default handling of SIGCHLD which
is to ingore it.

Obvious fix.

Signed-off-by: Brandon Bennett <bbennett@fb.com>

### Issues Resolved

Fixes #6393

### Check List

- [N/A] New functionality includes tests
- [X] All tests pass
- [N/A] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
