### PR TITLE
Switch from the Travis container to the VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-sudo: false
+sudo: required
 cache: bundler
 dist: trusty
 


### PR DESCRIPTION
    If `sudo` is `false`, then Travis CI will use a container for testing. If
    `sudo` is `required, then it will use a GCE VM. We've recently been
    seeing permission errors that appeared related to the Travis CI infrastructure.
    Switching to the VM resolves those errors. The downside is that it takes 50s
    instead of 5s to start up the tester, but given that our tests take 18 minutes
    that is okay.

    https://docs.travis-ci.com/user/reference/trusty/