### PR TITLE
[MSYS-725] [chef#6073] allow forcing sensitive to false on execute and batch resource if password is set.

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -133,7 +133,8 @@ class Chef
 
       property :password, String, sensitive: true
 
-      property :sensitive, [ TrueClass, FalseClass ], default: false, coerce: proc { |x| password ? true : x }
+      # lazy used to set default value of sensitive to true if password is set
+      property :sensitive, [ TrueClass, FalseClass ], default: lazy { |r| r.password ? true : false }
 
       property :elevated, [ TrueClass, FalseClass ], default: false
 

--- a/spec/support/shared/unit/execute_resource.rb
+++ b/spec/support/shared/unit/execute_resource.rb
@@ -139,7 +139,14 @@ shared_examples_for "an execute resource" do
     it "should be true if the password is non-nil but the value is explicitly set to false" do
       @resource.password("we.funk!")
       @resource.sensitive false
-      expect(@resource.sensitive).to eq(true)
+      expect(@resource.sensitive).to eq(false)
+    end
+
+    # added this test to ensure setting of password property after or before sensitive does not matter
+    it "should be false if the sensitive is set before password property" do
+      @resource.sensitive false
+      @resource.password("we.funk!")
+      expect(@resource.sensitive).to eq(false)
     end
 
   end


### PR DESCRIPTION
Allows forcing sensitive to false on execute and batch resource if password is set.

Resolves #6073 
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>