### PR TITLE
Remove support for Windows 2003

### DIFF
--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -55,8 +55,7 @@ class Chef
 
     default :event_loggers do
       evt_loggers = []
-      if ChefConfig.windows? && !(Chef::Platform.windows_server_2003? ||
-          Chef::Platform.windows_nano_server?)
+      if ChefConfig.windows? && !Chef::Platform.windows_nano_server?
         evt_loggers << :win_evt
       end
       evt_loggers

--- a/lib/chef/dsl/reboot_pending.rb
+++ b/lib/chef/dsl/reboot_pending.rb
@@ -44,14 +44,7 @@ class Chef
             registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') ||
 
           # Vista + Server 2008 and newer may have reboots pending from CBS
-            registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
-
-          # The mere existence of the UpdateExeVolatile key should indicate a pending restart for certain updates
-          # http://support.microsoft.com/kb/832475
-            Chef::Platform.windows_server_2003? &&
-              (registry_key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
-              !registry_get_values('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').select { |v| v[:name] == "Flags" }[0].nil? &&
-              [1, 2, 3].include?(registry_get_values('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').select { |v| v[:name] == "Flags" }[0][:data]))
+            registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending')
         elsif platform?("ubuntu")
           # This should work for Debian as well if update-notifier-common happens to be installed. We need an API for that.
           File.exists?("/var/run/reboot-required")

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -24,18 +24,6 @@ class Chef
         ChefConfig.windows?
       end
 
-      def windows_server_2003?
-        # WMI startup shouldn't be performed unless we're on Windows.
-        return false unless windows?
-        require "wmi-lite/wmi"
-
-        wmi = WmiLite::Wmi.new
-        host = wmi.first_of("Win32_OperatingSystem")
-        is_server_2003 = (host["version"] && host["version"].start_with?("5.2"))
-
-        is_server_2003
-      end
-
       def windows_nano_server?
         return false unless windows?
         require "win32/registry"

--- a/lib/chef/win32/eventlog.rb
+++ b/lib/chef/win32/eventlog.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-if Chef::Platform.windows? && (not Chef::Platform.windows_server_2003?)
+if Chef::Platform.windows?
   if !defined? Chef::Win32EventLogLoaded
     if defined? Windows::Constants
       [:INFINITE, :WAIT_FAILED, :FORMAT_MESSAGE_IGNORE_INSERTS, :ERROR_INSUFFICIENT_BUFFER].each do |c|

--- a/lib/chef/win32/security/sid.rb
+++ b/lib/chef/win32/security/sid.rb
@@ -248,8 +248,7 @@ class Chef
 
         # See https://technet.microsoft.com/en-us/library/cc961992.aspx
         # In practice, this is SID.Administrators if the current_user is an admin (even if not
-        # running elevated), and is current_user otherwise. On win2k3, it technically can be
-        # current_user in all cases if a certain group policy is set.
+        # running elevated), and is current_user otherwise.
         def self.default_security_object_owner
           token = Chef::ReservedNames::Win32::Security.open_current_process_token
           Chef::ReservedNames::Win32::Security.get_token_information_owner(token)

--- a/lib/chef/win32/version.rb
+++ b/lib/chef/win32/version.rb
@@ -76,15 +76,8 @@ class Chef
         @sp_minor_version = ver_info[:w_service_pack_minor]
 
         # Obtain sku information for the purpose of identifying
-        # datacenter, cluster, and core skus, the latter 2 only
-        # exist in releases after Windows Server 2003
-        if ! Chef::Platform.windows_server_2003?
-          @sku = get_product_info(@major_version, @minor_version, @sp_major_version, @sp_minor_version)
-        else
-          # The get_product_info API is not supported on Win2k3,
-          # use an alternative to identify datacenter skus
-          @sku = get_datacenter_product_info_windows_server_2003(ver_info)
-        end
+        # datacenter, cluster, and core skus
+        @sku = get_product_info(@major_version, @minor_version, @sp_major_version, @sp_minor_version)
       end
 
       marketing_names = Array.new
@@ -151,12 +144,6 @@ class Chef
         out = FFI::MemoryPointer.new(:uint32)
         GetProductInfo(major, minor, sp_major, sp_minor, out)
         out.get_uint(0)
-      end
-
-      def get_datacenter_product_info_windows_server_2003(ver_info)
-        # The intent is not to get the actual sku, just identify
-        # Windows Server 2003 datacenter
-        sku = (ver_info[:w_suite_mask] & VER_SUITE_DATACENTER) ? PRODUCT_DATACENTER_SERVER : 0
       end
 
     end

--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -19,12 +19,12 @@
 require "spec_helper"
 require "securerandom"
 require "chef/event_loggers/windows_eventlog"
