### PR TITLE
Update @content_class assignment from = to ||=

### DIFF
--- a/lib/chef/provider/remote_file.rb
+++ b/lib/chef/provider/remote_file.rb
@@ -25,7 +25,7 @@ class Chef
       provides :remote_file
 
       def initialize(new_resource, run_context)
-        @content_class = Chef::Provider::RemoteFile::Content
+        @content_class ||= Chef::Provider::RemoteFile::Content
         super
       end
 


### PR DESCRIPTION
### Description

Update the assignment of `@content_class` to use `||=` so that inheritance of
`Chef::Provider::RemoteFile` is easier to do.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
