### PR TITLE
Cleanup to some of the resource specs

### DIFF
--- a/spec/unit/resource/apt_package_spec.rb
+++ b/spec/unit/resource/apt_package_spec.rb
@@ -31,7 +31,7 @@ describe Chef::Resource::AptPackage, "initialize" do
 
   let(:resource) { Chef::Resource::AptPackage.new("foo") }
 
-  it "should support default_release" do
+  it "supports default_release" do
     resource.default_release("lenny-backports")
     expect(resource.default_release).to eql("lenny-backports")
   end

--- a/spec/unit/resource/bash_spec.rb
+++ b/spec/unit/resource/bash_spec.rb
@@ -20,21 +20,19 @@ require "spec_helper"
 
 describe Chef::Resource::Bash do
 
-  before(:each) do
-    @resource = Chef::Resource::Bash.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Bash.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Bash" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Bash)
   end
 
-  it "should create a new Chef::Resource::Bash" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Bash)
+  it "has a resource name of :bash" do
+    expect(resource.resource_name).to eql(:bash)
   end
 
-  it "should have a resource name of :bash" do
-    expect(@resource.resource_name).to eql(:bash)
-  end
-
-  it "should have an interpreter of bash" do
-    expect(@resource.interpreter).to eql("bash")
+  it "has an interpreter of bash" do
+    expect(resource.interpreter).to eql("bash")
   end
 
 end

--- a/spec/unit/resource/batch_spec.rb
+++ b/spec/unit/resource/batch_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Resource::Batch do
 
   end
 
-  it "should create a new Chef::Resource::Batch" do
+  it "creates a new Chef::Resource::Batch" do
     expect(@resource).to be_a_kind_of(Chef::Resource::Batch)
   end
 

--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -34,15 +34,15 @@ end
 describe Chef::Resource::ChefGem, "gem_binary" do
   let(:resource) { Chef::Resource::ChefGem.new("foo") }
 
-  it "should raise an exception when gem_binary is set" do
+  it "raises an exception when gem_binary is set" do
     expect { resource.gem_binary("/lol/cats/gem") }.to raise_error(ArgumentError)
   end
 
-  it "should set the gem_binary based on computing it from RbConfig" do
+  it "sets the gem_binary based on computing it from RbConfig" do
     expect(resource.gem_binary).to eql("#{RbConfig::CONFIG['bindir']}/gem")
   end
 
-  it "should set compile_time to false by default" do
+  it "sets compile_time to false by default" do
     expect(resource.compile_time).to be false
   end
 

--- a/spec/unit/resource/chocolatey_package_spec.rb
+++ b/spec/unit/resource/chocolatey_package_spec.rb
@@ -22,50 +22,50 @@ describe Chef::Resource::ChocolateyPackage do
 
   let(:resource) { Chef::Resource::ChocolateyPackage.new("fakey_fakerton") }
 
-  it "should create a new Chef::Resource::ChocolateyPackage" do
+  it "creates a new Chef::Resource::ChocolateyPackage" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
     expect(resource).to be_a_instance_of(Chef::Resource::ChocolateyPackage)
   end
 
-  it "should have a resource name of :python" do
+  it "has a resource name of :python" do
     expect(resource.resource_name).to eql(:chocolatey_package)
   end
 
-  it "should coerce its name to a package_name array" do
+  it "coerces its name to a package_name array" do
     expect(resource.package_name).to eql(["fakey_fakerton"])
   end
 
-  it "the package_name setter should coerce to arrays" do
+  it "the package_name setter coerces to arrays" do
     resource.package_name("git")
     expect(resource.package_name).to eql(["git"])
   end
 
-  it "the package_name setter should accept arrays" do
+  it "the package_name setter accepts arrays" do
     resource.package_name(%w{git unzip})
     expect(resource.package_name).to eql(%w{git unzip})
   end
 
-  it "the name should accept arrays" do
+  it "the name accepts arrays" do
     resource = Chef::Resource::ChocolateyPackage.new(%w{git unzip})
     expect(resource.package_name).to eql(%w{git unzip})
   end
 
-  it "the default version should be nil" do
+  it "the default version is nil" do
     expect(resource.version).to eql(nil)
   end
 
-  it "the version setter should coerce to arrays" do
+  it "the version setter coerces to arrays" do
     resource.version("1.2.3")
     expect(resource.version).to eql(["1.2.3"])
   end
 
-  it "the version setter should accept arrays" do
+  it "the version setter accepts arrays" do
     resource.version(["1.2.3", "4.5.6"])
     expect(resource.version).to eql(["1.2.3", "4.5.6"])
   end
 
-  it "the default returns should be 0" do
+  it "the default returns is 0" do
     expect(resource.returns).to eql([0])
   end
 

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -99,7 +99,7 @@ describe Chef::Resource::Conditional do
         expect(@conditional.continue?).to be_falsey
       end
 
-      it "should log a warning" do
+      it "logs a warning" do
         expect(Chef::Log).to receive(:warn).with("Command 'false' timed out")
         @conditional.continue?
       end
@@ -202,7 +202,7 @@ describe Chef::Resource::Conditional do
         expect(@conditional.continue?).to be_truthy
       end
 
-      it "should log a warning" do
+      it "logs a warning" do
         expect(Chef::Log).to receive(:warn).with("Command 'false' timed out")
         @conditional.continue?
       end

--- a/spec/unit/resource/cron_spec.rb
+++ b/spec/unit/resource/cron_spec.rb
@@ -20,157 +20,154 @@
 require "spec_helper"
 
 describe Chef::Resource::Cron do
+  let(:resource) { Chef::Resource::Cron.new("cronify") }
 
-  before(:each) do
-    @resource = Chef::Resource::Cron.new("cronify")
+  it "creates a new Chef::Resource::Cron" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Cron)
   end
 
-  it "should create a new Chef::Resource::Cron" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Cron)
+  it "has a name property" do
+    expect(resource.name).to eql("cronify")
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("cronify")
+  it "has a default action of [:create]" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "should have a default action of 'create'" do
-    expect(@resource.action).to eql([:create])
+  it "accepts create or delete for action" do
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :lolcat }.to raise_error(ArgumentError)
   end
 
-  it "should accept create or delete for action" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :delete }.not_to raise_error
-    expect { @resource.action :lolcat }.to raise_error(ArgumentError)
+  it "allows you to set a command" do
+    resource.command "/bin/true"
+    expect(resource.command).to eql("/bin/true")
   end
 
-  it "should allow you to set a command" do
-    @resource.command "/bin/true"
-    expect(@resource.command).to eql("/bin/true")
+  it "allows you to set a user" do
+    resource.user "daemon"
+    expect(resource.user).to eql("daemon")
   end
 
-  it "should allow you to set a user" do
-    @resource.user "daemon"
-    expect(@resource.user).to eql("daemon")
+  it "allows you to specify the minute" do
+    resource.minute "30"
+    expect(resource.minute).to eql("30")
   end
 
-  it "should allow you to specify the minute" do
-    @resource.minute "30"
-    expect(@resource.minute).to eql("30")
+  it "allows you to specify the hour" do
+    resource.hour "6"
+    expect(resource.hour).to eql("6")
   end
 
-  it "should allow you to specify the hour" do
-    @resource.hour "6"
-    expect(@resource.hour).to eql("6")
+  it "allows you to specify the day" do
+    resource.day "10"
+    expect(resource.day).to eql("10")
   end
 
-  it "should allow you to specify the day" do
-    @resource.day "10"
-    expect(@resource.day).to eql("10")
+  it "allows you to specify the month" do
+    resource.month "10"
+    expect(resource.month).to eql("10")
   end
 
-  it "should allow you to specify the month" do
-    @resource.month "10"
-    expect(@resource.month).to eql("10")
+  it "allows you to specify the weekday" do
+    resource.weekday "2"
+    expect(resource.weekday).to eql("2")
   end
 
-  it "should allow you to specify the weekday" do
-    @resource.weekday "2"
-    expect(@resource.weekday).to eql("2")
+  it "allows you to specify the mailto variable" do
+    resource.mailto "test@example.com"
+    expect(resource.mailto).to eql("test@example.com")
   end
 
-  it "should allow you to specify the mailto variable" do
-    @resource.mailto "test@example.com"
-    expect(@resource.mailto).to eql("test@example.com")
+  it "allows you to specify the path" do
+    resource.path "/usr/bin:/usr/sbin"
+    expect(resource.path).to eql("/usr/bin:/usr/sbin")
   end
 
-  it "should allow you to specify the path" do
-    @resource.path "/usr/bin:/usr/sbin"
-    expect(@resource.path).to eql("/usr/bin:/usr/sbin")
+  it "allows you to specify the home directory" do
+    resource.home "/root"
+    expect(resource.home).to eql("/root")
   end
 
-  it "should allow you to specify the home directory" do
-    @resource.home "/root"
-    expect(@resource.home).to eql("/root")
+  it "allows you to specify the shell to run the command with" do
+    resource.shell "/bin/zsh"
+    expect(resource.shell).to eql("/bin/zsh")
   end
 
-  it "should allow you to specify the shell to run the command with" do
-    @resource.shell "/bin/zsh"
-    expect(@resource.shell).to eql("/bin/zsh")
-  end
-
-  it "should allow you to specify environment variables hash" do
+  it "allows you to specify environment variables hash" do
     env = { "TEST" => "LOL" }
-    @resource.environment env
-    expect(@resource.environment).to eql(env)
+    resource.environment env
+    expect(resource.environment).to eql(env)
   end
 
-  it "should allow * for all time and date values" do
+  it "allows * for all time and date values" do
     %w{minute hour day month weekday}.each do |x|
-      expect(@resource.send(x, "*")).to eql("*")
+      expect(resource.send(x, "*")).to eql("*")
     end
   end
 
-  it "should allow ranges for all time and date values" do
+  it "allows ranges for all time and date values" do
     %w{minute hour day month weekday}.each do |x|
-      expect(@resource.send(x, "1-2,5")).to eql("1-2,5")
+      expect(resource.send(x, "1-2,5")).to eql("1-2,5")
     end
   end
 
-  it "should have a default value of * for all time and date values" do
+  it "has a default value of * for all time and date values" do
     %w{minute hour day month weekday}.each do |x|
-      expect(@resource.send(x)).to eql("*")
+      expect(resource.send(x)).to eql("*")
     end
   end
 
-  it "should have a default value of root for the user" do
-    expect(@resource.user).to eql("root")
+  it "has a default value of root for the user" do
+    expect(resource.user).to eql("root")
   end
 
-  it "should reject any minute over 59" do
-    expect { @resource.minute "60" }.to raise_error(RangeError)
+  it "rejects any minute over 59" do
+    expect { resource.minute "60" }.to raise_error(RangeError)
   end
 
-  it "should reject any hour over 23" do
-    expect { @resource.hour "24" }.to raise_error(RangeError)
+  it "rejects any hour over 23" do
+    expect { resource.hour "24" }.to raise_error(RangeError)
   end
 
-  it "should reject any day over 31" do
-    expect { @resource.day "32" }.to raise_error(RangeError)
+  it "rejects any day over 31" do
+    expect { resource.day "32" }.to raise_error(RangeError)
   end
 
-  it "should reject any month over 12" do
-    expect { @resource.month "13" }.to raise_error(RangeError)
+  it "rejects any month over 12" do
+    expect { resource.month "13" }.to raise_error(RangeError)
   end
 
   describe "weekday" do
-    it "should reject any weekday over 7" do
-      expect { @resource.weekday "8" }.to raise_error(RangeError)
+    it "rejects any weekday over 7" do
+      expect { resource.weekday "8" }.to raise_error(RangeError)
     end
-    it "should reject any symbols which don't represent day of week" do
-      expect { @resource.weekday :foo }.to raise_error(RangeError)
+    it "rejects any symbols which don't represent day of week" do
+      expect { resource.weekday :foo }.to raise_error(RangeError)
     end
   end
 
-  it "should convert integer schedule values to a string" do
+  it "converts integer schedule values to a string" do
     %w{minute hour day month weekday}.each do |x|
-      expect(@resource.send(x, 5)).to eql("5")
+      expect(resource.send(x, 5)).to eql("5")
     end
   end
 
   describe "when it has a time (minute, hour, day, month, weeekend) and user" do
     before do
-      @resource.command("tackle")
-      @resource.minute("1")
-      @resource.hour("2")
-      @resource.day("3")
-      @resource.month("4")
-      @resource.weekday("5")
-      @resource.user("root")
+      resource.command("tackle")
+      resource.minute("1")
+      resource.hour("2")
+      resource.day("3")
+      resource.month("4")
+      resource.weekday("5")
+      resource.user("root")
     end
 
     it "describes the state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:minute]).to eq("1")
       expect(state[:hour]).to eq("2")
       expect(state[:day]).to eq("3")
@@ -180,7 +177,7 @@ describe Chef::Resource::Cron do
     end
 
     it "returns the command as its identity" do
-      expect(@resource.identity).to eq("tackle")
+      expect(resource.identity).to eq("tackle")
     end
   end
 end

--- a/spec/unit/resource/csh_spec.rb
+++ b/spec/unit/resource/csh_spec.rb
@@ -20,21 +20,19 @@ require "spec_helper"
 
 describe Chef::Resource::Csh do
 
-  before(:each) do
-    @resource = Chef::Resource::Csh.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Csh.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Csh" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Csh)
   end
 
-  it "should create a new Chef::Resource::Csh" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Csh)
+  it "has a resource name of :csh" do
+    expect(resource.resource_name).to eql(:csh)
   end
 
-  it "should have a resource name of :csh" do
-    expect(@resource.resource_name).to eql(:csh)
-  end
-
-  it "should have an interpreter of csh" do
-    expect(@resource.interpreter).to eql("csh")
+  it "has an interpreter of csh" do
+    expect(resource.interpreter).to eql("csh")
   end
 
 end

--- a/spec/unit/resource/deploy_spec.rb
+++ b/spec/unit/resource/deploy_spec.rb
@@ -248,7 +248,7 @@ describe Chef::Resource::Deploy do
   end
 
   describe "when it has no timeout attribute" do
-    it "should have no default timeout" do
+    it "has no default timeout" do
       expect(@resource.timeout).to be_nil
     end
   end

--- a/spec/unit/resource/directory_spec.rb
+++ b/spec/unit/resource/directory_spec.rb
@@ -20,63 +20,60 @@
 require "spec_helper"
 
 describe Chef::Resource::Directory do
+  let(:resource) { Chef::Resource::Directory.new("fakey_fakerton") }
 
-  before(:each) do
-    @resource = Chef::Resource::Directory.new("fakey_fakerton")
+  it "creates a new Chef::Resource::Directory" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Directory)
   end
 
-  it "should create a new Chef::Resource::Directory" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Directory)
+  it "has a name" do
+    expect(resource.name).to eql("fakey_fakerton")
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("fakey_fakerton")
+  it "has a default action of 'create'" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "should have a default action of 'create'" do
-    expect(@resource.action).to eql([:create])
+  it "accepts create or delete for action" do
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :blues }.to raise_error(ArgumentError)
   end
 
-  it "should accept create or delete for action" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :delete }.not_to raise_error
-    expect { @resource.action :blues }.to raise_error(ArgumentError)
+  it "uses the object name as the path by default" do
+    expect(resource.path).to eql("fakey_fakerton")
   end
 
-  it "should use the object name as the path by default" do
-    expect(@resource.path).to eql("fakey_fakerton")
+  it "accepts a string as the path" do
+    expect { resource.path "/tmp" }.not_to raise_error
+    expect(resource.path).to eql("/tmp")
+    expect { resource.path Hash.new }.to raise_error(ArgumentError)
   end
 
-  it "should accept a string as the path" do
-    expect { @resource.path "/tmp" }.not_to raise_error
-    expect(@resource.path).to eql("/tmp")
-    expect { @resource.path Hash.new }.to raise_error(ArgumentError)
-  end
-
-  it "should allow you to have specify whether the action is recursive with true/false" do
-    expect { @resource.recursive true }.not_to raise_error
-    expect { @resource.recursive false }.not_to raise_error
-    expect { @resource.recursive "monkey" }.to raise_error(ArgumentError)
+  it "allows you to have specify whether the action is recursive with true/false" do
+    expect { resource.recursive true }.not_to raise_error
+    expect { resource.recursive false }.not_to raise_error
+    expect { resource.recursive "monkey" }.to raise_error(ArgumentError)
   end
 
   describe "when it has group, mode, and owner" do
     before do
-      @resource.path("/tmp/foo/bar/")
-      @resource.group("wheel")
-      @resource.mode("0664")
-      @resource.owner("root")
+      resource.path("/tmp/foo/bar/")
+      resource.group("wheel")
+      resource.mode("0664")
+      resource.owner("root")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:group]).to eq("wheel")
       expect(state[:mode]).to eq("0664")
       expect(state[:owner]).to eq("root")
     end
 
     it "returns the directory path as its identity" do
-      expect(@resource.identity).to eq("/tmp/foo/bar/")
+      expect(resource.identity).to eq("/tmp/foo/bar/")
     end
   end
 end

--- a/spec/unit/resource/dnf_package_spec.rb
+++ b/spec/unit/resource/dnf_package_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Resource::DnfPackage, "arch" do
     @resource = Chef::Resource::DnfPackage.new("foo")
   end
 
-  it "should set the arch variable to whatever is passed in" do
+  it "sets the arch variable to whatever is passed in" do
     @resource.arch("i386")
     expect(@resource.arch).to eql(["i386"])
   end
@@ -47,40 +47,40 @@ describe Chef::Resource::DnfPackage, "flush_cache" do
     @resource = Chef::Resource::DnfPackage.new("foo")
   end
 
-  it "should default the flush timing to false" do
+  it "defaults the flush timing to false" do
     flush_hash = { :before => false, :after => false }
     expect(@resource.flush_cache).to eq(flush_hash)
   end
 
-  it "should allow you to set the flush timing with an array" do
+  it "allows you to set the flush timing with an array" do
     flush_array = [ :before, :after ]
     flush_hash = { :before => true, :after => true }
     @resource.flush_cache(flush_array)
     expect(@resource.flush_cache).to eq(flush_hash)
   end
 
-  it "should allow you to set the flush timing with a hash" do
+  it "allows you to set the flush timing with a hash" do
     flush_hash = { :before => true, :after => true }
     @resource.flush_cache(flush_hash)
     expect(@resource.flush_cache).to eq(flush_hash)
   end
 
-  it "should allow 'true' for flush_cache" do
+  it "allows 'true' for flush_cache" do
     @resource.flush_cache(true)
     expect(@resource.flush_cache).to eq({ before: true, after: true })
   end
 
-  it "should allow 'false' for flush_cache" do
+  it "allows 'false' for flush_cache" do
     @resource.flush_cache(false)
     expect(@resource.flush_cache).to eq({ before: false, after: false })
   end
 
-  it "should allow ':before' for flush_cache" do
+  it "allows ':before' for flush_cache" do
     @resource.flush_cache(:before)
     expect(@resource.flush_cache).to eq({ before: true, after: false })
   end
 
-  it "should allow ':after' for flush_cache" do
+  it "allows ':after' for flush_cache" do
     @resource.flush_cache(:after)
     expect(@resource.flush_cache).to eq({ before: false, after: true })
   end
@@ -91,7 +91,7 @@ describe Chef::Resource::DnfPackage, "allow_downgrade" do
     @resource = Chef::Resource::DnfPackage.new("foo")
   end
 
-  it "should allow you to specify whether allow_downgrade is true or false" do
+  it "allows you to specify whether allow_downgrade is true or false" do
     Chef::Config[:treat_deprecation_warnings_as_errors] = false
     expect { @resource.allow_downgrade true }.not_to raise_error
     expect { @resource.allow_downgrade false }.not_to raise_error

--- a/spec/unit/resource/env_spec.rb
+++ b/spec/unit/resource/env_spec.rb
@@ -25,16 +25,16 @@ describe Chef::Resource::Env do
     @resource = Chef::Resource::Env.new("FOO")
   end
 
-  it "should create a new Chef::Resource::Env" do
+  it "creates a new Chef::Resource::Env" do
     expect(@resource).to be_a_kind_of(Chef::Resource)
     expect(@resource).to be_a_kind_of(Chef::Resource::Env)
   end
 
-  it "should have a name" do
+  it "has a name" do
     expect(@resource.name).to eql("FOO")
   end
 
-  it "should have a default action of 'create'" do
+  it "has a default action of 'create'" do
     expect(@resource.action).to eql([:create])
   end
 
@@ -48,19 +48,19 @@ describe Chef::Resource::Env do
     end
   end
 
-  it "should use the object name as the key_name by default" do
+  it "uses the object name as the key_name by default" do
     expect(@resource.key_name).to eql("FOO")
   end
 
-  it "should accept a string as the env value via 'value'" do
+  it "accepts a string as the env value via 'value'" do
     expect { @resource.value "bar" }.not_to raise_error
   end
 
-  it "should not accept a Hash for the env value via 'to'" do
+  it "does not accept a Hash for the env value via 'to'" do
     expect { @resource.value Hash.new }.to raise_error(ArgumentError)
   end
 
-  it "should allow you to set an env value via 'to'" do
+  it "allows you to set an env value via 'to'" do
     @resource.value "bar"
     expect(@resource.value).to eql("bar")
   end

--- a/spec/unit/resource/erl_call_spec.rb
+++ b/spec/unit/resource/erl_call_spec.rb
@@ -25,44 +25,44 @@ describe Chef::Resource::ErlCall do
     @resource = Chef::Resource::ErlCall.new("fakey_fakerton")
   end
 
