### PR TITLE
add the resources() dsl method back to providers

### DIFF
--- a/lib/chef/dsl/declare_resource.rb
+++ b/lib/chef/dsl/declare_resource.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,6 +166,27 @@ class Chef
         resource
       end
 
+      # Find existing resources by searching the list of existing resources.  Possible
+      # forms are:
+      #
+      #   find(:file => "foobar")
+      #   find(:file => [ "foobar", "baz" ])
+      #   find("file[foobar]", "file[baz]")
+      #   find("file[foobar,baz]")
+      #
+      # Calls `run_context.resource_collection.find(*args)`
+      #
+      # The is backcompat API, the use of find_resource, below, is encouraged.
+      #
+      # @return the matching resource, or an Array of matching resources.
+      #
+      # @raise ArgumentError if you feed it bad lookup information
+      # @raise RuntimeError if it can't find the resources you are looking for.
+      #
+      def resources(*args)
+        run_context.resource_collection.find(*args)
+      end
+
       # Lookup a resource in the resource collection by name.  If the resource is not
       # found this will raise Chef::Exceptions::ResourceNotFound.  This API is identical to the
       # resources() call and while it is a synonym it is not intended to deprecate that call.
@@ -292,6 +313,7 @@ class Chef
           enclosing_provider:  is_a?(Chef::Provider) ? self : nil
         ).build(&resource_attrs_block)
       end
+
     end
   end
 end

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,12 +64,6 @@ class Chef
     # Used in DSL mixins
     def node
       run_context.node
-    end
-
-    # Used by the DSL to look up resources when executing in the context of a
-    # recipe.
-    def resources(*args)
-      run_context.resource_collection.find(*args)
     end
 
     # This was moved to Chef::Node#tag, redirecting here for compatibility

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -23,6 +23,7 @@ require "chef/dsl/data_query"
 require "chef/dsl/registry_helper"
 require "chef/dsl/reboot_pending"
 require "chef/dsl/resources"
+require "chef/dsl/declare_resource"
 require "chef/json_compat"
 require "chef/mixin/convert_to_class_name"
 require "chef/guard_interpreter/resource_guard_interpreter"
@@ -51,6 +52,7 @@ class Chef
     # Generic User DSL (not resource-specific)
     #
 
+    include Chef::DSL::DeclareResource
     include Chef::DSL::DataQuery
     include Chef::DSL::RegistryHelper
     include Chef::DSL::RebootPending
@@ -95,26 +97,6 @@ class Chef
     #
     def node
       run_context && run_context.node
-    end
-
-    #
-    # Find existing resources by searching the list of existing resources.  Possible
-    # forms are:
-    #
-    #   find(:file => "foobar")
-    #   find(:file => [ "foobar", "baz" ])
-    #   find("file[foobar]", "file[baz]")
-    #   find("file[foobar,baz]")
-    #
-    # Calls `run_context.resource_collection.find(*args)`
-    #
-    # @return the matching resource, or an Array of matching resources.
-    #
-    # @raise ArgumentError if you feed it bad lookup information
-    # @raise RuntimeError if it can't find the resources you are looking for.
-    #
-    def resources(*args)
-      run_context.resource_collection.find(*args)
     end
 
     #

--- a/spec/unit/dsl/declare_resource_spec.rb
+++ b/spec/unit/dsl/declare_resource_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,15 @@ describe Chef::ResourceCollection do
 
   let(:recipe) do
     Chef::Recipe.new("hjk", "test", run_context)
+  end
+
+  describe "mixed in correctly" do
+    it "the resources() method winds up in the right classes" do
+      methods = [ :resources, :find_resource, :find_resource!, :edit_resource, :edit_resource!, :delete_resource, :delete_resource!, :declare_resource, :build_resource ]
+      expect(Chef::Resource.instance_methods).to include(*methods)
+      expect(Chef::Recipe.instance_methods).to include(*methods)
+      expect(Chef::Provider.instance_methods).to include(*methods)
+    end
   end
 
   describe "#declare_resource" do


### PR DESCRIPTION
Custom resource actions were picking this up via delegation to
the wrapping resource, and that wiring was removed in 14, so that
API then got dropped accidentally.  This should fix that back
up.  It also consistently injects the resource APIs into resources
and providers both now (and consistently across core resources
and custom resources).