### PR TITLE
registry_key: Properly limit allowed values for architecture

### DIFF
--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -15,14 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "chef/provider/registry_key"
+
 require "chef/resource"
 require "chef/digester"
 
 class Chef
   class Resource
-    # Use the registry_key resource to create and delete registry keys in Microsoft Windows.
     class RegistryKey < Chef::Resource
+      resource_name :registry_key
+      provides :registry_key
+
+      description "Use the registry_key resource to create and delete registry keys in Microsoft Windows."
+      introduced "11.0"
+
       identity_attr :key
       state_attrs :values
 
@@ -62,8 +67,6 @@ class Chef
 
       def initialize(name, run_context = nil)
         super
-        @architecture = :machine
-        @recursive = false
         @key = name
         @values, @unscrubbed_values = [], []
       end
@@ -102,21 +105,8 @@ class Chef
         end
       end
 
-      def recursive(arg = nil)
-        set_or_return(
-          :recursive,
-          arg,
-          :kind_of => [TrueClass, FalseClass]
-        )
-      end
-
-      def architecture(arg = nil)
-        set_or_return(
-          :architecture,
-          arg,
-          :kind_of => Symbol
-        )
-      end
+      property :recursive, [TrueClass, FalseClass], default: false
+      property :architecture, Symbol, default: :machine, equal_to: [:machine, :x86_64, :i386]
 
       private
 

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Resource::RegistryKey, "initialize" do
     expect(resource.resource_name).to eql(:registry_key)
   end
 
-  it "sets the key equal to the argument to initialize" do
+  it "sets the key property to the resource name" do
     expect(resource.key).to eql('HKCU\Software\Raxicoricofallapatorius')
   end
 
@@ -157,6 +157,10 @@ describe Chef::Resource::RegistryKey, "architecture" do
       resource.architecture(arch)
       expect(resource.architecture).to eql(arch)
     end
+  end
+
+  it "does not allow other symbols" do
+    expect { resource.architecture(:nope) }.to raise_error(ArgumentError)
   end
 
   it "does not allow a hash" do


### PR DESCRIPTION
Partially modernize registry_key resource. The main fix here is that we limit what symbols can be passed to the architecture property now where as before it was wide open. This will probably help a bit since the docs are a bit confusing and also enormous.

Signed-off-by: Tim Smith <tsmith@chef.io>