### PR TITLE
Use Chef::VersionConstraint in useradd_spec test

### DIFF
--- a/spec/functional/resource/user/useradd_spec.rb
+++ b/spec/functional/resource/user/useradd_spec.rb
@@ -646,7 +646,7 @@ describe Chef::Provider::User::Useradd, metadata do
             expect(@error.message).to include("Cannot unlock the password")
           end
         elsif %w{rhel}.include?(OHAI_SYSTEM["platform_family"]) &&
-            (OHAI_SYSTEM["platform_version"].to_f >= 6.8 || OHAI_SYSTEM["platform_version"].to_f >= 7.3)
+            (Chef::VersionConstraint.new("~> 6.8").include?(OHAI_SYSTEM["platform_version"].to_f) || Chef::VersionConstraint.new("~> 7.3").include?(OHAI_SYSTEM["platform_version"].to_f))
           # RHEL 6.8 and 7.3 ship with a fixed `usermod` command
           # Reference: https://access.redhat.com/errata/RHBA-2016:0864
           # Reference: https://access.redhat.com/errata/RHBA-2016:2322


### PR DESCRIPTION
Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>

This fixes the version constraint check used in one of the useradd_spec tests.