### PR TITLE
Fix windows_task idle_time validation

### DIFF
--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -82,7 +82,7 @@ class Chef
         validate_create_frequency_modifier(frequency, frequency_modifier)
         validate_create_day(day, frequency) if day
         validate_create_months(months, frequency) if months
-        validate_idle_time(idle_time, frequency) if ( !idle_time.nil? && ([:minute, :hourly, :daily, :weekly, :monthly].include? frequency)) || (idle_time.nil? || !(idle_time > 0 && idle_time <= 999)) && !([:minute, :hourly, :daily, :weekly, :monthly].include? frequency)
+        validate_idle_time(idle_time, frequency)
       end
 
       private
@@ -196,13 +196,13 @@ class Chef
       end
 
       def validate_idle_time(idle_time, frequency)
-        unless [:on_idle].include?(frequency)
+        if !idle_time.nil? && frequency != :on_idle
           raise ArgumentError, "idle_time property is only valid for tasks that run on_idle"
         end
-        if idle_time.nil?
+        if idle_time.nil? && frequency == :on_idle
           raise ArgumentError, "idle_time value should be set for :on_idle frequency."
         end
-        unless idle_time > 0 && idle_time <= 999
+        unless idle_time.nil? || idle_time > 0 && idle_time <= 999
           raise ArgumentError, "idle_time value #{idle_time} is invalid. Valid values for :on_idle frequency are 1 - 999."
         end
       end

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -271,7 +271,9 @@ describe Chef::Resource::WindowsTask do
 
   context "#validate_idle_time" do
     it "raises error if frequency is not :on_idle" do
-      expect  { resource.send(:validate_idle_time, 5, :hourly) }.to raise_error(ArgumentError, "idle_time property is only valid for tasks that run on_idle")
+      [:minute, :hourly, :daily, :weekly, :monthly, :once, :on_logon, :onstart, :none].each do |frequency|
+        expect  { resource.send(:validate_idle_time, 5, frequency) }.to raise_error(ArgumentError, "idle_time property is only valid for tasks that run on_idle")
+      end
     end
 
     it "raises error if idle_time > 999" do
@@ -284,6 +286,12 @@ describe Chef::Resource::WindowsTask do
 
     it "raises error if idle_time is not set" do
       expect  { resource.send(:validate_idle_time, nil, :on_idle) }.to raise_error(ArgumentError, "idle_time value should be set for :on_idle frequency.")
+    end
+
+    it "does not raises error if idle_time is not set for other frequencies" do
+      [:minute, :hourly, :daily, :weekly, :monthly, :once, :on_logon, :onstart, :none].each do |frequency|
+        expect  { resource.send(:validate_idle_time, nil, frequency) }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
### Description

Two improvements on the idle_time validation function for the windows_task resource:
- Compare frequency to :idle_time instead of comparing to an incomplete list of other frequencies.
- Keep all the validation logic in the function instead of splitting it between the function and where the function is called.

### Issues Resolved

I din't create an issue since it seemed like an easy fix, but the previous PR [#6714](https://github.com/chef/chef/pull/6714) on the matter had some of my windows_task resources fail when using the :onstart frequency.

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
