### PR TITLE
Add Ubuntu 18.04 Testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,6 +190,23 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
+      - bundle exec kitchen test base-ubuntu-1804
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+      - UBUNTU=18.04
+      - KITCHEN_YAML=.kitchen.travis.yml
+  - rvm: 2.4.3
+    services: docker
+    sudo: required
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
       - bundle exec kitchen test base-debian-8
     after_failure:
       - cat .kitchen/logs/kitchen.log

--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -93,6 +93,14 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get -y install sudo
 
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get -y install sudo
+
 - name: opensuse-leap
   driver:
     image: dokken/opensuse-leap
@@ -105,7 +113,7 @@ suites:
     run_list:
       - recipe[base::default]
   - name: awesome_customers_ubuntu
-    includes: [ubuntu-14.04, ubuntu-16.04]
+    includes: [ubuntu-14.04, ubuntu-16.04, ubuntu-18.04]
     run_list:
       - recipe[awesome_customers_ubuntu_wrapper::default]
   - name: awesome_customers_rhel


### PR DESCRIPTION
We have a dokken image for 18.04 based off the beta and rebuilding on a schedule in Docker Cloud.

Signed-off-by: Tim Smith <tsmith@chef.io>