### PR TITLE
Remove Attribute Lazy Caching, Add Per-Key Cache Flushing

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -179,6 +179,9 @@ class Chef
       policy_group(policy_group)
     end
 
+    # @api private
+    attr_writer :attributes
+
     def attributes
       @attributes ||= Chef::Node::Attribute.new({}, {}, {}, {}, self)
     end
@@ -509,13 +512,12 @@ class Chef
       node = new
       node.name(o["name"])
       node.chef_environment(o["chef_environment"])
+
       if o.has_key?("attributes")
         node.normal_attrs = o["attributes"]
       end
-      node.automatic_attrs = Mash.new(o["automatic"]) if o.has_key?("automatic")
-      node.normal_attrs = Mash.new(o["normal"]) if o.has_key?("normal")
-      node.default_attrs = Mash.new(o["default"]) if o.has_key?("default")
-      node.override_attrs = Mash.new(o["override"]) if o.has_key?("override")
+
+      node.attributes = Chef::Node::Attribute.new(o["normal"] || o["attributes"], o["default"], o["override"], o["automatic"], node)
 
       if o.has_key?("run_list")
         node.run_list.reset!(o["run_list"])

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -434,11 +434,13 @@ class Chef
                              Chef::Environment.load(chef_environment)
                            end
 
-      attributes.env_default = loaded_environment.default_attributes
-      attributes.env_override = loaded_environment.override_attributes
+      attributes.defer_cache_resetting do
+        attributes.env_default = loaded_environment.default_attributes
+        attributes.env_override = loaded_environment.override_attributes
 
-      attribute.role_default = expansion.default_attrs
-      attributes.role_override = expansion.override_attrs
+        attribute.role_default = expansion.default_attrs
+        attributes.role_override = expansion.override_attrs
+      end
     end
 
     # Transform the node to a Hash

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -77,8 +77,6 @@ class Chef
       @policy_name = nil
       @policy_group = nil
 
-      @attributes = Chef::Node::Attribute.new({}, {}, {}, {}, self)
-
       @run_state = {}
     end
 
@@ -182,7 +180,7 @@ class Chef
     end
 
     def attributes
-      @attributes
+      @attributes ||= Chef::Node::Attribute.new({}, {}, {}, {}, self)
     end
 
     alias :attribute :attributes

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -237,10 +237,21 @@ class Chef
         end
       end
 
+      # @api private
       def reset
         @deep_merge_cache = nil
       end
 
+      # avoid doing cache clearing work for an entire block of code, then nuke the entire cache
+      # @api private
+      def defer_cache_resetting
+        @disable_cache_reset = true
+        yield
+        @disable_cache_reset = false
+        reset
+      end
+
+      # @api private
       def reset_cache(*path)
         return if @disable_cache_reset
         if path.empty?
@@ -637,15 +648,6 @@ class Chef
             merge_with
           end
         end
-      end
-
-      # avoid doing cache clearing work for an entire block of code, then nuke the entire cache
-      # @api private
-      def defer_cache_resetting
-        @disable_cache_reset = true
-        yield
-        @disable_cache_reset = false
-        reset
       end
 
     end

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -229,13 +229,10 @@ class Chef
       end
 
       def reset
-        puts "TOTAL RESET"
-        #puts caller
         @deep_merge_cache = nil
       end
 
       def reset_cache(*path)
-        #puts "PATH: #{path}"
         if path.empty?
           reset
         else

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -185,9 +185,6 @@ class Chef
        # return the automatic level attribute component
       attr_reader :automatic
 
-      # return the immutablemash deep merge cache
-      attr_reader :deep_merge_cache
-
       def initialize(normal, default, override, automatic, node = nil)
         @default        = VividMash.new(default, self, node, :default)
         @env_default    = VividMash.new({}, self, node, :env_default)
@@ -203,8 +200,11 @@ class Chef
 
         @automatic      = VividMash.new(automatic, self, node, :automatic)
 
-        @deep_merge_cache = ImmutableMash.new({}, self, node, :merged)
         @__node__ = node
+      end
+
+      def deep_merge_cache
+        @deep_merge_cache ||= ImmutableMash.new({}, self, __node__, :merged)
       end
 
        # Debug what's going on with an attribute. +args+ is a path spec to the
