### PR TITLE
Use comments in the github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,31 +1,5 @@
-## Description
-
-Briefly describe the issue
-
-## Chef Version
-
-Tell us which version of chef-client you are using (see below for Server+ChefDK bugs).
-
-## Platform Version
-
-Tell us which Operating System distribution and version chef-client is running on.
-
-## Replication Case
-
-Tell us what steps to take to replicate your problem.  See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
-for information on how to create a good replication case.
-
-## Client Output
-
-The relevant output of the chef-client run or a link to a gist of the entire run, if there is one.
-
-The debug output (chef-client -l debug) may be useful, but please link to a gist, or truncate it.
-
-## Stacktrace
-
-Please include the stacktrace.out output or link to a gist of it, if there is one.
-
-### NOTE: CHEF CLIENT BUGS ONLY
+<!--- 
+!!!!!! NOTE: CHEF CLIENT BUGS ONLY !!!!!!
 
 This issue tracker is for the code contained within this repo -- `chef-client`, base `knife` functionality (not
 plugins), `chef-apply`, `chef-solo`, `chef-client -z`, etc.
@@ -34,3 +8,30 @@ plugins), `chef-apply`, `chef-solo`, `chef-client -z`, etc.
 * [Chef Server issues](https://github.com/chef/chef-server/issues/new)
 * [ChefDK issues](https://github.com/chef/chef-dk/issues/new)
 * Cookbook Issues (see the https://github.com/chef-cookbooks repos or search [Supermarket](https://supermarket.chef.io) or GitHub/Google)
+
+-->
+
+## Description
+<!--- Briefly describe the issue -->
+
+## Chef Version
+<!--- Tell us which version of chef-client you are using (see below for Server+ChefDK bugs). -->
+
+## Platform Version
+<!--- Tell us which Operating System distribution and version chef-client is running on. -->
+
+## Replication Case
+<!--- Tell us what steps to take to replicate your problem.  See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
+for information on how to create a good replication case. -->
+
+## Client Output
+<!--- The relevant output of the chef-client run or a link to a gist of the entire run, if there is one.
+
+The debug output (chef-client -l debug) may be useful, but please link to a gist, or truncate it. -->
+
+```
+
+```
+
+## Stacktrace
+<!--- Please include the stacktrace.out output or link to a gist of it, if there is one. -->


### PR DESCRIPTION
This way we don't see the end users notes when they submit it. This should make it easier to read the issues.