### PR TITLE
Fix windows_task resource not being idempotent for random_delay and execution_time_limit

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -251,9 +251,9 @@ class Chef
       def random_delay_updated?
         if new_resource.random_delay.nil?
           false
-        elsif current_resource.random_delay.nil? &&  new_resource.random_delay == "PT0S" # when user sets random_dealy to 0 sec
+        elsif current_resource.random_delay.nil? && new_resource.random_delay == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.random_delay.nil?  && !new_resource.random_delay.nil?
+        elsif current_resource.random_delay.nil? && !new_resource.random_delay.nil?
           true
         else
           ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
@@ -264,9 +264,9 @@ class Chef
       def execution_time_limit_updated?
         if new_resource.execution_time_limit.nil?
           false
-        elsif current_resource.execution_time_limit.nil? &&  new_resource.execution_time_limit == "PT0S" # when user sets random_dealy to 0 sec
+        elsif current_resource.execution_time_limit.nil? && new_resource.execution_time_limit == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.execution_time_limit.nil?  && !new_resource.execution_time_limit.nil?
+        elsif current_resource.execution_time_limit.nil? && !new_resource.execution_time_limit.nil?
           true
         else
           ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -229,8 +229,8 @@ class Chef
             current_resource.frequency_modifier != new_resource.frequency_modifier ||
             current_resource.frequency != new_resource.frequency ||
             current_resource.idle_time != new_resource.idle_time ||
-            current_resource.random_delay != new_resource.random_delay ||
-            !new_resource.execution_time_limit.include?(current_resource.execution_time_limit) ||
+            random_delay_updated? ||
+            execution_time_limit_updated? ||
             (new_resource.start_day && new_resource.start_day != "N/A" && start_day_updated?) ||
             (new_resource.start_time && new_resource.start_time != "N/A" && start_time_updated?)
         begin
@@ -241,6 +241,20 @@ class Chef
         end
 
         false
+      end
+
+      def random_delay_updated?
+        return false if current_resource.random_delay.nil? && new_resource.random_delay.nil?
+        return true if new_resource.random_delay.nil?
+        current_resource.random_delay = 0 if current_resource.random_delay.nil?
+        ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
+      end
+
+      def execution_time_limit_updated?
+        return false if current_resource.execution_time_limit.nil? && new_resource.execution_time_limit.nil?
+        return true if new_resource.execution_time_limit.nil?
+        current_resource.execution_time_limit = 0 if current_resource.execution_time_limit.nil?
+        ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)
       end
 
       def start_day_updated?

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -251,9 +251,9 @@ class Chef
       def random_delay_updated?
         if new_resource.random_delay.nil?
           false
-        elsif current_resource.random_delay.nil? &&  new_resource.random_delay == 'PT0S' # when user sets random_dealy to 0 sec
+        elsif current_resource.random_delay.nil? &&  new_resource.random_delay == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.random_delay.nil?  && new_resource.random_delay != nil
+        elsif current_resource.random_delay.nil?  && !new_resource.random_delay.nil?
           true
         else
           ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
@@ -264,9 +264,9 @@ class Chef
       def execution_time_limit_updated?
         if new_resource.execution_time_limit.nil?
           false
-        elsif current_resource.execution_time_limit.nil? &&  new_resource.execution_time_limit == 'PT0S' # when user sets random_dealy to 0 sec
+        elsif current_resource.execution_time_limit.nil? &&  new_resource.execution_time_limit == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.execution_time_limit.nil?  && new_resource.execution_time_limit != nil
+        elsif current_resource.execution_time_limit.nil?  && !new_resource.execution_time_limit.nil?
           true
         else
           ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -253,7 +253,7 @@ class Chef
           false
         elsif current_resource.random_delay.nil? && new_resource.random_delay == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.random_delay.nil? && !new_resource.random_delay.nil?
+        elsif current_resource.random_delay.nil?
           true
         else
           ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
@@ -266,7 +266,7 @@ class Chef
           false
         elsif current_resource.execution_time_limit.nil? && new_resource.execution_time_limit == "PT0S" # when user sets random_dealy to 0 sec
           false
