### PR TITLE
Only accept MM/DD/YYYY for windows_task start_day

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -489,7 +489,7 @@ class Chef
       end
 
       def parse_day(str)
-        Date.strptime(str, '%m/%d/%Y')
+        Date.strptime(str, "%m/%d/%Y")
       end
 
     end

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -220,7 +220,7 @@ class Chef
 
       def start_day_updated?
         current_day = DateTime.strptime(current_resource.start_day, convert_system_date_format_to_ruby_date_format)
-        new_day = DateTime.parse(new_resource.start_day)
+        new_day = parse_day(new_resource.start_day)
         current_day != new_day
       end
 
@@ -230,7 +230,7 @@ class Chef
       end
 
       def convert_user_date_to_system_date(date_in_string)
-        DateTime.parse(date_in_string).strftime(convert_system_date_format_to_ruby_long_date)
+        parse_day(date_in_string).strftime(convert_system_date_format_to_ruby_long_date)
       end
 
       def convert_system_date_format_to_ruby_long_date
@@ -486,6 +486,10 @@ class Chef
       def set_current_idle_time(idle_time)
         duration = ISO8601::Duration.new(idle_time)
         current_resource.idle_time(duration.minutes.atom.to_i)
+      end
+
+      def parse_day(str)
+        Date.strptime(str, '%m/%d/%Y')
       end
 
     end

--- a/spec/functional/resource/windows_task_spec.rb
+++ b/spec/functional/resource/windows_task_spec.rb
@@ -36,15 +36,20 @@ describe Chef::Resource::WindowsTask, :windows_only do
       subject do
         new_resource = Chef::Resource::WindowsTask.new(task_name, run_context)
         new_resource.command task_name
+        # Make sure MM/DD/YYYY is accepted
+        new_resource.start_day "09/20/2017"
         new_resource
       end
 
-      it "creates a scheduled task to run every 1 hr" do
+      it "creates a scheduled task to run every 1 hr starting on 09/20/2017" do
         subject.run_action(:create)
         task_details = windows_task_provider.send(:load_task_hash, task_name)
         expect(task_details[:TaskName]).to eq("\\chef-client")
         expect(task_details[:TaskToRun]).to eq("chef-client")
         expect(task_details[:"Repeat:Every"]).to eq("1 Hour(s), 0 Minute(s)")
+
+        # This test will not work across locales
+        expect(task_details[:StartDate]).to eq("9/20/2017")
       end
     end
 
@@ -300,7 +305,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
     context "when start_day is passed with frequency :onstart" do
       it "raises error" do
         subject.frequency :onstart
-        subject.start_day "mon"
+        subject.start_day "09/20/2017"
         expect { subject.after_created }.to raise_error("`start_day` property is not supported with frequency: onstart")
       end
     end

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -331,7 +331,7 @@ describe Chef::Provider::WindowsTask do
         new_resource.frequency_modifier 15
         new_resource.user "SYSTEM"
         new_resource.execution_time_limit "PT72H"
-        new_resource.start_day "30-Mar-2017"
+        new_resource.start_day "03/30/2017"
         new_resource.start_time "13:12"
       end
 
@@ -383,7 +383,7 @@ describe Chef::Provider::WindowsTask do
       new_resource.frequency_modifier 15
       new_resource.user "SYSTEM"
       new_resource.execution_time_limit "PT72H"
-      new_resource.start_day "30-Mar-2017"
+      new_resource.start_day "03/30/2017"
       new_resource.start_time "13:12"
     end
     context "when start_day not changed" do

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -429,9 +429,9 @@ describe Chef::Provider::WindowsTask do
   end
 
   describe "#convert_user_date_to_system_date" do
-    it "when current resource start date is '30-May-2017' then returns '05/30/2017'" do
-      allow(provider).to receive(:get_system_short_date_format).and_return("MM/dd/yyyy")
-      expect(provider.send(:convert_user_date_to_system_date, "30-May-2017")).to eq("05/30/2017")
+    it "when current resource start date is '05/30/2017' then returns '30/05/2017'" do
+      allow(provider).to receive(:get_system_short_date_format).and_return("dd/MM/yyyy")
+      expect(provider.send(:convert_user_date_to_system_date, "05/30/2017")).to eq("30/05/2017")
     end
   end
 


### PR DESCRIPTION
DateTime.parse is not really that well defined. It accepts a lot
of different dates, however not `MM/DD/YYYY`. It does `DD/MM/YYYY`.
We should be very specific in the format we accept, and continue
to support `MM/DD/YYYY` as it was in the cookbook

Fixes https://github.com/chef-cookbooks/chef-client/issues/523