### PR TITLE
Revert "Knife should give a useful error when the chef_server_url isn't a chef server API"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,6 @@ vendor/
 acceptance/vendor
 kitchen-tests/vendor
 
-*.swp
-
 # Visual Studio Code files
 .vscode
 

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -521,7 +521,5 @@ This error is most often caused by network issues (proxies, etc) outside of chef
 
     # exception specific to invalid usage of 'dsc_resource' resource
     class DSCModuleNameMissing < ArgumentError; end
-
-    class NotAChefServerException < ArgumentError; end
   end
 end

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -475,8 +475,6 @@ class Chef
       when Chef::Exceptions::InvalidRedirect
         ui.error "Invalid Redirect: #{e.message}"
         ui.info  "Change your server location in knife.rb to the server's FQDN to avoid unwanted redirections."
-      when Chef::Exceptions::NotAChefServerException
-        ui.error "#{Chef::Config[:chef_server_url]} is not a valid chef server"
       else
         ui.error "#{e.class.name}: #{e.message}"
       end

--- a/lib/chef/server_api.rb
+++ b/lib/chef/server_api.rb
@@ -25,7 +25,6 @@ require "chef/http/json_output"
 require "chef/http/remote_request_id"
 require "chef/http/validate_content_length"
 require "chef/http/api_versions"
-require "ffi_yajl"
 
 class Chef
   class ServerAPI < Chef::HTTP
@@ -57,21 +56,6 @@ class Chef
     alias :delete_rest :delete
     alias :post_rest :post
     alias :put_rest :put
-
-    def get(path, headers = {})
-      request(:GET, path, headers)
-    rescue Net::HTTPServerException => e
-      if e.response.kind_of?(Net::HTTPNotFound)
-        begin
-          FFI_Yajl::Parser.parse(e.response.body)
-        rescue FFI_Yajl::ParseError => e
-          raise Chef::Exceptions::NotAChefServerException
-        end
-        raise
-      else
-        raise
-      end
-    end
 
     # Makes an HTTP request to +path+ with the given +method+, +headers+, and
     # +data+ (if applicable). Does not apply any middleware, besides that

--- a/spec/unit/server_api_spec.rb
+++ b/spec/unit/server_api_spec.rb
@@ -58,36 +58,6 @@ describe Chef::ServerAPI do
     end
   end
 
-  describe "#get" do
-    context "when response is 404" do
-      context "body data is not json" do
-        it "throws not a Chef server exception" do
-          net_http_not_found = double()
-          allow(net_http_not_found).to receive(:kind_of?).and_return(Net::HTTPNotFound)
-          allow(net_http_not_found).to receive(:body).and_return("Not Found")
-
-          api = described_class.new(url, raw_key: SIGNING_KEY_DOT_PEM)
-          allow(api).to receive(:request).and_raise(Net::HTTPServerException.new("", net_http_not_found))
-
-          expect { api.get("/nodes") }.to raise_error(Chef::Exceptions::NotAChefServerException)
-        end
-      end
-
-      context "body data is json" do
-        it "bubbles up Exception" do
-          net_http_not_found = double()
-          allow(net_http_not_found).to receive(:kind_of?).and_return(Net::HTTPNotFound)
-          allow(net_http_not_found).to receive(:body).and_return("{}")
-
-          api = described_class.new(url, raw_key: SIGNING_KEY_DOT_PEM)
-          allow(api).to receive(:request).and_raise(Net::HTTPServerException.new("", net_http_not_found))
-
-          expect { api.get("/nodes") }.to raise_error(Net::HTTPServerException)
-        end
-      end
-    end
-  end
-
   context "versioned apis" do
     class VersionedClassV0
       extend Chef::Mixin::VersionedAPI


### PR DESCRIPTION
Reverts chef/chef#6253 - this PR breaks our proxy tests.