### PR TITLE
Move subversion specific properties from scm to subversion

### DIFF
--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -24,10 +24,6 @@ class Chef
       default_action :sync
       allowed_actions :checkout, :export, :sync, :diff, :log
 
-      def initialize(name, run_context = nil)
-        super
-      end
-
       property :destination, String, name_property: true, identity: true
       property :repository, String
       property :revision, String, default: "HEAD"
@@ -44,23 +40,6 @@ class Chef
       property :timeout, Integer
       property :checkout_branch, String, default: "deploy"
       property :environment, [Hash, nil], default: nil
-
-      def svn_arguments(arg = nil)
-        @svn_arguments, arg = nil, nil if arg == false
-        set_or_return(
-          :svn_arguments,
-          arg,
-          :kind_of => String
-        )
-      end
-
-      def svn_info_args(arg = nil)
-        @svn_info_args, arg = nil, nil if arg == false
-        set_or_return(
-          :svn_info_args,
-          arg,
-          :kind_of => String)
-      end
 
       alias :env :environment
     end

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -38,6 +38,23 @@ class Chef
         "#{self} (#{defined_at}) had an error: #{e.class.name}: #{svn_password ? e.message.gsub(svn_password, "[hidden_password]") : e.message}"
       end
 
+      def svn_arguments(arg = nil)
+        @svn_arguments, arg = nil, nil if arg == false
+        set_or_return(
+          :svn_arguments,
+          arg,
+          :kind_of => String
+        )
+      end
+
+      def svn_info_args(arg = nil)
+        @svn_info_args, arg = nil, nil if arg == false
+        set_or_return(
+          :svn_info_args,
+          arg,
+          :kind_of => String)
+      end
+
       property :svn_binary, String
     end
   end

--- a/spec/unit/resource/scm_spec.rb
+++ b/spec/unit/resource/scm_spec.rb
@@ -80,17 +80,6 @@ describe Chef::Resource::Scm do
     expect(resource.svn_password).to eql("taftplz")
   end
 
-  it "has a svn_arguments String attribute" do
-    resource.svn_arguments "--more-taft plz"
-    expect(resource.svn_arguments).to eql("--more-taft plz")
-  end
-
-  it "has a svn_info_args String attribute" do
-    expect(resource.svn_info_args).to be_nil
-    resource.svn_info_args("--no-moar-plaintext-creds yep")
-    expect(resource.svn_info_args).to eq("--no-moar-plaintext-creds yep")
-  end
-
   it "takes the depth as an integer for shallow clones" do
     resource.depth 5
     expect(resource.depth).to eq(5)

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -65,6 +65,18 @@ describe Chef::Resource::Subversion do
     expect(resource.svn_arguments).to be_nil
   end
 
+  it "has a svn_arguments String attribute" do
+    expect(resource.svn_arguments).to eq("--no-auth-cache") # the default
+    resource.svn_arguments "--more-taft plz"
+    expect(resource.svn_arguments).to eql("--more-taft plz")
+  end
+
+  it "has a svn_info_args String attribute" do
+    expect(resource.svn_info_args).to eq("--no-auth-cache") # the default
+    resource.svn_info_args("--no-moar-plaintext-creds yep")
+    expect(resource.svn_info_args).to eq("--no-moar-plaintext-creds yep")
+  end
+
   it "hides password from custom exception message" do
     resource.svn_password "l33th4x0rpa$$w0rd"
     e = resource.customize_exception(Chef::Exceptions::Exec.new "Exception with password #{resource.svn_password}")


### PR DESCRIPTION
We actually set the defaults for these in the subversion property, but the actual properties are in scm. Move them to subversion since they are subversion specific.

Signed-off-by: Tim Smith <tsmith@chef.io>