### PR TITLE
Fix remote_file with UNC paths failing

### DIFF
--- a/lib/chef/mixin/user_context.rb
+++ b/lib/chef/mixin/user_context.rb
@@ -23,7 +23,7 @@ class Chef
     module UserContext
 
       def with_user_context(user, password, domain = nil, &block)
-        if node["platform_family"] != "windows"
+        unless Chef::Platform.windows?
           raise Exceptions::UnsupportedPlatform, "User context impersonation is supported only on the Windows platform"
         end
 

--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -41,7 +41,6 @@ describe "a class that mixes in user_context" do
     before do
       allow(::Chef::Platform).to receive(:windows?).and_return(true)
       allow(::Chef::Util::Windows::LogonSession).to receive(:new).and_return(logon_session)
-      allow(instance_with_user_context).to receive(:node).and_return({ "platform_family" => "windows" })
     end
 
     let(:logon_session) { instance_double("::Chef::Util::Windows::LogonSession", :set_user_context => nil, :open => nil, :close => nil) }
@@ -99,7 +98,7 @@ describe "a class that mixes in user_context" do
 
   context "when not running on Windows" do
     before do
-      allow(instance_with_user_context).to receive(:node).and_return({ "platform_family" => "ubuntu" })
+      allow(::Chef::Platform).to receive(:windows?).and_return(false)
     end
 
     it "raises a ::Chef::Exceptions::UnsupportedPlatform exception" do

--- a/spec/unit/provider/remote_file/network_file_spec.rb
+++ b/spec/unit/provider/remote_file/network_file_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Provider::RemoteFile::NetworkFile do
     let(:source_file) { double("::File", :read => nil) }
 
     before do
-      allow(fetcher).to receive(:node).and_return({ "platform_family" => "windows" })
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
     end
 
     it "stages the local file to a temporary file" do


### PR DESCRIPTION
Our check here to see if we're on Windows uses node data that's not
available in this context. Use the same Chef::Platform.windows? check we
use above. Without this you get the following error:

[2017-10-02T21:40:42+00:00] DEBUG: Re-raising exception: NameError - remote_file[c:/foo/bar] (foo::default line 14) had an error: NameError: undefined local variable or method `node' for #<Chef::Provider::RemoteFile::NetworkFile:0x00000000064c0148>

Signed-off-by: Tim Smith <tsmith@chef.io>