### PR TITLE
Fix regression where message isn't an identity property in log resource

### DIFF
--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -39,7 +39,7 @@ class Chef
     class Log < Chef::Resource
       resource_name :log
 
-      property :message, String, name_property: true
+      property :message, String, name_property: true, identity: true
       property :level, Symbol, equal_to: [ :debug, :info, :warn, :error, :fatal ], default: :info
 
       allowed_actions :write


### PR DESCRIPTION
In chef 13.6 this was the case. In the cleanup this one was missed and
this breaks chefspec behavior

Signed-off-by: Tim Smith <tsmith@chef.io>