### PR TITLE
Dir.exists? -> Dir.exist? to avoid warning in rspec

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -235,7 +235,7 @@ module ChefConfig
       paths = paths.map { |home_path| home_path.gsub(path_separator, ::File::SEPARATOR) if home_path }
 
       # Filter out duplicate paths and paths that don't exist.
-      valid_paths = paths.select { |home_path| home_path && Dir.exists?(home_path.force_encoding("utf-8")) }
+      valid_paths = paths.select { |home_path| home_path && Dir.exist?(home_path.force_encoding("utf-8")) }
       valid_paths = valid_paths.uniq
 
       # Join all optional path elements at the end.


### PR DESCRIPTION
Avoids several annoying lines of warnings:

From appveyor:

C:/projects/chef/chef-config/lib/chef-config/path_helper.rb:238: warning: Dir.exists? is a deprecated name, use Dir.exist? instead
C:/projects/chef/chef-config/lib/chef-config/path_helper.rb:238: warning: Dir.exists? is a deprecated name, use Dir.exist? instead
C:/projects/chef/chef-config/lib/chef-config/path_helper.rb:238: warning: Dir.exists? is a deprecated name, use Dir.exist? instead
C:/projects/chef/chef-config/lib/chef-config/path_helper.rb:238: warning: Dir.exists? is a deprecated name, use Dir.exist? instead

Signed-off-by: Tim Smith <tsmith@chef.io>