@@ -229,7 +229,7 @@ class Chef
       end
 
       def reset
-        @deep_merge_cache = ImmutableMash.new({}, self, @__node__, :merged)
+        @deep_merge_cache = nil
       end
 
       def reset_cache(*path)
@@ -493,11 +493,11 @@ class Chef
       end
 
       def [](key)
-        @deep_merge_cache[key]
+        deep_merge_cache[key]
       end
 
       def merged_attributes
-        @deep_merge_cache
+        deep_merge_cache
       end
 
       def inspect

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -229,7 +229,8 @@ class Chef
       end
 
       def reset
-        #puts "TOTAL RESET"
+        puts "TOTAL RESET"
+        #puts caller
         @deep_merge_cache = nil
       end
 

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -186,21 +186,30 @@ class Chef
       attr_reader :automatic
 
       def initialize(normal, default, override, automatic, node = nil)
-        @default        = VividMash.new(default, self, node, :default)
-        @env_default    = VividMash.new({}, self, node, :env_default)
-        @role_default   = VividMash.new({}, self, node, :role_default)
-        @force_default  = VividMash.new({}, self, node, :force_default)
-
-        @normal         = VividMash.new(normal, self, node, :normal)
-
-        @override       = VividMash.new(override, self, node, :override)
-        @role_override  = VividMash.new({}, self, node, :role_override)
-        @env_override   = VividMash.new({}, self, node, :env_override)
-        @force_override = VividMash.new({}, self, node, :force_override)
-
-        @automatic      = VividMash.new(automatic, self, node, :automatic)
-
+        # Chef::Node and Chef::Node::Attribute are very tightly coupled
         @__node__ = node
+        node.attributes = self
+
+        defer_cache_resetting do
+          @default        = VividMash.new({}, self, node, :default)
+          @env_default    = VividMash.new({}, self, node, :env_default)
+          @role_default   = VividMash.new({}, self, node, :role_default)
+          @force_default  = VividMash.new({}, self, node, :force_default)
+
+          @normal         = VividMash.new({}, self, node, :normal)
+
+          @override       = VividMash.new({}, self, node, :override)
+          @role_override  = VividMash.new({}, self, node, :role_override)
+          @env_override   = VividMash.new({}, self, node, :env_override)
+          @force_override = VividMash.new({}, self, node, :force_override)
+
+          @automatic      = VividMash.new({}, self, node, :automatic)
+
+          @default        = VividMash.new(default, self, node, :default)
+          @normal         = VividMash.new(normal, self, node, :normal)
+          @override       = VividMash.new(override, self, node, :override)
+          @automatic      = VividMash.new(automatic, self, node, :automatic)
+        end
       end
 
       def deep_merge_cache
@@ -233,6 +242,7 @@ class Chef
       end
 
       def reset_cache(*path)
+        return if @disable_cache_reset
         if path.empty?
           reset
         else
@@ -249,60 +259,70 @@ class Chef
 
        # Set the cookbook level default attribute component to +new_data+.
       def default=(new_data)
-        reset
-        @default = VividMash.new(new_data, self, __node__, :default)
+        defer_cache_resetting do
+          @default = VividMash.new(new_data, self, __node__, :default)
+        end
       end
 
        # Set the role level default attribute component to +new_data+
       def role_default=(new_data)
-        reset
-        @role_default = VividMash.new(new_data, self, __node__, :role_default)
+        defer_cache_resetting do
+          @role_default = VividMash.new(new_data, self, __node__, :role_default)
+        end
       end
 
        # Set the environment level default attribute component to +new_data+
       def env_default=(new_data)
-        reset
-        @env_default = VividMash.new(new_data, self, __node__, :env_default)
+        defer_cache_resetting do
+          @env_default = VividMash.new(new_data, self, __node__, :env_default)
+        end
       end
 
        # Set the force_default (+default!+) level attributes to +new_data+
       def force_default=(new_data)
-        reset
-        @force_default = VividMash.new(new_data, self, __node__, :force_default)
+        defer_cache_resetting do
+          @force_default = VividMash.new(new_data, self, __node__, :force_default)
+        end
       end
 
        # Set the normal level attribute component to +new_data+
       def normal=(new_data)
