### PR TITLE
[MSYS-724] Chef::Util::Windows::LogonSession should allow having only the prescribed users permissions

### DIFF
--- a/lib/chef/mixin/user_context.rb
+++ b/lib/chef/mixin/user_context.rb
@@ -31,7 +31,7 @@ class Chef
           raise ArgumentError, "You must supply a block to `with_user_context`"
         end
 
-        login_session = nil
+        logon_session = nil
 
         begin
           if user

--- a/lib/chef/mixin/user_context.rb
+++ b/lib/chef/mixin/user_context.rb
@@ -22,7 +22,8 @@ class Chef
   module Mixin
     module UserContext
 
-      def with_user_context(user, password, domain = nil, &block)
+      # valid logon_type values => :remote, :local
+      def with_user_context(user, password, domain = nil, logon_type = :remote, &block)
         unless Chef::Platform.windows?
           raise Exceptions::UnsupportedPlatform, "User context impersonation is supported only on the Windows platform"
         end
@@ -35,7 +36,7 @@ class Chef
 
         begin
           if user
-            logon_session = Chef::Util::Windows::LogonSession.new(user, password, domain)
+            logon_session = Chef::Util::Windows::LogonSession.new(user, password, domain, logon_type)
             logon_session.open
             logon_session.set_user_context
           end

--- a/lib/chef/mixin/user_context.rb
+++ b/lib/chef/mixin/user_context.rb
@@ -22,8 +22,10 @@ class Chef
   module Mixin
     module UserContext
 
-      # valid logon_type values => :remote, :local
-      def with_user_context(user, password, domain = nil, logon_type = :remote, &block)
+      # valid values for authentication => :remote, :local
+      # When authentication = :local, we use the credentials to create a logon session against the local system, and then try to access the files.
+      # When authentication = :remote, we continue with the current user but pass the provided credentials to the remote system.
+      def with_user_context(user, password, domain = nil, authentication = :remote, &block)
         unless Chef::Platform.windows?
           raise Exceptions::UnsupportedPlatform, "User context impersonation is supported only on the Windows platform"
         end
@@ -36,7 +38,7 @@ class Chef
 
         begin
           if user
-            logon_session = Chef::Util::Windows::LogonSession.new(user, password, domain, logon_type)
+            logon_session = Chef::Util::Windows::LogonSession.new(user, password, domain, authentication)
             logon_session.open
             logon_session.set_user_context
           end

--- a/lib/chef/provider/remote_file/network_file.rb
+++ b/lib/chef/provider/remote_file/network_file.rb
@@ -43,7 +43,7 @@ class Chef
             tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
             Chef::Log.debug("#{new_resource} staging #{@source} to #{tempfile.path}")
 
-            with_user_context(new_resource.remote_user, new_resource.remote_password, new_resource.remote_domain, :remote) do
+            with_user_context(new_resource.remote_user, new_resource.remote_password, new_resource.remote_domain, new_resource.authentication) do
               ::File.open(@source, "rb") do |remote_file|
                 while data = remote_file.read(TRANSFER_CHUNK_SIZE)
                   tempfile.write(data)

--- a/lib/chef/provider/remote_file/network_file.rb
+++ b/lib/chef/provider/remote_file/network_file.rb
@@ -43,7 +43,7 @@ class Chef
             tempfile = Chef::FileContentManagement::Tempfile.new(new_resource).tempfile
             Chef::Log.debug("#{new_resource} staging #{@source} to #{tempfile.path}")
 
-            with_user_context(new_resource.remote_user, new_resource.remote_password, new_resource.remote_domain) do
+            with_user_context(new_resource.remote_user, new_resource.remote_password, new_resource.remote_domain, :remote) do
               ::File.open(@source, "rb") do |remote_file|
                 while data = remote_file.read(TRANSFER_CHUNK_SIZE)
                   tempfile.write(data)

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -139,6 +139,8 @@ class Chef
 
       property :remote_password, String, sensitive: true
 
+      property :authentication, equal_to: [:remote, :local], default: :remote
+
       def after_created
         validate_identity_platform(remote_user, remote_password, remote_domain)
         identity = qualify_user(remote_user, remote_password, remote_domain)

--- a/lib/chef/util/windows/logon_session.rb
+++ b/lib/chef/util/windows/logon_session.rb
@@ -25,7 +25,7 @@ class Chef
       class LogonSession
         include Chef::Mixin::WideString
 
-        def initialize(username, password, domain = nil, logon_type)
+        def initialize(username, password, domain = nil, logon_type = :remote)
           if username.nil? || password.nil?
             raise ArgumentError, "The logon session must be initialize with non-nil user name and password parameters"
           end

