### PR TITLE
dnf_resource: be more specific for rhel packages

### DIFF
--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -29,9 +29,11 @@ class Chef
 
       allowed_actions :install, :upgrade, :remove, :purge, :reconfig, :lock, :unlock, :flush_cache
 
-      provides :package, platform_family: %w{rhel fedora amazon} do
+      provides :package, platform_family: %w{fedora amazon} do
         which("dnf") && shell_out("rpm -q dnf").stdout =~ /^dnf-[1-9]/
       end
+
+      provides :package, platform_family: %{rhel}, platform_version: ">= 8"
 
       provides :dnf_package
 

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -708,18 +708,21 @@ describe Chef::ProviderResolver do
 
           "rhel" => {
     #        service: [ Chef::Resource::SystemdService, Chef::Provider::Service::Systemd ],
-            package:  [ Chef::Resource::YumPackage, Chef::Provider::Package::Yum ],
+            package:  [ Chef::Resource::DnfPackage, Chef::Provider::Package::Dnf ],
             ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig::Redhat ],
 
             %w{amazon xcp xenserver ibm_powerkvm cloudlinux parallels} => {
               "3.1.4" => {
+                package:  [ Chef::Resource::YumPackage, Chef::Provider::Package::Yum ],
     #            service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
               },
             },
             %w{redhat centos scientific oracle} => {
               "7.0" => {
+                package:  [ Chef::Resource::YumPackage, Chef::Provider::Package::Yum ],
               },
               "6.0" => {
+                package:  [ Chef::Resource::YumPackage, Chef::Provider::Package::Yum ],
     #            service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
               },
             },


### PR DESCRIPTION
### Description
With #6351 and #6377, the DNF package provider was fixed to use yum by
default on RHEL 7, but the resource was still calling the DNF provider
if it happened to be installed.

We want to use the default of yum for RHEL 7, and only use DNF if we
call `set_priority_map` directly.

Signed-off-by: Naomi Reeves <naomi.c.reeves@gmail.com>

### Issues Resolved
Unexpectedly switching package managers

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
