### PR TITLE
osx_profile: set identity on the property not using identity_attr

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -28,15 +28,13 @@ class Chef
       provides :osx_profile, os: "darwin"
       provides :osx_config_profile, os: "darwin"
 
-      identity_attr :profile_name
-
       description "12.7"
 
       default_action :install
 
       allowed_actions :install, :remove
 
-      property :profile_name, String, name_property: true
+      property :profile_name, String, name_property: true, identity: true
       property :profile, [ String, Hash ]
       property :identifier, String
       property :path, String


### PR DESCRIPTION
Use the modern method not identity_attr

Signed-off-by: Tim Smith <tsmith@chef.io>