### PR TITLE
Apt repo cleanup and testing expansion

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -200,7 +200,13 @@ class Chef
         end
       end
 
-      def install_key_from_keyserver(key, keyserver = new_resource.keyserver)
+      # build the apt-key command to install the keyserver
+      #
+      # @param [String] key the key to install
+      # @param [String] keyserver the key server to use
+      #
+      # @return [String] the full apt-key command to run
+      def keyserver_install_cmd(key, keyserver)
         cmd = "apt-key adv --recv"
         cmd << " --keyserver-options http-proxy=#{new_resource.key_proxy}" if new_resource.key_proxy
         cmd << " --keyserver "
@@ -211,9 +217,12 @@ class Chef
                end
 
         cmd << " #{key}"
+        cmd
+      end
 
+      def install_key_from_keyserver(key, keyserver = new_resource.keyserver)
         declare_resource(:execute, "install-key #{key}") do
-          command cmd
+          command keyserver_install_cmd(key, keyserver)
           sensitive new_resource.sensitive
           not_if do
             present = extract_fingerprints_from_cmd(LIST_APT_KEY_FINGERPRINTS).any? do |fp|

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -131,14 +131,27 @@ class Chef
         valid
       end
 
+      # return the specified cookbook name or the cookbook containing the
+      # resource.
+      #
+      # @return [String] name of the cookbook
       def cookbook_name
         new_resource.cookbook || new_resource.cookbook_name
       end
 
+      # determine if a cookbook file is available in the run
+      # @param [String] path the path to the cookbook file
+      #
+      # @return [Boolean] cookbook file exists or doesn't
       def has_cookbook_file?(fn)
         run_context.has_cookbook_file_in_cookbook?(cookbook_name, fn)
       end
 
+      # determine if there are any new keys by comparing the fingerprints of installed
+      # keys to those of the passed file
+      # @param [String] file the keyfile of the new repository
+      #
+      # @return [Boolean] true: no new keys in the file. false: there are new keys
       def no_new_keys?(file)
         # Now we are using the option --with-colons that works across old os versions
         # as well as the latest (16.10). This for both `apt-key` and `gpg` commands

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -36,7 +36,9 @@ class Chef
       end
 
       action :add do
-        unless new_resource.key.nil?
+        if new_resource.key.nil?
+          Chef::Log.debug "No 'key' property specified skipping key import"
+        else
           new_resource.key.each do |k|
             if is_key_id?(k) && !has_cookbook_file?(k)
               install_key_from_keyserver(k)

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -108,7 +108,6 @@ class Chef
 
       def extract_fingerprints_from_cmd(cmd)
         so = shell_out(cmd)
-        so.run_command
         so.stdout.split(/\n/).map do |t|
           if z = t.match(/^fpr:+([0-9A-F]+):/)
             z[1].split.join
@@ -120,7 +119,6 @@ class Chef
         valid = true
 
         so = shell_out(cmd)
