### PR TITLE
Pin appbundler at 0.10.0 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    appbundler (0.11.2)
+    appbundler (0.10.0)
       mixlib-cli (~> 1.4)
-      mixlib-shellout (~> 2.0)
     ast (2.4.0)
     backports (3.11.1)
     binding_of_caller (0.8.0)


### PR DESCRIPTION
We're looking for Ohai 14 in the appbundle for an unknown reason during the
build after the changes in omnibus to allow Ohai to be unpined from ~> 8.0
in omnibus#823.

Similar pins in oc_reporting#219999bd8bcdb0c917154043140ef7d21b4a2a03 and
automate#ee59099e0dd7f9cfbd008a1b9579bfe278ac6fc6 inspired me to try this
and it works.
