### PR TITLE
No longer test against 32-bit Ruby on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ cache:
 environment:
   matrix:
     - ruby_version: "24-x64"
-    - ruby_version: "24"
 
 clone_folder: c:\projects\chef
 clone_depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: "master-{build}"
 
-os: Visual Studio 2015
+os: Visual Studio 2017
 platform:
   - x64
 


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This PR removes 32-bit testing on Windows, now that we no longer support any 32-bit operating systems on Windows.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
