### PR TITLE
Check the platform family only in the apt_package provides

### DIFF
--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class AptPackage < Chef::Resource::Package
       resource_name :apt_package
-      provides :package, os: "linux", platform_family: "debian"
+      provides :package, platform_family: "debian"
 
       description "Use the apt_package resource to manage packages on Debian and Ubuntu platforms."
 


### PR DESCRIPTION
No reason for OS and platform_family.

Signed-off-by: Tim Smith <tsmith@chef.io>