### PR TITLE
Try using the old appveyor VS 2015 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Visual Studio 2015
+os: Previous Visual Studio 2015
 platform:
   - x64
 


### PR DESCRIPTION
They released a new build and we're getting name resolution errors now.
Lets try the old one so we can use this information to open a ticket.

Signed-off-by: Tim Smith <tsmith@chef.io>