### PR TITLE
Force deletion of tmpdir with sudo

### DIFF
--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -5,7 +5,7 @@ set -evx
 # Set up a custom tmpdir, and clean it up before and after the tests
 TMPDIR="${TMPDIR:-/tmp}/cheftest"
 export TMPDIR
-rm -rf $TMPDIR
+sudo rm -rf $TMPDIR
 mkdir -p $TMPDIR
 
 # $PROJECT_NAME is set by Jenkins, this allows us to use the same script to verify


### PR DESCRIPTION
This makes sure we don't fail on the very slim chance that an OS generated file (lookin' at you, AIX) ends up in this directory and blocks deletion.

Signed-off-by: Scott Hain <shain@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
