### PR TITLE
macos_userdefaults - fix improper boolean to int conversion

### DIFF
--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -43,7 +43,6 @@ class Chef
 
       property :value, [Integer, Float, String, TrueClass, FalseClass, Hash, Array],
                description: "The value of the key.",
-               coerce: proc { |v| coerce_booleans(v) },
                required: true
 
       property :type, String,
@@ -73,11 +72,12 @@ class Chef
       end
 
       load_current_value do |desired|
+        value = coerce_booleans(desired.value)
         drcmd = "defaults read '#{desired.domain}' "
         drcmd << "'#{desired.key}' " if desired.key
         shell_out_opts = {}
         shell_out_opts[:user] = desired.user unless desired.user.nil?
-        vc = shell_out("#{drcmd} | grep -qx '#{desired.value}'", shell_out_opts)
+        vc = shell_out("#{drcmd} | grep -qx '#{value}'", shell_out_opts)
         is_set vc.exitstatus == 0 ? true : false
       end
 

--- a/spec/unit/resource/macos_user_defaults_spec.rb
+++ b/spec/unit/resource/macos_user_defaults_spec.rb
@@ -28,18 +28,4 @@ describe Chef::Resource::MacosUserDefaults do
   it "has a default action of install" do
     expect(resource.action).to eql([:write])
   end
-
-  [true, "TRUE", "1", "true", "YES", "yes"].each do |val|
-    it "coerces value property from #{val} to 1" do
-      resource.value val
-      expect(resource.value).to eql(1)
-    end
-  end
-
-  [false, "FALSE", "0", "false", "NO", "no"].each do |val|
-    it "coerces value property from #{val} to 0" do
-      resource.value val
-      expect(resource.value).to eql(0)
-    end
-  end
 end


### PR DESCRIPTION
### Description

This is a fix for the improper boolean to int conversion occuring on macos_userdefaults

### Issues Resolved

Fix for https://github.com/chef/chef/issues/7127
