### PR TITLE
Stripping out Authorization header on redirect to a different host

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -381,7 +381,9 @@ class Chef
         elsif redirect_location = redirected_to(response)
           if [:GET, :HEAD].include?(method)
             follow_redirect do
-              send_http_request(method, url + redirect_location, headers, body, &response_handler)
+              redirected_url = url + redirect_location
+              headers.delete("Authorization") if url.host != redirected_url.host
+              send_http_request(method, redirected_url, headers, body, &response_handler)
             end
           else
             raise Exceptions::InvalidRedirect, "#{method} request was redirected from #{url} to #{redirect_location}. Only GET and HEAD support redirects."


### PR DESCRIPTION
### Description

In http, strips `Authorization` header on 302 redirects, just like curl does it.

### Issues Resolved

- https://github.com/chef/chef/issues/6984

### Check List

- [ ] New functionality includes tests. (Couldn't find a way to make tiny_server return a 302 to return. Seems like https://github.com/chef/chef/blob/master/spec/functional/http/simple_spec.rb is the right place to add such a test, but I didn't find a neat way to add one. I'm open to suggestions on how to test this.)
- [ ] All tests pass - master seems to be broken. http units are in the same state as I found them.
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
