### PR TITLE
Remove useless class tests and cleanup specs

### DIFF
--- a/spec/unit/resource/apt_preference_spec.rb
+++ b/spec/unit/resource/apt_preference_spec.rb
@@ -24,11 +24,6 @@ describe Chef::Resource::AptPreference do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptPreference.new("libmysqlclient16", run_context) }
 
-  it "creates a new Chef::Resource::AptPreference" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::AptPreference)
-  end
-
   it "resolves to a Noop class when on non-linux OS" do
     node.automatic[:os] = "windows"
     node.automatic[:platform_family] = "windows"

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -24,11 +24,6 @@ describe Chef::Resource::AptRepository do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptRepository.new("multiverse", run_context) }
 
-  it "creates a new Chef::Resource::AptRepository" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::AptRepository)
-  end
-
   it "uses keyserver.ubuntu.com as the keyserver" do
     expect(resource.keyserver).to eql("keyserver.ubuntu.com")
   end

--- a/spec/unit/resource/apt_update_spec.rb
+++ b/spec/unit/resource/apt_update_spec.rb
@@ -24,11 +24,6 @@ describe Chef::Resource::AptUpdate do
   let(:run_context) { Chef::RunContext.new(node, {}, events) }
   let(:resource) { Chef::Resource::AptUpdate.new("update", run_context) }
 
-  it "creates a new Chef::Resource::AptUpdate" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::AptUpdate)
-  end
-
   it "default frequency is set to be 1 day" do
     expect(resource.frequency).to eql(86_400)
   end

--- a/spec/unit/resource/bash_spec.rb
+++ b/spec/unit/resource/bash_spec.rb
@@ -22,9 +22,8 @@ describe Chef::Resource::Bash do
 
   let(:resource) { Chef::Resource::Bash.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Bash" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Bash)
+  it "is a subclass of Chef::Resource::Script" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Script)
   end
 
   it "has a resource name of :bash" do

--- a/spec/unit/resource/batch_spec.rb
+++ b/spec/unit/resource/batch_spec.rb
@@ -19,18 +19,15 @@
 require "spec_helper"
 
 describe Chef::Resource::Batch do
+  let(:node) { Chef::Node.new }
 
   before(:each) do
-    node = Chef::Node.new
-
     node.default["kernel"] = Hash.new
     node.default["kernel"][:machine] = :x86_64.to_s
     node.automatic[:os] = "windows"
 
     run_context = Chef::RunContext.new(node, nil, nil)
-
     @resource = Chef::Resource::Batch.new("batch_unit_test", run_context)
-
   end
 
   it "creates a new Chef::Resource::Batch" do

--- a/spec/unit/resource/cab_package_spec.rb
+++ b/spec/unit/resource/cab_package_spec.rb
@@ -22,10 +22,8 @@ describe Chef::Resource::CabPackage do
 
   let(:resource) { Chef::Resource::CabPackage.new("test_pkg") }
 
-  it "creates a new Chef::Resource::CabPackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
+  it "is a subclass of Chef::Resource::Package" do
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
-    expect(resource).to be_a_instance_of(Chef::Resource::CabPackage)
   end
 
   it "sets resource name as :cab_package" do

--- a/spec/unit/resource/chocolatey_package_spec.rb
+++ b/spec/unit/resource/chocolatey_package_spec.rb
@@ -22,10 +22,8 @@ describe Chef::Resource::ChocolateyPackage do
 
   let(:resource) { Chef::Resource::ChocolateyPackage.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::ChocolateyPackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
+  it "is a subclass of Chef::Resource::Package" do
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
-    expect(resource).to be_a_instance_of(Chef::Resource::ChocolateyPackage)
   end
 
   it "has a resource name of :python" do

--- a/spec/unit/resource/cron_spec.rb
+++ b/spec/unit/resource/cron_spec.rb
@@ -22,11 +22,6 @@ require "spec_helper"
 describe Chef::Resource::Cron do
   let(:resource) { Chef::Resource::Cron.new("cronify") }
 
-  it "creates a new Chef::Resource::Cron" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Cron)
-  end
-
   it "has a name property" do
     expect(resource.name).to eql("cronify")
   end

