### PR TITLE
fix for data bag names partially matching search reserved words

### DIFF
--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -5,7 +5,7 @@ class Chef
   module ChefFS
     module DataHandler
       class DataBagItemDataHandler < DataHandlerBase
-        RESERVED_NAMES = /node|role|environment|client/
+        RESERVED_NAMES = /^(node|role|environment|client)$/
 
         def normalize(data_bag_item, entry)
           # If it's wrapped with raw_data, unwrap it.

--- a/spec/unit/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/spec/unit/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -66,14 +66,17 @@ describe Chef::ChefFS::DataHandler::DataBagItemDataHandler do
       end
     end
 
-    context "valid data" do
-      let(:entry) { TestDataBagItem.new("luggage", "bag") }
-      let(:object) do
-        { "raw_data" => { "id" => "bag" } }
-      end
-      it "validates the data bag item" do
-        expect(handler.verify_integrity(object, entry)).to be_nil
+    context "using a reserved word as part of the data bag name" do
+      %w{xnode rolex xenvironmentx xclientx}.each do |bag_name|
+        let(:entry) { TestDataBagItem.new("#{bag_name}", "bag") }
+        let(:object) do
+          { "raw_data" => { "id" => "bag" } }
+        end
+        it "allows the data bag name '#{bag_name}'" do
+          expect(handler.verify_integrity(object, entry)).to be_nil
+        end
       end
     end
+
   end
 end

--- a/spec/unit/knife/data_bag_create_spec.rb
+++ b/spec/unit/knife/data_bag_create_spec.rb
@@ -46,8 +46,8 @@ describe Chef::Knife::DataBagCreate do
     allow(knife).to receive(:config).and_return(config)
   end
 
-  context "when data_bag already exist" do
-    it "doesn't creates a data bag" do
+  context "when data_bag already exists" do
+    it "doesn't create a data bag" do
       expect(knife).to receive(:create_object).and_yield(raw_hash)
       expect(rest).to receive(:get).with("data/#{bag_name}")
       expect(rest).to_not receive(:post).with("data", { "name" => bag_name })
@@ -111,6 +111,23 @@ describe Chef::Knife::DataBagCreate do
         expect(knife.ui).to receive(:info).with("Created data_bag[#{bag_name}]")
 
         knife.run
+      end
+    end
+
+    context "when given a data bag name partially matching a reserved name for search" do
+      %w{xnode rolex xenvironmentx xclientx}.each do |name|
+        let(:bag_name) { name }
+
+        before do
+          knife.name_args = [bag_name]
+        end
+
+        it "creates a data bag named '#{name}'" do
+          expect(rest).to receive(:post).with("data", { "name" => bag_name })
+          expect(knife.ui).to receive(:info).with("Created data_bag[#{bag_name}]")
+
+          knife.run
+        end
       end
     end
 


### PR DESCRIPTION
### Description

Allow data bag names containing, but not equal to, the search reserved words node, role, environment and client.

(Also fixes a couple of grammatical errors in text for other data bag tests).

### Issues Resolved

[#3058](https://github.com/chef/chef/issues/3058)

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
