### PR TITLE
Knife SSH prefix option

### DIFF
--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -185,7 +185,7 @@ describe Chef::Knife::Ssh do
       end
     end
 
-    context "when knife[:ssh_attribute] is not provided]" do
+    context "when knife[:ssh_attribute] is not provided" do
       before do
         setup_knife(["*:*", "uptime"])
         Chef::Config[:knife][:ssh_attribute] = nil

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -219,6 +219,53 @@ describe Chef::Knife::Ssh do
     end
   end
 
+  describe "prefix" do
+    context "when knife[:prefix_attribute] is set" do
+      before do
+        setup_knife(["*:*", "uptime"])
+        Chef::Config[:knife][:prefix_attribute] = "name"
+      end
+
+      it "uses the prefix_attribute" do
+        @knife.run
+        expect(@knife.get_prefix_attribute({ "prefix" => "name" })).to eq("name")
+      end
+    end
+
+    context "when knife[:prefix_attribute] is not provided" do
+      before do
+        setup_knife(["*:*", "uptime"])
+        Chef::Config[:knife][:prefix_attribute] = nil
+      end
+
+      it "falls back to nil" do
+        @knife.run
+        expect(@knife.get_prefix_attribute({})).to eq(nil)
+      end
+    end
+
+    context "when --prefix-attribute ec2.public_public_hostname is provided" do
+      before do
+        setup_knife(["--prefix-attribute", "ec2.public_hostname", "*:*", "uptime"])
+        Chef::Config[:knife][:prefix_attribute] = nil
+      end
+
+      it "should use the value on the command line" do
+        @knife.run
+        expect(@knife.config[:prefix_attribute]).to eq("ec2.public_hostname")
+      end
+
+      it "should override what is set in knife.rb" do
+        # This is the setting imported from knife.rb
+        Chef::Config[:knife][:prefix_attribute] = "fqdn"
+        # Then we run knife with the -b flag, which sets the above variable
+        setup_knife(["--prefix-attribute", "ec2.public_hostname", "*:*", "uptime"])
+        @knife.run
+        expect(@knife.config[:prefix_attribute]).to eq("ec2.public_hostname")
+      end
+    end
+  end
+
   describe "gateway" do
     context "when knife[:ssh_gateway] is set" do
       before do

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -181,7 +181,7 @@ describe Chef::Knife::Ssh do
 
       it "uses the ssh_attribute" do
         @knife.run
-        expect(@knife.get_ssh_attribute({ "knife_config" => "ec2.public_hostname" })).to eq("ec2.public_hostname")
+        expect(@knife.get_ssh_attribute({ "target" => "ec2.public_hostname" })).to eq("ec2.public_hostname")
       end
     end
 
@@ -199,22 +199,22 @@ describe Chef::Knife::Ssh do
 
     context "when -a ec2.public_public_hostname is provided" do
       before do
-        setup_knife(["-a ec2.public_hostname", "*:*", "uptime"])
+        setup_knife(["-a", "ec2.public_hostname", "*:*", "uptime"])
         Chef::Config[:knife][:ssh_attribute] = nil
       end
 
       it "should use the value on the command line" do
         @knife.run
-        expect(@knife.config[:attribute]).to eq("ec2.public_hostname")
+        expect(@knife.config[:ssh_attribute]).to eq("ec2.public_hostname")
       end
 
       it "should override what is set in knife.rb" do
         # This is the setting imported from knife.rb
         Chef::Config[:knife][:ssh_attribute] = "fqdn"
         # Then we run knife with the -a flag, which sets the above variable
-        setup_knife(["-a ec2.public_hostname", "*:*", "uptime"])
+        setup_knife(["-a", "ec2.public_hostname", "*:*", "uptime"])
         @knife.run
-        expect(@knife.config[:attribute]).to eq("ec2.public_hostname")
+        expect(@knife.config[:ssh_attribute]).to eq("ec2.public_hostname")
       end
     end
   end
@@ -305,7 +305,7 @@ describe Chef::Knife::Ssh do
     Chef::Config[:chef_server_url] = "http://localhost:9000"
 
     @api.post("/search/node?q=*:*&start=0&rows=1000", 200) do
-      %({"total":1, "start":0, "rows":[{"data": {"fqdn":"the.fqdn", "config": "the_public_hostname", "knife_config": "the_public_hostname" }}]})
+      %({"total":1, "start":0, "rows":[{"data": {"fqdn":"the.fqdn", "target": "the_public_hostname"}}]})
     end
   end
 

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -67,7 +67,7 @@ describe Chef::Knife::Ssh do
         end
       end
 
-      it "searchs for and returns an array of fqdns" do
+      it "searches for and returns an array of fqdns" do
         expect(@knife).to receive(:session_from_list).with([
           ["foo.example.org", nil],
           ["bar.example.org", nil],


### PR DESCRIPTION
### Description

```sh
# existing usage (no change)
$ knife ssh 'name:app-server' 'echo hello' 
ec2-10-0-0-1.compute-1.amazonaws.com hello

# new functionality
$ knife ssh --prefix-attribute name 'name:app-server' 'echo hello'
app-server hello
```

Allows an attribute to be specified which will determine how a node is identified in the output of `knife ssh` commands. It uses the long flag `--prefix-attribute` ~~and the short flag `-b`. The short flag was picked as a placeholder, chosen because `-p` is already in use for `--port`, this can be changed prior to merging to align with any sort of option/flag guidelines that may exist.~~ The config setting `Chef::Config[:knife][:prefix_attribute]` is also supported.

This feature makes use of the session properties assignment functionality documented [here](https://github.com/jamis/net-ssh-multi/blob/c0b0a0b9a84d0e2ba58dd6f78e0d5e28900e18c4/lib/net/ssh/multi/session.rb#L320) to attach the prefix to the session, and renames some internal keys (`config`, `knife_config`) in order to aid understanding of the code when reading and provide clear distinctions between the attribute keys used for the SSH target and the prefix.

### Issues Resolved

Resolves #6573

---

~~Tests seem to have been broken before I got here 🙁~~ Looks like it's been fixed \o/