-        elsif current_resource.execution_time_limit.nil? && !new_resource.execution_time_limit.nil?
+        elsif current_resource.execution_time_limit.nil?
           true
         else
           ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -229,8 +229,7 @@ class Chef
             current_resource.frequency_modifier != new_resource.frequency_modifier ||
             current_resource.frequency != new_resource.frequency ||
             current_resource.idle_time != new_resource.idle_time ||
-            random_delay_updated? ||
-            execution_time_limit_updated? ||
+            random_delay_updated? || execution_time_limit_updated? ||
             (new_resource.start_day && new_resource.start_day != "N/A" && start_day_updated?) ||
             (new_resource.start_time && new_resource.start_time != "N/A" && start_time_updated?)
         begin
@@ -243,18 +242,35 @@ class Chef
         false
       end
 
+      # Comparing random_delay values using ISO8601::Duration object Ref: https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
+      # di = ISO8601::Duration.new(65707200)
+      # ds = ISO8601::Duration.new('P65707200S')
+      # dp = ISO8601::Duration.new('P2Y1MT2H')
+      # di == dp # => true
+      # di == ds # => true
       def random_delay_updated?
-        return false if current_resource.random_delay.nil? && new_resource.random_delay.nil?
-        return true if new_resource.random_delay.nil?
-        current_resource.random_delay = 0 if current_resource.random_delay.nil?
-        ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
+        if new_resource.random_delay.nil?
+          false
+        elsif current_resource.random_delay.nil? &&  new_resource.random_delay == 'PT0S' # when user sets random_dealy to 0 sec
+          false
+        elsif current_resource.random_delay.nil?  && new_resource.random_delay != nil
+          true
+        else
+          ISO8601::Duration.new(current_resource.random_delay) != ISO8601::Duration.new(new_resource.random_delay)
+        end
       end
 
+      # Comparing execution_time_limit values using Ref: https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
       def execution_time_limit_updated?
-        return false if current_resource.execution_time_limit.nil? && new_resource.execution_time_limit.nil?
-        return true if new_resource.execution_time_limit.nil?
-        current_resource.execution_time_limit = 0 if current_resource.execution_time_limit.nil?
-        ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)
+        if new_resource.execution_time_limit.nil?
+          false
+        elsif current_resource.execution_time_limit.nil? &&  new_resource.execution_time_limit == 'PT0S' # when user sets random_dealy to 0 sec
+          false
+        elsif current_resource.execution_time_limit.nil?  && new_resource.execution_time_limit != nil
+          true
+        else
+          ISO8601::Duration.new(current_resource.execution_time_limit) != ISO8601::Duration.new(new_resource.execution_time_limit)
+        end
       end
 
       def start_day_updated?

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -205,11 +205,12 @@ class Chef
         end
       end
 
-      # Convert the number of seconds to an ISO8601 duration format
-      # @see http://tools.ietf.org/html/rfc2445#section-4.3.6
-      # @param [Integer] seconds The amount of seconds for this duration
+      # Converts the number of seconds to an ISO8601 duration format
+      # Ref : https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
+      # dur = ISO8601::Duration.new(65707200)
+      # dur => 'P65707200S'
       def sec_to_dur(seconds)
-        dur = seconds.to_i == 0 ? nil : ISO8601::Duration.new(seconds.to_i).to_s
+        dur = ISO8601::Duration.new(seconds.to_i).to_s
       end
 
     end

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -205,12 +205,13 @@ class Chef
         end
       end
 
-      # Converts the number of seconds to an ISO8601 duration format
+      # Converts the number of seconds to an ISO8601 duration format and returns it.
       # Ref : https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
-      # dur = ISO8601::Duration.new(65707200)
-      # dur => 'P65707200S'
+      # e.g.
+      # ISO8601::Duration.new(65707200)
+      # returns 'P65707200S'
       def sec_to_dur(seconds)
