### PR TITLE
Prefer proxy configs within client.rb over environment variables

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -979,14 +979,14 @@ module ChefConfig
       end
 
       path = uri.to_s
-      ENV["#{scheme}_proxy".downcase] = path unless ENV["#{scheme}_proxy".downcase]
-      ENV["#{scheme}_proxy".upcase] = path unless ENV["#{scheme}_proxy".upcase]
+      ENV["#{scheme}_proxy".downcase] = path
+      ENV["#{scheme}_proxy".upcase] = path
     end
 
     # @api private
     def self.export_no_proxy(value)
-      ENV["no_proxy"] = value unless ENV["no_proxy"]
-      ENV["NO_PROXY"] = value unless ENV["NO_PROXY"]
+      ENV["no_proxy"] = value
+      ENV["NO_PROXY"] = value
     end
 
     # Given a scheme, host, and port, return the correct proxy URI based on the


### PR DESCRIPTION
### Description

Today, if you define any of the following configurations within `client.rb` they are subsequently ignored on the Chef Client execution if the environment variable(s) are already defined. 

```
http_proxy
https_proxy
ftp_proxy
no_proxy
```
I would expect the configuration as defined within the `client.rb` to take precedence over the environment variables of the machine. As it stands today, you can't override the machine environment variables.

### Issues Resolved

I ran across this issue using Kitchen where my host machine has proxy environment variables defined and was overriding the values I had defined within my guests `client.rb` configuration.

https://github.com/test-kitchen/test-kitchen/issues/1366

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
