### PR TITLE
Backport the powershell spec fix to get Appveyor green again

### DIFF
--- a/spec/functional/mixin/powershell_out_spec.rb
+++ b/spec/functional/mixin/powershell_out_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,16 +22,8 @@ describe Chef::Mixin::PowershellOut, windows_only: true do
   include Chef::Mixin::PowershellOut
 
   describe "#powershell_out" do
-    context "for windows version less than 10", windows_lt_10: true do
-      it "runs a powershell command and collects stdout" do
-        expect(powershell_out("get-process").run_command.stdout).to match /Handles\s+NPM\(K\)\s+PM\(K\)\s+WS\(K\)\s+VM\(M\)\s+CPU\(s\)\s+Id\s+/
-      end
-    end
-
-    context "for windows version greater than 10", windows_gte_10: true do
-      it "runs a powershell command and collects stdout" do
-        expect(powershell_out("get-process").run_command.stdout).to match /Handles\s+NPM\(K\)\s+PM\(K\)\s+WS\(K\)\s+CPU\(s\)\s+Id\s+SI\s+ProcessName\s+/
-      end
+    it "runs a powershell command and collects stdout" do
+      expect(powershell_out("get-process").run_command.stdout).to match /Handles/
     end
 
     it "does not raise exceptions when the command is invalid" do
@@ -40,16 +32,8 @@ describe Chef::Mixin::PowershellOut, windows_only: true do
   end
 
   describe "#powershell_out!" do
-    context "for windows version less than 10", windows_lt_10: true do
-      it "runs a powershell command and collects stdout" do
-        expect(powershell_out!("get-process").run_command.stdout).to match /Handles\s+NPM\(K\)\s+PM\(K\)\s+WS\(K\)\s+VM\(M\)\s+CPU\(s\)\s+Id\s+/
-      end
-    end
-
-    context "for windows version less than 10", windows_gte_10: true do
-      it "runs a powershell command and collects stdout" do
-        expect(powershell_out("get-process").run_command.stdout).to match /Handles\s+NPM\(K\)\s+PM\(K\)\s+WS\(K\)\s+CPU\(s\)\s+Id\s+SI\s+ProcessName\s+/
-      end
+    it "runs a powershell command and collects stdout" do
+      expect(powershell_out!("get-process").run_command.stdout).to match /Handles/
     end
 
     it "raises exceptions when the command is invalid" do


### PR DESCRIPTION
we don't need to test the exact output of this powershell command, just
get literally anything that looks like it ran successfully.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>