-        dur = ISO8601::Duration.new(seconds.to_i).to_s
+        ISO8601::Duration.new(seconds.to_i).to_s
       end
 
     end

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -209,34 +209,7 @@ class Chef
       # @see http://tools.ietf.org/html/rfc2445#section-4.3.6
       # @param [Integer] seconds The amount of seconds for this duration
       def sec_to_dur(seconds)
-        seconds = seconds.to_i
-        iso_str = "P"
-        if seconds > 604_800 # more than a week
-          weeks = seconds / 604_800
-          seconds -= (604_800 * weeks)
-          iso_str << "#{weeks}W"
-        end
-        if seconds > 86_400 # more than a day
-          days = seconds / 86_400
-          seconds -= (86_400 * days)
-          iso_str << "#{days}D"
-        end
-        if seconds >= 0
-          iso_str << "T"
-          if seconds > 3600 # more than an hour
-            hours = seconds / 3600
-            seconds -= (3600 * hours)
-            iso_str << "#{hours}H"
-          end
-          if seconds > 60 # more than a minute
-            minutes = seconds / 60
-            seconds -= (60 * minutes)
-            iso_str << "#{minutes}M"
-          end
-          iso_str << "#{seconds}S"
-        end
-
-        iso_str
+        dur = seconds.to_i == 0 ? nil : ISO8601::Duration.new(seconds.to_i).to_s
       end
 
     end

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -636,39 +636,39 @@ describe Chef::Provider::WindowsTask do
       task_hash[:random_delay] = nil
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.random_delay = 'PT0S'
+      new_resource.random_delay = "PT0S"
       expect(provider.send(:random_delay_updated?)).to be(false)
     end
 
     it "returns false if current_resource.random_delay = 'P7D' & random_delay is set to '604800' seconds " do
-      task_hash[:random_delay] = 'P7D'
+      task_hash[:random_delay] = "P7D"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.random_delay = 'PT604800S'
+      new_resource.random_delay = "PT604800S"
       expect(provider.send(:random_delay_updated?)).to be(false)
     end
 
     it "returns false if current_resource.random_delay = 'P7DT1S' & random_delay is set to '604801' seconds" do
-      task_hash[:random_delay] = 'P7DT1S'
+      task_hash[:random_delay] = "P7DT1S"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.random_delay = 'PT604801S'
+      new_resource.random_delay = "PT604801S"
       expect(provider.send(:random_delay_updated?)).to be(false)
     end
 
     it "returns true if current_resource.random_delay = 'PT1S' & random_delay is set to '3600' seconds" do
-      task_hash[:random_delay] = 'PT1S'
+      task_hash[:random_delay] = "PT1S"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.random_delay = 'PT3600S'
+      new_resource.random_delay = "PT3600S"
       expect(provider.send(:random_delay_updated?)).to be(true)
     end
 
     it "returns false if current_resource.random_delay = 'P2Y1MT2H' & random_delay is set to '65707200' seconds" do
-      task_hash[:random_delay] = 'P2Y1MT2H'
+      task_hash[:random_delay] = "P2Y1MT2H"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.random_delay = 'PT65707200S'
+      new_resource.random_delay = "PT65707200S"
       expect(provider.send(:random_delay_updated?)).to be(false)
     end
   end
@@ -683,34 +683,34 @@ describe Chef::Provider::WindowsTask do
     end
 
     it "returns false if current_resource.execution_time_limit = 'P7D' & execution_time_limit is set to 604800 seconds " do
-      task_hash[:execution_time_limit] = 'P7D'
+      task_hash[:execution_time_limit] = "P7D"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.execution_time_limit = 'PT604800S'
+      new_resource.execution_time_limit = "PT604800S"
       expect(provider.send(:execution_time_limit_updated?)).to be(false)
     end
 
     it "returns false if current_resource.execution_time_limit = 'P7DT1S' & execution_time_limit is set to 604801 seconds" do
-      task_hash[:execution_time_limit] = 'P7DT1S'
+      task_hash[:execution_time_limit] = "P7DT1S"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.execution_time_limit = 'PT604801S'
+      new_resource.execution_time_limit = "PT604801S"
       expect(provider.send(:execution_time_limit_updated?)).to be(false)
     end
 
     it "returns true if current_resource.execution_time_limit = 'PT1S' & execution_time_limit is set to '3600' seconds" do
