### PR TITLE
prune remotes with git fetch, fixes #3929

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -194,8 +194,8 @@ class Chef
         converge_by("fetch updates for #{new_resource.remote}") do
           # since we're in a local branch already, just reset to specified revision rather than merge
           logger.trace "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
-          git("fetch", new_resource.remote, cwd: cwd)
-          git("fetch", new_resource.remote, "--tags", cwd: cwd)
+          git("fetch", "--prune", new_resource.remote, cwd: cwd)
+          git("fetch", "--prune-tags", new_resource.remote, "--tags", cwd: cwd)
           git("reset", "--hard", target_revision, cwd: cwd)
         end
       end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -425,9 +425,9 @@ SHAS
 
   it "runs a sync command with default options" do
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    expected_cmd1 = "git fetch origin"
+    expected_cmd1 = "git fetch --prune origin"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    expected_cmd2 = "git fetch origin --tags"
+    expected_cmd2 = "git fetch --prune-tags origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
@@ -440,12 +440,12 @@ SHAS
     @resource.group("thisis")
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
 
-    expected_cmd1 = "git fetch origin"
+    expected_cmd1 = "git fetch --prune origin"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir",
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
                                                                   :environment => { "HOME" => "/home/whois" })
-    expected_cmd2 = "git fetch origin --tags"
+    expected_cmd2 = "git fetch --prune-tags origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir",
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
@@ -461,9 +461,9 @@ SHAS
   it "configures remote tracking branches when remote is ``origin''" do
     @resource.remote "origin"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command1 = "git fetch origin"
+    fetch_command1 = "git fetch --prune origin"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch origin --tags"
+    fetch_command2 = "git fetch --prune-tags origin --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
@@ -473,9 +473,9 @@ SHAS
   it "configures remote tracking branches when remote is not ``origin''" do
     @resource.remote "opscode"
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
-    fetch_command1 = "git fetch opscode"
+    fetch_command1 = "git fetch --prune opscode"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch opscode --tags"
+    fetch_command2 = "git fetch --prune-tags opscode --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")


### PR DESCRIPTION
### Description

high branch/tag churn requires pruning or it will break once a branch name gets re-used. This is very common in feature branch-workflows.

### Issues Resolved

solves #3929

### Check List

- [X ] New functionality includes tests
- [ X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
