### PR TITLE
Modify the provides for all resources from cookbooks so chef wins

### DIFF
--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -23,7 +23,7 @@ class Chef
     # @since 13.3
     class AptPreference < Chef::Resource
       resource_name :apt_preference
-      provides :apt_preference
+      provides(:apt_preference) { true }
 
       description "The apt_preference resource allows for the creation of APT preference"\
                   " files. Preference files are used to control which package versions and"\

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptRepository < Chef::Resource
       resource_name :apt_repository
-      provides :apt_repository
+      provides(:apt_repository) { true }
 
       description "Use the apt_repository resource to specify additional APT repositories."\
                   " Adding a new repository will update APT package cache immediately."

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class AptUpdate < Chef::Resource
       resource_name :apt_update
-      provides :apt_update
+      provides(:apt_update) { true }
 
       description "Use the apt_update resource to manage APT repository updates on Debian and Ubuntu platforms."
       introduced "12.7"

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -20,7 +20,7 @@ class Chef
   class Resource
     class BuildEssential < Chef::Resource
       resource_name :build_essential
-      provides :build_essential
+      provides(:build_essential) { true }
 
       description "Use the build_essential resource to install packages required for compiling C software from source"
       introduced "14.0"

--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -19,7 +19,7 @@ class Chef
   class Resource
     class ChefHandler < Chef::Resource
       resource_name :chef_handler
-      provides :chef_handler
+      provides(:chef_handler) { true }
 
       description "Use the chef_handler resource to install or uninstall Chef reporting/exception handlers."
       introduced "14.0"

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -21,6 +21,7 @@ class Chef
   class Resource
     class DmgPackage < Chef::Resource
       resource_name :dmg_package
+      provides(:dmg_package) { true }
 
       description "Use the dmg_package resource to install a dmg 'package'. The resource will retrieve the"\
                   " dmg file from a remote URL, mount it using OS X's hdidutil, copy the application (.app directory)"\

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -24,6 +24,7 @@ class Chef
   class Resource
     class HomebrewCask < Chef::Resource
       resource_name :homebrew_cask
+      provides(:homebrew_cask) { true }
 
       description "Use the homebrew_cask resource to install binaries distributed via the Homebrew package manager."
       introduced "14.0"

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -24,6 +24,7 @@ class Chef
   class Resource
     class HomebrewTap < Chef::Resource
       resource_name :homebrew_tap
+      provides(:homebrew_tap) { true }
 
       description "Use the homebrew_tap resource to add additional formula repositories to the Homebrew package manager."
       introduced "14.0"

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -22,8 +22,8 @@ class Chef
     class MacosUserDefaults < Chef::Resource
       # align with apple's marketing department
       resource_name :macos_userdefaults
-      provides :mac_os_x_userdefaults
-      provides :macos_userdefaults
+      provides(:mac_os_x_userdefaults) { true }
+      provides(:macos_userdefaults) { true }
 
       description "Use the macos_userdefaults resource to manage the macOS user defaults system. The properties"\
                   " of this resource are passed to the defaults command, and the parameters follow the convention"\

--- a/lib/chef/resource/ohai_hint.rb
+++ b/lib/chef/resource/ohai_hint.rb
@@ -19,7 +19,7 @@ class Chef
   class Resource
     class OhaiHint < Chef::Resource
       resource_name :ohai_hint
-      provides :ohai_hint
+      provides(:ohai_hint) { true }
 
       description "Use the ohai_hint resource to pass hint data to Ohai to aid in configuration detection."
       introduced "14.0"

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -24,6 +24,7 @@ class Chef
       include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_dhparam
+      provides(:openssl_dhparam) { true }
 
       description "Use the openssl_dhparam resource to generate dhparam.pem files. If a"\
                   " valid dhparam.pem file is found at the specified location, no new file"\

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -24,8 +24,8 @@ class Chef
       include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_rsa_private_key
-      provides :openssl_rsa_private_key
-      provides :openssl_rsa_key # legacy cookbook resource name
+      provides(:openssl_rsa_private_key) { true }
+      provides(:openssl_rsa_key) { true } # legacy cookbook resource name
 
       description "Use the openssl_rsa_private_key resource to generate RSA private key files."\
                   " If a valid RSA key file can be opened at the specified location, no new file"\

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -24,6 +24,7 @@ class Chef
       include Chef::Mixin::OpenSSLHelper
 
       resource_name :openssl_rsa_public_key
+      provides(:openssl_rsa_public_key) { true }
 
       description "Use the openssl_rsa_public_key resource to generate RSA public key files given a RSA private key"
       introduced "14.0"

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class RegistryKey < Chef::Resource
       resource_name :registry_key
