### PR TITLE
Remove update-rc.d -n (dryrun) option.

### DIFF
--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -53,7 +53,7 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             a.assertion { @so_priority.exitstatus == 0 }
-            a.failure_message Chef::Exceptions::Service, "/usr/sbin/update-rc.d -n -f #{current_resource.service_name} failed - #{@so_priority.inspect}"
+            a.failure_message Chef::Exceptions::Service, "/usr/sbin/update-rc.d -f #{current_resource.service_name} failed - #{@so_priority.inspect}"
             # This can happen if the service is not yet installed,so we'll fake it.
             a.whyrun ["Unable to determine priority of service, assuming service would have been correctly installed earlier in the run.",
                       "Assigning temporary priorities to continue.",
@@ -73,7 +73,7 @@ class Chef
         def get_priority
           priority = {}
 
-          @so_priority = shell_out!("/usr/sbin/update-rc.d -n -f #{current_resource.service_name} remove")
+          @so_priority = shell_out!("/usr/sbin/update-rc.d -f #{current_resource.service_name} remove")
 
           [@so_priority.stdout, @so_priority.stderr].each do |iop|
             iop.each_line do |line|


### PR DESCRIPTION
init-system-helpers 1.50 removed the broken -n (dryrun) option.

https://anonscm.debian.org/git/collab-maint/init-system-helpers.git/commit/?id=e0d3d2261c91c5d3dd8a980fcc5244b3b6ce8158

Signed-off-by: Vinson Lee <vlee@freedesktop.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
