### PR TITLE
Ensure data bags names can contain reserved words

### DIFF
--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -33,7 +33,7 @@ class Chef
     include Chef::Mixin::ParamsValidate
 
     VALID_NAME = /^[\.\-[:alnum:]_]+$/
-    RESERVED_NAMES = /node|role|environment|client/
+    RESERVED_NAMES = /^(node|role|environment|client)$/
 
     attr_accessor :chef_server_rest
 


### PR DESCRIPTION

### Description

I think there was a bug introduced by #3058 where any data bag *containing* reserved words are seen as invalid

### Issues Resolved

#3058

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
