### PR TITLE
Update our tests based on new resources we ship

### DIFF
--- a/kitchen-tests/cookbooks/base/metadata.rb
+++ b/kitchen-tests/cookbooks/base/metadata.rb
@@ -8,8 +8,6 @@ version          "0.1.0"
 
 gem              "chef-sugar"
 
-depends          "apt"
-depends          "build-essential"
 depends          "chef-client"
 depends          "logrotate"
 depends          "multipackage"
@@ -31,6 +29,6 @@ supports         "opensuse"
 supports         "fedora"
 supports         "amazon"
 
-chef_version     ">= 13"
+chef_version     ">= 14"
 issues_url       "https://github.com/chef/chef/issues"
 source_url       "https://github.com/chef/chef"

--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -25,7 +25,7 @@ yum_repository "epel" do
   only_if { platform_family?("rhel") }
 end
 
-include_recipe "build-essential"
+build_essential "install compilation tools"
 
 include_recipe "::packages"
 


### PR DESCRIPTION
apt cookbook wasn't being used anywhere and build_essential resource is
built in now

Signed-off-by: Tim Smith <tsmith@chef.io>