-  it "should create a new Chef::Resource::ErlCall" do
+  it "creates a new Chef::Resource::ErlCall" do
     expect(@resource).to be_a_kind_of(Chef::Resource)
     expect(@resource).to be_a_kind_of(Chef::Resource::ErlCall)
   end
 
-  it "should have a resource name of :erl_call" do
+  it "has a resource name of :erl_call" do
     expect(@resource.resource_name).to eql(:erl_call)
   end
 
-  it "should have a default action of run" do
+  it "has a default action of run" do
     expect(@resource.action).to eql([:run])
   end
 
-  it "should accept run as an action" do
+  it "accepts run as an action" do
     expect { @resource.action :run }.not_to raise_error
   end
 
-  it "should allow you to set the code attribute" do
+  it "allows you to set the code attribute" do
     @resource.code "q()."
     expect(@resource.code).to eql("q().")
   end
 
-  it "should allow you to set the cookie attribute" do
+  it "allows you to set the cookie attribute" do
     @resource.cookie "nomnomnom"
     expect(@resource.cookie).to eql("nomnomnom")
   end
 
-  it "should allow you to set the distributed attribute" do
+  it "allows you to set the distributed attribute" do
     @resource.distributed true
     expect(@resource.distributed).to eql(true)
   end
 
-  it "should allow you to set the name_type attribute" do
+  it "allows you to set the name_type attribute" do
     @resource.name_type "sname"
     expect(@resource.name_type).to eql("sname")
   end
 
-  it "should allow you to set the node_name attribute" do
+  it "allows you to set the node_name attribute" do
     @resource.node_name "chef@erlang"
     expect(@resource.node_name).to eql("chef@erlang")
   end

--- a/spec/unit/resource/execute_spec.rb
+++ b/spec/unit/resource/execute_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::Execute do
   let(:execute_resource) { Chef::Resource::Execute.new(resource_instance_name) }
   it_behaves_like "an execute resource"
 
-  it "default guard interpreter should be :execute interpreter" do
+  it "default guard interpreter is :execute interpreter" do
     expect(execute_resource.guard_interpreter).to be(:execute)
   end
 
@@ -59,13 +59,13 @@ describe Chef::Resource::Execute do
 
   shared_examples_for "it received valid credentials" do
     describe "the validation method" do
-      it "should not raise an error" do
+      it "does not raise an error" do
         expect { execute_resource.validate_identity_platform(username, password, domain) }.not_to raise_error
       end
     end
 
     describe "the name qualification method" do
-      it "should correctly translate the user and domain" do
+      it "correctly translates the user and domain" do
         identity = nil
         expect { identity = execute_resource.qualify_user(username, password, domain) }.not_to raise_error
         expect(identity[:domain]).to eq(domain)
@@ -76,7 +76,7 @@ describe Chef::Resource::Execute do
 
   shared_examples_for "it received invalid credentials" do
     describe "the validation method" do
-      it "should raise an error" do
+      it "raises an error" do
         expect { execute_resource.validate_identity_platform(username, password, domain, elevated) }.to raise_error(ArgumentError)
       end
     end
@@ -84,7 +84,7 @@ describe Chef::Resource::Execute do
 
   shared_examples_for "it received invalid username and domain" do
     describe "the validation method" do
-      it "should raise an error" do
+      it "raises an error" do
         expect { execute_resource.qualify_user(username, password, domain) }.to raise_error(ArgumentError)
       end
     end
@@ -92,7 +92,7 @@ describe Chef::Resource::Execute do
 
   shared_examples_for "it received credentials that are not valid on the platform" do
     describe "the validation method" do
-      it "should raise an error" do
+      it "raises an error" do
         expect { execute_resource.validate_identity_platform(username, password, domain) }.to raise_error(Chef::Exceptions::UnsupportedPlatform)
       end
     end

--- a/spec/unit/resource/file_spec.rb
+++ b/spec/unit/resource/file_spec.rb
@@ -20,88 +20,86 @@ require "spec_helper"
 
 describe Chef::Resource::File do
 
-  before(:each) do
-    @resource = Chef::Resource::File.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::File.new("fakey_fakerton") }
+
+  it "has a name" do
+    expect(resource.name).to eql("fakey_fakerton")
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("fakey_fakerton")
+  it "has a default action of 'create'" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "should have a default action of 'create'" do
-    expect(@resource.action).to eql([:create])
+  it "has a default content of nil" do
+    expect(resource.content).to be_nil
   end
 
-  it "should have a default content of nil" do
-    expect(@resource.content).to be_nil
+  it "is set to back up 5 files by default" do
+    expect(resource.backup).to eql(5)
   end
 
-  it "should be set to back up 5 files by default" do
-    expect(@resource.backup).to eql(5)
+  it "only accept strings for content" do
+    expect { resource.content 5 }.to raise_error(ArgumentError)
+    expect { resource.content :foo }.to raise_error(ArgumentError)
+    expect { resource.content "hello" => "there" }.to raise_error(ArgumentError)
+    expect { resource.content "hi" }.not_to raise_error
   end
 
-  it "should only accept strings for content" do
-    expect { @resource.content 5 }.to raise_error(ArgumentError)
-    expect { @resource.content :foo }.to raise_error(ArgumentError)
-    expect { @resource.content "hello" => "there" }.to raise_error(ArgumentError)
-    expect { @resource.content "hi" }.not_to raise_error
+  it "only accept false or a number for backup" do
+    expect { resource.backup true }.to raise_error(ArgumentError)
+    expect { resource.backup false }.not_to raise_error
+    expect { resource.backup 10 }.not_to raise_error
+    expect { resource.backup "blues" }.to raise_error(ArgumentError)
   end
 
-  it "should only accept false or a number for backup" do
-    expect { @resource.backup true }.to raise_error(ArgumentError)
-    expect { @resource.backup false }.not_to raise_error
-    expect { @resource.backup 10 }.not_to raise_error
-    expect { @resource.backup "blues" }.to raise_error(ArgumentError)
+  it "accepts a sha256 for checksum" do
+    expect { resource.checksum "0fd012fdc96e96f8f7cf2046522a54aed0ce470224513e45da6bc1a17a4924aa" }.not_to raise_error
+    expect { resource.checksum "monkey!" }.to raise_error(ArgumentError)
   end
 
-  it "should accept a sha256 for checksum" do
-    expect { @resource.checksum "0fd012fdc96e96f8f7cf2046522a54aed0ce470224513e45da6bc1a17a4924aa" }.not_to raise_error
-    expect { @resource.checksum "monkey!" }.to raise_error(ArgumentError)
+  it "accepts create, delete or touch for action" do
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :touch }.not_to raise_error
+    expect { resource.action :blues }.to raise_error(ArgumentError)
   end
 
-  it "should accept create, delete or touch for action" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :delete }.not_to raise_error
-    expect { @resource.action :touch }.not_to raise_error
-    expect { @resource.action :blues }.to raise_error(ArgumentError)
+  it "accepts a block, symbol, or string for verify" do
+    expect { resource.verify {} }.not_to raise_error
+    expect { resource.verify "" }.not_to raise_error
+    expect { resource.verify :json }.not_to raise_error
+    expect { resource.verify true }.to raise_error(ArgumentError)
+    expect { resource.verify false }.to raise_error(ArgumentError)
   end
 
-  it "should accept a block, symbol, or string for verify" do
-    expect { @resource.verify {} }.not_to raise_error
-    expect { @resource.verify "" }.not_to raise_error
-    expect { @resource.verify :json }.not_to raise_error
-    expect { @resource.verify true }.to raise_error(ArgumentError)
-    expect { @resource.verify false }.to raise_error(ArgumentError)
+  it "accepts multiple verify statements" do
+    resource.verify "foo"
+    resource.verify "bar"
+    resource.verify.length == 2
   end
 
-  it "should accept multiple verify statements" do
-    @resource.verify "foo"
-    @resource.verify "bar"
-    @resource.verify.length == 2
+  it "uses the object name as the path by default" do
+    expect(resource.path).to eql("fakey_fakerton")
   end
 
-  it "should use the object name as the path by default" do
-    expect(@resource.path).to eql("fakey_fakerton")
-  end
-
-  it "should accept a string as the path" do
-    expect { @resource.path "/tmp" }.not_to raise_error
-    expect(@resource.path).to eql("/tmp")
-    expect { @resource.path Hash.new }.to raise_error(ArgumentError)
+  it "accepts a string as the path" do
+    expect { resource.path "/tmp" }.not_to raise_error
+    expect(resource.path).to eql("/tmp")
+    expect { resource.path Hash.new }.to raise_error(ArgumentError)
   end
 
   describe "when it has a path, owner, group, mode, and checksum" do
     before do
-      @resource.path("/tmp/foo.txt")
-      @resource.owner("root")
-      @resource.group("wheel")
-      @resource.mode("0644")
-      @resource.checksum("1" * 64)
+      resource.path("/tmp/foo.txt")
+      resource.owner("root")
+      resource.group("wheel")
+      resource.mode("0644")
+      resource.checksum("1" * 64)
     end
 
     context "on unix", :unix_only do
       it "describes its state" do
-        state = @resource.state_for_resource_reporter
+        state = resource.state_for_resource_reporter
         expect(state[:owner]).to eq("root")
         expect(state[:group]).to eq("wheel")
         expect(state[:mode]).to eq("0644")
@@ -110,21 +108,20 @@ describe Chef::Resource::File do
     end
 
     it "returns the file path as its identity" do
-      expect(@resource.identity).to eq("/tmp/foo.txt")
+      expect(resource.identity).to eq("/tmp/foo.txt")
     end
 
   end
 
   describe "when access controls are set on windows", :windows_only => true do
     before do
-      @resource.rights :read, "Everyone"
-      @resource.rights :full_control, "DOMAIN\User"
+      resource.rights :read, "Everyone"
+      resource.rights :full_control, "DOMAIN\User"
     end
     it "describes its state including windows ACL attributes" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:rights]).to eq([ { :permissions => :read, :principals => "Everyone" },
                                { :permissions => :full_control, :principals => "DOMAIN\User" } ])
     end
   end
-
 end

--- a/spec/unit/resource/freebsd_package_spec.rb
+++ b/spec/unit/resource/freebsd_package_spec.rb
@@ -30,22 +30,22 @@ describe Chef::Resource::FreebsdPackage do
   end
 
   describe "Initialization" do
-    it "should return a Chef::Resource::FreebsdPackage" do
+    it "returns a Chef::Resource::FreebsdPackage" do
       expect(@resource).to be_a_kind_of(Chef::Resource::FreebsdPackage)
     end
 
-    it "should set the resource_name to :freebsd_package" do
+    it "sets the resource_name to :freebsd_package" do
       expect(@resource.resource_name).to eql(:freebsd_package)
     end
 
-    it "should not set the provider" do
+    it "does not set the provider" do
       expect(@resource.provider).to be_nil
     end
   end
 
   describe "Assigning provider after creation" do
     describe "if ports specified as source" do
-      it "should be Freebsd::Port" do
+      it "is Freebsd::Port" do
         @resource.source("ports")
         @resource.after_created
         expect(@resource.provider).to eq(Chef::Provider::Package::Freebsd::Port)
@@ -53,7 +53,7 @@ describe Chef::Resource::FreebsdPackage do
     end
 
     describe "if freebsd_version is greater than or equal to 1000017" do
-      it "should be Freebsd::Pkgng" do
+      it "is Freebsd::Pkgng" do
         [1000017, 1000018, 1000500, 1001001, 1100000].each do |freebsd_version|
           @node.automatic_attrs[:os_version] = freebsd_version
           @resource.after_created
@@ -63,7 +63,7 @@ describe Chef::Resource::FreebsdPackage do
     end
 
     describe "if pkgng enabled" do
-      it "should be Freebsd::Pkgng" do
+      it "is Freebsd::Pkgng" do
         pkg_enabled = OpenStruct.new(:stdout => "yes\n")
         allow(@resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
         @resource.after_created
@@ -72,7 +72,7 @@ describe Chef::Resource::FreebsdPackage do
     end
 
     describe "if freebsd_version is less than 1000017 and pkgng not enabled" do
-      it "should be Freebsd::Pkg" do
+      it "is Freebsd::Pkg" do
         pkg_enabled = OpenStruct.new(:stdout => "\n")
         allow(@resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
 

--- a/spec/unit/resource/gem_package_spec.rb
+++ b/spec/unit/resource/gem_package_spec.rb
@@ -35,7 +35,7 @@ describe Chef::Resource::GemPackage, "gem_binary" do
     @resource = Chef::Resource::GemPackage.new("foo")
   end
 
-  it "should set the gem_binary variable to whatever is passed in" do
+  it "sets the gem_binary variable to whatever is passed in" do
     @resource.gem_binary("/opt/local/bin/gem")
     expect(@resource.gem_binary).to eql("/opt/local/bin/gem")
   end

--- a/spec/unit/resource/git_spec.rb
+++ b/spec/unit/resource/git_spec.rb
@@ -28,23 +28,21 @@ describe Chef::Resource::Git do
     action: :sync
   )
 
-  before(:each) do
-    @git = Chef::Resource::Git.new("my awesome webapp")
-  end
+  let(:resource) { Chef::Resource::Git.new("my awesome webapp") }
 
   it "is a kind of Scm Resource" do
-    expect(@git).to be_a_kind_of(Chef::Resource::Scm)
-    expect(@git).to be_an_instance_of(Chef::Resource::Git)
+    expect(resource).to be_a_kind_of(Chef::Resource::Scm)
+    expect(resource).to be_an_instance_of(Chef::Resource::Git)
   end
 
   it "uses aliases revision as branch" do
-    @git.branch "HEAD"
-    expect(@git.revision).to eql("HEAD")
+    resource.branch "HEAD"
+    expect(resource.revision).to eql("HEAD")
   end
 
   it "aliases revision as reference" do
-    @git.reference "v1.0 tag"
-    expect(@git.revision).to eql("v1.0 tag")
+    resource.reference "v1.0 tag"
+    expect(resource.revision).to eql("v1.0 tag")
   end
 
 end

--- a/spec/unit/resource/group_spec.rb
+++ b/spec/unit/resource/group_spec.rb
@@ -20,143 +20,133 @@
 require "spec_helper"
 
 describe Chef::Resource::Group, "initialize" do
-  before(:each) do
-    @resource = Chef::Resource::Group.new("admin")
+  let(:resource) { Chef::Resource::Group.new("admin") }
+
+  it "creates a new Chef::Resource::Group" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Group)
   end
 
-  it "should create a new Chef::Resource::Group" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Group)
+  it "sets the resource_name to :group" do
+    expect(resource.resource_name).to eql(:group)
   end
 
-  it "should set the resource_name to :group" do
-    expect(@resource.resource_name).to eql(:group)
+  it "sets the group_name equal to the argument to initialize" do
+    expect(resource.group_name).to eql("admin")
   end
 
-  it "should set the group_name equal to the argument to initialize" do
-    expect(@resource.group_name).to eql("admin")
+  it "defaults gid to nil" do
+    expect(resource.gid).to eql(nil)
   end
 
-  it "should default gid to nil" do
-    expect(@resource.gid).to eql(nil)
+  it "defaults members to an empty array" do
+    expect(resource.members).to eql([])
   end
 
-  it "should default members to an empty array" do
-    expect(@resource.members).to eql([])
+  it "aliases users to members, also an empty array" do
+    expect(resource.users).to eql([])
   end
 
-  it "should alias users to members, also an empty array" do
-    expect(@resource.users).to eql([])
-  end
-
-  it "should set action to :create" do
-    expect(@resource.action).to eql([:create])
+  it "sets action to :create" do
+    expect(resource.action).to eql([:create])
   end
 
   %w{create remove modify manage}.each do |action|
