### PR TITLE
Fix knife status to show seconds when needed #5055

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -101,9 +101,10 @@ class Chef
             fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
-            hours, minutes, = time_difference_in_hms(node["ohai_time"])
+            hours, minutes, seconds = time_difference_in_hms(node["ohai_time"])
             hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
             minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"
+            seconds_text = "#{seconds} second#{seconds == 1 ? ' ' : 's'}"
             run_list = "#{node['run_list']}" if config[:run_list]
             if hours > 24
               color = :red
@@ -111,9 +112,12 @@ class Chef
             elsif hours >= 1
               color = :yellow
               text = hours_text
-            else
+	    elsif minutes >= 1
               color = :green
               text = minutes_text
+	    else
+	      color = :green
+	      text = seconds_text	      
             end
 
             line_parts = Array.new

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -112,12 +112,12 @@ class Chef
             elsif hours >= 1
               color = :yellow
               text = hours_text
-	    elsif minutes >= 1
+            elsif minutes >= 1
               color = :green
               text = minutes_text
-	    else
-	      color = :green
-	      text = seconds_text	      
+            else
+              color = :green
+              text = seconds_text
             end
 
             line_parts = Array.new


### PR DESCRIPTION
### Description

When a node.save operation is executed and a "knife status" is
immediately executed I get "xx minutes" instead of "xx seconds".

The code behind 'knife status' isn't designed to have the ability to
format the time difference in seconds.

To remediate issue, make sure there is a condition in place to format
the time difference in seconds when appropriate.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

No pre-existing issue(s).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
