### PR TITLE
Don't fail on every hostname with windows

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -203,7 +203,7 @@ class Chef
           end
 
         else # windows
-          raise "Windows hostnames cannot contain a period." if new_resource.hostname.match?(/./)
+          raise "Windows hostnames cannot contain a period." if new_resource.hostname.match?(/\./)
 
           # suppress EC2 config service from setting our hostname
           if ::File.exist?('C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml')


### PR DESCRIPTION
Look for periods instead of the regex value .

Discovered with BFT tests

Signed-off-by: Tim Smith <tsmith@chef.io>