-    it "should allow action #{action}" do
-      expect(@resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
+    it "allows action #{action}" do
+      expect(resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
     end
   end
 
-  it "should accept domain groups (@ or \ separator) on non-windows" do
-    expect { @resource.group_name "domain\@group" }.not_to raise_error
-    expect(@resource.group_name).to eq("domain\@group")
-    expect { @resource.group_name "domain\\group" }.not_to raise_error
-    expect(@resource.group_name).to eq("domain\\group")
-    expect { @resource.group_name "domain\\group^name" }.not_to raise_error
-    expect(@resource.group_name).to eq("domain\\group^name")
+  it "accepts domain groups (@ or \ separator) on non-windows" do
+    expect { resource.group_name "domain\@group" }.not_to raise_error
+    expect(resource.group_name).to eq("domain\@group")
+    expect { resource.group_name "domain\\group" }.not_to raise_error
+    expect(resource.group_name).to eq("domain\\group")
+    expect { resource.group_name "domain\\group^name" }.not_to raise_error
+    expect(resource.group_name).to eq("domain\\group^name")
   end
 end
 
 describe Chef::Resource::Group, "group_name" do
-  before(:each) do
-    @resource = Chef::Resource::Group.new("admin")
+  let(:resource) { Chef::Resource::Group.new("admin") }
+
+  it "allows a string" do
+    resource.group_name "pirates"
+    expect(resource.group_name).to eql("pirates")
   end
 
-  it "should allow a string" do
-    @resource.group_name "pirates"
-    expect(@resource.group_name).to eql("pirates")
-  end
-
-  it "should not allow a hash" do
-    expect { @resource.send(:group_name, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
+  it "does not allow a hash" do
+    expect { resource.send(:group_name, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 end
 
 describe Chef::Resource::Group, "gid" do
-  before(:each) do
-    @resource = Chef::Resource::Group.new("admin")
+  let(:resource) { Chef::Resource::Group.new("admin") }
+
+  it "allows an integer" do
+    resource.gid 100
+    expect(resource.gid).to eql(100)
   end
 
-  it "should allow an integer" do
-    @resource.gid 100
-    expect(@resource.gid).to eql(100)
-  end
-
-  it "should not allow a hash" do
-    expect { @resource.send(:gid, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
+  it "does not allow a hash" do
+    expect { resource.send(:gid, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 end
 
 describe Chef::Resource::Group, "members" do
-  before(:each) do
-    @resource = Chef::Resource::Group.new("admin")
-  end
+  let(:resource) { Chef::Resource::Group.new("admin") }
 
   [ :users, :members].each do |method|
-    it "(#{method}) should allow and convert a string" do
-      @resource.send(method, "aj")
-      expect(@resource.send(method)).to eql(["aj"])
+    it "(#{method}) allows and convert a string" do
+      resource.send(method, "aj")
+      expect(resource.send(method)).to eql(["aj"])
     end
 
     it "(#{method}) should split a string on commas" do
-      @resource.send(method, "aj,adam")
-      expect(@resource.send(method)).to eql( %w{aj adam} )
+      resource.send(method, "aj,adam")
+      expect(resource.send(method)).to eql( %w{aj adam} )
     end
 
-    it "(#{method}) should allow an array" do
-      @resource.send(method, %w{aj adam})
-      expect(@resource.send(method)).to eql( %w{aj adam} )
+    it "(#{method}) allows an array" do
+      resource.send(method, %w{aj adam})
+      expect(resource.send(method)).to eql( %w{aj adam} )
     end
 
-    it "(#{method}) should not allow a hash" do
-      expect { @resource.send(method, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
+    it "(#{method}) does not allow a hash" do
+      expect { resource.send(method, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
     end
   end
 end
 
 describe Chef::Resource::Group, "append" do
-  before(:each) do
-    @resource = Chef::Resource::Group.new("admin")
+  let(:resource) { Chef::Resource::Group.new("admin") }
+
+  it "defaults to false" do
+    expect(resource.append).to eql(false)
   end
 
-  it "should default to false" do
-    expect(@resource.append).to eql(false)
+  it "allows a boolean" do
+    resource.append true
+    expect(resource.append).to eql(true)
   end
 
-  it "should allow a boolean" do
-    @resource.append true
-    expect(@resource.append).to eql(true)
-  end
-
-  it "should not allow a hash" do
-    expect { @resource.send(:gid, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
+  it "does not allow a hash" do
+    expect { resource.send(:gid, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 
   describe "when it has members" do
     before do
-      @resource.group_name("pokemon")
-      @resource.members(%w{blastoise pikachu})
+      resource.group_name("pokemon")
+      resource.members(%w{blastoise pikachu})
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:members]).to eql(%w{blastoise pikachu})
     end
 
     it "returns the group name as its identity" do
-      expect(@resource.identity).to eq("pokemon")
+      expect(resource.identity).to eq("pokemon")
     end
   end
 end

--- a/spec/unit/resource/http_request_spec.rb
+++ b/spec/unit/resource/http_request_spec.rb
@@ -20,39 +20,36 @@
 require "spec_helper"
 
 describe Chef::Resource::HttpRequest do
+  let(:resource) { Chef::Resource::HttpRequest.new("fakey_fakerton") }
 
-  before(:each) do
-    @resource = Chef::Resource::HttpRequest.new("fakey_fakerton")
+  it "creates a new Chef::Resource::HttpRequest" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::HttpRequest)
   end
 
-  it "should create a new Chef::Resource::HttpRequest" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::HttpRequest)
+  it "sets url to a string" do
+    resource.url "http://slashdot.org"
+    expect(resource.url).to eql("http://slashdot.org")
   end
 
-  it "should set url to a string" do
-    @resource.url "http://slashdot.org"
-    expect(@resource.url).to eql("http://slashdot.org")
+  it "sets the message to the name by default" do
+    expect(resource.message).to eql("fakey_fakerton")
   end
 
-  it "should set the message to the name by default" do
-    expect(@resource.message).to eql("fakey_fakerton")
-  end
-
-  it "should set message to a string" do
-    @resource.message "monkeybars"
-    expect(@resource.message).to eql("monkeybars")
+  it "sets message to a string" do
+    resource.message "monkeybars"
+    expect(resource.message).to eql("monkeybars")
   end
 
   describe "when it has a message and headers" do
     before do
-      @resource.url("http://www.trololol.net")
-      @resource.message("Get sum post brah.")
-      @resource.headers({ "head" => "tail" })
+      resource.url("http://www.trololol.net")
+      resource.message("Get sum post brah.")
+      resource.headers({ "head" => "tail" })
     end
 
     it "returns the url as its identity" do
-      expect(@resource.identity).to eq("http://www.trololol.net")
+      expect(resource.identity).to eq("http://www.trololol.net")
     end
   end
 

--- a/spec/unit/resource/ifconfig_spec.rb
+++ b/spec/unit/resource/ifconfig_spec.rb
@@ -55,7 +55,7 @@ describe Chef::Resource::Ifconfig do
       @node.automatic_attrs[:platform_version] = version
     end
 
-    it "should use an ordinary Provider::Ifconfig as a provider for #{platform} #{version}" do
+    it "uses an ordinary Provider::Ifconfig as a provider for #{platform} #{version}" do
       expect(@resource.provider_for_action(:add).class).to eq(Chef::Provider::Ifconfig)
     end
   end
@@ -68,7 +68,7 @@ describe Chef::Resource::Ifconfig do
       @node.automatic_attrs[:platform_version] = version
     end
 
-    it "should use an Provider::Ifconfig::Redhat as a provider for #{platform} #{version}" do
+    it "uses an Provider::Ifconfig::Redhat as a provider for #{platform} #{version}" do
       expect(@resource.provider_for_action(:add)).to be_a_kind_of(Chef::Provider::Ifconfig::Redhat)
     end
   end
@@ -81,7 +81,7 @@ describe Chef::Resource::Ifconfig do
       @node.automatic_attrs[:platform_version] = version
     end
 
-    it "should use an Ifconfig::Debian as a provider for #{platform} #{version}" do
+    it "uses an Ifconfig::Debian as a provider for #{platform} #{version}" do
       expect(@resource.provider_for_action(:add)).to be_a_kind_of(Chef::Provider::Ifconfig::Debian)
     end
   end

--- a/spec/unit/resource/ips_package_spec.rb
+++ b/spec/unit/resource/ips_package_spec.rb
@@ -29,12 +29,10 @@ describe Chef::Resource::IpsPackage, "initialize" do
     os: "solaris2"
   )
 
-  before(:each) do
-    @resource = Chef::Resource::IpsPackage.new("crypto/gnupg")
-  end
+  let(:resource) { Chef::Resource::IpsPackage.new("crypto/gnupg") }
 
   it "should support accept_license" do
-    @resource.accept_license(true)
-    expect(@resource.accept_license).to eql(true)
+    resource.accept_license(true)
+    expect(resource.accept_license).to eql(true)
   end
 end

--- a/spec/unit/resource/ksh_spec.rb
+++ b/spec/unit/resource/ksh_spec.rb
@@ -20,21 +20,19 @@ require "spec_helper"
 
 describe Chef::Resource::Ksh do
 
-  before(:each) do
-    @resource = Chef::Resource::Ksh.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Ksh.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Ksh" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Ksh)
   end
 
-  it "should create a new Chef::Resource::Ksh" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Ksh)
+  it "has a resource name of :ksh" do
+    expect(resource.resource_name).to eql(:ksh)
   end
 
-  it "should have a resource name of :ksh" do
-    expect(@resource.resource_name).to eql(:ksh)
-  end
-
-  it "should have an interpreter of ksh" do
-    expect(@resource.interpreter).to eql("ksh")
+  it "has an interpreter of ksh" do
+    expect(resource.interpreter).to eql("ksh")
   end
 
 end

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -1,29 +1,36 @@
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "spec_helper"
 
 describe Chef::Resource::Launchd do
-  @launchd = Chef::Resource::Launchd.new("io.chef.chef-client")
-  let(:resource) do
-    Chef::Resource::Launchd.new(
-    "io.chef.chef-client",
-    run_context
-  ) end
+  let(:resource) { Chef::Resource::Launchd.new("io.chef.chef-client" ) }
 
-  it "should create a new Chef::Resource::Launchd" do
+  it "creates a new Chef::Resource::Launchd" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::Launchd)
   end
 
-  it "should have a resource name of Launchd" do
+  it "has a resource name of Launchd" do
     expect(resource.resource_name).to eql(:launchd)
   end
 
-  it "should have a default action of create" do
+  it "has a default action of create" do
     expect(resource.action).to eql([:create])
   end
 
-  it "should accept enable, disable, create, and delete as actions" do
+  it "accepts enable, disable, create, and delete as actions" do
     expect { resource.action :enable }.not_to raise_error
     expect { resource.action :disable }.not_to raise_error
     expect { resource.action :create }.not_to raise_error

--- a/spec/unit/resource/link_spec.rb
+++ b/spec/unit/resource/link_spec.rb
@@ -20,115 +20,115 @@
 require "spec_helper"
 
 describe Chef::Resource::Link do
+  let(:resource) { Chef::Resource::Link.new("fakey_fakerton") }
 
   before(:each) do
     expect_any_instance_of(Chef::Resource::Link).to receive(:verify_links_supported!).and_return(true)
-    @resource = Chef::Resource::Link.new("fakey_fakerton")
   end
 
-  it "should create a new Chef::Resource::Link" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Link)
+  it "creates a new Chef::Resource::Link" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Link)
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("fakey_fakerton")
+  it "has a name" do
+    expect(resource.name).to eql("fakey_fakerton")
   end
 
-  it "should have a default action of 'create'" do
-    expect(@resource.action).to eql([:create])
+  it "has a default action of 'create'" do
+    expect(resource.action).to eql([:create])
   end
 
   { :create => false, :delete => false, :blues => true }.each do |action, bad_value|
     it "should #{bad_value ? 'not' : ''} accept #{action}" do
       if bad_value
-        expect { @resource.action action }.to raise_error(ArgumentError)
+        expect { resource.action action }.to raise_error(ArgumentError)
       else
-        expect { @resource.action action }.not_to raise_error
+        expect { resource.action action }.not_to raise_error
       end
     end
   end
 
-  it "should use the object name as the target_file by default" do
-    expect(@resource.target_file).to eql("fakey_fakerton")
+  it "uses the object name as the target_file by default" do
+    expect(resource.target_file).to eql("fakey_fakerton")
   end
 
-  it "should accept a delayed evaluator as the target path" do
-    @resource.target_file Chef::DelayedEvaluator.new { "my_lazy_name" }
-    expect(@resource.target_file).to eql("my_lazy_name")
+  it "accepts a delayed evaluator as the target path" do
+    resource.target_file Chef::DelayedEvaluator.new { "my_lazy_name" }
+    expect(resource.target_file).to eql("my_lazy_name")
   end
 
-  it "should accept a delayed evaluator when accessing via 'path'" do
-    @resource.target_file Chef::DelayedEvaluator.new { "my_lazy_name" }
-    expect(@resource.path).to eql("my_lazy_name")
+  it "accepts a delayed evaluator when accessing via 'path'" do
+    resource.target_file Chef::DelayedEvaluator.new { "my_lazy_name" }
+    expect(resource.path).to eql("my_lazy_name")
   end
 
-  it "should accept a delayed evaluator via 'to'" do
-    @resource.to Chef::DelayedEvaluator.new { "my_lazy_name" }
-    expect(@resource.to).to eql("my_lazy_name")
+  it "accepts a delayed evaluator via 'to'" do
+    resource.to Chef::DelayedEvaluator.new { "my_lazy_name" }
+    expect(resource.to).to eql("my_lazy_name")
   end
 
-  it "should accept a string as the link source via 'to'" do
-    expect { @resource.to "/tmp" }.not_to raise_error
+  it "accepts a string as the link source via 'to'" do
+    expect { resource.to "/tmp" }.not_to raise_error
   end
 
-  it "should not accept a Hash for the link source via 'to'" do
-    expect { @resource.to Hash.new }.to raise_error(ArgumentError)
+  it "does not accept a Hash for the link source via 'to'" do
+    expect { resource.to Hash.new }.to raise_error(ArgumentError)
   end
 
-  it "should allow you to set a link source via 'to'" do
-    @resource.to "/tmp/foo"
-    expect(@resource.to).to eql("/tmp/foo")
+  it "allows you to set a link source via 'to'" do
+    resource.to "/tmp/foo"
+    expect(resource.to).to eql("/tmp/foo")
   end
 
-  it "should allow you to specify the link type" do
-    @resource.link_type "symbolic"
-    expect(@resource.link_type).to eql(:symbolic)
+  it "allows you to specify the link type" do
+    resource.link_type "symbolic"
+    expect(resource.link_type).to eql(:symbolic)
   end
 
-  it "should default to a symbolic link" do
-    expect(@resource.link_type).to eql(:symbolic)
+  it "defaults to a symbolic link" do
+    expect(resource.link_type).to eql(:symbolic)
   end
 
-  it "should accept a hard link_type" do
-    @resource.link_type :hard
-    expect(@resource.link_type).to eql(:hard)
+  it "accepts a hard link_type" do
+    resource.link_type :hard
+    expect(resource.link_type).to eql(:hard)
   end
 
-  it "should reject any other link_type but :hard and :symbolic" do
-    expect { @resource.link_type "x-men" }.to raise_error(ArgumentError)
+  it "rejects any other link_type but :hard and :symbolic" do
+    expect { resource.link_type "x-men" }.to raise_error(ArgumentError)
   end
 
-  it "should accept a group name or id for group" do
-    expect { @resource.group "root" }.not_to raise_error
-    expect { @resource.group 123 }.not_to raise_error
-    expect { @resource.group "root:goo" }.to raise_error(ArgumentError)
+  it "accepts a group name or id for group" do
+    expect { resource.group "root" }.not_to raise_error
+    expect { resource.group 123 }.not_to raise_error
+    expect { resource.group "root:goo" }.to raise_error(ArgumentError)
   end
 
-  it "should accept a user name or id for owner" do
-    expect { @resource.owner "root" }.not_to raise_error
-    expect { @resource.owner 123 }.not_to raise_error
-    expect { @resource.owner "root:goo" }.to raise_error(ArgumentError)
+  it "accepts a user name or id for owner" do
+    expect { resource.owner "root" }.not_to raise_error
+    expect { resource.owner 123 }.not_to raise_error
+    expect { resource.owner "root:goo" }.to raise_error(ArgumentError)
   end
 
   describe "when it has to, link_type, owner, and group" do
     before do
-      @resource.target_file("/var/target.tar")
-      @resource.to("/to/dir/file.tar")
-      @resource.link_type(:symbolic)
-      @resource.owner("root")
-      @resource.group("0664")
+      resource.target_file("/var/target.tar")
+      resource.to("/to/dir/file.tar")
+      resource.link_type(:symbolic)
+      resource.owner("root")
+      resource.group("0664")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:to]).to eq("/to/dir/file.tar")
       expect(state[:owner]).to eq("root")
       expect(state[:group]).to eq("0664")
     end
 
     it "returns the target file as its identity" do
-      expect(@resource.identity).to eq("/var/target.tar")
+      expect(resource.identity).to eq("/var/target.tar")
     end
   end
 end

--- a/spec/unit/resource/log_spec.rb
+++ b/spec/unit/resource/log_spec.rb
@@ -21,53 +21,49 @@ require "spec_helper"
 
 describe Chef::Resource::Log do
 
-  before(:each) do
-    @log_str = "this is my string to log"
-    @resource = Chef::Resource::Log.new(@log_str)
-  end
+  let(:log_str) { "this is my string to log" }
+  let(:resource) { Chef::Resource::Log.new(log_str) }
 
-  it "should create a new Chef::Resource::Log" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Log)
+  it "creates a new Chef::Resource::Log" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Log)
   end
 
   it "supports the :write actions" do
-    expect(@resource.allowed_actions).to include(:write)
+    expect(resource.allowed_actions).to include(:write)
   end
 
-  it "should have a name of log" do
-    expect(@resource.resource_name).to eq(:log)
+  it "has a name of log" do
+    expect(resource.resource_name).to eq(:log)
   end
 
-  it "should allow you to set a log string" do
-    expect(@resource.name).to eq(@log_str)
+  it "allows you to set a log string" do
+    expect(resource.name).to eq(log_str)
   end
 
-  it "should set the message to the first argument to new" do
-    expect(@resource.message).to eq(@log_str)
+  it "sets the message to the first argument to new" do
+    expect(resource.message).to eq(log_str)
   end
 
-  it "should accept a string for the log message" do
-    @resource.message "this is different"
-    expect(@resource.message).to eq("this is different")
+  it "accepts a string for the log message" do
+    resource.message "this is different"
+    expect(resource.message).to eq("this is different")
   end
 
-  it "should accept a vaild level option" do
-    @resource.level :debug
-    @resource.level :info
-    @resource.level :warn
-    @resource.level :error
-    @resource.level :fatal
-    expect { @resource.level :unsupported }.to raise_error(ArgumentError)
+  it "accepts a vaild level option" do
+    resource.level :debug
+    resource.level :info
+    resource.level :warn
+    resource.level :error
+    resource.level :fatal
+    expect { resource.level :unsupported }.to raise_error(ArgumentError)
   end
 
   describe "when the identity is defined" do
-    before do
-      @resource = Chef::Resource::Log.new("ery day I'm loggin-in")
-    end
+    let(:resource) { Chef::Resource::Log.new("ery day I'm loggin-in") }
 
     it "returns the log string as its identity" do
-      expect(@resource.identity).to eq("ery day I'm loggin-in")
+      expect(resource.identity).to eq("ery day I'm loggin-in")
     end
   end
 end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -21,86 +21,84 @@ require "spec_helper"
 
 describe Chef::Resource::Mdadm do
 
-  before(:each) do
-    @resource = Chef::Resource::Mdadm.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Mdadm.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Mdadm" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Mdadm)
   end
 
-  it "should create a new Chef::Resource::Mdadm" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Mdadm)
+  it "has a resource name of :mdadm" do
+    expect(resource.resource_name).to eql(:mdadm)
   end
 
-  it "should have a resource name of :mdadm" do
-    expect(@resource.resource_name).to eql(:mdadm)
+  it "has a default action of create" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "should have a default action of create" do
-    expect(@resource.action).to eql([:create])
+  it "accepts create, assemble, stop as actions" do
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :assemble }.not_to raise_error
+    expect { resource.action :stop }.not_to raise_error
   end
 
-  it "should accept create, assemble, stop as actions" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :assemble }.not_to raise_error
-    expect { @resource.action :stop }.not_to raise_error
+  it "allows you to set the raid_device attribute" do
+    resource.raid_device "/dev/md3"
+    expect(resource.raid_device).to eql("/dev/md3")
   end
 
-  it "should allow you to set the raid_device attribute" do
-    @resource.raid_device "/dev/md3"
-    expect(@resource.raid_device).to eql("/dev/md3")
+  it "allows you to set the chunk attribute" do
+    resource.chunk 256
+    expect(resource.chunk).to eql(256)
   end
 
-  it "should allow you to set the chunk attribute" do
-    @resource.chunk 256
-    expect(@resource.chunk).to eql(256)
+  it "allows you to set the level attribute" do
+    resource.level 1
+    expect(resource.level).to eql(1)
   end
 
-  it "should allow you to set the level attribute" do
-    @resource.level 1
-    expect(@resource.level).to eql(1)
+  it "allows you to set the metadata attribute" do
+    resource.metadata "1.2"
+    expect(resource.metadata).to eql("1.2")
   end
 
-  it "should allow you to set the metadata attribute" do
-    @resource.metadata "1.2"
-    expect(@resource.metadata).to eql("1.2")
+  it "allows you to set the bitmap attribute" do
+    resource.bitmap "internal"
+    expect(resource.bitmap).to eql("internal")
   end
 
-  it "should allow you to set the bitmap attribute" do
-    @resource.bitmap "internal"
-    expect(@resource.bitmap).to eql("internal")
+  it "allows you to set the layout attribute" do
+    resource.layout "f2"
+    expect(resource.layout).to eql("f2")
   end
 
-  it "should allow you to set the layout attribute" do
-    @resource.layout "f2"
-    expect(@resource.layout).to eql("f2")
+  it "allows you to set the devices attribute" do
+    resource.devices ["/dev/sda", "/dev/sdb"]
+    expect(resource.devices).to eql(["/dev/sda", "/dev/sdb"])
   end
 
-  it "should allow you to set the devices attribute" do
-    @resource.devices ["/dev/sda", "/dev/sdb"]
-    expect(@resource.devices).to eql(["/dev/sda", "/dev/sdb"])
-  end
-
-  it "should allow you to set the exists attribute" do
-    @resource.exists true
-    expect(@resource.exists).to eql(true)
+  it "allows you to set the exists attribute" do
+    resource.exists true
+    expect(resource.exists).to eql(true)
   end
 
   describe "when it has devices, level, and chunk" do
     before do
-      @resource.raid_device("raider")
-      @resource.devices(%w{device1 device2})
-      @resource.level(1)
-      @resource.chunk(42)
+      resource.raid_device("raider")
+      resource.devices(%w{device1 device2})
+      resource.level(1)
+      resource.chunk(42)
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:devices]).to eql(%w{device1 device2})
       expect(state[:level]).to eq(1)
       expect(state[:chunk]).to eq(42)
     end
 
     it "returns the raid device as its identity" do
-      expect(@resource.identity).to eq("raider")
+      expect(resource.identity).to eq("raider")
     end
   end
 

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -20,189 +20,187 @@
 require "spec_helper"
 
 describe Chef::Resource::Mount do
-  before(:each) do
-    @resource = Chef::Resource::Mount.new("filesystem")
+  let(:resource) { Chef::Resource::Mount.new("filesystem") }
+
+  it "creates a new Chef::Resource::Mount" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Mount)
   end
 
-  it "should create a new Chef::Resource::Mount" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Mount)
+  it "has a name" do
+    expect(resource.name).to eql("filesystem")
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("filesystem")
+  it "sets mount_point to the name" do
+    expect(resource.mount_point).to eql("filesystem")
   end
 
-  it "should set mount_point to the name" do
-    expect(@resource.mount_point).to eql("filesystem")
+  it "has a default action of mount" do
+    expect(resource.action).to eql([:mount])
   end
 
-  it "should have a default action of mount" do
-    expect(@resource.action).to eql([:mount])
+  it "accepts mount, umount, unmount and remount as actions" do
+    expect { resource.action :mount }.not_to raise_error
+    expect { resource.action :umount }.not_to raise_error
+    expect { resource.action :unmount }.not_to raise_error
+    expect { resource.action :remount }.not_to raise_error
+    expect { resource.action :brooklyn }.to raise_error(ArgumentError)
   end
 
-  it "should accept mount, umount, unmount and remount as actions" do
-    expect { @resource.action :mount }.not_to raise_error
-    expect { @resource.action :umount }.not_to raise_error
-    expect { @resource.action :unmount }.not_to raise_error
-    expect { @resource.action :remount }.not_to raise_error
-    expect { @resource.action :brooklyn }.to raise_error(ArgumentError)
+  it "allows you to set the device attribute" do
+    resource.device "/dev/sdb3"
+    expect(resource.device).to eql("/dev/sdb3")
   end
 
-  it "should allow you to set the device attribute" do
-    @resource.device "/dev/sdb3"
-    expect(@resource.device).to eql("/dev/sdb3")
+  it "sets fsck_device to '-' by default" do
+    expect(resource.fsck_device).to eql("-")
   end
 
-  it "should set fsck_device to '-' by default" do
-    expect(@resource.fsck_device).to eql("-")
+  it "allows you to set the fsck_device attribute" do
+    resource.fsck_device "/dev/rdsk/sdb3"
+    expect(resource.fsck_device).to eql("/dev/rdsk/sdb3")
   end
 
-  it "should allow you to set the fsck_device attribute" do
-    @resource.fsck_device "/dev/rdsk/sdb3"
-    expect(@resource.fsck_device).to eql("/dev/rdsk/sdb3")
+  it "allows you to set the fstype attribute" do
+    resource.fstype "nfs"
+    expect(resource.fstype).to eql("nfs")
   end
 
-  it "should allow you to set the fstype attribute" do
-    @resource.fstype "nfs"
-    expect(@resource.fstype).to eql("nfs")
+  it "allows you to set the dump attribute" do
+    resource.dump 1
+    expect(resource.dump).to eql(1)
   end
 
-  it "should allow you to set the dump attribute" do
-    @resource.dump 1
-    expect(@resource.dump).to eql(1)
+  it "allows you to set the pass attribute" do
+    resource.pass 1
+    expect(resource.pass).to eql(1)
   end
 
-  it "should allow you to set the pass attribute" do
-    @resource.pass 1
-    expect(@resource.pass).to eql(1)
+  it "sets the options attribute to defaults" do
+    expect(resource.options).to eql(["defaults"])
   end
 
-  it "should set the options attribute to defaults" do
-    expect(@resource.options).to eql(["defaults"])
+  it "allows options to be sent as a string, and convert to array" do
+    resource.options "rw,noexec"
+    expect(resource.options).to be_a_kind_of(Array)
   end
 
-  it "should allow options to be sent as a string, and convert to array" do
-    @resource.options "rw,noexec"
-    expect(@resource.options).to be_a_kind_of(Array)
+  it "allows options attribute as an array" do
+    resource.options %w{ro nosuid}
+    expect(resource.options).to be_a_kind_of(Array)
   end
 
