### PR TITLE
Use Ruby 2.4+'s .match? method

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -119,7 +119,7 @@ class Chef::Application::Client < Chef::Application
       :description =>
         "Daemonize the process. Accepts an optional integer which is the " \
         "number of seconds to wait before the first daemonized run.",
-      :proc => lambda { |wait| wait =~ /^\d+$/ ? wait.to_i : true }
+      :proc => lambda { |wait| wait.match?(/^\d+$/) ? wait.to_i : true }
   end
 
   option :pid_file,

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "win32/service"
 end
 require "chef/config"

--- a/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
+++ b/lib/chef/chef_fs/data_handler/data_bag_item_data_handler.rb
@@ -55,7 +55,7 @@ class Chef
           base_name = remove_dot_json(entry.name)
           if object["raw_data"]["id"] != base_name
             yield("ID in #{entry.path_for_printing} must be '#{base_name}' (is '#{object['raw_data']['id']}')")
-          elsif entry.parent.name =~ RESERVED_NAMES
+          elsif entry.parent.name.match?(RESERVED_NAMES)
             yield("Data bag name ('#{entry.parent.name}') must not match #{RESERVED_NAMES.inspect}")
           end
         end

--- a/lib/chef/chef_fs/path_utils.rb
+++ b/lib/chef/chef_fs/path_utils.rb
@@ -115,7 +115,7 @@ class Chef
         return nil unless PathUtils.os_path_eq?(candidate_fragment, ancestor)
         if ancestor.length == path.length
           ""
