### PR TITLE
Fix the invalid version comparison of apt packages.

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -128,10 +128,15 @@ class Chef
         private
 
         def version_compare(v1, v2)
-          gem_v1 =  v1.gsub(/[_+]/, "+" => "-", "_" => "-") unless v1.nil?
-          gem_v2 =  v2.gsub(/[_+]/, "+" => "-", "_" => "-") unless v2.nil?
-
-          Gem::Version.new(gem_v1) <=> Gem::Version.new(gem_v2)
+          dpkg_v1 = v1 || '0'
+          dpkg_v2 = v2 || '0'
+          if shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "gt", dpkg_v2).status.success?
+            1
+          elsif shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "eq", dpkg_v2).status.success?
+            0
+          else
+            -1
+          end
         end
 
         # Runs command via shell_out with magic environment to disable


### PR DESCRIPTION
### Description
The strings of dpkg versions are more complex than the Gem::Version
and not compatible with it.
Using Gem::Version to compare versions of dpkg packages will cause
mistakes or raise the exeption of 'Malformed version number..'.

please see a simple example:
https://gist.github.com/komazarari/c6b33b29a0e31e9c62bbc2f0b2091647

Prefer to use the dpkg cli.
https://debian-handbook.info/browse/en-US/stable/sect.manipulating-packages-with-dpkg.html

[Please describe what this change achieves]

### Issues Resolved
none
### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>