### PR TITLE
Add support for network family in ifconfig for Debian platforms

### DIFF
--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -36,11 +36,11 @@ class Chef
 <% if new_resource.onboot == "yes" %>auto <%= new_resource.device %><% end %>
 <% case new_resource.bootproto
    when "dhcp" %>
-iface <%= new_resource.device %> inet dhcp
+iface <%= new_resource.device %> <%= new_resource.family %> dhcp
 <% when "bootp" %>
-iface <%= new_resource.device %> inet bootp
+iface <%= new_resource.device %> <%= new_resource.family %> bootp
 <% else %>
-iface <%= new_resource.device %> inet static
+iface <%= new_resource.device %> <%= new_resource.family %> static
     <% if new_resource.target %>address <%= new_resource.target %><% end %>
     <% if new_resource.mask %>netmask <%= new_resource.mask %><% end %>
     <% if new_resource.network %>network <%= new_resource.network %><% end %>

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -38,6 +38,7 @@ class Chef
       property :target, String, name_property: true
       property :hwaddr, String
       property :mask, String
+      property :family, String, default: 'inet'
       property :inet_addr, String
       property :bcast, String
       property :mtu, String

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -38,7 +38,7 @@ class Chef
       property :target, String, name_property: true
       property :hwaddr, String
       property :mask, String
-      property :family, String, default: 'inet'
+      property :family, String, default: "inet"
       property :inet_addr, String
       property :bcast, String
       property :mtu, String


### PR DESCRIPTION
### Description

This PR allows customization of the network family option in Debian/Ubuntu platforms, defaulting to the currently used 'inet' family. It will open the door to IPv6 networking eventually, but I didn't want to overload the scope of this change with adding IPv6 support.

### Issues Resolved

None

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