-      provides :registry_key
+      provides(:registry_key) { true }
 
       description "Use the registry_key resource to create and delete registry keys in Microsoft Windows."
       introduced "11.0"

--- a/lib/chef/resource/rhsm_errata.rb
+++ b/lib/chef/resource/rhsm_errata.rb
@@ -21,6 +21,7 @@ class Chef
   class Resource
     class RhsmErrata < Chef::Resource
       resource_name :rhsm_errata
+      provides(:rhsm_errata) { true }
 
       description "Use the rhsm_errata resource to install packages associated with a given Red"\
                   " Hat Subscription Manager Errata ID. This is helpful if packages"\

--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -21,6 +21,7 @@ class Chef
   class Resource
     class RhsmErrataLevel < Chef::Resource
       resource_name :rhsm_errata_level
+      provides(:rhsm_errata_level) { true }
 
       description " Use the rhsm_errata_level resource to install all packages of a specified errata level"\
                   " from the Red Hat Subscript Manager. For example, you can ensure that all packages associated"\

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -22,6 +22,7 @@ class Chef
   class Resource
     class RhsmRegister < Chef::Resource
       resource_name :rhsm_register
+      provides(:rhsm_register) { true }
 
       description "Use the rhsm_register resource to register a node with the Red Hat Subscription Manager"\
                   " or a local Red Hat Satellite server."

--- a/lib/chef/resource/rhsm_repo.rb
+++ b/lib/chef/resource/rhsm_repo.rb
@@ -21,6 +21,7 @@ class Chef
   class Resource
     class RhsmRepo < Chef::Resource
       resource_name :rhsm_repo
+      provides(:rhsm_repo) { true }
 
       description "Use the rhsm_repo resource to enable or disable Red Hat Subscription Manager"\
                   " repositories that are made available via attached subscriptions."

--- a/lib/chef/resource/rhsm_subscription.rb
+++ b/lib/chef/resource/rhsm_subscription.rb
@@ -21,6 +21,7 @@ class Chef
   class Resource
     class RhsmSubscription < Chef::Resource
       resource_name :rhsm_subscription
+      provides(:rhsm_subscription) { true }
 
       description "Use the rhsm_subscription resource to add or remove Red Hat Subscription Manager"\
                   " subscriptions from your host. This can be used when a host's activation_key"\

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -24,8 +24,8 @@ require "chef/resource"
 class Chef
   class Resource
     class Sudo < Chef::Resource
-      resource_name "sudo"
-      provides "sudo"
+      resource_name :sudo
+      provides(:sudo) { true }
 
       description "Use the sudo resource to add or remove individual sudo entries using sudoers.d files."\
                   " Sudo version 1.7.2 or newer is required to use the sudo resource, as it relies on the"\

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -21,7 +21,7 @@ class Chef
   class Resource
     class SwapFile < Chef::Resource
       resource_name :swap_file
-      provides :swap_file
+      provides(:swap_file) { true }
 
       description "Use the swap_file resource to create or delete swap files on Linux systems, and optionally to manage the swappiness configuration for a host."
       introduced "14.0"

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -21,8 +21,8 @@ class Chef
   class Resource
     class Sysctl < Chef::Resource
       resource_name :sysctl
-      provides :sysctl
-      provides :sysctl_param
+      provides(:sysctl) { true }
+      provides(:sysctl_param) { true }
 
       description "Use the sysctl resource to set kernel parameters using the sysctl"\
                   " command line tool and configuration files in the system's sysctl.d directory."\

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -22,7 +22,7 @@ require "iniparse"
 class Chef
   class Resource
     class SystemdUnit < Chef::Resource
-      resource_name :systemd_unit
+      resource_name(:systemd_unit) { true }
 
       description "Use the systemd_unit resource to create, manage, and run systemd units."
       introduced "12.11"

--- a/lib/chef/resource/windows_auto_run.rb
+++ b/lib/chef/resource/windows_auto_run.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsAutorun < Chef::Resource
       resource_name :windows_auto_run
-      provides :windows_auto_run
+      provides(:windows_auto_run) { true }
 
       description "Use the windows_auto_run resource to set applications to run at logon."
       introduced "14.0"

--- a/lib/chef/resource/windows_feature.rb
+++ b/lib/chef/resource/windows_feature.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsFeature < Chef::Resource
       resource_name :windows_feature
-      provides :windows_feature
+      provides(:windows_feature) { true }
 
       description "Use the windows_feature resource to add, remove or delete Windows features and roles. This resource calls"\
                   " the 'windows_feature_dism' or 'windows_feature_powershell' resources depending on the specified installation"\

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsFeatureDism < Chef::Resource
       resource_name :windows_feature_dism
