### PR TITLE
Escape single-quoted strings from the context in knife bootstrap

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -255,7 +255,7 @@ validation_client_name "#{@chef_config[:validation_client_name]}"
                   content << "mkdir #{file_on_node}\n"
                 else
                   content << "cat > #{file_on_node} <<'EOP'\n" +
-                    f.read + "\nEOP\n"
+                    f.read.gsub("'", "'\\\\''") + "\nEOP\n"
                 end
               end
             end

--- a/spec/data/client.d_00/02-strings.rb
+++ b/spec/data/client.d_00/02-strings.rb
@@ -1,0 +1,2 @@
+# 02-strings.rb
+something '/foo/bar'

--- a/spec/support/shared/unit/application_dot_d.rb
+++ b/spec/support/shared/unit/application_dot_d.rb
@@ -38,9 +38,11 @@ shared_examples_for "an application that loads a dot d" do
     it "loads the configuration in order" do
       expect(IO).to receive(:read).with(Pathname.new("#{client_d_dir}/00-foo.rb").cleanpath.to_s).and_return("foo 0")
       expect(IO).to receive(:read).with(Pathname.new("#{client_d_dir}/01-bar.rb").cleanpath.to_s).and_return("bar 0")
+      expect(IO).to receive(:read).with(Pathname.new("#{client_d_dir}/02-strings.rb").cleanpath.to_s).and_return("strings 0")
       allow(app).to receive(:apply_config).with(anything(), Chef::Config.platform_specific_path("/etc/chef/client.rb")).and_call_original.ordered
       expect(app).to receive(:apply_config).with("foo 0", Pathname.new("#{client_d_dir}/00-foo.rb").cleanpath.to_s).and_call_original.ordered
       expect(app).to receive(:apply_config).with("bar 0", Pathname.new("#{client_d_dir}/01-bar.rb").cleanpath.to_s).and_call_original.ordered
+      expect(app).to receive(:apply_config).with("strings 0", Pathname.new("#{client_d_dir}/02-strings.rb").cleanpath.to_s).and_call_original.ordered
       app.reconfigure
     end
   end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -516,6 +516,11 @@ describe Chef::Knife::Bootstrap do
       end
 
       context "a flat directory structure" do
+        it "escapes single-quotes" do
+          expect(rendered_template).to match("cat > /etc/chef/client.d/02-strings.rb <<'EOP'")
+          expect(rendered_template).to match("something '\\\\''/foo/bar'\\\\''")
+        end
+
         it "creates a file 00-foo.rb" do
           expect(rendered_template).to match("cat > /etc/chef/client.d/00-foo.rb <<'EOP'")
           expect(rendered_template).to match("d6f9b976-289c-4149-baf7-81e6ffecf228")


### PR DESCRIPTION
Fixes #6680

Signed-off-by: Allan Espinosa <aespinosa33@bloomberg.net>

### Description

`knife bootstrap` runs eveyrhint in `sh -c ' XXX '`.  As such single quotes gets removed. Details about the issue are in #6680 

### Issues Resolved

#6680 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
