### PR TITLE
Tweak the knife banners for multi-arg commands.

### DIFF
--- a/lib/chef/knife/client_delete.rb
+++ b/lib/chef/knife/client_delete.rb
@@ -32,7 +32,7 @@ class Chef
        :long => "--delete-validators",
        :description => "Force deletion of client if it's a validator"
 
-      banner "knife client delete [CLIENT[,CLIENT]] (options)"
+      banner "knife client delete [CLIENT [CLIENT]] (options)"
 
       def run
         if @name_args.length == 0

--- a/lib/chef/knife/node_delete.rb
+++ b/lib/chef/knife/node_delete.rb
@@ -27,7 +27,7 @@ class Chef
         require "chef/json_compat"
       end
 
-      banner "knife node delete [NODE[,NODE]] (options)"
+      banner "knife node delete [NODE [NODE]] (options)"
 
       def run
         if @name_args.length == 0

--- a/lib/chef/knife/node_run_list_add.rb
+++ b/lib/chef/knife/node_run_list_add.rb
@@ -27,7 +27,7 @@ class Chef
         require "chef/json_compat"
       end
 
-      banner "knife node run_list add [NODE] [ENTRY[,ENTRY]] (options)"
+      banner "knife node run_list add [NODE] [ENTRY [ENTRY]] (options)"
 
       option :after,
         :short => "-a ITEM",

--- a/lib/chef/knife/node_run_list_remove.rb
+++ b/lib/chef/knife/node_run_list_remove.rb
@@ -27,7 +27,7 @@ class Chef
         require "chef/json_compat"
       end
 
-      banner "knife node run_list remove [NODE] [ENTRY[,ENTRY]] (options)"
+      banner "knife node run_list remove [NODE] [ENTRY [ENTRY]] (options)"
 
       def run
         node = Chef::Node.load(@name_args[0])

--- a/lib/chef/knife/role_env_run_list_add.rb
+++ b/lib/chef/knife/role_env_run_list_add.rb
@@ -27,7 +27,7 @@ class Chef
         require "chef/json_compat"
       end
 
-      banner "knife role env_run_list add [ROLE] [ENVIRONMENT] [ENTRY[,ENTRY]] (options)"
+      banner "knife role env_run_list add [ROLE] [ENVIRONMENT] [ENTRY [ENTRY]] (options)"
 
       option :after,
         :short => "-a ITEM",

--- a/lib/chef/knife/role_run_list_add.rb
+++ b/lib/chef/knife/role_run_list_add.rb
@@ -27,7 +27,7 @@ class Chef
         require "chef/json_compat"
       end
 
-      banner "knife role run_list add [ROLE] [ENTRY[,ENTRY]] (options)"
+      banner "knife role run_list add [ROLE] [ENTRY [ENTRY]] (options)"
 
       option :after,
         :short => "-a ITEM",


### PR DESCRIPTION
We don't actually use commas in command lines.

Fixes #6465.