### PR TITLE
Enforce chef_type validation #5086

### DIFF
--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -43,6 +43,7 @@ class Chef
       @private_key = nil
       @admin = false
       @validator = false
+      @chef_type = "client"
     end
 
     # Gets or sets the client name.
@@ -67,6 +68,11 @@ class Chef
         arg,
         :kind_of => [ TrueClass, FalseClass ]
       )
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     # Gets or sets the public key.

--- a/lib/chef/api_client_v1.rb
+++ b/lib/chef/api_client_v1.rb
@@ -54,6 +54,7 @@ class Chef
       @admin = false
       @validator = false
       @create_key = nil
+      @chef_type = "client"
     end
 
     def chef_rest_v0
@@ -90,6 +91,11 @@ class Chef
         arg,
         :kind_of => [ TrueClass, FalseClass ]
       )
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     # Gets or sets the public key.

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -48,6 +48,7 @@ class Chef
     def initialize(chef_server_rest: nil)
       @name = ""
       @chef_server_rest = chef_server_rest
+      @chef_type = "data_bag"
     end
 
     def name(arg = nil)
@@ -56,6 +57,11 @@ class Chef
         arg,
         :regex => VALID_NAME
       )
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     def to_hash

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -43,6 +43,7 @@ class Chef
       @override_attributes = Mash.new
       @cookbook_versions = Hash.new
       @chef_server_rest = chef_server_rest
+      @chef_type = "environment"
     end
 
     def chef_server_rest
@@ -67,6 +68,11 @@ class Chef
         arg,
         :kind_of => String
       )
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     def default_attributes(arg = nil)

--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -89,6 +89,12 @@ class Chef
           when /\.(js|json)$/
             r = FFI_Yajl::Parser.parse(IO.read(filename))
 
+            # Ensure JSON file is the correct chef type.
+            if @klass.chef_type != r["chef_type"]
+              ui.error("#{filename} is not a #{@klass.chef_type} type.")
+              exit(1)
+            end
+
             # Chef::DataBagItem doesn't work well with the json_create method
             if @klass == Chef::DataBagItem
               r
@@ -98,6 +104,13 @@ class Chef
           when /\.rb$/
             r = klass.new
             r.from_file(filename)
+
+            # Ensure Ruby file is the correct chef type.
+            if @klass.chef_type != r.chef_type
+              ui.error("#{filename} is not a #{@klass.chef_type} type.")
+              exit(1)
+            end
+
             r
           else
             ui.fatal("File must end in .js, .json, or .rb")

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -80,6 +80,8 @@ class Chef
       @attributes = Chef::Node::Attribute.new({}, {}, {}, {}, self)
 
       @run_state = {}
+
+      @chef_type = "node"
     end
 
     # after the run_context has been set on the node, go through the cookbook_collection
@@ -197,6 +199,11 @@ class Chef
     # might be missing
     def normal
       attributes.normal
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     # Set a default of this node, but auto-vivify any Mashes that might

--- a/lib/chef/role.rb
+++ b/lib/chef/role.rb
@@ -41,6 +41,7 @@ class Chef
       @override_attributes = Mash.new
       @env_run_lists = { "_default" => Chef::RunList.new }
       @chef_server_rest = chef_server_rest
+      @chef_type = "role"
     end
 
     def chef_server_rest
@@ -128,6 +129,11 @@ class Chef
         arg,
         :kind_of => Hash
       )
+    end
+
+    # Get the chef type.
+    def chef_type
+      @chef_type
     end
 
     def to_hash

--- a/spec/unit/api_client_spec.rb
+++ b/spec/unit/api_client_spec.rb
@@ -271,6 +271,12 @@ describe Chef::ApiClient do
 
   end
 
+  describe "chef_type" do
+    it "should return the current chef type" do
+      expect(@client.chef_type).to eq("client")
+    end
+  end
+
   describe "when requesting a new key" do
     before do
       @http_client = double("Chef::ServerAPI mock")

--- a/spec/unit/api_client_v1_spec.rb
+++ b/spec/unit/api_client_v1_spec.rb
@@ -323,6 +323,12 @@ describe Chef::ApiClientV1 do
     end
   end
 
+  describe "chef_type" do
+    it "should return the correct chef type" do
+      expect(@client.chef_type).to eq("client")
+    end
+  end
+
   describe "Versioned API Interactions" do
     let(:response_406) { OpenStruct.new(:code => "406") }
     let(:exception_406) { Net::HTTPServerException.new("406 Not Acceptable", response_406) }

--- a/spec/unit/data_bag_spec.rb
+++ b/spec/unit/data_bag_spec.rb
@@ -56,6 +56,12 @@ describe Chef::DataBag do
     end
   end
 
+  describe "chef_type" do
+    it "should return the correct chef type" do
+      expect(@data_bag.chef_type).to eq("data_bag")
+    end
+  end
+
   describe "deserialize" do
     before(:each) do
       @data_bag.name("mars_volta")

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -71,6 +71,12 @@ describe Chef::Environment do
     end
   end
 
+  describe "chef_type" do
+    it "should return the correct chef type" do
+      expect(@environment.chef_type).to eq("environment")
+    end
+  end
+
   describe "default attributes" do
     it "should let you set the attributes hash explicitly" do
       expect(@environment.default_attributes({ :one => "two" })).to eq({ :one => "two" })

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -135,6 +135,12 @@ describe Chef::Node do
     end
   end
 
+  describe "chef_type" do
+    it "should return the correct chef type" do
+      expect(node.chef_type).to eq("node")
+    end
+  end
+
   describe "policy_name" do
 
     it "defaults to nil" do

--- a/spec/unit/role_spec.rb
+++ b/spec/unit/role_spec.rb
@@ -132,6 +132,12 @@ describe Chef::Role do
     end
   end
 
+  describe "chef_type" do
+    it "should return the correct chef type" do
+      expect(@role.chef_type).to eq("role")
+    end
+  end
+
   describe "update_from!" do
     before(:each) do
       @role.name("mars_volta")


### PR DESCRIPTION
### Description

With `knife environment from file` or `knife role from file`, the
chef_type specification is not enforced. A user can easily upload an
environments JSON as a role by doing this: knife role from file
Dev.json, when Dev.json is really an environments file.

Signed-off-by: Chibuikem Amaechi <cramaechi@me.com>

### Issues Resolved

No preexisting issue(s).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
