### PR TITLE
Prevent knife search --id-only from outputting IDs in the same format…

### DIFF
--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -98,7 +98,9 @@ class Chef
         begin
           q.search(@type, @query, search_args) do |item|
             formatted_item = Hash.new
-            if item.is_a?(Hash)
+            if config[:id_only]
+              formatted_item = format_for_display({ 'id' => item["__display_name"] })
+            elsif item.is_a?(Hash)
               # doing a little magic here to set the correct name
               formatted_item[item["__display_name"]] = item.reject { |k| k == "__display_name" }
             else

--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -99,7 +99,7 @@ class Chef
           q.search(@type, @query, search_args) do |item|
             formatted_item = Hash.new
             if config[:id_only]
-              formatted_item = format_for_display({ 'id' => item["__display_name"] })
+              formatted_item = format_for_display({ "id" => item["__display_name"] })
             elsif item.is_a?(Hash)
               # doing a little magic here to set the correct name
               formatted_item[item["__display_name"]] = item.reject { |k| k == "__display_name" }


### PR DESCRIPTION
… as an empty hash

### Description

This fixes the formatting of `knife search --id-only` output to restore the behavior prior to chef v13.4.32.
https://github.com/chef/chef/pull/6438 caused the output of this command to change from displaying each id on its own line to displaying each id followed by a colon and an empty line.
See the related issue and comments for more details.

### Issues Resolved

https://github.com/chef/chef-dk/issues/1475

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
