### PR TITLE
Fix variable name in solaris service provider

### DIFF
--- a/lib/chef/provider/service/solaris.rb
+++ b/lib/chef/provider/service/solaris.rb
@@ -31,7 +31,7 @@ class Chef
           super
           @init_command   = "/usr/sbin/svcadm"
           @status_command = "/bin/svcs"
-          @maintenace     = false
+          @maintenance    = false
         end
 
         def load_current_resource
@@ -101,7 +101,6 @@ class Chef
           end
 
           # check service state
-          @maintenance = false
           case status["state"]
           when "online"
             @current_resource.enabled(true)


### PR DESCRIPTION
Without setting "maintenance" to false service restart
fails with error "service is not in a maintenance or degraded state"
on solaris nodes

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Fix typo 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
