### PR TITLE
Remove the :uninstall action from chocolatey_package - CHEF-21

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -124,14 +124,6 @@ EOS
           choco_command("uninstall -y", cmd_args(include_source: false), *names)
         end
 
-        # Support :uninstall as an action in order for users to easily convert
-        # from the `chocolatey` provider in the cookbook.  It is, however,
-        # already deprecated.
-        def action_uninstall
-          Chef::Log.deprecation "The use of action :uninstall on the chocolatey_package provider is deprecated, please use :remove"
-          action_remove
-        end
-
         # Choco does not have dpkg's distinction between purge and remove
         alias purge_package remove_package
 

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -28,7 +28,7 @@ class Chef
                   " on the Microsoft Windows platform."
       introduced "12.7"
 
-      allowed_actions :install, :upgrade, :remove, :uninstall, :purge, :reconfig
+      allowed_actions :install, :upgrade, :remove, :purge, :reconfig
 
       # windows can't take Array options yet
       property :options, String

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -439,19 +439,6 @@ munin-node|1.6.1.20130823
       expect(new_resource).to be_updated_by_last_action
     end
   end
-
-  describe "#action_uninstall" do
-    it "should call :remove with a deprecation warning" do
-      Chef::Config[:treat_deprecation_warnings_as_errors] = false
-      expect(Chef::Log).to receive(:deprecation).with(/please use :remove/)
-      allow_remote_list(["ConEmu"])
-      new_resource.package_name("ConEmu")
-      provider.load_current_resource
-      expect(provider).to receive(:remove_package)
-      provider.run_action(:uninstall)
-      expect(new_resource).to be_updated_by_last_action
-    end
-  end
 end
 
 describe "behavior when Chocolatey is not installed" do


### PR DESCRIPTION
Remove the previously deprecated :uninstall action for
chocolatey_package. This is noted in CHEF-21 (https://docs.chef.io/deprecations_chocolatey_uninstall.html)

Signed-off-by: Tim Smith <tsmith@chef.io>