### PR TITLE
only warn about skipping sync once

### DIFF
--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -154,6 +154,7 @@ class Chef
 
       queue = Chef::Util::ThreadedJobQueue.new
 
+      Chef::Log.warn("skipping cookbook synchronization! DO NOT LEAVE THIS ENABLED IN PRODUCTION!!!") if Chef::Config[:skip_cookbook_sync]
       files.each do |file|
         queue << lambda do |lock|
           full_file_path = sync_file(file)
@@ -279,10 +280,7 @@ class Chef
     end
 
     def cached_copy_up_to_date?(local_path, expected_checksum)
-      if Chef::Config[:skip_cookbook_sync]
-        Chef::Log.warn "skipping cookbook synchronization!  DO NOT LEAVE THIS ENABLED IN PRODUCTION!!!"
-        return true
-      end
+      return true if Chef::Config[:skip_cookbook_sync]
       if cache.has_key?(local_path)
         current_checksum = CookbookVersion.checksum_cookbook_file(cache.load(local_path, false))
         expected_checksum == current_checksum

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -547,7 +547,9 @@ describe Chef::CookbookSynchronizer do
           with("cookbooks/cookbook_a/files/default/megaman.conf", false).
           once.
           and_return("/file-cache/cookbooks/cookbook_a/files/default/megaman.conf")
-        expect(Chef::Log).to receive(:warn).with("skipping cookbook synchronization! DO NOT LEAVE THIS ENABLED IN PRODUCTION!!!").once
+        expect(Chef::Log).to receive(:warn).
+          with("skipping cookbook synchronization! DO NOT LEAVE THIS ENABLED IN PRODUCTION!!!").
+          once
         synchronizer.sync_cookbooks
       end
     end


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

Does not modify the functionality of CookbookSynchronizer, but moves the warning out of the loop so it only warns once.

### Issues Resolved

https://github.com/chef/chef/issues/6402

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>