### PR TITLE
Properly validate reboot_action in dsc_resource

### DIFF
--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -55,7 +55,6 @@ class Chef
         super
         @properties = ToTextHash.new
         @resource = nil
-        @reboot_action = :nothing
       end
 
       def resource(value = nil)
@@ -105,13 +104,7 @@ class Chef
       # If the set method of the DSC resource indicate that a reboot
       # is necessary, reboot_action provides the mechanism for a reboot to
       # be requested.
-      def reboot_action(value = nil)
-        if value
-          @reboot_action = value
-        else
-          @reboot_action
-        end
-      end
+      property :reboot_action, Symbol, default: :nothing, equal_to: [:nothing, :reboot_now, :request_reboot]
 
       def timeout(arg = nil)
         set_or_return(


### PR DESCRIPTION
Check the passed value to see if it's one of the values we support instead of failing hard later when the user passes the wrong thing.

Signed-off-by: Tim Smith <tsmith@chef.io>