### PR TITLE
only rhel >= 8 and fedora >= 22 get dnf

### DIFF
--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -41,6 +41,11 @@ class Chef
         # fedora >= 22 uses DNF
         provides :package, platform: "fedora", platform_version: ">= 22"
 
+        # amazon will eventually use DNF
+        provides :package, platform: "amazon" do
+          which("dnf")
+        end
+
         provides :dnf_package
 
         #

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -35,13 +35,13 @@ class Chef
         use_multipackage_api
         use_package_name_for_source
 
-        provides :package, platform_family: %w{fedora amazon} do
-          which("dnf") && shell_out("rpm -q dnf").stdout =~ /^dnf-[1-9]/
-        end
+        # all rhel variants >= 8 will use DNF
+        provides :package, platform_family: "rhel", platform_version: ">= 8"
 
-        provides :package, platform_family: %w{rhel}, platform_version: ">= 8"
+        # fedora >= 22 uses DNF
+        provides :package, platform: "fedora", platform_version: ">= 22"
 
-        provides :dnf_package, os: "linux"
+        provides :dnf_package
 
         #
         # Most of the magic in this class happens in the python helper script.  The ruby side of this

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -29,11 +29,11 @@ class Chef
 
       allowed_actions :install, :upgrade, :remove, :purge, :reconfig, :lock, :unlock, :flush_cache
 
-      provides :package, platform_family: %w{fedora amazon} do
-        which("dnf") && shell_out("rpm -q dnf").stdout =~ /^dnf-[1-9]/
-      end
+      # all rhel variants >= 8 will use DNF
+      provides :package, platform_family: "rhel", platform_version: ">= 8"
 
-      provides :package, platform_family: %{rhel}, platform_version: ">= 8"
+      # fedora >= 22 uses DNF
+      provides :package, platform: "fedora", platform_version: ">= 22"
 
       provides :dnf_package
 

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -35,6 +35,11 @@ class Chef
       # fedora >= 22 uses DNF
       provides :package, platform: "fedora", platform_version: ">= 22"
 
+      # amazon will eventually use DNF
+      provides :package, platform: "amazon" do
+        which("dnf")
+      end
+
       provides :dnf_package
 
       # Install a specific arch


### PR DESCRIPTION
the shell_out approach to parse the version string from rpm is a bit of
a failed experiment.

the shell_out that gets incurred on every package provider is a bit
terrible for performance.

DNF < 1.00 has also never formally landed in any distribution and its
very difficult at this point to deploy it.

when amazon deploys DNF we should add a version comparison for that.

If this patch causes issues we can go back to adding some form of

`provides :package ... { which("dnf" }`

That will be much faster than having the shell_out().

