### PR TITLE
Fix regression in #6980, add functional tests

### DIFF
--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -646,7 +646,7 @@ class Chef
         Token.new(Handle.new(token.read_pointer))
       end
 
-      def test_and_raise_lsa_nt_status(result)
+      def self.test_and_raise_lsa_nt_status(result)
         win32_error = LsaNtStatusToWinError(result)
         if win32_error != 0
           Chef::ReservedNames::Win32::Error.raise!(nil, win32_error)


### PR DESCRIPTION
The logging refactor in #6980 should have been a class variable. This fixes that.

Also adds functional tests that would catch that and the original #6980 bug.