### PR TITLE
Remove redundant parentheses

### DIFF
--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -153,7 +153,7 @@ class Chef
       end
     end
 
-    def destroy(data_bag = self.data_bag(), databag_item = name)
+    def destroy(data_bag = self.data_bag, databag_item = name)
       chef_server_rest.delete("data/#{data_bag}/#{databag_item}")
     end
 

--- a/lib/chef/file_content_management/deploy.rb
+++ b/lib/chef/file_content_management/deploy.rb
@@ -27,9 +27,9 @@ class Chef
     class Deploy
       def self.strategy(atomic_update)
         if atomic_update
-          Chef::Platform.windows? ? MvWindows.new() : MvUnix.new()
+          Chef::Platform.windows? ? MvWindows.new : MvUnix.new
         else
-          Cp.new()
+          Cp.new
         end
       end
     end

--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -102,7 +102,7 @@ class Chef
         if purge
           Dir.glob(::File.join(Chef::Util::PathHelper.escape_glob_dir(path), "**", "*"), ::File::FNM_DOTMATCH).sort!.reverse!.each do |file|
             # skip '.' and '..'
-            next if [".", ".."].include?(Pathname.new(file).basename().to_s)
+            next if [".", ".."].include?(Pathname.new(file).basename.to_s)
 
             # Clean the path.  This is required because of the ::File.join
             file = Chef::Util::PathHelper.cleanpath(file)

--- a/spec/data/cookbooks/angrybash/recipes/default.rb
+++ b/spec/data/cookbooks/angrybash/recipes/default.rb
@@ -1,6 +1,6 @@
 bash "go off the rails" do
   code <<-END
-    for i in localhost 127.0.0.1 #{Socket.gethostname()}
+    for i in localhost 127.0.0.1 #{Socket.gethostname}
     do
       echo "grant all on *.* to root@'$i' identified by 'a_password'; flush privileges;" | mysql -u root -h 127.0.0.1
     done

--- a/spec/unit/chef_fs/config_spec.rb
+++ b/spec/unit/chef_fs/config_spec.rb
@@ -23,7 +23,7 @@ require "lib/chef/chef_fs/config.rb"
 describe Chef::ChefFS::Config do
   describe "initialize" do
     it "warns when hosted setups use 'everything'" do
-      base_config = Hash.new()
+      base_config = Hash.new
       base_config[:repo_mode] = "everything"
       base_config[:chef_server_url] = "http://foo.com/organizations/fake_org/"
 
@@ -34,7 +34,7 @@ describe Chef::ChefFS::Config do
     end
 
     it "doesn't warn when hosted setups use 'hosted_everything'" do
-      base_config = Hash.new()
+      base_config = Hash.new
       base_config[:repo_mode] = "hosted_everything"
       base_config[:chef_server_url] = "http://foo.com/organizations/fake_org/"
 
@@ -45,7 +45,7 @@ describe Chef::ChefFS::Config do
     end
 
     it "doesn't warn when non-hosted setups use 'everything'" do
-      base_config = Hash.new()
+      base_config = Hash.new
       base_config[:repo_mode] = "everything"
       base_config[:chef_server_url] = "http://foo.com/"
 

--- a/spec/unit/http/json_input_spec.rb
+++ b/spec/unit/http/json_input_spec.rb
@@ -21,7 +21,7 @@ require "chef/http/json_input"
 
 describe Chef::HTTP::JSONInput do
 
-  let(:json_encoder) { described_class.new() }
+  let(:json_encoder) { described_class.new }
 
   let(:url) { URI.parse("http://example.com") }
   let(:headers) { {} }

--- a/spec/unit/knife/client_bulk_delete_spec.rb
+++ b/spec/unit/knife/client_bulk_delete_spec.rb
@@ -45,7 +45,7 @@ describe Chef::Knife::ClientBulkDelete do
     clients = Hash.new
 
     nonvalidator_client_names.each do |client_name|
-      client = Chef::ApiClientV1.new()
+      client = Chef::ApiClientV1.new
       client.name(client_name)
       allow(client).to receive(:destroy).and_return(true)
       clients[client_name] = client
@@ -59,7 +59,7 @@ describe Chef::Knife::ClientBulkDelete do
     clients = Hash.new
 
     validator_client_names.each do |validator_client_name|
