### PR TITLE
fix node assignment of ImmutableArrays to VividMashes/AttrArrays (Chef-13 backport)

### DIFF
--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -92,6 +92,7 @@ class Chef
       private
 
       def convert_value(value)
+        value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
           value
@@ -189,6 +190,7 @@ class Chef
       # AttrArray for consistency and to ensure that the added parts of the
       # attribute tree will have the correct cache invalidation behavior.
       def convert_value(value)
+        value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
           value

--- a/lib/chef/node/mixin/state_tracking.rb
+++ b/lib/chef/node/mixin/state_tracking.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1304,4 +1304,19 @@ describe Chef::Node::Attribute do
       expect { @attributes["foo"]["bar"][0] << "buzz" }.to raise_error(RuntimeError, "can't modify frozen String")
     end
   end
+
+  describe "assigning lazy ungenerated caches to other attributes" do
+    it "works with arrays" do
+      @attributes.default["foo"]["baz"] = %w{one two}
+      @attributes.default["bar"]["baz"] = @attributes["foo"]["baz"]
+      expect(@attributes.default["bar"]["baz"]).to eql(%w{one two})
+    end
+
+    it "works with hashes" do
+      @attributes.default["foo"]["baz"] = { "one" => "two" }
+      @attributes.default["bar"]["baz"] = @attributes["foo"]["baz"]
+      expect(@attributes.default["bar"]["baz"]).to eql({ "one" => "two" })
+    end
+  end
+
 end


### PR DESCRIPTION
node.default['foo'] = node['bar'] need to have node['bar'] have its
cache vivified otherwise we potentially get an empty hash or array.

in the case of hashes, the assignment must have been walking though
the values with #each or something which poked the cache on the target
hash which caused it to vivify, so this bug only affected Arrays
where the AttrArray initializer likely did a quick-n-dirty copy of
the internal structure of the ImmutableArray which was empty.
