### PR TITLE
ignore leading whitespace changes when displaying diffs

### DIFF
--- a/lib/chef/util/diff.rb
+++ b/lib/chef/util/diff.rb
@@ -89,8 +89,8 @@ class Chef
         diff_str = ""
         file_length_difference = 0
 
-        old_data = IO.readlines(old_file).map { |e| e.chomp }
-        new_data = IO.readlines(new_file).map { |e| e.chomp }
+        old_data = IO.readlines(old_file).map { |e| e.strip }
+        new_data = IO.readlines(new_file).map { |e| e.strip }
         diff_data = ::Diff::LCS.diff(old_data, new_data)
 
         return diff_str if old_data.empty? && new_data.empty?


### PR DESCRIPTION
### Description

This patch ignores leading whitespace-changes when displaying diffs as well. For our use cases (some groovy files as templates) it stops lots of unnecessary diff-displaying in case of indentation-changes.

I  cannot judge what the overall preference is here. Maybe it should be made configurable, but for us it stops lots of complaints from the administrators.

### Issues Resolved

### Check List
