### PR TITLE
fix typo in macports error handling

### DIFF
--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -91,7 +91,7 @@ class Chef
             raise Chef::Exceptions::Package, "Could not read from STDOUT on command: #{command}"
           end
           unless status.exitstatus == 0 || status.exitstatus == 1
-            raise Chef::Exceptions::Package, "#{command} failed - #{status.insect}!"
+            raise Chef::Exceptions::Package, "#{command} failed - #{status.inspect}!"
           end
           output
         end


### PR DESCRIPTION
Fixed minor typo in macports.rb: status.insect -> status.inspect