-        reset
-        @normal = VividMash.new(new_data, self, __node__, :normal)
+        defer_cache_resetting do
+          @normal = VividMash.new(new_data, self, __node__, :normal)
+        end
       end
 
        # Set the cookbook level override attribute component to +new_data+
       def override=(new_data)
-        reset
-        @override = VividMash.new(new_data, self, __node__, :override)
+        defer_cache_resetting do
+          @override = VividMash.new(new_data, self, __node__, :override)
+        end
       end
 
        # Set the role level override attribute component to +new_data+
       def role_override=(new_data)
-        reset
-        @role_override = VividMash.new(new_data, self, __node__, :role_override)
+        defer_cache_resetting do
+          @role_override = VividMash.new(new_data, self, __node__, :role_override)
+        end
       end
 
        # Set the environment level override attribute component to +new_data+
       def env_override=(new_data)
-        reset
-        @env_override = VividMash.new(new_data, self, __node__, :env_override)
+        defer_cache_resetting do
+          @env_override = VividMash.new(new_data, self, __node__, :env_override)
+        end
       end
 
       def force_override=(new_data)
-        reset
-        @force_override = VividMash.new(new_data, self, __node__, :force_override)
+        defer_cache_resetting do
+          @force_override = VividMash.new(new_data, self, __node__, :force_override)
+        end
       end
 
       def automatic=(new_data)
-        reset
-        @automatic = VividMash.new(new_data, self, __node__, :automatic)
+        defer_cache_resetting do
+          @automatic = VividMash.new(new_data, self, __node__, :automatic)
+        end
       end
 
        #
@@ -617,6 +637,15 @@ class Chef
             merge_with
           end
         end
+      end
+
+      # avoid doing cache clearing work for an entire block of code, then nuke the entire cache
+      # @api private
+      def defer_cache_resetting
+        @disable_cache_reset = true
+        yield
+        @disable_cache_reset = false
+        reset
       end
 
     end

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -190,6 +190,8 @@ class Chef
         @__node__ = node
         node.attributes = self
 
+        @disable_cache_reset = false
+
         defer_cache_resetting do
           @default        = VividMash.new({}, self, node, :default)
           @env_default    = VividMash.new({}, self, node, :env_default)
@@ -245,10 +247,11 @@ class Chef
       # avoid doing cache clearing work for an entire block of code, then nuke the entire cache
       # @api private
       def defer_cache_resetting
+        saved = @disable_cache_reset
         @disable_cache_reset = true
         yield
-        @disable_cache_reset = false
-        reset
+        @disable_cache_reset = saved
+        reset_cache
       end
 
       # @api private

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -236,10 +236,13 @@ class Chef
         if path.empty?
           reset
         else
+          key = path.pop
           container = read(*path)
           case container
-          when Hash, Array
+          when Array
             container.reset
+          when Hash
+            container.reset_key(key)
           end
         end
       end

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -229,10 +229,12 @@ class Chef
       end
 
       def reset
+        #puts "TOTAL RESET"
         @deep_merge_cache = nil
       end
 
       def reset_cache(*path)
+        #puts "PATH: #{path}"
         if path.empty?
           reset
         else

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -148,7 +148,7 @@ class Chef
       # also invalidate the cached `merged_attributes` on the root Attribute
       # object.
 
-      def delete(key, &block)
+      def delete(key, &block) # XXX: why did i do this here and not in define_method below?
         ret = super
         send_reset_cache(__path__)
         ret
@@ -169,15 +169,17 @@ class Chef
       def [](key)
         value = super
         if !key?(key)
-          value = self.class.new({}, __root__)
+          value = convert_value({}, __path__ + [ key ])
           self[key] = value
+          send_reset_cache(__path__ + [ key ])
+          value
         else
           value
         end
       end
 
       def []=(key, value)
-        ret = super
+        ret = regular_writer(convert_key(key), convert_value(value, __path__ + [ key ]))
         send_reset_cache(__path__ + [ key ])
         ret # rubocop:disable Lint/Void
       end
