### PR TITLE
Fix dscl group provider gid_used?

### DIFF
--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -93,7 +93,7 @@ class Chef
           # dscl -search should not return anything if the gid doesn't exist,
           # but on the off-chance that it does, check whether the given gid is
           # in the output.
-          !!(search_gids =~ /\b#{gid.to_s}\b/)
+          !!(search_gids =~ /\b#{gid}\b/)
         end
 
         def set_gid

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -88,8 +88,12 @@ class Chef
 
         def gid_used?(gid)
           return false unless gid
-          search_gids = safe_dscl('search', '/Groups', 'gid', gid.to_s)
-          !search_gids.strip.empty?
+          search_gids = safe_dscl("search", "/Groups", "PrimaryGroupID", gid.to_s)
+
+          # dscl -search should not return anything if the gid doesn't exist,
+          # but on the off-chance that it does, check whether the given gid is
+          # in the output.
+          !!(search_gids =~ /\b#{gid.to_s}\b/)
         end
 
         def set_gid

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -88,8 +88,8 @@ class Chef
 
         def gid_used?(gid)
           return false unless gid
-          groups_gids = safe_dscl("list", "/Groups", "gid")
-          !!( groups_gids =~ Regexp.new("#{Regexp.escape(gid.to_s)}\n") )
+          search_gids = safe_dscl('search', '/Groups', 'gid', gid.to_s)
+          !search_gids.strip.empty?
         end
 
         def set_gid

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -177,7 +177,7 @@ describe Chef::Provider::Group::Dscl do
     describe "with a valid gid number which is not already in use" do
       it "should run safe_dscl with create /Groups/group PrimaryGroupID gid" do
         allow(@provider).to receive(:get_free_gid).and_return(50)
-        expect(@provider).to receive(:safe_dscl).with(*"search /Groups PrimaryGroupID 50".split(" ")).and_return('')
+        expect(@provider).to receive(:safe_dscl).with(*"search /Groups PrimaryGroupID 50".split(" ")).and_return("")
         expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 50).and_return(true)
         @provider.set_gid
       end

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -117,7 +117,9 @@ describe Chef::Provider::Group::Dscl do
     before do
       @node = Chef::Node.new
       @provider = Chef::Provider::Group::Dscl.new(@node, @new_resource)
-      allow(@provider).to receive(:safe_dscl).and_return("\naj      500\n")
+      allow(@provider).to receive(:safe_dscl).and_return(
+        "\naj      500\nab      518\n"
+      )
     end
 
     it "should run safe_dscl with list /Groups gid" do
@@ -131,6 +133,7 @@ describe Chef::Provider::Group::Dscl do
 
     it "should return false for an unused gid number" do
       expect(@provider.gid_used?(501)).to be_falsey
+      expect(@provider.gid_used?(18)).to be_falsey
     end
 
     it "should return false if not given any valid gid number" do

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -135,7 +135,10 @@ describe Chef::Provider::Group::Dscl do
     end
 
     it "should return false for an unused gid number" do
-      expect(@provider.gid_used?(501)).to be_falsey
+      expect(@provider.gid_used?(0)).to be_falsey
+      expect(@provider.gid_used?(50)).to be_falsey
+      expect(@provider.gid_used?(5000)).to be_falsey
+      expect(@provider.gid_used?(1500)).to be_falsey
       expect(@provider.gid_used?(18)).to be_falsey
     end
 

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -117,25 +117,24 @@ describe Chef::Provider::Group::Dscl do
     before do
       @node = Chef::Node.new
       @provider = Chef::Provider::Group::Dscl.new(@node, @new_resource)
-    end
-
-    it "should run safe_dscl with search /Groups gid" do
-      expect(@provider).to receive(:safe_dscl).with(*"search /Groups gid 500".split(" ")).and_return('')
-      @provider.gid_used?(500)
-    end
-
-    it "should return true for a used gid number" do
       allow(@provider).to receive(:safe_dscl).and_return(<<-eos
         someprogram		somethingElse:gid = (
             500
         )
         eos
       )
+    end
+
+    it "should run safe_dscl with search /Groups gid" do
+      expect(@provider).to receive(:safe_dscl).with(*"search /Groups PrimaryGroupID 500".split(" "))
+      @provider.gid_used?(500)
+    end
+
+    it "should return true for a used gid number" do
       expect(@provider.gid_used?(500)).to be_truthy
     end
 
     it "should return false for an unused gid number" do
-      allow(@provider).to receive(:safe_dscl).and_return('')
       expect(@provider.gid_used?(501)).to be_falsey
       expect(@provider.gid_used?(18)).to be_falsey
     end
@@ -178,7 +177,7 @@ describe Chef::Provider::Group::Dscl do
     describe "with a valid gid number which is not already in use" do
       it "should run safe_dscl with create /Groups/group PrimaryGroupID gid" do
         allow(@provider).to receive(:get_free_gid).and_return(50)
-        expect(@provider).to receive(:safe_dscl).with(*"search /Groups gid 50".split(" ")).and_return('')
+        expect(@provider).to receive(:safe_dscl).with(*"search /Groups PrimaryGroupID 50".split(" ")).and_return('')
         expect(@provider).to receive(:safe_dscl).with("create", "/Groups/aj", "PrimaryGroupID", 50).and_return(true)
         @provider.set_gid
       end


### PR DESCRIPTION
### Description

To check whether a requested gid is used by the system already, the macOS dscl group provider lists all gids on the system and parses the output. There's a bug wherein the parsing looks for the number and a newline, but this yields false positives, e.g. if `dscl . list /Groups gid` returns:
```
group1          100
group2          148
```
and the code `gid_used?(48)` is run currently, it will return `true` even though gid 48 isn't present.

### Issues Resolved

None

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
