### PR TITLE
[MSYS-733]Move sec_to_dur method to chef\mixin

### DIFF
--- a/lib/chef/mixin/sec_to_dur.rb
+++ b/lib/chef/mixin/sec_to_dur.rb
@@ -1,0 +1,33 @@
+#
+# Author:: Dheeraj Dubey (<dheeraj.dubey@msystechnologies.com>)
+# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require "iso8601"
+
+class Chef
+  module Mixin
+    module SecToDur
+       # Converts the number of seconds to an ISO8601 duration format and returns it.
+       # Ref : https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
+       # e.g.
+       # ISO8601::Duration.new(65707200)
+       # returns 'P65707200S'
+      def sec_to_dur(seconds)
+        ISO8601::Duration.new(seconds.to_i).to_s
+      end
+     end
+  end
+end

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -18,7 +18,7 @@
 
 require "chef/mixin/shell_out"
 require "rexml/document"
-require "iso8601"
+require "chef/mixin/sec_to_dur"
 require "chef/mixin/powershell_out"
 
 class Chef
@@ -26,6 +26,7 @@ class Chef
     class WindowsTask < Chef::Provider
       include Chef::Mixin::ShellOut
       include Chef::Mixin::PowershellOut
+      include Chef::Mixin::SecToDur
 
       provides :windows_task, os: "windows"
 

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource"
+require "chef/mixin/sec_to_dur"
 
 class Chef
   class Resource
@@ -24,6 +25,7 @@ class Chef
     # or later due to API usage.
     # @since 13.0
     class WindowsTask < Chef::Resource
+      include Chef::Mixin::SecToDur
 
       resource_name :windows_task
       provides :windows_task, os: "windows"
@@ -204,16 +206,6 @@ class Chef
           raise ArgumentError, "idle_time value #{idle_time} is invalid. Valid values for :on_idle frequency are 1 - 999."
         end
       end
-
-      # Converts the number of seconds to an ISO8601 duration format and returns it.
-      # Ref : https://github.com/arnau/ISO8601/blob/master/lib/iso8601/duration.rb#L18-L23
-      # e.g.
-      # ISO8601::Duration.new(65707200)
-      # returns 'P65707200S'
-      def sec_to_dur(seconds)
-        ISO8601::Duration.new(seconds.to_i).to_s
-      end
-
     end
   end
 end


### PR DESCRIPTION


### Description

Move `sec_to_duration` logic from windows_task resource to a mixin

### Issues Resolved

https://github.com/chef/chef/issues/6623