--- a/spec/unit/resource/csh_spec.rb
+++ b/spec/unit/resource/csh_spec.rb
@@ -22,9 +22,8 @@ describe Chef::Resource::Csh do
 
   let(:resource) { Chef::Resource::Csh.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Csh" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Csh)
+  it "is a subclass of Chef::Resource::Script" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Script)
   end
 
   it "has a resource name of :csh" do

--- a/spec/unit/resource/directory_spec.rb
+++ b/spec/unit/resource/directory_spec.rb
@@ -22,12 +22,7 @@ require "spec_helper"
 describe Chef::Resource::Directory do
   let(:resource) { Chef::Resource::Directory.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Directory" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Directory)
-  end
-
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("fakey_fakerton")
   end
 

--- a/spec/unit/resource/dnf_package_spec.rb
+++ b/spec/unit/resource/dnf_package_spec.rb
@@ -32,68 +32,62 @@ describe Chef::Resource::DnfPackage, "initialize" do
 end
 
 describe Chef::Resource::DnfPackage, "arch" do
-  before(:each) do
-    @resource = Chef::Resource::DnfPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::DnfPackage.new("foo") }
 
   it "sets the arch variable to whatever is passed in" do
-    @resource.arch("i386")
-    expect(@resource.arch).to eql(["i386"])
+    resource.arch("i386")
+    expect(resource.arch).to eql(["i386"])
   end
 end
 
 describe Chef::Resource::DnfPackage, "flush_cache" do
-  before(:each) do
-    @resource = Chef::Resource::DnfPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::DnfPackage.new("foo") }
 
   it "defaults the flush timing to false" do
     flush_hash = { :before => false, :after => false }
-    expect(@resource.flush_cache).to eq(flush_hash)
+    expect(resource.flush_cache).to eq(flush_hash)
   end
 
   it "allows you to set the flush timing with an array" do
     flush_array = [ :before, :after ]
     flush_hash = { :before => true, :after => true }
-    @resource.flush_cache(flush_array)
-    expect(@resource.flush_cache).to eq(flush_hash)
+    resource.flush_cache(flush_array)
+    expect(resource.flush_cache).to eq(flush_hash)
   end
 
   it "allows you to set the flush timing with a hash" do
     flush_hash = { :before => true, :after => true }
-    @resource.flush_cache(flush_hash)
-    expect(@resource.flush_cache).to eq(flush_hash)
+    resource.flush_cache(flush_hash)
+    expect(resource.flush_cache).to eq(flush_hash)
   end
 
   it "allows 'true' for flush_cache" do
-    @resource.flush_cache(true)
-    expect(@resource.flush_cache).to eq({ before: true, after: true })
+    resource.flush_cache(true)
+    expect(resource.flush_cache).to eq({ before: true, after: true })
   end
 
   it "allows 'false' for flush_cache" do
-    @resource.flush_cache(false)
-    expect(@resource.flush_cache).to eq({ before: false, after: false })
+    resource.flush_cache(false)
+    expect(resource.flush_cache).to eq({ before: false, after: false })
   end
 
   it "allows ':before' for flush_cache" do
-    @resource.flush_cache(:before)
-    expect(@resource.flush_cache).to eq({ before: true, after: false })
+    resource.flush_cache(:before)
+    expect(resource.flush_cache).to eq({ before: true, after: false })
   end
 
   it "allows ':after' for flush_cache" do
-    @resource.flush_cache(:after)
-    expect(@resource.flush_cache).to eq({ before: false, after: true })
+    resource.flush_cache(:after)
+    expect(resource.flush_cache).to eq({ before: false, after: true })
   end
 end
 
 describe Chef::Resource::DnfPackage, "allow_downgrade" do
-  before(:each) do
-    @resource = Chef::Resource::DnfPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::DnfPackage.new("foo") }
 
   it "allows you to specify whether allow_downgrade is true or false" do
     Chef::Config[:treat_deprecation_warnings_as_errors] = false
-    expect { @resource.allow_downgrade true }.not_to raise_error
-    expect { @resource.allow_downgrade false }.not_to raise_error
+    expect { resource.allow_downgrade true }.not_to raise_error
+    expect { resource.allow_downgrade false }.not_to raise_error
   end
 end

