### PR TITLE
Don't run sudo on every travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: required
 cache: bundler
 dist: trusty
 


### PR DESCRIPTION
We already specify sudo where we need it. Enabling it everywhere just
means we have to run full boxes that take longer to spin up.

Signed-off-by: Tim Smith <tsmith@chef.io>