### PR TITLE
Remove angrychef from 'chef-13'

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -3,7 +3,6 @@
 # The name of the product keys for this product (from mixlib-install)
 product_key:
   - chef
-  - angrychef
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:


### PR DESCRIPTION
### Description

We no longer care about angrychef for Chef 13

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
