### PR TITLE
Remove path helpers from window_pagefile

### DIFF
--- a/spec/unit/resource/windows_pagefile_spec.rb
+++ b/spec/unit/resource/windows_pagefile_spec.rb
@@ -18,19 +18,19 @@
 require "spec_helper"
 
 describe Chef::Resource::WindowsPagefile do
-  let(:resource) { Chef::Resource::WindowsPagefile.new("C:/pagefile.sys") }
+  let(:resource) { Chef::Resource::WindowsPagefile.new("C:\\pagefile.sys") }
 
   it "sets resource name as :windows_pagefile" do
     expect(resource.resource_name).to eql(:windows_pagefile)
   end
 
   it "sets the path as its name" do
-    expect(resource.path).to eql("C:/pagefile.sys")
+    expect(resource.path).to eql("C:\\pagefile.sys")
   end
 
-  it "coerces backslashes in the path property to forward slashes" do
-    resource.path 'C:\pagefile.sys'
-    expect(resource.path).to eql("C:/pagefile.sys")
+  it "coerces forward slashes in the path property to back slashes" do
+    resource.path "C:/pagefile.sys"
+    expect(resource.path).to eql("C:\\pagefile.sys")
   end
 
   it "sets the default action as :set" do


### PR DESCRIPTION
I backported locate_sysnative_cmd initially, but after chatting with Stuart this isn't something we need anymore. This removes it and instead uses wmic.exe directly, which in testing works just fine. This also removes the windows friendly path helper which is really just a gsub on the slashes. Instead I changed the coerce to get us what we need in terms of path formats. I copied this to a Windows 2016 box and it works fine with both formats of paths. I'm making this same change to the windows cookbook.

Signed-off-by: Tim Smith <tsmith@chef.io>