### PR TITLE
Save the node's UUID as an attribute

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -712,6 +712,12 @@ module ChefConfig
     # The selected profile when using credentials.
     default :profile, nil
 
+    default :chef_guid_path do
+      PathHelper.join(config_dir, "chef_guid")
+    end
+
+    default :chef_guid, nil
+
     # knife configuration data
     config_context :knife do
       # XXX: none of these default values are applied to knife (and would create a backcompat

--- a/lib/chef/data_collector/messages/helpers.rb
+++ b/lib/chef/data_collector/messages/helpers.rb
@@ -106,7 +106,7 @@ class Chef
         # @return [String] UUID for the node
         #
         def node_uuid
-          read_node_uuid || generate_node_uuid
+          Chef::Config[:chef_guid] || read_node_uuid || generate_node_uuid
         end
 
         #

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -330,6 +330,7 @@ class Chef
       Chef::Log.debug("Platform is #{platform} version #{version}")
       automatic[:platform] = platform
       automatic[:platform_version] = version
+      automatic[:chef_guid] = Chef::Config[:chef_guid]
       automatic[:name] = name
       automatic[:chef_environment] = chef_environment
     end

--- a/spec/support/shared/context/client.rb
+++ b/spec/support/shared/context/client.rb
@@ -162,6 +162,7 @@ shared_context "a client run" do
     Chef::Config[:cache_path] = windows? ? 'C:\chef' : "/var/chef"
     Chef::Config[:why_run] = false
     Chef::Config[:audit_mode] = :enabled
+    Chef::Config[:chef_guid] = "default-guid"
 
     stub_const("Chef::Client::STDOUT_FD", stdout)
     stub_const("Chef::Client::STDERR_FD", stderr)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -560,7 +560,6 @@ EOM
         expect { client.node_name }.to raise_error(Chef::Exceptions::CannotDetermineNodeName)
       end
     end
-
   end
 
   describe "always attempt to run handlers" do

--- a/spec/unit/data_collector/messages/helpers_spec.rb
+++ b/spec/unit/data_collector/messages/helpers_spec.rb
@@ -124,8 +124,16 @@ describe Chef::DataCollector::Messages::Helpers do
   end
 
   describe "#node_uuid" do
+    context "when the node UUID is available in Chef::Config" do
+      it "returns the configured value" do
+        Chef::Config[:chef_guid] = "configured_uuid"
+        expect(TestMessage.node_uuid).to eq("configured_uuid")
+      end
+    end
+
     context "when the node UUID can be read" do
       it "returns the read-in node UUID" do
+        Chef::Config[:chef_guid] = nil
         allow(TestMessage).to receive(:read_node_uuid).and_return("read_uuid")
         expect(TestMessage.node_uuid).to eq("read_uuid")
       end
@@ -133,6 +141,7 @@ describe Chef::DataCollector::Messages::Helpers do
 
     context "when the node UUID cannot be read" do
       it "generated a new node UUID" do
+        Chef::Config[:chef_guid] = nil
         allow(TestMessage).to receive(:read_node_uuid).and_return(nil)
         allow(TestMessage).to receive(:generate_node_uuid).and_return("generated_uuid")
         expect(TestMessage.node_uuid).to eq("generated_uuid")

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -953,6 +953,14 @@ describe Chef::Node do
       expect(node.automatic_attrs[:platform_version]).to eq("23.42")
     end
 
+    it "sets the chef guid attribute correctly" do
+      guid = Chef::Config[:chef_guid]
+      Chef::Config[:chef_guid] = "test-guid-guid"
+      node.consume_external_attrs(@ohai_data, {})
+      expect(node.automatic_attrs[:chef_guid]).to eq("test-guid-guid")
+      Chef::Config[:chef_guid] = guid
+    end
+
     it "consumes the run list from provided json attributes" do
       node.consume_external_attrs(@ohai_data, { "run_list" => ["recipe[unicorn]"] })
       expect(node.run_list).to eq(["recipe[unicorn]"])


### PR DESCRIPTION
We generate the UUID as part of the data collector report, but we didn't
make that available to the node or the chef server otherwise.

cc @jquick