### PR TITLE
registry_key: Add sensitive property support for suppressing output (fixes #5695)

### DIFF
--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -126,12 +126,18 @@ class Chef
               value[:data] = value[:data].to_i
             end
             unless current_value[:type] == value[:type] && current_value[:data] == value[:data]
-              converge_by("set value #{value}") do
+              converge_by_value = value
+              converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+
+              converge_by("set value #{converge_by_value}") do
                 registry.set_value(new_resource.key, value)
               end
             end
           else
-            converge_by("set value #{value}") do
+            converge_by_value = value
+            converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+
+            converge_by("set value #{converge_by_value}") do
               registry.set_value(new_resource.key, value)
             end
           end
@@ -146,7 +152,10 @@ class Chef
         end
         new_resource.unscrubbed_values.each do |value|
           unless @name_hash.has_key?(value[:name].downcase)
-            converge_by("create value #{value}") do
+            converge_by_value = value
+            converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+
+            converge_by("create value #{converge_by_value}") do
               registry.set_value(new_resource.key, value)
             end
           end
@@ -157,7 +166,10 @@ class Chef
         if registry.key_exists?(new_resource.key)
           new_resource.unscrubbed_values.each do |value|
             if @name_hash.has_key?(value[:name].downcase)
-              converge_by("delete value #{value}") do
+              converge_by_value = value
+              converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+
+              converge_by("delete value #{converge_by_value}") do
                 registry.delete_value(new_resource.key, value)
               end
             end


### PR DESCRIPTION
### Description

This PR adds the `sensitive` property to `registry_key` but needs some help before it's ready to be merged.

I'm not sure if the `sensitive: true` sets the `values` property to default to sensitive or if when `sensitive` is true on the resource, `values` will be masked.

Re tests, looking at the `execute` resource it looks like I should be copying across something like below, but not sure where it should sit.

```
    context "when sensitive is set true" do
      it "should honor sensitive attribute" do
        new_resource.sensitive true
        # Since the resource is sensitive, it should not have :live_stream set
        opts.delete(:live_stream)
        expect(provider).to receive(:shell_out_with_systems_locale!).with(new_resource.name, opts)
        expect(provider).to receive(:converge_by).with("registry_key sensitive resource").and_call_original
        expect(Chef::Log).not_to receive(:warn)
        provider.run_action(:run)
        expect(new_resource).to be_updated
      end
    end
```

### Issues Resolved

#5695 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
