### PR TITLE
Sleep for another interval after handling SIGHUP

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -501,7 +501,7 @@ class Chef::Application::Client < Chef::Application
       # we need to sleep again after reconfigure to avoid stampeding when logrotate runs out of cron
       if signal == RECONFIGURE_SIGNAL
         reconfigure
-        interval_sleep(sleep)
+        interval_sleep(sec)
       end
     else
       sleep(sec)


### PR DESCRIPTION
Signed-off-by: Giedrius Rekasius <giedrius.rekasius@gmail.com>

### Description

This change resolves a bug of chef-client service going into infinite sleep after handling SIGHUP. The logic is to sleep for another interval after handling SIGHUP.

### Issues Resolved

chef-client service going to infinite sleep after handling SIGHUP (Issue: [6411](https://github.com/chef/chef/issues/6411))

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
