### PR TITLE
Causes immediate exit on calls to Chef::Application.fatal!

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -355,7 +355,7 @@ class Chef
       # Log a fatal error message to both STDERR and the Logger, exit the application
       def fatal!(msg, err = nil)
         Chef::Log.fatal(msg)
-        Process.exit(normalize_exit_code(err))
+        Process.exit!(normalize_exit_code(err))
       end
 
       def exit!(msg, err = nil)


### PR DESCRIPTION
Signed-off-by: Ryan Frantz <ryanleefrantz@gmail.com>

### Description

This update forces the Chef run to exit immediately on a call to `Chef::Application.fatal!` rather than raising a `SystemExit` exception.

I need `chef-client` to exit immediately as I'm working on a start handler that looks for a node attribute and stops the Chef run if present. That handler looks a bit like this:

```ruby
require 'chef/handler'
require 'chef/application'

class Chef::Handler::IsChefDisabled < Chef::Handler
  def report
    Chef::Application.fatal!("chef-client is disabled (node['disable_chef'] is defined). Exiting converge!", 1) if node['disable_chef']
  end
end
```

I noticed that calling `Chef::Application.fatal!` doesn't cause the Chef run to terminate. In fact, it completes the converge phase. Calling `Process.exit!` stops the Chef run immediately. An immediate exit seems like appropriate behavior for `Chef::Application.fatal!`

For extra context, we run `chef-client` on a cron like so:

```
# Chef Name: chef-client
0,15,30,45 * * * * /usr/bin/chef-client --run-lock-timeout 300 --no-fork --lockfile /var/run/chef/chef-client.lock > /dev/null 2>&1
```

**NOTE**: This update does not modify the behavior for `Chef::Application.exit!`; it still calls `Process.exit` which will raise the `SystemExit` exception.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
