### PR TITLE
Improve comma separated list splitting in group resource

### DIFF
--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -20,45 +20,20 @@
 class Chef
   class Resource
     class Group < Chef::Resource
-      state_attrs :members
-
       description "Use the group resource to manage a local group."
 
       allowed_actions :create, :remove, :modify, :manage
       default_action :create
 
-      def initialize(name, run_context = nil)
-        super
-        @members = []
-        @excluded_members = []
-      end
-
       property :group_name, String, name_property: true, identity: true
       property :gid, [ String, Integer ]
-
-      def members(arg = nil)
-        converted_members = arg.is_a?(String) ? arg.split(",") : arg
-        set_or_return(
-          :members,
-          converted_members,
-          :kind_of => [ Array ]
-        )
-      end
-
-      alias_method :users, :members
-
-      def excluded_members(arg = nil)
-        converted_members = arg.is_a?(String) ? arg.split(",") : arg
-        set_or_return(
-          :excluded_members,
-          converted_members,
-          :kind_of => [ Array ]
-        )
-      end
-
+      property :members, [Array, String], default: lazy { [] }, coerce: proc { |arg| arg.is_a?(String) ? arg.split(/\s*,\s*/) : arg }
+      property :excluded_members, [Array, String], default: lazy { [] }, coerce: proc { |arg| arg.is_a?(String) ? arg.split(/\s*,\s*/) : arg }
       property :append, [ TrueClass, FalseClass ], default: false
       property :system, [ TrueClass, FalseClass ], default: false
       property :non_unique, [ TrueClass, FalseClass ], default: false
+
+      alias_method :users, :members
     end
   end
 end

--- a/spec/unit/resource/group_spec.rb
+++ b/spec/unit/resource/group_spec.rb
@@ -93,23 +93,23 @@ describe Chef::Resource::Group, "members" do
   let(:resource) { Chef::Resource::Group.new("fakey_fakerton") }
 
   [ :users, :members].each do |method|
-    it "(#{method}) allows and convert a string" do
-      resource.send(method, "aj")
-      expect(resource.send(method)).to eql(["aj"])
+    it "(#{method}) allows a String and coerces it to an Array" do
+      resource.send(method, "some_user")
+      expect(resource.send(method)).to eql(["some_user"])
     end
 
-    it "(#{method}) should split a string on commas" do
-      resource.send(method, "aj,adam")
-      expect(resource.send(method)).to eql( %w{aj adam} )
+    it "(#{method}) coerces a comma separated list of users to an Array" do
+      resource.send(method, "some_user, other_user ,another_user,just_one_more_user")
+      expect(resource.send(method)).to eql( %w{some_user other_user another_user just_one_more_user} )
     end
 
-    it "(#{method}) allows an array" do
-      resource.send(method, %w{aj adam})
-      expect(resource.send(method)).to eql( %w{aj adam} )
+    it "(#{method}) allows an Array" do
+      resource.send(method, %w{some_user other_user})
+      expect(resource.send(method)).to eql( %w{some_user other_user} )
     end
 
-    it "(#{method}) does not allow a hash" do
-      expect { resource.send(method, { :aj => "is freakin awesome" }) }.to raise_error(ArgumentError)
+    it "(#{method}) does not allow a Hash" do
+      expect { resource.send(method, { :some_user => "is freakin awesome" }) }.to raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
This is the same thing I did in sudo. It just makes the string parsing a bit more user spacing proof.

accepted before:
  - 1,2,3

accepted now:
  - 1,2,3
  - 1, 2, 3
  - 1 ,2 ,3
  - any combo of the above 3

Signed-off-by: Tim Smith <tsmith@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