--- a/lib/chef/util/windows/logon_session.rb
+++ b/lib/chef/util/windows/logon_session.rb
@@ -25,7 +25,7 @@ class Chef
       class LogonSession
         include Chef::Mixin::WideString
 
-        def initialize(username, password, domain = nil, logon_type = :remote)
+        def initialize(username, password, domain = nil, authentication = :remote)
           if username.nil? || password.nil?
             raise ArgumentError, "The logon session must be initialize with non-nil user name and password parameters"
           end
@@ -33,7 +33,7 @@ class Chef
           @original_username = username
           @original_password = password
           @original_domain = domain
-          @logon_type = logon_type
+          @authentication = authentication
           @token = FFI::Buffer.new(:pointer)
           @session_opened = false
           @impersonating = false
@@ -48,9 +48,9 @@ class Chef
           password = wstring(original_password)
           domain = wstring(original_domain)
 
-          if logon_type == :remote
+          if authentication == :remote
             status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NEW_CREDENTIALS, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
-          elsif logon_type == :local
+          elsif authentication == :local
             status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NETWORK, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
           end
 
@@ -115,7 +115,7 @@ class Chef
         attr_reader :original_username
         attr_reader :original_password
         attr_reader :original_domain
-        attr_reader :logon_type
+        attr_reader :authentication
 
         attr_reader :token
         attr_reader :session_opened

--- a/lib/chef/util/windows/logon_session.rb
+++ b/lib/chef/util/windows/logon_session.rb
@@ -48,11 +48,8 @@ class Chef
           password = wstring(original_password)
           domain = wstring(original_domain)
 
-          if authentication == :remote
-            status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NEW_CREDENTIALS, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
-          elsif authentication == :local
-            status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NETWORK, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
-          end
+          logon_type = (authentication == :local) ? (Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NETWORK) : (Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NEW_CREDENTIALS)
+          status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, logon_type, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
 
           if !status
             last_error = FFI::LastError.error

--- a/lib/chef/util/windows/logon_session.rb
+++ b/lib/chef/util/windows/logon_session.rb
@@ -25,7 +25,7 @@ class Chef
       class LogonSession
         include Chef::Mixin::WideString
 
-        def initialize(username, password, domain = nil)
+        def initialize(username, password, domain = nil, logon_type)
           if username.nil? || password.nil?
             raise ArgumentError, "The logon session must be initialize with non-nil user name and password parameters"
           end
@@ -33,6 +33,7 @@ class Chef
           @original_username = username
           @original_password = password
           @original_domain = domain
+          @logon_type = logon_type
           @token = FFI::Buffer.new(:pointer)
           @session_opened = false
           @impersonating = false
@@ -47,7 +48,11 @@ class Chef
           password = wstring(original_password)
           domain = wstring(original_domain)
 
-          status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NEW_CREDENTIALS, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
+          if logon_type == :remote
+            status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NEW_CREDENTIALS, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
+          elsif logon_type == :local
+            status = Chef::ReservedNames::Win32::API::Security.LogonUserW(username, domain, password, Chef::ReservedNames::Win32::API::Security::LOGON32_LOGON_NETWORK, Chef::ReservedNames::Win32::API::Security::LOGON32_PROVIDER_DEFAULT, token)
+          end
 
           if !status
             last_error = FFI::LastError.error
@@ -110,6 +115,7 @@ class Chef
         attr_reader :original_username
         attr_reader :original_password
         attr_reader :original_domain
+        attr_reader :logon_type
 
         attr_reader :token
         attr_reader :session_opened

--- a/lib/chef/win32/api/security.rb
+++ b/lib/chef/win32/api/security.rb
@@ -303,6 +303,17 @@ class Chef
              :SecurityDelegation,
         ]
 
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/bb530718%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
+        ELEVATION_TYPE = enum :ELEVATION_TYPE, [
+            :TokenElevationTypeDefault, 1,
+            :TokenElevationTypeFull,
+            :TokenElevationTypeLimited
+        ]
+
+        class TOKEN_ELEVATION_TYPE < FFI::Struct
+          layout :ElevationType, :ELEVATION_TYPE
+        end
+
         # SECURITY_DESCRIPTOR is an opaque structure whose contents can vary.  Pass the
         # pointer around and free it with LocalFree.
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa379561(v=vs.85).aspx

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -652,7 +652,7 @@ class Chef
           begin
             process_token = open_current_process_token(TOKEN_READ)
           rescue Exception => run_error
