### PR TITLE
scrub tempfile names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,31 +36,31 @@ matrix:
   include:
   - env:
       INTEGRATION_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       INTEGRATION_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -68,7 +68,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_25: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -76,7 +76,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       CHEFSTYLE: 1
-    rvm: 2.5.0
+    rvm: 2.5.1
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -86,43 +86,43 @@ matrix:
   - env:
       TEST_GEM: sethvargo/chef-sugar
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       PEDANT_OPTS: --skip-oc_id
       TEST_GEM: chef/chef-zero
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec cheffs
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/cheffish
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chefspec/chefspec
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: foodcritic/foodcritic
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake test
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: poise/halite
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: poise/poise
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.5.0
+    rvm: 2.5.1
   ### START TEST KITCHEN ONLY ###
   #
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -139,7 +139,7 @@ matrix:
     env:
       - AMAZON=2
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -156,7 +156,7 @@ matrix:
     env:
       - AMAZON=201X
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -173,7 +173,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -190,7 +190,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -207,7 +207,7 @@ matrix:
     env:
       - UBUNTU=18.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -224,7 +224,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -241,7 +241,7 @@ matrix:
     env:
       - DEBIAN=9
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -258,7 +258,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -275,7 +275,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -292,7 +292,7 @@ matrix:
     env:
       - FEDORA=latest
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -309,7 +309,7 @@ matrix:
     env:
      - OPENSUSELEAP=42
      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -326,7 +326,7 @@ matrix:
 #    env:
 #      - AWESOME_CUSTOMERS_UBUNTU=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -344,7 +344,7 @@ matrix:
 #      - AWESOME_CUSTOMERS_RHEL=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
 #    ### END TEST KITCHEN ONLY ###
-  - rvm: 2.5.0
+  - rvm: 2.5.1
     sudo: required
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,7 @@ class Chef
         # the leading "[.]chef-" here should be considered a public API and should not be changed
         basename.insert 0, "chef-"
         basename.insert 0, "." unless Chef::Platform.windows? # dotfile if we're not on windows
-        basename
+        basename.scrub
       end
 
       # this is similar to File.extname() but greedy about the extension (from the first dot, not the last dot)
@@ -76,7 +76,7 @@ class Chef
         # complexity here is due to supporting mangling non-UTF8 strings (e.g. latin-1 filenames with characters that are illegal in UTF-8)
         b = File.basename(@new_resource.path)
         i = b.index(".")
-        i.nil? ? "" : b[i..-1]
+        i.nil? ? "" : b[i..-1].scrub
       end
 
       # Returns the possible directories for the tempfile to be created in.


### PR DESCRIPTION
this keeps Tempfile.open from internally barfing on ruby-2.5.1

also bumps the ruby version in the travis matrix for testing.

closes #7100