-  it "should allow options attribute as an array" do
-    @resource.options %w{ro nosuid}
-    expect(@resource.options).to be_a_kind_of(Array)
+  it "allows options to be sent as a delayed evaluator" do
+    resource.options Chef::DelayedEvaluator.new { %w{rw noexec} }
+    expect(resource.options).to eql(%w{rw noexec})
   end
 
-  it "should allow options to be sent as a delayed evaluator" do
-    @resource.options Chef::DelayedEvaluator.new { %w{rw noexec} }
-    expect(@resource.options).to eql(%w{rw noexec})
+  it "allows options to be sent as a delayed evaluator, and convert to array" do
+    resource.options Chef::DelayedEvaluator.new { "rw,noexec" }
+    expect(resource.options).to be_a_kind_of(Array)
+    expect(resource.options).to eql(%w{rw noexec})
   end
 
-  it "should allow options to be sent as a delayed evaluator, and convert to array" do
-    @resource.options Chef::DelayedEvaluator.new { "rw,noexec" }
-    expect(@resource.options).to be_a_kind_of(Array)
-    expect(@resource.options).to eql(%w{rw noexec})
+  it "accepts true for mounted" do
+    resource.mounted(true)
+    expect(resource.mounted).to eql(true)
   end
 
-  it "should accept true for mounted" do
-    @resource.mounted(true)
-    expect(@resource.mounted).to eql(true)
+  it "accepts false for mounted" do
+    resource.mounted(false)
+    expect(resource.mounted).to eql(false)
   end
 
-  it "should accept false for mounted" do
-    @resource.mounted(false)
-    expect(@resource.mounted).to eql(false)
+  it "sets mounted to false by default" do
+    expect(resource.mounted).to eql(false)
   end
 
-  it "should set mounted to false by default" do
-    expect(@resource.mounted).to eql(false)
+  it "does not accept a string for mounted" do
+    expect { resource.mounted("poop") }.to raise_error(ArgumentError)
   end
 
-  it "should not accept a string for mounted" do
-    expect { @resource.mounted("poop") }.to raise_error(ArgumentError)
+  it "accepts true for enabled" do
+    resource.enabled(true)
+    expect(resource.enabled).to eql(true)
   end
 
-  it "should accept true for enabled" do
-    @resource.enabled(true)
-    expect(@resource.enabled).to eql(true)
+  it "accepts false for enabled" do
+    resource.enabled(false)
+    expect(resource.enabled).to eql(false)
   end
 
-  it "should accept false for enabled" do
-    @resource.enabled(false)
-    expect(@resource.enabled).to eql(false)
+  it "sets enabled to false by default" do
+    expect(resource.enabled).to eql(false)
   end
 
-  it "should set enabled to false by default" do
-    expect(@resource.enabled).to eql(false)
+  it "does not accept a string for enabled" do
+    expect { resource.enabled("poop") }.to raise_error(ArgumentError)
   end
 
-  it "should not accept a string for enabled" do
-    expect { @resource.enabled("poop") }.to raise_error(ArgumentError)
-  end
-
-  it "should default all feature support to false" do
+  it "defaults all feature support to false" do
     support_hash = { :remount => false }
-    expect(@resource.supports).to eq(support_hash)
+    expect(resource.supports).to eq(support_hash)
   end
 
-  it "should allow you to set feature support as an array" do
+  it "allows you to set feature support as an array" do
     support_array = [ :remount ]
     support_hash = { :remount => true }
-    @resource.supports(support_array)
-    expect(@resource.supports).to eq(support_hash)
+    resource.supports(support_array)
+    expect(resource.supports).to eq(support_hash)
   end
 
-  it "should allow you to set feature support as a hash" do
+  it "allows you to set feature support as a hash" do
     support_hash = { :remount => true }
-    @resource.supports(support_hash)
-    expect(@resource.supports).to eq(support_hash)
+    resource.supports(support_hash)
+    expect(resource.supports).to eq(support_hash)
   end
 
-  it "should allow you to set username" do
-    @resource.username("Administrator")
-    expect(@resource.username).to eq("Administrator")
+  it "allows you to set username" do
+    resource.username("Administrator")
+    expect(resource.username).to eq("Administrator")
   end
 
-  it "should allow you to set password" do
-    @resource.password("Jetstream123!")
-    expect(@resource.password).to eq("Jetstream123!")
+  it "allows you to set password" do
+    resource.password("Jetstream123!")
+    expect(resource.password).to eq("Jetstream123!")
   end
 
-  it "should allow you to set domain" do
-    @resource.domain("TEST_DOMAIN")
-    expect(@resource.domain).to eq("TEST_DOMAIN")
+  it "allows you to set domain" do
+    resource.domain("TEST_DOMAIN")
+    expect(resource.domain).to eq("TEST_DOMAIN")
   end
 
   describe "when it has mount point, device type, and fstype" do
     before do
-      @resource.device("charmander")
-      @resource.mount_point("123.456")
-      @resource.device_type(:device)
-      @resource.fstype("ranked")
+      resource.device("charmander")
+      resource.mount_point("123.456")
+      resource.device_type(:device)
+      resource.fstype("ranked")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:mount_point]).to eq("123.456")
       expect(state[:device_type]).to eql(:device)
       expect(state[:fstype]).to eq("ranked")
     end
 
     it "returns the device as its identity" do
-      expect(@resource.identity).to eq("charmander")
+      expect(resource.identity).to eq("charmander")
     end
   end
 
   describe "when it has username, password and domain" do
     before do
-      @resource.mount_point("T:")
-      @resource.device("charmander")
-      @resource.username("Administrator")
-      @resource.password("Jetstream123!")
-      @resource.domain("TEST_DOMAIN")
+      resource.mount_point("T:")
+      resource.device("charmander")
+      resource.username("Administrator")
+      resource.password("Jetstream123!")
+      resource.domain("TEST_DOMAIN")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:mount_point]).to eq("T:")
       expect(state[:username]).to eq("Administrator")
       expect(state[:password]).to eq("*sensitive value suppressed*")

--- a/spec/unit/resource/ohai_spec.rb
+++ b/spec/unit/resource/ohai_spec.rb
@@ -20,41 +20,39 @@ require "spec_helper"
 
 describe Chef::Resource::Ohai do
 
-  before(:each) do
-    @resource = Chef::Resource::Ohai.new("ohai_reload")
+  let(:resource) { Chef::Resource::Ohai.new("ohai_reload") }
+
+  it "creates a new Chef::Resource::Ohai" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Ohai)
   end
 
-  it "should create a new Chef::Resource::Ohai" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Ohai)
+  it "has a resource name of :ohai" do
+    expect(resource.resource_name).to eql(:ohai)
   end
 
-  it "should have a resource name of :ohai" do
-    expect(@resource.resource_name).to eql(:ohai)
+  it "has a default action of reload" do
+    expect(resource.action).to eql([:reload])
   end
 
-  it "should have a default action of reload" do
-    expect(@resource.action).to eql([:reload])
-  end
-
-  it "should allow you to set the plugin attribute" do
-    @resource.plugin "passwd"
-    expect(@resource.plugin).to eql("passwd")
+  it "allows you to set the plugin attribute" do
+    resource.plugin "passwd"
+    expect(resource.plugin).to eql("passwd")
   end
 
   describe "when it has a plugin value" do
     before do
-      @resource.name("test")
-      @resource.plugin("passwd")
+      resource.name("test")
+      resource.plugin("passwd")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:plugin]).to eq("passwd")
     end
 
     it "returns the name as its identity" do
-      expect(@resource.identity).to eq("test")
+      expect(resource.identity).to eq("test")
     end
   end
 

--- a/spec/unit/resource/openbsd_package_spec.rb
+++ b/spec/unit/resource/openbsd_package_spec.rb
@@ -32,15 +32,15 @@ describe Chef::Resource::OpenbsdPackage do
   end
 
   describe "Initialization" do
-    it "should return a Chef::Resource::OpenbsdPackage" do
+    it "returns a Chef::Resource::OpenbsdPackage" do
       expect(@resource).to be_a_kind_of(Chef::Resource::OpenbsdPackage)
     end
 
-    it "should set the resource_name to :openbsd_package" do
+    it "sets the resource_name to :openbsd_package" do
       expect(@resource.resource_name).to eql(:openbsd_package)
     end
 
-    it "should not set the provider" do
+    it "does not set the provider" do
       expect(@resource.provider).to be_nil
     end
   end

--- a/spec/unit/resource/osx_profile_spec.rb
+++ b/spec/unit/resource/osx_profile_spec.rb
@@ -25,36 +25,36 @@ describe Chef::Resource::OsxProfile do
     run_context)
   end
 
-  it "should create a new Chef::Resource::OsxProfile" do
+  it "creates a new Chef::Resource::OsxProfile" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::OsxProfile)
   end
 
-  it "should have a resource name of profile" do
+  it "has a resource name of profile" do
     expect(resource.resource_name).to eql(:osx_profile)
   end
 
-  it "should have a default action of install" do
+  it "has a default action of install" do
     expect(resource.action).to eql([:install])
   end
 
-  it "should accept install and remove as actions" do
+  it "accepts install and remove as actions" do
     expect { resource.action :install }.not_to raise_error
     expect { resource.action :remove }.not_to raise_error
   end
 
-  it "should allow you to set the profile attribute" do
+  it "allows you to set the profile attribute" do
     resource.profile "com.testprofile.screensaver"
     expect(resource.profile).to eql("com.testprofile.screensaver")
   end
 
-  it "should allow you to set the profile attribute to a string" do
+  it "allows you to set the profile attribute to a string" do
     resource.profile "com.testprofile.screensaver"
     expect(resource.profile).to be_a(String)
     expect(resource.profile).to eql("com.testprofile.screensaver")
   end
 
-  it "should allow you to set the profile attribute to a hash" do
+  it "allows you to set the profile attribute to a hash" do
     test_profile = { "profile" => false }
     resource.profile test_profile
     expect(resource.profile).to be_a(Hash)

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -20,84 +20,80 @@
 require "spec_helper"
 
 describe Chef::Resource::Package do
+  let(:resource) { Chef::Resource::Package.new("emacs") }
 
-  before(:each) do
-    @resource = Chef::Resource::Package.new("emacs")
+  it "creates a new Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
   end
 
-  it "should create a new Chef::Resource::Package" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Package)
+  it "sets the package_name to the first argument to new" do
+    expect(resource.package_name).to eql("emacs")
   end
 
-  it "should set the package_name to the first argument to new" do
-    expect(@resource.package_name).to eql("emacs")
+  it "accepts a string for the package name" do
+    resource.package_name "something"
+    expect(resource.package_name).to eql("something")
   end
 
-  it "should accept a string for the package name" do
-    @resource.package_name "something"
-    expect(@resource.package_name).to eql("something")
+  it "accepts a string for the version" do
+    resource.version "something"
+    expect(resource.version).to eql("something")
   end
 
-  it "should accept a string for the version" do
-    @resource.version "something"
-    expect(@resource.version).to eql("something")
+  it "accepts a string for the response file" do
+    resource.response_file "something"
+    expect(resource.response_file).to eql("something")
   end
 
-  it "should accept a string for the response file" do
-    @resource.response_file "something"
-    expect(@resource.response_file).to eql("something")
+  it "accepts a hash for response file template variables" do
+    resource.response_file_variables({ :variables => true })
+    expect(resource.response_file_variables).to eql({ :variables => true })
   end
 
-  it "should accept a hash for response file template variables" do
-    @resource.response_file_variables({ :variables => true })
-    expect(@resource.response_file_variables).to eql({ :variables => true })
+  it "accepts a string for the source" do
+    resource.source "something"
+    expect(resource.source).to eql("something")
   end
 
-  it "should accept a string for the source" do
-    @resource.source "something"
-    expect(@resource.source).to eql("something")
+  it "accepts a string for the options" do
+    resource.options "something"
+    expect(resource.options).to eql(["something"])
   end
 
-  it "should accept a string for the options" do
-    @resource.options "something"
-    expect(@resource.options).to eql(["something"])
-  end
-
-  it "should split options" do
-    @resource.options "-a -b 'arg with spaces' -b \"and quotes\""
-    expect(@resource.options).to eql(["-a", "-b", "arg with spaces", "-b", "and quotes"])
+  it "splits options" do
+    resource.options "-a -b 'arg with spaces' -b \"and quotes\""
+    expect(resource.options).to eql(["-a", "-b", "arg with spaces", "-b", "and quotes"])
   end
 
   describe "when it has a package_name and version" do
     before do
-      @resource.package_name("tomcat")
-      @resource.version("10.9.8")
-      @resource.options("-al")
+      resource.package_name("tomcat")
+      resource.version("10.9.8")
+      resource.options("-al")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:version]).to eq("10.9.8")
       expect(state[:options]).to eq(["-al"])
     end
 
     it "returns the file path as its identity" do
-      expect(@resource.identity).to eq("tomcat")
+      expect(resource.identity).to eq("tomcat")
     end
 
     it "takes options as an array" do
-      @resource.options [ "-a", "-l" ]
-      expect(@resource.options).to eq(["-a", "-l" ])
+      resource.options [ "-a", "-l" ]
+      expect(resource.options).to eq(["-a", "-l" ])
     end
   end
 
   # String, Integer
   [ "600", 600 ].each do |val|
     it "supports setting a timeout as a #{val.class}" do
-      @resource.timeout(val)
-      expect(@resource.timeout).to eql(val)
+      resource.timeout(val)
+      expect(resource.timeout).to eql(val)
     end
   end
-
 end

--- a/spec/unit/resource/perl_spec.rb
+++ b/spec/unit/resource/perl_spec.rb
@@ -20,21 +20,18 @@ require "spec_helper"
 
 describe Chef::Resource::Perl do
 
-  before(:each) do
-    @resource = Chef::Resource::Perl.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Perl.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Perl" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Perl)
   end
 
-  it "should create a new Chef::Resource::Perl" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Perl)
+  it "has a resource name of :perl" do
+    expect(resource.resource_name).to eql(:perl)
   end
 
-  it "should have a resource name of :perl" do
-    expect(@resource.resource_name).to eql(:perl)
+  it "has an interpreter of perl" do
+    expect(resource.interpreter).to eql("perl")
   end
-
-  it "should have an interpreter of perl" do
-    expect(@resource.interpreter).to eql("perl")
-  end
-
 end

--- a/spec/unit/resource/portage_package_spec.rb
+++ b/spec/unit/resource/portage_package_spec.rb
@@ -16,23 +16,21 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
+require "spec_helper"
 
 describe Chef::Resource::PortagePackage, "initialize" do
 
-  before(:each) do
-    @resource = Chef::Resource::PortagePackage.new("foo")
+  let(:resource) { Chef::Resource::PortagePackage.new("foo") }
+
+  it "returns a Chef::Resource::PortagePackage" do
+    expect(resource).to be_a_kind_of(Chef::Resource::PortagePackage)
   end
 
-  it "should return a Chef::Resource::PortagePackage" do
-    expect(@resource).to be_a_kind_of(Chef::Resource::PortagePackage)
+  it "sets the resource_name to :portage_package" do
+    expect(resource.resource_name).to eql(:portage_package)
   end
 
-  it "should set the resource_name to :portage_package" do
-    expect(@resource.resource_name).to eql(:portage_package)
-  end
-
-  it "should set the provider to Chef::Provider::Package::Portage" do
-    expect(@resource.provider).to eql(Chef::Provider::Package::Portage)
+  it "sets the provider to Chef::Provider::Package::Portage" do
+    expect(resource.provider).to eql(Chef::Provider::Package::Portage)
   end
 end

--- a/spec/unit/resource/powershell_package_spec.rb
+++ b/spec/unit/resource/powershell_package_spec.rb
@@ -22,46 +22,46 @@ describe Chef::Resource::PowershellPackage do
 
   let(:resource) { Chef::Resource::PowershellPackage.new("test_package") }
 
-  it "should create a new Chef::Resource::PowershellPackage" do
+  it "creates a new Chef::Resource::PowershellPackage" do
     expect(resource).to be_a_kind_of(Chef::Resource)
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
     expect(resource).to be_a_instance_of(Chef::Resource::PowershellPackage)
   end
 
   #to check the value of resource.resource_name
-  it "should have a resource name of :python" do
+  it "has a resource name of :python" do
     expect(resource.resource_name).to eql(:powershell_package)
   end
 
-  it "should coerce its name to a package_name array" do
+  it "coerces its name to a package_name array" do
     expect(resource.package_name).to eql(["test_package"])
   end
 
-  it "the package_name setter should coerce to arrays" do
+  it "the package_name setter coerces to arrays" do
     resource.package_name("git")
     expect(resource.package_name).to eql(["git"])
   end
 
-  it "the package_name setter should accept arrays" do
+  it "the package_name setter accepts arrays" do
     resource.package_name(%w{git unzip})
     expect(resource.package_name).to eql(%w{git unzip})
   end
 
-  it "the name should accept arrays" do
+  it "the name accepts arrays" do
     resource = Chef::Resource::PowershellPackage.new(%w{git unzip})
     expect(resource.package_name).to eql(%w{git unzip})
   end
 
-  it "the default version should be nil" do
+  it "the default version is nil" do
     expect(resource.version).to eql(nil)
   end
 
-  it "the version setter should coerce to arrays" do
+  it "the version setter coerces to arrays" do
     resource.version("1.2.3")
     expect(resource.version).to eql(["1.2.3"])
   end
 
-  it "the version setter should accept arrays" do
+  it "the version setter accepts arrays" do
     resource.version(["1.2.3", "4.5.6"])
     expect(resource.version).to eql(["1.2.3", "4.5.6"])
   end

--- a/spec/unit/resource/python_spec.rb
+++ b/spec/unit/resource/python_spec.rb
@@ -20,21 +20,18 @@ require "spec_helper"
 
 describe Chef::Resource::Python do
 
-  before(:each) do
-    @resource = Chef::Resource::Python.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::Python.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::Python" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Python)
   end
 
-  it "should create a new Chef::Resource::Python" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Python)
+  it "has a resource name of :python" do
+    expect(resource.resource_name).to eql(:python)
   end
 
-  it "should have a resource name of :python" do
-    expect(@resource.resource_name).to eql(:python)
+  it "has an interpreter of python" do
+    expect(resource.interpreter).to eql("python")
   end
-
-  it "should have an interpreter of python" do
-    expect(@resource.interpreter).to eql("python")
-  end
-
 end

--- a/spec/unit/resource/reboot_spec.rb
+++ b/spec/unit/resource/reboot_spec.rb
@@ -19,34 +19,32 @@ require "spec_helper"
 
 describe Chef::Resource::Reboot do
 
-  before(:each) do
-    @resource = Chef::Resource::Reboot.new("reboot me!")
+  let(:resource) { Chef::Resource::Reboot.new("reboot me!") }
+
+  it "creates a new Chef::Resource::Reboot" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Reboot)
   end
 
-  it "should create a new Chef::Resource::Reboot" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Reboot)
-  end
-
-  it "should have a default action of :nothing" do
-    expect(@resource.action).to eql([:nothing])
+  it "has a default action of :nothing" do
+    expect(resource.action).to eql([:nothing])
   end
 
   it "supports the :nothing, :request_reboot, :reboot_now, and :cancel actions" do
-    expect(@resource.allowed_actions).to include(:nothing, :request_reboot, :reboot_now, :cancel)
+    expect(resource.allowed_actions).to include(:nothing, :request_reboot, :reboot_now, :cancel)
   end
 
-  it "should have a resource_name of :reboot" do
-    expect(@resource.resource_name).to eq(:reboot)
+  it "has a resource_name of :reboot" do
+    expect(resource.resource_name).to eq(:reboot)
   end
 
-  it "should accept a String for the reboot reason" do
-    @resource.reason "reasons"
-    expect(@resource.reason).to eq("reasons")
+  it "accepts a String for the reboot reason" do
+    resource.reason "reasons"
+    expect(resource.reason).to eq("reasons")
   end
 
-  it "should accept an Integer for delay_mins" do
-    @resource.delay_mins 100
-    expect { @resource.delay_mins "100" }.to raise_error(ArgumentError)
+  it "accepts an Integer for delay_mins" do
+    resource.delay_mins 100
+    expect { resource.delay_mins "100" }.to raise_error(ArgumentError)
   end
 end

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -19,197 +19,183 @@
 require "spec_helper"
 
 describe Chef::Resource::RegistryKey, "initialize" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
+
+  it "creates a new Chef::Resource::RegistryKey" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::RegistryKey)
   end
 
-  it "should create a new Chef::Resource::RegistryKey" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::RegistryKey)
+  it "sets the resource_name to :registry_key" do
+    expect(resource.resource_name).to eql(:registry_key)
   end
 
-  it "should set the resource_name to :registry_key" do
-    expect(@resource.resource_name).to eql(:registry_key)
+  it "sets the key equal to the argument to initialize" do
+    expect(resource.key).to eql('HKCU\Software\Raxicoricofallapatorius')
   end
 
-  it "should set the key equal to the argument to initialize" do
-    expect(@resource.key).to eql('HKCU\Software\Raxicoricofallapatorius')
+  it "defaults recursive to false" do
+    expect(resource.recursive).to eql(false)
   end
 
-  it "should default recursive to false" do
-    expect(@resource.recursive).to eql(false)
+  it "defaults architecture to :machine" do
+    expect(resource.architecture).to eql(:machine)
   end
 
