### PR TITLE
Avoid compile time error in apt_repository

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -119,15 +119,6 @@ class Chef
         end.compact
       end
 
-      # see if the keyfile is invalid such as a text file that is not actually a gpg key
-      # @param [String] keyfile the path to the keyfile
-      #
-      # @return [Boolean] is the key file invalid
-      def keyfile_is_invalid?(keyfile)
-        so = shell_out("gpg #{keyfile}")
-        so.error?
-      end
-
       # validate the key against the apt keystore to see if that version is expired
       # @param [String] key
       #
@@ -210,9 +201,13 @@ class Chef
           mode "0644"
           sensitive new_resource.sensitive
           action :create
+          notifies :run, "execute[validate keyfile]", :immediately
         end
 
-        raise "The key #{cached_keyfile} is invalid and cannot be used to verify an apt repository." if keyfile_is_invalid?(cached_keyfile)
+        declare_resource(:execute, "validate keyfile") do
+          action :nothing
+          command "gpg #{cached_keyfile}"
+        end
 
         declare_resource(:execute, "apt-key add #{cached_keyfile}") do
           sensitive new_resource.sensitive

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -201,12 +201,7 @@ class Chef
           mode "0644"
           sensitive new_resource.sensitive
           action :create
-          notifies :run, "execute[validate keyfile]", :immediately
-        end
-
-        declare_resource(:execute, "validate keyfile") do
-          action :nothing
-          command "gpg #{cached_keyfile}"
+          verify "gpg %{path}"
         end
 
         declare_resource(:execute, "apt-key add #{cached_keyfile}") do

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -251,16 +251,4 @@ C5986B4F1257FFA86632CBA746181433FBB75451
       expect(provider.build_repo("ppa:chef/main", "unstable", "main", false, nil)).to eql(target)
     end
   end
-
-  describe "#keyfile_is_invalid?" do
-    it "returns true if the file is invalid" do
-      expect(provider).to receive(:shell_out).and_return(gpg_shell_out_failure)
-      expect(provider.keyfile_is_invalid?("/foo/bar.key")).to be_truthy
-    end
-
-    it "returns false if the file is valid" do
-      expect(provider).to receive(:shell_out).and_return(gpg_shell_out_success)
-      expect(provider.keyfile_is_invalid?("/foo/bar.key")).to be_falsey
-    end
-  end
 end


### PR DESCRIPTION
My previous PR to apt_repository introduced a bug where gpg keys couldn't validate. This converts a raise to an execute so it all happens during converge.

Signed-off-by: Tim Smith <tsmith@chef.io>