### PR TITLE
Deprecate vendor branches with `knife cookbook site install`

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -268,6 +268,16 @@ class Chef
       end
     end
 
+    class CookbookInstallVendor < Base
+      def id
+        20
+      end
+
+      def target
+        "cookbook_install_vendor.html"
+      end
+    end
+
     # id 3694 was deleted
 
     class Generic < Base

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -258,16 +258,6 @@ class Chef
       end
     end
 
-    class DeployResource < Base
-      def id
-        21
-      end
-
-      def target
-        "deploy_resource.html"
-      end
-    end
-
     class CookbookInstallVendor < Base
       def id
         20
@@ -275,6 +265,16 @@ class Chef
 
       def target
         "cookbook_install_vendor.html"
+      end
+    end
+
+    class DeployResource < Base
+      def id
+        21
+      end
+
+      def target
+        "deploy_resource.html"
       end
     end
 

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -101,10 +101,12 @@ class Chef
         #cookbook_path = File.join(vendor_path, name_args[0])
         upstream_file = File.join(@install_path, "#{@cookbook_name}.tar.gz")
 
-        @repo.sanity_check
-        unless config[:use_current_branch] || config[:no_vendor]
-          @repo.reset_to_default_state
-          @repo.prepare_to_import(@cookbook_name)
+        unless config[:no_vendor]
+          @repo.sanity_check
+          unless config[:use_current_branch]
+            @repo.reset_to_default_state
+            @repo.prepare_to_import(@cookbook_name)
+          end
         end
 
         downloader = download_cookbook_to(upstream_file)


### PR DESCRIPTION
So we can kill it for Chef 14. This adds a CLI option to not vendor and warns if you don't use it. I think I did the option correctly but I should probably make some kind of test for this.

💣 💥 