### PR TITLE
Add missing installed logic for macos in build_essential

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -47,21 +47,23 @@ class Chef
           declare_resource(:package,  "devel/m4")
           declare_resource(:package,  "devel/gettext")
         when "mac_os_x"
-          # This script was graciously borrowed and modified from Tim Sutton's
-          # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
-          declare_resource(:execute, "install XCode Command Line tools") do
-            command <<-EOH.gsub(/^ {14}/, "")
-              # create the placeholder file that's checked by CLI updates' .dist code
-              # in Apple's SUS catalog
-              touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-              # find the CLI Tools update
-              PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
-              # install it
-              softwareupdate -i "$PROD" --verbose
-              # Remove the placeholder to prevent perpetual appearance in the update utility
-              rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-            EOH
-            # rubocop:enable Metrics/LineLength
+          unless xcode_cli_installed?
+            # This script was graciously borrowed and modified from Tim Sutton's
+            # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
+            declare_resource(:execute, "install XCode Command Line tools") do
+              command <<-EOH.gsub(/^ {14}/, "")
+                # create the placeholder file that's checked by CLI updates' .dist code
+                # in Apple's SUS catalog
+                touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+                # find the CLI Tools update. We tail here because sometimes there's 2 and newest is last
+                PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+                # install it
+                softwareupdate -i "$PROD" --verbose
+                # Remove the placeholder to prevent perpetual appearance in the update utility
+                rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+              EOH
+              # rubocop:enable Metrics/LineLength
+            end
           end
         when "omnios"
           declare_resource(:package,  "developer/gcc48")
@@ -109,6 +111,22 @@ class Chef
         The build_essential resource does not currently support the '#{node['platform_family']}'
         platform family. Skipping...
         EOH
+        end
+      end
+
+      action_class do
+        #
+        # Determine if the XCode Command Line Tools are installed
+        #
+        # @return [true, false]
+        #
+        def xcode_cli_installed?
+          cmd = Mixlib::ShellOut.new("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
+          cmd.run_command
+          cmd.error!
+          true
+        rescue Mixlib::ShellOut::ShellCommandFailed
+          false
         end
       end
 

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -122,6 +122,7 @@ class Chef
         def xcode_cli_installed?
           cmd = Mixlib::ShellOut.new("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
           cmd.run_command
+          # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
         end
       end

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -122,10 +122,7 @@ class Chef
         def xcode_cli_installed?
           cmd = Mixlib::ShellOut.new("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
           cmd.run_command
-          cmd.error!
-          true
-        rescue Mixlib::ShellOut::ShellCommandFailed
-          false
+          cmd.error? ? false : true
         end
       end
 

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -62,7 +62,6 @@ class Chef
                 # Remove the placeholder to prevent perpetual appearance in the update utility
                 rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
               EOH
-              # rubocop:enable Metrics/LineLength
             end
           end
         when "omnios"


### PR DESCRIPTION
Add the missing installed? check that makes this fast. Also use tail
instead of head in the execute so we install the latest not the oldest
xcode release if more than 1 is available on the system (upgrades).

Signed-off-by: Tim Smith <tsmith@chef.io>