-            return false if run_error.message.match(/Access is denied/)
+            return false if run_error.message =~ /Access is denied/
             Chef::ReservedNames::Win32::Error.raise!
           end
 

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -350,7 +350,8 @@ class Chef
         end
         info_ptr = FFI::MemoryPointer.new(:pointer)
         token_info_pointer = TOKEN_ELEVATION_TYPE.new info_ptr
-        unless GetTokenInformation(token.handle.handle, :TokenElevationType, token_info_pointer, 4, token_result_size)
+        token_info_length = 4
+        unless GetTokenInformation(token.handle.handle, :TokenElevationType, token_info_pointer, token_info_length, token_result_size)
           Chef::ReservedNames::Win32::Error.raise!
         end
         token_info_pointer[:ElevationType]

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -647,7 +647,14 @@ class Chef
 
           true
         else
-          process_token = open_current_process_token(TOKEN_READ)
+          # a regular user doesn't have privileges to call Chef::ReservedNames::Win32::Security.OpenProcessToken
+          # hence we return false if the open_current_process_token fails with `Access is denied.` error message.
+          begin
+            process_token = open_current_process_token(TOKEN_READ)
+          rescue Exception => run_error
+            return false if run_error.message.match(/Access is denied/)
+            Chef::ReservedNames::Win32::Error.raise!
+          end
 
           # display token elevation details
           token_elevation_type = get_token_information_elevation_type(process_token)

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -341,6 +341,21 @@ class Chef
         SID.new(group_result[:PrimaryGroup], group_result_storage)
       end
 
+      def self.get_token_information_elevation_type(token)
+        token_result_size = FFI::MemoryPointer.new(:ulong)
+        if GetTokenInformation(token.handle.handle, :TokenElevationType, nil, 0, token_result_size)
+          raise "Expected ERROR_INSUFFICIENT_BUFFER from GetTokenInformation, and got no error!"
+        elsif FFI::LastError.error != ERROR_INSUFFICIENT_BUFFER
+          Chef::ReservedNames::Win32::Error.raise!
+        end
+        info_ptr = FFI::MemoryPointer.new(:pointer)
+        token_info_pointer = TOKEN_ELEVATION_TYPE.new info_ptr
+        unless GetTokenInformation(token.handle.handle, :TokenElevationType, token_info_pointer, 4, token_result_size)
+          Chef::ReservedNames::Win32::Error.raise!
+        end
+        token_info_pointer[:ElevationType]
+      end
+
       def self.initialize_acl(acl_size)
         acl = FFI::MemoryPointer.new acl_size
         unless InitializeAcl(acl, acl_size, ACL_REVISION)
@@ -633,6 +648,11 @@ class Chef
           true
         else
           process_token = open_current_process_token(TOKEN_READ)
+
+          # display token elevation details
+          token_elevation_type = get_token_information_elevation_type(process_token)
+          Chef::Log.debug("Token Elevation Type: #{token_elevation_type}")
+
           elevation_result = FFI::Buffer.new(:ulong)
           elevation_result_size = FFI::MemoryPointer.new(:uint32)
           success = GetTokenInformation(process_token.handle.handle, :TokenElevation, elevation_result, 4, elevation_result_size)

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -122,4 +122,31 @@ describe "Chef::Win32::Security", :windows_only do
       end
     end
   end
+
+  describe ".get_token_information_elevation_type" do
+    let(:token_rights) { Chef::ReservedNames::Win32::Security::TOKEN_READ }
+
+    let(:token) do
+      Chef::ReservedNames::Win32::Security.open_process_token(
+        Chef::ReservedNames::Win32::Process.get_current_process,
+        token_rights)
+    end
+
+    context "when the token is valid" do
+      let(:token_elevation_type) { [:TokenElevationTypeDefault, :TokenElevationTypeFull, :TokenElevationTypeLimited] }
+
+      it "returns the token elevation type" do
+        elevation_type = Chef::ReservedNames::Win32::Security.get_token_information_elevation_type(token)
+        expect(token_elevation_type).to include(elevation_type)
+      end
+    end
+
+    context "when the token is invalid" do
+      it "raises `handle invalid` error" do
+        # If `OpenProcessToken` is stubbed, `open_process_token` returns an invalid token
+        allow(Chef::ReservedNames::Win32::Security).to receive(:OpenProcessToken).and_return(true)
+        expect { Chef::ReservedNames::Win32::Security.get_token_information_elevation_type(token) }.to raise_error(Chef::Exceptions::Win32APIError)
+      end
+    end
+  end
 end

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -17,6 +17,8 @@
 #
 
 require "spec_helper"