-      validator_client = Chef::ApiClientV1.new()
+      validator_client = Chef::ApiClientV1.new
       validator_client.name(validator_client_name)
       allow(validator_client).to receive(:validator).and_return(true)
       allow(validator_client).to receive(:destroy).and_return(true)

--- a/spec/unit/knife/cookbook_site_share_spec.rb
+++ b/spec/unit/knife/cookbook_site_share_spec.rb
@@ -175,7 +175,7 @@ describe Chef::Knife::CookbookSiteShare do
       response_text = Chef::JSONCompat.to_json({ :uri => "https://supermarket.chef.io/cookbooks/cookbook_name" })
       allow(@upload_response).to receive(:body).and_return(response_text)
       allow(@upload_response).to receive(:code).and_return(201)
-      expect(Chef::CookbookSiteStreamingUploader).to receive(:post).with(/supermarket\.chef\.io/, anything(), anything(), anything())
+      expect(Chef::CookbookSiteStreamingUploader).to receive(:post).with(/supermarket\.chef\.io/, anything, anything, anything)
       @knife.run
     end
 

--- a/spec/unit/knife/node_bulk_delete_spec.rb
+++ b/spec/unit/knife/node_bulk_delete_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Knife::NodeBulkDelete do
   describe "run" do
     before do
       @inflatedish_list = @nodes.keys.inject({}) do |nodes_by_name, name|
-        node = Chef::Node.new()
+        node = Chef::Node.new
         node.name(name)
         allow(node).to receive(:destroy).and_return(true)
         nodes_by_name[name] = node

--- a/spec/unit/knife/node_delete_spec.rb
+++ b/spec/unit/knife/node_delete_spec.rb
@@ -29,8 +29,8 @@ describe Chef::Knife::NodeDelete do
     allow(@knife).to receive(:output).and_return(true)
     allow(@knife).to receive(:confirm).and_return(true)
 
-    @adam_node = Chef::Node.new()
-    @ben_node = Chef::Node.new()
+    @adam_node = Chef::Node.new
+    @ben_node = Chef::Node.new
     allow(@ben_node).to receive(:destroy).and_return(true)
     allow(@adam_node).to receive(:destroy).and_return(true)
     allow(Chef::Node).to receive(:load).with("adam").and_return(@adam_node)

--- a/spec/unit/knife/node_edit_spec.rb
+++ b/spec/unit/knife/node_edit_spec.rb
@@ -35,7 +35,7 @@ describe Chef::Knife::NodeEdit do
       :print_after => nil,
     }
     @knife.name_args = [ "adam" ]
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
   end
 
   it "should load the node" do

--- a/spec/unit/knife/node_environment_set_spec.rb
+++ b/spec/unit/knife/node_environment_set_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Knife::NodeEnvironmentSet do
     @knife = Chef::Knife::NodeEnvironmentSet.new
     @knife.name_args = %w{adam bar}
     allow(@knife).to receive(:output).and_return(true)
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
     @node.name("knifetest-node")
     @node.chef_environment << "foo"
     allow(@node).to receive(:save).and_return(true)

--- a/spec/unit/knife/node_from_file_spec.rb
+++ b/spec/unit/knife/node_from_file_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::NodeFromFile do
     @knife.name_args = [ "adam.rb" ]
     allow(@knife).to receive(:output).and_return(true)
     allow(@knife).to receive(:confirm).and_return(true)
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
     allow(@node).to receive(:save)
     allow(@knife.loader).to receive(:load_from).and_return(@node)
     @stdout = StringIO.new

--- a/spec/unit/knife/node_policy_set_spec.rb
+++ b/spec/unit/knife/node_policy_set_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::Knife::NodePolicySet do
   let(:node) do
-    node = Chef::Node.new()
+    node = Chef::Node.new
     node.name("adam")
     node.run_list = ["role[base]"]
     node

