### PR TITLE
Use the license_scout that comes with Omnibus gem

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software"
-gem "license_scout", git: "https://github.com/chef/license_scout"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,22 +1,13 @@
 GIT
-  remote: https://github.com/chef/license_scout
-  revision: d044136f0b464ed3894a172f06a50167106ec5d1
-  specs:
-    license_scout (0.1.3)
-      ffi-yajl (~> 2.2)
-      mixlib-shellout (~> 2.2)
-      toml-rb (~> 1.0)
-
-GIT
   remote: https://github.com/chef/omnibus
-  revision: 9f281bfb7fb44aa5d152b38e73ce04805fdb8958
+  revision: 68c301587d8856c6ec4445a24ec49365bb22a314
   specs:
-    omnibus (5.6.4)
+    omnibus (5.6.8)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
-      license_scout
+      license_scout (~> 1.0)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
       ohai (~> 8.0)
@@ -26,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 4f03b681b46e9d7300dd6764d8b68b1f6b8a16b8
+  revision: 4ef2d1a5b9162f4f5f52617d2a0122796b4f3c43
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -38,13 +29,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.125)
-      aws-sdk-resources (= 2.10.125)
-    aws-sdk-core (2.10.125)
+    aws-sdk (2.10.128)
+      aws-sdk-resources (= 2.10.128)
+    aws-sdk-core (2.10.128)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.125)
-      aws-sdk-core (= 2.10.125)
+    aws-sdk-resources (2.10.128)
+      aws-sdk-core (= 2.10.128)
     aws-sigv4 (1.0.2)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -79,7 +70,7 @@ GEM
     buff-shell_out (0.2.0)
       buff-ruby_engine (~> 0.1.0)
     builder (3.2.3)
-    byebug (9.1.0)
+    byebug (10.0.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     celluloid-io (0.16.2)
@@ -99,9 +90,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
-    ffi (1.9.18-x64-mingw32)
-    ffi (1.9.18-x86-mingw32)
+    ffi (1.9.21)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -111,7 +100,6 @@ GEM
       builder (>= 2.1.2)
     hashie (3.5.7)
     hitimes (1.2.6)
-    hitimes (1.2.6-x86-mingw32)
     httpclient (2.7.2)
     iostruct (0.0.4)
     ipaddress (0.8.3)
@@ -120,6 +108,10 @@ GEM
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
+    license_scout (1.0.0)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (~> 2.2)
+      toml-rb (~> 1.0)
     little-plugger (1.1.4)
     logging (2.2.2)
       little-plugger (~> 1.1)
@@ -137,9 +129,6 @@ GEM
       thor
     mixlib-log (1.7.1)
     mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
-      win32-process (~> 0.8.2)
-      wmi-lite (~> 1.0)
     mixlib-versioning (1.2.2)
     molinillo (0.4.5)
     multi_json (1.13.1)
@@ -176,8 +165,8 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.5.1)
-      byebug (~> 9.1)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
       pry (~> 0.10)
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
@@ -232,8 +221,6 @@ GEM
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)
-    win32-process (0.8.3)
-      ffi (>= 1.0.0)
     winrm (2.2.3)
       builder (>= 2.1.2)
       erubis (~> 2.7)
@@ -256,13 +243,10 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
-  x86-mingw32
 
 DEPENDENCIES
   berkshelf (~> 4.0)
   kitchen-vagrant (~> 0.19.0)
-  license_scout!
   omnibus!
   omnibus-software!
   pedump
@@ -273,4 +257,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.16.1
+   1.15.1


### PR DESCRIPTION
### Description

LicenseScout is being refactored. We have released a 1.x version that is pinned within the Omnibus gem.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
