### PR TITLE
[SUSTAIN-731] Don't spin in powershell module that launches chef processes

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -73,6 +73,8 @@ platforms:
   #
   #   KITCHEN_LOCAL_YAML=.kitchen.vmware.yml kitchen converge chefdk-macosx-109
   #
+
+  # OSX
   <% %w(
     10.9
     10.10
@@ -86,9 +88,15 @@ platforms:
       - ['../../omnibus', '/Users/vagrant/omnibus']
       - ['../../omnibus-software', '/Users/vagrant/omnibus-software']
   <% end %>
-  - name: windows-2012r2-standard
+
+  <% %w(
+    10-enterprise
+    server-2012r2-standard
+  ).each do |win_version| %>
+  # Windows 64-bit
+  - name: windows-<%= win_version %>
     driver:
-      box: chef/windows-server-2012r2-standard # private
+      box: chef/windows-<%= win_version %> # private
       synced_folders:
       # We have to mount this repos enclosing folder as the Omnibus build
       # gets cranky if the mounted Chef source folder is a symlink. This
@@ -102,16 +110,14 @@ platforms:
           build_user_group:    Administrators
           build_user_password: vagrant
       chef_omnibus_root: /opscode/angrychef
+
+  # Windows 32-bit
   # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
   # will load the 32-bit version of the MinGW toolchain.
-  - name: windows-2012r2-standard-i386
+  - name: windows-<%= win_version %>-i386
     driver:
-      box: chef/windows-server-2012r2-standard # private
+      box: chef/windows-<%= win_version %> # private
       synced_folders:
-      # We have to mount this repos enclosing folder as the Omnibus build
-      # gets cranky if the mounted ChefDK source folder is a symlink. This
-      # mounts at `C:\vagrant\code` and the ChefDK source folder is available
-      # at `C:\vagrant\code\chef-dk`
       - ['../..', '/vagrant/code']
     provisioner:
       attributes:
@@ -120,6 +126,7 @@ platforms:
           build_user_group:    Administrators
           build_user_password: vagrant
       chef_omnibus_root: /opscode/angrychef
+  <% end %>
 
 suites:
   # - name: angrychef


### PR DESCRIPTION
Signed-off-by: Kartik Null Cating-Subramanian <ksubramanian@chef.io>

### Description

Fixes an issue where on a single CPU machine, the powershell wrapper module using a lots of CPU and spin-waits until the chef process it is waiting on produces the first byte of output on STDOUT/STDERR.

This was a weird edge case issue introduced in https://github.com/chef/chef/pull/5549 that none of us noticed.

I added some improvements to the omnibus kitchen files in order to simplify launching windows 10 builders.

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