-  it "should default architecture to :machine" do
-    expect(@resource.architecture).to eql(:machine)
-  end
-
-  it "should set action to :create" do
-    expect(@resource.action).to eql([:create])
+  it "sets action to :create" do
+    expect(resource.action).to eql([:create])
   end
 
   %w{create create_if_missing delete delete_key}.each do |action|
-    it "should allow action #{action}" do
-      expect(@resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
+    it "allows action #{action}" do
+      expect(resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
     end
   end
 end
 
 describe Chef::Resource::RegistryKey, "key" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
+
+  it "allows a string" do
+    resource.key 'HKCU\Software\Poosh'
+    expect(resource.key).to eql('HKCU\Software\Poosh')
   end
 
-  it "should allow a string" do
-    @resource.key 'HKCU\Software\Poosh'
-    expect(@resource.key).to eql('HKCU\Software\Poosh')
+  it "does not allow an integer" do
+    expect { resource.send(:key, 100) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow an integer" do
-    expect { @resource.send(:key, 100) }.to raise_error(ArgumentError)
-  end
-
-  it "should not allow a hash" do
-    expect { @resource.send(:key, { :sonic => "screwdriver" }) }.to raise_error(ArgumentError)
+  it "does not allow a hash" do
+    expect { resource.send(:key, { :sonic => "screwdriver" }) }.to raise_error(ArgumentError)
   end
 end
 
 describe Chef::Resource::RegistryKey, "values" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
+
+  it "allows a single proper hash of registry values" do
+    resource.values( { :name => "poosh", :type => :string, :data => "carmen" } )
+    expect(resource.values).to eql([ { :name => "poosh", :type => :string, :data => "carmen" } ])
   end
 
-  it "should allow a single proper hash of registry values" do
-    @resource.values( { :name => "poosh", :type => :string, :data => "carmen" } )
-    expect(@resource.values).to eql([ { :name => "poosh", :type => :string, :data => "carmen" } ])
+  it "allows an array of proper hashes of registry values" do
+    resource.values [ { :name => "poosh", :type => :string, :data => "carmen" } ]
+    expect(resource.values).to eql([ { :name => "poosh", :type => :string, :data => "carmen" } ])
   end
 
-  it "should allow an array of proper hashes of registry values" do
-    @resource.values [ { :name => "poosh", :type => :string, :data => "carmen" } ]
-    expect(@resource.values).to eql([ { :name => "poosh", :type => :string, :data => "carmen" } ])
+  it "returns checksummed data if the type is unsafe" do
+    resource.values( { :name => "poosh", :type => :binary, :data => 255.chr * 1 })
+    expect(resource.values).to eql([ { :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" } ])
   end
 
-  it "should return checksummed data if the type is unsafe" do
-    @resource.values( { :name => "poosh", :type => :binary, :data => 255.chr * 1 })
-    expect(@resource.values).to eql([ { :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" } ])
+  it "raises an exception if the name field is missing" do
+    expect { resource.values [ { :type => :string, :data => "carmen" } ] }.to raise_error(ArgumentError)
   end
 
-  it "should raise an exception if the name field is missing" do
-    expect { @resource.values [ { :type => :string, :data => "carmen" } ] }.to raise_error(ArgumentError)
+  it "raises an exception if extra fields are present" do
+    expect { resource.values [ { :name => "poosh", :type => :string, :data => "carmen", :screwdriver => "sonic" } ] }.to raise_error(ArgumentError)
   end
 
-  it "should raise an exception if extra fields are present" do
-    expect { @resource.values [ { :name => "poosh", :type => :string, :data => "carmen", :screwdriver => "sonic" } ] }.to raise_error(ArgumentError)
+  it "does not allow a string" do
+    expect { resource.send(:values, "souffle") }.to raise_error(ArgumentError)
   end
 
-  it "should not allow a string" do
-    expect { @resource.send(:values, "souffle") }.to raise_error(ArgumentError)
+  it "does not allow an integer" do
+    expect { resource.send(:values, 100) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow an integer" do
-    expect { @resource.send(:values, 100) }.to raise_error(ArgumentError)
+  it "raises an exception if type of name is not string" do
+    expect { resource.values([ { :name => 123, :type => :string, :data => "carmen" } ]) }.to raise_error(ArgumentError)
   end
 
-  it "should raise an exception if type of name is not string" do
-    expect { @resource.values([ { :name => 123, :type => :string, :data => "carmen" } ]) }.to raise_error(ArgumentError)
-  end
-
-  it "should not raise an exception if type of name is string" do
-    expect { @resource.values([ { :name => "123", :type => :string, :data => "carmen" } ]) }.to_not raise_error
+  it "does not raise an exception if type of name is string" do
+    expect { resource.values([ { :name => "123", :type => :string, :data => "carmen" } ]) }.to_not raise_error
   end
 
   context "type key not given" do
-    it "should not raise an exception" do
-      expect { @resource.values([ { :name => "123", :data => "carmen" } ]) }.to_not raise_error
+    it "does not raise an exception" do
+      expect { resource.values([ { :name => "123", :data => "carmen" } ]) }.to_not raise_error
     end
   end
 
   context "type key given" do
-    it "should raise an exception if type of type is not symbol" do
-      expect { @resource.values([ { :name => "123", :type => "string", :data => "carmen" } ]) }.to raise_error(ArgumentError)
+    it "raises an exception if type of type is not symbol" do
+      expect { resource.values([ { :name => "123", :type => "string", :data => "carmen" } ]) }.to raise_error(ArgumentError)
     end
 
-    it "should not raise an exception if type of type is symbol" do
-      expect { @resource.values([ { :name => "123", :type => :string, :data => "carmen" } ]) }.to_not raise_error
+    it "does not raise an exception if type of type is symbol" do
+      expect { resource.values([ { :name => "123", :type => :string, :data => "carmen" } ]) }.to_not raise_error
     end
   end
 end
 
 describe Chef::Resource::RegistryKey, "recursive" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
+
+  it "allows a boolean" do
+    resource.recursive(true)
+    expect(resource.recursive).to eql(true)
   end
 
-  it "should allow a boolean" do
-    @resource.recursive(true)
-    expect(@resource.recursive).to eql(true)
+  it "does not allow a hash" do
+    expect { resource.recursive({ :sonic => :screwdriver }) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow a hash" do
-    expect { @resource.recursive({ :sonic => :screwdriver }) }.to raise_error(ArgumentError)
+  it "does not allow an array" do
+    expect { resource.recursive([:nose, :chin]) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow an array" do
-    expect { @resource.recursive([:nose, :chin]) }.to raise_error(ArgumentError)
+  it "does not allow a string" do
+    expect { resource.recursive("souffle") }.to raise_error(ArgumentError)
   end
 
-  it "should not allow a string" do
-    expect { @resource.recursive("souffle") }.to raise_error(ArgumentError)
-  end
-
-  it "should not allow an integer" do
-    expect { @resource.recursive(100) }.to raise_error(ArgumentError)
+  it "does not allow an integer" do
+    expect { resource.recursive(100) }.to raise_error(ArgumentError)
   end
 end
 
 describe Chef::Resource::RegistryKey, "architecture" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
-  end
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
 
   [ :i386, :x86_64, :machine ].each do |arch|
-    it "should allow #{arch} as a symbol" do
-      @resource.architecture(arch)
-      expect(@resource.architecture).to eql(arch)
+    it "allows #{arch} as a symbol" do
+      resource.architecture(arch)
+      expect(resource.architecture).to eql(arch)
     end
   end
 
-  it "should not allow a hash" do
-    expect { @resource.architecture({ :sonic => :screwdriver }) }.to raise_error(ArgumentError)
+  it "does not allow a hash" do
+    expect { resource.architecture({ :sonic => :screwdriver }) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow an array" do
-    expect { @resource.architecture([:nose, :chin]) }.to raise_error(ArgumentError)
+  it "does not allow an array" do
+    expect { resource.architecture([:nose, :chin]) }.to raise_error(ArgumentError)
   end
 
-  it "should not allow a string" do
-    expect { @resource.architecture("souffle") }.to raise_error(ArgumentError)
+  it "does not allow a string" do
+    expect { resource.architecture("souffle") }.to raise_error(ArgumentError)
   end
 
-  it "should not allow an integer" do
-    expect { @resource.architecture(100) }.to raise_error(ArgumentError)
+  it "does not allow an integer" do
+    expect { resource.architecture(100) }.to raise_error(ArgumentError)
   end
 end
 
 describe Chef::Resource::RegistryKey, ":unscrubbed_values" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
-  end
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
 
-  it "should return unsafe data as-is" do
+  it "returns unsafe data as-is" do
     key_values = [ { :name => "poosh", :type => :binary, :data => 255.chr * 1 } ]
-    @resource.values(key_values)
-    expect(@resource.unscrubbed_values).to eql(key_values)
+    resource.values(key_values)
+    expect(resource.unscrubbed_values).to eql(key_values)
   end
 end
 
 describe Chef::Resource::RegistryKey, "state" do
-  before(:each) do
-    @resource = Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius')
-  end
+  let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
 
-  it "should return scrubbed values" do
-    @resource.values([ { :name => "poosh", :type => :binary, :data => 255.chr * 1 } ])
-    expect(@resource.state_for_resource_reporter).to eql( { :values => [{ :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" }] } )
+  it "returns scrubbed values" do
+    resource.values([ { :name => "poosh", :type => :binary, :data => 255.chr * 1 } ])
+    expect(resource.state_for_resource_reporter).to eql( { :values => [{ :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" }] } )
   end
 end

--- a/spec/unit/resource/remote_directory_spec.rb
+++ b/spec/unit/resource/remote_directory_spec.rb
@@ -20,78 +20,76 @@ require "spec_helper"
 
 describe Chef::Resource::RemoteDirectory do
 
-  before(:each) do
-    @resource = Chef::Resource::RemoteDirectory.new("/etc/dunk")
+  let(:resource) { Chef::Resource::RemoteDirectory.new("/etc/dunk") }
+
+  it "creates a new Chef::Resource::RemoteDirectory" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::RemoteDirectory)
   end
 
-  it "should create a new Chef::Resource::RemoteDirectory" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::RemoteDirectory)
+  it "sets the path to the first argument to new" do
+    expect(resource.path).to eql("/etc/dunk")
   end
 
-  it "should set the path to the first argument to new" do
-    expect(@resource.path).to eql("/etc/dunk")
+  it "accepts a string for the remote directory source" do
+    resource.source "foo"
+    expect(resource.source).to eql("foo")
   end
 
-  it "should accept a string for the remote directory source" do
-    @resource.source "foo"
-    expect(@resource.source).to eql("foo")
+  it "has the basename of the remote directory resource as the default source" do
+    expect(resource.source).to eql("dunk")
   end
 
-  it "should have the basename of the remote directory resource as the default source" do
-    expect(@resource.source).to eql("dunk")
+  it "accepts a number for the remote files backup" do
+    resource.files_backup 1
+    expect(resource.files_backup).to eql(1)
   end
 
-  it "should accept a number for the remote files backup" do
-    @resource.files_backup 1
-    expect(@resource.files_backup).to eql(1)
+  it "accepts false for the remote files backup" do
+    resource.files_backup false
+    expect(resource.files_backup).to eql(false)
   end
 
-  it "should accept false for the remote files backup" do
-    @resource.files_backup false
-    expect(@resource.files_backup).to eql(false)
+  it "accepts 3 or 4 digets for the files_mode" do
+    resource.files_mode 100
+    expect(resource.files_mode).to eql(100)
+    resource.files_mode 1000
+    expect(resource.files_mode).to eql(1000)
   end
 
-  it "should accept 3 or 4 digets for the files_mode" do
-    @resource.files_mode 100
-    expect(@resource.files_mode).to eql(100)
-    @resource.files_mode 1000
-    expect(@resource.files_mode).to eql(1000)
+  it "accepts a string or number for the files group" do
+    resource.files_group "heart"
+    expect(resource.files_group).to eql("heart")
+    resource.files_group 1000
+    expect(resource.files_group).to eql(1000)
   end
 
-  it "should accept a string or number for the files group" do
-    @resource.files_group "heart"
-    expect(@resource.files_group).to eql("heart")
-    @resource.files_group 1000
-    expect(@resource.files_group).to eql(1000)
-  end
-
-  it "should accept a string or number for the files owner" do
-    @resource.files_owner "heart"
-    expect(@resource.files_owner).to eql("heart")
-    @resource.files_owner 1000
-    expect(@resource.files_owner).to eql(1000)
+  it "accepts a string or number for the files owner" do
+    resource.files_owner "heart"
+    expect(resource.files_owner).to eql("heart")
+    resource.files_owner 1000
+    expect(resource.files_owner).to eql(1000)
   end
 
   describe "when it has cookbook, files owner, files mode, and source" do
     before do
-      @resource.path("/var/path/")
-      @resource.cookbook("pokemon.rb")
-      @resource.files_owner("root")
-      @resource.files_group("supergroup")
-      @resource.files_mode("0664")
-      @resource.source("/var/source/")
+      resource.path("/var/path/")
+      resource.cookbook("pokemon.rb")
+      resource.files_owner("root")
+      resource.files_group("supergroup")
+      resource.files_mode("0664")
+      resource.source("/var/source/")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:files_owner]).to eq("root")
       expect(state[:files_group]).to eq("supergroup")
       expect(state[:files_mode]).to eq("0664")
     end
 
     it "returns the path  as its identity" do
-      expect(@resource.identity).to eq("/var/path/")
+      expect(resource.identity).to eq("/var/path/")
     end
   end
 end

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -21,147 +21,145 @@ require "spec_helper"
 
 describe Chef::Resource::RemoteFile do
 
-  before(:each) do
-    @resource = Chef::Resource::RemoteFile.new("fakey_fakerton")
-  end
+  let(:resource) { Chef::Resource::RemoteFile.new("fakey_fakerton") }
 
   describe "initialize" do
-    it "should create a new Chef::Resource::RemoteFile" do
-      expect(@resource).to be_a_kind_of(Chef::Resource)
-      expect(@resource).to be_a_kind_of(Chef::Resource::File)
-      expect(@resource).to be_a_kind_of(Chef::Resource::RemoteFile)
+    it "creates a new Chef::Resource::RemoteFile" do
+      expect(resource).to be_a_kind_of(Chef::Resource)
+      expect(resource).to be_a_kind_of(Chef::Resource::File)
+      expect(resource).to be_a_kind_of(Chef::Resource::RemoteFile)
     end
   end
 
   it "says its provider is RemoteFile when the source is an absolute URI" do
-    @resource.source("http://www.google.com/robots.txt")
-    expect(@resource.provider).to eq(Chef::Provider::RemoteFile)
-    expect(@resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
+    resource.source("http://www.google.com/robots.txt")
+    expect(resource.provider).to eq(Chef::Provider::RemoteFile)
+    expect(resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 
   it "says its provider is RemoteFile when the source is a network share" do
-    @resource.source("\\\\fakey\\fakerton\\fake.txt")
-    expect(@resource.provider).to eq(Chef::Provider::RemoteFile)
-    expect(@resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
+    resource.source("\\\\fakey\\fakerton\\fake.txt")
+    expect(resource.provider).to eq(Chef::Provider::RemoteFile)
+    expect(resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 
   describe "source" do
     it "does not have a default value for 'source'" do
-      expect(@resource.source).to eql([])
+      expect(resource.source).to eql([])
     end
 
-    it "should accept a URI for the remote file source" do
-      @resource.source "http://opscode.com/"
-      expect(@resource.source).to eql([ "http://opscode.com/" ])
+    it "accepts a URI for the remote file source" do
+      resource.source "http://opscode.com/"
+      expect(resource.source).to eql([ "http://opscode.com/" ])
     end
 
-    it "should accept a windows network share source" do
-      @resource.source "\\\\fakey\\fakerton\\fake.txt"
-      expect(@resource.source).to eql([ "\\\\fakey\\fakerton\\fake.txt" ])
+    it "accepts a windows network share source" do
+      resource.source "\\\\fakey\\fakerton\\fake.txt"
+      expect(resource.source).to eql([ "\\\\fakey\\fakerton\\fake.txt" ])
     end
 
-    it "should accept file URIs with spaces" do
-      @resource.source("file:///C:/foo bar")
-      expect(@resource.source).to eql(["file:///C:/foo bar"])
+    it "accepts file URIs with spaces" do
+      resource.source("file:///C:/foo bar")
+      expect(resource.source).to eql(["file:///C:/foo bar"])
     end
 
-    it "should accept a delayed evalutator (string) for the remote file source" do
-      @resource.source Chef::DelayedEvaluator.new { "http://opscode.com/" }
-      expect(@resource.source).to eql([ "http://opscode.com/" ])
+    it "accepts a delayed evalutator (string) for the remote file source" do
+      resource.source Chef::DelayedEvaluator.new { "http://opscode.com/" }
+      expect(resource.source).to eql([ "http://opscode.com/" ])
     end
 
-    it "should accept an array of URIs for the remote file source" do
-      @resource.source([ "http://opscode.com/", "http://puppetlabs.com/" ])
-      expect(@resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
+    it "accepts an array of URIs for the remote file source" do
+      resource.source([ "http://opscode.com/", "http://puppetlabs.com/" ])
+      expect(resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
     end
 
-    it "should accept a delated evaluator (array) for the remote file source" do
-      @resource.source Chef::DelayedEvaluator.new { [ "http://opscode.com/", "http://puppetlabs.com/" ] }
-      expect(@resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
+    it "accepts a delated evaluator (array) for the remote file source" do
+      resource.source Chef::DelayedEvaluator.new { [ "http://opscode.com/", "http://puppetlabs.com/" ] }
+      expect(resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
     end
 
-    it "should accept an multiple URIs as arguments for the remote file source" do
-      @resource.source("http://opscode.com/", "http://puppetlabs.com/")
-      expect(@resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
+    it "accepts an multiple URIs as arguments for the remote file source" do
+      resource.source("http://opscode.com/", "http://puppetlabs.com/")
+      expect(resource.source).to eql([ "http://opscode.com/", "http://puppetlabs.com/" ])
     end
 
-    it "should only accept a single argument if a delayed evalutor is used" do
+    it "only accept a single argument if a delayed evalutor is used" do
       expect do
-        @resource.source("http://opscode.com/", Chef::DelayedEvaluator.new { "http://opscode.com/" })
+        resource.source("http://opscode.com/", Chef::DelayedEvaluator.new { "http://opscode.com/" })
       end.to raise_error(Chef::Exceptions::InvalidRemoteFileURI)
     end
 
-    it "should only accept a single array item if a delayed evalutor is used" do
+    it "only accept a single array item if a delayed evalutor is used" do
       expect do
-        @resource.source(["http://opscode.com/", Chef::DelayedEvaluator.new { "http://opscode.com/" }])
+        resource.source(["http://opscode.com/", Chef::DelayedEvaluator.new { "http://opscode.com/" }])
       end.to raise_error(Chef::Exceptions::InvalidRemoteFileURI)
     end
 
     it "does not accept a non-URI as the source" do
-      expect { @resource.source("not-a-uri") }.to raise_error(Chef::Exceptions::InvalidRemoteFileURI)
+      expect { resource.source("not-a-uri") }.to raise_error(Chef::Exceptions::InvalidRemoteFileURI)
     end
 
     it "does not accept a non-URI as the source when read from a delayed evaluator" do
       expect do
-        @resource.source(Chef::DelayedEvaluator.new { "not-a-uri" })
-        @resource.source
+        resource.source(Chef::DelayedEvaluator.new { "not-a-uri" })
+        resource.source
       end.to raise_error(Chef::Exceptions::InvalidRemoteFileURI)
     end
 
-    it "should raise an exception when source is an empty array" do
-      expect { @resource.source([]) }.to raise_error(ArgumentError)
+    it "raises an exception when source is an empty array" do
+      expect { resource.source([]) }.to raise_error(ArgumentError)
     end
 
   end
 
   describe "checksum" do
-    it "should accept a string for the checksum object" do
-      @resource.checksum "asdf"
-      expect(@resource.checksum).to eql("asdf")
+    it "accepts a string for the checksum object" do
+      resource.checksum "asdf"
+      expect(resource.checksum).to eql("asdf")
     end
 
-    it "should default to nil" do
-      expect(@resource.checksum).to eq(nil)
+    it "defaults to nil" do
+      expect(resource.checksum).to eq(nil)
     end
   end
 
   describe "ftp_active_mode" do
-    it "should accept a boolean for the ftp_active_mode object" do
-      @resource.ftp_active_mode true
-      expect(@resource.ftp_active_mode).to be_truthy
+    it "accepts a boolean for the ftp_active_mode object" do
+      resource.ftp_active_mode true
+      expect(resource.ftp_active_mode).to be_truthy
     end
 
-    it "should default to false" do
-      expect(@resource.ftp_active_mode).to be_falsey
+    it "defaults to false" do
+      expect(resource.ftp_active_mode).to be_falsey
     end
   end
 
   describe "conditional get options" do
     it "defaults to using etags and last modified" do
-      expect(@resource.use_etags).to be_truthy
-      expect(@resource.use_last_modified).to be_truthy
+      expect(resource.use_etags).to be_truthy
+      expect(resource.use_last_modified).to be_truthy
     end
 
     it "enable or disables etag and last modified options as a group" do
-      @resource.use_conditional_get(false)
-      expect(@resource.use_etags).to be_falsey
-      expect(@resource.use_last_modified).to be_falsey
+      resource.use_conditional_get(false)
+      expect(resource.use_etags).to be_falsey
+      expect(resource.use_last_modified).to be_falsey
 
-      @resource.use_conditional_get(true)
-      expect(@resource.use_etags).to be_truthy
-      expect(@resource.use_last_modified).to be_truthy
+      resource.use_conditional_get(true)
+      expect(resource.use_etags).to be_truthy
+      expect(resource.use_last_modified).to be_truthy
     end
 
     it "disables etags indivdually" do
-      @resource.use_etags(false)
-      expect(@resource.use_etags).to be_falsey
-      expect(@resource.use_last_modified).to be_truthy
+      resource.use_etags(false)
+      expect(resource.use_etags).to be_falsey
+      expect(resource.use_last_modified).to be_truthy
     end
 
     it "disables last modified individually" do
-      @resource.use_last_modified(false)
-      expect(@resource.use_last_modified).to be_falsey
-      expect(@resource.use_etags).to be_truthy
+      resource.use_last_modified(false)
+      expect(resource.use_last_modified).to be_falsey
+      expect(resource.use_etags).to be_truthy
     end
 
   end
@@ -169,21 +167,21 @@ describe Chef::Resource::RemoteFile do
   describe "when it has group, mode, owner, source, and checksum" do
     before do
       if Chef::Platform.windows?
-        @resource.path("C:/temp/origin/file.txt")
-        @resource.rights(:read, "Everyone")
-        @resource.deny_rights(:full_control, "Clumsy_Sam")
+        resource.path("C:/temp/origin/file.txt")
+        resource.rights(:read, "Everyone")
+        resource.deny_rights(:full_control, "Clumsy_Sam")
       else
-        @resource.path("/this/path/")
-        @resource.group("pokemon")
-        @resource.mode("0664")
-        @resource.owner("root")
+        resource.path("/this/path/")
+        resource.group("pokemon")
+        resource.mode("0664")
+        resource.owner("root")
       end
-      @resource.source("https://www.google.com/images/srpr/logo3w.png")
-      @resource.checksum("1" * 26)
+      resource.source("https://www.google.com/images/srpr/logo3w.png")
+      resource.checksum("1" * 26)
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       if Chef::Platform.windows?
         puts state
         expect(state[:rights]).to eq([{ :permissions => :read, :principals => "Everyone" }])
@@ -198,9 +196,9 @@ describe Chef::Resource::RemoteFile do
 
     it "returns the path as its identity" do
       if Chef::Platform.windows?
-        expect(@resource.identity).to eq("C:/temp/origin/file.txt")
+        expect(resource.identity).to eq("C:/temp/origin/file.txt")
       else
-        expect(@resource.identity).to eq("/this/path/")
+        expect(resource.identity).to eq("/this/path/")
       end
     end
   end

--- a/spec/unit/resource/route_spec.rb
+++ b/spec/unit/resource/route_spec.rb
@@ -21,87 +21,85 @@ require "spec_helper"
 
 describe Chef::Resource::Route do
 
-  before(:each) do
-    @resource = Chef::Resource::Route.new("10.0.0.10")
+  let(:resource) { Chef::Resource::Route.new("10.0.0.10") }
+
+  it "creates a new Chef::Resource::Route" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Route)
   end
 
-  it "should create a new Chef::Resource::Route" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Route)
+  it "has a name" do
+    expect(resource.name).to eql("10.0.0.10")
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("10.0.0.10")
+  it "has a default action of 'add'" do
+    expect(resource.action).to eql([:add])
   end
 
-  it "should have a default action of 'add'" do
-    expect(@resource.action).to eql([:add])
+  it "accepts add or delete for action" do
+    expect { resource.action :add }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :lolcat }.to raise_error(ArgumentError)
   end
 
-  it "should accept add or delete for action" do
-    expect { @resource.action :add }.not_to raise_error
-    expect { @resource.action :delete }.not_to raise_error
-    expect { @resource.action :lolcat }.to raise_error(ArgumentError)
+  it "uses the object name as the target by default" do
+    expect(resource.target).to eql("10.0.0.10")
   end
 
-  it "should use the object name as the target by default" do
-    expect(@resource.target).to eql("10.0.0.10")
+  it "allows you to specify the netmask" do
+    resource.netmask "255.255.255.0"
+    expect(resource.netmask).to eql("255.255.255.0")
   end
 
-  it "should allow you to specify the netmask" do
-    @resource.netmask "255.255.255.0"
-    expect(@resource.netmask).to eql("255.255.255.0")
+  it "allows you to specify the gateway" do
+    resource.gateway "10.0.0.1"
+    expect(resource.gateway).to eql("10.0.0.1")
   end
 
-  it "should allow you to specify the gateway" do
-    @resource.gateway "10.0.0.1"
-    expect(@resource.gateway).to eql("10.0.0.1")
+  it "allows you to specify the metric" do
+    resource.metric 10
+    expect(resource.metric).to eql(10)
   end
 
-  it "should allow you to specify the metric" do
-    @resource.metric 10
-    expect(@resource.metric).to eql(10)
+  it "allows you to specify the device" do
+    resource.device "eth0"
+    expect(resource.device).to eql("eth0")
   end
 
-  it "should allow you to specify the device" do
-    @resource.device "eth0"
-    expect(@resource.device).to eql("eth0")
+  it "allows you to specify the route type" do
+    resource.route_type "host"
+    expect(resource.route_type).to eql(:host)
   end
 
-  it "should allow you to specify the route type" do
-    @resource.route_type "host"
-    expect(@resource.route_type).to eql(:host)
+  it "defaults to a host route type" do
+    expect(resource.route_type).to eql(:host)
   end
 
-  it "should default to a host route type" do
-    expect(@resource.route_type).to eql(:host)
+  it "accepts a net route type" do
+    resource.route_type :net
+    expect(resource.route_type).to eql(:net)
   end
 
-  it "should accept a net route type" do
-    @resource.route_type :net
-    expect(@resource.route_type).to eql(:net)
-  end
-
-  it "should reject any other route_type but :host and :net" do
-    expect { @resource.route_type "lolcat" }.to raise_error(ArgumentError)
+  it "rejects any other route_type but :host and :net" do
+    expect { resource.route_type "lolcat" }.to raise_error(ArgumentError)
   end
 
   describe "when it has netmask, gateway, and device" do
     before do
-      @resource.target("charmander")
-      @resource.netmask("lemask")
-      @resource.gateway("111.111.111")
-      @resource.device("forcefield")
+      resource.target("charmander")
+      resource.netmask("lemask")
+      resource.gateway("111.111.111")
+      resource.device("forcefield")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:netmask]).to eq("lemask")
       expect(state[:gateway]).to eq("111.111.111")
     end
 
     it "returns the target  as its identity" do
-      expect(@resource.identity).to eq("charmander")
+      expect(resource.identity).to eq("charmander")
     end
   end
 end

--- a/spec/unit/resource/rpm_package_spec.rb
+++ b/spec/unit/resource/rpm_package_spec.rb
@@ -34,13 +34,11 @@ describe Chef::Resource::RpmPackage, "initialize" do
 end
 
 describe Chef::Resource::RpmPackage, "allow_downgrade" do
-  before(:each) do
-    @resource = Chef::Resource::RpmPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::RpmPackage.new("foo") }
 
-  it "should allow you to specify whether allow_downgrade is true or false" do
-    expect { @resource.allow_downgrade true }.not_to raise_error
-    expect { @resource.allow_downgrade false }.not_to raise_error
-    expect { @resource.allow_downgrade "monkey" }.to raise_error(ArgumentError)
+  it "allows you to specify whether allow_downgrade is true or false" do
+    expect { resource.allow_downgrade true }.not_to raise_error
+    expect { resource.allow_downgrade false }.not_to raise_error
+    expect { resource.allow_downgrade "monkey" }.to raise_error(ArgumentError)
   end
 end

--- a/spec/unit/resource/ruby_block_spec.rb
+++ b/spec/unit/resource/ruby_block_spec.rb
@@ -21,41 +21,39 @@ require "spec_helper"
 
 describe Chef::Resource::RubyBlock do
 
-  before(:each) do
-    @resource = Chef::Resource::RubyBlock.new("fakey_fakerton")
+  let(:resource) { Chef::Resource::RubyBlock.new("fakey_fakerton") }
+
+  it "creates a new Chef::Resource::RubyBlock" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::RubyBlock)
   end
 
-  it "should create a new Chef::Resource::RubyBlock" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::RubyBlock)
+  it "has a default action of 'run'" do
+    expect(resource.action).to eql([:run])
   end
 
-  it "should have a default action of 'run'" do
-    expect(@resource.action).to eql([:run])
+  it "has a resource name of :ruby_block" do
+    expect(resource.resource_name).to eql(:ruby_block)
   end
 
-  it "should have a resource name of :ruby_block" do
-    expect(@resource.resource_name).to eql(:ruby_block)
-  end
-
-  it "should accept a ruby block/proc/.. for the 'block' parameter" do
-    expect(@resource.block do
+  it "accepts a ruby block/proc/.. for the 'block' parameter" do
+    expect(resource.block do
       "foo"
     end.call).to eql("foo")
   end
 
   it "allows the action to be 'create'" do
-    @resource.action :create
-    expect(@resource.action).to eq([:create])
+    resource.action :create
+    expect(resource.action).to eq([:create])
   end
 
   describe "when it has been initialized with block code" do
     before do
-      @resource.block_name("puts 'harrrr'")
+      resource.block_name("puts 'harrrr'")
     end
 
     it "returns the block as its identity" do
-      expect(@resource.identity).to eq("puts 'harrrr'")
+      expect(resource.identity).to eq("puts 'harrrr'")
     end
   end
 end

--- a/spec/unit/resource/ruby_spec.rb
+++ b/spec/unit/resource/ruby_spec.rb
@@ -19,22 +19,18 @@
 require "spec_helper"
 
 describe Chef::Resource::Ruby do
+  let(:resource) { Chef::Resource::Ruby.new("fakey_fakerton") }
 
-  before(:each) do
-    @resource = Chef::Resource::Ruby.new("fakey_fakerton")
+  it "creates a new Chef::Resource::Ruby" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Ruby)
   end
 
-  it "should create a new Chef::Resource::Ruby" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Ruby)
+  it "has a resource name of :ruby" do
+    expect(resource.resource_name).to eql(:ruby)
   end
 
-  it "should have a resource name of :ruby" do
-    expect(@resource.resource_name).to eql(:ruby)
+  it "has an interpreter of ruby" do
+    expect(resource.interpreter).to eql("ruby")
   end
-
-  it "should have an interpreter of ruby" do
-    expect(@resource.interpreter).to eql("ruby")
-  end
-
 end

--- a/spec/unit/resource/scm_spec.rb
+++ b/spec/unit/resource/scm_spec.rb
@@ -20,174 +20,171 @@
 require "spec_helper"
 
 describe Chef::Resource::Scm do
+  let(:resource) { Chef::Resource::Scm.new("my awesome app") }
 
-  before(:each) do
-    @resource = Chef::Resource::Scm.new("my awesome app")
-  end
-
-  it "should be a SCM resource" do
-    expect(@resource).to be_a_kind_of(Chef::Resource::Scm)
+  it "is a SCM resource" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Scm)
   end
 
   it "supports :checkout, :export, :sync, :diff, and :log actions" do
-    expect(@resource.allowed_actions).to include(:checkout)
-    expect(@resource.allowed_actions).to include(:export)
-    expect(@resource.allowed_actions).to include(:sync)
-    expect(@resource.allowed_actions).to include(:diff)
-    expect(@resource.allowed_actions).to include(:log)
+    expect(resource.allowed_actions).to include(:checkout)
+    expect(resource.allowed_actions).to include(:export)
+    expect(resource.allowed_actions).to include(:sync)
+    expect(resource.allowed_actions).to include(:diff)
+    expect(resource.allowed_actions).to include(:log)
   end
 
   it "takes the destination path as a string" do
-    @resource.destination "/path/to/deploy/dir"
-    expect(@resource.destination).to eql("/path/to/deploy/dir")
+    resource.destination "/path/to/deploy/dir"
+    expect(resource.destination).to eql("/path/to/deploy/dir")
   end
 
   it "takes a string for the repository URL" do
-    @resource.repository "git://github.com/opscode/chef.git"
-    expect(@resource.repository).to eql("git://github.com/opscode/chef.git")
+    resource.repository "git://github.com/opscode/chef.git"
+    expect(resource.repository).to eql("git://github.com/opscode/chef.git")
   end
 
   it "takes a string for the revision" do
-    @resource.revision "abcdef"
-    expect(@resource.revision).to eql("abcdef")
+    resource.revision "abcdef"
+    expect(resource.revision).to eql("abcdef")
   end
 
   it "defaults to the ``HEAD'' revision" do
-    expect(@resource.revision).to eql("HEAD")
+    expect(resource.revision).to eql("HEAD")
   end
 
   it "takes a string for the user to run as" do
-    @resource.user "dr_deploy"
-    expect(@resource.user).to eql("dr_deploy")
+    resource.user "dr_deploy"
+    expect(resource.user).to eql("dr_deploy")
   end
 
   it "also takes an integer for the user to run as" do
-    @resource.user 0
-    expect(@resource.user).to eql(0)
+    resource.user 0
+    expect(resource.user).to eql(0)
   end
 
   it "takes a string for the group to run as, defaulting to nil" do
-    expect(@resource.group).to be_nil
-    @resource.group "opsdevs"
-    expect(@resource.group).to eq("opsdevs")
+    expect(resource.group).to be_nil
+    resource.group "opsdevs"
+    expect(resource.group).to eq("opsdevs")
   end
 
   it "also takes an integer for the group to run as" do
-    @resource.group 23
-    expect(@resource.group).to eq(23)
+    resource.group 23
+    expect(resource.group).to eq(23)
   end
 
   it "has a svn_username String attribute" do
-    @resource.svn_username "moartestsplz"
-    expect(@resource.svn_username).to eql("moartestsplz")
+    resource.svn_username "moartestsplz"
+    expect(resource.svn_username).to eql("moartestsplz")
   end
 
   it "has a svn_password String attribute" do
-    @resource.svn_password "taftplz"
-    expect(@resource.svn_password).to eql("taftplz")
+    resource.svn_password "taftplz"
+    expect(resource.svn_password).to eql("taftplz")
   end
 
   it "has a svn_arguments String attribute" do
-    @resource.svn_arguments "--more-taft plz"
-    expect(@resource.svn_arguments).to eql("--more-taft plz")
+    resource.svn_arguments "--more-taft plz"
+    expect(resource.svn_arguments).to eql("--more-taft plz")
   end
 
   it "has a svn_info_args String attribute" do
-    expect(@resource.svn_info_args).to be_nil
-    @resource.svn_info_args("--no-moar-plaintext-creds yep")
-    expect(@resource.svn_info_args).to eq("--no-moar-plaintext-creds yep")
+    expect(resource.svn_info_args).to be_nil
+    resource.svn_info_args("--no-moar-plaintext-creds yep")
+    expect(resource.svn_info_args).to eq("--no-moar-plaintext-creds yep")
   end
 
   it "takes the depth as an integer for shallow clones" do
-    @resource.depth 5
-    expect(@resource.depth).to eq(5)
-    expect { @resource.depth "five" }.to raise_error(ArgumentError)
+    resource.depth 5
+    expect(resource.depth).to eq(5)
+    expect { resource.depth "five" }.to raise_error(ArgumentError)
   end
 
   it "defaults to nil depth for a full clone" do
-    expect(@resource.depth).to be_nil
+    expect(resource.depth).to be_nil
   end
 
   it "takes a boolean for #enable_submodules" do
-    @resource.enable_submodules true
-    expect(@resource.enable_submodules).to be_truthy
-    expect { @resource.enable_submodules "lolz" }.to raise_error(ArgumentError)
+    resource.enable_submodules true
+    expect(resource.enable_submodules).to be_truthy
+    expect { resource.enable_submodules "lolz" }.to raise_error(ArgumentError)
   end
 
   it "defaults to not enabling submodules" do
-    expect(@resource.enable_submodules).to be_falsey
+    expect(resource.enable_submodules).to be_falsey
   end
 
   it "takes a boolean for #enable_checkout" do
-    @resource.enable_checkout true
-    expect(@resource.enable_checkout).to be_truthy
-    expect { @resource.enable_checkout "lolz" }.to raise_error(ArgumentError)
+    resource.enable_checkout true
+    expect(resource.enable_checkout).to be_truthy
+    expect { resource.enable_checkout "lolz" }.to raise_error(ArgumentError)
   end
 
   it "defaults to enabling checkout" do
-    expect(@resource.enable_checkout).to be_truthy
+    expect(resource.enable_checkout).to be_truthy
   end
 
   it "takes a string for the remote" do
-    @resource.remote "opscode"
-    expect(@resource.remote).to eql("opscode")
-    expect { @resource.remote 1337 }.to raise_error(ArgumentError)
+    resource.remote "opscode"
+    expect(resource.remote).to eql("opscode")
+    expect { resource.remote 1337 }.to raise_error(ArgumentError)
   end
 
   it "defaults to ``origin'' for the remote" do
-    expect(@resource.remote).to eq("origin")
+    expect(resource.remote).to eq("origin")
   end
 
   it "takes a string for the ssh wrapper" do
-    @resource.ssh_wrapper "with_ssh_fu"
-    expect(@resource.ssh_wrapper).to eql("with_ssh_fu")
+    resource.ssh_wrapper "with_ssh_fu"
+    expect(resource.ssh_wrapper).to eql("with_ssh_fu")
   end
 
   it "defaults to nil for the ssh wrapper" do
-    expect(@resource.ssh_wrapper).to be_nil
+    expect(resource.ssh_wrapper).to be_nil
   end
 
   it "defaults to nil for the environment" do
-    expect(@resource.environment).to be_nil
+    expect(resource.environment).to be_nil
   end
 
   describe "when it has a timeout attribute" do
     let(:ten_seconds) { 10 }
-    before { @resource.timeout(ten_seconds) }
+    before { resource.timeout(ten_seconds) }
     it "stores this timeout" do
-      expect(@resource.timeout).to eq(ten_seconds)
+      expect(resource.timeout).to eq(ten_seconds)
     end
   end
   describe "when it has no timeout attribute" do
-    it "should have no default timeout" do
-      expect(@resource.timeout).to be_nil
+    it "has no default timeout" do
+      expect(resource.timeout).to be_nil
     end
   end
 
   describe "when it has repository, revision, user, and group" do
     before do
-      @resource.destination("hell")
-      @resource.repository("apt")
-      @resource.revision("1.2.3")
-      @resource.user("root")
-      @resource.group("super_adventure_club")
+      resource.destination("hell")
+      resource.repository("apt")
+      resource.revision("1.2.3")
+      resource.user("root")
+      resource.group("super_adventure_club")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:revision]).to eq("1.2.3")
     end
 
     it "returns the destination as its identity" do
-      expect(@resource.identity).to eq("hell")
+      expect(resource.identity).to eq("hell")
     end
   end
 
   describe "when it has a environment attribute" do
     let(:test_environment) { { "CHEF_ENV" => "/tmp" } }
-    before { @resource.environment(test_environment) }
+    before { resource.environment(test_environment) }
     it "stores this environment" do
-      expect(@resource.environment).to eq(test_environment)
+      expect(resource.environment).to eq(test_environment)
     end
   end
 end

--- a/spec/unit/resource/script_spec.rb
+++ b/spec/unit/resource/script_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Resource::Script do
   let(:script_resource) { Chef::Resource::Script.new(resource_instance_name) }
   let(:resource_name) { :script }
 
-  it "should accept a string for the interpreter" do
+  it "accepts a string for the interpreter" do
     script_resource.interpreter "naaaaNaNaNaaNaaNaaNaa"
     expect(script_resource.interpreter).to eql("naaaaNaNaNaaNaaNaaNaa")
   end

--- a/spec/unit/resource/service_spec.rb
+++ b/spec/unit/resource/service_spec.rb
@@ -20,180 +20,177 @@
 require "spec_helper"
 
 describe Chef::Resource::Service do
+  let(:resource) { Chef::Resource::Service.new("chef") }
 
-  before(:each) do
-    @resource = Chef::Resource::Service.new("chef")
+  it "creates a new Chef::Resource::Service" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::Service)
   end
 
-  it "should create a new Chef::Resource::Service" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Service)
+  it "does not set a provider unless node[:init_package] is defined as systemd" do
+    expect(resource.provider).to eq(nil)
   end
 
-  it "should not set a provider unless node[:init_package] is defined as systemd" do
-    expect(@resource.provider).to eq(nil)
+  it "sets the service_name to the first argument to new" do
+    expect(resource.service_name).to eql("chef")
   end
 
-  it "should set the service_name to the first argument to new" do
-    expect(@resource.service_name).to eql("chef")
+  it "sets the pattern to be the service name by default" do
+    expect(resource.pattern).to eql("chef")
   end
 
-  it "should set the pattern to be the service name by default" do
-    expect(@resource.pattern).to eql("chef")
+  it "accepts a string for the service name" do
+    resource.service_name "something"
+    expect(resource.service_name).to eql("something")
   end
 
-  it "should accept a string for the service name" do
-    @resource.service_name "something"
-    expect(@resource.service_name).to eql("something")
+  it "accepts a string for the service pattern" do
+    resource.pattern ".*"
+    expect(resource.pattern).to eql(".*")
   end
 
-  it "should accept a string for the service pattern" do
-    @resource.pattern ".*"
-    expect(@resource.pattern).to eql(".*")
-  end
-
-  it "should not accept a regexp for the service pattern" do
+  it "does not accept a regexp for the service pattern" do
     expect do
-      @resource.pattern /.*/
+      resource.pattern /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service start command" do
-    @resource.start_command "/etc/init.d/chef start"
-    expect(@resource.start_command).to eql("/etc/init.d/chef start")
+  it "accepts a string for the service start command" do
+    resource.start_command "/etc/init.d/chef start"
+    expect(resource.start_command).to eql("/etc/init.d/chef start")
   end
 
-  it "should not accept a regexp for the service start command" do
+  it "does not accept a regexp for the service start command" do
     expect do
-      @resource.start_command /.*/
+      resource.start_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service stop command" do
-    @resource.stop_command "/etc/init.d/chef stop"
-    expect(@resource.stop_command).to eql("/etc/init.d/chef stop")
+  it "accepts a string for the service stop command" do
+    resource.stop_command "/etc/init.d/chef stop"
+    expect(resource.stop_command).to eql("/etc/init.d/chef stop")
   end
 
-  it "should not accept a regexp for the service stop command" do
+  it "does not accept a regexp for the service stop command" do
     expect do
-      @resource.stop_command /.*/
+      resource.stop_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service status command" do
-    @resource.status_command "/etc/init.d/chef status"
-    expect(@resource.status_command).to eql("/etc/init.d/chef status")
+  it "accepts a string for the service status command" do
+    resource.status_command "/etc/init.d/chef status"
+    expect(resource.status_command).to eql("/etc/init.d/chef status")
   end
 
-  it "should not accept a regexp for the service status command" do
+  it "does not accept a regexp for the service status command" do
     expect do
-      @resource.status_command /.*/
+      resource.status_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service restart command" do
-    @resource.restart_command "/etc/init.d/chef restart"
-    expect(@resource.restart_command).to eql("/etc/init.d/chef restart")
+  it "accepts a string for the service restart command" do
+    resource.restart_command "/etc/init.d/chef restart"
+    expect(resource.restart_command).to eql("/etc/init.d/chef restart")
   end
 
-  it "should not accept a regexp for the service restart command" do
+  it "does not accept a regexp for the service restart command" do
     expect do
-      @resource.restart_command /.*/
+      resource.restart_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service reload command" do
-    @resource.reload_command "/etc/init.d/chef reload"
-    expect(@resource.reload_command).to eql("/etc/init.d/chef reload")
+  it "accepts a string for the service reload command" do
+    resource.reload_command "/etc/init.d/chef reload"
+    expect(resource.reload_command).to eql("/etc/init.d/chef reload")
   end
 
-  it "should not accept a regexp for the service reload command" do
+  it "does not accept a regexp for the service reload command" do
     expect do
-      @resource.reload_command /.*/
+      resource.reload_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept a string for the service init command" do
-    @resource.init_command "/etc/init.d/chef"
-    expect(@resource.init_command).to eql("/etc/init.d/chef")
+  it "accepts a string for the service init command" do
+    resource.init_command "/etc/init.d/chef"
+    expect(resource.init_command).to eql("/etc/init.d/chef")
   end
 
-  it "should not accept a regexp for the service init command" do
+  it "does not accept a regexp for the service init command" do
     expect do
-      @resource.init_command /.*/
+      resource.init_command /.*/
     end.to raise_error(ArgumentError)
   end
 
-  it "should accept an array for options" do
-    @resource.options ["-r", "-s"]
-    expect(@resource.options).to eql(["-r", "-s"])
+  it "accepts an array for options" do
+    resource.options ["-r", "-s"]
+    expect(resource.options).to eql(["-r", "-s"])
   end
 
-  it "should accept a string for options" do
-    @resource.options "-r"
-    expect(@resource.options).to eql(["-r"])
+  it "accepts a string for options" do
+    resource.options "-r"
+    expect(resource.options).to eql(["-r"])
   end
 
-  it "should accept a string with multiple flags for options" do
-    @resource.options "-r -s"
-    expect(@resource.options).to eql(["-r", "-s"])
+  it "accepts a string with multiple flags for options" do
+    resource.options "-r -s"
+    expect(resource.options).to eql(["-r", "-s"])
   end
 
-  it "should not accept a boolean for options" do
+  it "does not accept a boolean for options" do
     expect do
-      @resource.options true
+      resource.options true
     end.to raise_error(ArgumentError)
   end
 
   %w{enabled running}.each do |attrib|
-    it "should accept true for #{attrib}" do
-      @resource.send(attrib, true)
-      expect(@resource.send(attrib)).to eql(true)
+    it "accepts true for #{attrib}" do
+      resource.send(attrib, true)
+      expect(resource.send(attrib)).to eql(true)
     end
 
-    it "should accept false for #{attrib}" do
-      @resource.send(attrib, false)
-      expect(@resource.send(attrib)).to eql(false)
+    it "accepts false for #{attrib}" do
+      resource.send(attrib, false)
+      expect(resource.send(attrib)).to eql(false)
     end
 
-    it "should not accept a string for #{attrib}" do
-      expect { @resource.send(attrib, "poop") }.to raise_error(ArgumentError)
+    it "does not accept a string for #{attrib}" do
+      expect { resource.send(attrib, "poop") }.to raise_error(ArgumentError)
     end
 
-    it "should default all the feature support to nil" do
+    it "defaults all the feature support to nil" do
       support_hash = { :status => nil, :restart => nil, :reload => nil }
-      expect(@resource.supports).to eq(support_hash)
+      expect(resource.supports).to eq(support_hash)
     end
 
-    it "should allow you to set what features this resource supports as a array" do
+    it "allows you to set what features this resource supports as a array" do
       support_array = [ :status, :restart ]
       support_hash = { :status => true, :restart => true }
-      @resource.supports(support_array)
-      expect(@resource.supports).to eq(support_hash)
+      resource.supports(support_array)
+      expect(resource.supports).to eq(support_hash)
     end
 
-    it "should allow you to set what features this resource supports as a hash" do
+    it "allows you to set what features this resource supports as a hash" do
       support_hash = { :status => true, :restart => true }
-      @resource.supports(support_hash)
-      expect(@resource.supports).to eq(support_hash)
+      resource.supports(support_hash)
+      expect(resource.supports).to eq(support_hash)
     end
   end
 
   describe "when it has pattern and supports" do
     before do
-      @resource.service_name("superfriend")
-      @resource.enabled(true)
-      @resource.running(false)
+      resource.service_name("superfriend")
+      resource.enabled(true)
+      resource.running(false)
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:enabled]).to eql(true)
       expect(state[:running]).to eql(false)
     end
 
     it "returns the service name as its identity" do
-      expect(@resource.identity).to eq("superfriend")
+      expect(resource.identity).to eq("superfriend")
     end
   end
 end

--- a/spec/unit/resource/smartos_package_spec.rb
+++ b/spec/unit/resource/smartos_package_spec.rb
@@ -30,4 +30,9 @@ describe Chef::Resource::SmartosPackage, "initialize" do
     platform_family: "smartos"
   )
 
+  let(:resource) { Chef::Resource::SmartosPackage.new("foo") }
+
+  it "sets the package_name to the name provided" do
+    expect(resource.package_name).to eql("foo")
+  end
 end

--- a/spec/unit/resource/solaris_package_spec.rb
+++ b/spec/unit/resource/solaris_package_spec.rb
@@ -32,11 +32,9 @@ describe Chef::Resource::SolarisPackage, "initialize" do
     )
   end
 
-  before(:each) do
-    @resource = Chef::Resource::SolarisPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::SolarisPackage.new("foo") }
 
-  it "should set the package_name to the name provided" do
-    expect(@resource.package_name).to eql("foo")
+  it "sets the package_name to the name provided" do
+    expect(resource.package_name).to eql("foo")
   end
 end

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -35,6 +35,10 @@ describe Chef::Resource::Subversion do
     expect(resource).to be_a_kind_of(Chef::Resource::Scm)
   end
 
+  it "set destination property to the name_property" do
+    expect(resource.destination).to eq("ohai, svn project!")
+  end
+
   it "allows the force_export action" do
     expect(resource.allowed_actions).to include(:force_export)
   end

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -28,44 +28,42 @@ describe Chef::Resource::Subversion do
     action: :install
   )
 
-  before do
-    @svn = Chef::Resource::Subversion.new("ohai, svn project!")
-  end
+  let(:resource) { Chef::Resource::Subversion.new("ohai, svn project!") }
 
   it "is a subclass of Resource::Scm" do
-    expect(@svn).to be_an_instance_of(Chef::Resource::Subversion)
-    expect(@svn).to be_a_kind_of(Chef::Resource::Scm)
+    expect(resource).to be_an_instance_of(Chef::Resource::Subversion)
+    expect(resource).to be_a_kind_of(Chef::Resource::Scm)
   end
 
   it "allows the force_export action" do
-    expect(@svn.allowed_actions).to include(:force_export)
+    expect(resource.allowed_actions).to include(:force_export)
   end
 
   it "sets svn info arguments to --no-auth-cache by default" do
-    expect(@svn.svn_info_args).to eq("--no-auth-cache")
+    expect(resource.svn_info_args).to eq("--no-auth-cache")
   end
 
   it "resets svn info arguments to nil when given false in the setter" do
-    @svn.svn_info_args(false)
-    expect(@svn.svn_info_args).to be_nil
+    resource.svn_info_args(false)
+    expect(resource.svn_info_args).to be_nil
   end
 
   it "sets svn arguments to --no-auth-cache by default" do
-    expect(@svn.svn_arguments).to eq("--no-auth-cache")
+    expect(resource.svn_arguments).to eq("--no-auth-cache")
   end
 
   it "sets svn binary to nil by default" do
-    expect(@svn.svn_binary).to be_nil
+    expect(resource.svn_binary).to be_nil
   end
 
   it "resets svn arguments to nil when given false in the setter" do
-    @svn.svn_arguments(false)
-    expect(@svn.svn_arguments).to be_nil
+    resource.svn_arguments(false)
+    expect(resource.svn_arguments).to be_nil
   end
 
   it "hides password from custom exception message" do
-    @svn.svn_password "l33th4x0rpa$$w0rd"
-    e = @svn.customize_exception(Chef::Exceptions::Exec.new "Exception with password #{@svn.svn_password}")
-    expect(e.message.include?(@svn.svn_password)).to be_falsey
+    resource.svn_password "l33th4x0rpa$$w0rd"
+    e = resource.customize_exception(Chef::Exceptions::Exec.new "Exception with password #{resource.svn_password}")
+    expect(e.message.include?(resource.svn_password)).to be_falsey
   end
 end

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -19,12 +19,8 @@
 require "spec_helper"
 
 describe Chef::Resource::SystemdUnit do
-  before(:each) do
-    @resource = Chef::Resource::SystemdUnit.new("sysstat-collect.timer")
-  end
-
+  let(:resource) { Chef::Resource::SystemdUnit.new("sysstat-collect.timer") }
   let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
-
   let(:unit_content_hash) do
     {
       "Unit" => {
@@ -40,76 +36,76 @@ describe Chef::Resource::SystemdUnit do
   end
 
   it "creates a new Chef::Resource::SystemdUnit" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::SystemdUnit)
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::SystemdUnit)
   end
 
-  it "should have a name" do
-    expect(@resource.name).to eql("sysstat-collect.timer")
+  it "has a name" do
+    expect(resource.name).to eql("sysstat-collect.timer")
   end
 
   it "has a default action of nothing" do
-    expect(@resource.action).to eql([:nothing])
+    expect(resource.action).to eql([:nothing])
   end
 
   it "supports appropriate unit actions" do
-    expect { @resource.action :create }.not_to raise_error
-    expect { @resource.action :delete }.not_to raise_error
-    expect { @resource.action :enable }.not_to raise_error
-    expect { @resource.action :disable }.not_to raise_error
-    expect { @resource.action :mask }.not_to raise_error
-    expect { @resource.action :unmask }.not_to raise_error
-    expect { @resource.action :start }.not_to raise_error
-    expect { @resource.action :stop }.not_to raise_error
-    expect { @resource.action :restart }.not_to raise_error
-    expect { @resource.action :reload }.not_to raise_error
-    expect { @resource.action :wrong }.to raise_error(ArgumentError)
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :enable }.not_to raise_error
+    expect { resource.action :disable }.not_to raise_error
+    expect { resource.action :mask }.not_to raise_error
+    expect { resource.action :unmask }.not_to raise_error
+    expect { resource.action :start }.not_to raise_error
+    expect { resource.action :stop }.not_to raise_error
+    expect { resource.action :restart }.not_to raise_error
+    expect { resource.action :reload }.not_to raise_error
+    expect { resource.action :wrong }.to raise_error(ArgumentError)
   end
 
   it "accepts boolean state properties" do
-    expect { @resource.active false }.not_to raise_error
-    expect { @resource.active true }.not_to raise_error
-    expect { @resource.active "yes" }.to raise_error(ArgumentError)
+    expect { resource.active false }.not_to raise_error
+    expect { resource.active true }.not_to raise_error
+    expect { resource.active "yes" }.to raise_error(ArgumentError)
 
-    expect { @resource.enabled true }.not_to raise_error
-    expect { @resource.enabled false }.not_to raise_error
-    expect { @resource.enabled "no" }.to raise_error(ArgumentError)
+    expect { resource.enabled true }.not_to raise_error
+    expect { resource.enabled false }.not_to raise_error
+    expect { resource.enabled "no" }.to raise_error(ArgumentError)
 
-    expect { @resource.masked true }.not_to raise_error
-    expect { @resource.masked false }.not_to raise_error
-    expect { @resource.masked :nope }.to raise_error(ArgumentError)
+    expect { resource.masked true }.not_to raise_error
+    expect { resource.masked false }.not_to raise_error
+    expect { resource.masked :nope }.to raise_error(ArgumentError)
 
-    expect { @resource.static true }.not_to raise_error
-    expect { @resource.static false }.not_to raise_error
-    expect { @resource.static "yep" }.to raise_error(ArgumentError)
+    expect { resource.static true }.not_to raise_error
+    expect { resource.static false }.not_to raise_error
+    expect { resource.static "yep" }.to raise_error(ArgumentError)
   end
 
   it "accepts the content property" do
-    expect { @resource.content nil }.not_to raise_error
-    expect { @resource.content "test" }.not_to raise_error
-    expect { @resource.content({}) }.not_to raise_error
-    expect { @resource.content 5 }.to raise_error(ArgumentError)
+    expect { resource.content nil }.not_to raise_error
+    expect { resource.content "test" }.not_to raise_error
+    expect { resource.content({}) }.not_to raise_error
+    expect { resource.content 5 }.to raise_error(ArgumentError)
   end
 
   it "accepts the user property" do
-    expect { @resource.user nil }.not_to raise_error
-    expect { @resource.user "deploy" }.not_to raise_error
-    expect { @resource.user 5 }.to raise_error(ArgumentError)
+    expect { resource.user nil }.not_to raise_error
+    expect { resource.user "deploy" }.not_to raise_error
+    expect { resource.user 5 }.to raise_error(ArgumentError)
   end
 
   it "accepts the triggers_reload property" do
-    expect { @resource.triggers_reload true }.not_to raise_error
-    expect { @resource.triggers_reload false }.not_to raise_error
-    expect { @resource.triggers_reload "no" }.to raise_error(ArgumentError)
+    expect { resource.triggers_reload true }.not_to raise_error
+    expect { resource.triggers_reload false }.not_to raise_error
+    expect { resource.triggers_reload "no" }.to raise_error(ArgumentError)
   end
 
   it "reports its state" do
-    @resource.active true
-    @resource.enabled true
-    @resource.masked false
-    @resource.static false
-    @resource.content "test"
-    state = @resource.state_for_resource_reporter
+    resource.active true
+    resource.enabled true
+    resource.masked false
+    resource.static false
+    resource.content "test"
+    state = resource.state_for_resource_reporter
     expect(state[:active]).to eq(true)
     expect(state[:enabled]).to eq(true)
     expect(state[:masked]).to eq(false)
@@ -118,16 +114,16 @@ describe Chef::Resource::SystemdUnit do
   end
 
   it "returns the unit name as its identity" do
-    expect(@resource.identity).to eq("sysstat-collect.timer")
+    expect(resource.identity).to eq("sysstat-collect.timer")
   end
 
   it "serializes to ini with a string-formatted content property" do
-    @resource.content(unit_content_string)
-    expect(@resource.to_ini).to eq unit_content_string
+    resource.content(unit_content_string)
+    expect(resource.to_ini).to eq unit_content_string
   end
 
   it "serializes to ini with a hash-formatted content property" do
-    @resource.content(unit_content_hash)
-    expect(@resource.to_ini).to eq unit_content_string
+    resource.content(unit_content_hash)
+    expect(resource.to_ini).to eq unit_content_string
   end
 end

--- a/spec/unit/resource/template_spec.rb
+++ b/spec/unit/resource/template_spec.rb
@@ -19,76 +19,73 @@
 require "spec_helper"
 
 describe Chef::Resource::Template do
-
-  before(:each) do
-    @resource = Chef::Resource::Template.new("fakey_fakerton")
-  end
+  let(:resource) { Chef::Resource::Template.new("fakey_fakerton") }
 
   describe "initialize" do
-    it "should create a new Chef::Resource::Template" do
-      expect(@resource).to be_a_kind_of(Chef::Resource)
-      expect(@resource).to be_a_kind_of(Chef::Resource::File)
-      expect(@resource).to be_a_kind_of(Chef::Resource::Template)
+    it "creates a new Chef::Resource::Template" do
+      expect(resource).to be_a_kind_of(Chef::Resource)
+      expect(resource).to be_a_kind_of(Chef::Resource::File)
+      expect(resource).to be_a_kind_of(Chef::Resource::Template)
     end
   end
 
   describe "source" do
-    it "should accept a string for the template source" do
-      @resource.source "something"
-      expect(@resource.source).to eql("something")
+    it "accepts a string for the template source" do
+      resource.source "something"
+      expect(resource.source).to eql("something")
     end
 
-    it "should have a default based on the param name with .erb appended" do
-      expect(@resource.source).to eql("fakey_fakerton.erb")
+    it "has a default based on the param name with .erb appended" do
+      expect(resource.source).to eql("fakey_fakerton.erb")
     end
 
-    it "should use only the basename of the file as the default" do
+    it "uses only the basename of the file as the default" do
       r = Chef::Resource::Template.new("/tmp/obit/fakey_fakerton")
       expect(r.source).to eql("fakey_fakerton.erb")
     end
   end
 
   describe "variables" do
-    it "should accept a hash for the variable list" do
-      @resource.variables({ :reluctance => :awkward })
-      expect(@resource.variables).to eq({ :reluctance => :awkward })
+    it "accepts a hash for the variable list" do
+      resource.variables({ :reluctance => :awkward })
+      expect(resource.variables).to eq({ :reluctance => :awkward })
     end
   end
 
   describe "cookbook" do
-    it "should accept a string for the cookbook name" do
-      @resource.cookbook("foo")
-      expect(@resource.cookbook).to eq("foo")
+    it "accepts a string for the cookbook name" do
+      resource.cookbook("foo")
+      expect(resource.cookbook).to eq("foo")
     end
 
-    it "should default to nil" do
-      expect(@resource.cookbook).to eq(nil)
+    it "defaults to nil" do
+      expect(resource.cookbook).to eq(nil)
     end
   end
 
   describe "local" do
-    it "should accept a boolean for whether a template is local or remote" do
-      @resource.local(true)
-      expect(@resource.local).to eq(true)
+    it "accepts a boolean for whether a template is local or remote" do
+      resource.local(true)
+      expect(resource.local).to eq(true)
     end
 
-    it "should default to false" do
-      expect(@resource.local).to eq(false)
+    it "defaults to false" do
+      expect(resource.local).to eq(false)
     end
   end
 
   describe "when it has a path, owner, group, mode, and checksum" do
     before do
-      @resource.path("/tmp/foo.txt")
-      @resource.owner("root")
-      @resource.group("wheel")
-      @resource.mode("0644")
-      @resource.checksum("1" * 64)
+      resource.path("/tmp/foo.txt")
+      resource.owner("root")
+      resource.group("wheel")
+      resource.mode("0644")
+      resource.checksum("1" * 64)
     end
 
     context "on unix", :unix_only do
       it "describes its state" do
-        state = @resource.state_for_resource_reporter
+        state = resource.state_for_resource_reporter
         expect(state[:owner]).to eq("root")
         expect(state[:group]).to eq("wheel")
         expect(state[:mode]).to eq("0644")
@@ -102,7 +99,7 @@ describe Chef::Resource::Template do
     end
 
     it "returns the file path as its identity" do
-      expect(@resource.identity).to eq("/tmp/foo.txt")
+      expect(resource.identity).to eq("/tmp/foo.txt")
     end
   end
 
@@ -115,16 +112,16 @@ describe Chef::Resource::Template do
     end
 
     it "collects helper method bodies as blocks" do
-      @resource.helper(:example_1) { "example_1" }
-      @resource.helper(:example_2) { "example_2" }
-      expect(@resource.inline_helper_blocks[:example_1].call).to eq("example_1")
-      expect(@resource.inline_helper_blocks[:example_2].call).to eq("example_2")
+      resource.helper(:example_1) { "example_1" }
+      resource.helper(:example_2) { "example_2" }
+      expect(resource.inline_helper_blocks[:example_1].call).to eq("example_1")
+      expect(resource.inline_helper_blocks[:example_2].call).to eq("example_2")
     end
 
     it "compiles helper methods into a module" do
-      @resource.helper(:example_1) { "example_1" }
-      @resource.helper(:example_2) { "example_2" }
-      modules = @resource.helper_modules
+      resource.helper(:example_1) { "example_1" }
+      resource.helper(:example_2) { "example_2" }
+      modules = resource.helper_modules
       expect(modules.size).to eq(1)
       o = Object.new
       modules.each { |m| o.extend(m) }
@@ -133,38 +130,38 @@ describe Chef::Resource::Template do
     end
 
     it "compiles helper methods with arguments into a module" do
-      @resource.helper(:shout) { |quiet| quiet.upcase }
-      modules = @resource.helper_modules
+      resource.helper(:shout) { |quiet| quiet.upcase }
+      modules = resource.helper_modules
       o = Object.new
       modules.each { |m| o.extend(m) }
       expect(o.shout("shout")).to eq("SHOUT")
     end
 
     it "raises an error when attempting to define a helper method without a method body" do
-      expect { @resource.helper(:example) }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { resource.helper(:example) }.to raise_error(Chef::Exceptions::ValidationFailed)
     end
 
     it "raises an error when attempting to define a helper method with a non-Symbod method name" do
-      expect { @resource.helper("example") { "fail" } }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { resource.helper("example") { "fail" } }.to raise_error(Chef::Exceptions::ValidationFailed)
     end
 
     it "collects helper module bodies as blocks" do
-      @resource.helpers do
+      resource.helpers do
         def example_1
           "example_1"
         end
       end
-      module_body = @resource.inline_helper_modules.first
+      module_body = resource.inline_helper_modules.first
       expect(module_body).to be_a(Proc)
     end
 
     it "compiles helper module bodies into modules" do
-      @resource.helpers do
+      resource.helpers do
         def example_1
           "example_1"
         end
       end
-      modules = @resource.helper_modules
+      modules = resource.helper_modules
       expect(modules.size).to eq(1)
       o = Object.new
       modules.each { |m| o.extend(m) }
@@ -172,39 +169,37 @@ describe Chef::Resource::Template do
     end
 
     it "raises an error when no block or module name is given for helpers definition" do
-      expect { @resource.helpers() }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { resource.helpers() }.to raise_error(Chef::Exceptions::ValidationFailed)
     end
 
     it "raises an error when a non-module is given for helpers definition" do
-      expect { @resource.helpers("NotAModule") }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { resource.helpers("NotAModule") }.to raise_error(Chef::Exceptions::ValidationFailed)
     end
 
     it "raises an error when a module name and block are both given for helpers definition" do
-      expect { @resource.helpers(ExampleHelpers) { module_code } }.to raise_error(Chef::Exceptions::ValidationFailed)
+      expect { resource.helpers(ExampleHelpers) { module_code } }.to raise_error(Chef::Exceptions::ValidationFailed)
     end
 
     it "collects helper modules" do
-      @resource.helpers(ExampleHelpers)
-      expect(@resource.helper_modules).to include(ExampleHelpers)
+      resource.helpers(ExampleHelpers)
+      expect(resource.helper_modules).to include(ExampleHelpers)
     end
 
     it "combines all helpers into a set of compiled modules" do
-      @resource.helpers(ExampleHelpers)
-      @resource.helpers do
+      resource.helpers(ExampleHelpers)
+      resource.helpers do
         def inline_module
           "inline_module"
         end
       end
-      @resource.helper(:inline_method) { "inline_method" }
-      expect(@resource.helper_modules.size).to eq(3)
+      resource.helper(:inline_method) { "inline_method" }
+      expect(resource.helper_modules.size).to eq(3)
 
       o = Object.new
-      @resource.helper_modules.each { |m| o.extend(m) }
+      resource.helper_modules.each { |m| o.extend(m) }
       expect(o.static_example).to eq("static_example")
       expect(o.inline_module).to eq("inline_module")
       expect(o.inline_method).to eq("inline_method")
     end
-
   end
-
 end

--- a/spec/unit/resource/user_spec.rb
+++ b/spec/unit/resource/user_spec.rb
@@ -19,115 +19,109 @@
 require "spec_helper"
 
 describe Chef::Resource::User, "initialize" do
-  before(:each) do
-    @resource = Chef::Resource::User.new("adam")
+  let(:resource) { Chef::Resource::User.new("adam") }
+
+  it "creates a new Chef::Resource::User" do
+    expect(resource).to be_a_kind_of(Chef::Resource)
+    expect(resource).to be_a_kind_of(Chef::Resource::User)
   end
 
-  it "should create a new Chef::Resource::User" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::User)
+  it "sets the resource_name to :user" do
+    expect(resource.resource_name).to eql(:user_resource_abstract_base_class)
   end
 
-  it "should set the resource_name to :user" do
-    expect(@resource.resource_name).to eql(:user_resource_abstract_base_class)
-  end
-
-  it "should set the username equal to the argument to initialize" do
-    expect(@resource.username).to eql("adam")
+  it "sets the username equal to the argument to initialize" do
+    expect(resource.username).to eql("adam")
   end
 
   %w{comment uid gid home shell password}.each do |attrib|
-    it "should set #{attrib} to nil" do
-      expect(@resource.send(attrib)).to eql(nil)
+    it "sets #{attrib} to nil" do
+      expect(resource.send(attrib)).to eql(nil)
     end
   end
 
-  it "should set action to :create" do
-    expect(@resource.action).to eql([:create])
+  it "sets action to :create" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "should set manage_home to false" do
-    expect(@resource.manage_home).to eql(false)
+  it "sets manage_home to false" do
+    expect(resource.manage_home).to eql(false)
   end
 
-  it "should set non_unique to false" do
-    expect(@resource.non_unique).to eql(false)
+  it "sets non_unique to false" do
+    expect(resource.non_unique).to eql(false)
   end
 
-  it "should set force to false" do
-    expect(@resource.force).to eql(false)
+  it "sets force to false" do
+    expect(resource.force).to eql(false)
   end
 
   %w{create remove modify manage lock unlock}.each do |action|
-    it "should allow action #{action}" do
-      expect(@resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
+    it "allows action #{action}" do
+      expect(resource.allowed_actions.detect { |a| a == action.to_sym }).to eql(action.to_sym)
     end
   end
 
-  it "should accept domain users (@ or \ separator) on non-windows" do
-    expect { @resource.username "domain\@user" }.not_to raise_error
-    expect(@resource.username).to eq("domain\@user")
-    expect { @resource.username "domain\\user" }.not_to raise_error
-    expect(@resource.username).to eq("domain\\user")
+  it "accepts domain users (@ or \ separator) on non-windows" do
+    expect { resource.username "domain\@user" }.not_to raise_error
+    expect(resource.username).to eq("domain\@user")
+    expect { resource.username "domain\\user" }.not_to raise_error
+    expect(resource.username).to eq("domain\\user")
   end
 end
 
 %w{username comment home shell password}.each do |attrib|
   describe Chef::Resource::User, attrib do
-    before(:each) do
-      @resource = Chef::Resource::User.new("adam")
+    let(:resource) { Chef::Resource::User.new("adam") }
+
+    it "allows a string" do
+      resource.send(attrib, "adam")
+      expect(resource.send(attrib)).to eql("adam")
     end
 
-    it "should allow a string" do
-      @resource.send(attrib, "adam")
-      expect(@resource.send(attrib)).to eql("adam")
-    end
-
-    it "should not allow a hash" do
-      expect { @resource.send(attrib, { :woot => "i found it" }) }.to raise_error(ArgumentError)
+    it "does not allow a hash" do
+      expect { resource.send(attrib, { :woot => "i found it" }) }.to raise_error(ArgumentError)
     end
   end
 end
 
 %w{uid gid}.each do |attrib|
   describe Chef::Resource::User, attrib do
-    before(:each) do
-      @resource = Chef::Resource::User.new("adam")
+    let(:resource) { Chef::Resource::User.new("adam") }
+
+    it "allows a string" do
+      resource.send(attrib, "100")
+      expect(resource.send(attrib)).to eql("100")
     end
 
-    it "should allow a string" do
-      @resource.send(attrib, "100")
-      expect(@resource.send(attrib)).to eql("100")
+    it "allows an integer" do
+      resource.send(attrib, 100)
+      expect(resource.send(attrib)).to eql(100)
     end
 
-    it "should allow an integer" do
-      @resource.send(attrib, 100)
-      expect(@resource.send(attrib)).to eql(100)
-    end
-
-    it "should not allow a hash" do
-      expect { @resource.send(attrib, { :woot => "i found it" }) }.to raise_error(ArgumentError)
+    it "does not allow a hash" do
+      expect { resource.send(attrib, { :woot => "i found it" }) }.to raise_error(ArgumentError)
     end
   end
 
   describe "when it has uid, gid, and home" do
+    let(:resource) { Chef::Resource::User.new("root") }
+
     before do
-      @resource = Chef::Resource::User.new("root")
-      @resource.uid(123)
-      @resource.gid(456)
-      @resource.home("/usr/local/root/")
+      resource.uid(123)
+      resource.gid(456)
+      resource.home("/usr/local/root/")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:uid]).to eq(123)
       expect(state[:gid]).to eq(456)
       expect(state[:home]).to eq("/usr/local/root/")
     end
 
     it "returns the username as its identity" do
-      expect(@resource.identity).to eq("root")
+      expect(resource.identity).to eq("root")
     end
   end
-
 end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -88,7 +88,7 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     let(:resource_source) { "https://foo.bar/solitare.msi" }
     let(:resource) { Chef::Resource::WindowsPackage.new(resource_source) }
 
-    it "should return the source unmodified" do
+    it "returns the source unmodified" do
       expect(resource.source).to eq(resource_source)
     end
   end

--- a/spec/unit/resource/windows_path_spec.rb
+++ b/spec/unit/resource/windows_path_spec.rb
@@ -19,20 +19,21 @@
 require "spec_helper"
 
 describe Chef::Resource::WindowsPath do
-  subject { Chef::Resource::WindowsPath.new("some_path") }
+  let(:resource) { Chef::Resource::WindowsPath.new("some_path") }
 
-  it { is_expected.to be_a_kind_of(Chef::Resource) }
-  it { is_expected.to be_a_instance_of(Chef::Resource::WindowsPath) }
+  it "returns a Chef::Resource::WindowsPath" do
+    expect(resource).to be_a_kind_of(Chef::Resource::WindowsPath)
+  end
 
   it "sets resource name as :windows_path" do
-    expect(subject.resource_name).to eql(:windows_path)
+    expect(resource.resource_name).to eql(:windows_path)
   end
 
   it "sets the path as its name" do
-    expect(subject.path).to eql("some_path")
+    expect(resource.path).to eql("some_path")
   end
 
   it "sets the default action as :add" do
-    expect(subject.action).to eql(:add)
+    expect(resource.action).to eql(:add)
   end
 end

--- a/spec/unit/resource/windows_path_spec.rb
+++ b/spec/unit/resource/windows_path_spec.rb
@@ -21,10 +21,6 @@ require "spec_helper"
 describe Chef::Resource::WindowsPath do
   let(:resource) { Chef::Resource::WindowsPath.new("some_path") }
 
-  it "returns a Chef::Resource::WindowsPath" do
-    expect(resource).to be_a_kind_of(Chef::Resource::WindowsPath)
-  end
-
   it "sets resource name as :windows_path" do
     expect(resource.resource_name).to eql(:windows_path)
   end
@@ -35,5 +31,11 @@ describe Chef::Resource::WindowsPath do
 
   it "sets the default action as :add" do
     expect(resource.action).to eql(:add)
+  end
+
+  it "supports :add and :remove actions" do
+    expect { resource.action :add }.not_to raise_error
+    expect { resource.action :remove }.not_to raise_error
+    expect { resource.action :delete }.to raise_error(ArgumentError)
   end
 end

--- a/spec/unit/resource/yum_package_spec.rb
+++ b/spec/unit/resource/yum_package_spec.rb
@@ -78,7 +78,7 @@ describe Chef::Resource::YumPackage, "arch" do
     @resource = Chef::Resource::YumPackage.new("foo")
   end
 
-  it "should set the arch variable to whatever is passed in" do
+  it "sets the arch variable to whatever is passed in" do
     @resource.arch("i386")
     expect(@resource.arch).to eql("i386")
   end

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -24,12 +24,64 @@ describe Chef::Resource::YumRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::YumRepository.new("multiverse", run_context) }
 
-  context "on linux", :linux_only do
-    it "creates a new Chef::Resource::YumRepository" do
-      expect(resource).to be_a_kind_of(Chef::Resource)
-      expect(resource).to be_a_kind_of(Chef::Resource::YumRepository)
-    end
+  it "has a resource_name of :yum_repository" do
+    expect(resource.resource_name).to eq(:yum_repository)
+  end
 
+  it "the repositoryid property is the name_property" do
+    expect(resource.repositoryid).to eq("multiverse")
+  end
+
+  it "the timeout property expects numeric Strings" do
+    expect { resource.timeout "123" }.not_to raise_error(ArgumentError)
+    expect { resource.timeout "123foo" }.to raise_error(ArgumentError)
+  end
+
+  it "the priority property expects numeric Strings from '1' to '99'" do
+    expect { resource.priority "99" }.not_to raise_error(ArgumentError)
+    expect { resource.priority "1" }.not_to raise_error(ArgumentError)
+    expect { resource.priority "100" }.to raise_error(ArgumentError)
+  end
+
+  it "the failovermethod property accepts 'priority' or 'roundrobin'" do
+    expect { resource.failovermethod "priority" }.not_to raise_error(ArgumentError)
+    expect { resource.failovermethod "roundrobin" }.not_to raise_error(ArgumentError)
+    expect { resource.failovermethod "bob" }.to raise_error(ArgumentError)
+  end
+
+  it "the http_caching property accepts 'packages', 'all', or 'none'" do
+    expect { resource.http_caching "packages" }.not_to raise_error(ArgumentError)
+    expect { resource.http_caching "all" }.not_to raise_error(ArgumentError)
+    expect { resource.http_caching "none" }.not_to raise_error(ArgumentError)
+    expect { resource.http_caching "bob" }.to raise_error(ArgumentError)
+  end
+
+  it "the metadata_expire property accepts a time value or 'never'" do
+    expect { resource.metadata_expire "100" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "100d" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "100h" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "100m" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "never" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "100s" }.to raise_error(ArgumentError)
+  end
+
+  it "the mirror_expire property accepts a time value" do
+    expect { resource.mirror_expire "100" }.not_to raise_error(ArgumentError)
+    expect { resource.mirror_expire "100d" }.not_to raise_error(ArgumentError)
+    expect { resource.mirror_expire "100h" }.not_to raise_error(ArgumentError)
+    expect { resource.mirror_expire "100m" }.not_to raise_error(ArgumentError)
+    expect { resource.mirror_expire "never" }.to raise_error(ArgumentError)
+  end
+
+  it "the mirrorlist_expire property accepts a time value" do
+    expect { resource.mirrorlist_expire "100" }.not_to raise_error(ArgumentError)
+    expect { resource.mirrorlist_expire "100d" }.not_to raise_error(ArgumentError)
+    expect { resource.mirrorlist_expire "100h" }.not_to raise_error(ArgumentError)
+    expect { resource.mirrorlist_expire "100m" }.not_to raise_error(ArgumentError)
+    expect { resource.mirrorlist_expire "never" }.to raise_error(ArgumentError)
+  end
+
+  context "on linux", :linux_only do
     it "resolves to a Noop class when yum is not found" do
       expect(Chef::Provider::YumRepository).to receive(:which).with("yum").and_return(false)
       expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -25,24 +25,24 @@ describe Chef::Resource::YumRepository do
   let(:resource) { Chef::Resource::YumRepository.new("multiverse", run_context) }
 
   context "on linux", :linux_only do
-    it "should create a new Chef::Resource::YumRepository" do
+    it "creates a new Chef::Resource::YumRepository" do
       expect(resource).to be_a_kind_of(Chef::Resource)
       expect(resource).to be_a_kind_of(Chef::Resource::YumRepository)
     end
 
-    it "should resolve to a Noop class when yum is not found" do
+    it "resolves to a Noop class when yum is not found" do
       expect(Chef::Provider::YumRepository).to receive(:which).with("yum").and_return(false)
       expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
     end
 
-    it "should resolve to a YumRepository class when yum is found" do
+    it "resolves to a YumRepository class when yum is found" do
       expect(Chef::Provider::YumRepository).to receive(:which).with("yum").and_return(true)
       expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::YumRepository)
     end
   end
 
   context "on windows", :windows_only do
-    it "should resolve to a NoOp provider" do
+    it "resolves to a NoOp provider" do
       expect(resource.provider_for_action(:add)).to be_a(Chef::Provider::Noop)
     end
   end

--- a/spec/unit/resource/zypper_repository_spec.rb
+++ b/spec/unit/resource/zypper_repository_spec.rb
@@ -24,37 +24,27 @@ describe Chef::Resource::ZypperRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::ZypperRepository.new("repo-source", run_context) }
 
