### PR TITLE
use a stricter comparison so knife ssh only fails if --exit-on-error

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -448,7 +448,7 @@ class Chef
         ssh.config[:ssh_identity_file] = config[:ssh_identity_file] || config[:identity_file]
         ssh.config[:manual] = true
         ssh.config[:host_key_verify] = config[:host_key_verify]
-        ssh.config[:on_error] = :raise
+        ssh.config[:on_error] = true
         ssh
       end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -335,7 +335,7 @@ class Chef
         command = fixup_sudo(command)
         command.force_encoding("binary") if command.respond_to?(:force_encoding)
         subsession.open_channel do |chan|
-          if config[:on_error] && exit_status != 0
+          if config[:on_error] == :raise && exit_status != 0
             chan.close()
           else
             chan.request_pty

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -122,7 +122,7 @@ class Chef
         :long => "--exit-on-error",
         :description => "Immediately exit if an error is encountered",
         :boolean => true,
-        :proc => Proc.new { :raise }
+        :default => false
 
       option :tmux_split,
         :long => "--tmux-split",
@@ -131,15 +131,13 @@ class Chef
         :default => false
 
       def session
-        config[:on_error] ||= :skip
         ssh_error_handler = Proc.new do |server|
-          case config[:on_error]
-          when :skip
-            ui.warn "Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}"
-            $!.backtrace.each { |l| Chef::Log.debug(l) }
-          when :raise
+          if config[:on_error]
             #Net::SSH::Multi magic to force exception to be re-raised.
             throw :go, :raise
+          else
+            ui.warn "Failed to connect to #{server.host} -- #{$!.class.name}: #{$!.message}"
+            $!.backtrace.each { |l| Chef::Log.debug(l) }
           end
         end
 
@@ -335,7 +333,7 @@ class Chef
         command = fixup_sudo(command)
         command.force_encoding("binary") if command.respond_to?(:force_encoding)
         subsession.open_channel do |chan|
-          if config[:on_error] == :raise && exit_status != 0
+          if config[:on_error] && exit_status != 0
             chan.close()
           else
             chan.request_pty


### PR DESCRIPTION
### Description

This is required due to config[:on_error] being set here: https://github.com/chef/chef/blob/93fe1aca2beff64b30910daa2aac615bc623d259/lib/chef/knife/ssh.rb#L134. This conditional will allow ssh_commands that return non-zero status to be executed on entire pool of servers returned by the knife query when --exit-on-error is NOT specified. 


### Issues Resolved

https://github.com/chef/chef/issues/6581

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
