### PR TITLE
add additional systemd_unit actions

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nathan Williams (<nath.e.will@gmail.com>)
-# Copyright:: Copyright 2016, Nathan Williams
+# Copyright:: Copyright 2016-2018, Nathan Williams
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,6 +74,18 @@ class Chef
         end
       end
 
+      def action_preset
+        converge_by("restoring enable/disable preset configuration for unit: #{new_resource.unit_name}") do
+          systemctl_execute!(:preset, new_resource.unit_name)
+        end
+      end
+
+      def action_revert
+        converge_by("reverting to vendor version of unit: #{new_resource.unit_name}") do
+          systemctl_execute!(:revert, new_resource.unit_name)
+        end
+      end
+
       def action_enable
         if current_resource.static
           Chef::Log.debug("#{new_resource.unit_name} is a static unit, enabling is a NOP.")
@@ -95,6 +107,12 @@ class Chef
           converge_by("disabling unit: #{new_resource.unit_name}") do
             systemctl_execute!(:disable, new_resource.unit_name)
           end
+        end
+      end
+
+      def action_reenable
+        converge_by("reenabling unit: #{new_resource.unit_name}") do
+          systemctl_execute!(:reenable, new_resource.unit_name)
         end
       end
 

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nathan Williams (<nath.e.will@gmail.com>)
-# Copyright:: Copyright 2016, Nathan Williams
+# Copyright:: Copyright 2016-2018, Nathan Williams
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,8 @@ class Chef
 
       default_action :nothing
       allowed_actions :create, :delete,
-                      :enable, :disable,
+                      :preset, :revert,
+                      :enable, :disable, :reenable,
                       :mask, :unmask,
                       :start, :stop,
                       :restart, :reload,

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nathan Williams (<nath.e.will@gmail.com>)
-# Copyright:: Copyright 2016, Nathan Williams
+# Copyright:: Copyright 2016-2018, Nathan Williams
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,8 +46,11 @@ describe Chef::Resource::SystemdUnit do
   it "supports appropriate unit actions" do
     expect { resource.action :create }.not_to raise_error
     expect { resource.action :delete }.not_to raise_error
+    expect { resource.action :preset }.not_to raise_error
+    expect { resource.action :revert }.not_to raise_error
     expect { resource.action :enable }.not_to raise_error
     expect { resource.action :disable }.not_to raise_error
+    expect { resource.action :reenable }.not_to raise_error
     expect { resource.action :mask }.not_to raise_error
     expect { resource.action :unmask }.not_to raise_error
     expect { resource.action :start }.not_to raise_error


### PR DESCRIPTION
### Description

MOAR ACTIONS FOR THE ACTION GOD

adds support for additional systemd_unit actions supported by systemctl:

- [preset](https://www.freedesktop.org/software/systemd/man/systemctl.html#preset%20NAME…): restore enable/disable status based on preset files
- [revert](https://www.freedesktop.org/software/systemd/man/systemctl.html#revert%20NAME…): remove any non-vendor overrides (drop-ins, same-name user-provided units, etc)
- [reenable](https://www.freedesktop.org/software/systemd/man/systemctl.html#reenable%20NAME…): disable then enable (alias regenerator)

### Issues Resolved

https://github.com/chef/chef/issues/6823

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>