### PR TITLE
Add basic hostname validation on Windows

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -11,8 +11,6 @@ class Chef
       introduced "14.0"
 
       property :hostname, String,
-               regex: /^([A-Za-z0-9])+([A-Za-z0-9-._])*$/, # http://rubular.com/r/c5xKppWX4i
-               validation_message: "Hostnames can contain alphanumeric characters, -, ., and _ ,but must start with an alphanumeric character.",
                description: "The hostname if different than the resource's name",
                name_property: true
 
@@ -68,12 +66,12 @@ class Chef
       action :set do
         description "Sets the node's hostname"
 
-        ohai "reload hostname" do
-          plugin "hostname"
-          action :nothing
-        end
-
         if node["platform_family"] != "windows"
+          ohai "reload hostname" do
+            plugin "hostname"
+            action :nothing
+          end
+
           # set the hostname via /bin/hostname
           declare_resource(:execute, "set hostname to #{new_resource.hostname}") do
             command "/bin/hostname #{new_resource.hostname}"
@@ -205,8 +203,9 @@ class Chef
           end
 
         else # windows
+          raise "Windows hostnames cannot contain a period." if new_resource.hostname.match?(/./)
 
-        # suppress EC2 config service from setting our hostname
+          # suppress EC2 config service from setting our hostname
           if ::File.exist?('C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml')
             xml_contents = updated_ec2_config_xml
             if xml_contents.empty?

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -11,6 +11,8 @@ class Chef
       introduced "14.0"
 
       property :hostname, String,
+               regex: /^([A-Za-z0-9])+([A-Za-z0-9-._])*$/, # http://rubular.com/r/c5xKppWX4i
+               validation_message: "Hostnames can contain alphanumeric characters, -, ., and _ ,but must start with an alphanumeric character.",
                description: "The hostname if different than the resource's name",
                name_property: true
 

--- a/spec/unit/resource/hostname_spec.rb
+++ b/spec/unit/resource/hostname_spec.rb
@@ -25,6 +25,31 @@ describe Chef::Resource::Hostname do
     expect(resource.resource_name).to eql(:hostname)
   end
 
+  it "hostname fails validation with invalid characters" do
+    expect { resource.hostname "something^" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something^" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something!" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something@" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something#" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something$" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something%" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something*" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something[" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something]" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something(" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "something)" }.to raise_error Chef::Exceptions::ValidationFailed
+  end
+
+  it "hostname fails validation if it starts with _, -, or ." do
+    expect { resource.hostname ".something" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "-something" }.to raise_error Chef::Exceptions::ValidationFailed
+    expect { resource.hostname "_something" }.to raise_error Chef::Exceptions::ValidationFailed
+  end
+
+  it "hostname can contain ., _, or -" do
+    expect { resource.hostname "something._-something" }.to_not raise_error Chef::Exceptions::ValidationFailed
+  end
+
   it "has a default action of set" do
     expect(resource.action).to eql([:set])
   end

--- a/spec/unit/resource/hostname_spec.rb
+++ b/spec/unit/resource/hostname_spec.rb
@@ -25,31 +25,6 @@ describe Chef::Resource::Hostname do
     expect(resource.resource_name).to eql(:hostname)
   end
 
-  it "hostname fails validation with invalid characters" do
-    expect { resource.hostname "something^" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something^" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something!" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something@" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something#" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something$" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something%" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something*" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something[" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something]" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something(" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "something)" }.to raise_error Chef::Exceptions::ValidationFailed
-  end
-
-  it "hostname fails validation if it starts with _, -, or ." do
-    expect { resource.hostname ".something" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "-something" }.to raise_error Chef::Exceptions::ValidationFailed
-    expect { resource.hostname "_something" }.to raise_error Chef::Exceptions::ValidationFailed
-  end
-
-  it "hostname can contain ., _, or -" do
-    expect { resource.hostname "something._-something" }.to_not raise_error Chef::Exceptions::ValidationFailed
-  end
-
   it "has a default action of set" do
     expect(resource.action).to eql([:set])
   end


### PR DESCRIPTION
alphanumeric, -, . or _
Starts with an alphanumeric

We could get a lot more complex here and that might not be a bad idea, but this is probably a step in the right direction.

Signed-off-by: Tim Smith <tsmith@chef.io>