### PR TITLE
Raise fatal error If FQDN duplicated

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -183,7 +183,7 @@ class Chef
           end
           exit 10
         end
-        if %i(warn fatal).include?(config[:duplicated_fqdns])
+        if %i{warn fatal}.include?(config[:duplicated_fqdns])
           fqdns = list.map { |v| v[0] }
           if fqdns.count != fqdns.uniq.count
             duplicated_fqdns = fqdns.uniq

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -177,11 +177,11 @@ class Chef
           end
           exit 10
         end
-        ips = list.map { |v| v.first }
-        if ips.count != ips.uniq.count
-          duplicated_ips = ips.uniq
-          ui.fatal("SSH #{duplicated_ips.count > 1 ? 'nodes are' : 'node is'} " +
-                   "duplicated: #{duplicated_ips.join(',')}")
+        fqdns = list.map { |v| v[0] }
+        if fqdns.count != fqdns.uniq.count
+          duplicated_fqdns = fqdns.uniq
+          ui.fatal("SSH #{duplicated_fqdns.count > 1 ? 'nodes are' : 'node is'} " +
+                   "duplicated: #{duplicated_fqdns.join(',')}")
           exit 10
         end
         session_from_list(list)

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -180,9 +180,8 @@ class Chef
         fqdns = list.map { |v| v[0] }
         if fqdns.count != fqdns.uniq.count
           duplicated_fqdns = fqdns.uniq
-          ui.fatal("SSH #{duplicated_fqdns.count > 1 ? 'nodes are' : 'node is'} " +
-                   "duplicated: #{duplicated_fqdns.join(',')}")
-          exit 10
+          ui.warn("SSH #{duplicated_fqdns.count > 1 ? 'nodes are' : 'node is'} " +
+                  "duplicated: #{duplicated_fqdns.join(',')}")
         end
         session_from_list(list)
       end

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -177,6 +177,13 @@ class Chef
           end
           exit 10
         end
+        ips = list.map { |v| v.first }
+        if ips.count != ips.uniq.count
+          duplicated_ips = ips.uniq
+          ui.fatal("SSH #{duplicated_ips.count > 1 ? 'nodes are' : 'node is'} " +
+                   "duplicated: #{duplicated_ips.join(',')}")
+          exit 10
+        end
         session_from_list(list)
       end
 

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -123,6 +123,11 @@ class Chef
         :boolean => true,
         :proc => Proc.new { :raise }
 
+      option :skip_on_duplicated_fqdns,
+        :long => "--skip-on-duplicated-fqdns",
+        :description => "Skip exits even if FQDNs are duplicated",
+        :boolean => true
+
       option :tmux_split,
         :long => "--tmux-split",
         :description => "Split tmux window.",
@@ -177,11 +182,14 @@ class Chef
           end
           exit 10
         end
-        fqdns = list.map { |v| v[0] }
-        if fqdns.count != fqdns.uniq.count
-          duplicated_fqdns = fqdns.uniq
-          ui.warn("SSH #{duplicated_fqdns.count > 1 ? 'nodes are' : 'node is'} " +
-                  "duplicated: #{duplicated_fqdns.join(',')}")
+        unless config[:skip_on_duplicated_fqdns]
+          fqdns = list.map { |v| v[0] }
+          if fqdns.count != fqdns.uniq.count
+            duplicated_fqdns = fqdns.uniq
+            ui.warn("SSH #{duplicated_fqdns.count > 1 ? 'nodes are' : 'node is'} " +
+                    "duplicated: #{duplicated_fqdns.join(',')}")
+            exit 10
+          end
         end
         session_from_list(list)
       end

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -140,12 +140,14 @@ describe Chef::Knife::Ssh do
 
       context "when there are some hosts found but IPs duplicated" do
         before do
+          @knife.config[:skip_on_duplicated_fqdns] = false
           @node_foo["fqdn"] = "foo.example.org"
           @node_bar["fqdn"] = "foo.example.org"
         end
 
-        it "should be warned" do
+        it "should raise a specific error" do
           expect(@knife.ui).to receive(:warn).with(/^SSH node is duplicated: foo\.example\.org/)
+          expect(@knife).to receive(:exit).with(10)
           expect(@knife).to receive(:session_from_list).with([
             ["foo.example.org", nil, nil],
             ["foo.example.org", nil, nil],

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -144,9 +144,8 @@ describe Chef::Knife::Ssh do
           @node_bar["fqdn"] = "foo.example.org"
         end
 
-        it "should raise a specific error" do
-          expect(@knife.ui).to receive(:fatal).with(/^SSH node is duplicated: foo\.example\.org/)
-          expect(@knife).to receive(:exit).with(10)
+        it "should be warned" do
+          expect(@knife.ui).to receive(:warn).with(/^SSH node is duplicated: foo\.example\.org/)
           expect(@knife).to receive(:session_from_list).with([
             ["foo.example.org", nil, nil],
             ["foo.example.org", nil, nil],

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -137,6 +137,23 @@ describe Chef::Knife::Ssh do
           @knife.configure_session
         end
       end
+
+      context "when there are some hosts found but IPs duplicated" do
+        before do
+          @node_foo["fqdn"] = "foo.example.org"
+          @node_bar["fqdn"] = "foo.example.org"
+        end
+
+        it "should raise a specific error" do
+          expect(@knife.ui).to receive(:fatal).with(/^SSH node is duplicated: foo\.example\.org/)
+          expect(@knife).to receive(:exit).with(10)
+          expect(@knife).to receive(:session_from_list).with([
+            ["foo.example.org", nil, nil],
+            ["foo.example.org", nil, nil],
+          ])
+          @knife.configure_session
+        end
+      end
     end
 
     context "manual is set to true" do

--- a/spec/unit/knife/ssh_spec.rb
+++ b/spec/unit/knife/ssh_spec.rb
@@ -138,15 +138,15 @@ describe Chef::Knife::Ssh do
         end
       end
 
-      context "when there are some hosts found but IPs duplicated" do
+      context "when there are some hosts found but IPs duplicated if duplicated_fqdns option sets :fatal" do
         before do
-          @knife.config[:skip_on_duplicated_fqdns] = false
+          @knife.config[:duplicated_fqdns] = :fatal
           @node_foo["fqdn"] = "foo.example.org"
           @node_bar["fqdn"] = "foo.example.org"
         end
 
         it "should raise a specific error" do
-          expect(@knife.ui).to receive(:warn).with(/^SSH node is duplicated: foo\.example\.org/)
+          expect(@knife.ui).to receive(:fatal).with(/^SSH node is duplicated: foo\.example\.org/)
           expect(@knife).to receive(:exit).with(10)
           expect(@knife).to receive(:session_from_list).with([
             ["foo.example.org", nil, nil],


### PR DESCRIPTION
### Description

If fqdn is duplicated, it raises fatal error. Because it sometimes does not notice that it is duplicated.

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
