### PR TITLE
Remove Bundle Audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,12 +80,6 @@ matrix:
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
-  - env:
-      AUDIT_CHECK: 1
-    rvm: 2.5.0
-    script: bundle exec bundle-audit check --update
-    # also remove integration / external tests
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   #
   # External tests
   #

--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ group(:development, :test) do
 end
 
 group(:travis) do
-  # See `bundler-audit` in .travis.yml
-  gem "bundler-audit"
   gem "travis"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,9 +103,6 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    bundler-audit (0.6.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
     byebug (10.0.0)
     chef-vault (3.3.0)
     chef-zero (14.0.1)
@@ -384,7 +381,6 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
-  bundler-audit
   chef!
   chef-config!
   chef-vault


### PR DESCRIPTION
With GitHub's built in security checking service this has increasingly limited value, and with travis getting slower and slower removing a test has real value.