### PR TITLE
Remove duplicate source property in the sudo resource

### DIFF
--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -171,7 +171,6 @@ class Chef
           end
         else
           declare_resource(:template, "#{target}#{new_resource.filename}") do
-            source "sudoer.erb"
             source ::File.expand_path("../support/sudoer.erb", __FILE__)
             local true
             mode "0440"


### PR DESCRIPTION
This was just a typo that came in from the sudo cookbook

Signed-off-by: Tim Smith <tsmith@chef.io>