### PR TITLE
feat: Exclude extensions with remote_directory

### DIFF
--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -36,7 +36,7 @@ class Chef
 
       def_delegators :new_resource, :purge, :path, :source, :cookbook, :cookbook_name
       def_delegators :new_resource, :files_rights, :files_mode, :files_group, :files_owner, :files_backup
-      def_delegators :new_resource, :rights, :mode, :group, :owner
+      def_delegators :new_resource, :rights, :mode, :group, :owner, :exclude_extensions
 
       # The overwrite property on the resource.  Delegates to new_resource but can be mutated.
       #
@@ -111,6 +111,9 @@ class Chef
 
             # Skip files that we've sync'd and their parent dirs
             next if managed_files.include?(file)
+
+            # Skip files that have a excluded extensions
+            next if exclude_extensions.find { |ext| file.end_with?(ext) }
 
             if ::File.directory?(file)
               if !Chef::Platform.windows? && file_class.symlink?(file.dup)

--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -46,6 +46,7 @@ class Chef
         @files_mode = 0644 unless Chef::Platform.windows?
         @overwrite = true
         @cookbook = nil
+        @exclude_extensions = []
       end
 
       if Chef::Platform.windows?
@@ -114,6 +115,14 @@ class Chef
           :cookbook,
           args,
           :kind_of => String
+        )
+      end
+
+      def exclude_extensions(args = nil)
+        set_or_return(
+          :exclude_extensions,
+          args,
+          :kind_of => [ Array ]
         )
       end
 


### PR DESCRIPTION
### Description

This enhancement gives the ability to include an array of file
extensions that should not be purged. Extremely useful if shipping a
python module via chef since `.pyc` files will be created. However, as
files get changed, renamed, moved, etc. the directory will become dirty
without the `purge` option.

`exclude_extensions` is optional and takes an array:

    ['.tmp', '.pyc']

I am still trying to figure out how/where to add this as a test.

### Issues Resolved

n/a

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
