### PR TITLE
Require Ruby 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Install:
 
 * git
 * C compiler, header files, etc.
-* ruby 2.3.3 or later
+* ruby 2.4 or later
 * rubygems
 * bundler gem
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
 


### PR DESCRIPTION
We're removed testing on 2.3 so at this point we wouldn't know if we
introduced some Ruby 2.4+ code.

Signed-off-by: Tim Smith <tsmith@chef.io>