### PR TITLE
Detect new "automatically" installed string in Zypper

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -41,7 +41,7 @@ class Chef
             when /^Version *: (.+) *$/
               candidate_version = $1.strip
               Chef::Log.debug("#{new_resource} version #{candidate_version}")
-            when /^Installed *: Yes *(\(automatically\))?$/ # http://rubular.com/r/qhPeO6vP9h
+            when /^Installed *: Yes.*$/ # http://rubular.com/r/9StcAMjOn6
               is_installed = true
               Chef::Log.debug("#{new_resource} is installed")
             when /^Status *: out-of-date \(version (.+) installed\) *$/

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -41,7 +41,7 @@ class Chef
             when /^Version *: (.+) *$/
               candidate_version = $1.strip
               Chef::Log.debug("#{new_resource} version #{candidate_version}")
-            when /^Installed *: Yes *$/
+            when /^Installed *: Yes *(\(automatically\))?$/ # http://rubular.com/r/qhPeO6vP9h
               is_installed = true
               Chef::Log.debug("#{new_resource} is installed")
             when /^Status *: out-of-date \(version (.+) installed\) *$/

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -88,6 +88,14 @@ describe Chef::Provider::Package::Zypper do
       provider.load_current_resource
     end
 
+    it "should set the installed version if zypper info has one (zypper version >= 1.13.17)" do
+      status = double(:stdout => "Version        : 1.0\nInstalled      : Yes (automatically)\n", :exitstatus => 0)
+
+      allow(provider).to receive(:shell_out!).and_return(status)
+      expect(current_resource).to receive(:version).with(["1.0"]).and_return(true)
+      provider.load_current_resource
+    end
+
     it "should set the candidate version if zypper info has one (zypper version < 1.13.0)" do
       status = double(:stdout => "Version: 1.0\nInstalled: No\nStatus: out-of-date (version 0.9 installed)", :exitstatus => 0)
 


### PR DESCRIPTION
This resolves issue #6836 which explains the issue in great detail.
TLDR: Packages that are installed as deps on another package have a
different string when you get info on them now. This updates the regex
to detect both. Based on the zypper changelog I believe this was
introduced in 1.13.17.

Signed-off-by: Tim Smith <tsmith@chef.io>