### PR TITLE
Chef 14: Remove deprecated knife ssh csshx command

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -588,10 +588,6 @@ class Chef
             macterm
           when "cssh"
             cssh
-          when "csshx"
-            Chef::Log.warn("knife ssh csshx will be deprecated in a future release")
-            Chef::Log.warn("please use knife ssh cssh instead")
-            cssh
           else
             ssh_command(@name_args[1..-1].join(" "))
           end


### PR DESCRIPTION
This was replaced with knife ssh cssh

Signed-off-by: Tim Smith <tsmith@chef.io>