### PR TITLE
windows_feature_dism: Be case insensitive with feature names

### DIFF
--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -30,7 +30,7 @@ class Chef
 
       property :feature_name, [Array, String],
                description: "The name of the feature/role(s) to install if it differs from the resource name.",
-               coerce: proc { |x| x.is_a?(String) ? x.split(/\s*,\s*/) : x },
+               coerce: proc { |x| to_lowercase_array(x) },
                name_property: true
 
       property :source, String,
@@ -43,6 +43,11 @@ class Chef
       property :timeout, Integer,
                description: "Specifies a timeout (in seconds) for feature install.",
                default: 600
+
+      def to_lowercase_array(x)
+        x = x.split(/\s*,\s*/) if x.is_a?(String) # split multiple forms of a comma separated list
+        x.map(&:downcase)
+      end
 
       action :install do
         description "Install a Windows role/feature using DISM"
@@ -188,7 +193,7 @@ class Chef
         # @return [void]
         def add_to_feature_mash(feature_type, feature_string)
           feature_details = feature_string.strip.split(/\s+[|]\s+/)
-          node.override["dism_features_cache"][feature_type] << feature_details.first
+          node.override["dism_features_cache"][feature_type] << feature_details.first.downcase # lowercase so we can compare properly
         end
 
         # Fail if any of the packages are in a removed state

--- a/spec/unit/resource/windows_feature_dism.rb
+++ b/spec/unit/resource/windows_feature_dism.rb
@@ -32,7 +32,7 @@ describe Chef::Resource::WindowsFeatureDism do
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces comma separated lists of features to a lowercase arrays" do
+  it "coerces comma separated lists of features to a lowercase array" do
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end

--- a/spec/unit/resource/windows_feature_dism.rb
+++ b/spec/unit/resource/windows_feature_dism.rb
@@ -29,17 +29,17 @@ describe Chef::Resource::WindowsFeatureDism do
   end
 
   it "sets the feature_name property as its name property" do
-    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+    expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces comma separated lists of features to arrays" do
+  it "coerces comma separated lists of features to a lowercase arrays" do
     resource.feature_name "SNMP, DHCP"
-    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+    expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces a single feature as a String into an array" do
+  it "coerces a single feature as a String to a lowercase array" do
     resource.feature_name "SNMP"
-    expect(resource.feature_name).to eql(["SNMP"])
+    expect(resource.feature_name).to eql(["snmp"])
   end
 
   it "supports :install, :remove, and :delete actions" do


### PR DESCRIPTION
We took what they user gave us and compared it to the list of available
packages from dism.exe. In doing so we were case sensitive, but the CLI
doesn't actually care. This just downcases what the user gives us and
what dism gives us so it doesn't matter.

This same change is in windows cookbook 4.1.2

Signed-off-by: Tim Smith <tsmith@chef.io>