### PR TITLE
Modernize macosx_service

### DIFF
--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -21,7 +21,7 @@ require "chef/resource/service"
 class Chef
   class Resource
     class MacosxService < Chef::Resource::Service
-
+      resource_name :macosx_service
       provides :macosx_service, os: "darwin"
       provides :service, os: "darwin"
 
@@ -29,29 +29,11 @@ class Chef
 
       state_attrs :enabled, :running
 
-      def initialize(name, run_context = nil)
-        super
-        @plist = nil
-        @session_type = nil
-      end
-
       # This will enable user to pass a plist in the case
       # that the filename and label for the service dont match
-      def plist(arg = nil)
-        set_or_return(
-          :plist,
-          arg,
-          :kind_of => String
-        )
-      end
+      property :plist, String
 
-      def session_type(arg = nil)
-        set_or_return(
-          :session_type,
-          arg,
-          :kind_of => String
-        )
-      end
+      property :session_type, String
 
     end
   end


### PR DESCRIPTION
Use properties throughout instead of set_or_return

Signed-off-by: Tim Smith <tsmith@chef.io>