### PR TITLE
check identifier to resolve exported cookbooks by chef export

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -309,7 +309,10 @@ class Chef
         elsif %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length == 3
           with_entry([path[0]]) do |entry|
             cookbook_type = path[0]
-            cookbook_entry = entry.children.select { |child| child.chef_object.full_name == "#{path[1]}-#{path[2]}" }[0]
+            cookbook_entry = entry.children.select { |child|
+              child.chef_object.full_name == "#{path[1]}-#{path[2]}" ||
+              (child.chef_object.name.to_s == path[1] && child.chef_object.identifier == path[2])
+            }[0]
             raise ChefZero::DataStore::DataNotFoundError.new(path) if cookbook_entry.nil?
             result = nil
             begin


### PR DESCRIPTION
### Description

#6471 includes regression. We will not be able to find a cookbook based on identifier saved by chef export.

### Issues Resolved

Not in this repository. External thing, integration test of my plugin now fails.

- https://github.com/higanworks/knife-zero/issues/118

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: SAWANOBORI Yukihiko <sawanoboriyu@higanworks.com>