+require "mixlib/shellout"
+require "chef/mixin/user_context"
 if Chef::Platform.windows?
   require "chef/win32/security"
 end
@@ -26,13 +28,37 @@ describe "Chef::Win32::Security", :windows_only do
     expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to eq(true)
   end
 
-  # We've done some investigation adding a negative test and it turned
-  # out to be a lot of work since mixlib-shellout doesn't have user
-  # support for windows.
-  #
-  # TODO - Add negative tests once mixlib-shellout has user support
-  it "has_admin_privileges? returns false when running as non-admin" do
-    skip "requires user support in mixlib-shellout"
+  describe "running as non admin user" do
+    include Chef::Mixin::UserContext
+    let(:user) { "security_user" }
+    let(:password) { "Security@123" }
+
+    let(:domain) do
+      whoami = Mixlib::ShellOut.new("whoami")
+      whoami.run_command
+      whoami.error!
+      whoami.stdout.split("\\")[0]
+    end
+    before do
+      allow_any_instance_of(Chef::Mixin::UserContext).to receive(:node).and_return({ "platform_family" => "windows" })
+      allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
+      allow(Chef::ReservedNames::Win32::Security).to receive(:OpenProcessToken).and_return(true)
+      add_user = Mixlib::ShellOut.new("net user #{user} #{password} /ADD")
+      add_user.run_command
+      add_user.error!
+    end
+
+    after do
+      delete_user = Mixlib::ShellOut.new("net user #{user} /delete")
+      delete_user.run_command
+      delete_user.error!
+    end
+    it "has_admin_privileges? returns false" do
+      has_admin_privileges = with_user_context(user, password, domain) do
+        Chef::ReservedNames::Win32::Security.has_admin_privileges?
+      end
+      expect(has_admin_privileges).to eq(false)
+    end
   end
 
   describe "get_file_security" do

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -42,7 +42,6 @@ describe "Chef::Win32::Security", :windows_only do
     before do
       allow_any_instance_of(Chef::Mixin::UserContext).to receive(:node).and_return({ "platform_family" => "windows" })
       allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
-      allow(Chef::ReservedNames::Win32::Security).to receive(:OpenProcessToken).and_return(true)
       add_user = Mixlib::ShellOut.new("net user #{user} #{password} /ADD")
       add_user.run_command
       add_user.error!
@@ -54,7 +53,7 @@ describe "Chef::Win32::Security", :windows_only do
       delete_user.error!
     end
     it "has_admin_privileges? returns false" do
-      has_admin_privileges = with_user_context(user, password, domain) do
+      has_admin_privileges = with_user_context(user, password, domain, :local) do
         Chef::ReservedNames::Win32::Security.has_admin_privileges?
       end
       expect(has_admin_privileges).to eq(false)

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -39,6 +39,7 @@ describe "Chef::Win32::Security", :windows_only do
       whoami.error!
       whoami.stdout.split("\\")[0]
     end
+
     before do
       allow_any_instance_of(Chef::Mixin::UserContext).to receive(:node).and_return({ "platform_family" => "windows" })
       allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)

--- a/spec/unit/util/windows/logon_session_spec.rb
+++ b/spec/unit/util/windows/logon_session_spec.rb
@@ -27,7 +27,8 @@ describe ::Chef::Util::Windows::LogonSession do
     stub_const("Chef::ReservedNames::Win32::API::System", Class.new )
   end
 
-  let(:session) { ::Chef::Util::Windows::LogonSession.new(session_user, password, session_domain) }
+  let(:session) { ::Chef::Util::Windows::LogonSession.new(session_user, password, session_domain, logon_type) }
+  let(:logon_type) { :remote }
 
   shared_examples_for "it received syntactically invalid credentials" do
     it "does not raisees an exception when it is initialized" do

--- a/spec/unit/util/windows/logon_session_spec.rb
+++ b/spec/unit/util/windows/logon_session_spec.rb
@@ -27,8 +27,8 @@ describe ::Chef::Util::Windows::LogonSession do
     stub_const("Chef::ReservedNames::Win32::API::System", Class.new )
   end
 
-  let(:session) { ::Chef::Util::Windows::LogonSession.new(session_user, password, session_domain, logon_type) }
-  let(:logon_type) { :remote }
+  let(:session) { ::Chef::Util::Windows::LogonSession.new(session_user, password, session_domain, authentication) }
+  let(:authentication) { :remote }
 
   shared_examples_for "it received syntactically invalid credentials" do
     it "does not raisees an exception when it is initialized" do

