### PR TITLE
create `/etc/apt/sources.list.d/` before dropping files in it.

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -71,6 +71,17 @@ class Chef
           new_resource.deb_src
         )
 
+        # /etc/apt/sources.list.d needs to exist before we can create files in it
+        declare_resource(:directory, '/etc/apt/sources.list.d') do
+          owner "root"
+          group "root"
+          mode "0644"
+          # you might question why we even want a guard here. If permissions for
+          # this resource are being defined elsewhere we want to preserve any
+          # configuration that is being specified
+          not_if { ::File.exist? '/etc/apt/sources.list.d' }
+        end
+
         declare_resource(:file, "/etc/apt/sources.list.d/#{new_resource.name}.list") do
           owner "root"
           group "root"


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

Fixes #6564 by ensuring that the directory `/etc/apt/sources.list.d/` is present before attempting to create files inside

### Issues Resolved
#6564 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