-      task_hash[:execution_time_limit] = 'PT1S'
+      task_hash[:execution_time_limit] = "PT1S"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.execution_time_limit = 'PT3600S'
+      new_resource.execution_time_limit = "PT3600S"
       expect(provider.send(:execution_time_limit_updated?)).to be(true)
     end
 
     it "returns false if current_resource.execution_time_limit = 'P2Y1MT2H' & execution_time_limit is set to '65707200' seconds" do
-      task_hash[:execution_time_limit] = 'P2Y1MT2H'
+      task_hash[:execution_time_limit] = "P2Y1MT2H"
       allow(provider).to receive(:load_task_hash).and_return(task_hash)
       provider.load_current_resource
-      new_resource.execution_time_limit = 'PT65707200S'
+      new_resource.execution_time_limit = "PT65707200S"
       expect(provider.send(:execution_time_limit_updated?)).to be(false)
     end
   end

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -620,4 +620,98 @@ describe Chef::Provider::WindowsTask do
       expect(provider.send(:frequency_modifier_allowed)).to be(false)
     end
   end
+
+  # In windows_task resource sec_to_dur method converts seconds to duration in format 60 == 'PT60S'
+  # random_delay_updated? method use the value return by sec_to_dur as input for comparison for new_resource.random_delay mocking the same here
+  describe "#random_delay_updated?" do
+    before do
+      new_resource.command "chef-client"
+      new_resource.run_level :highest
+      new_resource.frequency :minute
+      new_resource.frequency_modifier 15
+      new_resource.user "SYSTEM"
+    end
+
+    it "returns false if current_resource.random_delay = nil & random_delay is set to '0' seconds" do
+      task_hash[:random_delay] = nil
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.random_delay = 'PT0S'
+      expect(provider.send(:random_delay_updated?)).to be(false)
+    end
+
+    it "returns false if current_resource.random_delay = 'P7D' & random_delay is set to '604800' seconds " do
+      task_hash[:random_delay] = 'P7D'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.random_delay = 'PT604800S'
+      expect(provider.send(:random_delay_updated?)).to be(false)
+    end
+
+    it "returns false if current_resource.random_delay = 'P7DT1S' & random_delay is set to '604801' seconds" do
+      task_hash[:random_delay] = 'P7DT1S'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.random_delay = 'PT604801S'
+      expect(provider.send(:random_delay_updated?)).to be(false)
+    end
+
+    it "returns true if current_resource.random_delay = 'PT1S' & random_delay is set to '3600' seconds" do
+      task_hash[:random_delay] = 'PT1S'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.random_delay = 'PT3600S'
+      expect(provider.send(:random_delay_updated?)).to be(true)
+    end
+
+    it "returns false if current_resource.random_delay = 'P2Y1MT2H' & random_delay is set to '65707200' seconds" do
+      task_hash[:random_delay] = 'P2Y1MT2H'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.random_delay = 'PT65707200S'
+      expect(provider.send(:random_delay_updated?)).to be(false)
+    end
+  end
+
+  describe "#execution_time_limit_updated?" do
+    before do
+      new_resource.command "chef-client"
+      new_resource.run_level :highest
+      new_resource.frequency :minute
+      new_resource.frequency_modifier 15
+      new_resource.user "SYSTEM"
+    end
+
+    it "returns false if current_resource.execution_time_limit = 'P7D' & execution_time_limit is set to 604800 seconds " do
+      task_hash[:execution_time_limit] = 'P7D'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.execution_time_limit = 'PT604800S'
+      expect(provider.send(:execution_time_limit_updated?)).to be(false)
+    end
+
+    it "returns false if current_resource.execution_time_limit = 'P7DT1S' & execution_time_limit is set to 604801 seconds" do
+      task_hash[:execution_time_limit] = 'P7DT1S'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.execution_time_limit = 'PT604801S'
+      expect(provider.send(:execution_time_limit_updated?)).to be(false)
+    end
+
+    it "returns true if current_resource.execution_time_limit = 'PT1S' & execution_time_limit is set to '3600' seconds" do
+      task_hash[:execution_time_limit] = 'PT1S'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.execution_time_limit = 'PT3600S'
+      expect(provider.send(:execution_time_limit_updated?)).to be(true)
+    end
+
+    it "returns false if current_resource.execution_time_limit = 'P2Y1MT2H' & execution_time_limit is set to '65707200' seconds" do
+      task_hash[:execution_time_limit] = 'P2Y1MT2H'
+      allow(provider).to receive(:load_task_hash).and_return(task_hash)
+      provider.load_current_resource
+      new_resource.execution_time_limit = 'PT65707200S'
+      expect(provider.send(:execution_time_limit_updated?)).to be(false)
+    end
+  end
 end

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -282,7 +282,7 @@ describe Chef::Resource::WindowsTask do
 
   context "#sec_to_dur" do
     it "return nil when passed 0" do
