### PR TITLE
fix double-logging bug

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,7 +177,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && !Chef::Config[:daemonize]
+      !( Chef::Config[:log_location].is_a?(IO) && Chef::Config[:log_location].tty? ) && !Chef::Config[:daemonize]
     end
 
     def configure_stdout_logger


### PR DESCRIPTION
somehow we're getting an IO object here which is a STDOUT wired up to
file descriptor 10 which is not the same as "STDOUT" which is wired up
to file descriptor 1.

i can't track down where or how this is happening.

this works around the problem by just inspecting if the log_location is
set to an IO object which is a tty or not which should be broadly
equivalent (and perhaps more correct than the old code?  not sure if
the edge cases matter or not).

also i'm not smart enough right now to figure out how to test this
adequately, particularly in ways that would actually catch if it
really breaks in the future (particularly due to the gnarliness of
wanting to have a functional test which constructs a tty when run on
travis without a tty....)
