### PR TITLE
Remove apt recipe from acceptance, which is no longer needed

### DIFF
--- a/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/recipes/provision.rb
+++ b/acceptance/top-cookbooks/.acceptance/acceptance-cookbook/recipes/provision.rb
@@ -1,1 +1,3 @@
+apt_update if platform_family?('debian')
+
 top_cookbooks "converge"

--- a/acceptance/top-cookbooks/.kitchen.docker.yml
+++ b/acceptance/top-cookbooks/.kitchen.docker.yml
@@ -8,6 +8,5 @@ suites:
       docker:
         version: 1.10.0
     run_list:
-      - recipe[apt]
       - recipe[chef-apt-docker]
     includes: [ubuntu-14.04]

--- a/acceptance/top-cookbooks/.kitchen.git.yml
+++ b/acceptance/top-cookbooks/.kitchen.git.yml
@@ -1,7 +1,7 @@
 suites:
   - name: git-default
     # Ubuntu images need to run apt update
-    run_list: ["recipe[apt]","recipe[git]"]
+    run_list: ["recipe[git]"]
     includes: [ubuntu-14.04]
   - name: git-source
     run_list: ["recipe[git::source]"]


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

I verified this on both the chef-12 and the master branch with fresh builds.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
