### PR TITLE
Switch to a smaller gem to install in kitchen runs

### DIFF
--- a/kitchen-tests/cookbooks/base/recipes/packages.rb
+++ b/kitchen-tests/cookbooks/base/recipes/packages.rb
@@ -15,7 +15,7 @@ pkgs.each do |pkg|
   multipackage pkgs
 end
 
-gems = %w{fpm aws-sdk}
+gems = %w{fpm community_cookbook_releaser}
 
 gems.each do |gem|
   chef_gem gem do


### PR DESCRIPTION
aws-sdk is 132 gems now. It takes *forever* to install on some platforms
like CentOS 6. Use a simple gem.

Signed-off-by: Tim Smith <tsmith@chef.io>