### PR TITLE
Chef 17361 - enable yum_package on AIX

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon aix}
-        provides :yum_package, os: %{linux aix}
+        provides :package, platform_family: %w{rhel fedora amazon}
+        provides :yum_package, os: "linux"
 
         # Multipackage API
         allow_nils

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon}
-        provides :yum_package, os: "linux"
+        provides :package, platform_family: %w{rhel fedora amazon aix}
+        provides :yum_package, os: %{linux aix}
 
         # Multipackage API
         allow_nils

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -29,8 +29,8 @@ class Chef
       class Yum < Chef::Provider::Package
         include Chef::Mixin::GetSourceFromPackage
 
-        provides :package, platform_family: %w{rhel fedora amazon}
-        provides :yum_package, os: "linux"
+        provides :package, platform_family: %w{rhel fedora amazon aix}
+        provides :yum_package, os: %w{linux aix}
 
         # Multipackage API
         allow_nils


### PR DESCRIPTION
### Description

We are using yum on AIX, and want to start installing packages with Chef.  When using  yum_package, however, we get the following error message : 

Error executing action `install` on resource 'yum_package[logrotate]' 
Chef::Exceptions::ProviderNotFound 
Cannot find a provider for yum_package[logrotate] on aix version 7.1

When taking a look at the source for the yum provider, it seems indeed that only linux is supported as OS.  This pull request solves this issue, and enables yum_package on AIX.  When implementing this patch on our AIX chef clients, yum_package works successfully on AIX.

Our current Chef client is v12.21.4, but this issue has also been tested and confirmed with the latest Chef-client v13. 

### Issues Resolved

Chef ticket #17361 (https://getchef.zendesk.com/hc/en-us/requests/17361)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