--- a/spec/unit/knife/node_run_list_add_spec.rb
+++ b/spec/unit/knife/node_run_list_add_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::NodeRunListAdd do
     }
     @knife.name_args = [ "adam", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
     allow(@node).to receive(:save).and_return(true)
     allow(Chef::Node).to receive(:load).and_return(@node)
   end

--- a/spec/unit/knife/node_run_list_remove_spec.rb
+++ b/spec/unit/knife/node_run_list_remove_spec.rb
@@ -24,7 +24,7 @@ describe Chef::Knife::NodeRunListRemove do
     @knife = Chef::Knife::NodeRunListRemove.new
     @knife.config[:print_after] = nil
     @knife.name_args = [ "adam", "role[monkey]" ]
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
     @node.name("knifetest-node")
     @node.run_list << "role[monkey]"
     allow(@node).to receive(:save).and_return(true)

--- a/spec/unit/knife/node_run_list_set_spec.rb
+++ b/spec/unit/knife/node_run_list_set_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::NodeRunListSet do
     @knife.config = {}
     @knife.name_args = [ "adam", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
-    @node = Chef::Node.new()
+    @node = Chef::Node.new
     allow(@node).to receive(:save).and_return(true)
     allow(Chef::Node).to receive(:load).and_return(@node)
   end

--- a/spec/unit/knife/node_show_spec.rb
+++ b/spec/unit/knife/node_show_spec.rb
@@ -21,7 +21,7 @@ require "spec_helper"
 describe Chef::Knife::NodeShow do
 
   let(:node) do
-    node = Chef::Node.new()
+    node = Chef::Node.new
     node.name("adam")
     node.run_list = ["role[base]"]
     node

--- a/spec/unit/knife/role_bulk_delete_spec.rb
+++ b/spec/unit/knife/role_bulk_delete_spec.rb
@@ -31,7 +31,7 @@ describe Chef::Knife::RoleBulkDelete do
     allow(@knife.ui).to receive(:confirm).and_return(true)
     @roles = Hash.new
     %w{dev staging production}.each do |role_name|
-      role = Chef::Role.new()
+      role = Chef::Role.new
       role.name(role_name)
       allow(role).to receive(:destroy).and_return(true)
       @roles[role_name] = role

--- a/spec/unit/knife/role_create_spec.rb
+++ b/spec/unit/knife/role_create_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Knife::RoleCreate do
     }
     @knife.name_args = [ "adam" ]
     allow(@knife).to receive(:output).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:save)
     allow(Chef::Role).to receive(:new).and_return(@role)
     allow(@knife).to receive(:edit_data).and_return(@role)

--- a/spec/unit/knife/role_delete_spec.rb
+++ b/spec/unit/knife/role_delete_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Knife::RoleDelete do
     @knife.name_args = [ "adam" ]
     allow(@knife).to receive(:output).and_return(true)
     allow(@knife).to receive(:confirm).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:destroy).and_return(true)
     allow(Chef::Role).to receive(:load).and_return(@role)
     @stdout = StringIO.new

--- a/spec/unit/knife/role_edit_spec.rb
+++ b/spec/unit/knife/role_edit_spec.rb
@@ -25,7 +25,7 @@ describe Chef::Knife::RoleEdit do
     @knife.config[:print_after] = nil
     @knife.name_args = [ "adam" ]
     allow(@knife.ui).to receive(:output).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:save)
     allow(Chef::Role).to receive(:load).and_return(@role)
     allow(@knife.ui).to receive(:edit_data).and_return(@role)

--- a/spec/unit/knife/role_env_run_list_add_spec.rb
+++ b/spec/unit/knife/role_env_run_list_add_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Knife::RoleEnvRunListAdd do
     }
     @knife.name_args = [ "will", "QA", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:save).and_return(true)
     allow(Chef::Role).to receive(:load).and_return(@role)
   end