-        elsif path[ancestor.length, 1] =~ /#{PathUtils.regexp_path_separator}/
+        elsif path[ancestor.length, 1].match?(/#{PathUtils.regexp_path_separator}/)
           path[ancestor.length + 1..-1]
         else
           nil

--- a/lib/chef/cookbook/chefignore.rb
+++ b/lib/chef/cookbook/chefignore.rb
@@ -62,7 +62,7 @@ class Chef
       end
 
       def find_ignore_file(path)
-        if File.basename(path) =~ /chefignore/
+        if File.basename(path).match?(/chefignore/)
           path
         else
           File.join(path, "chefignore")

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -373,7 +373,7 @@ class Chef
       def recipes_from_cookbook_version(cookbook)
         cookbook.fully_qualified_recipe_names.map do |recipe_name|
           unqualified_name =
-            if recipe_name =~ /::default$/
+            if recipe_name.match?(/::default$/)
               name.to_s
             else
               recipe_name

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -360,7 +360,7 @@ class Chef
                                    platform, version = Chef::Platform.find_platform_and_version(node)
                                  rescue ArgumentError => e
                                    # Skip platform/version if they were not found by find_platform_and_version
-                                   if e.message =~ /Cannot find a (?:platform|version)/
+                                   if e.message.match?(/Cannot find a (?:platform|version)/)
                                      platform = "/unknown_platform/"
                                      version = "/unknown_platform_version/"
                                    else
@@ -491,7 +491,7 @@ class Chef
         cb["version"]
       end
     rescue Net::HTTPServerException => e
-      if e.to_s =~ /^404/
+      if e.to_s.match?(/^404/)
         Chef::Log.error("Cannot find a cookbook named #{cookbook_name}")
         nil
       else

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -36,10 +36,10 @@ class Chef
     RESERVED_NAMES = /^(node|role|environment|client)$/
 
     def self.validate_name!(name)
-      unless name =~ VALID_NAME
+      unless name.match?(VALID_NAME)
         raise Exceptions::InvalidDataBagName, "DataBags must have a name matching #{VALID_NAME.inspect}, you gave #{name.inspect}"
       end
-      if name =~ RESERVED_NAMES
+      if name.match?(RESERVED_NAMES)
         raise Exceptions::InvalidDataBagName, "DataBags may not have a name matching #{RESERVED_NAMES.inspect}, you gave #{name.inspect}"
       end
     end

--- a/lib/chef/file_access_control.rb
+++ b/lib/chef/file_access_control.rb
@@ -26,7 +26,7 @@ class Chef
   # the values specified by a value object, usually a Chef::Resource.
   class FileAccessControl
 
-    if RUBY_PLATFORM =~ /mswin|mingw|windows/
+    if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
       require "chef/file_access_control/windows"
       include FileAccessControl::Windows
     else

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -309,7 +309,7 @@ class Chef
     # @api private
     def create_url(path)
       return path if path.is_a?(URI)
-      if path =~ /^(http|https|chefzero):\/\//i
+      if path.match?(/^(http|https|chefzero):\/\//i)
         URI.parse(path)
       elsif path.nil? || path.empty?
         URI.parse(@url)

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -126,7 +126,7 @@ class Chef
       rescue NoMethodError => e
         # http://redmine.ruby-lang.org/issues/show/2708
         # http://redmine.ruby-lang.org/issues/show/2758
-        if e.to_s =~ /#{Regexp.escape(%q{undefined method `closed?' for nil:NilClass})}/
+        if e.to_s.match?(/#{Regexp.escape(%q{undefined method `closed?' for nil:NilClass})}/)
           Chef::Log.debug("Rescued error in http connect, re-raising as Errno::ECONNREFUSED to hide bug in net/http")
           Chef::Log.debug("#{e.class.name}: #{e}")
           Chef::Log.debug(e.backtrace.join("\n"))

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -46,7 +46,7 @@ class Chef
         # temporary hack, skip processing if return_value is false
         # needed to keep conditional get stuff working correctly.
         return [http_response, rest_request, return_value] if return_value == false
-        if http_response["content-type"] =~ /json/
+        if http_response["content-type"].match?(/json/)
           if http_response.body.nil?
             return_value = nil
           elsif raw_output

--- a/lib/chef/knife/cookbook_delete.rb
+++ b/lib/chef/knife/cookbook_delete.rb
@@ -89,7 +89,7 @@ class Chef
           url_and_version["versions"].map { |url_by_version| url_by_version["version"] }
         end.flatten
       rescue Net::HTTPServerException => e
-        if e.to_s =~ /^404/
+        if e.to_s.match?(/^404/)
           ui.error("Cannot find a cookbook named #{@cookbook_name} to delete")
           nil
         else

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -135,7 +135,7 @@ class Chef
         res = Chef::JSONCompat.from_json(http_resp.body)
         if http_resp.code.to_i != 201
           if res["error_messages"]
-            if res["error_messages"][0] =~ /Version already exists/
+            if res["error_messages"][0].match?(/Version already exists/)
               ui.error "The same version of this cookbook already exists on Supermarket."
               exit(1)
             else

--- a/lib/chef/knife/core/cookbook_scm_repo.rb
+++ b/lib/chef/knife/core/cookbook_scm_repo.rb
@@ -58,7 +58,7 @@ class Chef
           exit 1
         end
         cmd = git("status --porcelain")
-        if cmd.stdout =~ DIRTY_REPO
+        if cmd.stdout.match?(DIRTY_REPO)
           ui.error "You have uncommitted changes to your cookbook repo (#{repo_path}):"
           ui.msg cmd.stdout
           ui.info "Commit or stash your changes before importing cookbooks"

--- a/lib/chef/knife/node_run_list_remove.rb
+++ b/lib/chef/knife/node_run_list_remove.rb
@@ -49,7 +49,7 @@ class Chef
             node.run_list.remove(e)
           else
             ui.warn "#{e} is not in the run list"
-            unless e =~ /^(recipe|role)\[/
+            unless e.match?(/^(recipe|role)\[/)
               ui.warn "(did you forget recipe[] or role[] around it?)"
             end
           end

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -366,7 +366,7 @@ class Chef
               raise ArgumentError, "Cannot execute #{command}" unless success
               ch.on_data do |ichannel, data|
                 print_data(ichannel.connection[:prefix], data)
-                if data =~ /^knife sudo password: /
+                if data.match?(/^knife sudo password: /)
                   print_data(ichannel.connection[:prefix], "\n")
                   ichannel.send_data("#{get_password}\n")
                 end

--- a/lib/chef/mixin/create_path.rb
+++ b/lib/chef/mixin/create_path.rb
@@ -37,7 +37,7 @@ class Chef
           file_path = File.expand_path(file_path).split(File::SEPARATOR)
           file_path.shift if file_path[0] == ""
           # Check if path starts with a separator or drive letter (Windows)
-          unless file_path[0].match("^#{File::SEPARATOR}|^[a-zA-Z]:")
+          unless file_path[0].match?("^#{File::SEPARATOR}|^[a-zA-Z]:")
             file_path[0] = "#{File::SEPARATOR}#{file_path[0]}"
           end
         end

--- a/lib/chef/mixin/securable.rb
+++ b/lib/chef/mixin/securable.rb
@@ -172,14 +172,14 @@ class Chef
         end
       end
 
-      if RUBY_PLATFORM =~ /mswin|mingw|windows/
+      if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
         include WindowsSecurableAttributes
       end
 
       # Callback that fires when included; will extend the including class
       # with WindowsMacros and define #rights and #deny_rights on it.
       def self.included(including_class)
-        if RUBY_PLATFORM =~ /mswin|mingw|windows/
+        if RUBY_PLATFORM.match?(/mswin|mingw|windows/)
           including_class.extend(WindowsMacros)
           # create a default 'rights' attribute
           including_class.rights_attribute(:rights)

--- a/lib/chef/monkey_patches/win32/registry.rb
+++ b/lib/chef/monkey_patches/win32/registry.rb
@@ -57,7 +57,7 @@ module Win32
 
     end
 
-    if RUBY_VERSION =~ /^2\.1/
+    if RUBY_VERSION.match?(/^2\.1/)
       # ::Win32::Registry#write does not correctly handle data in Ruby 2.1
       # This bug is _reportedly_ resolved in Ruby 2.1.7 and 2.2.3
       # but fails in appveyor on 2.1.8 unless we keep applying this monkeypatch

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -128,7 +128,7 @@ class Chef
 
         so = shell_out("apt-key list")
         so.stdout.split(/\n/).map do |t|
-          if t =~ %r{^\/#{key}.*\[expired: .*\]$}
+          if t.match?(%r{^\/#{key}.*\[expired: .*\]$})
             Chef::Log.debug "Found expired key: #{t}"
             valid = false
             break

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -76,7 +76,7 @@ class Chef
           gid = nil; next_gid_guess = 200
           groups_gids = safe_dscl("list", "/Groups", "gid")
           while next_gid_guess < search_limit + 200
-            if groups_gids =~ Regexp.new("#{Regexp.escape(next_gid_guess.to_s)}\n")
+            if groups_gids.match?(Regexp.new("#{Regexp.escape(next_gid_guess.to_s)}\n"))
               next_gid_guess += 1
             else
               gid = next_gid_guess

--- a/lib/chef/provider/group/windows.rb
+++ b/lib/chef/provider/group/windows.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef/provider/user"
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "chef/util/windows/net_group"
 end
 

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -55,7 +55,7 @@ class Chef
 
         @net_tools_version = shell_out("ifconfig --version")
         @net_tools_version.stderr.each_line do |line|
-          if line =~ /^net-tools (\d+.\d+)/
+          if line.match?(/^net-tools (\d+.\d+)/)
             @ifconfig_version = line.match(/^net-tools (\d+.\d+)/)[1]
           end
         end
@@ -111,7 +111,7 @@ class Chef
           @status = shell_out("ifconfig")
           @status.stdout.each_line do |line|
             addr_regex = /^(\w+):?(\d*):?\ .+$/
-            if line =~ addr_regex
+            if line.match?(addr_regex)
               if line.match(addr_regex).nil?
                 @int_name = "nil"
               elsif line.match(addr_regex)[2] == ""

--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -196,7 +196,7 @@ class Chef
             ::File.open("/etc/filesystems", "r").each_line do |line|
               case line
               when /^\/.+:\s*$/
-                if line =~ /#{Regexp.escape(@new_resource.mount_point)}+:/
+                if line.match?(/#{Regexp.escape(@new_resource.mount_point)}+:/)
                   found_device = true
                 else
                   found_device = false

--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef/provider/mount"
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "chef/util/windows/net_use"
   require "chef/util/windows/volume"
 end
@@ -30,7 +30,7 @@ class Chef
         provides :mount, os: "windows"
 
         def is_volume(name)
-          name =~ /^\\\\\?\\Volume\{[\w-]+\}\\$/ ? true : false
+          name.match?(/^\\\\\?\\Volume\{[\w-]+\}\\$/) ? true : false
         end
 
         def initialize(new_resource, run_context)

--- a/lib/chef/provider/noop.rb
+++ b/lib/chef/provider/noop.rb
@@ -26,7 +26,7 @@ class Chef
       end
 
       def method_missing(method_sym, *arguments, &block)
-        if method_sym.to_s =~ /^action_/
+        if method_sym.to_s.match?(/^action_/)
           Chef::Log.debug("NoOp-ing for #{method_sym}")
         else
           super

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -33,7 +33,7 @@ class Chef
             unless current_resource.version
               case new_resource.source
               when /^http/, /^ftp/
-                if new_resource.source =~ /\/$/
+                if new_resource.source.match?(/\/$/)
                   shell_out_compact_timeout!("pkg_add", "-r", package_name, env: { "PACKAGESITE" => new_resource.source, "LC_ALL" => nil }).status
                 else
                   shell_out_compact_timeout!("pkg_add", "-r", package_name, env: { "PACKAGEROOT" => new_resource.source, "LC_ALL" => nil }).status

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -57,7 +57,7 @@ class Chef
           end
           requirements.assert(:all_actions) do |a|
             a.assertion do
-              if new_resource.package_name =~ /^(.+?)--(.+)/
+              if new_resource.package_name.match?(/^(.+?)--(.+)/)
                 !new_resource.version
               else
                 true

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -66,7 +66,7 @@ class Chef
           txt.each_line do |line|
             if line =~ /\*\s+#{PACKAGE_NAME_PATTERN}/
               found_package_name = $&.delete("*").strip
-              if package =~ /\// # the category is specified
+              if package.match?(/\//) # the category is specified
                 if found_package_name == package
                   availables[found_package_name] = nil
                 end

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -413,7 +413,7 @@ class Chef
         end
 
         def is_omnibus?
-          if RbConfig::CONFIG["bindir"] =~ %r{/(opscode|chef|chefdk)/embedded/bin}
+          if RbConfig::CONFIG["bindir"].match?(%r{/(opscode|chef|chefdk)/embedded/bin})
             Chef::Log.debug("#{new_resource} detected omnibus installation in #{RbConfig::CONFIG['bindir']}")
             # Omnibus installs to a static path because of linking on unix, find it.
             true

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -128,7 +128,7 @@ class Chef
           # which tricks Chef::REST into decompressing the response body. In this
           # case you'd end up with a tar archive (no gzip) named, e.g., foo.tgz,
           # which is not what you wanted.
-          if uri.to_s =~ /gz$/
+          if uri.to_s.match?(/gz$/)
             Chef::Log.debug("Turning gzip compression off due to filename ending in gz")
             opts[:disable_gzip] = true
           end

--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -83,7 +83,7 @@ class Chef
                 # debian runlevels: 0 Halt, 1 Singleuser, 2 Multiuser, 3-5 == 2, 6 Reboot
                 priority[$1] = [($2 == "S" ? :start : :stop), $3]
               end
-              if line =~ UPDATE_RC_D_ENABLED_MATCHES
+              if line.match?(UPDATE_RC_D_ENABLED_MATCHES)
                 enabled = true
               end
             end

--- a/lib/chef/provider/service/openbsd.rb
+++ b/lib/chef/provider/service/openbsd.rb
@@ -91,7 +91,7 @@ class Chef
               old_services_list = rc_conf_local.match(/^pkg_scripts="(.*)"/)
               old_services_list = old_services_list ? old_services_list[1].split(" ") : []
               new_services_list = old_services_list + [new_resource.service_name]
-              if rc_conf_local =~ /^pkg_scripts="(.*)"/
+              if rc_conf_local.match?(/^pkg_scripts="(.*)"/)
                 new_rcl = rc_conf_local.sub(/^pkg_scripts="(.*)"/, "pkg_scripts=\"#{new_services_list.join(' ')}\"")
               else
                 new_rcl = rc_conf_local + "\n" + "pkg_scripts=\"#{new_services_list.join(' ')}\"\n"
@@ -158,7 +158,7 @@ class Chef
           result = false
           var_name = builtin_service_enable_variable_name
           if var_name
-            if rc_conf =~ /^#{Regexp.escape(var_name)}=(.*)/
+            if rc_conf.match?(/^#{Regexp.escape(var_name)}=(.*)/)
               result = true
             end
           end

--- a/lib/chef/provider/service/redhat.rb
+++ b/lib/chef/provider/service/redhat.rb
@@ -87,7 +87,7 @@ class Chef
               chkconfig.stdout.split(/\s+/)[1..-1].each do |level|
                 index = level.split(":").first
                 status = level.split(":").last
-                if level =~ CHKCONFIG_ON
+                if level.match?(CHKCONFIG_ON)
                   @current_run_levels << index.to_i
                   all_levels_match = false unless run_levels.include?(index.to_i)
                 else

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -145,7 +145,7 @@ class Chef
             Chef::Log.debug "#{@new_resource} attempting to match '#{@new_resource.pattern}' (#{r.inspect}) against process list"
             begin
               shell_out!(ps_cmd).stdout.each_line do |line|
-                if r.match(line)
+                if r.match?(line)
                   @current_resource.running true
                   break
                 end

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -20,7 +20,7 @@
 
 require "chef/provider/service/simple"
 require "chef/win32_service_constants"
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "chef/win32/error"
   require "win32/service"
 end

--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -122,7 +122,7 @@ class Chef
       # If the specified revision is an integer, trust it.
       def revision_int
         @revision_int ||= begin
-          if new_resource.revision =~ /^\d+$/
+          if new_resource.revision.match?(/^\d+$/)
             new_resource.revision
           else
             command = scm(:info, new_resource.repository, new_resource.svn_info_args, authentication, "-r#{new_resource.revision}")

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -237,7 +237,7 @@ user password using shadow hash.")
           next_uid_guess = base_uid
           users_uids = run_dscl("list", "/Users", "uid")
           while next_uid_guess < search_limit + base_uid
-            if users_uids =~ Regexp.new("#{Regexp.escape(next_uid_guess.to_s)}\n")
+            if users_uids.match?(Regexp.new("#{Regexp.escape(next_uid_guess.to_s)}\n"))
               next_uid_guess += 1
             else
               uid = next_uid_guess
@@ -312,7 +312,7 @@ user password using shadow hash.")
         end
 
         def validate_home_dir_specification!
-          unless new_resource.home =~ /^\//
+          unless new_resource.home.match?(/^\//)
             raise(Chef::Exceptions::InvalidHomeDirectory, "invalid path spec for User: '#{new_resource.username}', home directory: '#{new_resource.home}'")
           end
         end

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -101,7 +101,7 @@ class Chef
           passwd_s = shell_out_compact("passwd", "-S", new_resource.username, returns: [ 0, 1 ])
 
           # checking "does not exist" has to come before exit code handling since centos and ubuntu differ in exit codes
-          if passwd_s.stderr =~ /does not exist/
+          if passwd_s.stderr.match?(/does not exist/)
             return false if whyrun_mode?
             raise Chef::Exceptions::User, "User #{new_resource.username} does not exist when checking lock status for #{new_resource}"
           end

--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -18,7 +18,7 @@
 
 require "chef/provider/user"
 require "chef/exceptions"
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "chef/util/windows/net_user"
 end
 

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -58,7 +58,7 @@ class Chef
       end
 
       def assign_provider
-        @provider = if source.to_s =~ /^ports$/i
+        @provider = if source.to_s.match?(/^ports$/i)
                       Chef::Provider::Package::Freebsd::Port
                     elsif supports_pkgng?
                       Chef::Provider::Package::Freebsd::Pkgng

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -72,7 +72,7 @@ class Chef
 
       def device_type(arg = nil)
         real_arg = arg.kind_of?(String) ? arg.to_sym : arg
-        valid_devices = if RUBY_PLATFORM =~ /solaris/i
+        valid_devices = if RUBY_PLATFORM.match?(/solaris/i)
                           [ :device ]
                         else
                           [ :device, :label, :uuid ]

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -36,7 +36,7 @@ class Chef
 
       property :source, String,
                description: "A local filesystem path or URI to source the font file from.",
-               coerce: proc { |x| x =~ /^.:.*/ ? x.tr('\\', "/").gsub("//", "/") : x }
+               coerce: proc { |x| x.match?(/^.:.*/) ? x.tr('\\', "/").gsub("//", "/") : x }
 
       action :install do
         description "Install a font to the system fonts directory."

--- a/lib/chef/util/editor.rb
+++ b/lib/chef/util/editor.rb
@@ -61,7 +61,7 @@ class Chef
         count = 0
 
         @lines.map! do |line|
-          if line.match(search)
+          if line.match?(search)
             count += 1
             line.gsub!(search, replace)
           else
@@ -76,7 +76,7 @@ class Chef
         count = 0
 
         @lines.map! do |line|
-          if line.match(search)
+          if line.match?(search)
             count += 1
             replace
           else

--- a/lib/chef/win32/file.rb
+++ b/lib/chef/win32/file.rb
@@ -113,7 +113,7 @@ class Chef
 
           # Return the link destination (strip off \??\ at the beginning, which is a local filesystem thing)
           link_dest = reparse_buffer.reparse_buffer.substitute_name
-          if link_dest =~ /^\\\?\?\\/
+          if link_dest.match?(/^\\\?\?\\/)
             link_dest = link_dest[4..-1]
           end
           link_dest

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -20,7 +20,7 @@ require "chef/reserved_names"
 require "chef/win32/api"
 require "chef/mixin/wide_string"
 
-if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
   require "chef/monkey_patches/win32/registry"
   require "chef/win32/api/registry"
   require "win32/registry"
@@ -31,7 +31,7 @@ class Chef
   class Win32
     class Registry
 
-      if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+      if RUBY_PLATFORM.match?(/mswin|mingw32|windows/)
         include Chef::ReservedNames::Win32::API::Registry
         extend Chef::ReservedNames::Win32::API::Registry
       end


### PR DESCRIPTION
We're not longer testing 2.3 in Travis so we should officially remove support. With that gone we should use a handy Ruby 2.4-ism: .match? It's faster than =~ because it doesn't actually store the match. This is just autocorrected from Rubocop's Performance/RegexpMatch