### PR TITLE
fix non-daemonized umask

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -90,6 +90,7 @@ class Chef
       load_config_file
       Chef::Config.export_proxies
       Chef::Config.init_openssl
+      File.umask Chef::Config[:umask]
     end
 
     # Parse the config file


### PR DESCRIPTION
We are ignoring this setting in non-daemonized (--no-fork) runs.

