### PR TITLE
Fix issue #2351, chef-client doesn't make /etc/chef if the directory …

### DIFF
--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -19,6 +19,7 @@
 require "chef/config"
 require "chef/server_api"
 require "chef/exceptions"
+require "fileutils"
 
 class Chef
   class ApiClient
@@ -69,6 +70,13 @@ class Chef
       end
 
       def assert_destination_writable!
+        if !File.exists?(File.dirname(destination))
+          begin
+            FileUtils.mkdir_p(File.dirname(destination))
+          rescue Errno::EACCES
+            raise Chef::Exceptions::CannotWritePrivateKey, "I can't write your private key to #{abs_path} - check permissions?"
+          end
+        end
         if (File.exists?(destination) && !File.writable?(destination)) || !File.writable?(File.dirname(destination))
           abs_path = File.expand_path(destination)
           raise Chef::Exceptions::CannotWritePrivateKey, "I can't write your private key to #{abs_path} - check permissions?"


### PR DESCRIPTION
…doesn't exist

### Description

Creates the /etc/chef directory if it doesn't already exist.

### Issues Resolved

#2351

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco> (Not sure how to go about this)
