### PR TITLE
Rename the OpenSSL mixin to avoid name conflicts

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -17,7 +17,7 @@
 
 class Chef
   module Mixin
-    module OpenSSL
+    module OpenSSLHelper
       def self.included(_base)
         require "openssl" unless defined?(::OpenSSL)
       end

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -26,8 +26,8 @@ class Chef
     #
     # @since 14.0
     class OpensslDhparam < Chef::Resource
-      require "chef/mixin/openssl"
-      include Chef::Mixin::OpenSSL
+      require "chef/mixin/openssl_helper"
+      include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_dhparam
 

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -27,8 +27,8 @@ class Chef
     #
     # @since 14.0
     class OpensslRsaPrivateKey < Chef::Resource
-      require "chef/mixin/openssl"
-      include Chef::Mixin::OpenSSL
+      require "chef/mixin/openssl_helper"
+      include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_rsa_private_key
       provides :openssl_rsa_private_key

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -23,8 +23,8 @@ class Chef
     #
     # @since 14.0
     class OpensslRsaPublicKey < Chef::Resource
-      require "chef/mixin/openssl"
-      include Chef::Mixin::OpenSSL
+      require "chef/mixin/openssl_helper"
+      include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_rsa_public_key
 

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 require "spec_helper"
-require "chef/mixin/openssl"
+require "chef/mixin/openssl_helper"
 
-describe Chef::Mixin::OpenSSL do
+describe Chef::Mixin::OpenSSLHelper do
   let(:instance) do
-    Class.new { include Chef::Mixin::OpenSSL }.new
+    Class.new { include Chef::Mixin::OpenSSLHelper }.new
   end
 
   describe ".included" do


### PR DESCRIPTION
This way people don't have to refactor their code from OpenSSL::Whatever to ::OpenSSL::Whatever

Signed-off-by: Tim Smith <tsmith@chef.io>