### PR TITLE
Fix "knife ssh" authentication scheme #4342

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -560,6 +560,11 @@ class Chef
           config[:ssh_password] = get_stripped_unfrozen_value(ssh_password ||
                              Chef::Config[:knife][:ssh_password])
         end
+
+        # CHEF-4342 Diable host key verification if a password has been given.
+        if config[:ssh_password]
+          config[:host_key_verify] = false
+        end
       end
 
       def configure_ssh_identity_file

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -560,11 +560,6 @@ class Chef
           config[:ssh_password] = get_stripped_unfrozen_value(ssh_password ||
                              Chef::Config[:knife][:ssh_password])
         end
-
-        # CHEF-4342 Diable host key verification if a password has been given.
-        if config[:ssh_password]
-          config[:host_key_verify] = false
-        end
       end
 
       def configure_ssh_identity_file
@@ -581,8 +576,13 @@ class Chef
         configure_user
         configure_password
         @password = config[:ssh_password] if config[:ssh_password]
-        configure_ssh_identity_file
-        configure_ssh_gateway_identity
+
+        # If a password was not given, check for SSH identity file.
+        if !@password
+          configure_ssh_identity_file
+          configure_ssh_gateway_identity
+        end
+
         configure_gateway
         configure_session
 


### PR DESCRIPTION
### Description

Affects at least knife 12.5.1

When a user uses knife ssh in "password, not key" mode, it fails.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

closes #4342 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
