### PR TITLE
Fix array parsing in windows_feature_dism / windows_feature_powershell

### DIFF
--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -33,7 +33,7 @@ class Chef
 
       property :feature_name, [Array, String],
                description: "The name of the feature/role(s) to install if it differs from the resource name.",
-               coerce: proc { |x| Array(x) },
+               coerce: proc { |x| x.is_a?(String) ? x.split(/\s*,\s*/) : x },
                name_property: true
 
       property :source, String,

--- a/spec/unit/resource/windows_feature_dism.rb
+++ b/spec/unit/resource/windows_feature_dism.rb
@@ -18,7 +18,7 @@
 require "spec_helper"
 
 describe Chef::Resource::WindowsFeatureDism do
-  let(:resource) { Chef::Resource::WindowsFeatureDism.new("SNMP") }
+  let(:resource) { Chef::Resource::WindowsFeatureDism.new(%w{SNMP DHCP}) }
 
   it "sets resource name as :windows_feature_dism" do
     expect(resource.resource_name).to eql(:windows_feature_dism)
@@ -28,7 +28,17 @@ describe Chef::Resource::WindowsFeatureDism do
     expect(resource.action).to eql([:install])
   end
 
-  it "sets the feature_name property as its name and coerces it to an array" do
+  it "sets the feature_name property as its name property" do
+    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+  end
+
+  it "coerces comma separated lists of features to arrays" do
+    resource.feature_name "SNMP, DHCP"
+    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+  end
+
+  it "coerces a single feature as a String into an array" do
+    resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["SNMP"])
   end
 

--- a/spec/unit/resource/windows_feature_powershell.rb
+++ b/spec/unit/resource/windows_feature_powershell.rb
@@ -18,7 +18,7 @@
 require "spec_helper"
 
 describe Chef::Resource::WindowsFeaturePowershell do
-  let(:resource) { Chef::Resource::WindowsFeaturePowershell.new("SNMP") }
+  let(:resource) { Chef::Resource::WindowsFeaturePowershell.new(%w{SNMP DHCP}) }
 
   it "sets resource name as :windows_feature_powershell" do
     expect(resource.resource_name).to eql(:windows_feature_powershell)
@@ -28,7 +28,17 @@ describe Chef::Resource::WindowsFeaturePowershell do
     expect(resource.action).to eql([:install])
   end
 
-  it "sets the feature_name property as its name and coerces it to an array" do
+  it "sets the feature_name property as its name property" do
+    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+  end
+
+  it "coerces comma separated lists of features to arrays" do
+    resource.feature_name "SNMP, DHCP"
+    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+  end
+
+  it "coerces a single feature as a String into an array" do
+    resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["SNMP"])
   end
 


### PR DESCRIPTION
This fixes how we parse out the arrays and adds testing to make sure it's doing what we want.

Plus it properly continues on when the user has removed all local feature but specified an external source of those via the registry. That was a reported issue that came in on the cookbook after the rewrite.

Lastly this also fixes a bad method call to the dism method that came over when diffing from the cookbook.

Signed-off-by: Tim Smith <tsmith@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
