### PR TITLE
Revert "add missing functional tests for users"

### DIFF
--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -17,8 +17,6 @@
 #
 
 require "spec_helper"
-require "mixlib/shellout"
-require "chef/mixin/user_context"
 if Chef::Platform.windows?
   require "chef/win32/security"
 end
@@ -28,37 +26,13 @@ describe "Chef::Win32::Security", :windows_only do
     expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to eq(true)
   end
 
-  describe "running as non admin user" do
-    include Chef::Mixin::UserContext
-    let(:user) { "security_user" }
-    let(:password) { "Security@123" }
-
-    let(:domain) do
-      whoami = Mixlib::ShellOut.new("whoami")
-      whoami.run_command
-      whoami.error!
-      whoami.stdout.split("\\")[0]
-    end
-    before do
-      allow_any_instance_of(Chef::Mixin::UserContext).to receive(:node).and_return({ "platform_family" => "windows" })
-      allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
-      allow(Chef::ReservedNames::Win32::Security).to receive(:OpenProcessToken).and_return(true)
-      add_user = Mixlib::ShellOut.new("net user #{user} #{password} /ADD")
-      add_user.run_command
-      add_user.error!
-    end
-
-    after do
-      delete_user = Mixlib::ShellOut.new("net user #{user} /delete")
-      delete_user.run_command
-      delete_user.error!
-    end
-    it "has_admin_privileges? returns false" do
-      has_admin_privileges = with_user_context(user, password, domain) do
-        Chef::ReservedNames::Win32::Security.has_admin_privileges?
-      end
-      expect(has_admin_privileges).to eq(false)
-    end
+  # We've done some investigation adding a negative test and it turned
+  # out to be a lot of work since mixlib-shellout doesn't have user
+  # support for windows.
+  #
+  # TODO - Add negative tests once mixlib-shellout has user support
+  it "has_admin_privileges? returns false when running as non-admin" do
+    skip "requires user support in mixlib-shellout"
   end
 
   describe "get_file_security" do


### PR DESCRIPTION
testing to see if appveyor goes green or not.

so somewhere between v13.5.28 and v13.6.7 we broke appveyor.

looks like it was fa6e4e89b586bb8eaee767d5602b13cb75f6c073