### PR TITLE
Bump depenencies to pull in Ohai 13.8 / InSpec 1.51.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "cheffish", "~> 13" # required for rspec tests
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec"
+  gem "inspec", "~> 1"
   gem "chef-vault"
 end
 
@@ -52,10 +52,7 @@ group(:development, :test) do
   gem "rake"
   gem "simplecov"
   gem "webmock"
-
-  # for testing new chefstyle rules
-  # gem 'chefstyle', github: 'chef/chefstyle'
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "chefstyle", "0.6.0"
 end
 
 group(:travis) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/chef/chefstyle.git
-  revision: 4eb575a63ce5679d9166211d684c9e3fff168d2a
-  branch: master
-  specs:
-    chefstyle (0.6.0)
-      rubocop (= 0.49.1)
-
-GIT
   remote: https://github.com/rubysec/bundler-audit.git
   revision: b84d88f76c4d656421c1d810c9760b0fdea5d13a
   specs:
@@ -103,14 +95,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    appbundler (0.10.0)
+    appbundler (0.11.2)
       mixlib-cli (~> 1.4)
-    ast (2.3.0)
-    backports (3.11.0)
-    binding_of_caller (0.7.3)
+      mixlib-shellout (~> 2.0)
+    ast (2.4.0)
+    backports (3.11.1)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    byebug (9.1.0)
+    byebug (10.0.0)
     chef-vault (3.3.0)
     chef-zero (13.1.0)
       ffi-yajl (~> 2.2)
@@ -121,20 +114,22 @@ GEM
     cheffish (13.1.0)
       chef-zero (~> 13.0)
       net-ssh
+    chefstyle (0.6.0)
+      rubocop (= 0.49.1)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
-    docker-api (1.34.0)
+    docker-api (1.34.1)
       excon (>= 0.47.0)
       multi_json
     erubis (2.7.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
     excon (0.60.0)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
@@ -163,7 +158,7 @@ GEM
     htmlentities (4.3.4)
     httpclient (2.8.3)
     iniparse (1.4.4)
-    inspec (1.49.2)
+    inspec (1.51.21)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -222,7 +217,7 @@ GEM
     nori (2.6.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (13.7.1)
+    ohai (13.8.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -235,17 +230,17 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     parallel (1.12.1)
-    parser (2.4.0.2)
-      ast (~> 2.3)
-    parslet (1.8.1)
+    parser (2.5.0.2)
+      ast (~> 2.4.0)
+    parslet (1.8.2)
     plist (3.4.0)
     powerpack (0.1.1)
     proxifier (1.0.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.5.1)
-      byebug (~> 9.1)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
       pry (~> 0.10)
     pry-remote (0.1.8)
       pry (~> 0.9)
@@ -340,7 +335,7 @@ GEM
       ethon (>= 0.8.0)
     unicode-display_width (1.3.0)
     uuidtools (2.1.5)
-    webmock (3.2.1)
+    webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -374,7 +369,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-fs (1.1.1)
+    winrm-fs (1.2.0)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -394,8 +389,8 @@ DEPENDENCIES
   chef-config!
   chef-vault
   cheffish (~> 13)
-  chefstyle!
-  inspec
+  chefstyle (= 0.6.0)
+  inspec (~> 1)
   netrc
   octokit
   ohai (~> 13)

--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rake" # required to build some native extensions
 gem "chef", path: ".."
+gem "inspec", "~> 1.0"
 gem "berkshelf", git: "https://github.com/berkshelf/berkshelf.git", branch: "master"
 gem "kitchen-appbundle-updater", git: "https://github.com/chef/kitchen-appbundle-updater", branch: "master"
 gem "kitchen-dokken", "< 2.0" # 2.x fails atm: https://travis-ci.org/chef/chef/jobs/199125787

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 68c301587d8856c6ec4445a24ec49365bb22a314
+  revision: 9a3a97bb0c6b437524fdea15b4cd15a65ff6ac29
   specs:
-    omnibus (5.6.8)
+    omnibus (5.6.10)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
@@ -10,14 +10,14 @@ GIT
       license_scout (~> 1.0)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
-      ohai (~> 8.0)
+      ohai (>= 8.6.0.alpha.1, < 15)
       pedump
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 4ef2d1a5b9162f4f5f52617d2a0122796b4f3c43
+  revision: f0c34cd3a21c4da6207721914213ac775b44570f
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -29,13 +29,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.128)
-      aws-sdk-resources (= 2.10.128)
-    aws-sdk-core (2.10.128)
+    aws-sdk (2.11.8)
+      aws-sdk-resources (= 2.11.8)
+    aws-sdk-core (2.11.8)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.128)
-      aws-sdk-core (= 2.10.128)
+    aws-sdk-resources (2.11.8)
+      aws-sdk-core (= 2.11.8)
     aws-sigv4 (1.0.2)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -76,7 +76,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (13.7.16)
+    chef-config (13.8.0)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -90,9 +90,9 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21)
-    ffi (1.9.21-x64-mingw32)
-    ffi (1.9.21-x86-mingw32)
+    ffi (1.9.23)
+    ffi (1.9.23-x64-mingw32)
+    ffi (1.9.23-x86-mingw32)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -111,7 +111,7 @@ GEM
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.0)
+    license_scout (1.0.1)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -125,8 +125,8 @@ GEM
       mixlib-log
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.4)
-    mixlib-install (3.9.0)
+    mixlib-config (2.2.5)
+    mixlib-install (3.9.3)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -148,7 +148,7 @@ GEM
     nori (2.6.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (8.26.1)
+    ohai (13.8.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -177,7 +177,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable


### PR DESCRIPTION
This new Ohai fixes fetching Softlayer Metadata