### PR TITLE
Remove "unreleased" from the Chef 14 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,5 @@
 _This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes._
 
-# Unreleased
-
 # Chef Client Release Notes 14.0:
 
 ## New Resources


### PR DESCRIPTION
This is an obvious fix so no DCO