### PR TITLE
[MSYS-692] Fix issue with PowerShell function buffer

### DIFF
--- a/distro/powershell/chef/chef.psm1
+++ b/distro/powershell/chef/chef.psm1
@@ -236,7 +236,6 @@ function Run-ExecutableAndWait($AppPath, $ArgumentString) {
     throw "Unable to create process [$ArgumentString].  Error code $reason."
   }
 
-  $sb = New-Object System.Text.StringBuilder
   $buffer = New-Object byte[] 1024
 
   # Initialize reference variables
@@ -270,7 +269,7 @@ function Run-ExecutableAndWait($AppPath, $ArgumentString) {
       while ([Chef.Kernel32]::ReadFile($hReadOut, $buffer, $buffer.Length, [ref] $bytesRead, 0)) {
         $output = [Text.Encoding]::UTF8.GetString($buffer, 0, $bytesRead)
         if ($output) {
-          [void]$sb.Append($output)
+          $output
         }
         if ($bytesRead -lt $buffer.Length) {
           # Partial buffer indicating the end of stream, break out of ReadFile loop
@@ -306,9 +305,6 @@ function Run-ExecutableAndWait($AppPath, $ArgumentString) {
       $isActive = $false
     }
   }
-
-  # Return output obtained from child process stdout/stderr
-  $sb.ToString()
 
   # Cleanup handles
   $success = [Chef.Kernel32]::CloseHandle($pi.hProcess)


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

Submitted with contributions also from @btm 

### Description

When a command, like knife, is run using the chef.psm1 function the output of the command was buffered until the command completed so that an object could be created and passed through a pipe. This prevents UI elements from being visible to the user as well as stdout during the running of the ruby command. By instead passing the output of the ruby command direct instead of storing it in a string buffer this helps with both piping commands and allow for UI elements to be visible.

Note: If a UI element is piped such as `knife client delete fake-node > output.txt` the UI element will be in the text file not in the console.

### Issues Resolved

https://github.com/chef/chef-dk/issues/1236
Sustaining Eng MSYS-692
ZenDesk 16768

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