--- a/spec/unit/resource/env_spec.rb
+++ b/spec/unit/resource/env_spec.rb
@@ -20,65 +20,57 @@
 require "spec_helper"
 
 describe Chef::Resource::Env do
+  let(:resource) { Chef::Resource::Env.new("FOO") }
 
-  before(:each) do
-    @resource = Chef::Resource::Env.new("FOO")
-  end
-
-  it "creates a new Chef::Resource::Env" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::Env)
-  end
-
-  it "has a name" do
-    expect(@resource.name).to eql("FOO")
+  it "has a name property" do
+    expect(resource.name).to eql("FOO")
   end
 
   it "has a default action of 'create'" do
-    expect(@resource.action).to eql([:create])
+    expect(resource.action).to eql([:create])
   end
 
   { :create => false, :delete => false, :modify => false, :flibber => true }.each do |action, bad_value|
     it "should #{bad_value ? 'not' : ''} accept #{action}" do
       if bad_value
-        expect { @resource.action action }.to raise_error(ArgumentError)
+        expect { resource.action action }.to raise_error(ArgumentError)
       else
-        expect { @resource.action action }.not_to raise_error
+        expect { resource.action action }.not_to raise_error
       end
     end
   end
 
   it "uses the object name as the key_name by default" do
-    expect(@resource.key_name).to eql("FOO")
+    expect(resource.key_name).to eql("FOO")
   end
 
   it "accepts a string as the env value via 'value'" do
-    expect { @resource.value "bar" }.not_to raise_error
+    expect { resource.value "bar" }.not_to raise_error
   end
 
   it "does not accept a Hash for the env value via 'to'" do
-    expect { @resource.value Hash.new }.to raise_error(ArgumentError)
+    expect { resource.value Hash.new }.to raise_error(ArgumentError)
   end
 
   it "allows you to set an env value via 'to'" do
-    @resource.value "bar"
-    expect(@resource.value).to eql("bar")
+    resource.value "bar"
+    expect(resource.value).to eql("bar")
   end
 
   describe "when it has key name and value" do
     before do
-      @resource.key_name("charmander")
-      @resource.value("level7")
-      @resource.delim("hi")
+      resource.key_name("charmander")
+      resource.value("level7")
+      resource.delim("hi")
     end
 
     it "describes its state" do
-      state = @resource.state_for_resource_reporter
+      state = resource.state_for_resource_reporter
       expect(state[:value]).to eq("level7")
     end
 
     it "returns the key name as its identity" do
-      expect(@resource.identity).to eq("charmander")
+      expect(resource.identity).to eq("charmander")
     end
   end
 

--- a/spec/unit/resource/file_spec.rb
+++ b/spec/unit/resource/file_spec.rb
@@ -22,7 +22,7 @@ describe Chef::Resource::File do
 
   let(:resource) { Chef::Resource::File.new("fakey_fakerton") }
 
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("fakey_fakerton")
   end
 

--- a/spec/unit/resource/freebsd_package_spec.rb
+++ b/spec/unit/resource/freebsd_package_spec.rb
@@ -22,42 +22,41 @@ require "spec_helper"
 require "ostruct"
 
 describe Chef::Resource::FreebsdPackage do
-  before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-    @resource = Chef::Resource::FreebsdPackage.new("foo", @run_context)
-  end
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::FreebsdPackage.new("foo", run_context) }
 
   describe "Initialization" do
-    it "returns a Chef::Resource::FreebsdPackage" do
-      expect(@resource).to be_a_kind_of(Chef::Resource::FreebsdPackage)
+
+    it "is a subclass of Chef::Resource::Package" do
+      expect(resource).to be_a_kind_of(Chef::Resource::Package)
     end
 
     it "sets the resource_name to :freebsd_package" do
-      expect(@resource.resource_name).to eql(:freebsd_package)
+      expect(resource.resource_name).to eql(:freebsd_package)
     end
 
     it "does not set the provider" do
-      expect(@resource.provider).to be_nil
+      expect(resource.provider).to be_nil
     end
   end
 
   describe "Assigning provider after creation" do
     describe "if ports specified as source" do
       it "is Freebsd::Port" do
