### PR TITLE
Added Flag to distinguish between gateway and host key to fix issue #6210

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -285,7 +285,7 @@ class Chef
         list.each do |item|
           host, ssh_port = item
           Chef::Log.debug("Adding #{host}")
-          session_opts = session_options(host, ssh_port, 0)
+          session_opts = session_options(host, ssh_port, gateway: false)
           # Handle port overrides for the main connection.
           session_opts[:port] = Chef::Config[:knife][:ssh_port] if Chef::Config[:knife][:ssh_port]
           session_opts[:port] = config[:ssh_port] if config[:ssh_port]

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -248,14 +248,14 @@ class Chef
       # @param host [String] Hostname for this session.
       # @param port [String] SSH port for this session.
       # @param user [String] Optional username for this session.
-      # @param gatway [Boolean] Flag: host or gateway key
+      # @param gateway [Boolean] Flag: host or gateway key
       # @return [Hash<Symbol, Object>]
-      def session_options(host, port, user = nil, gateway = false)
+      def session_options(host, port, user = nil, gateway: false)
         ssh_config = Net::SSH.configuration_for(host, true)
         {}.tap do |opts|
           # Chef::Config[:knife][:ssh_user] is parsed in #configure_user and written to config[:ssh_user]
           opts[:user] = user || config[:ssh_user] || ssh_config[:user]
-          if gateway == false && config[:ssh_identity_file]
+          if !gateway && config[:ssh_identity_file]
             opts[:keys] = File.expand_path(config[:ssh_identity_file])
             opts[:keys_only] = true
           elsif gateway && config[:ssh_gateway_identity]

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -151,7 +151,7 @@ class Chef
         if config[:ssh_gateway]
           gw_host, gw_user = config[:ssh_gateway].split("@").reverse
           gw_host, gw_port = gw_host.split(":")
-          gw_opts = session_options(gw_host, gw_port, 1, gw_user)
+          gw_opts = session_options(gw_host, gw_port, gw_user, gateway: true)
           user = gw_opts.delete(:user)
 
           begin
@@ -247,18 +247,18 @@ class Chef
       # @since 12.5.0
       # @param host [String] Hostname for this session.
       # @param port [String] SSH port for this session.
-      # @param type [Integer] Flag: host or gateway key
       # @param user [String] Optional username for this session.
+      # @param gatway [Boolean] Flag: host or gateway key
       # @return [Hash<Symbol, Object>]
-      def session_options(host, port, type = 0, user = nil)
+      def session_options(host, port, user = nil, gateway = false)
         ssh_config = Net::SSH.configuration_for(host, true)
         {}.tap do |opts|
           # Chef::Config[:knife][:ssh_user] is parsed in #configure_user and written to config[:ssh_user]
           opts[:user] = user || config[:ssh_user] || ssh_config[:user]
-          if type == 0 && config[:ssh_identity_file]
+          if gateway == false && config[:ssh_identity_file]
             opts[:keys] = File.expand_path(config[:ssh_identity_file])
             opts[:keys_only] = true
-          elsif type == 1 && config[:ssh_gateway_identity]
+          elsif gateway && config[:ssh_gateway_identity]
             opts[:keys] = File.expand_path(config[:ssh_gateway_identity])
             opts[:keys_only] = true
           elsif config[:ssh_password]


### PR DESCRIPTION
Signed-off-by: Erik <Erik.Parra4@gmail.com>

### Description

When using option --ssh-gateway-identity and -ssh-identity, both with be utilized by the session_options definition.

### Issues Resolved

[Issue #6210 ](https://github.com/chef/chef/issues/6210) Resolves the issue of --ssh-gateway-identity being used for both gateway and target node.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
