### PR TITLE
add Chef::NodeMap#delete_class API (Chef 13 backport)

### DIFF
--- a/lib/chef/node_map.rb
+++ b/lib/chef/node_map.rb
@@ -118,6 +118,29 @@ class Chef
       end.map { |matcher| matcher[:klass] }
     end
 
+    # Remove a class from all its matchers in the node_map, will remove mappings completely if its the last matcher left
+    #
+    # @param klass [Class] the class to seek and destroy
+    #
+    # @return [Hash] deleted entries in the same format as the @map
+    def delete_class(klass)
+      raise "please use a Class type for the klass argument" unless klass.is_a?(Class)
+      deleted = {}
+      map.each do |key, matchers|
+        deleted_matchers = []
+        matchers.delete_if do |matcher|
+          # because matcher[:klass] may be a string (which needs to die), coerce both to strings to compare somewhat canonically
+          if matcher[:klass].to_s == klass.to_s
+            deleted_matchers << matcher
+            true
+          end
+        end
+        deleted[key] = deleted_matchers unless deleted_matchers.empty?
+        map.delete(key) if matchers.empty?
+      end
+      deleted
+    end
+
     # Seriously, don't use this, it's nearly certain to change on you
     # @return remaining
     # @api private

--- a/lib/chef/node_map.rb
+++ b/lib/chef/node_map.rb
@@ -120,6 +120,9 @@ class Chef
 
     # Remove a class from all its matchers in the node_map, will remove mappings completely if its the last matcher left
     #
+    # Note that this leaks the internal structure out a bit, but the main consumer of this (poise/halite) cares only about
+    # the keys in the returned Hash.
+    #
     # @param klass [Class] the class to seek and destroy
     #
     # @return [Hash] deleted entries in the same format as the @map

--- a/spec/unit/node_map_spec.rb
+++ b/spec/unit/node_map_spec.rb
@@ -139,14 +139,14 @@ describe Chef::NodeMap do
   describe "deleting classes" do
     it "deletes a class and removes the mapping completely" do
       node_map.set(:thing, Bar)
-      expect( node_map.delete_class(Bar) ).to eql({:thing=>[{:klass=>Bar}]})
+      expect( node_map.delete_class(Bar) ).to eql({ :thing => [{ :klass => Bar }] })
       expect( node_map.get(node, :thing) ).to eql(nil)
     end
 
     it "deletes a class and leaves the mapping that still has an entry" do
       node_map.set(:thing, Bar)
       node_map.set(:thing, Foo)
-      expect( node_map.delete_class(Bar) ).to eql({:thing=>[{:klass=>Bar}]})
+      expect( node_map.delete_class(Bar) ).to eql({ :thing => [{ :klass => Bar }] })
       expect( node_map.get(node, :thing) ).to eql(Foo)
     end
 
@@ -154,7 +154,7 @@ describe Chef::NodeMap do
       node_map.set(:thing1, Bar)
       node_map.set(:thing2, Bar)
       node_map.set(:thing2, Foo)
-      expect( node_map.delete_class(Bar) ).to eql({:thing1=>[{:klass=>Bar}], :thing2=>[{:klass=>Bar}]})
+      expect( node_map.delete_class(Bar) ).to eql({ :thing1 => [{ :klass => Bar }], :thing2 => [{ :klass => Bar }] })
       expect( node_map.get(node, :thing1) ).to eql(nil)
       expect( node_map.get(node, :thing2) ).to eql(Foo)
     end


### PR DESCRIPTION
Backport of #6846 will be useful to retire the somewhat janky code in halite sooner rather than later.