-if Chef::Platform.windows? && (not Chef::Platform.windows_server_2003?)
+if Chef::Platform.windows?
   require "win32/eventlog"
   include Win32
 end
 
-describe Chef::EventLoggers::WindowsEventLogger, :windows_only, :not_supported_on_win2k3 do
+describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
   def rand
     random.rand(1 << 32).to_s
   end

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -172,7 +172,7 @@ describe Chef::Resource::Link do
     create_resource
   end
 
-  describe "when supported on platform", :not_supported_on_win2k3 do
+  describe "when supported on platform" do
     shared_examples_for "delete errors out" do
       it "delete errors out" do
         expect { resource.run_action(:delete) }.to raise_error(Chef::Exceptions::Link)
@@ -692,12 +692,6 @@ describe Chef::Resource::Link do
           include_context "delete is noop"
         end
       end
-    end
-  end
-
-  describe "when not supported on platform", :win2k3_only do
-    it "raises error" do
-      expect { resource }.to raise_error(Chef::Exceptions::Win32APIFunctionNotImplemented)
     end
   end
 end

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -36,8 +36,6 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
   let(:cmdlet_exit_code_success_content) { "get-item ." }
   let(:windows_process_exit_code_success_content) { "#{ENV['SystemRoot']}\\system32\\attrib.exe $env:systemroot" }
   let(:windows_process_exit_code_not_found_content) { "findstr /notavalidswitch" }
-  # Note that process exit codes on 32-bit Win2k3 cannot
-  # exceed maximum value of signed integer
   let(:arbitrary_nonzero_process_exit_code) { 4193 }
   let(:arbitrary_nonzero_process_exit_code_content) { "exit #{arbitrary_nonzero_process_exit_code}" }
   let(:invalid_powershell_interpreter_flag) { "/thisflagisinvalid" }

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -42,7 +42,6 @@ describe "Chef::Win32::Security", :windows_only do
 
     before do
       allow_any_instance_of(Chef::Mixin::UserContext).to receive(:node).and_return({ "platform_family" => "windows" })
-      allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
       add_user = Mixlib::ShellOut.new("net user #{user} #{password} /ADD")
       add_user.run_command
       add_user.error!

--- a/spec/functional/win32/versions_spec.rb
+++ b/spec/functional/win32/versions_spec.rb
@@ -21,7 +21,7 @@ if Chef::Platform.windows?
   require "chef/win32/version"
 end
 
-describe "Chef::ReservedNames::Win32::Version", :windows_only, :not_supported_on_win2k3 do
+describe "Chef::ReservedNames::Win32::Version", :windows_only do
   before do
 
     wmi = WmiLite::Wmi.new
@@ -31,14 +31,12 @@ describe "Chef::ReservedNames::Win32::Version", :windows_only, :not_supported_on
     # On Win2k8R2 and later, we can dynamically obtain marketing
     # names for comparison from WMI so the test should not
     # need to be modified when new Windows releases arise.
-    # For Win2k3 and Win2k8, we use static names in this test
-    # based on the version number information from WMI. The names
-    # from WMI contain extended characters such as registered
-    # trademark on Win2k8 and Win2k3 that we're not using in our
-    # library, so we have to set the expectation statically.
-    if Chef::Platform.windows_server_2003?
-      @current_os_version = "Windows Server 2003 R2"
-    elsif is_windows_server_2008?(host)
+    # For Win2k8 we use static names in this test based on the
+    # version number information from WMI. The names from WMI
+    # contain extended characters such as registered trademark
+    # on Win2k8 that we're not using in our library, so we have
+    # to set the expectation statically.
+    if is_windows_server_2008?(host)
       @current_os_version = "Windows Server 2008"
     else
       # The name from WMI is actually what we want in Win2k8R2+.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,11 +146,9 @@ RSpec.configure do |config|
   config.filter_run_excluding :not_supported_on_mac_osx_106 => true if mac_osx_106?
   config.filter_run_excluding :not_supported_on_mac_osx => true if mac_osx?
   config.filter_run_excluding :mac_osx_only => true if !mac_osx?
-  config.filter_run_excluding :not_supported_on_win2k3 => true if windows_win2k3?
   config.filter_run_excluding :not_supported_on_solaris => true if solaris?
   config.filter_run_excluding :not_supported_on_gce => true if gce?
   config.filter_run_excluding :not_supported_on_nano => true if windows_nano_server?
-  config.filter_run_excluding :win2k3_only => true unless windows_win2k3?
   config.filter_run_excluding :win2012r2_only => true unless windows_2012r2?
   config.filter_run_excluding :windows_2008r2_or_later => true unless windows_2008r2_or_later?
   config.filter_run_excluding :windows64_only => true unless windows64?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -51,11 +51,6 @@ def windows_domain_joined?
   computer_system["partofdomain"]
 end
 
