### PR TITLE
Remove deprecated knife ssh --identity-file option

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -102,10 +102,6 @@ class Chef
         :description => "Enable SSH agent forwarding",
         :boolean => true
 
-      option :identity_file,
-        :long => "--identity-file IDENTITY_FILE",
-        :description => "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead."
-
       option :ssh_identity_file,
         :short => "-i IDENTITY_FILE",
         :long => "--ssh-identity-file IDENTITY_FILE",
@@ -557,8 +553,7 @@ class Chef
       end
 
       def configure_ssh_identity_file
-        # config[:identity_file] is DEPRECATED in favor of :ssh_identity_file
-        config[:ssh_identity_file] = get_stripped_unfrozen_value(config[:ssh_identity_file] || config[:identity_file] || Chef::Config[:knife][:ssh_identity_file])
+        config[:ssh_identity_file] = get_stripped_unfrozen_value(config[:ssh_identity_file] || Chef::Config[:knife][:ssh_identity_file])
       end
 
       def configure_ssh_gateway_identity


### PR DESCRIPTION
This was replaced with --ssh_identity_file

Signed-off-by: Tim Smith <tsmith@chef.io>