### PR TITLE
Update /etc/fstab on FreeBSD #4959

### DIFF
--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -158,7 +158,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/fstab", "a") do |fstab|
-            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? "defaults" : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? "rw" : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
             Chef::Log.debug("#{@new_resource} is enabled at #{@new_resource.mount_point}")
           end
         end

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -146,13 +146,9 @@ class Chef
           end
         end
 
-        # Return appropriate default mount options according to the input os.
-        def default_mount_options(os)
-          if os == "freebsd"
-            "rw"
-          else
-            "defaults"
-          end
+        # Return appropriate default mount options according to the given os.
+        def default_mount_options
+          node[:os] == "linux" ? "defaults" : "rw"
         end
 
         def enable_fs
@@ -167,7 +163,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/fstab", "a") do |fstab|
-            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options(node[:os]) : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
             Chef::Log.debug("#{@new_resource} is enabled at #{@new_resource.mount_point}")
           end
         end

--- a/lib/chef/provider/mount/mount.rb
+++ b/lib/chef/provider/mount/mount.rb
@@ -146,6 +146,15 @@ class Chef
           end
         end
 
+        # Return appropriate default mount options according to the input os.
+        def default_mount_options(os)
+          if os == "freebsd"
+            "rw"
+          else
+            "defaults"
+          end
+        end
+
         def enable_fs
           if @current_resource.enabled && mount_options_unchanged?
             Chef::Log.debug("#{@new_resource} is already enabled - nothing to do")
@@ -158,7 +167,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/fstab", "a") do |fstab|
-            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? "rw" : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
+            fstab.puts("#{device_fstab} #{@new_resource.mount_point} #{@new_resource.fstype} #{@new_resource.options.nil? ? default_mount_options(node[:os]) : @new_resource.options.join(",")} #{@new_resource.dump} #{@new_resource.pass}")
             Chef::Log.debug("#{@new_resource} is enabled at #{@new_resource.mount_point}")
           end
         end

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -375,12 +375,24 @@ describe Chef::Provider::Mount::Mount do
     end
 
     describe "default_mount_options" do
-      it "should return the correct default mount options for FreeBSD" do
-        expect(@provider.default_mount_options("freebsd")).to eq("rw")
+      it "should return the correct default mount options for Linux" do
+        @provider.node.override[:os] = "linux"
+        expect(@provider.default_mount_options).to eq("defaults")
       end
 
-      it "should return the correct default mount options for Linux" do
-        expect(@provider.default_mount_options("linux")).to eq("defaults")
+      it "should return the correct default mount options for AIX" do
+        @provider.node.override[:os] = "aix"
+        expect(@provider.default_mount_options).to eq("rw")
+      end
+
+      it "should return the correct default mount options for Darwin" do
+        @provider.node.override[:os] = "darwin"
+        expect(@provider.default_mount_options).to eq("rw")
+      end
+
+      it "should return the correct default mount options for FreeBSD" do
+        @provider.node.override[:os] = "freebsd"
+        expect(@provider.default_mount_options).to eq("rw")
       end
     end
 

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -374,6 +374,16 @@ describe Chef::Provider::Mount::Mount do
       end
     end
 
+    describe "default_mount_options" do
+      it "should return the correct default mount options for FreeBSD" do
+        expect(@provider.default_mount_options("freebsd")).to eq("rw")
+      end
+
+      it "should return the correct default mount options for Linux" do
+        expect(@provider.default_mount_options("linux")).to eq("defaults")
+      end
+    end
+
     describe "when enabling the fs" do
       it "should enable if enabled isn't true" do
         @current_resource.enabled(false)


### PR DESCRIPTION
### Description

/etc/fstab contains: /source /destination nullfs defaults 0 0

This does not mount after reboot. It should be:
/source /destination nullfs rw 0 0

So "defaults" does not work on FreeBSD and must be replaced.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

No preexisting issue(s).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>