### PR TITLE
Fixes to package upgrade behaviour

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -365,7 +365,7 @@ class Chef
       # `version_satisfied_by?(version, constraint)` might be a better name to make this generic.
       #
       def version_requirement_satisfied?(current_version, new_version)
-        version_equals?(current_version, new_version)
+        target_version_already_installed?(current_version, new_version)
       end
 
       # @todo: extract apt/dpkg specific preseeding to a helper class

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -127,6 +127,13 @@ class Chef
 
         private
 
+        def version_compare(v1, v2)
+          gem_v1 =  v1.gsub(/[_+]/, "+" => "-", "_" => "-") unless v1.nil?
+          gem_v2 =  v2.gsub(/[_+]/, "+" => "-", "_" => "-") unless v2.nil?
+
+          Gem::Version.new(gem_v1) <=> Gem::Version.new(gem_v2)
+        end
+
         # Runs command via shell_out with magic environment to disable
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -141,6 +141,17 @@ EOS
 
         private
 
+        def version_compare(v1, v2)
+          if v1 == "latest" || v2 == "latest"
+            return 0
+          end
+
+          gem_v1 = Gem::Version.new(v1)
+          gem_v2 = Gem::Version.new(v2)
+
+          gem_v1 <=> gem_v2
+        end
+
         # Magic to find where chocolatey is installed in the system, and to
         # return the full path of choco.exe
         #

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -126,6 +126,10 @@ class Chef
           end
         end
 
+        def version_compare(v1, v2)
+          python_helper.compare_versions(v1, v2)
+        end
+
         # @returns Array<Version>
         def available_version(index)
           @available_version ||= []

--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -26,6 +26,14 @@ def flushcache():
         pass
     get_sack().load_system_repo(build_cache=True)
 
+def versioncompare(versions):
+    sack = get_sack()
+    if (versions[0] is None) or (versions[1] is None):
+      sys.stdout.write('0\n')
+    else:
+      evr_comparison = sack.evr_cmp(versions[0], versions[1])
+      sys.stdout.write('{}\n'.format(evr_comparison))
+
 def query(command):
     sack = get_sack()
 
@@ -86,5 +94,7 @@ while 1:
         query(command)
     elif command['action'] == "flushcache":
         flushcache()
+    elif command['action'] == "versioncompare":
+        versioncompare(command['versions'])
     else:
         raise RuntimeError("bad command")

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -61,6 +61,15 @@ class Chef
             start if stdin.nil?
           end
 
+          def compare_versions(version1, version2)
+            with_helper do
+              json = build_version_query("versioncompare", [version1, version2])
+              Chef::Log.debug "sending '#{json}' to python helper"
+              stdin.syswrite json + "\n"
+              stdout.sysread(4096).chomp.to_i
+            end
+          end
+
           # @returns Array<Version>
           def query(action, provides, version = nil, arch = nil)
             with_helper do
@@ -106,6 +115,12 @@ class Chef
             hash["provides"] = provides
             add_version(hash, version) unless version.nil?
             hash["arch" ] = arch unless arch.nil?
+            FFI_Yajl::Encoder.encode(hash)
+          end
+
+          def build_version_query(action, versions)
+            hash = { "action" => action }
+            hash["versions"] = versions
             FFI_Yajl::Encoder.encode(hash)
           end
 

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -18,6 +18,7 @@
 require "chef/provider/package"
 require "chef/resource/package"
 require "chef/mixin/get_source_from_package"
+require "chef/provider/package/yum/rpm_utils"
 
 class Chef
   class Provider
@@ -108,6 +109,10 @@ class Chef
         end
 
         private
+
+        def version_compare(v1, v2)
+          Chef::Provider::Package::Yum::RPMVersion.parse(v1) <=> Chef::Provider::Package::Yum::RPMVersion.parse(v2)
+        end
 
         def uri_scheme?(str)
           scheme = URI.split(str).first

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -179,6 +179,17 @@ class Chef
 
         private
 
