### PR TITLE
Escape single quotes in validation_client_name #5130

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -88,7 +88,7 @@ class Chef
         def config_content
           client_rb = <<-CONFIG
 chef_server_url  "#{@chef_config[:chef_server_url]}"
-validation_client_name "#{@chef_config[:validation_client_name]}"
+validation_client_name "#{@chef_config[:validation_client_name]}".gsub(/'/) { "\'" }
           CONFIG
 
           if !(@chef_config[:config_log_level].nil? || @chef_config[:config_log_level].empty?)


### PR DESCRIPTION
### Description

When you have a single quote in the validation_client_name of knife.rb
it doesn't get escaped properly when running knife bootstrap.

In the reporter's case, he had literally set the validation_client_name
to "A path that doesn't exist" because of another bug he was running
into with some code.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

No preexisting issue(s).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>