### PR TITLE
Support new CriticalOhaiPlugins (backport #6486 to chef-12)

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -605,6 +605,9 @@ class Chef
       filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
       ohai.all_plugins(filter)
       events.ohai_completed(node)
+    rescue Ohai::Exceptions::CriticalPluginFailure => e
+      Chef::Log.error("Critical Ohai plugins failed: #{e.message}")
+      exit(false)
     end
 
     #

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -44,6 +44,17 @@ describe Chef::Client do
     end
   end
 
+  context "when Ohai tells us to fail" do
+    it "fails" do
+      ohai_system = Ohai::System.new
+      module Ohai::Exceptions
+        class CriticalPluginFailure < Error; end
+      end
+      expect(ohai_system).to receive(:all_plugins) { raise Ohai::Exceptions::CriticalPluginFailure }
+      expect { client.run_ohai }.to raise_error(SystemExit)
+    end
+  end
+
   describe "authentication protocol selection" do
     context "when FIPS is disabled" do
       before do


### PR DESCRIPTION
### Description

We should not stack-trace, we should exit with a clean error

Signed-off-by: Phil Dibowitz <phil@ipom.com>

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
