### PR TITLE
Revert deprecation of use_inline_resources

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -71,10 +71,10 @@ class Chef
 
     # Deprecation stub for the old use_inline_resources mode.
     #
-    # @deprecated
     # @return [void]
     def self.use_inline_resources
-      Chef.deprecated(:use_inline_resources, "The use_inline_resources mode is no longer optional and the line enabling it can be removed")
+      # Uncomment this in Chef 13.6.
+      # Chef.deprecated(:use_inline_resources, "The use_inline_resources mode is no longer optional and the line enabling it can be removed")
     end
 
     #--
@@ -96,14 +96,10 @@ class Chef
       self.class.include_resource_dsl_module(new_resource)
     end
 
-    # are we currently running in why-run mode?
-    # @return [Boolean]
     def whyrun_mode?
       Chef::Config[:why_run]
     end
 
-    # is why run mode supported by the provider? We assume yes by default since 13.0
-    # @return [Boolean]
     def whyrun_supported?
       true
     end
@@ -117,8 +113,6 @@ class Chef
       run_context && run_context.resource_collection
     end
 
-    # the name of the current cookbook
-    # @return [String]
     def cookbook_name
       new_resource.cookbook_name
     end

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -197,6 +197,7 @@ describe Chef::Provider do
 
   context "when using use_inline_resources" do
     it "should log a deprecation warning" do
+      pending Chef::VERSION.start_with?("13.6")
       expect(Chef).to receive(:deprecated).with(:use_inline_resources, kind_of(String))
       Class.new(described_class) { use_inline_resources }
     end

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -197,7 +197,7 @@ describe Chef::Provider do
 
   context "when using use_inline_resources" do
     it "should log a deprecation warning" do
-      pending Chef::VERSION.start_with?("13.6")
+      pending Chef::VERSION.start_with?("14.1")
       expect(Chef).to receive(:deprecated).with(:use_inline_resources, kind_of(String))
       Class.new(described_class) { use_inline_resources }
     end


### PR DESCRIPTION
We're pushing this to 14.1 so we don't hold up Chef 14 migrations for the deletion of a simple method on our side.