### PR TITLE
Don't use the safe navigation operator which requires Ruby 2.3

### DIFF
--- a/lib/chef/util/dsc/lcm_output_parser.rb
+++ b/lib/chef/util/dsc/lcm_output_parser.rb
@@ -85,7 +85,7 @@ class Chef
             resources = []
             lcm_output.lines.each do |line|
               op_action , op_value = line.strip.split(":")
-              op_action&.strip!
+              op_action && op_action.strip!
               case op_action
               when "InDesiredState"
                 current_resource[:skipped] = op_value.strip == "True" ? true : false


### PR DESCRIPTION
This was backported from Chef 13 where we require Ruby 2.3. This won't work in Ruby 2.2.

Signed-off-by: Tim Smith <tsmith@chef.io>