### PR TITLE
Git ignore any node json generated during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ kitchen-tests/vendor
 
 # Visual Studio Code files
 .vscode
+
+# ignore nodes generated during local testing
+nodes/


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

During development, users `bundle exec chef-client` (amongst other commands) in order to test their changes.  On a system without any overridden configuration specified in client.rb or at the command line this leads to the creation of a `nodes/` folder containing data relating to the development node.  This PR simply excludes this folder from accidentally being committed.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
