### PR TITLE
[MSYS-722] Fixes of Knife search not working with forward slash.

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -61,6 +61,7 @@ class Chef
       #
       def search(type, query = "*:*", *args, &block)
         validate_type(type)
+        query = build_query(type, query)
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
@@ -120,6 +121,13 @@ class Chef
             "        `knife search environment QUERY (options)`"
           raise Chef::Exceptions::InvalidSearchQuery, msg
         end
+      end
+
+      def build_query(type, query)
+        if query[-1] == "*" && type == "node"
+          query = query.gsub(/(?:\/\/\*)|(?:\/\*)/, "//*")
+        end
+        query
       end
 
       def hashify_args(*args)

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -253,6 +253,20 @@ describe Chef::Search::Query do
       query.search(:client, "messi", fuzz: true)
     end
 
+    it "returns search results when the query contains a forward slash with asterisk as (/*)" do
+      rows, start, total = query.search(:node, "platform:rhel/*")
+      expect(rows).to equal(response["rows"])
+      expect(start).to equal(response["start"])
+      expect(total).to equal(response["total"])
+    end
+
+    it "returns search results when the query contains a double forward slash with asterisk as (//*)" do
+      rows, start, total = query.search(:node, "platform:rhel//*")
+      expect(rows).to equal(response["rows"])
+      expect(start).to equal(response["start"])
+      expect(total).to equal(response["total"])
+    end
+
     context "when :filter_result is provided as a result" do
       include_context "filtered search" do
         let(:filter_key) { :filter_result }


### PR DESCRIPTION
**Knife search not working with forward slash**
**Pass:**
```
knife search node 'stack_id:arn\:aws\:cloudformation\:eu-west-1\:569478613970\:stack//*'
knife search node 'stack_id:arn\:aws\:cloudformation\:eu-west-1\:569478613970\:stack/*'
```
```
$ bundle exec knife search node 'stack_id:arn\:aws\:cloudformation\:eu-west-1\:569478613970\:stack//*'
2 items found

Node Name:   ammy-cnt
Environment: _default
FQDN:        ammy-cnt.ammy-cnt.d7.internal.cloudapp.net
IP:          10.158.218.44
Run List:    
Roles:       
Recipes:     
Platform:    centos 7.1.1503
Tags:        

Node Name:   msys
Environment: _default
FQDN:        msys-Lenovo-E41-80
IP:          192.168.101.66
Run List:    recipe[cache_replication_group]
Roles:       
Recipes:     cache_replication_group, cache_replication_group::default
Platform:    ubuntu 16.04
Tags:        

$ bundle exec knife search node 'stack_id:arn\:aws\:cloudformation\:eu-west-1\:569478613970\:stack/*'
2 items found

Node Name:   ammy-cnt
Environment: _default
FQDN:        ammy-cnt.ammy-cnt.d7.internal.cloudapp.net
IP:          10.158.218.44
Run List:    
Roles:       
Recipes:     
Platform:    centos 7.1.1503
Tags:        

Node Name:   msys
Environment: _default
FQDN:        msys-Lenovo-E41-80
IP:          192.168.101.66
Run List:    recipe[cache_replication_group]
Roles:       
Recipes:     cache_replication_group, cache_replication_group::default
Platform:    ubuntu 16.04
Tags:        
```

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
