### PR TITLE
allow #attribute? to check deep

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -244,11 +244,8 @@ class Chef
 
     # Return true if this Node has a given attribute, false if not.  Takes either a symbol or
     # a string.
-    #
-    # Only works on the top level. Preferred way is to use the normal [] style
-    # lookup and call attribute?()
-    def attribute?(attrib)
-      attributes.attribute?(attrib)
+    def attribute?(*attrib)
+      attributes.attribute?(*attrib)
     end
 
     # Yield each key of the top level to the block.

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -207,16 +207,11 @@ class Chef
 
       # check for the existence of attributes
       def attribute?(*args)
-        r = nil
+        r = self
         until args.empty?
           a = args.shift
-          if r
-            return false unless r.has_key?(a)
-            r = r[a]
-          else
-            return false unless has_key?(a)
-            r = self[a]
-          end
+          return false unless r.has_key?(a)
+          r = r[a]
         end
         true
       rescue NoMethodError

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -207,22 +207,20 @@ class Chef
 
       # check for the existence of attributes
       def attribute?(*args)
-        begin
-          r = nil
-          until args.empty?
-            a = args.shift
-            if r
-              return false unless r.has_key?(a)
-              r = r[a]
-            else
-              return false unless self.has_key?(a)
-              r = self[a]
-            end
+        r = nil
+        until args.empty?
+          a = args.shift
+          if r
+            return false unless r.has_key?(a)
+            r = r[a]
+          else
+            return false unless has_key?(a)
+            r = self[a]
           end
-          true
-        rescue NoMethodError
-          false
         end
+        true
+      rescue NoMethodError
+        false
       end
 
        # Debug what's going on with an attribute. +args+ is a path spec to the

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -205,6 +205,26 @@ class Chef
         super(nil, self, node, :merged)
       end
 
+      # check for the existence of attributes
+      def attribute?(*args)
+        begin
+          r = nil
+          until args.empty?
+            a = args.shift
+            if r
+              return false unless r.has_key?(a)
+              r = r[a]
+            else
+              return false unless self.has_key?(a)
+              r = self[a]
+            end
+          end
+          true
+        rescue NoMethodError
+          false
+        end
+      end
+
        # Debug what's going on with an attribute. +args+ is a path spec to the
        # attribute you're interested in. For example, to debug where the value
        # of `node[:network][:default_interface]` is coming from, use:
@@ -465,7 +485,6 @@ class Chef
         send(level).unlink!(*path)
       end
 
-      alias :attribute? :has_key?
       alias :member? :has_key?
       alias :include? :has_key?
       alias :key? :has_key?

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -566,6 +566,25 @@ describe Chef::Node::Attribute do
       expect(@attributes.attribute?("ninja")).to eq(false)
     end
 
+    it "should return true if an attribute exists (nested)" do
+      expect(@attributes.attribute?('music', 'deeper')).to eq(true)
+    end
+
+    it "should return false if an attribute does not exist (nested)" do
+      expect(@attributes.attribute?('music', 'wrong')).to eq(false)
+    end
+
+    it "should return true if an attribute exists (nested - deep)" do
+      expect(@attributes.attribute?('music', 'deeper', 'gates_of_ishtar')).to eq(true)
+    end
+
+    it "should return false if an attribute does not exist (nested - deep)" do
+      expect(@attributes.attribute?('music', 'deeper', 'wrong')).to eq(false)
+    end
+
+    it "should return false if an attribute does not exist (nested - too deep)" do
+      expect(@attributes.attribute?('music', 'deeper', 'gates_of_ishtar', 'wrong')).to eq(false)
+    end
   end
 
   describe "keys" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -232,6 +232,17 @@ describe Chef::Node do
       expect(node.attribute?("no dice")).to eql(false)
     end
 
