### PR TITLE
Remove explicit setting of @provider and depend on ProviderResolver

### DIFF
--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -37,7 +37,6 @@ class Chef
         @use_last_modified = true
         @ftp_active_mode = false
         @headers = {}
-        @provider = Chef::Provider::RemoteFile
       end
 
       # source can take any of the following as arguments

--- a/spec/unit/resource/remote_file_spec.rb
+++ b/spec/unit/resource/remote_file_spec.rb
@@ -31,13 +31,11 @@ describe Chef::Resource::RemoteFile do
 
   it "says its provider is RemoteFile when the source is an absolute URI" do
     resource.source("http://www.google.com/robots.txt")
-    expect(resource.provider).to eq(Chef::Provider::RemoteFile)
     expect(resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 
   it "says its provider is RemoteFile when the source is a network share" do
     resource.source("\\\\fakey\\fakerton\\fake.txt")
-    expect(resource.provider).to eq(Chef::Provider::RemoteFile)
     expect(resource.provider_for_action(:create)).to be_kind_of(Chef::Provider::RemoteFile)
   end
 


### PR DESCRIPTION
### Description

Remove `remote_file` explicit setting of `@provider` in favor of `Chef::ProviderResolver` way of being.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
