### PR TITLE
invites_sort_fail: Clean the invites array before sorting it

### DIFF
--- a/lib/chef/chef_fs/data_handler/organization_invites_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/organization_invites_data_handler.rb
@@ -5,7 +5,7 @@ class Chef
     module DataHandler
       class OrganizationInvitesDataHandler < DataHandlerBase
         def normalize(invites, entry)
-          invites.map { |invite| invite.is_a?(Hash) ? invite["username"] : invite }.sort.uniq
+          invites.map { |invite| invite.is_a?(Hash) ? invite["username"] : invite }.compact.sort.uniq
         end
 
         def minimize(invites, entry)


### PR DESCRIPTION
Sort threw an error trying to compare nil with a string while running
knife ec backup.  This change deletes the nil entries before sorting.

### Description

knife ec backup failed trying to compare nil with a string while running a backup.

### Issues Resolved

New issue

### Check List

- [x ] New functionality includes tests
- [ ] All tests pass
- [ x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
