### PR TITLE
speed up http func tests

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -5,7 +5,7 @@
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2009-2017, Chef Software Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/http/simple_spec.rb
+++ b/spec/functional/http/simple_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,11 +26,17 @@ describe Chef::HTTP::Simple do
   let(:http_client) { described_class.new(source) }
   let(:http_client_disable_gzip) { described_class.new(source, { :disable_gzip => true } ) }
 
-  before(:each) do
-    start_tiny_server
+  before(:all) do
+    start_tiny_server(RequestTimeout: 1)
   end
 
-  after(:each) do
+  before(:each) do
+    Chef::Config[:rest_timeout] = 2
+    Chef::Config[:http_retry_delay] = 0
+    Chef::Config[:http_retry_count] = 0
+  end
+
+  after(:all) do
     stop_tiny_server
   end
 
@@ -46,10 +52,10 @@ describe Chef::HTTP::Simple do
   end
 
   shared_examples_for "validates content length and throws an exception" do
-    it "successfully downloads a streaming request" do
+    it "a streaming request throws a content length exception" do
       expect { http_client.streaming_request(source) }.to raise_error(Chef::Exceptions::ContentLengthMismatch)
     end
-    it "successfully does a non-streaming GET request" do
+    it "a non-streaming GET request throws a content length exception" do
       expect { http_client.get(source) }.to raise_error(Chef::Exceptions::ContentLengthMismatch)
     end
   end


### PR DESCRIPTION
For the truncated downloads the tiny server needs to hit its
RequestTimeout in order to terminate the truncated request, so that
is set to 1 second.  Then also drop down the retries and the
rest_timeout on the client side (but keep the rest_timeout to 2 to
keep it above the tiny_server timeout)

