### PR TITLE
chef-12: Add allow_downgrade to zypper_package resource

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -157,6 +157,10 @@ class Chef
             "--no-gpg-checks"
           end
         end
+
+        def allow_downgrade
+          "--oldpackage" if new_resource.allow_downgrade
+        end
       end
     end
   end

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -23,6 +23,7 @@ class Chef
     class ZypperPackage < Chef::Resource::Package
       resource_name :zypper_package
       provides :package, platform_family: "suse"
+      property :allow_downgrade, [ true, false ], default: false
     end
   end
 end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -133,8 +133,8 @@ describe Chef::Provider::Package::Zypper do
       )
       provider.install_package(["emacs"], ["1.0"])
     end
-    it "setting the property should allow downgrade" do
-      new_resource.allow_downgrade true
+    it "should install with the package name and version and even allow downgrade" do
+      allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
       shell_out_expectation!(
         "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -134,7 +134,7 @@ describe Chef::Provider::Package::Zypper do
       provider.install_package(["emacs"], ["1.0"])
     end
     it "should install with the package name and version and even allow downgrade" do
-      allow(Chef::Config).to receive(:[]).with(:zypper_check_gpg).and_return(true)
+      new_resource.allow_downgrade true
       shell_out_expectation!(
         "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -133,6 +133,13 @@ describe Chef::Provider::Package::Zypper do
       )
       provider.install_package(["emacs"], ["1.0"])
     end
+    it "setting the property should allow downgrade" do
+      new_resource.allow_downgrade true
+      shell_out_expectation!(
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
+      )
+      provider.install_package(["emacs"], ["1.0"])
+    end
   end
 
   describe "upgrade_package" do


### PR DESCRIPTION
### Description

Add allow_downgrade to zypper_package resource on chef 12

### Issues Resolved

none

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
