### PR TITLE
Don't use String.new in the cron provider

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -95,8 +95,8 @@ class Chef
       end
 
       def action_create
-        crontab = String.new
-        newcron = String.new
+        crontab = +""
+        newcron = +""
         cron_found = false
 
         newcron = get_crontab_entry
@@ -156,7 +156,7 @@ class Chef
 
       def action_delete
         if @cron_exists
-          crontab = String.new
+          crontab = +""
           cron_found = false
           read_crontab.each_line do |line|
             case line.chomp

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -95,8 +95,8 @@ class Chef
       end
 
       def action_create
-        crontab = +""
-        newcron = +""
+        crontab = ""
+        newcron = ""
         cron_found = false
 
         newcron = get_crontab_entry
@@ -156,7 +156,7 @@ class Chef
 
       def action_delete
         if @cron_exists
-          crontab = +""
+          crontab = ""
           cron_found = false
           read_crontab.each_line do |line|
             case line.chomp


### PR DESCRIPTION
This is another Rubocop performance cop. Here's their description:

```
In Ruby 2.3 or later, use unary plus operator to unfreeze a string literal instead of String#dup and String.new. Unary plus operator is faster than String#dup.

Note: String.new (without operator) is not exactly the same as +''. These differ in encoding. String.new.encoding is always ASCII-8BIT. However, (+'').encoding is the same as script encoding(e.g. UTF-8). So, if you expect ASCII-8BIT encoding, disable this cop.
```

Signed-off-by: Tim Smith <tsmith@chef.io>