-def windows_win2k3?
-  return false unless windows?
-  (host_version && host_version.start_with?("5.2"))
-end
-
 def windows_2008r2_or_later?
   return false unless windows?
   return false unless host_version

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -399,7 +399,7 @@ shared_examples_for "a configured file resource" do
     content
   end
 
-  context "when the target file is a symlink", :not_supported_on_win2k3 do
+  context "when the target file is a symlink" do
     let(:symlink_target) do
       File.join(CHEF_SPEC_DATA, "file-test-target")
     end

--- a/spec/unit/dsl/reboot_pending_spec.rb
+++ b/spec/unit/dsl/reboot_pending_spec.rb
@@ -49,19 +49,6 @@ describe Chef::DSL::RebootPending do
           allow(recipe).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending').and_return(true)
           expect(recipe.reboot_pending?).to be_truthy
         end
-
-        context "version is server 2003" do
-          before do
-            allow(Chef::Platform).to receive(:windows_server_2003?).and_return(true)
-          end
-
-          it 'should return true if value "HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile" contains specific data on 2k3' do
-            allow(recipe).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(true)
-            allow(recipe).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile').and_return(
-                  [{ :name => "Flags", :type => :dword, :data => 3 }])
-            expect(recipe.reboot_pending?).to be_truthy
-          end
-        end
       end
 
       context "platform is ubuntu" do

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -18,19 +18,6 @@
 
 require "spec_helper"
 
-describe "Chef::Platform#windows_server_2003?" do
-  it "returns false early when not on windows" do
-    allow(ChefConfig).to receive(:windows?).and_return(false)
-    expect(Chef::Platform).not_to receive(:require)
-    expect(Chef::Platform.windows_server_2003?).to be_falsey
-  end
-
-  # CHEF-4888: Need to call WIN32OLE.ole_initialize in new threads
-  it "does not raise an exception" do
-    expect { Thread.fork { Chef::Platform.windows_server_2003? }.join }.not_to raise_error
-  end
-end
-
 describe "Chef::Platform#windows_nano_server?" do
   include_context "Win32"
 

--- a/spec/unit/provider/link_spec.rb
+++ b/spec/unit/provider/link_spec.rb
@@ -25,7 +25,7 @@ if Chef::Platform.windows?
   require "chef/win32/file" #probably need this in spec_helper
 end
 
-describe Chef::Resource::Link, :not_supported_on_win2k3 do
+describe Chef::Resource::Link do
   let(:provider) do
     node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -193,7 +193,7 @@ describe Chef::Provider::RemoteDirectory do
         expect(::File.exist?(@destination_dir + "/a/multiply/nested/directory/qux.txt")).to be_falsey
       end
 
-      it "removes directory symlinks properly", :not_supported_on_win2k3 do
+      it "removes directory symlinks properly" do
         symlinked_dir_path = @destination_dir + "/symlinked_dir"
         @provider.action = :create
         @provider.run_action

--- a/spec/unit/win32/security_spec.rb
+++ b/spec/unit/win32/security_spec.rb
@@ -65,14 +65,8 @@ describe "Chef::Win32::Security", :windows_only do
   end
 
   describe "self.has_admin_privileges?" do
-    it "returns true for windows server 2003" do
-      allow(Chef::Platform).to receive(:windows_server_2003?).and_return(true)
-      expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to be true
-    end
-
     context "when the user doesn't have admin privileges" do
       it "returns false" do
-        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
         allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token).and_raise("Access is denied.")
         expect(Chef::ReservedNames::Win32::Security.has_admin_privileges?).to be false
       end
@@ -80,7 +74,6 @@ describe "Chef::Win32::Security", :windows_only do
 
     context "when open_current_process_token fails with some other error than `Access is Denied`" do
       it "raises error" do
-        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
         allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token).and_raise("boom")
         expect { Chef::ReservedNames::Win32::Security.has_admin_privileges? }.to raise_error(Chef::Exceptions::Win32APIError)
       end
@@ -88,7 +81,6 @@ describe "Chef::Win32::Security", :windows_only do
 
     context "when the user has admin privileges" do
       it "returns true" do
-        allow(Chef::Platform).to receive(:windows_server_2003?).and_return(false)
         allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token)
         token = Chef::ReservedNames::Win32::Security.open_current_process_token
         allow(token).to receive_message_chain(:handle, :handle)


### PR DESCRIPTION
Windows 2003 is fully end of life at this point and hasn't been supported by Chef for quite a while. EXTENDED support for Windows 2003 ended July 14, 2015. We avoid a good number of WMI queries by removing this support entirely.

Signed-off-by: Tim Smith <tsmith@chef.io>