--- a/spec/unit/knife/role_env_run_list_clear_spec.rb
+++ b/spec/unit/knife/role_env_run_list_clear_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Knife::RoleEnvRunListClear do
     @knife.name_args = %w{will QA}
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_env_run_list_remove_spec.rb
+++ b/spec/unit/knife/role_env_run_list_remove_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Knife::RoleEnvRunListRemove do
     @knife.name_args = [ "will", "QA", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_env_run_list_replace_spec.rb
+++ b/spec/unit/knife/role_env_run_list_replace_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Knife::RoleEnvRunListReplace do
     @knife.name_args = [ "will", "QA", "role[dude]", "role[person]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_env_run_list_set_spec.rb
+++ b/spec/unit/knife/role_env_run_list_set_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Knife::RoleEnvRunListSet do
     @knife.name_args = [ "will", "QA", "role[owen]", "role[mauntel]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_from_file_spec.rb
+++ b/spec/unit/knife/role_from_file_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::RoleFromFile do
     @knife.name_args = [ "adam.rb" ]
     allow(@knife).to receive(:output).and_return(true)
     allow(@knife).to receive(:confirm).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:save)
     allow(@knife.loader).to receive(:load_from).and_return(@role)
     @stdout = StringIO.new

--- a/spec/unit/knife/role_run_list_add_spec.rb
+++ b/spec/unit/knife/role_run_list_add_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Knife::RoleRunListAdd do
     }
     @knife.name_args = [ "will", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     allow(@role).to receive(:save).and_return(true)
     allow(Chef::Role).to receive(:load).and_return(@role)
   end

--- a/spec/unit/knife/role_run_list_clear_spec.rb
+++ b/spec/unit/knife/role_run_list_clear_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Knife::RoleRunListClear do
     @knife.name_args = [ "will" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_run_list_remove_spec.rb
+++ b/spec/unit/knife/role_run_list_remove_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Knife::RoleRunListRemove do
     @knife.name_args = [ "will", "role[monkey]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_run_list_replace_spec.rb
+++ b/spec/unit/knife/role_run_list_replace_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Knife::RoleRunListReplace do
     @knife.name_args = [ "will", "role[dude]", "role[person]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/knife/role_run_list_set_spec.rb
+++ b/spec/unit/knife/role_run_list_set_spec.rb
@@ -32,7 +32,7 @@ describe Chef::Knife::RoleRunListSet do
     @knife.name_args = [ "will", "role[owen]", "role[mauntel]" ]
     allow(@knife).to receive(:output).and_return(true)
 
-    @role = Chef::Role.new()
+    @role = Chef::Role.new
     @role.name("will")
     allow(@role).to receive(:save).and_return(true)
 

--- a/spec/unit/mixin/homebrew_user_spec.rb
+++ b/spec/unit/mixin/homebrew_user_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Mixin::HomebrewUser do
     let(:brew_owner) { 2001 }
     let(:default_brew_path) { "/usr/local/bin/brew" }
     let(:stat_double) do
-      d = double()
+      d = double
       expect(d).to receive(:uid).and_return(brew_owner)
       d
     end

--- a/spec/unit/provider/mount/mount_spec.rb
+++ b/spec/unit/provider/mount/mount_spec.rb
@@ -59,7 +59,7 @@ describe Chef::Provider::Mount::Mount do
       @new_resource.device "d21afe51-a0fe-4dc6-9152-ac733763ae0a"
       @stdout_findfs = double("STDOUT", :first => "/dev/sdz1")
       expect(@provider).to receive(:shell_out).with("/sbin/findfs UUID=d21afe51-a0fe-4dc6-9152-ac733763ae0a").and_return(@status)
-      @provider.load_current_resource()
+      @provider.load_current_resource
       @provider.mountable?
     end
 
@@ -99,36 +99,36 @@ describe Chef::Provider::Mount::Mount do
       @new_resource.device "d21afe51-a0fe-4dc6-9152-ac733763ae0a"
       expect(@provider).to receive(:shell_out).with("/sbin/findfs UUID=d21afe51-a0fe-4dc6-9152-ac733763ae0a").and_return(status)
       expect(::File).to receive(:exists?).with("").and_return(false)
-      expect { @provider.load_current_resource(); @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
+      expect { @provider.load_current_resource; @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
     it "should raise an error if the mount point does not exist" do
       allow(::File).to receive(:exists?).with("/tmp/foo").and_return false
-      expect { @provider.load_current_resource(); @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
+      expect { @provider.load_current_resource; @provider.mountable? }.to raise_error(Chef::Exceptions::Mount)
     end
 
     %w{tmpfs fuse cgroup vboxsf zfs}.each do |fstype|
       it "does not expect the device to exist for #{fstype}" do
         @new_resource.fstype(fstype)
         @new_resource.device("whatever")
-        expect { @provider.load_current_resource(); @provider.mountable? }.not_to raise_error
+        expect { @provider.load_current_resource; @provider.mountable? }.not_to raise_error
       end
     end
 
     it "does not expect the device to exist if it's none" do
       @new_resource.device("none")
-      expect { @provider.load_current_resource(); @provider.mountable? }.not_to raise_error
+      expect { @provider.load_current_resource; @provider.mountable? }.not_to raise_error
     end
 
     it "should set mounted true if the mount point is found in the mounts list" do
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => "/dev/sdz1 on /tmp/foo type ext3 (rw)\n"))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_truthy
     end
 
     it "should set mounted false if another mount point beginning with the same path is found in the mounts list" do
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => "/dev/sdz1 on /tmp/foobar type ext3 (rw)\n"))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_falsey
     end
 
@@ -140,7 +140,7 @@ describe Chef::Provider::Mount::Mount do
       allow(::File).to receive(:readlink).with("#{@new_resource.device}").and_return(target)
 
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => "#{target} on /tmp/foo type ext3 (rw)\n"))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_truthy
     end
 
@@ -154,7 +154,7 @@ describe Chef::Provider::Mount::Mount do
       allow(::File).to receive(:readlink).with("#{@new_resource.device}").and_return(target)
 
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => "#{absolute_target} on /tmp/foo type ext3 (rw)\n"))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_truthy
     end
 
