### PR TITLE
Fix the invalid version comparison in apt/dpkg providers

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -477,6 +477,9 @@ class Chef
                 elsif candidate_version.nil?
                   Chef::Log.debug("#{new_resource} #{package_name} has no candidate_version to upgrade to")
                   target_version_array.push(nil)
+                elsif current_version.nil?
+                  Chef::Log.debug("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
+                  target_version_array.push(candidate_version)
                 elsif version_compare(current_version, candidate_version) == 1 && !new_resource.allow_downgrade
                   Chef::Log.debug("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{candidate_version}. Skipping...)")
                   target_version_array.push(nil)

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -127,12 +127,16 @@ class Chef
 
         private
 
+        # compare 2 versions to each other to see which is newer.
+        # this differs from the standard package method because we
+        # need to be able to parse debian version strings which contain
+        # tildes which Gem cannot properly parse
+        #
+        # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
         def version_compare(v1, v2)
-          dpkg_v1 = v1 || '0'
-          dpkg_v2 = v2 || '0'
-          if shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "gt", dpkg_v2).status.success?
+          if !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
             1
-          elsif shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "eq", dpkg_v2).status.success?
+          elsif !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
             0
           else
             -1

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -128,10 +128,15 @@ class Chef
         private
 
         def version_compare(v1, v2)
-          gem_v1 =  v1.gsub(/[_+]/, "+" => "-", "_" => "-") unless v1.nil?
-          gem_v2 =  v2.gsub(/[_+]/, "+" => "-", "_" => "-") unless v2.nil?
-
-          Gem::Version.new(gem_v1) <=> Gem::Version.new(gem_v2)
+          dpkg_v1 = v1 || '0'
+          dpkg_v2 = v2 || '0'
+          if shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "gt", dpkg_v2).status.success?
+            1
+          elsif shell_out_compact_timeout("dpkg", "--compare-versions", dpkg_v1, "eq", dpkg_v2).status.success?
+            0
+          else
+            -1
+          end
         end
 
         # Runs command via shell_out with magic environment to disable

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -106,6 +106,22 @@ class Chef
 
         private
 
+        # compare 2 versions to each other to see which is newer.
+        # this differs from the standard package method because we
+        # need to be able to parse debian version strings which contain
+        # tildes which Gem cannot properly parse
+        #
+        # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
+        def version_compare(v1, v2)
+          if !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
+            1
+          elsif !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
+            0
+          else
+            -1
+          end
+        end
+
         def read_current_version_of_package(package_name)
           Chef::Log.debug("#{new_resource} checking install state of #{package_name}")
           status = shell_out_compact_timeout!("dpkg", "-s", package_name, returns: [0, 1])


### PR DESCRIPTION
This is builds on the work that @komazarari did in https://github.com/chef/chef/pull/6554 to fix comparison of version strings that Gem can't handle.

If we don't have a version installed yet we shouldn't go do a version
comparison with nil. No matter what that's a waste of time and in
dpkg/apt it's going to require shelling out now. Instead just do the
install.

This also adds the same version comparison method to the dpkg resource.
At the moment it doesn't look like this is going to get called since our
upgrade action there is a bit broken (doesn't actually compare
versions), but that's going to get fixed next.

This also cleans up the version comparison to make sure we're
always dealing with strings