-        @resource.source("ports")
-        @resource.after_created
-        expect(@resource.provider).to eq(Chef::Provider::Package::Freebsd::Port)
+        resource.source("ports")
+        resource.after_created
+        expect(resource.provider).to eq(Chef::Provider::Package::Freebsd::Port)
       end
     end
 
     describe "if freebsd_version is greater than or equal to 1000017" do
       it "is Freebsd::Pkgng" do
         [1000017, 1000018, 1000500, 1001001, 1100000].each do |freebsd_version|
-          @node.automatic_attrs[:os_version] = freebsd_version
-          @resource.after_created
-          expect(@resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkgng)
+          node.automatic_attrs[:os_version] = freebsd_version
+          resource.after_created
+          expect(resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkgng)
         end
       end
     end
@@ -65,21 +64,21 @@ describe Chef::Resource::FreebsdPackage do
     describe "if pkgng enabled" do
       it "is Freebsd::Pkgng" do
         pkg_enabled = OpenStruct.new(:stdout => "yes\n")
-        allow(@resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
-        @resource.after_created
-        expect(@resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkgng)
+        allow(resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
+        resource.after_created
+        expect(resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkgng)
       end
     end
 
     describe "if freebsd_version is less than 1000017 and pkgng not enabled" do
       it "is Freebsd::Pkg" do
         pkg_enabled = OpenStruct.new(:stdout => "\n")
-        allow(@resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
+        allow(resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", :env => nil).and_return(pkg_enabled)
 
         [1000016, 1000000, 901503, 902506, 802511].each do |freebsd_version|
-          @node.automatic_attrs[:os_version] = freebsd_version
-          @resource.after_created
-          expect(@resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkg)
+          node.automatic_attrs[:os_version] = freebsd_version
+          resource.after_created
+          expect(resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkg)
         end
       end
     end

--- a/spec/unit/resource/gem_package_spec.rb
+++ b/spec/unit/resource/gem_package_spec.rb
@@ -31,12 +31,10 @@ describe Chef::Resource::GemPackage, "initialize" do
 end
 
 describe Chef::Resource::GemPackage, "gem_binary" do
-  before(:each) do
-    @resource = Chef::Resource::GemPackage.new("foo")
-  end
+  let(:resource) { Chef::Resource::GemPackage.new("foo") }
 
   it "sets the gem_binary variable to whatever is passed in" do
-    @resource.gem_binary("/opt/local/bin/gem")
-    expect(@resource.gem_binary).to eql("/opt/local/bin/gem")
+    resource.gem_binary("/opt/local/bin/gem")
+    expect(resource.gem_binary).to eql("/opt/local/bin/gem")
   end
 end

--- a/spec/unit/resource/git_spec.rb
+++ b/spec/unit/resource/git_spec.rb
@@ -30,9 +30,8 @@ describe Chef::Resource::Git do
 
   let(:resource) { Chef::Resource::Git.new("my awesome webapp") }
 
-  it "is a kind of Scm Resource" do
+  it "is a subclass of Chef::Resource::Scm" do
     expect(resource).to be_a_kind_of(Chef::Resource::Scm)
-    expect(resource).to be_an_instance_of(Chef::Resource::Git)
   end
 
   it "uses aliases revision as branch" do

--- a/spec/unit/resource/group_spec.rb
+++ b/spec/unit/resource/group_spec.rb
@@ -22,11 +22,6 @@ require "spec_helper"
 describe Chef::Resource::Group, "initialize" do
   let(:resource) { Chef::Resource::Group.new("admin") }
 
-  it "creates a new Chef::Resource::Group" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Group)
-  end
-
   it "sets the resource_name to :group" do
     expect(resource.resource_name).to eql(:group)
   end

--- a/spec/unit/resource/homebrew_package_spec.rb
+++ b/spec/unit/resource/homebrew_package_spec.rb
@@ -30,6 +30,10 @@ describe Chef::Resource::HomebrewPackage, "initialize" do
 
   let(:resource) { Chef::Resource::HomebrewPackage.new("emacs") }
 
+  it "is a subclass of Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
+  end
+
   shared_examples "home_brew user set and returned" do
     it "returns the configured homebrew_user" do
       resource.homebrew_user user

--- a/spec/unit/resource/http_request_spec.rb
+++ b/spec/unit/resource/http_request_spec.rb
@@ -22,11 +22,6 @@ require "spec_helper"
 describe Chef::Resource::HttpRequest do
   let(:resource) { Chef::Resource::HttpRequest.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::HttpRequest" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::HttpRequest)
-  end
-
   it "sets url to a string" do
     resource.url "http://slashdot.org"
     expect(resource.url).to eql("http://slashdot.org")

--- a/spec/unit/resource/ips_package_spec.rb
+++ b/spec/unit/resource/ips_package_spec.rb
@@ -31,6 +31,10 @@ describe Chef::Resource::IpsPackage, "initialize" do
 
   let(:resource) { Chef::Resource::IpsPackage.new("crypto/gnupg") }
 
+  it "is a subclass of Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
+  end
+
   it "should support accept_license" do
     resource.accept_license(true)
     expect(resource.accept_license).to eql(true)

--- a/spec/unit/resource/ksh_spec.rb
+++ b/spec/unit/resource/ksh_spec.rb
@@ -22,9 +22,8 @@ describe Chef::Resource::Ksh do
 
   let(:resource) { Chef::Resource::Ksh.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Ksh" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Ksh)
+  it "is a subclass of Chef::Resource::Script" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Script)
   end
 
   it "has a resource name of :ksh" do

--- a/spec/unit/resource/launchd_spec.rb
+++ b/spec/unit/resource/launchd_spec.rb
@@ -17,11 +17,6 @@ require "spec_helper"
 describe Chef::Resource::Launchd do
   let(:resource) { Chef::Resource::Launchd.new("io.chef.chef-client" ) }
 
-  it "creates a new Chef::Resource::Launchd" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Launchd)
-  end
-
   it "has a resource name of Launchd" do
     expect(resource.resource_name).to eql(:launchd)
   end

--- a/spec/unit/resource/link_spec.rb
+++ b/spec/unit/resource/link_spec.rb
@@ -26,12 +26,7 @@ describe Chef::Resource::Link do
     expect_any_instance_of(Chef::Resource::Link).to receive(:verify_links_supported!).and_return(true)
   end
 
-  it "creates a new Chef::Resource::Link" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Link)
-  end
-
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("fakey_fakerton")
   end
 

--- a/spec/unit/resource/log_spec.rb
+++ b/spec/unit/resource/log_spec.rb
@@ -24,11 +24,6 @@ describe Chef::Resource::Log do
   let(:log_str) { "this is my string to log" }
   let(:resource) { Chef::Resource::Log.new(log_str) }
 
-  it "creates a new Chef::Resource::Log" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Log)
-  end
-
   it "supports the :write actions" do
     expect(resource.allowed_actions).to include(:write)
   end

--- a/spec/unit/resource/mdadm_spec.rb
+++ b/spec/unit/resource/mdadm_spec.rb
@@ -23,11 +23,6 @@ describe Chef::Resource::Mdadm do
 
   let(:resource) { Chef::Resource::Mdadm.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Mdadm" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Mdadm)
-  end
-
   it "has a resource name of :mdadm" do
     expect(resource.resource_name).to eql(:mdadm)
   end

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -22,12 +22,7 @@ require "spec_helper"
 describe Chef::Resource::Mount do
   let(:resource) { Chef::Resource::Mount.new("filesystem") }
 
-  it "creates a new Chef::Resource::Mount" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Mount)
-  end
-
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("filesystem")
   end
 

--- a/spec/unit/resource/msu_package_spec.rb
+++ b/spec/unit/resource/msu_package_spec.rb
@@ -21,10 +21,8 @@ require "spec_helper"
 describe Chef::Resource::MsuPackage do
   let(:resource) { Chef::Resource::MsuPackage.new("test_pkg") }
 
-  it "creates a new Chef::Resource::MsuPackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
+  it "is a subclass of Chef::Resource::Package" do
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
-    expect(resource).to be_a_instance_of(Chef::Resource::MsuPackage)
   end
 
   it "sets resource name as :msu_package" do

--- a/spec/unit/resource/ohai_spec.rb
+++ b/spec/unit/resource/ohai_spec.rb
@@ -22,11 +22,6 @@ describe Chef::Resource::Ohai do
 
   let(:resource) { Chef::Resource::Ohai.new("ohai_reload") }
 
-  it "creates a new Chef::Resource::Ohai" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Ohai)
-  end
-
   it "has a resource name of :ohai" do
     expect(resource.resource_name).to eql(:ohai)
   end

