### PR TITLE
Remove cookbook_artifacts from CHEF_11_OSS_STATIC_OBJECTS

### DIFF
--- a/lib/chef/chef_fs/config.rb
+++ b/lib/chef/chef_fs/config.rb
@@ -66,7 +66,7 @@ class Chef
       # upgrade/migration of older Chef Servers, so they should be considered
       # frozen in time.
 
-      CHEF_11_OSS_STATIC_OBJECTS = %w{cookbooks cookbook_artifacts data_bags environments roles}.freeze
+      CHEF_11_OSS_STATIC_OBJECTS = %w{cookbooks data_bags environments roles}.freeze
       CHEF_11_OSS_DYNAMIC_OBJECTS = %w{clients nodes users}.freeze
       RBAC_OBJECT_NAMES = %w{acls containers groups }.freeze
       CHEF_12_OBJECTS = %w{ cookbook_artifacts policies policy_groups client_keys }.freeze


### PR DESCRIPTION
Signed-off-by: Josh Hudson <jhudson@chef.io>

Fixes an issue where newer versions of ChefFS cannot be used with Chef 11 servers because policyfiles did not exist then. I believe this was a mistaken addition (it is included in `CHEF_12_OBJECTS` properly) that only affected Chef 11 servers.