### PR TITLE
Remove deprecated -r option for Solo mode

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -238,16 +238,9 @@ class Chef::Application::Solo < Chef::Application
 
     Chef::Config[:solo] = true
 
-    Chef::Log.deprecation("-r MUST be changed to --recipe-url, the -r option will be changed in Chef 13.0") if ARGV.include?("-r")
-
     if !Chef::Config[:solo_legacy_mode]
       # Because we re-parse ARGV when we move to chef-client, we need to tidy up some options first.
       ARGV.delete("--ez")
-
-      # -r means something entirely different in chef-client land, so let's replace it with a "safe" value
-      if dash_r = ARGV.index("-r")
-        ARGV[dash_r] = "--recipe-url"
-      end
 
       # For back compat reasons, we need to ensure that we try and use the cache_path as a repo first
       Chef::Log.debug "Current chef_repo_path is #{Chef::Config.chef_repo_path}"

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@junglist.gen.nz>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -202,13 +202,6 @@ Enable chef-client interval runs by setting `:client_fork = true` in your config
         ARGV << "--ez"
         app.reconfigure
         expect(ARGV.include?("--ez")).to be_falsey
-      end
-
-      it "replaces -r with --recipe-url" do
-        ARGV.push("-r", "http://junglist.gen.nz/recipes.tgz")
-        app.reconfigure
-        expect(ARGV.include?("-r")).to be_falsey
-        expect(ARGV.include?("--recipe-url")).to be_truthy
       end
     end
 


### PR DESCRIPTION
We claimed we were going to remove this in Chef 13. Let's stop rewriting
ARGs now.

Signed-off-by: Tim Smith <tsmith@chef.io>