--- a/spec/unit/resource/openbsd_package_spec.rb
+++ b/spec/unit/resource/openbsd_package_spec.rb
@@ -20,28 +20,24 @@
 #
 
 require "spec_helper"
-require "ostruct"
 
 describe Chef::Resource::OpenbsdPackage do
-
-  before(:each) do
-    @node = Chef::Node.new
-    @events = Chef::EventDispatch::Dispatcher.new
-    @run_context = Chef::RunContext.new(@node, {}, @events)
-    @resource = Chef::Resource::OpenbsdPackage.new("foo", @run_context)
-  end
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::OpenbsdPackage.new("foo", run_context) }
 
   describe "Initialization" do
-    it "returns a Chef::Resource::OpenbsdPackage" do
-      expect(@resource).to be_a_kind_of(Chef::Resource::OpenbsdPackage)
+    it "is a subclass of Chef::Resource::Package" do
+      expect(resource).to be_a_kind_of(Chef::Resource::Package)
     end
 
     it "sets the resource_name to :openbsd_package" do
-      expect(@resource.resource_name).to eql(:openbsd_package)
+      expect(resource.resource_name).to eql(:openbsd_package)
     end
 
     it "does not set the provider" do
-      expect(@resource.provider).to be_nil
+      expect(resource.provider).to be_nil
     end
   end
 