@@ -163,7 +163,7 @@ describe Chef::Provider::Mount::Mount do
       mount << "#{@new_resource.device} on #{@new_resource.mount_point} type ext3 (rw)\n"
 
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => mount))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_truthy
     end
 
@@ -172,13 +172,13 @@ describe Chef::Provider::Mount::Mount do
       mount << "/dev/sdy1 on #{@new_resource.mount_point} type ext3 (rw)\n"
 
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => mount))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_falsey
     end
 
     it "mounted should be false if the mount point is not found in the mounts list" do
       allow(@provider).to receive(:shell_out!).and_return(OpenStruct.new(:stdout => "/dev/sdy1 on /tmp/foo type ext3 (rw)\n"))
-      @provider.load_current_resource()
+      @provider.load_current_resource
       expect(@provider.current_resource.mounted).to be_falsey
     end
 
@@ -296,14 +296,14 @@ describe Chef::Provider::Mount::Mount do
     describe "mount_fs" do
       it "should mount the filesystem if it is not mounted" do
         expect(@provider).to receive(:shell_out!).with("mount -t ext3 -o defaults /dev/sdz1 /tmp/foo")
-        @provider.mount_fs()
+        @provider.mount_fs
       end
 
       it "should mount the filesystem with options if options were passed" do
         options = "rw,noexec,noauto"
         @new_resource.options(%w{rw noexec noauto})
         expect(@provider).to receive(:shell_out!).with("mount -t ext3 -o rw,noexec,noauto /dev/sdz1 /tmp/foo")
-        @provider.mount_fs()
+        @provider.mount_fs
       end
 
       it "should mount the filesystem specified by uuid", :not_supported_on_solaris do
@@ -314,13 +314,13 @@ describe Chef::Provider::Mount::Mount do
         @stdout_mock = double("stdout mock")
         allow(@stdout_mock).to receive(:each).and_yield("#{@new_resource.device} on #{@new_resource.mount_point}")
         expect(@provider).to receive(:shell_out!).with("mount -t #{@new_resource.fstype} -o defaults -U #{@new_resource.device} #{@new_resource.mount_point}").and_return(@stdout_mock)
-        @provider.mount_fs()
+        @provider.mount_fs
       end
 
       it "should not mount the filesystem if it is mounted" do
         allow(@current_resource).to receive(:mounted).and_return(true)
         expect(@provider).not_to receive(:shell_out!)
-        @provider.mount_fs()
+        @provider.mount_fs
       end
 
     end
@@ -329,13 +329,13 @@ describe Chef::Provider::Mount::Mount do
       it "should umount the filesystem if it is mounted" do
         @current_resource.mounted(true)
         expect(@provider).to receive(:shell_out!).with("umount /tmp/foo")
-        @provider.umount_fs()
+        @provider.umount_fs
       end
 
       it "should not umount the filesystem if it is not mounted" do
         @current_resource.mounted(false)
         expect(@provider).not_to receive(:shell_out!)
-        @provider.umount_fs()
+        @provider.umount_fs
       end
     end
 
@@ -362,7 +362,7 @@ describe Chef::Provider::Mount::Mount do
         expect(@provider).to receive(:umount_fs)
         expect(@provider).to receive(:sleep).with(1)
         expect(@provider).to receive(:mount_fs)
-        @provider.remount_fs()
+        @provider.remount_fs
       end
 
       it "should not try to remount at all if mounted is false" do
@@ -370,7 +370,7 @@ describe Chef::Provider::Mount::Mount do
         expect(@provider).not_to receive(:shell_out!)
         expect(@provider).not_to receive(:umount_fs)
         expect(@provider).not_to receive(:mount_fs)
-        @provider.remount_fs()
+        @provider.remount_fs
       end
     end
 