+  it "has a resource_name of :zypper_repository" do
+    expect(resource.resource_name).to eq(:zypper_repository)
+  end
+
+  it "repo_name is the name_property" do
+    expect(resource.repo_name).to eql("repo-source")
+  end
+
+  it "has a default action of create" do
+    expect(resource.action).to eql([:create])
+  end
+
+  it "supports all valid actions" do
+    expect { resource.action :add }.not_to raise_error
+    expect { resource.action :remove }.not_to raise_error
+    expect { resource.action :create }.not_to raise_error
+    expect { resource.action :refresh }.not_to raise_error
+    expect { resource.action :delete }.to raise_error(ArgumentError)
+  end
+
   context "on linux", :linux_only do
-    it "has a resource_name of :zypper_repository" do
-      expect(resource.resource_name).to eq(:zypper_repository)
-    end
-
-    it "repo_name is the name_property" do
-      expect(resource.repo_name).to eql("repo-source")
-    end
-
-    it "has a default action of create" do
-      expect(resource.action).to eql([:create])
-    end
-
-    it "aliases the uri property to baseurl" do
-      resource.uri = "something"
-      expect(resource.baseurl).to eql("something")
-    end
-
-    it "aliases the key property to gpgkey" do
-      resource.key = "something"
-      expect(resource.gpgkey).to eql("something")
-    end
-
-    it "supports all valid actions" do
-      expect { resource.action :add }.not_to raise_error
-      expect { resource.action :remove }.not_to raise_error
-      expect { resource.action :create }.not_to raise_error
-      expect { resource.action :refresh }.not_to raise_error
-      expect { resource.action :delete }.to raise_error(ArgumentError)
-    end
-
     it "resolves to a Noop class when on non-linux OS" do
       node.automatic[:os] = "windows"
       node.automatic[:platform_family] = "windows"