--- a/spec/unit/resource/osx_profile_spec.rb
+++ b/spec/unit/resource/osx_profile_spec.rb
@@ -25,11 +25,6 @@ describe Chef::Resource::OsxProfile do
     run_context)
   end
 
-  it "creates a new Chef::Resource::OsxProfile" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::OsxProfile)
-  end
-
   it "has a resource name of profile" do
     expect(resource.resource_name).to eql(:osx_profile)
   end

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -22,11 +22,6 @@ require "spec_helper"
 describe Chef::Resource::Package do
   let(:resource) { Chef::Resource::Package.new("emacs") }
 
-  it "creates a new Chef::Resource::Package" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Package)
-  end
-
   it "sets the package_name to the first argument to new" do
     expect(resource.package_name).to eql("emacs")
   end

--- a/spec/unit/resource/perl_spec.rb
+++ b/spec/unit/resource/perl_spec.rb
@@ -22,9 +22,8 @@ describe Chef::Resource::Perl do
 
   let(:resource) { Chef::Resource::Perl.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Perl" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Perl)
+  it "is a subclass of Chef::Resource::Script" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Script)
   end
 
   it "has a resource name of :perl" do

--- a/spec/unit/resource/portage_package_spec.rb
+++ b/spec/unit/resource/portage_package_spec.rb
@@ -22,8 +22,8 @@ describe Chef::Resource::PortagePackage, "initialize" do
 
   let(:resource) { Chef::Resource::PortagePackage.new("foo") }
 
-  it "returns a Chef::Resource::PortagePackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource::PortagePackage)
+  it "is a subclass of Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
   end
 
   it "sets the resource_name to :portage_package" do

--- a/spec/unit/resource/powershell_package_spec.rb
+++ b/spec/unit/resource/powershell_package_spec.rb
@@ -22,10 +22,8 @@ describe Chef::Resource::PowershellPackage do
 
   let(:resource) { Chef::Resource::PowershellPackage.new("test_package") }
 
-  it "creates a new Chef::Resource::PowershellPackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
+  it "is a subclass of Chef::Resource::Package" do
     expect(resource).to be_a_kind_of(Chef::Resource::Package)
-    expect(resource).to be_a_instance_of(Chef::Resource::PowershellPackage)
   end
 
   #to check the value of resource.resource_name

