### PR TITLE
The end of our long travis unit testing nightmare

### DIFF
--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -19,6 +19,9 @@ require "spec_helper"
 require "ostruct"
 
 describe Chef::Daemon do
+  let(:testuser) { "thisisausernamewhichshouldnotexist" }
+  let(:testgroup) { "thisisagroupnamewhichshouldnotexist" }
+
   before do
     if windows?
       mock_struct = #Struct::Passwd.new(nil, nil, 111, 111)
@@ -75,7 +78,7 @@ describe Chef::Daemon do
     before do
       allow(Chef::Daemon).to receive(:_change_privilege)
       allow(Chef::Application).to receive(:fatal!).and_return(true)
-      Chef::Config[:user] = "aj"
+      Chef::Config[:user] = testuser
       allow(Dir).to receive(:chdir)
     end
 
@@ -87,28 +90,28 @@ describe Chef::Daemon do
     describe "when the user and group options are supplied" do
 
       before do
-        Chef::Config[:group] = "staff"
+        Chef::Config[:group] = testgroup
       end
 
       it "should log an appropriate info message" do
-        expect(Chef::Log).to receive(:info).with("About to change privilege to aj:staff")
+        expect(Chef::Log).to receive(:info).with("About to change privilege to #{testuser}:#{testgroup}")
         Chef::Daemon.change_privilege
       end
 
       it "should call _change_privilege with the user and group" do
-        expect(Chef::Daemon).to receive(:_change_privilege).with("aj", "staff")
+        expect(Chef::Daemon).to receive(:_change_privilege).with(testuser, testgroup)
         Chef::Daemon.change_privilege
       end
     end
 
     describe "when just the user option is supplied" do
       it "should log an appropriate info message" do
-        expect(Chef::Log).to receive(:info).with("About to change privilege to aj")
+        expect(Chef::Log).to receive(:info).with("About to change privilege to #{testuser}")
         Chef::Daemon.change_privilege
       end
 
       it "should call _change_privilege with just the user" do
-        expect(Chef::Daemon).to receive(:_change_privilege).with("aj")
+        expect(Chef::Daemon).to receive(:_change_privilege).with(testuser)
         Chef::Daemon.change_privilege
       end
     end
@@ -139,18 +142,18 @@ describe Chef::Daemon do
       end
 
       it "should initialize the supplemental group list" do
-        expect(Process).to receive(:initgroups).with("aj", 20)
-        Chef::Daemon._change_privilege("aj")
+        expect(Process).to receive(:initgroups).with(testuser, 20)
+        Chef::Daemon._change_privilege(testuser)
       end
 
       it "should attempt to change the process GID" do
         expect(Process::GID).to receive(:change_privilege).with(20).and_return(20)
-        Chef::Daemon._change_privilege("aj")
+        Chef::Daemon._change_privilege(testuser)
       end
 
       it "should attempt to change the process UID" do
         expect(Process::UID).to receive(:change_privilege).with(501).and_return(501)
-        Chef::Daemon._change_privilege("aj")
+        Chef::Daemon._change_privilege(testuser)
       end
     end
 
@@ -172,7 +175,7 @@ describe Chef::Daemon do
           error = "Not owner"
         end
         expect(Chef::Application).to receive(:fatal!).with("Permission denied when trying to change 999:999 to 501:20. #{error}")
-        Chef::Daemon._change_privilege("aj")
+        Chef::Daemon._change_privilege(testuser)
       end
     end
 

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@junglist.gen.nz>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,6 +73,7 @@ describe Chef::Daemon do
   describe ".change_privilege" do
 
     before do
+      allow(Chef::Daemon).to receive(:_change_privilege)
       allow(Chef::Application).to receive(:fatal!).and_return(true)
       Chef::Config[:user] = "aj"
       allow(Dir).to receive(:chdir)
@@ -157,6 +158,11 @@ describe Chef::Daemon do
       before do
         allow(Process).to receive(:euid).and_return(999)
         allow(Process).to receive(:egid).and_return(999)
+      end
+
+      after do
+        allow(Process).to receive(:euid).and_call_original
+        allow(Process).to receive(:egid).and_call_original
       end
 
       it "should log an appropriate error message and fail miserably" do


### PR DESCRIPTION
The only line here which is actually a bugfix is this one:

https://github.com/chef/chef/pull/6888/files#diff-1c826d5d40b34ba0095996a6453ca135R79

Which stubs and no-ops :_change_privilege. Most of the rest of the specs in this describe block setup expectations on that method, but the first test does not, which means that it really calls that function and really changes privs.

Also added some defensive checking which will blow up if this ever happens again (and has an edge case where it throws out a false positive which is responsible for the other couple lines of spec fixes).

EDIT: also after actually tracking down the root cause changed the fake user + group this set of spec tests uses.