-      expect(resource.send(:sec_to_dur, 0)).to eql(nil)
+      expect(resource.send(:sec_to_dur, 0)).to eql('PT0S')
     end
     it "return PT1S when passed 1" do
       expect(resource.send(:sec_to_dur, 1)).to eql("PT1S")

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -281,23 +281,23 @@ describe Chef::Resource::WindowsTask do
   end
 
   context "#sec_to_dur" do
-    it "return PT0S when passed 0" do
-      expect(resource.send(:sec_to_dur, 0)).to eql("PT0S")
+    it "return nil when passed 0" do
+      expect(resource.send(:sec_to_dur, 0)).to eql(nil)
     end
     it "return PT1S when passed 1" do
       expect(resource.send(:sec_to_dur, 1)).to eql("PT1S")
     end
-    it "return PT24H0S when passed 86400" do
-      expect(resource.send(:sec_to_dur, 86400)).to eql("PT24H0S")
+    it "return PT86400S when passed 86400" do
+      expect(resource.send(:sec_to_dur, 86400)).to eql("PT86400S")
     end
-    it "return P1DT1S when passed 86401" do
-      expect(resource.send(:sec_to_dur, 86401)).to eql("P1DT1S")
+    it "return PT86401S when passed 86401" do
+      expect(resource.send(:sec_to_dur, 86401)).to eql("PT86401S")
     end
-    it "return P1DT1M40S when passed 86500" do
-      expect(resource.send(:sec_to_dur, 86500)).to eql("P1DT1M40S")
+    it "return PT86500S when passed 86500" do
+      expect(resource.send(:sec_to_dur, 86500)).to eql("PT86500S")
     end
-    it "return P1WT1S when passed 604801" do
-      expect(resource.send(:sec_to_dur, 604801)).to eql("P1WT1S")
+    it "return PT604801S when passed 604801" do
+      expect(resource.send(:sec_to_dur, 604801)).to eql("PT604801S")
     end
   end
 end

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -282,7 +282,7 @@ describe Chef::Resource::WindowsTask do
 
   context "#sec_to_dur" do
     it "return nil when passed 0" do
-      expect(resource.send(:sec_to_dur, 0)).to eql('PT0S')
+      expect(resource.send(:sec_to_dur, 0)).to eql("PT0S")
     end
     it "return PT1S when passed 1" do
       expect(resource.send(:sec_to_dur, 1)).to eql("PT1S")


### PR DESCRIPTION
windows_task resource is not idempotent for random_delay and execution_time_limit property
```
windows_task 'chef-client 5' do
  command 'chef-client'
  run_level :highest
  frequency :weekly
  frequency_modifier 3
  random_delay '60'
  day 'Mon'
end
```

```
windows_task 'chef-client 5' do
  command 'chef-client'
  run_level :highest
  frequency :weekly
  frequency_modifier 3
  execution_time_limit '60'
  day 'Mon'
end
```
#6638 partially fixed because if day is not set the resource is still not idempotent for day. We will address this issue in different PR.
 
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>
