### PR TITLE
Solaris: Fix svcadm clear to only run in maintenance state

### DIFF
--- a/lib/chef/provider/service/solaris.rb
+++ b/lib/chef/provider/service/solaris.rb
@@ -54,6 +54,8 @@ class Chef
         end
 
         def enable_service
+          # Running service status to update maintenance status to invoke svcadm clear
+          service_status
           shell_out!(default_init_command, "clear", @new_resource.service_name) if @maintenance
           enable_flags = [ "-s", @new_resource.options ].flatten.compact
           shell_out!(default_init_command, "enable", *enable_flags, @new_resource.service_name)
@@ -92,6 +94,9 @@ class Chef
           # contract_id  1115271
           # dependency   require_all/error svc:/milestone/multi-user:default (online)
           # $
+
+          # Set the default value for maintenance
+          @maintenance = false
 
           # load output into hash
           status = {}

--- a/spec/unit/provider/service/solaris_smf_service_spec.rb
+++ b/spec/unit/provider/service/solaris_smf_service_spec.rb
@@ -118,6 +118,7 @@ describe Chef::Provider::Service::Solaris do
       it "should create a current resource with the name of the new resource" do
         expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
         expect(Chef::Resource::Service).to receive(:new).and_return(@current_resource)
+        expect(@provider.maintenance).to be_falsey
         @provider.load_current_resource
       end
 
@@ -162,7 +163,7 @@ describe Chef::Provider::Service::Solaris do
       end
 
       it "should call svcadm enable -s chef" do
-        expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
+        expect(@provider).to receive(:shell_out!).twice.with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
         expect(@provider).not_to receive(:shell_out!).with("/usr/sbin/svcadm", "clear", @current_resource.service_name)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "enable", "-s", @current_resource.service_name).and_return(@success)
         @provider.load_current_resource
@@ -172,7 +173,7 @@ describe Chef::Provider::Service::Solaris do
       end
 
       it "should call svcadm enable -s chef for start_service" do
-        expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
+        expect(@provider).to receive(:shell_out!).twice.with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
         expect(@provider).not_to receive(:shell_out!).with("/usr/sbin/svcadm", "clear", @current_resource.service_name)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "enable", "-s", @current_resource.service_name).and_return(@success)
         @provider.load_current_resource
@@ -182,7 +183,7 @@ describe Chef::Provider::Service::Solaris do
 
       it "should call svcadm clear chef for start_service when state maintenance" do
         # we are in maint mode
-        expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@maintenance_svc_status)
+        expect(@provider).to receive(:shell_out!).twice.with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@maintenance_svc_status)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "clear", @current_resource.service_name).and_return(@success)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "enable", "-s", @current_resource.service_name).and_return(@success)
 
@@ -205,7 +206,7 @@ describe Chef::Provider::Service::Solaris do
 
       it "should call svcadm enable -s -r chef" do
         @new_resource.options("-r")
-        expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
+        expect(@provider).to receive(:shell_out!).twice.with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
         expect(@provider).not_to receive(:shell_out!).with("/usr/sbin/svcadm", "clear", @current_resource.service_name)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "enable", "-s", "-r", @current_resource.service_name).and_return(@success)
         @provider.load_current_resource
@@ -215,7 +216,7 @@ describe Chef::Provider::Service::Solaris do
 
       it "should call svcadm enable -s -r -t chef when passed an array of options" do
         @new_resource.options(["-r", "-t"])
-        expect(@provider).to receive(:shell_out!).with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
+        expect(@provider).to receive(:shell_out!).twice.with("/bin/svcs", "-l", "chef", { :returns => [0, 1] }).and_return(@enabled_svc_status)
         expect(@provider).not_to receive(:shell_out!).with("/usr/sbin/svcadm", "clear", @current_resource.service_name)
         expect(@provider).to receive(:shell_out!).with("/usr/sbin/svcadm", "enable", "-s", "-r", "-t", @current_resource.service_name).and_return(@success)
         @provider.load_current_resource


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>
Signed-off-by: Patrick Wright <patrick@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
