### PR TITLE
Update the acceptance chef-config pin for chef 14

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -15,5 +15,5 @@ gem "berkshelf"
 # packages are not always immediately available via the omnitruck API.
 gem "mixlib-install", "1.2.3"
 
-# for chef-13 development - pin to the released rubygems version
-gem "chef-config", "< 13.0"
+# for chef-14 development - pin to the released rubygems version
+gem "chef-config", "< 14.0"


### PR DESCRIPTION
There's no reason to exclude chef 13 at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>