### PR TITLE
Remove unused chef_server_fqdn argument: run_status

### DIFF
--- a/lib/chef/data_collector/messages.rb
+++ b/lib/chef/data_collector/messages.rb
@@ -36,7 +36,7 @@ class Chef
       #
       def self.run_start_message(run_status)
         {
-          "chef_server_fqdn"  => chef_server_fqdn(run_status),
+          "chef_server_fqdn"  => chef_server_fqdn,
           "entity_uuid"       => node_uuid,
           "id"                => run_status.run_id,
           "message_version"   => "1.0.0",
@@ -61,7 +61,7 @@ class Chef
         run_status = reporter_data[:run_status]
 
         message = {
-          "chef_server_fqdn"       => chef_server_fqdn(run_status),
+          "chef_server_fqdn"       => chef_server_fqdn,
           "entity_uuid"            => node_uuid,
           "expanded_run_list"      => reporter_data[:expanded_run_list],
           "id"                     => run_status.run_id,

--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -31,7 +31,7 @@ class Chef
         #
         # @return [String] FQDN of the configured Chef Server, or node/localhost if not found.
         #
-        def chef_server_fqdn(run_status)
+        def chef_server_fqdn
           if !Chef::Config[:chef_server_url].nil?
             URI(Chef::Config[:chef_server_url]).host
           elsif !Chef::Config[:node_name].nil?


### PR DESCRIPTION
### Description

Removes an unused argument from `#chef_server_fqdn`

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
