### PR TITLE
Hide sensitive properties in converge_if_changed.

### DIFF
--- a/spec/integration/recipes/resource_converge_if_changed_spec.rb
+++ b/spec/integration/recipes/resource_converge_if_changed_spec.rb
@@ -17,7 +17,7 @@ describe "Resource::ActionClass#converge_if_changed" do
   before { Namer.current_index += 1 }
   before { Namer.incrementing_value = 0 }
 
-  context "when the resource has identity, state and control properties" do
+  context "when the resource has identity, state, control, and sensitive properties" do
     let(:resource_name) { :"converge_if_changed_dsl#{Namer.current_index}" }
     let(:resource_class) do
       result = Class.new(Chef::Resource) do
@@ -28,6 +28,7 @@ describe "Resource::ActionClass#converge_if_changed" do
         property :control1, desired_state: false, default: "default_control1"
         property :state1, default: "default_state1"
         property :state2, default: "default_state2"
+        property :sensitive1, default: "default_dontprintme", sensitive: true
         attr_accessor :converged
         def initialize(*args)
           super
@@ -54,6 +55,7 @@ describe "Resource::ActionClass#converge_if_changed" do
           resource_class.load_current_value do
             state1 "current_state1"
             state2 "current_state2"
+            sensitive1 "current_dontprintme"
           end
         end
 
@@ -130,6 +132,26 @@ EOM
   - update default_identity1
   -   set state1 to (suppressed sensitive property)
   -   set state2 to (suppressed sensitive property)
+EOM
+          end
+        end
+
+        context "and sensitive1 is set to a new value" do
+          let(:converge_recipe) do
+            <<-EOM
+              #{resource_name} 'blah' do
+                sensitive1 'new_dontprintme'
+              end
+            EOM
+          end
+
+          it "the resource updates sensitive1" do
+            expect(resource.converged).to eq 1
+            expect(resource.updated?).to be_truthy
+            expect(converged_recipe.stdout).to eq <<-EOM
+* #{resource_name}[blah] action create
+  - update default_identity1
+  -   set sensitive1 to (suppressed sensitive property)
 EOM
           end
         end
@@ -244,19 +266,21 @@ EOM
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
   - create default_identity1
-  -   set identity1 to "default_identity1" (default value)
-  -   set state1    to "default_state1" (default value)
-  -   set state2    to "default_state2" (default value)
+  -   set identity1  to "default_identity1" (default value)
+  -   set state1     to "default_state1" (default value)
+  -   set state2     to "default_state2" (default value)
+  -   set sensitive1 to (suppressed sensitive property) (default value)
 EOM
           end
         end
 
-        context "and state1 and state2 are set" do
+        context "and state1, state2, and sensitive1 are set" do
           let(:converge_recipe) do
             <<-EOM
               #{resource_name} 'blah' do
                 state1 'new_state1'
                 state2 'new_state2'
+                sensitive1 'new_dontprintme'
               end
             EOM
           end
@@ -267,9 +291,10 @@ EOM
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
   - create default_identity1
-  -   set identity1 to "default_identity1" (default value)
-  -   set state1    to "new_state1"
-  -   set state2    to "new_state2"
+  -   set identity1  to "default_identity1" (default value)
+  -   set state1     to "new_state1"
+  -   set state2     to "new_state2"
+  -   set sensitive1 to (suppressed sensitive property)
 EOM
           end
         end
@@ -291,9 +316,10 @@ EOM
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
   - create default_identity1
-  -   set identity1 to (suppressed sensitive property) (default value)
-  -   set state1    to (suppressed sensitive property)
-  -   set state2    to (suppressed sensitive property)
+  -   set identity1  to (suppressed sensitive property) (default value)
+  -   set state1     to (suppressed sensitive property)
+  -   set state2     to (suppressed sensitive property)
+  -   set sensitive1 to (suppressed sensitive property) (default value)
 EOM
           end
         end
@@ -307,6 +333,9 @@ EOM
             new_resource.converged += 1
           end
           converge_if_changed :state2 do
+            new_resource.converged += 1
+          end
+          converge_if_changed :sensitive1 do
             new_resource.converged += 1
           end
         end
@@ -415,6 +444,26 @@ EOM
 EOM
           end
         end
+
+        context "and sensitive1 is set to a new value" do
+          let(:converge_recipe) do
+            <<-EOM
+              #{resource_name} 'blah' do
+                sensitive1 'new_dontprintme'
+              end
+            EOM
+          end
+
+          it "the resource updates sensitive1" do
+            expect(resource.converged).to eq 1
+            expect(resource.updated?).to be_truthy
+            expect(converged_recipe.stdout).to eq <<-EOM
+* #{resource_name}[blah] action create
+  - update default_identity1
+  -   set sensitive1 to (suppressed sensitive property)
+EOM
+          end
+        end
       end
 
       context "and no current_resource" do
@@ -430,7 +479,7 @@ EOM
           end
 
           it "the resource is created" do
-            expect(resource.converged).to eq 2
+            expect(resource.converged).to eq 3
             expect(resource.updated?).to  be_truthy
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
@@ -438,22 +487,25 @@ EOM
   -   set state1 to "default_state1" (default value)
   - create default_identity1
   -   set state2 to "default_state2" (default value)
+  - create default_identity1
+  -   set sensitive1 to (suppressed sensitive property) (default value)
 EOM
           end
         end
 
-        context "and state1 and state2 are set to new values" do
+        context "and state1, state2, and sensitive1 are set to new values" do
           let(:converge_recipe) do
             <<-EOM
               #{resource_name} 'blah' do
                 state1 'new_state1'
                 state2 'new_state2'
+                sensitive1 'new_dontprintme'
               end
             EOM
           end
 
           it "the resource is created" do
-            expect(resource.converged).to eq 2
+            expect(resource.converged).to eq 3
             expect(resource.updated?).to  be_truthy
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
@@ -461,6 +513,8 @@ EOM
   -   set state1 to "new_state1"
   - create default_identity1
   -   set state2 to "new_state2"
+  - create default_identity1
+  -   set sensitive1 to (suppressed sensitive property)
 EOM
           end
         end
@@ -477,7 +531,7 @@ EOM
           end
 
           it "the resource is created" do
-            expect(resource.converged).to eq 2
+            expect(resource.converged).to eq 3
             expect(resource.updated?).to be_truthy
             expect(converged_recipe.stdout).to eq <<-EOM
 * #{resource_name}[blah] action create
@@ -485,6 +539,8 @@ EOM
   -   set state1 to (suppressed sensitive property)
   - create default_identity1
   -   set state2 to (suppressed sensitive property)
+  - create default_identity1
+  -   set sensitive1 to (suppressed sensitive property) (default value)
 EOM
           end
         end


### PR DESCRIPTION
### Description

Hides value of resource properties marked as sensitive in the output of converge_if_changed.

### Issues Resolved

Closes #6571 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
