### PR TITLE
Add throttle and metalink options to yum_repository

### DIFF
--- a/lib/chef/provider/support/yum_repo.erb
+++ b/lib/chef/provider/support/yum_repo.erb
@@ -61,6 +61,9 @@ keepalive=1
 <% if @config.metadata_expire %>
 metadata_expire=<%= @config.metadata_expire %>
 <% end %>
+<% if @config.metalink %>
+metalink=<%= @config.metalink %>
+<% end %>
 <% if @config.mirrorlist %>
 mirrorlist=<%= @config.mirrorlist %>
 <% end %>
@@ -111,6 +114,9 @@ sslclientkey=<%= @config.sslclientkey %>
 <% end %>
 <% unless @config.sslverify.nil? %>
 sslverify=<%= ( @config.sslverify ) ? 'true' : 'false' %>
+<% end %>
+<% if @config.throttle %>
+throttle=<%= @config.throttle %>
 <% end %>
 <% if @config.timeout %>
 timeout=<%= @config.timeout %>

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -24,7 +24,8 @@ class Chef
       resource_name :yum_repository
       provides :yum_repository
 
-      # http://linux.die.net/man/5/yum.conf
+      # http://linux.die.net/man/5/yum.conf as well as
+      # http://dnf.readthedocs.io/en/latest/conf_ref.html
       property :baseurl, [String, Array], regex: /.*/
       property :clean_headers, [TrueClass, FalseClass], default: false # deprecated
       property :clean_metadata, [TrueClass, FalseClass], default: true
@@ -44,6 +45,7 @@ class Chef
       property :make_cache, [TrueClass, FalseClass], default: true
       property :max_retries, [String, Integer]
       property :metadata_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/, /never/]
+      property :metalink, String, regex: /.*/
       property :mirror_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/]
       property :mirrorexpire, String, regex: /.*/
       property :mirrorlist_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/]
@@ -65,6 +67,7 @@ class Chef
       property :sslclientkey, String, regex: /.*/
       property :sslverify, [TrueClass, FalseClass]
       property :timeout, String, regex: /^\d+$/
+      property :throttle, [String, Integer]
       property :username, String, regex: /.*/
 
       default_action :create

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -26,9 +26,9 @@ class Chef
 
       # http://linux.die.net/man/5/yum.conf
       property :baseurl, [String, Array], regex: /.*/
-      property :cost, String, regex: /^\d+$/
       property :clean_headers, [TrueClass, FalseClass], default: false # deprecated
       property :clean_metadata, [TrueClass, FalseClass], default: true
+      property :cost, String, regex: /^\d+$/
       property :description, String, regex: /.*/, default: "Yum Repository"
       property :enabled, [TrueClass, FalseClass], default: true
       property :enablegroups, [TrueClass, FalseClass]
@@ -44,17 +44,17 @@ class Chef
       property :make_cache, [TrueClass, FalseClass], default: true
       property :max_retries, [String, Integer]
       property :metadata_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/, /never/]
-      property :mirrorexpire, String, regex: /.*/
-      property :mirrorlist, String, regex: /.*/
       property :mirror_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/]
+      property :mirrorexpire, String, regex: /.*/
       property :mirrorlist_expire, String, regex: [/^\d+$/, /^\d+[mhd]$/]
+      property :mirrorlist, String, regex: /.*/
       property :mode, default: "0644"
-      property :priority, String, regex: /^(\d?[0-9]|[0-9][0-9])$/
-      property :proxy, String, regex: /.*/
-      property :proxy_username, String, regex: /.*/
-      property :proxy_password, String, regex: /.*/
-      property :username, String, regex: /.*/
+      property :options, Hash
       property :password, String, regex: /.*/
+      property :priority, String, regex: /^(\d?[0-9]|[0-9][0-9])$/
+      property :proxy_password, String, regex: /.*/
+      property :proxy_username, String, regex: /.*/
+      property :proxy, String, regex: /.*/
       property :repo_gpgcheck, [TrueClass, FalseClass]
       property :report_instanceid, [TrueClass, FalseClass]
       property :repositoryid, String, regex: /.*/, name_property: true
@@ -65,7 +65,7 @@ class Chef
       property :sslclientkey, String, regex: /.*/
       property :sslverify, [TrueClass, FalseClass]
       property :timeout, String, regex: /^\d+$/
-      property :options, Hash
+      property :username, String, regex: /.*/
 
       default_action :create
       allowed_actions :create, :remove, :makecache, :add, :delete


### PR DESCRIPTION
These two config options were missing. You can pass them via options, but they should be supported out the box just like the other options.