--- a/spec/unit/win32/security_spec.rb
+++ b/spec/unit/win32/security_spec.rb
@@ -63,4 +63,19 @@ describe "Chef::Win32::Security", :windows_only do
       end
     end
   end
+
+  describe "self.get_token_information_elevation_type" do
+    let(:token_rights) { Chef::ReservedNames::Win32::Security::TOKEN_READ }
+
+    let(:token) do
+      Chef::ReservedNames::Win32::Security.open_process_token(
+        Chef::ReservedNames::Win32::Process.get_current_process,
+        token_rights)
+    end
+
+    it "raises error if GetTokenInformation fails" do
+      allow(Chef::ReservedNames::Win32::Security).to receive(:GetTokenInformation).and_return(false)
+      expect { Chef::ReservedNames::Win32::Security.get_token_information_elevation_type(token) }.to raise_error(Chef::Exceptions::Win32APIError)
+    end
+  end
 end

--- a/spec/unit/win32/security_spec.rb
+++ b/spec/unit/win32/security_spec.rb
@@ -64,6 +64,42 @@ describe "Chef::Win32::Security", :windows_only do
     end
   end
 
+  describe "self.has_admin_privileges?" do
+    it "returns true for windows server 2003" do
+      allow(Chef::Platform).to receive(:windows_server_2003?).and_return(true)
+      expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to be true
+    end
+
+    context "when the user doesn't have admin privileges" do
+      it "returns false" do
+        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
+        allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token).and_raise("Access is denied.")
+        expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to be false
+      end
+    end
+
+    context "when open_current_process_token fails with some other error than `Access is Denied`" do
+      it "raises error" do
+        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
+        allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token).and_raise("boom")
+        expect { Chef::ReservedNames::Win32::Security.has_admin_privileges? }.to raise_error(Chef::Exceptions::Win32APIError)
+      end
+    end
+
+    context "when the user has admin privileges" do
+      it "returns true" do
+        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
+        allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token)
+        token = Chef::ReservedNames::Win32::Security.open_current_process_token
+        allow(token).to receive_message_chain(:handle, :handle)
+        allow(Chef::ReservedNames::Win32::Security).to receive(:get_token_information_elevation_type)
+        allow(Chef::ReservedNames::Win32::Security).to receive(:GetTokenInformation).and_return(true)
+        allow_any_instance_of(FFI::Buffer).to receive(:read_ulong).and_return(1)
+        expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to be true
+      end
+    end
+  end
+
   describe "self.get_token_information_elevation_type" do
     let(:token_rights) { Chef::ReservedNames::Win32::Security::TOKEN_READ }
 


### PR DESCRIPTION
### Description

While finishing https://github.com/chef/chef/pull/5832,  we changed the logon type in `Chef::Util::Windows::LogonSession` from `LOGON32_LOGON_NETWORK` to `LOGON32_LOGON_NEW_CREDENTIALS` to facilitate passing credentials to a remote system without logging in locally using those credentials, to handle a use case where those credentials were valid on the remote system but not on the local system.
However, this means that `Chef::Mixin::UserContext.with_user_context` might log on to the local system as a new user but continue using the old users token and thus the old/original users privileges.
`Chef::ReservedNames::Win32::Security.has_admin_privileges?` is really looking to see if we're elevated, not 'admin' per se. We should print some debug information about the token like if it is elevated. With this information you'll see that when we run chef from an elevated shell, we still have an elevated token even if we run `has_admin_privileges?` from inside `with_user_context` using a regular user.
The above functionality was masked by this line in the before block in ```spec\functional\win32\security_spec.rb:
allow(Chef::ReservedNames::Win32::Security).to receive(:OpenProcessToken).and_return(true)```
This caused the 'running as non admin user' test to pass even though it should fail. Fixing this might be hard, because a regular user cannot use much of the functionality in `has_admin_privileges`, maybe not even calling `open_current_process_token`. One solution might be catching the access denied results and returning false, presuming that if we get an access denied in this area then we aren't elevated.

Note that we reverted the functional tests in https://github.com/chef/chef/pull/6588 due odd behavior on Appveyor.

### Acceptance Criteria

- [x] able to run a ruby block with only the privileges of another user, while preserving the functionality needed by remote_file.
- [x] `Chef::ReservedNames::Win32::Security.has_admin_privileges?` prints a debug message that contains token elevation information.
- [x] The Chef::Win32::Security functional test for running as a non-admin user that was reverted is returned and does not return a false positive.
- [x] The functional tests pass on appveyor or we have a documented reason to exclude them on appveyor. 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
