### PR TITLE
Update error handling for "knife status" #3287

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -101,6 +101,11 @@ class Chef
             fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
+            if !node["ohai_time"]
+              ui.error("Ohai has not yet ran on node #{name}.")
+              exit(1)
+            end
+
             hours, minutes, seconds = time_difference_in_hms(node["ohai_time"])
             hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
             minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -101,32 +101,32 @@ class Chef
             fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
-            if !node["ohai_time"]
-              ui.error("Ohai has not yet ran on node #{name}.")
-              exit(1)
-            end
-
-            hours, minutes, seconds = time_difference_in_hms(node["ohai_time"])
-            hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
-            minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"
-            seconds_text = "#{seconds} second#{seconds == 1 ? ' ' : 's'}"
             run_list = "#{node['run_list']}" if config[:run_list]
-            if hours > 24
-              color = :red
-              text = hours_text
-            elsif hours >= 1
-              color = :yellow
-              text = hours_text
-            elsif minutes >= 1
-              color = :green
-              text = minutes_text
+            line_parts = Array.new
+
+            if node["ohai_time"]
+              hours, minutes, seconds = time_difference_in_hms(node["ohai_time"])
+              hours_text   = "#{hours} hour#{hours == 1 ? ' ' : 's'}"
+              minutes_text = "#{minutes} minute#{minutes == 1 ? ' ' : 's'}"
+              seconds_text = "#{seconds} second#{seconds == 1 ? ' ' : 's'}"
+              if hours > 24
+                color = :red
+                text = hours_text
+              elsif hours >= 1
+                color = :yellow
+                text = hours_text
+              elsif minutes >= 1
+                color = :green
+                text = minutes_text
+              else
+                color = :green
+                text = seconds_text
+              end
+              line_parts << @ui.color(text, color) + " ago" << name
             else
-              color = :green
-              text = seconds_text
+              line_parts << "Node #{name} has not yet converged"
             end
 
-            line_parts = Array.new
-            line_parts << @ui.color(text, color) + " ago" << name
             line_parts << fqdn if fqdn
             line_parts << ip if ip
             line_parts << run_list if run_list


### PR DESCRIPTION
### Description

If a node object's ohai_time value is "nil" then the calculated
time-since-last-run value is incorrect because the "nil" gets converted
to integer "0".

"knife status" should signal an error when a node's ohai_time value
is nil.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

No preexisting issue(s)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
