### PR TITLE
Windows MSI: files are now re-unzipped during repair mode

### DIFF
--- a/omnibus/resources/chef/msi/source.wxs.erb
+++ b/omnibus/resources/chef/msi/source.wxs.erb
@@ -98,7 +98,7 @@
                   Return="ignore" />
 
     <InstallExecuteSequence>
-      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
 
       <Custom Action="CreateChefClientScheduledTask" After="InstallFiles">


### PR DESCRIPTION
This change allows the Windows Installer (MSI) to attempt to unzip files during repair mode.  This allows for am attempted repair of the Chef Client in case the local install has become damaged.  This change will also be applied to the Chef 13 branch.

Signed-off-by: Stuart Preston <stuart@chef.io>

### Issues Resolved

Related #7103 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
