### PR TITLE
Added source_file to FromFile

### DIFF
--- a/lib/chef/mixin/from_file.rb
+++ b/lib/chef/mixin/from_file.rb
@@ -21,11 +21,15 @@ class Chef
   module Mixin
     module FromFile
 
+      # Source path from which the object was loaded
+      attr_accessor :source_file
+
       # Loads a given ruby file, and runs instance_eval against it in the context of the current
       # object.
       #
       # Raises an IOError if the file cannot be found, or is not readable.
       def from_file(filename)
+        self.source_file = filename
         if File.exists?(filename) && File.readable?(filename)
           instance_eval(IO.read(filename), filename, 1)
         else
@@ -38,6 +42,7 @@ class Chef
       #
       # Raises an IOError if the file cannot be found, or is not readable.
       def class_from_file(filename)
+        self.source_file = filename
         if File.exists?(filename) && File.readable?(filename)
           class_eval(IO.read(filename), filename, 1)
         else

--- a/spec/data/mixin/invalid_data.rb
+++ b/spec/data/mixin/invalid_data.rb
@@ -1,0 +1,3 @@
+# For spec/functional/mixin/from_file_spec.rb
+a :foo
+c :bar

--- a/spec/data/mixin/real_data.rb
+++ b/spec/data/mixin/real_data.rb
@@ -1,0 +1,2 @@
+# For spec/functional/mixin/from_file_spec.rb
+a :foo

--- a/spec/functional/mixin/from_file_spec.rb
+++ b/spec/functional/mixin/from_file_spec.rb
@@ -1,0 +1,82 @@
+#
+# Copyright:: Copyright 2014-2018, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Mixin::FromFile do
+  REAL_DATA = File.join(CHEF_SPEC_DATA, "mixin", "real_data.rb")
+  INVALID_DATA = File.join(CHEF_SPEC_DATA, "mixin", "invalid_data.rb")
+  NO_DATA = File.join(CHEF_SPEC_DATA, "mixin", "non_existant_data.rb")
+
+  class TestData
+    include Chef::Mixin::FromFile
+
+    def a(a = nil)
+      @a = a if a
+      @a
+    end
+  end
+
+  class ClassTestData
+    class <<self
+      include Chef::Mixin::FromFile
+
+      def a(a = nil)
+        @a = a if a
+        @a
+      end
+    end
+  end
+
+  describe "from_file" do
+    it "should load data" do
+      datum = TestData.new
+      datum.from_file(REAL_DATA)
+      expect(datum.a).to eq(:foo)
+    end
+
+    it "should load class data" do
+      datum = ClassTestData
+      datum.class_from_file(REAL_DATA)
+      expect(datum.a).to eq(:foo)
+    end
+
+    it "should set source_file" do
+      datum = TestData.new
+      datum.from_file(REAL_DATA)
+      expect(datum.source_file).to eq(REAL_DATA)
+    end
+
+    it "should set class source_file" do
+      datum = ClassTestData
+      datum.class_from_file(REAL_DATA)
+      expect(datum.source_file).to eq(REAL_DATA)
+    end
+
+    it "should fail on invalid data" do
+      datum = TestData.new
+      expect do
+        datum.from_file(INVALID_DATA)
+      end.to raise_error(NoMethodError)
+    end
+
+    it "should fail on nonexistant data" do
+      datum = TestData.new
+      expect { datum.from_file(NO_DATA) }.to raise_error(IOError)
+    end
+  end
+end


### PR DESCRIPTION
### Description

This adds a new field `source_file` to the `FromFile` mixin that contains the source file used to load the object.

This is useful if you want to trace back a Role/Cookbook::Metadata to the file it was generated from.

We have some scripts that do some custom validation on Role/Cookbook::Metadata objects and currently monkeypatch the FromFile class to contain this attribute, but it'd be nice to have upstream and get rid of the monkeypatch. They mostly use this information to provide meaningful error messages to users in the event that this custom validation fails.

I double-checked that none of the classes using FromFile were already using the name `source_file` for something else, so this won't conflict with any of the code in the chef repo. Happy to rename if desired.

I didn't update `RELEASE_NOTES.d` since I thought this was a small change, but I can do that too, if necessary.

### Issues Resolved

*None*

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
