### PR TITLE
Don't check both platform_family / os in provides when platform_family will do

### DIFF
--- a/lib/chef/provider/apt_preference.rb
+++ b/lib/chef/provider/apt_preference.rb
@@ -24,7 +24,7 @@ require "chef/log"
 class Chef
   class Provider
     class AptPreference < Chef::Provider
-      provides :apt_preference, os: "linux", platform_family: "debian"
+      provides :apt_preference, platform_family: "debian"
 
       APT_PREFERENCE_DIR = "/etc/apt/preferences.d".freeze
 

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -27,7 +27,7 @@ class Chef
     class AptRepository < Chef::Provider
       include Chef::Mixin::ShellOut
 
-      provides :apt_repository, os: "linux", platform_family: "debian"
+      provides :apt_repository, platform_family: "debian"
 
       LIST_APT_KEYS = "apt-key list".freeze
       LIST_APT_KEY_FINGERPRINTS = "apt-key adv --list-public-keys --with-fingerprint --with-colons".freeze

--- a/lib/chef/provider/apt_update.rb
+++ b/lib/chef/provider/apt_update.rb
@@ -23,7 +23,7 @@ require "chef/dsl/declare_resource"
 class Chef
   class Provider
     class AptUpdate < Chef::Provider
-      provides :apt_update, os: "linux", platform_family: "debian"
+      provides :apt_update, platform_family: "debian"
 
       APT_CONF_DIR = "/etc/apt/apt.conf.d"
       STAMP_DIR = "/var/lib/apt/periodic"

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -3,7 +3,7 @@
 #           Bryan McLellan (btm@loftninjas.org)
 #           Matthew Landauer (matthew@openaustralia.org)
 #           Ben Rockwood (benr@joyent.com)
-# Copyright:: Copyright 2009-2016, Bryan McLellan, Matthew Landauer
+# Copyright:: Copyright 2009-2018, Bryan McLellan, Matthew Landauer
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ class Chef
         attr_accessor :is_virtual_package
 
         provides :package, platform: "smartos"
-        provides :smartos_package, platform: "smartos"
+        provides :smartos_package, platform_family: "smartos"
 
         def load_current_resource
           Chef::Log.debug("#{new_resource} loading current resource")

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -30,7 +30,7 @@ class Chef
         attr_accessor :is_virtual_package
 
         provides :package, platform: "smartos"
-        provides :smartos_package, os: "solaris2", platform_family: "smartos"
+        provides :smartos_package, platform_family: "smartos"
 
         def load_current_resource
           Chef::Log.debug("#{new_resource} loading current resource")

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -30,7 +30,7 @@ class Chef
         attr_accessor :is_virtual_package
 
         provides :package, platform: "smartos"
-        provides :smartos_package, platform_family: "smartos"
+        provides :smartos_package, platform: "smartos"
 
         def load_current_resource
           Chef::Log.debug("#{new_resource} loading current resource")


### PR DESCRIPTION
We're already going specific enough here to identify the platform_family. Debian is always going to be on Linux and SmartOS on Solaris2. Don't both checking both.

Signed-off-by: Tim Smith <tsmith@chef.io>