### PR TITLE
Revert "Stripping out Authorization header on redirect to a different host

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -381,9 +381,7 @@ class Chef
         elsif redirect_location = redirected_to(response)
           if [:GET, :HEAD].include?(method)
             follow_redirect do
-              redirected_url = url + redirect_location
-              headers.delete("Authorization") if url.host != redirected_url.host
-              send_http_request(method, redirected_url, headers, body, &response_handler)
+              send_http_request(method, url + redirect_location, headers, body, &response_handler)
             end
           else
             raise Exceptions::InvalidRedirect, "#{method} request was redirected from #{url} to #{redirect_location}. Only GET and HEAD support redirects."


### PR DESCRIPTION
This introduced a failure when using the http_request resource that we experienced internally using Chef 14 builds. 

```

    ================================================================================
    Error executing action `delete` on resource 'http_request[delete-indicies]'
    ================================================================================

    FrozenError
    -----------
    can't modify frozen Hash

    Resource Declaration:
    ---------------------
    313:   http_request 'delete-indicies' do
    314:     url 'http://localhost:9200/_all'
    315:     action :delete
    316:   end
    317:

```