### PR TITLE
DSCL: Check for set home property before file existence (fixes #5777)

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -318,7 +318,7 @@ user password using shadow hash.")
         end
 
         def current_home_exists?
-          ::File.exist?(current_resource.home)
+          !!current_resource.home && ::File.exist?(current_resource.home)
         end
 
         def new_home_exists?

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -213,6 +213,32 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
     end
   end
 
+  describe "current_home_exists?" do
+    let(:current_resource) do
+      new_resource.dup
+    end
+
+    before do
+      provider.current_resource = current_resource
+    end
+
+    it "returns false for nil home dir" do
+      current_resource.home nil
+      expect(provider.current_home_exists?).to be_falsey
+    end
+
+    it "is false for empty string" do
+      current_resource.home ""
+      expect(provider.current_home_exists?).to be_falsey
+    end
+
+    it "is true for existing directory" do
+      current_resource.home "/Users/blah"
+      allow(::File).to receive(:exist?).with("/Users/blah").and_return(true)
+      expect(provider.current_home_exists?).to be_truthy
+    end
+  end
+
   describe "when modifying the home directory" do
     let(:current_resource) do
       new_resource.dup


### PR DESCRIPTION
Signed-off-by: Sean Karlage <skarlage@fb.com>

### Description

This is a re-do of https://github.com/chef/chef/pull/6225. This still currently blocks some user operations on chef > 12.17.44 for macOS.

### Issues Resolved

#5777

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