+        def version_compare(v1, v2)
+          if v1 == "latest" || v2 == "latest"
+            return 0
+          end
+
+          gem_v1 = Gem::Version.new(v1)
+          gem_v2 = Gem::Version.new(v2)
+
+          gem_v1 <=> gem_v2
+        end
+
         def uninstall_registry_entries
           @uninstall_registry_entries ||= Chef::Provider::Package::Windows::RegistryUninstallEntry.find_entries(new_resource.package_name)
         end

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -165,6 +165,10 @@ class Chef
         #
         # @return [Boolean] true if new_version is equal to or included in current_version
         def target_version_already_installed?(current_version, new_version)
+          version_equals?(current_version, new_version)
+        end
+
+        def version_equals?(current_version, new_version)
           Chef::Log.debug("Checking if #{new_resource} version '#{new_version}' is already installed. #{current_version} is currently installed")
           if current_version.is_a?(Array)
             current_version.include?(new_version)

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -156,26 +156,6 @@ class Chef
           yum_command("-d0 -e0 -y#{expand_options(new_resource.options)} versionlock delete #{unlock_str}")
         end
 
-        # Keep upgrades from trying to install an older candidate version. Can happen when a new
-        # version is installed then removed from a repository, now the older available version
-        # shows up as a viable install candidate.
-        #
-        # Can be done in upgrade_package but an upgraded from->to log message slips out
-        #
-        # Hacky - better overall solution? Custom compare in Package provider?
-        def action_upgrade
-          # Could be uninstalled or have no candidate
-          if current_resource.version.nil? || !candidate_version_array.any?
-            super
-          elsif candidate_version_array.zip(current_version_array).any? do |c, i|
-                  RPMVersion.parse(c) > RPMVersion.parse(i)
-                end
-            super
-          else
-            Chef::Log.debug("#{new_resource} is at the latest version - nothing to do")
-          end
-        end
-
         private
 
         #
@@ -188,6 +168,10 @@ class Chef
               yum_binary = new_resource.yum_binary if new_resource.is_a?(Chef::Resource::YumPackage)
               yum_binary ||= ::File.exist?("/usr/bin/yum-deprecated") ? "yum-deprecated" : "yum"
             end
+        end
+
+        def version_compare(v1, v2)
+          RPMVersion.parse(v1) <=> RPMVersion.parse(v2)
         end
 
         # Enable or disable YumCache extra_repo_control

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -383,6 +383,11 @@ describe Chef::Provider::Package::Rubygems do
       provider.load_current_resource
       expect(provider.target_version_already_installed?(provider.current_resource.version, new_resource.version)).to be_falsey
     end
+
+    it "version_equals? should return false so that we can search for candidates" do
+      provider.load_current_resource
+      expect(provider.version_equals?(provider.current_resource.version, new_resource.version)).to be_falsey
+    end
   end
 
   describe "when new_resource version is an rspec version" do


### PR DESCRIPTION
### Description

This pull request introduces fixes to the behaviour of the various providers of the "package" resource (and subtypes like dnf_package etc) when a more recent version of the package has been installed than that present in an available repository or file source and "action :upgrade" is called against the package.

Currently, a number of package providers will attempt to *downgrade* a package under this scenario, where the desired action should be to recognise that a more up to date version is already installed and do nothing.

The PR introduces a ```version_compare``` method to the package superclass which by default uses ```Gem::Version``` comparison with spaceship-operator semantics to ensure that an upgrade is attempted only when the candidate version is *not* older than the current version.

For package management systems (such as dnf) requiring more specific implementations of ```version_compare```, a method has been added to the relevant subclass.

This PR has been tested against the following package managers (and associated providers), and behaves correctly (that is, Chef will not attempt to upgrade to an older package version):

* apt
* dpkg
* rpm
* yum
* dnf
* gem
* zypper
* homebrew

Additionally, this PR introduces a method called ```version_equals?``` which is functionally identical to ```target_version_already_installed?``` (and that method now in fact calls ```version_equals?```. This has been done to clarify the purpose and functionality of that method, but since it's a public API, deprecation of the old method name will have to be done more gradually.

### Issues Resolved

Resolves #6352 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