--- a/spec/unit/resource/python_spec.rb
+++ b/spec/unit/resource/python_spec.rb
@@ -22,11 +22,6 @@ describe Chef::Resource::Python do
 
   let(:resource) { Chef::Resource::Python.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Python" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Python)
-  end
-
   it "has a resource name of :python" do
     expect(resource.resource_name).to eql(:python)
   end

--- a/spec/unit/resource/reboot_spec.rb
+++ b/spec/unit/resource/reboot_spec.rb
@@ -21,11 +21,6 @@ describe Chef::Resource::Reboot do
 
   let(:resource) { Chef::Resource::Reboot.new("reboot me!") }
 
-  it "creates a new Chef::Resource::Reboot" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Reboot)
-  end
-
   it "has a default action of :nothing" do
     expect(resource.action).to eql([:nothing])
   end

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -21,11 +21,6 @@ require "spec_helper"
 describe Chef::Resource::RegistryKey, "initialize" do
   let(:resource) { Chef::Resource::RegistryKey.new('HKCU\Software\Raxicoricofallapatorius') }
 
-  it "creates a new Chef::Resource::RegistryKey" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::RegistryKey)
-  end
-
   it "sets the resource_name to :registry_key" do
     expect(resource.resource_name).to eql(:registry_key)
   end

--- a/spec/unit/resource/remote_directory_spec.rb
+++ b/spec/unit/resource/remote_directory_spec.rb
@@ -22,11 +22,6 @@ describe Chef::Resource::RemoteDirectory do
 
   let(:resource) { Chef::Resource::RemoteDirectory.new("/etc/dunk") }
 
-  it "creates a new Chef::Resource::RemoteDirectory" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::RemoteDirectory)
-  end
-
   it "sets the path to the first argument to new" do
     expect(resource.path).to eql("/etc/dunk")
   end

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -24,10 +24,8 @@ describe Chef::Resource::RemoteFile do
   let(:resource) { Chef::Resource::RemoteFile.new("fakey_fakerton") }
 
   describe "initialize" do
-    it "creates a new Chef::Resource::RemoteFile" do
-      expect(resource).to be_a_kind_of(Chef::Resource)
+    it "is a subclass of Chef::Resource::File" do
       expect(resource).to be_a_kind_of(Chef::Resource::File)
-      expect(resource).to be_a_kind_of(Chef::Resource::RemoteFile)
     end
   end
 

--- a/spec/unit/resource/route_spec.rb
+++ b/spec/unit/resource/route_spec.rb
@@ -23,12 +23,7 @@ describe Chef::Resource::Route do
 
   let(:resource) { Chef::Resource::Route.new("10.0.0.10") }
 
-  it "creates a new Chef::Resource::Route" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Route)
-  end
-
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("10.0.0.10")
   end
 

--- a/spec/unit/resource/rpm_package_spec.rb
+++ b/spec/unit/resource/rpm_package_spec.rb
@@ -36,6 +36,10 @@ end
 describe Chef::Resource::RpmPackage, "allow_downgrade" do
   let(:resource) { Chef::Resource::RpmPackage.new("foo") }
 
+  it "is a subclass of Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
+  end
+
   it "allows you to specify whether allow_downgrade is true or false" do
     expect { resource.allow_downgrade true }.not_to raise_error
     expect { resource.allow_downgrade false }.not_to raise_error

--- a/spec/unit/resource/ruby_block_spec.rb
+++ b/spec/unit/resource/ruby_block_spec.rb
@@ -23,11 +23,6 @@ describe Chef::Resource::RubyBlock do
 
   let(:resource) { Chef::Resource::RubyBlock.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::RubyBlock" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::RubyBlock)
-  end
-
   it "has a default action of 'run'" do
     expect(resource.action).to eql([:run])
   end

--- a/spec/unit/resource/ruby_spec.rb
+++ b/spec/unit/resource/ruby_spec.rb
@@ -21,11 +21,6 @@ require "spec_helper"
 describe Chef::Resource::Ruby do
   let(:resource) { Chef::Resource::Ruby.new("fakey_fakerton") }
 
-  it "creates a new Chef::Resource::Ruby" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Ruby)
-  end
-
   it "has a resource name of :ruby" do
     expect(resource.resource_name).to eql(:ruby)
   end

--- a/spec/unit/resource/scm_spec.rb
+++ b/spec/unit/resource/scm_spec.rb
@@ -22,10 +22,6 @@ require "spec_helper"
 describe Chef::Resource::Scm do
   let(:resource) { Chef::Resource::Scm.new("my awesome app") }
 
