### PR TITLE
Add ohai_time to minimal_ohai filter

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -602,7 +602,7 @@ class Chef
     # @api private
     #
     def run_ohai
-      filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version os os_version} : nil
+      filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version ohai_time os os_version} : nil
       ohai.all_plugins(filter)
       events.ohai_completed(node)
     rescue Ohai::Exceptions::CriticalPluginFailure => e

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -38,7 +38,7 @@ describe Chef::Client do
     end
 
     it "runs ohai with only the minimum required plugins" do
-      expected_filter = %w{fqdn machinename hostname platform platform_version os os_version}
+      expected_filter = %w{fqdn machinename hostname platform platform_version ohai_time os os_version}
       expect(ohai_system).to receive(:all_plugins).with(expected_filter)
       client.run_ohai
     end


### PR DESCRIPTION
We need ohai_time to get the 'Last Check-In' time on the Chef Server.
There is really no risk to including it.