+    it 'deep attribute? checking' do
+      node.normal['deep']['nested']['attribute'] = 'blue'
+      expect(node.attribute?('deep')).to eq(true)
+      expect(node.attribute?('wrong')).to eq(false)
+      expect(node.attribute?('deep', 'nested')).to eq(true)
+      expect(node.attribute?('deep', 'wrong')).to eq(false)
+      expect(node.attribute?('deep', 'nested', 'attribute')).to eq(true)
+      expect(node.attribute?('deep', 'nested', 'wrong')).to eq(false)
+      expect(node.attribute?('deep', 'nested', 'attribute', 'wrong')).to eq(false)
+    end
+
     it "should let you go deep with attribute?" do
       node.normal["battles"]["people"]["wonkey"] = true
       expect(node["battles"]["people"].attribute?("wonkey")).to eq(true)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -234,12 +234,14 @@ describe Chef::Node do
 
     it 'deep attribute? checking' do
       node.normal['deep']['nested']['attribute'] = 'blue'
-      expect(node.attribute?('deep')).to eq(true)
-      expect(node.attribute?('wrong')).to eq(false)
       expect(node.attribute?('deep', 'nested')).to eq(true)
       expect(node.attribute?('deep', 'wrong')).to eq(false)
+      expect(node['deep'].attribute?('nested')).to eq(true)
+      expect(node['deep'].attribute?('wrong')).to eq(false)
       expect(node.attribute?('deep', 'nested', 'attribute')).to eq(true)
       expect(node.attribute?('deep', 'nested', 'wrong')).to eq(false)
+      expect(node['deep']['nested'].attribute?('attribute')).to eq(true)
+      expect(node['deep']['nested'].attribute?('wrong')).to eq(false)
       expect(node.attribute?('deep', 'nested', 'attribute', 'wrong')).to eq(false)
     end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -232,17 +232,17 @@ describe Chef::Node do
       expect(node.attribute?("no dice")).to eql(false)
     end
 
-    it 'deep attribute? checking' do
-      node.normal['deep']['nested']['attribute'] = 'blue'
-      expect(node.attribute?('deep', 'nested')).to eq(true)
-      expect(node.attribute?('deep', 'wrong')).to eq(false)
-      expect(node['deep'].attribute?('nested')).to eq(true)
-      expect(node['deep'].attribute?('wrong')).to eq(false)
-      expect(node.attribute?('deep', 'nested', 'attribute')).to eq(true)
-      expect(node.attribute?('deep', 'nested', 'wrong')).to eq(false)
-      expect(node['deep']['nested'].attribute?('attribute')).to eq(true)
-      expect(node['deep']['nested'].attribute?('wrong')).to eq(false)
-      expect(node.attribute?('deep', 'nested', 'attribute', 'wrong')).to eq(false)
+    it "deep attribute? checking" do
+      node.normal["deep"]["nested"]["attribute"] = "blue"
+      expect(node.attribute?("deep", "nested")).to eq(true)
+      expect(node.attribute?("deep", "wrong")).to eq(false)
+      expect(node["deep"].attribute?("nested")).to eq(true)
+      expect(node["deep"].attribute?("wrong")).to eq(false)
+      expect(node.attribute?("deep", "nested", "attribute")).to eq(true)
+      expect(node.attribute?("deep", "nested", "wrong")).to eq(false)
+      expect(node["deep"]["nested"].attribute?("attribute")).to eq(true)
+      expect(node["deep"]["nested"].attribute?("wrong")).to eq(false)
+      expect(node.attribute?("deep", "nested", "attribute", "wrong")).to eq(false)
     end
 
     it "should let you go deep with attribute?" do


### PR DESCRIPTION
### Description

Allows `Chef::Node#attribute?` and `Chef::Node::Attribute#attribute?` to check deep into the attribute Mash for existence of attributes.

### Issues Resolved

Couldnt find any related github issues from a quick search, but these are top results on google for `chef nested attribute`:
- https://discourse.chef.io/t/node-attribute-check-nested/4191/2
- https://stackoverflow.com/questions/18986096/what-is-the-correct-way-to-check-for-the-existence-of-a-nested-attribute-in-chef

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
