### PR TITLE
Fix Knife search ID only option to actually filter result set

### DIFF
--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -91,6 +91,8 @@ class Chef
           search_args[:filter_result] = create_result_filter(config[:filter_result])
         elsif (not ui.config[:attribute].nil?) && (not ui.config[:attribute].empty?)
           search_args[:filter_result] = create_result_filter_from_attributes(ui.config[:attribute])
+        elsif config[:id_only]
+          search_args[:filter_result] = create_result_filter_from_attributes([])
         end
 
         begin


### PR DESCRIPTION
Signed-off-by: Dmitry Shestoperov <dmitry@shestoperov.info>

### Description

Prevents knife -i to pull whole object for post-fitering on client-side

### Issues Resolved

#5192

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
