### PR TITLE
[knife] Don't crash when a deprecated cookbook has no replacement (#6853)

### DIFF
--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -47,7 +47,12 @@ class Chef
       def run
         if current_cookbook_deprecated?
           message = "DEPRECATION: This cookbook has been deprecated. "
-          message << "It has been replaced by #{replacement_cookbook}."
+          replacement = replacement_cookbook
+          if !replacement.to_s.strip.empty?
+            message << "It has been replaced by #{replacement}."
+          else
+            message << "No replacement has been defined."
+          end
           ui.warn message
 
           unless config[:force]
@@ -105,7 +110,7 @@ class Chef
       end
 
       def replacement_cookbook
-        File.basename(current_cookbook_data["replacement"])
+        File.basename(current_cookbook_data["replacement"] || "")
       end
 
       def specific_cookbook_version_url


### PR DESCRIPTION
When installing the postgres cookbook, the following error was reported "TypeError: no implicit conversion of nil into String". Debugging the code, I found that the issue was caused by a missing "replacement" attribute on the cookbook while "deprecated"=>true. This commit is my proposed change to fix this issue. The updated code produces the following warning as opposed to an error: WARNING: DEPRECATION: This cookbook has been deprecated. No replacement has been defined.

Below is the error that I came across as I was trying to install the postgresql cookbook.

```
$ knife cookbook site install postgresql
Installing postgresql to /home/rlyders/chef-repo/cookbooks
Checking out the master branch.
Pristine copy branch (chef-vendor-postgresql) exists, switching to it.
Downloading postgresql from Supermarket at version 6.1.1 to /home/rlyders/chef-repo/cookbooks/postgresql.tar.gz
Cookbook saved: /home/rlyders/chef-repo/cookbooks/postgresql.tar.gz
Removing pre-existing version.
Uncompressing postgresql version 6.1.1.
Removing downloaded tarball
No changes made to postgresql
Checking out the master branch.
Installing compat_resource to /home/rlyders/chef-repo/cookbooks
Checking out the master branch.
Pristine copy branch (chef-vendor-compat_resource) exists, switching to it.
ERROR: TypeError: no implicit conversion of nil into String
```

The following is the debug log output that lead me to the source code:

```
$ knife cookbook site install postgresql -VV
. . .
/opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_download.rb:108:in `basename': no implicit conversion of nil into String (TypeError)
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_download.rb:108:in `replacement_cookbook'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_download.rb:50:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_install.rb:147:in `download_cookbook_to'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_install.rb:98:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_install.rb:124:in `block in run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_install.rb:119:in `each'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife/cookbook_site_install.rb:119:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife.rb:442:in `block in run_with_pretty_exceptions'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/local_mode.rb:44:in `with_server_connectivity'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife.rb:441:in `run_with_pretty_exceptions'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/knife.rb:219:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/application/knife.rb:156:in `run'
        from /opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/bin/knife:25:in `<top (required)>'
        from /opt/chefdk/embedded/bin/knife:23:in `load'
        from /opt/chefdk/embedded/bin/knife:23:in `<main>'
```

### Description

 Allows successful installation of a deprecated cookbook even if the "replacement" cookbook attribute is not defined.

### Issues Resolved

I am not aware of this issue being reported prior to this.