--- a/spec/unit/provider/mount/solaris_spec.rb
+++ b/spec/unit/provider/mount/solaris_spec.rb
@@ -350,7 +350,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         expect(File).to receive(:symlink?).with(device).at_least(:once).and_return(true)
         expect(File).to receive(:readlink).with(device).at_least(:once).and_return(target)
 
-        provider.load_current_resource()
+        provider.load_current_resource
       end
 
       it "should set mounted true if the symlink target of the device is found in the mounts list" do
@@ -387,7 +387,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         expect(File).to receive(:symlink?).with(device).at_least(:once).and_return(true)
         expect(File).to receive(:readlink).with(device).at_least(:once).and_return(target)
 
-        provider.load_current_resource()
+        provider.load_current_resource
       end
 
       it "should set mounted true if the symlink target of the device is found in the mounts list" do
@@ -411,7 +411,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         EOF
       end
       it "should set mounted true" do
-        provider.load_current_resource()
+        provider.load_current_resource
         expect(provider.current_resource.mounted).to be_truthy
       end
     end
@@ -424,7 +424,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         EOF
       end
       it "should set mounted false" do
-        provider.load_current_resource()
+        provider.load_current_resource
         expect(provider.current_resource.mounted).to be_falsey
       end
     end
@@ -436,7 +436,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         EOF
       end
       it "should set mounted false" do
-        provider.load_current_resource()
+        provider.load_current_resource
         expect(provider.current_resource.mounted).to be_falsey
       end
     end
@@ -448,7 +448,7 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
         EOF
       end
       it "should set mounted false" do
-        provider.load_current_resource()
+        provider.load_current_resource
         expect(provider.current_resource.mounted).to be_falsey
       end
     end
@@ -539,28 +539,28 @@ describe Chef::Provider::Mount::Solaris, :unix_only do
     describe "mount_fs" do
       it "should mount the filesystem" do
         expect(provider).to receive(:shell_out!).with("mount -F #{fstype} -o defaults #{device} #{mountpoint}")
-        provider.mount_fs()
+        provider.mount_fs
       end
 
       it "should mount the filesystem with options if options were passed" do
         options = "logging,noatime,largefiles,nosuid,rw,quota"
         new_resource.options(options.split(/,/))
         expect(provider).to receive(:shell_out!).with("mount -F #{fstype} -o #{options} #{device} #{mountpoint}")
-        provider.mount_fs()
+        provider.mount_fs
       end
 
       it "should delete the 'noauto' magic option" do
         options = "rw,noauto"
         new_resource.options(%w{rw noauto})
         expect(provider).to receive(:shell_out!).with("mount -F #{fstype} -o rw #{device} #{mountpoint}")
-        provider.mount_fs()
+        provider.mount_fs
       end
     end
 
     describe "umount_fs" do
       it "should umount the filesystem if it is mounted" do
         expect(provider).to receive(:shell_out!).with("umount #{mountpoint}")
-        provider.umount_fs()
+        provider.umount_fs
       end
     end
 

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -45,14 +45,14 @@ describe Chef::Provider::Package::Openbsd do
 
     context "when not already installed" do
       before do
