### PR TITLE
Fix NoMethodError when (un)locking single packages in apt and zypper

### DIFF
--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -70,12 +70,22 @@ class Chef
           @candidate_version ||= get_candidate_versions
         end
 
-        def package_locked(name, version)
-          locked = shell_out_compact_timeout!("apt-mark", "showhold")
-          locked_packages = locked.stdout.each_line.map do |line|
-            line.strip
-          end
-          name.all? { |n| locked_packages.include? n }
+        def packages_all_locked?(names, versions)
+          names.all? { |n| locked_packages.include? n }
+        end
+
+        def packages_all_unlocked?(names, versions)
+          names.all? { |n| !locked_packages.include? n }
+        end
+
+        def locked_packages
+          @locked_packages ||=
+            begin
+              locked = shell_out_compact_timeout!("apt-mark", "showhold")
+              locked.stdout.each_line.map do |line|
+                line.strip
+              end
+            end
         end
 
         def install_package(name, version)

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -75,12 +75,22 @@ class Chef
           end
         end
 
-        def package_locked(name, version)
-          locked = shell_out_compact_timeout!("zypper", "locks")
-          locked_packages = locked.stdout.each_line.map do |line|
-            line.split("|").shift(2).last.strip
-          end
-          name.all? { |n| locked_packages.include? n }
+        def packages_all_locked?(names, versions)
+          names.all? { |n| locked_packages.include? n }
+        end
+
+        def packages_all_unlocked?(names, versions)
+          names.all? { |n| !locked_packages.include? n }
+        end
+
+        def locked_packages
+          @locked_packages ||=
+            begin
+              locked = shell_out_compact_timeout!("zypper", "locks")
+              locked.stdout.each_line.map do |line|
+                line.split("|").shift(2).last.strip
+              end
+            end
         end
 
         def load_current_resource

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -422,7 +422,6 @@ mpg123 1.12.1-0ubuntu1
                     )
         expect(logger).to receive(:trace).with("#{@provider.new_resource} is already locked")
 
-        @provider.new_resource.package_name = ["irssi"]
         @provider.action_lock
       end
     end
@@ -444,7 +443,6 @@ mpg123 1.12.1-0ubuntu1
                     )
         expect(logger).to receive(:trace).with("#{@provider.new_resource} is already unlocked")
 
-        @provider.new_resource.package_name = ["irssi"]
         @provider.action_unlock
       end
     end


### PR DESCRIPTION
Signed-off-by: Jonathan Hartman <j@hartman.io>

### Description

These resources don't coerce `package_name` to an array so would raise an
exception when trying to call `name.all?` when `package_name`, and thus `name`,
was a string.

Before applying the provider changes:

```shell
✗ bundle exec rspec spec/unit/provider/package/apt_spec.rb
...
Failures:

  1) Chef::Provider::Package::Apt after loading the current resource when locking a package should not lock if the package is already locked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "irssi":String
     # ./lib/chef/provider/package/apt.rb:78:in `package_locked'
     # ./lib/chef/provider/package.rb:226:in `action_lock'
     # ./spec/unit/provider/package/apt_spec.rb:425:in `block (4 levels) in <top (required)>'

  2) Chef::Provider::Package::Apt after loading the current resource when unlocking a package should not unlock if the package is already unlocked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "irssi":String
     # ./lib/chef/provider/package/apt.rb:78:in `package_locked'
     # ./lib/chef/provider/package.rb:245:in `action_unlock'
     # ./spec/unit/provider/package/apt_spec.rb:446:in `block (4 levels) in <top (required)>'

✗ bundle exec rspec spec/unit/provider/package/zypper_spec.rb
...
Failures:

  1) Chef::Provider::Package::Zypper action_lock should lock if the package is not already locked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "cups":String
     # ./lib/chef/provider/package/zypper.rb:83:in `package_locked'
     # ./lib/chef/provider/package.rb:226:in `action_lock'
     # ./spec/unit/provider/package/zypper_spec.rb:284:in `block (3 levels) in <top (required)>'

  2) Chef::Provider::Package::Zypper action_lock should not lock if the package is already locked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "cups":String
     # ./lib/chef/provider/package/zypper.rb:83:in `package_locked'
     # ./lib/chef/provider/package.rb:226:in `action_lock'
     # ./spec/unit/provider/package/zypper_spec.rb:300:in `block (3 levels) in <top (required)>'

  3) Chef::Provider::Package::Zypper action_unlock should unlock if the package is not already unlocked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "cups":String
     # ./lib/chef/provider/package/zypper.rb:83:in `package_locked'
     # ./lib/chef/provider/package.rb:245:in `action_unlock'
     # ./spec/unit/provider/package/zypper_spec.rb:341:in `block (3 levels) in <top (required)>'

  4) Chef::Provider::Package::Zypper action_unlock should not unlock if the package is already unlocked
     Failure/Error: name.all? { |n| locked_packages.include? n }
     
     NoMethodError:
       undefined method `all?' for "cups":String
     # ./lib/chef/provider/package/zypper.rb:83:in `package_locked'
     # ./lib/chef/provider/package.rb:245:in `action_unlock'
     # ./spec/unit/provider/package/zypper_spec.rb:356:in `block (3 levels) in <top (required)>'

```

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- ~RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>