-  it "is a SCM resource" do
-    expect(resource).to be_a_kind_of(Chef::Resource::Scm)
-  end
-
   it "supports :checkout, :export, :sync, :diff, and :log actions" do
     expect(resource.allowed_actions).to include(:checkout)
     expect(resource.allowed_actions).to include(:export)

--- a/spec/unit/resource/service_spec.rb
+++ b/spec/unit/resource/service_spec.rb
@@ -22,11 +22,6 @@ require "spec_helper"
 describe Chef::Resource::Service do
   let(:resource) { Chef::Resource::Service.new("chef") }
 
-  it "creates a new Chef::Resource::Service" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::Service)
-  end
-
   it "does not set a provider unless node[:init_package] is defined as systemd" do
     expect(resource.provider).to eq(nil)
   end

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -35,12 +35,7 @@ describe Chef::Resource::SystemdUnit do
     }
   end
 
-  it "creates a new Chef::Resource::SystemdUnit" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::SystemdUnit)
-  end
-
-  it "has a name" do
+  it "has a name property" do
     expect(resource.name).to eql("sysstat-collect.timer")
   end
 

--- a/spec/unit/resource/template_spec.rb
+++ b/spec/unit/resource/template_spec.rb
@@ -22,10 +22,8 @@ describe Chef::Resource::Template do
   let(:resource) { Chef::Resource::Template.new("fakey_fakerton") }
 
   describe "initialize" do
-    it "creates a new Chef::Resource::Template" do
-      expect(resource).to be_a_kind_of(Chef::Resource)
+    it "is a subclass of Chef::Resource::File" do
       expect(resource).to be_a_kind_of(Chef::Resource::File)
-      expect(resource).to be_a_kind_of(Chef::Resource::Template)
     end
   end
 

--- a/spec/unit/resource/user_spec.rb
+++ b/spec/unit/resource/user_spec.rb
@@ -21,11 +21,6 @@ require "spec_helper"
 describe Chef::Resource::User, "initialize" do
   let(:resource) { Chef::Resource::User.new("adam") }
 
-  it "creates a new Chef::Resource::User" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_kind_of(Chef::Resource::User)
-  end
-
   it "sets the resource_name to :user" do
     expect(resource.resource_name).to eql(:user_resource_abstract_base_class)
   end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -33,8 +33,8 @@ describe Chef::Resource::WindowsPackage, "initialize" do
 
   let(:resource) { Chef::Resource::WindowsPackage.new("solitaire.msi") }
 
-  it "returns a Chef::Resource::WindowsPackage" do
-    expect(resource).to be_a_kind_of(Chef::Resource::WindowsPackage)
+  it "is a subclass of Chef::Resource::Package" do
+    expect(resource).to be_a_kind_of(Chef::Resource::Package)
   end
 
   it "sets the resource_name to :windows_package" do

--- a/spec/unit/resource/windows_service_spec.rb
+++ b/spec/unit/resource/windows_service_spec.rb
@@ -29,10 +29,6 @@ describe Chef::Resource::WindowsService, "initialize" do
 
   let(:resource) { Chef::Resource::WindowsService.new("BITS") }
 
-  it "returns a Chef::Resource::WindowsService" do
-    expect(resource).to be_a_kind_of(Chef::Resource::WindowsService)
-  end
-
   it "sets the resource_name to :windows_service" do
     expect(resource.resource_name).to eql(:windows_service)
   end

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -21,11 +21,6 @@ require "spec_helper"
 describe Chef::Resource::WindowsTask do
   let(:resource) { Chef::Resource::WindowsTask.new("sample_task") }
 
-  it "creates a new Chef::Resource::WindowsTask" do
-    expect(resource).to be_a_kind_of(Chef::Resource)
-    expect(resource).to be_a_instance_of(Chef::Resource::WindowsTask)
-  end
-
   it "sets resource name as :windows_task" do
     expect(resource.resource_name).to eql(:windows_task)
   end


### PR DESCRIPTION
We create the class then instantly check that it's exactly what we created. There's not much value in that. This also converts more things over to let.

Signed-off-by: Tim Smith <tsmith@chef.io>