### PR TITLE
add delegator for property_is_set? to providers

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -42,6 +42,7 @@ class Chef
 
     include Chef::Mixin::WhyRun
     extend Chef::Mixin::Provides
+    extend Forwardable
 
     # includes the "core" DSL and not the "recipe" DSL by design
     include Chef::DSL::Core
@@ -76,6 +77,10 @@ class Chef
       # Uncomment this in Chef 13.6.
       # Chef.deprecated(:use_inline_resources, "The use_inline_resources mode is no longer optional and the line enabling it can be removed")
     end
+
+    # delegate to the resource
+    #
+    def_delegators :@new_resource, :property_is_set?
 
     #--
     # TODO: this should be a reader, and the action should be passed in the


### PR DESCRIPTION
This was dropped in Chef 14.0.190 by chef/chef#6952 as a side effect
of stripping out all the Chef::Resource automagic delegators.

People were using this one inside of provider code, and it seems fine
to continue to use it.

Moving it to inject it directly into the Provider class instead of
just custom resource action_classes to make our API more consistent.