@@ -192,7 +194,7 @@ class Chef
       # We override it here to convert hash or array values to VividMash or
       # AttrArray for consistency and to ensure that the added parts of the
       # attribute tree will have the correct cache invalidation behavior.
-      def convert_value(value)
+      def convert_value(value, path = nil)
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
@@ -200,9 +202,9 @@ class Chef
         when AttrArray
           value
         when Hash
-          VividMash.new(value, __root__, __node__, __precedence__)
+          VividMash.new(value, __root__, __node__, __precedence__, path)
         when Array
-          AttrArray.new(value, __root__, __node__, __precedence__)
+          AttrArray.new(value, __root__, __node__, __precedence__, path)
         else
           value
         end

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -93,7 +93,6 @@ class Chef
       private
 
       def convert_value(value, path = nil)
-        puts "CONVERT_VALUE: #{path}"
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
@@ -201,7 +200,6 @@ class Chef
       # AttrArray for consistency and to ensure that the added parts of the
       # attribute tree will have the correct cache invalidation behavior.
       def convert_value(value, path = nil)
-        puts "CONVERT_VALUE: #{path}"
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -93,6 +93,7 @@ class Chef
       private
 
       def convert_value(value, path = nil)
+        puts "CONVERT_VALUE: #{path}"
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
@@ -184,6 +185,11 @@ class Chef
         ret # rubocop:disable Lint/Void
       end
 
+      def update(other_hash)
+        other_hash.each_pair { |key, value| regular_writer(convert_key(key), convert_value(value, __path__ + [ key ])) }
+        self
+      end
+
       alias :attribute? :has_key?
 
       def convert_key(key)
@@ -195,6 +201,7 @@ class Chef
       # AttrArray for consistency and to ensure that the added parts of the
       # attribute tree will have the correct cache invalidation behavior.
       def convert_value(value, path = nil)
+        puts "CONVERT_VALUE: #{path}"
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -178,7 +178,7 @@ class Chef
 
       def []=(key, value)
         ret = super
-        send_reset_cache(__path__)
+        send_reset_cache(__path__ + [ key ])
         ret # rubocop:disable Lint/Void
       end
 

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -69,8 +69,9 @@ class Chef
       end
 
       def delete(key, &block)
+        ret = super
         send_reset_cache(__path__)
-        super
+        ret
       end
 
       def initialize(data = [])
@@ -148,14 +149,16 @@ class Chef
       # object.
 
       def delete(key, &block)
+        ret = super
         send_reset_cache(__path__)
-        super
+        ret
       end
 
       MUTATOR_METHODS.each do |mutator|
         define_method(mutator) do |*args, &block|
+          ret = super(*args, &block)
           send_reset_cache(__path__)
-          super(*args, &block)
+          ret
         end
       end
 

--- a/lib/chef/node/attribute_collections.rb
+++ b/lib/chef/node/attribute_collections.rb
@@ -76,7 +76,7 @@ class Chef
 
       def initialize(data = [])
         super(data)
-        map! { |e| convert_value(e) }
+        map! { |e| convert_value(e, __path__) }
       end
 
       # For elements like Fixnums, true, nil...
@@ -92,7 +92,7 @@ class Chef
 
       private
 
-      def convert_value(value)
+      def convert_value(value, path = nil)
         value.ensure_generated_cache! if value.respond_to?(:ensure_generated_cache!)
         case value
         when VividMash
@@ -100,9 +100,9 @@ class Chef
         when AttrArray
           value
         when Hash
-          VividMash.new(value, __root__, __node__, __precedence__)
+          VividMash.new(value, __root__, __node__, __precedence__, path)
         when Array
-          AttrArray.new(value, __root__, __node__, __precedence__)
+          AttrArray.new(value, __root__, __node__, __precedence__, path)
         else
           value
         end

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -132,13 +132,11 @@ class Chef
       def reset
         @short_circuit_attr_level = nil
         generate_cache
-        @generated_cache = true
       end
 
       # @api private
       def ensure_generated_cache!
         generate_cache unless @generated_cache
-        @generated_cache = true
       end
 
       # This can be set to e.g. [ :@default ] by the parent container to cause this container
@@ -197,6 +195,7 @@ class Chef
             value.short_circuit_attr_levels = @tracked_components if value.respond_to?(:short_circuit_attr_levels)
           end
         end
