### PR TITLE
Lazy eval empty Hash/Array resource properties.

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -31,13 +31,13 @@ class Chef
       property :repo_name, String, name_property: true
       property :uri, String
       property :distribution, [ String, nil, false ], default: lazy { node["lsb"]["codename"] }, coerce: proc { |x| x ? x : nil }
-      property :components, Array, default: []
+      property :components, Array, default: lazy { [] }
       property :arch, [String, nil, false], default: nil, coerce: proc { |x| x ? x : nil }
       property :trusted, [TrueClass, FalseClass], default: false
       # whether or not to add the repository as a source repo, too
       property :deb_src, [TrueClass, FalseClass], default: false
       property :keyserver, [String, nil, false], default: "keyserver.ubuntu.com", coerce: proc { |x| x ? x : nil }
-      property :key, [String, Array, nil, false], default: [], coerce: proc { |x| x ? Array(x) : nil }
+      property :key, [String, Array, nil, false], default: lazy { [] }, coerce: proc { |x| x ? Array(x) : nil }
       property :key_proxy, [String, nil, false], default: nil, coerce: proc { |x| x ? x : nil }
 
       property :cookbook, [String, nil, false], default: nil, desired_state: false, coerce: proc { |x| x ? x : nil }

--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -33,7 +33,7 @@ class Chef
 
       property :arguments, [Array, Hash],
                description: "Arguments to pass the handler's class initializer.",
-               default: []
+               default: lazy { [] }
 
       property :type, Hash,
                description: "The type of Chef Handler to register as, i.e. :report, :exception or both.",

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -143,7 +143,7 @@ class Chef
       property :shell, String
       property :command, String, identity: true
       property :user, String, default: "root"
-      property :environment, Hash, default: {}
+      property :environment, Hash, default: lazy { Hash.new }
 
       private
 

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -25,7 +25,7 @@ class Chef
                   " in a git repository. git version 1.6.5 (or higher) is required to"\
                   " use all of the functionality in the git resource."
 
-      property :additional_remotes, Hash, default: {}
+      property :additional_remotes, Hash, default: lazy { Hash.new }
 
       alias :branch :revision
       alias :reference :revision

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -33,7 +33,7 @@ class Chef
       allowed_actions :get, :patch, :put, :post, :delete, :head, :options
 
       property :url, String, identity: true
-      property :headers, Hash, default: {}
+      property :headers, Hash, default: lazy { Hash.new }
 
       def initialize(name, run_context = nil)
         super

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -33,7 +33,7 @@ class Chef
       allowed_actions :create, :assemble, :stop
 
       property :chunk, Integer, default: 16
-      property :devices, Array, default: []
+      property :devices, Array, default: lazy { [] }
       property :exists, [ TrueClass, FalseClass ], default: false
       property :level, Integer, default: 1
       property :metadata, String, default: "0.90"

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -44,12 +44,12 @@ class Chef
 
       property :users, [String, Array],
                description: "User(s) to provide sudo privileges to. This accepts either an array or a comma separated.",
-               default: [],
+               default: lazy { [] },
                coerce: proc { |x| x.is_a?(Array) ? x : x.split(/\s*,\s*/) }
 
       property :groups, [String, Array],
                description: "Group(s) to provide sudo privileges to. This accepts either an array or a comma separated list. Leading % on group names is optional.",
-               default: [],
+               default: lazy { [] },
                coerce: proc { |x| coerce_groups(x) }
 
       property :commands, Array,
@@ -81,11 +81,11 @@ class Chef
 
       property :defaults, Array,
                description: "An array of defaults for the user/group.",
-               default: []
+               default: lazy { [] }
 
       property :command_aliases, Array,
                description: "Command aliases that can be used as allowed commands later in the config",
-               default: []
+               default: lazy { [] }
 
       property :setenv, [TrueClass, FalseClass],
                description: "Whether to permit the preserving of environment with sudo -E.",
@@ -93,11 +93,11 @@ class Chef
 
       property :env_keep_add, Array,
                description: "An array of strings to add to env_keep.",
-               default: []
+               default: lazy { [] }
 
       property :env_keep_subtract, Array,
                description: "An array of strings to remove from env_keep.",
-               default: []
+               default: lazy { [] }
 
       property :visudo_path, String,
                description: "The path to visudo for config verification.",


### PR DESCRIPTION
Lamont pointed out that without a lazy eval we're freezing these and then if we try to append them later chef fails.

Signed-off-by: Tim Smith <tsmith@chef.io>