### PR TITLE
Backport 6094 to Chef 12: apt-key finger no longer matches extract fingerprints regex

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -31,6 +31,9 @@ class Chef
       include Chef::Mixin::ShellOut
       extend Chef::Mixin::Which
 
+      LIST_APT_KEYS = "apt-key list".freeze
+      LIST_APT_KEY_FINGERPRINTS = "apt-key adv --list-public-keys --with-fingerprint --with-colons".freeze
+
       provides :apt_repository do
         which("apt-get")
       end
@@ -149,7 +152,7 @@ class Chef
       def no_new_keys?(file)
         # Now we are using the option --with-colons that works across old os versions
         # as well as the latest (16.10). This for both `apt-key` and `gpg` commands
-        installed_keys = extract_fingerprints_from_cmd("apt-key adv --list-public-keys --with-fingerprint --with-colons")
+        installed_keys = extract_fingerprints_from_cmd(LIST_APT_KEY_FINGERPRINTS)
         proposed_keys = extract_fingerprints_from_cmd("gpg --with-fingerprint --with-colons #{file}")
         (installed_keys & proposed_keys).sort == proposed_keys.sort
       end
@@ -200,15 +203,15 @@ class Chef
           command cmd
           sensitive new_resource.sensitive
           not_if do
-            present = extract_fingerprints_from_cmd("apt-key finger").any? do |fp|
+            present = extract_fingerprints_from_cmd(LIST_APT_KEY_FINGERPRINTS).any? do |fp|
               fp.end_with? key.upcase
             end
-            present && key_is_valid?("apt-key list", key.upcase)
+            present && key_is_valid?(LIST_APT_KEYS, key.upcase)
           end
           notifies :run, "execute[apt-cache gencaches]", :immediately
         end
 
-        raise "The key #{key} is invalid and cannot be used to verify an apt repository." unless key_is_valid?("apt-key list", key.upcase)
+        raise "The key #{key} is invalid and cannot be used to verify an apt repository." unless key_is_valid?(LIST_APT_KEYS, key.upcase)
       end
 
       def install_ppa_key(owner, repo)


### PR DESCRIPTION
Signed-off-by: Matt Whiteley <mattwhiteley@gmail.com>

### Description

Backport #6094 to Chef 12

This is just a cherry pick of the commit there and then I cleaned up the small conflict

### Issues Resolved

#6094 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
