### PR TITLE
Remove the ciphers that openSSH 7.6 doesn't support

### DIFF
--- a/kitchen-tests/Berksfile.lock
+++ b/kitchen-tests/Berksfile.lock
@@ -53,6 +53,6 @@ GRAPH
   sudo (4.0.0)
   ubuntu (2.0.1)
     apt (>= 0.0.0)
-  users (5.2.2)
-  windows (3.4.0)
+  users (5.3.0)
+  windows (3.4.1)
     ohai (>= 4.0.0)

--- a/kitchen-tests/cookbooks/base/attributes/default.rb
+++ b/kitchen-tests/cookbooks/base/attributes/default.rb
@@ -27,7 +27,7 @@ default["openssh"]["client"]["strict_host_key_checking"] = "no"
 default["openssh"]["client"]["protocol"] = "2"
 
 # it is mostly important that the aes*-ctr ciphers appear first in this list, the cbc ciphers are for compatibility
-default["openssh"]["server"]["ciphers"] = "aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,blowfish-cbc,3des-cbc,cast128-cbc"
+default["openssh"]["server"]["ciphers"] = "aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc"
 # DNS causes long timeouts when connecting clients have busted DNS
 default["openssh"]["server"]["use_dns"] = "no"
 default["openssh"]["server"]["syslog_facility"] = "AUTH"


### PR DESCRIPTION
fedora-latest just went to Fedora 27 and blowfish / cast have been removed with the inclusion of openSSH 7.6. The cookbook is fine, but we set this here.

Signed-off-by: Tim Smith <tsmith@chef.io>