### PR TITLE
Add support for knife bootstrap-preinstall-command

### DIFF
--- a/distro/common/html/knife_bootstrap.html
+++ b/distro/common/html/knife_bootstrap.html
@@ -66,6 +66,8 @@
 <dd>Use to enable SSH agent forwarding.</dd>
 <dt><tt class="docutils literal"><span class="pre">--bootstrap-curl-options</span> <span class="pre">OPTIONS</span></tt></dt>
 <dd>Use to specify arbitrary options to be added to the bootstrap command when using cURL. This option may not be used in the same command with <tt class="docutils literal"><span class="pre">--bootstrap-install-command</span></tt>.</dd>
+<dt><tt class="docutils literal"><span class="pre">--bootstrap-preinstall-command</span> <span class="pre">COMMAND</span></tt></dt>
+<dd>Use to execute a custom command before installation of the chef-client.</dd>
 <dt><tt class="docutils literal"><span class="pre">--bootstrap-install-command</span> <span class="pre">COMMAND</span></tt></dt>
 <dd>Use to execute a custom installation command sequence for the chef-client. This option may not be used in the same command with <tt class="docutils literal"><span class="pre">--bootstrap-curl-options</span></tt>, <tt class="docutils literal"><span class="pre">--bootstrap-install-sh</span></tt>, or <tt class="docutils literal"><span class="pre">--bootstrap-wget-options</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">--bootstrap-install-sh</span> <span class="pre">URL</span></tt></dt>

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -219,6 +219,11 @@ class Chef
         :description => "Custom command to install chef-client",
         :proc        => Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
+      option :bootstrap_preinstall_command,
+             :long        => "--bootstrap-preinstall-command COMMANDS",
+             :description => "Custom commands to run before installing chef-client",
+             :proc        => Proc.new { |preic| Chef::Config[:knife][:bootstrap_preinstall_command] = preic }
+
       option :bootstrap_wget_options,
         :long        => "--bootstrap-wget-options OPTIONS",
         :description => "Add options to wget when installing chef-client",

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -162,6 +162,12 @@ do_download() {
   return 16
 }
 
+<%# Run any custom commands before installing chef-client -%>
+<%# Ex. wait for cloud-init to complete -%>
+<% if knife_config[:bootstrap_preinstall_command] %>
+  <%= knife_config[:bootstrap_preinstall_command] %>
+<% end %>
+
 <% if knife_config[:bootstrap_install_command] %>
   <%= knife_config[:bootstrap_install_command] %>
 <% else %>

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -84,6 +84,18 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
+  context "with --bootstrap-preinstall-command" do
+    command = "while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do\n   echo 'waiting for dpkg lock';\n   sleep 1;\n  done;"
+    let(:bootstrap_cli_options) { [ "--bootstrap-preinstall-command", command ] }
+    let(:rendered_template) do
+      knife.merge_configs
+      knife.render_template
+    end
+    it "configures the preinstall command in the bootstrap template correctly" do
+      expect(rendered_template).to match(%r{command})
+    end
+  end
+
   context "with :distro and :bootstrap_template cli options" do
     let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "--distro", "other-template" ] }
 


### PR DESCRIPTION
Signed-off-by: S. Cavallo <smcavallo@hotmail.com>

Add support for knife bootstrap-preinstall-command

Allows custom pre-install commands to be inserted into the bootstrap template.
A common use case is waiting for cloud-init to complete or any existing package manager locks to be released.  It is possible to do this by customizing the install command or using custom bootstrap templates.  Maintaining custom bootstrap templates can be difficult to keep up to date.
Allowing a custom pre-install bootstrap command would allow us to use the built-in templates without having to fork or customize the templates.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