+        @generated_cache = true
       end
 
       # needed for __path__
@@ -317,7 +316,6 @@ class Chef
       # @api private
       def ensure_generated_cache!
         generate_cache unless @generated_cache
-        @generated_cache = true
       end
 
       # @api private
@@ -350,6 +348,7 @@ class Chef
             value.short_circuit_attr_levels = tracked_components if value.respond_to?(:short_circuit_attr_levels)
           end
         end
+        @generated_cache = true
       end
 
       prepend Chef::Node::Mixin::StateTracking

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -291,6 +291,29 @@ class Chef
         generate_cache
       end
 
+      def reset_key(key)
+        key = key.to_s
+        components = short_circuit_attr_levels ? short_circuit_attr_levels : Attribute::COMPONENTS.reverse
+        # tracked_components is not entirely accurate due to the short-circuit
+        tracked_components = []
+        components.each do |component|
+          subhash = __node__.attributes.instance_variable_get(component).read(*__path__)
+          unless subhash.nil? # FIXME: nil is used for not present
+            tracked_components << component
+            if subhash.kind_of?(Hash)
+              if subhash.key?(key)
+                value = subhash[key]
+                value.short_circuit_attr_levels = short_circuit_attr_levels if value.respond_to?(:short_circuit_attr_levels)
+                internal_set(key, value)
+                break
+              end
+            else
+              break
+            end
+          end
+        end
+      end
+
       # @api private
       def ensure_generated_cache!
         generate_cache unless @generated_cache

--- a/lib/chef/node/immutable_collections.rb
+++ b/lib/chef/node/immutable_collections.rb
@@ -95,7 +95,7 @@ class Chef
       end
 
       def initialize(array_data = [])
-        # Immutable collections no longer have initialized state
+        ensure_generated_cache!
       end
 
       # For elements like Fixnums, true, nil...
@@ -130,9 +130,9 @@ class Chef
       end
 
       def reset
-        @generated_cache = false
         @short_circuit_attr_level = nil
-        internal_clear # redundant?
+        generate_cache
+        @generated_cache = true
       end
 
       # @api private
@@ -245,7 +245,7 @@ class Chef
       end
 
       def initialize(mash_data = {})
-        # Immutable collections no longer have initialized state
+        ensure_generated_cache!
       end
 
       alias :attribute? :has_key?
@@ -287,9 +287,8 @@ class Chef
       end
 
       def reset
-        @generated_cache = false
         @short_circuit_attr_level = nil
-        internal_clear # redundant?
+        generate_cache
       end
 
       # @api private

--- a/lib/chef/node/mixin/state_tracking.rb
+++ b/lib/chef/node/mixin/state_tracking.rb
@@ -25,14 +25,12 @@ class Chef
         attr_reader :__precedence__
 
         def initialize(data = nil, root = self, node = nil, precedence = nil, path = nil)
-          # __path__ and __root__ must be nil when we call super so it knows
-          # to avoid resetting the cache on construction
-          data.nil? ? super() : super(data)
+          @__node__ = node
+          @__precedence__ = precedence
           @__path__ = path
           @__path__ ||= []
           @__root__ = root
-          @__node__ = node
-          @__precedence__ = precedence
+          data.nil? ? super() : super(data)
         end
 
         def [](*args)

--- a/lib/chef/policy_builder/expand_node_object.rb
+++ b/lib/chef/policy_builder/expand_node_object.rb
@@ -3,7 +3,7 @@
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,8 +122,10 @@ class Chef
         # consume_external_attrs may add items to the run_list. Save the
         # expanded run_list, which we will pass to the server later to
         # determine which versions of cookbooks to use.
-        node.reset_defaults_and_overrides
-        node.consume_external_attrs(ohai_data, @json_attribs)
+        node.attributes.defer_cache_resetting do
+          node.reset_defaults_and_overrides
+          node.consume_external_attrs(ohai_data, @json_attribs)
+        end
 
         setup_run_list_override
 

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1318,5 +1318,4 @@ describe Chef::Node::Attribute do
       expect(@attributes.default["bar"]["baz"]).to eql({ "one" => "two" })
     end
   end
