### PR TITLE
splat array arguments of shell_out_*

### DIFF
--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -27,7 +27,7 @@ class Chef
           argdup = args.dup
           cmd = argdup.shift
           shellcmd = [ "dscl", ".", "-#{cmd}", argdup ]
-          status = shell_out_compact(shellcmd)
+          status = shell_out_compact(*shellcmd)
           stdout_result = ""
           stderr_result = ""
           status.stdout.each_line { |line| stdout_result << line }

--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -48,7 +48,7 @@ class Chef
             command += [ "-M", new_resource.members.join(",") ]
           end
 
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
         end
 
         # Manage the group when it already exists

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -163,7 +163,7 @@ class Chef
           unless new_resource.device == loopback_device
             command = add_command
             converge_by("run #{command.join(' ')} to add #{new_resource}") do
-              shell_out_compact!(command)
+              shell_out_compact!(*command)
               Chef::Log.info("#{new_resource} added")
             end
           end
@@ -179,7 +179,7 @@ class Chef
         return if new_resource.device == loopback_device
         command = enable_command
         converge_by("run #{command.join(' ')} to enable #{new_resource}") do
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
           Chef::Log.info("#{new_resource} enabled")
         end
       end
@@ -189,7 +189,7 @@ class Chef
         if current_resource.device
           command = delete_command
           converge_by("run #{command.join(' ')} to delete #{new_resource}") do
-            shell_out_compact!(command)
+            shell_out_compact!(*command)
             Chef::Log.info("#{new_resource} deleted")
           end
         else
@@ -204,7 +204,7 @@ class Chef
         if current_resource.device
           command = disable_command
           converge_by("run #{command.join(' ')} to disable #{new_resource}") do
-            shell_out_compact!(command)
+            shell_out_compact!(*command)
             Chef::Log.info("#{new_resource} disabled")
           end
         else

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -68,7 +68,7 @@ class Chef
           command = [ "pkg", options, "install", "-q" ]
           command << "--accept" if new_resource.accept_license
           command << "#{name}@#{version}"
-          shell_out_compact_timeout!(command)
+          shell_out_compact_timeout!(*command)
         end
 
         def upgrade_package(name, version)

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -49,21 +49,21 @@ class Chef
           unless current_resource.version == version
             command = [ "port", options, "install", name ]
             command << "@#{version}" if version && !version.empty?
-            shell_out_compact_timeout!(command)
+            shell_out_compact_timeout!(*command)
           end
         end
 
         def purge_package(name, version)
           command = [ "port", options, "uninstall", name ]
           command << "@#{version}" if version && !version.empty?
-          shell_out_compact_timeout!(command)
+          shell_out_compact_timeout!(*command)
         end
 
         def remove_package(name, version)
           command = [ "port", options, "deactivate", name ]
           command << "@#{version}" if version && !version.empty?
 
-          shell_out_compact_timeout!(command)
+          shell_out_compact_timeout!(*command)
         end
 
         def upgrade_package(name, version)
@@ -84,7 +84,7 @@ class Chef
 
         def get_response_from_command(command)
           output = nil
-          status = shell_out_compact_timeout(command)
+          status = shell_out_compact_timeout(*command)
           begin
             output = status.stdout
           rescue Exception

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -106,7 +106,7 @@ class Chef
                       else
                         [ "pkgadd", "-n", "-d", new_resource.source, "all" ]
                       end
-            shell_out_compact_timeout!(command)
+            shell_out_compact_timeout!(*command)
             Chef::Log.debug("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
             command = if ::File.directory?(new_resource.source) # CHEF-4469

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -133,7 +133,7 @@ class Chef
         else
           command = generate_command(:add)
           converge_by("run #{command.join(' ')} to add route") do
-            shell_out_compact!(command)
+            shell_out_compact!(*command)
             Chef::Log.info("#{new_resource} added")
           end
         end
@@ -146,7 +146,7 @@ class Chef
         if is_running
           command = generate_command(:delete)
           converge_by("run #{command.join(' ')} to delete route ") do
-            shell_out_compact!(command)
+            shell_out_compact!(*command)
             Chef::Log.info("#{new_resource} removed")
           end
         else

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -43,7 +43,7 @@ class Chef
         def remove_user
           command = [ "pw", "userdel", new_resource.username ]
           command << "-r" if new_resource.manage_home
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
         end
 
         def check_lock

--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -33,7 +33,7 @@ class Chef
             useradd.concat(universal_options)
             useradd.concat(useradd_options)
           end
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
         end
 
         def manage_user
@@ -41,7 +41,7 @@ class Chef
           command = compile_command("usermod") do |u|
             u.concat(universal_options)
           end
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
         end
 
         def remove_user
@@ -49,7 +49,7 @@ class Chef
           command << "-r" if new_resource.manage_home
           command << "-f" if new_resource.force
           command << new_resource.username
-          shell_out_compact!(command)
+          shell_out_compact!(*command)
         end
 
         def check_lock


### PR DESCRIPTION
lib/chef/mixin/shell_out.rb contains these methods:
```
def shell_out_compact(*args, **options)`
def shell_out_compact_timeout(*args, **options)
```

Some callers, e.g. lib/chef/provider/package/macports.rb pass the command as an array:
```
command = [ "port", "installed", new_resource.package_name ]
status = shell_out_compact_timeout(command)
```

This works fine in most cases:
```
def shell_out_compact_timeout(*args, **options)
  puts "args: " + args.inspect
  puts "options: " + options.inspect
end

command = [ "port", "installed", "zip" ]
status = shell_out_compact_timeout(command)
args: [["port", "installed", "zip"]]
options: {}
```

Things get more complicated when some cookbook has run `require 'extlib'`. Extlib monkey patches Array to have a to_hash method and this is very confusing to the shell_out_ methods:

```
require 'extlib'
# same as above
status = shell_out_compact_timeout(command)
args: [{"port"=>nil, "installed"=>nil, "zip"=>nil}]
options: {}
# in the macports case, this results in: port= command not found 
```

It seems that ruby is trying to use some implicit conversion here, but things go horribly wrong. One solution is to splat the argument to avoid the conversion: `shell_out_compact_timeout(*command)`. This PR adds such spats to all usages of shell_out *args/**options methods that I could find. 

I'm not a ruby expert, so I'm not sure if that's even the right approach to solving it? 
Note that some usages of shell_out that pass the command as an array already splat it. 