### PR TITLE
Add support for route metric

### DIFF
--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -174,7 +174,7 @@ class Chef
             conf[dev] = "" if conf[dev].nil?
             case @action
             when :add
-              conf[dev] << config_file_contents(:add, comment: resource.comment, target: resource.target, netmask: resource.netmask, gateway: resource.gateway) if resource.action == [:add]
+              conf[dev] << config_file_contents(:add, comment: resource.comment, target: resource.target, metric: resource.metric, netmask: resource.netmask, gateway: resource.gateway) if resource.action == [:add]
             when :delete
               # need to do this for the case when the last route on an int
               # is removed
@@ -219,6 +219,7 @@ class Chef
           command = [ "ip", "route", "replace", target ]
           command += [ "via", new_resource.gateway ] if new_resource.gateway
           command += [ "dev", new_resource.device ] if new_resource.device
+          command += [ "metric", new_resource.metric ] if new_resource.metric
         when :delete
           command = [ "ip", "route", "delete", target ]
           command += [ "via", new_resource.gateway ] if new_resource.gateway
@@ -235,6 +236,7 @@ class Chef
           content << (options[:target]).to_s
           content << "/#{MASK[options[:netmask].to_s]}" if options[:netmask]
           content << " via #{options[:gateway]}" if options[:gateway]
+          content << " metric #{options[:metric]}" if options[:metric]
           content << "\n"
         end
 

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -29,7 +29,7 @@ class Chef
 
       property :target, String, identity: true, name_property: true
       property :comment, [String, nil]
-      property :metric, [String, nil]
+      property :metric, [Integer, nil]
       property :netmask, [String, nil]
       property :gateway, [String, nil]
       property :device, [String, nil], desired_state: false # Has a partial default in the provider of eth0.

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -29,6 +29,7 @@ class Chef
 
       property :target, String, identity: true, name_property: true
       property :comment, [String, nil]
+      property :metric, [String, nil]
       property :netmask, [String, nil]
       property :gateway, [String, nil]
       property :device, [String, nil], desired_state: false # Has a partial default in the provider of eth0.
@@ -40,7 +41,6 @@ class Chef
       property :hostname, [String, nil], desired_state: false
       property :domainname, [String, nil], desired_state: false
       property :domain, [String, nil], desired_state: false
-      property :metric, [Integer, nil], desired_state: false
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

### Description

This allows specifying route metric. metric are already supported by the ifconfig resource so add here also

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
