### PR TITLE
Remove duplicate files from acceptance / chef-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ kitchen-tests/vendor
 
 # ignore nodes generated during local testing
 nodes/
+
+# acceptance
+acceptance/.acceptance_logs
+acceptance/.acceptance_data
+acceptance/data-collector/Berksfile.lock
+
+# chef-config
+chef-config/.bundle
+chef-config/Gemfile.lock

--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -1,3 +1,0 @@
-.acceptance_logs
-.acceptance_data
-data-collector/Berksfile.lock

--- a/chef-config/.gitignore
+++ b/chef-config/.gitignore
@@ -1,9 +1,0 @@
-/.bundle/
-/.yardoc
-/Gemfile.lock
-/_yardoc/
-/coverage/
-/doc/
-/pkg/
-/spec/reports/
-/tmp/

--- a/chef-config/README.md
+++ b/chef-config/README.md
@@ -1,4 +1,0 @@
-# ChefConfig
-
-This repo is experimental. Use at your own risk.
-

--- a/chef-config/chef-config.gemspec
+++ b/chef-config/chef-config.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency(rspec, "~> 3.2")
   end
 
-  spec.files = %w{Rakefile LICENSE README.md} + Dir.glob("*.gemspec") +
+  spec.files = %w{Rakefile LICENSE} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   spec.bindir        = "bin"


### PR DESCRIPTION
Squash down to a single gitignore file and remove the readme from chef-config that dates back to when it was its own repo

Signed-off-by: Tim Smith <tsmith@chef.io>