### PR TITLE
Stripping Authorization header upon redirects (second try)

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -354,6 +354,11 @@ module ChefConfig
 
     default :http_retry_count, 5
     default :http_retry_delay, 5
+    # Whether or not to send the Authorization header again on http redirects.
+    # As per the plan in https://github.com/chef/chef/pull/7006, this will be
+    # False in Chef 14, True in Chef 15, and will be removed entirely in Chef 16.
+    default :http_disable_auth_on_redirect, false
+
     default :interval, nil
     default :once, nil
     default :json_attribs, nil


### PR DESCRIPTION
Signed-off-by: Noam Lerner <noamler@fb.com>

### Description
This is another attempt of https://github.com/chef/chef/pull/6985. This makes it so that chef won't sent the `Authorization` header on `GET` or `POST` redirects.

### Issues Resolved

- https://github.com/chef/chef/issues/6984

### Check List

- [ ] New functionality includes tests. (Tested manually, see examples later.)
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

### Testing. 
As a previous PR broke the `:delete` action and got reverted (https://github.com/chef/chef/pull/6996), I'd like to be extra careful here. Please let me know how if you'd like me to test this further. Here's what I did.
- Ran a similar test script using `chef-apply`: https://gist.github.com/bugok/53add64fbb7b2c605068bc648cdb3ccd
- Added the following snippet to one of my cookbooks, and ran chef (successfully): 

```
http_request 'dummy' do
  action :get
  url 'https://httpbin.org/redirect-to?url=https://www.google.com'
  headers({'Authorization' => "Basic #{
    Base64.encode64('username:password')}",
  })
end

http_request 'delete-indicies' do
  url 'https://httpbin.org/delete'
  action :delete
end
```

- One time without setting the `http_disable_auth_on_redirect `: https://gist.github.com/bugok/b06b4b527921823b3b4cabf56ea6596a (You can see that the header is forwarded).
- The second time is with overriding the value of `http_disable_auth_on_redirect` in `lib/chef/config.rb` (I found multiple `client.rb` files, and the one in /etc/chef/ wasn't getting read properly for some reason): https://gist.github.com/bugok/87a6f8290a61b2e797fee06afd93a3cc. You can see that the Authorization header wasn't forwarded.

