### PR TITLE
Force encoding to UTF_8 in chef-shell to prevent failures

### DIFF
--- a/bin/chef-shell
+++ b/bin/chef-shell
@@ -23,6 +23,8 @@ begin
 rescue LoadError
 end
 
+Encoding.default_external = Encoding::UTF_8
+
 require "irb"
 require "irb/completion"
 require "irb/ext/save-history"


### PR DESCRIPTION
Currently on some distros where the default isn't UTF (SUSE/omnios/probably others) chef-shell fails to launch with a nasty rb-readline error. It's not the best user experience. Lifting this line from Berkshelf fixes it and makes it easier to troubleshoot on those platforms.

Closes #6446 

Signed-off-by: Tim Smith <tsmith@chef.io>