### PR TITLE
Don't try to install old GCC packages on Amazon Linux 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,11 +139,28 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
+      - bundle exec kitchen test base-amazonlinux-2
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+      - AMAZON=2
+      - KITCHEN_YAML=.kitchen.travis.yml
+  - rvm: 2.4.3
+    services: docker
+    sudo: required
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
       - bundle exec kitchen test base-amazonlinux
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
-      - AMAZON=LATEST
+      - AMAZON=201X
       - KITCHEN_YAML=.kitchen.travis.yml
   - rvm: 2.4.3
     services: docker

--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -37,6 +37,15 @@ platforms:
       - RUN yum -y install sudo
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install sudo
+      - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
+
+
 - name: debian-8
   driver:
     image: dokken/debian-8

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -40,7 +40,7 @@ class Chef
           declare_resource(:package,  %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch })
 
           # Ensure GCC 4 is available on older pre-6 EL
-          declare_resource(:package,  %w{ gcc44 gcc44-c++ }) if node["platform_version"].to_i < 6
+          declare_resource(:package,  %w{ gcc44 gcc44-c++ }) if platform_family?("rhel") && node["platform_version"].to_i < 6
         when "freebsd"
           declare_resource(:package,  "devel/gmake")
           declare_resource(:package,  "devel/autoconf")


### PR DESCRIPTION
This worked until Amazon released 2.0

Signed-off-by: Tim Smith <tsmith@chef.io>