### PR TITLE
Add MSIFASTINSTALL property, supported by Windows Installer 5.0

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -9,9 +9,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: fd1451bca299d0d71aa2c58d63fee5120572f739
+  revision: 9f281bfb7fb44aa5d152b38e73ce04805fdb8958
   specs:
-    omnibus (5.6.3)
+    omnibus (5.6.4)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
@@ -26,7 +26,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 45fbdeb158cc16984a65104681d842b3d026e111
+  revision: 4f03b681b46e9d7300dd6764d8b68b1f6b8a16b8
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -38,13 +38,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.124)
-      aws-sdk-resources (= 2.10.124)
-    aws-sdk-core (2.10.124)
+    aws-sdk (2.10.125)
+      aws-sdk-resources (= 2.10.125)
+    aws-sdk-core (2.10.125)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.124)
-      aws-sdk-core (= 2.10.124)
+    aws-sdk-resources (2.10.125)
+      aws-sdk-core (= 2.10.125)
     aws-sigv4 (1.0.2)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)

--- a/omnibus/resources/chef/msi/source.wxs.erb
+++ b/omnibus/resources/chef/msi/source.wxs.erb
@@ -28,6 +28,13 @@
 
     <Media Id="1" Cabinet="ChefClient.cab" EmbedCab="yes" CompressionLevel="high" />
 
+    <!--
+    Take advantage of Windows Installer 5.0 feature (if available) to disable 
+    checkpointing and other costings that take significant amounts of time 
+    ref: https://msdn.microsoft.com/en-us/library/windows/desktop/dd408005(v=vs.85).aspx
+    -->
+    <Property Id="MSIFASTINSTALL" Value="7" />
+
     <Property Id="CHEF_SERVICE_OPTIONS_RADIO_BUTTON_GROUP" Value="None" />
 
     <!--


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This change adds an MSIFASTINSTALL property to the Windows Installer set with a value that skips most of the costings, when used on a system that supports Windows Installer 5.0 (i.e. Windows 2008 R2 upwards) [ref](https://msdn.microsoft.com/en-us/library/windows/desktop/aa372856(v=vs.85).aspx).  It should result in a slight speed improvement on install/upgrade.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
