### PR TITLE
Remove a useless regex in zypper_repository resource

### DIFF
--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -43,7 +43,7 @@ class Chef
       property :keeppackages, [true, false], default: false
       property :mode, default: "0644"
       property :refresh_cache, [true, false], default: true
-      property :source, String, regex: /.*/
+      property :source, String
       property :cookbook, String
       property :gpgautoimportkeys, [true, false], default: true
 


### PR DESCRIPTION
Pretty sure I mistakenly copied this from yum_repository. There's no real point and it's just going to slow things down.

Signed-off-by: Tim Smith <tsmith@chef.io>