### PR TITLE
Makes life easier for hook authors switching from the older report handler syntax

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -299,7 +299,7 @@ class Chef
         run_status.stop_clock
         Chef::Log.info("Chef Run complete in #{run_status.elapsed_time} seconds")
         run_completed_successfully
-        events.run_completed(node)
+        events.run_completed(node, run_status)
 
         # keep this inside the main loop to get exception backtraces
         end_profiling
@@ -315,7 +315,7 @@ class Chef
           run_status.exception = run_error
           run_failed
         end
-        events.run_failed(run_error)
+        events.run_failed(run_error, run_status)
       ensure
         Chef::RequestID.instance.reset_request_id
         @run_status = nil

--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -36,11 +36,11 @@ class Chef
       end
 
       # Called at the end a successful Chef run.
-      def run_completed(node)
+      def run_completed(node, run_status)
       end
 
       # Called at the end of a failed Chef run.
-      def run_failed(exception)
+      def run_failed(exception, run_status)
       end
 
       # Called right after ohai runs.


### PR DESCRIPTION
Added at the end to comply with our magic compat code rules (i.e. new arguments at the end are allowed because we auto-trip to match the arity of older event sinks).