--- a/spec/unit/resource/zypper_repository_spec.rb
+++ b/spec/unit/resource/zypper_repository_spec.rb
@@ -38,13 +38,13 @@ describe Chef::Resource::ZypperRepository do
     end
 
     it "aliases the uri property to baseurl" do
-      resource.uri = 'something'
-      expect(resource.baseurl).to eql('something')
+      resource.uri = "something"
+      expect(resource.baseurl).to eql("something")
     end
 
     it "aliases the key property to gpgkey" do
-      resource.key = 'something'
-      expect(resource.gpgkey).to eql('something')
+      resource.key = "something"
+      expect(resource.gpgkey).to eql("something")
     end
 
     it "supports all valid actions" do

--- a/spec/unit/resource/zypper_repository_spec.rb
+++ b/spec/unit/resource/zypper_repository_spec.rb
@@ -25,16 +25,16 @@ describe Chef::Resource::ZypperRepository do
   let(:resource) { Chef::Resource::ZypperRepository.new("repo-source", run_context) }
 
   context "on linux", :linux_only do
-    it "should create a new Chef::Resource::ZypperRepository" do
+    it "creates a new Chef::Resource::ZypperRepository" do
       expect(resource).to be_a_kind_of(Chef::Resource)
       expect(resource).to be_a_kind_of(Chef::Resource::ZypperRepository)
     end
 
