### PR TITLE
update version of Ruby tested under in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,31 +36,31 @@ matrix:
   include:
   - env:
       INTEGRATION_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       INTEGRATION_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -68,7 +68,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -76,7 +76,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       CHEFSTYLE: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -86,43 +86,43 @@ matrix:
   - env:
       TEST_GEM: sethvargo/chef-sugar
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       PEDANT_OPTS: --skip-oc_id
       TEST_GEM: chef/chef-zero
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec cheffs
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/cheffish
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chefspec/chefspec
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: foodcritic/foodcritic
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake test
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: poise/halite
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: poise/poise
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   ### START TEST KITCHEN ONLY ###
   #
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -139,7 +139,7 @@ matrix:
     env:
       - AMAZON=2
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -156,7 +156,7 @@ matrix:
     env:
       - AMAZON=201X
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -173,7 +173,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -190,7 +190,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -207,7 +207,7 @@ matrix:
     env:
       - UBUNTU=18.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -224,7 +224,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -241,7 +241,7 @@ matrix:
     env:
       - DEBIAN=9
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -258,7 +258,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -275,7 +275,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -292,7 +292,7 @@ matrix:
     env:
       - FEDORA=latest
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -309,7 +309,7 @@ matrix:
     env:
      - OPENSUSELEAP=42
      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -326,7 +326,7 @@ matrix:
 #    env:
 #      - AWESOME_CUSTOMERS_UBUNTU=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -344,7 +344,7 @@ matrix:
 #      - AWESOME_CUSTOMERS_RHEL=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
 #    ### END TEST KITCHEN ONLY ###
-  - rvm: 2.5.0
+  - rvm: 2.5.1
     sudo: required
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)


### PR DESCRIPTION
To go along with [the Ruby upgrade from 2.5.0 to 2.5.1](https://github.com/chef/chef/pull/7090), let's test with the latest point release, too.

### Description

The spec suite will run with the same version of Ruby that is packaged in the omnibus.

### Check List

- ~New functionality includes tests~
- [ ] All tests pass
- ~RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
