### PR TITLE
Speed up Appveyor testing with bundler caching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,18 +26,20 @@ install:
   - echo %OMNIBUS_RUBYGEMS%
   - ps: $env:OMNIBUS_BUNDLER=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
   - echo %OMNIBUS_BUNDLER%
-  - ruby --version
   - gem --version
   - gem update --system %OMNIBUS_RUBYGEMS% || gem update --system %OMNIBUS_RUBYGEMS% || gem update --system %OMNIBUS_RUBYGEMS%
-  - gem --version
-  - bundler --version
-  - SET BUNDLE_WITHOUT=server:docgen:maintenance:pry:travis:integration:ci
   - appveyor DownloadFile http://curl.haxx.se/ca/cacert.pem -FileName C:\cacert.pem
   - set SSL_CERT_FILE=C:\cacert.pem
-  - bundle env
-
-build_script:
+  - SET BUNDLE_WITHOUT=server:docgen:maintenance:pry:travis:integration:ci
   - bundle install || bundle install || bundle install
+
+build: off
+
+before_test:
+  - ruby --version
+  - gem --version
+  - bundler --version
+  - bundle env
 
 test_script:
   - SET SPEC_OPTS=--format progress

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ os: Visual Studio 2015
 platform:
   - x64
 
+cache:
+- vendor/bundle
+
 environment:
   matrix:
     - ruby_version: "24-x64"
@@ -31,6 +34,7 @@ install:
   - appveyor DownloadFile http://curl.haxx.se/ca/cacert.pem -FileName C:\cacert.pem
   - set SSL_CERT_FILE=C:\cacert.pem
   - SET BUNDLE_WITHOUT=server:docgen:maintenance:pry:travis:integration:ci
+  - bundle config --local path vendor/bundle # use the cache we define above
   - bundle install || bundle install || bundle install
 
 build: off


### PR DESCRIPTION
Start by shuffling around the config to not do a build. This makes it easier to follow and matches their Ruby guide. Then enable bundler caching per their docs.

Signed-off-by: Tim Smith <tsmith@chef.io>