### PR TITLE
Remove testing of Debian 7 as it's going EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,23 +190,6 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test base-debian-7
-    after_failure:
-      - cat .kitchen/logs/kitchen.log
-    env:
-      - DEBIAN=7
-      - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
-    services: docker
-    sudo: required
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
-    before_script:
-      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      - cd kitchen-tests
-    script:
       - bundle exec kitchen test base-debian-8
     after_failure:
       - cat .kitchen/logs/kitchen.log

--- a/acceptance/.shared/kitchen_acceptance/.kitchen.ec2.yml
+++ b/acceptance/.shared/kitchen_acceptance/.kitchen.ec2.yml
@@ -64,17 +64,6 @@ platforms:
         image-type: machine
     transport:
       username: admin
-  - name: debian-7
-    driver:
-      image_search:
-        name: debian-wheezy-*
-        owner-id: "379101102735"
-        architecture: x86_64
-        virtualization-type: hvm
-        block-device-mapping.volume-type: standard
-        image-type: machine
-    transport:
-      username: admin
   #
   # Ubuntu
   #

--- a/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
+++ b/acceptance/.shared/kitchen_acceptance/.kitchen.vagrant.yml
@@ -25,8 +25,6 @@ verifier:
 platforms:
 <% %w(
 debian-8
-debian-7
-debian-6
 ubuntu-15.10
 ubuntu-14.04
 el-7

--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -37,15 +37,6 @@ platforms:
       - RUN yum -y install sudo
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: debian-7
-  driver:
-    image: dokken/debian-7
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
-      - RUN /bin/mkdir /var/run/sshd
-
 - name: debian-8
   driver:
     image: dokken/debian-8

--- a/kitchen-tests/.kitchen.yml
+++ b/kitchen-tests/.kitchen.yml
@@ -26,7 +26,6 @@ platforms:
       box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
-  - name: debian-7
   - name: debian-8
   - name: debian-9
   - name: opensuse-leap-42

--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -47,9 +47,6 @@ include_recipe "chef-client"
 include_recipe "chef-apt-docker"
 include_recipe "chef-yum-docker"
 
-# hack needed for debian-7 on docker
-directory "/var/run/sshd"
-
 include_recipe "openssh"
 
 include_recipe "nscd"

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -39,10 +39,6 @@ platforms:
     run_list: yum-epel::default
   - name: centos-7.2
     run_list: yum-epel::default
-  - name: debian-6.0.8
-    run_list: apt::default
-  - name: debian-7.9
-    run_list: apt::default
   - name: debian-8.2
     run_list: apt::default
   - name: freebsd-9.3


### PR DESCRIPTION
Debian 7 goes EOL 31st May 2018. We should merge this around that time.

Signed-off-by: Tim Smith <tsmith@chef.io>