-        allow(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
+        allow(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{name}->0", anything).and_return(instance_double("shellout", :stdout => ""))
       end
 
       context "when there is a single candidate" do
 
         context "when source is not provided" do
           it "should run the installation command" do
-            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything()).and_return(
+            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything).and_return(
               instance_double("shellout", :stdout => "#{name}-#{version}\n"))
             expect(provider).to receive(:shell_out!).with(
               "pkg_add", "-r", "#{name}-#{version}",
@@ -83,8 +83,8 @@ describe Chef::Provider::Package::Openbsd do
 
           context "if no version is specified" do
             it "should run the installation command" do
-              expect(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{package_name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
-              expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything()).and_return(
+              expect(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{package_name}->0", anything).and_return(instance_double("shellout", :stdout => ""))
+              expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything).and_return(
                 instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor}\n"))
               expect(provider).to receive(:shell_out!).with(
                 "pkg_add", "-r", "#{name}-#{version}-#{flavor}",
@@ -98,7 +98,7 @@ describe Chef::Provider::Package::Openbsd do
 
         context "if a version is specified" do
           it "should use the flavor from the version" do
-            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", "#{name}-#{version}-#{flavor_b}", anything()).and_return(
+            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", "#{name}-#{version}-#{flavor_b}", anything).and_return(
               instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor_a}\n"))
 
             new_resource.version("#{version}-#{flavor_b}")

--- a/spec/unit/provider/package/smartos_spec.rb
+++ b/spec/unit/provider/package/smartos_spec.rb
@@ -75,7 +75,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
     end
 
     it "should lookup the candidate_version if the variable is not already set (pkgin separated by spaces)" do
-      search = double()
+      search = double
       expect(search).to receive(:each_line).
         and_yield("something-varnish-1.1.1   something varnish like\n").
         and_yield("varnish-2.3.4             actual varnish\n")
@@ -85,7 +85,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
     end
 
     it "should lookup the candidate_version if the variable is not already set (pkgin separated by semicolons)" do
-      search = double()
+      search = double
       expect(search).to receive(:each_line).
         and_yield("something-varnish-1.1.1;;something varnish like\n").
         and_yield("varnish-2.3.4;;actual varnish\n")

--- a/spec/unit/util/threaded_job_queue_spec.rb
+++ b/spec/unit/util/threaded_job_queue_spec.rb
@@ -22,7 +22,7 @@ describe Chef::Util::ThreadedJobQueue do
   let(:queue) { Chef::Util::ThreadedJobQueue.new }
 
   it "should pass mutex to jobs with an arity of 1" do
-    job = double()
+    job = double
     expect(job).to receive(:arity).at_least(:once).and_return(1)
     expect(job).to receive(:call).exactly(5).times.with(an_instance_of(Mutex))
 
@@ -31,7 +31,7 @@ describe Chef::Util::ThreadedJobQueue do
   end
 
   it "should pass nothing to jobs with an arity of 0" do
-    job = double()
+    job = double
     expect(job).to receive(:arity).at_least(:once).and_return(0)
     expect(job).to receive(:call).exactly(5).times.with(no_args)
 

--- a/spec/unit/win32/registry_spec.rb
+++ b/spec/unit/win32/registry_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Win32::Registry do
   let(:key_to_delete) { "OpscodeNumbers" }
   let(:sub_key) { "OpscodePrimes" }
   let(:missing_key_path) { 'HKCU\Software' }
-  let(:registry) { Chef::Win32::Registry.new() }
+  let(:registry) { Chef::Win32::Registry.new }
   let(:hive_mock) { double("::Win32::Registry::KHKEY_CURRENT_USER") }
   let(:reg_mock) { double("reg") }
 
@@ -252,7 +252,7 @@ describe Chef::Win32::Registry do
       expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
       expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
       expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
-      expect(reg_mock).to receive(:each_key).and_return(no_args())
+      expect(reg_mock).to receive(:each_key).and_return(no_args)
       expect(registry.has_subkeys?(key_path)).to eq(false)
     end
 
@@ -290,7 +290,7 @@ describe Chef::Win32::Registry do
       expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
       expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
       expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
-      expect(reg_mock).to receive(:any?).and_yield(no_args())
+      expect(reg_mock).to receive(:any?).and_yield(no_args)
       registry.value_exists?(key_path, value1) == false
     end
   end
@@ -305,7 +305,7 @@ describe Chef::Win32::Registry do
       expect(registry).to receive(:key_exists!).with(key_path).and_return(true)
       expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
       expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "1")
+      expect(reg_mock).to receive(:each).with(no_args).and_yield("one", 1, "1")
       expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
       expect(registry.data_exists?(key_path, value1)).to eq(true)
     end
@@ -315,7 +315,7 @@ describe Chef::Win32::Registry do
       expect(registry).to receive(:get_hive_and_key).with(key_path).and_return([hive_mock, key])
       expect(hive_mock).to receive(:open).with(key, ::Win32::Registry::KEY_READ | registry.registry_system_architecture).and_yield(reg_mock)
       expect(registry).to receive(:get_type_from_name).with(:string).and_return(1)
-      expect(reg_mock).to receive(:each).with(no_args()).and_yield("one", 1, "2")
+      expect(reg_mock).to receive(:each).with(no_args).and_yield("one", 1, "2")
       expect(registry.data_exists?(key_path, value1)).to eq(false)
     end
   end


### PR DESCRIPTION
Rubymine was mad about these. There's a rubocop rule we should probably turn on

Signed-off-by: Tim Smith <tsmith@chef.io>