### PR TITLE
Net:SSH config uses verify_host_key instead of paranoid

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -270,7 +270,7 @@ class Chef
           opts[:port] = port unless port.nil?
           opts[:logger] = Chef::Log.logger if Chef::Log.level == :debug
           if !config[:host_key_verify]
-            opts[:paranoid] = false
+            opts[:verify_host_key] = false
             opts[:user_known_hosts_file] = "/dev/null"
           end
           if ssh_config[:keepalive]


### PR DESCRIPTION
Signed-off-by: Pete Cheslock <petecheslock@gmail.com>

### Description

In net-ssh 4.2.0 - they are deprecating the term `paranoid` and using `verify_host_key` instead as a config option.  When using knife ssh you will get the following warning when using chef 13.4.24 and net-ssh 4.2.0
```
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
```

### Issues Resolved

The changes in net-ssh
https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt#L11
https://github.com/net-ssh/net-ssh/pull/524/files

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
