### PR TITLE
Fail with a warning if users specify apt/yum/zypper repos with slashes

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -28,7 +28,11 @@ class Chef
                   " Adding a new repository will update APT package cache immediately."
       introduced "12.9"
 
-      property :repo_name, String, name_property: true
+      property :repo_name, String,
+               regex: [/^[^\/]+$/],
+               validation_message: "repo_name property cannot contain a forward slash '/'",
+               name_property: true
+
       property :uri, String
       property :distribution, [ String, nil, false ], default: lazy { node["lsb"]["codename"] }, coerce: proc { |x| x ? x : nil }
       property :components, Array, default: lazy { [] }

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -65,7 +65,12 @@ class Chef
       property :proxy, String
       property :repo_gpgcheck, [TrueClass, FalseClass]
       property :report_instanceid, [TrueClass, FalseClass]
-      property :repositoryid, String, name_property: true
+
+      property :repositoryid, String,
+               regex: [/^[^\/]+$/],
+               validation_message: "repositoryid property cannot contain a forward slash '/'",
+               name_property: true
+
       property :skip_if_unavailable, [TrueClass, FalseClass]
       property :source, String
       property :sslcacert, String

--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -30,7 +30,11 @@ class Chef
                   " zypper cookbook."
       introduced "13.3"
 
-      property :repo_name, String, name_property: true
+      property :repo_name, String,
+               regex: [/^[^\/]+$/],
+               validation_message: "repo_name property cannot contain a forward slash '/'",
+               name_property: true
+
       property :description, String
       property :type, String, default: "NONE"
       property :enabled, [TrueClass, FalseClass], default: true

--- a/spec/unit/resource/apt_repository_spec.rb
+++ b/spec/unit/resource/apt_repository_spec.rb
@@ -28,6 +28,10 @@ describe Chef::Resource::AptRepository do
     expect(resource.keyserver).to eql("keyserver.ubuntu.com")
   end
 
+  it "fails if the user provides a repo_name with a forward slash" do
+    expect { resource.repo_name "foo/bar" }.to raise_error(ArgumentError)
+  end
+
   it "resolves to a Noop class when on non-linux OS" do
     node.automatic[:os] = "windows"
     node.automatic[:platform_family] = "windows"

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -32,6 +32,10 @@ describe Chef::Resource::YumRepository do
     expect(resource.repositoryid).to eq("multiverse")
   end
 
+  it "fails if the user provides a repositoryid with a forward slash" do
+    expect { resource.repositoryid "foo/bar" }.to raise_error(ArgumentError)
+  end
+
   it "the timeout property expects numeric Strings" do
     expect { resource.timeout "123" }.not_to raise_error(ArgumentError)
     expect { resource.timeout "123foo" }.to raise_error(ArgumentError)

--- a/spec/unit/resource/zypper_repository_spec.rb
+++ b/spec/unit/resource/zypper_repository_spec.rb
@@ -32,6 +32,10 @@ describe Chef::Resource::ZypperRepository do
     expect(resource.repo_name).to eql("repo-source")
   end
 
+  it "fails if the user provides a repo_name with a forward slash" do
+    expect { resource.repo_name "foo/bar" }.to raise_error(ArgumentError)
+  end
+
   it "has a default action of create" do
     expect(resource.action).to eql([:create])
   end


### PR DESCRIPTION
We can't write out a filename like foo/bar.repo so we should properly warn the user if they try to give us that. There's probably other things, but this one makes particular sense for apt since people want to use the slash in PPA repo names.

Fixes #6564 

Signed-off-by: Tim Smith <tsmith@chef.io>