-    it "should have a name of repo-source" do
+    it "has a name of repo-source" do
       expect(resource.name).to eql("repo-source")
     end
 
-    it "should have a default action of create" do
+    it "has a default action of create" do
       expect(resource.action).to eql([:create])
     end
 

--- a/spec/unit/resource/zypper_repository_spec.rb
+++ b/spec/unit/resource/zypper_repository_spec.rb
@@ -25,17 +25,26 @@ describe Chef::Resource::ZypperRepository do
   let(:resource) { Chef::Resource::ZypperRepository.new("repo-source", run_context) }
 
   context "on linux", :linux_only do
-    it "creates a new Chef::Resource::ZypperRepository" do
-      expect(resource).to be_a_kind_of(Chef::Resource)
-      expect(resource).to be_a_kind_of(Chef::Resource::ZypperRepository)
+    it "has a resource_name of :zypper_repository" do
+      expect(resource.resource_name).to eq(:zypper_repository)
     end
 
-    it "has a name of repo-source" do
-      expect(resource.name).to eql("repo-source")
+    it "repo_name is the name_property" do
+      expect(resource.repo_name).to eql("repo-source")
     end
 
     it "has a default action of create" do
       expect(resource.action).to eql([:create])
+    end
+
+    it "aliases the uri property to baseurl" do
+      resource.uri = 'something'
+      expect(resource.baseurl).to eql('something')
+    end
+
+    it "aliases the key property to gpgkey" do
+      resource.key = 'something'
+      expect(resource.gpgkey).to eql('something')
     end
 
     it "supports all valid actions" do


### PR DESCRIPTION
Expand some of the resource specs to test inputs, actions, and name properties, while not testing the resource class which we just defined in the let block

Remove usage of "should" to make rspec folks happy

Convert before -> let for the resources

Add a few missing package specs