### PR TITLE
Prevent creation of data bags named node, role, client or environment

### DIFF
--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -5,6 +5,8 @@ class Chef
   module ChefFS
     module DataHandler
       class DataBagItemDataHandler < DataHandlerBase
+        RESERVED_NAMES = /node|role|environment|client/
+
         def normalize(data_bag_item, entry)
           # If it's wrapped with raw_data, unwrap it.
           if data_bag_item["json_class"] == "Chef::DataBagItem" && data_bag_item["raw_data"]
@@ -43,6 +45,7 @@ class Chef
         end
 
         # Verify that the JSON hash for this type has a key that matches its name.
+        # Also check that the data bag name is not a reserved search index name.
         #
         # @param object [Object] JSON hash of the object
         # @param entry [Chef::ChefFS::FileSystem::BaseFSObject] filesystem object we are verifying
@@ -52,6 +55,8 @@ class Chef
           base_name = remove_dot_json(entry.name)
           if object["raw_data"]["id"] != base_name
             yield("ID in #{entry.path_for_printing} must be '#{base_name}' (is '#{object['raw_data']['id']}')")
+          elsif entry.parent.name =~ RESERVED_NAMES
+            yield("Data bag name ('#{entry.parent.name}') must not match #{RESERVED_NAMES.inspect}")
           end
         end
 

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -33,12 +33,16 @@ class Chef
     include Chef::Mixin::ParamsValidate
 
     VALID_NAME = /^[\.\-[:alnum:]_]+$/
+    RESERVED_NAMES = /node|role|environment|client/
 
     attr_accessor :chef_server_rest
 
     def self.validate_name!(name)
       unless name =~ VALID_NAME
         raise Exceptions::InvalidDataBagName, "DataBags must have a name matching #{VALID_NAME.inspect}, you gave #{name.inspect}"
+      end
+      if name =~ RESERVED_NAMES
+        raise Exceptions::InvalidDataBagName, "DataBags may not have a name matching #{RESERVED_NAMES.inspect}, you gave #{name.inspect}"
       end
     end
 

--- a/spec/unit/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/spec/unit/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -1,0 +1,79 @@
+#
+# Author:: Sandra Tiffin (<sandi.tiffin@gmail.com>)
+# Copyright:: Copyright 2014-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb"
+
+class TestDataBag < Mash
+  attr_accessor :name
+
+  def initialize(bag_name)
+    @name = bag_name
+  end
+end
+
+class TestDataBagItem < Mash
+  attr_accessor :name, :parent
+
+  def path_for_printing
+    "/some/path"
+  end
+
+  def initialize(bag_name, item_name)
+    @name = "#{item_name}.json"
+    @parent = TestDataBag.new(bag_name)
+  end
+end
+
+describe Chef::ChefFS::DataHandler::DataBagItemDataHandler do
+  let(:handler) { described_class.new }
+
+  describe "#verify_integrity" do
+    context "json id does not match data bag item name" do
+      let(:entry) { TestDataBagItem.new("luggage", "bag") }
+      let(:object) do
+        { "raw_data" => { "id" => "duffel" } }
+      end
+      it "rejects the data bag item name" do
+        expect { |b| handler.verify_integrity(object, entry, &b) }.to yield_with_args
+      end
+    end
+
+    context "using a reserved word for the data bag name" do
+      %w(node role environment client).each do |reserved_word|
+        let(:entry) { TestDataBagItem.new(reserved_word, "bag") }
+        let(:object) do
+          { "raw_data" => { "id" => "bag" } }
+        end
+        it "rejects the data bag name '#{reserved_word}'" do
+          expect { |b| handler.verify_integrity(object, entry, &b) }.to yield_with_args
+        end
+      end
+    end
+
+    context "valid data" do
+      let(:entry) { TestDataBagItem.new("luggage", "bag") }
+      let(:object) do
+        { "raw_data" => { "id" => "bag" } }
+      end
+      it "validates the data bag item" do
+        expect(handler.verify_integrity(object, entry)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/knife/data_bag_create_spec.rb
+++ b/spec/unit/knife/data_bag_create_spec.rb
@@ -72,6 +72,14 @@ describe Chef::Knife::DataBagCreate do
       expect { knife.run }.to exit_with_code(1)
     end
 
+    it "won't create a data bag with a reserved name for search" do
+      ['node', 'role', 'client', 'environment'].each do |name|
+        knife.name_args = [name]
+        expect(Chef::DataBag).to receive(:validate_name!).with(knife.name_args[0]).and_raise(Chef::Exceptions::InvalidDataBagName)
+        expect { knife.run }.to exit_with_code(1)
+      end
+    end
+
     context "when given one argument" do
       before do
         knife.name_args = [bag_name]


### PR DESCRIPTION
…ment.

Signed-off-by: Sandra Tiffin <sandi.tiffin@gmail.com>

### Description

Prevent creation of data bags named node, role, client or environment, using knife.

### Issues Resolved

https://github.com/chef/chef/issues/3058

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
