### PR TITLE
RFC 106: expose name and chef_environment as attrs

### DIFF
--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -330,6 +330,8 @@ class Chef
       Chef::Log.debug("Platform is #{platform} version #{version}")
       automatic[:platform] = platform
       automatic[:platform_version] = version
+      automatic[:name] = name
+      automatic[:chef_environment] = chef_environment
     end
 
     def consume_ohai_data(ohai_data)
@@ -421,6 +423,7 @@ class Chef
 
       apply_expansion_attributes(expansion)
 
+      automatic_attrs[:chef_environment] = chef_environment
       expansion
     end
 
@@ -510,7 +513,16 @@ class Chef
       return o if o.kind_of? Chef::Node
       node = new
       node.name(o["name"])
-      node.chef_environment(o["chef_environment"])
+
+      node.policy_name = o["policy_name"] if o.has_key?("policy_name")
+      node.policy_group = o["policy_group"] if o.has_key?("policy_group")
+
+      unless node.policy_group.nil?
+        node.chef_environment(o["policy_group"])
+      else
+        node.chef_environment(o["chef_environment"])
+      end
+
       if o.has_key?("attributes")
         node.normal_attrs = o["attributes"]
       end
@@ -524,9 +536,6 @@ class Chef
       elsif o.has_key?("recipes")
         o["recipes"].each { |r| node.recipes << r }
       end
-
-      node.policy_name = o["policy_name"] if o.has_key?("policy_name")
-      node.policy_group = o["policy_group"] if o.has_key?("policy_group")
 
       node
     end

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -164,6 +164,11 @@ class Chef
         events.node_load_completed(node, run_list_with_versions_for_display, Chef::Config)
         events.run_list_expanded(run_list_expansion_ish)
 
+        # we must do this after `node.consume_external_attrs`
+        node.automatic_attrs[:policy_name] = node.policy_name
+        node.automatic_attrs[:policy_group] = node.policy_group
+        node.automatic_attrs[:chef_environment] = node.policy_group
+
         node
       rescue Exception => e
         events.node_load_failed(node_name, e, Chef::Config)
@@ -400,6 +405,7 @@ class Chef
 
         node.policy_name = policy_name_to_set
         node.policy_group = policy_group_to_set
+        node.chef_environment = policy_group_to_set
 
         Chef::Config[:policy_name] = policy_name_to_set
         Chef::Config[:policy_group] = policy_group_to_set

--- a/spec/unit/knife/core/node_editor_spec.rb
+++ b/spec/unit/knife/core/node_editor_spec.rb
@@ -100,10 +100,10 @@ describe Chef::Knife::NodeEditor do
         expect(updated_node).to be_a(Chef::Node)
 
         # Expected to have been changed
-        expect(updated_node.chef_environment).to eql(updated_data["chef_environment"])
         expect(updated_node.normal_attrs).to eql(updated_data["normal"])
         expect(updated_node.policy_name).to eql(updated_data["policy_name"])
         expect(updated_node.policy_group).to eql(updated_data["policy_group"])
+        expect(updated_node.chef_environment).to eql(updated_data["policy_group"])
         expect(updated_node.run_list.map(&:to_s)).to eql(updated_data["run_list"])
 
         # Expected not to have changed
@@ -131,7 +131,7 @@ describe Chef::Knife::NodeEditor do
         updated_node = subject.apply_updates(updated_data)
         expect(updated_node).to be_a(Chef::Node)
 
-        expect(updated_node.chef_environment).to eql(updated_data["chef_environment"])
+        expect(updated_node.chef_environment).to eql(updated_data["policy_group"])
         expect(updated_node.automatic_attrs).to eql(updated_data["automatic"])
         expect(updated_node.normal_attrs).to eql(updated_data["normal"])
         expect(updated_node.default_attrs).to eql(updated_data["default"])
@@ -173,7 +173,7 @@ describe Chef::Knife::NodeEditor do
           end
 
           it "returns an array of the changed property names" do
-            expect(subject.updated?).to eql %w{ normal policy_name policy_group run_list }
+            expect(subject.updated?).to eql %w{ chef_environment normal policy_name policy_group run_list }
           end
         end
 
@@ -190,7 +190,7 @@ describe Chef::Knife::NodeEditor do
 
           it "returns an array of property names that doesn't include " +
             "the non-editable properties" do
-            expect(subject.updated?).to eql %w{ normal policy_name policy_group run_list }
+            expect(subject.updated?).to eql %w{ chef_environment normal policy_name policy_group run_list }
           end
         end
       end

--- a/spec/unit/knife/node_edit_spec.rb
+++ b/spec/unit/knife/node_edit_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Knife::NodeEdit do
 
   # helper to convert the view from Chef objects into Ruby objects representing JSON
   def deserialized_json_view
-    actual = Chef::JSONCompat.from_json(Chef::JSONCompat.to_json_pretty(@knife.node_editor.send(:view)))
+    Chef::JSONCompat.from_json(Chef::JSONCompat.to_json_pretty(@knife.node_editor.send(:view)))
   end
 
   before(:each) do
@@ -45,6 +45,8 @@ describe Chef::Knife::NodeEdit do
 
   describe "after loading the node" do
     before do
+      @knife.config[:all_attributes] = false
+
       allow(@knife).to receive(:node).and_return(@node)
       @node.automatic_attrs = { :go => :away }
       @node.default_attrs = { :hide => :me }

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -186,7 +186,7 @@ describe Chef::Node do
       expect { node.policy_group = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:." }.to_not raise_error
     end
 
-    it "sets an environment with chef_environment(something)" do
+    it "sets a policy_group with policy_group(something)" do
       node.policy_group("staging")
       expect(node.policy_group).to eq("staging")
     end
@@ -1353,6 +1353,7 @@ describe Chef::Node do
 
         expect(round_tripped_node.policy_name).to eq("my-application")
         expect(round_tripped_node.policy_group).to eq("staging")
+        expect(round_tripped_node.chef_environment).to eq("staging")
       end
 
     end

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -574,6 +574,10 @@ describe Chef::PolicyBuilder::Policyfile do
               expect(Chef::Config[:policy_group]).to eq("policy_group_from_node_json")
               expect(node.policy_name).to eq("policy_name_from_node_json")
               expect(node.policy_group).to eq("policy_group_from_node_json")
+              expect(node.automatic_attrs[:policy_name]).to eq("policy_name_from_node_json")
+              expect(node.automatic_attrs[:policy_group]).to eq("policy_group_from_node_json")
+              expect(node.automatic_attrs[:chef_environment]).to eq("policy_group_from_node_json")
+
             end
 
           end
@@ -623,6 +627,7 @@ describe Chef::PolicyBuilder::Policyfile do
           it "create node.automatic_attrs[:recipes]" do
             expect(node.automatic_attrs[:recipes]).to eq(["example1::default", "example2::server"])
           end
+
         end
 
         context "when a named run_list is given" do


### PR DESCRIPTION
We also now set chef_environment the same as policy group when that's
appropriate