-
 end

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -21,11 +21,13 @@ require "spec_helper"
 require "chef/node/attribute"
 
 describe Chef::Node::Attribute do
-  let(:events) { instance_double(Chef::EventDispatch::Dispatcher) }
-  let(:run_context) { instance_double(Chef::RunContext, :events => events) }
-  let(:node) { instance_double(Chef::Node, :run_context => run_context) }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:attributes) { Chef::Node::Attribute.new(@attribute_hash, @default_hash, @override_hash, @automatic_hash, node) }
+
   before(:each) do
-    allow(events).to receive(:attribute_changed)
+    run_context # de-lazy the run_context + the event object + wire to the node
     @attribute_hash =
       { "dmi" => {},
         "command" => { "ps" => "ps -ef" },
@@ -170,8 +172,7 @@ describe Chef::Node::Attribute do
       },
     }
     @automatic_hash = { "week" => "friday" }
-    @attributes = Chef::Node::Attribute.new(@attribute_hash, @default_hash, @override_hash, @automatic_hash, node)
-    allow(node).to receive(:attributes).and_return(@attributes)
+    @attributes = attributes
   end
 
   describe "initialize" do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1809,4 +1809,20 @@ describe Chef::Node do
       expect(node["a"]["key"]).to eql(1)
     end
   end
+
+  describe "lazy ungenerated caches work with ruby internal APIs" do
+    it "works with hashes when first created" do
+      node.default["foo"] = { "one" => "two" }
+      result = {}.merge!(node["foo"])
+      expect(result).to eql({ "one" => "two" })
+    end
+
+    it "works with hashes that receive a reset" do
+      node.default["foo"] = { "one" => "two" }
+      node["foo"].to_h
+      node.default["foo"]["bar"] = "baz"
+      result = {}.merge!(node["foo"])
+      expect(result).to eql({ "one" => "two", "bar" => "baz" })
+    end
+  end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -477,10 +477,9 @@ describe Chef::Node do
 
       context "with array indexes" do
         before do
-          node.role_default["mysql"]["server"][0]["port"] = 1234
-          node.normal["mysql"]["server"][0]["port"] = 2345
-          node.override["mysql"]["server"][0]["port"] = 3456
-          node.override["mysql"]["server"][1]["port"] = 3456
+          node.role_default["mysql"]["server"] = [ { "port" => 1234 } ]
+          node.normal["mysql"]["server"] = [ { "port" => 2345 } ]
+          node.override["mysql"]["server"] = [ { "port" => 3456 }, { "port" => 3456 } ]
         end
 
         it "deletes the array element" do


### PR DESCRIPTION
🚧  🚧  🚧  🚧  🚧  🚧  🚧  🚧  🚧  BROKEN SPECS

The changes in #6424 did two things:

- moved the cache to per-container so that resets could be sent to e.g. `node["foo"]["bar"]["baz"]` and only values under that would need to be recomputed.
- made all the caches lazy caches so that when `node["foo"]["bar"]["baz"]` was reset the cache reset code would just create an empty container there, which was marked that it needed cache population on access.

The problem with the the lazy caches was that all the cache objects inherited directly from Array or Hash, so while all the methods on those objects were intercepted and would lazily create the cache on access, it is not really possible to intercept messages to e.g. Hash#merge on actual hash objects (e.g. the `{}.merge(node['foo'])` case.  This would work better with decorators since most APIs internal to ruby call `#to_h/#to_a` on things which do not inherit from Hash/Array, but objects which inherit result in the APIs poking around directly at the internal Hash/Array structure without calling methods on the target objects themselves for speed.

This PR removes the lazy caching, so that when `node["foo"]["bar"]["baz"]` is reset it immediately rebuilds the entire cache underneath it.  As a result cache flushing needs to be accurate (previously we could bang on the cache flushing API and sending three messages to flush a cache was cheap, but now it is expensive and results in three rebuilds).

It was also necessary to implement per-key flushing on Mashes.  This is necessary to avoid a write to `node["foo"]` rebuilding all of `node` (and on down the line, but this is the really expensive case).

This is still faster than 12.21.31 or 13.0 attribute performance but is not as fast as 13.7.16 was.