### PR TITLE
RFC-102: Deprecation warning in resources

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -280,6 +280,13 @@ class Chef
 
     # id 3694 was deleted
 
+    # Returned when using the deprecated option on a property
+    class Property < Base
+      def inspect
+        "#{message}\n#{location}"
+      end
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client.html"

--- a/lib/chef/mixin/properties.rb
+++ b/lib/chef/mixin/properties.rb
@@ -149,6 +149,10 @@ class Chef
           Property.derive(**options)
         end
 
+        def deprecated_property_alias(from, to, message)
+          Property.emit_deprecated_alias(from, to, message, self)
+        end
+
         #
         # Create a lazy value for assignment to a default value.
         #

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -148,6 +148,7 @@ class Chef
       @not_if = []
       @only_if = []
       @source_line = nil
+      @deprecated = false
       # We would like to raise an error when the user gives us a guard
       # interpreter and a ruby_block to the guard. In order to achieve this
       # we need to understand when the user overrides the default guard
@@ -1181,8 +1182,8 @@ class Chef
     # Internal Resource Interface (for Chef)
     #
 
-    FORBIDDEN_IVARS = [:@run_context, :@logger, :@not_if, :@only_if, :@enclosing_provider, :@description, :@introduced, :@examples, :@validation_message]
-    HIDDEN_IVARS = [:@allowed_actions, :@resource_name, :@source_line, :@run_context, :@logger, :@name, :@not_if, :@only_if, :@elapsed_time, :@enclosing_provider, :@description, :@introduced, :@examples, :@validation_message]
+    FORBIDDEN_IVARS = [:@run_context, :@logger, :@not_if, :@only_if, :@enclosing_provider, :@description, :@introduced, :@examples, :@validation_message, :@deprecated]
+    HIDDEN_IVARS = [:@allowed_actions, :@resource_name, :@source_line, :@run_context, :@logger, :@name, :@not_if, :@only_if, :@elapsed_time, :@enclosing_provider, :@description, :@introduced, :@examples, :@validation_message, :@deprecated]
 
     include Chef::Mixin::ConvertToClassName
     extend Chef::Mixin::ConvertToClassName
@@ -1404,6 +1405,14 @@ class Chef
         @examples = examples
       end
       @examples
+    end
+
+    def self.deprecated(deprecated = "NOT_PASSED")
+      if deprecated != "NOT_PASSED"
+        @deprecated = true
+        @deprecated_message = deprecated
+      end
+      @deprecated
     end
 
     #

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -118,6 +118,19 @@ describe "Chef::Resource.property" do
     end
   end
 
+  context "deprecated properties" do
+    it "does not create a deprecation warning on definition" do
+      expect { resource_class.class_eval { property :x, String, deprecated: 10 } }.not_to raise_error Chef::Exceptions::DeprecatedFeatureError
+    end
+
+    with_property ":x, deprecated: 'a deprecated property'" do
+      it "deprecated properties emit a deprecation warning" do
+        expect(Chef).to receive(:deprecated).with(:property, "a deprecated property")
+        expect(resource.x 10).to eq 10
+      end
+    end
+  end
+
   with_property ":x, name_property: true" do
     context "and subclass" do
       let(:subresource_class) do
@@ -1141,6 +1154,17 @@ describe "Chef::Resource.property" do
       end
     end
 
+  end
+
+  context "with aliased properties" do
+    with_property ":real, Integer" do
+      it "should set the real property and emit a deprecation message" do
+        expect(Chef).to receive(:deprecated).with(:property, "we don't like the deprecated property no more")
+        resource_class.class_eval { deprecated_property_alias :deprecated, :real, "we don't like the deprecated property no more" }
+        resource.deprecated 10
+        expect(resource.real).to eq 10
+      end
+    end
   end
 
   context "redefining Object methods" do


### PR DESCRIPTION
* `deprecated_property_alias` allows the resource author to provide
   transition from old properties to new ones with a deprecation
   warning.
* The `deprecated` option on a property emits a deprecation warning.
* The `deprecated` method on a resource takes a message, but does not
  yet emit a deprecation warning.