### PR TITLE
Open apt resources up to prevent breaking change

### DIFF
--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptPreference < Chef::Resource
       resource_name :apt_preference
-      provides :apt_preference, os: "linux", platform_family: "debian"
+      provides :apt_preference
 
       property :package_name, String, name_property: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
       property :glob, String

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptRepository < Chef::Resource
       resource_name :apt_repository
-      provides :apt_repository, os: "linux", platform_family: "debian"
+      provides :apt_repository
 
       property :repo_name, String, name_property: true
       property :uri, String

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptUpdate < Chef::Resource
       resource_name :apt_update
-      provides :apt_update, os: "linux", platform_family: "debian"
+      provides :apt_update
 
       # allow bare apt_update with no name
       property :name, String, default: ""


### PR DESCRIPTION
If we want these to throw a no ops vs. a hard failure we need them to be
wide open. Since a lot of people (including all of chef-cookbooks) have
coded as if these will gracefully skip this would have been a breaking
change.

Signed-off-by: Tim Smith <tsmith@chef.io>