-      provides :windows_feature_dism
+      provides(:windows_feature_dism) { true }
 
       description "Using the windows_feature_dism resource to add, remove or"\
                   " delete Windows features and roles using DISM"

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -24,7 +24,7 @@ class Chef
   class Resource
     class WindowsFeaturePowershell < Chef::Resource
       resource_name :windows_feature_powershell
-      provides :windows_feature_powershell
+      provides(:windows_feature_powershell) { true }
 
       description "Use the windows_feature_powershell resource to add, remove or"\
                   " delete Windows features and roles using PowerShell. This resource"\

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -23,7 +23,7 @@ class Chef
       require "chef/util/path_helper"
 
       resource_name :windows_font
-      provides :windows_font
+      provides(:windows_font) { true }
 
       description "Use the windows_font resource to install font files on Windows."\
                   " By default, the font is sourced from the cookbook using the resource, but a URI"\

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -27,7 +27,7 @@ class Chef
       include Chef::Mixin::Uris
 
       resource_name :windows_package
-      provides :windows_package
+      provides(:windows_package) { true }
       provides :package, os: "windows"
 
       description "Use the windows_package resource to manage Microsoft Installer Package"\

--- a/lib/chef/resource/windows_pagefile.rb
+++ b/lib/chef/resource/windows_pagefile.rb
@@ -21,7 +21,7 @@ class Chef
   class Resource
     class WindowsPagefile < Chef::Resource
       resource_name :windows_pagefile
-      provides :windows_pagefile
+      provides(:windows_pagefile) { true }
 
       description "Use the windows_pagefile resource to configure pagefile settings on Windows."
       introduced "14.0"

--- a/lib/chef/resource/windows_path.rb
+++ b/lib/chef/resource/windows_path.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsPath < Chef::Resource
       resource_name :windows_path
-      provides :windows_path
+      provides(:windows_path) { true }
 
       description "Use the windows_path resource to manage the path environment variable on Microsoft Windows."
       introduced "13.4"

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -25,7 +25,7 @@ class Chef
       require "resolv"
 
       resource_name :windows_printer
-      provides :windows_printer
+      provides(:windows_printer) { true }
 
       description "Use the windows_printer resource to setup Windows printers. Note"\
                   " that this doesn't currently install a printer driver. You must"\

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -25,7 +25,7 @@ class Chef
       require "resolv"
 
       resource_name :windows_printer_port
-      provides :windows_printer_port
+      provides(:windows_printer_port) { true }
 
       description "Use the windows_printer_port resource to create and delete TCP/IPv4 printer ports on Windows."
       introduced "14.0"

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -33,7 +33,7 @@ class Chef
       # Until #1773 is resolved, you need to manually specify the windows_service resource
       # to use action :configure_startup and attribute startup_type
 
-      provides :windows_service
+      provides(:windows_service) { true }
       provides :service, os: "windows"
 
       description "Use the windows_service resource to manage a service on the Microsoft Windows platform."

--- a/lib/chef/resource/windows_shortcut.rb
+++ b/lib/chef/resource/windows_shortcut.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsShortcut < Chef::Resource
       resource_name :windows_shortcut
-      provides :windows_shortcut
+      provides(:windows_shortcut) { true }
 
       description "Use the windows_shortcut resource to create shortcut files on Windows"
       introduced "14.0"

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class WindowsTask < Chef::Resource
       resource_name :windows_task
-      provides :windows_task
+      provides(:windows_task) { true }
 
       description "Use the windows_task resource to create, delete or run a Windows"\
                   " scheduled task. Requires Windows Server 2008 or later due to API usage."

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class YumRepository < Chef::Resource
       resource_name :yum_repository
-      provides :yum_repository
+      provides(:yum_repository) { true }
 
       description "Use the yum_repository resource to manage a Yum repository configuration"\
                   " file located at /etc/yum.repos.d/repositoryid.repo on the local machine."\

--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -22,7 +22,8 @@ class Chef
   class Resource
     class ZypperRepository < Chef::Resource
       resource_name :zypper_repository
-      provides :zypper_repo
+      provides(:zypper_repository) { true }
+      provides(:zypper_repo) { true }
 
       description "Use the zypper_repository resource to create Zypper package repositories"\
                   " on SUSE Enterprise Linux and openSUSE systems. This resource maintains"\


### PR DESCRIPTION
Due to changes in chef-client 14 old cookbooks started winning and this causes lots of problems, especially for old incompatible resources. Chef client should always win here.

Signed-off-by: Tim Smith <tsmith@chef.io>