### PR TITLE
Use new 'docker_images' Expeditor syntax

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,6 +15,9 @@ rubygems:
   - chef
   - chef-config
 
+docker_images:
+  - chef
+
 github:
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
   # is bumped automatically via the `built_in:bump_version` merge_action.


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Use new `docker_images` syntax. 

### Issues Resolved

Failing to build Docker Images

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