-        so.run_command
         so.stdout.split(/\n/).map do |t|
           if t =~ %r{^\/#{key}.*\[expired: .*\]$}
             Chef::Log.debug "Found expired key: #{t}"

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -98,11 +98,19 @@ class Chef
         end
       end
 
+      # is the provided ID a key ID from a keyserver. Looks at length and HEX only values
+      # @param [String] id the key value passed by the user that *may* be an ID
       def is_key_id?(id)
         id = id[2..-1] if id.start_with?("0x")
         id =~ /^\h+$/ && [8, 16, 40].include?(id.length)
       end
 
+      # run the specified command and extract the fingerprints from the output
+      # accepts a command so it can be used to extract both the current key's fingerprints
+      # and the fingerprint of the new key
+      # @param [String] cmd the command to run
+      #
+      # @return [Array] an array of fingerprints
       def extract_fingerprints_from_cmd(cmd)
         so = shell_out(cmd)
         so.stdout.split(/\n/).map do |t|
@@ -112,6 +120,11 @@ class Chef
         end.compact
       end
 
+      # validate the key
+      # @param [Sting] cmd
+      # @param [Sting] key
+      #
+      # @return [Boolean] is the key valid or not
       def key_is_valid?(cmd, key)
         valid = true
 
@@ -174,6 +187,11 @@ class Chef
         end
       end
 
+      # Fetch the key using either cookbook_file or remote_file, validate it,
+      # and install it with apt-key add
+      # @param [String] key the key to install
+      #
+      # @return [void]
       def install_key_from_uri(key)
         key_name = key.gsub(/[^0-9A-Za-z\-]/, "_")
         cached_keyfile = ::File.join(Chef::Config[:file_cache_path], key_name)
@@ -215,6 +233,9 @@ class Chef
         cmd
       end
 
+      # @param [Sting] key
+      # @param [Sting] keyserver
+      # @return [void]
       def install_key_from_keyserver(key, keyserver = new_resource.keyserver)
         declare_resource(:execute, "install-key #{key}") do
           command keyserver_install_cmd(key, keyserver)

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -180,9 +180,7 @@ class Chef
         declare_resource(:execute, "apt-key add #{cached_keyfile}") do
           sensitive new_resource.sensitive
           action :run
-          not_if do
-            no_new_keys?(cached_keyfile)
-          end
+          not_if { no_new_keys?(cached_keyfile) }
           notifies :run, "execute[apt-cache gencaches]", :immediately
         end
       end

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -244,6 +244,10 @@ class Chef
         raise "Could not access Launchpad ppa API: #{e.message}"
       end
 
+      # determine if the repository URL is a PPA
+      # @param [String] url the url of the repository
+      #
+      # @return [Boolean] is the repo URL a PPA
       def is_ppa_url?(url)
         url.start_with?("ppa:")
       end

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -58,16 +58,10 @@ class Chef
           action :nothing
         end
 
-        components = if is_ppa_url?(new_resource.uri) && new_resource.components.empty?
-                       "main"
-                     else
-                       new_resource.components
-                     end
-
         repo = build_repo(
           new_resource.uri,
           new_resource.distribution,
-          components,
+          repo_components,
           new_resource.trusted,
           new_resource.arch,
           new_resource.deb_src
@@ -250,6 +244,20 @@ class Chef
       # @return [Boolean] is the repo URL a PPA
       def is_ppa_url?(url)
         url.start_with?("ppa:")
+      end
+
+      # determine the repository's components:
+      #  - "components" property if defined
+      #  - "main" if "components" not defined and the repo is a PPA URL
+      #  - otherwise nothing
+      #
+      # @return [String] the repository component
+      def repo_components
+        if is_ppa_url?(new_resource.uri) && new_resource.components.empty?
+          "main"
+        else
+          new_resource.components
+        end
       end
 
       def make_ppa_url(ppa)

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -283,7 +283,6 @@ class Chef
       end
 
       def make_ppa_url(ppa)
-        return unless is_ppa_url?(ppa)
         owner, repo = ppa[4..-1].split("/")
         repo ||= "ppa"
 

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -92,8 +92,9 @@ class Chef
               ignore_failure true
               action :nothing
             end
-
           end
+        else
+          Chef::Log.debug("/etc/apt/sources.list.d/#{new_resource.name}.list does not exist. Nothing to do")
         end
       end
 

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -83,16 +83,16 @@ C5986B4F1257FFA86632CBA746181433FBB75451
   end
 
   describe "#is_key_id?" do
-    it "should detect a key" do
+    it "detects a key" do
       expect(provider.is_key_id?("A4FF2279")).to be_truthy
     end
-    it "should detect a key with a hex signifier" do
+    it "detects a key with a hex signifier" do
       expect(provider.is_key_id?("0xA4FF2279")).to be_truthy
     end
-    it "should reject a key with the wrong length" do
+    it "rejects a key with the wrong length" do
       expect(provider.is_key_id?("4FF2279")).to be_falsey
     end
-    it "should reject a key with non-hex characters" do
+    it "rejects a key with non-hex characters" do
       expect(provider.is_key_id?("A4KF2279")).to be_falsey
     end
   end
@@ -102,12 +102,12 @@ C5986B4F1257FFA86632CBA746181433FBB75451
       expect(Mixlib::ShellOut).to receive(:new).and_return(apt_key_finger)
     end
 
-    it "should run the desired command" do
+    it "runs the desired command" do
       expect(apt_key_finger).to receive(:run_command)
       provider.extract_fingerprints_from_cmd(apt_key_finger_cmd)
     end
 
-    it "should return a list of key fingerprints" do
+    it "returns a list of key fingerprints" do
       expect(provider.extract_fingerprints_from_cmd(apt_key_finger_cmd)).to eql(apt_fingerprints)
     end
   end

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -157,6 +157,35 @@ C5986B4F1257FFA86632CBA746181433FBB75451
     end
   end
 
+  describe "#is_ppa_url" do
+    it "returns true if the URL starts with ppa:" do
+      expect(provider.is_ppa_url?("ppa://example.com")).to be_truthy
+    end
+
+    it "returns false if the URL does not start with ppa:" do
+      expect(provider.is_ppa_url?("example.com")).to be_falsey
+    end
+  end
+
+  describe "#repo_components" do
+    it "returns 'main' if a PPA and components property not set" do
+      expect(provider).to receive(:is_ppa_url?).and_return(true)
+      expect(provider).repo_components.to eq('main')
+    end
+
+    it "returns components property if a PPA and components is set" do
+      new_resource.components('foo')
+      expect(provider).to receive(:is_ppa_url?).and_return(true)
+      expect(provider).repo_components.to eq('foo')
+    end
+
+    it "returns components property if not a PPA" do
+      new_resource.components('foo')
+      expect(provider).to receive(:is_ppa_url?).and_return(false)
+      expect(provider).repo_components.to eq('foo')
+    end
+  end
+
   describe "#install_ppa_key" do
     let(:url) { "https://launchpad.net/api/1.0/~chef/+archive/main" }
     let(:key) { "C5986B4F1257FFA86632CBA746181433FBB75451" }


### PR DESCRIPTION
So this all started when @coderanger pointed out that we didn't need to use the run_command on the shell_out helper method since it does that internally already. I fixed that here and realized the logic could be broken out to ease readability and expand testing. I added yard comments, broke out some logic into smaller methods, added more unit tests, and added a bit more debug logging.