### PR TITLE
homebrew_tap / homebrew_cask: Fix compile time errors with the user mixin

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -48,7 +48,7 @@ class Chef
 
       property :owner, String,
                description: "The owner of the homebrew installation.",
-               default: lazy { Chef::Mixin::HomebrewUser.find_homebrew_username }
+               default: lazy { find_homebrew_username }
 
       action :install do
         description "Install an application packaged as a Homebrew cask."

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -49,7 +49,7 @@ class Chef
 
       property :owner, String,
                description: "The owner of the homebrew installation",
-               default: lazy { Chef::Mixin::HomebrewUser.find_homebrew_username }
+               default: lazy { find_homebrew_username }
 
       action :tap do
         description "Add a Homebrew tap."


### PR DESCRIPTION
Turns out I was doing this entirely wrong. I've confirmed this fixes the issue I introduced by trying to fix another issue with the usage of the mixin.

Thanks @coderanger for the pointer

Signed-off-by: Tim Smith <tsmith@chef.io>