### PR TITLE
Remove epic_fail alias to ignore_failure

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -536,11 +536,6 @@ class Chef
     property :ignore_failure, [ TrueClass, FalseClass ], default: false, desired_state: false
 
     #
-    # Equivalent to #ignore_failure.
-    #
-    alias :epic_fail :ignore_failure
-
-    #
     # Make this resource into an exact (shallow) copy of the other resource.
     #
     # @param resource [Chef::Resource] The resource to copy from.


### PR DESCRIPTION
We deprecated this in 13.7 and we have a Foodcritic rule to identify it.
There's only 1 person using it on the entire Supermarket since we
haven't documented it since Chef docs were on the wiki.

Signed-off-by: Tim Smith <tsmith@chef.io>