### PR TITLE
Some options, i.e. metric, require specifying dev

### DIFF
--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -174,7 +174,7 @@ class Chef
             conf[dev] = "" if conf[dev].nil?
             case @action
             when :add
-              conf[dev] << config_file_contents(:add, comment: resource.comment, target: resource.target, metric: resource.metric, netmask: resource.netmask, gateway: resource.gateway) if resource.action == [:add]
+              conf[dev] << config_file_contents(:add, comment: resource.comment, device: resource.device, target: resource.target, metric: resource.metric, netmask: resource.netmask, gateway: resource.gateway) if resource.action == [:add]
             when :delete
               # need to do this for the case when the last route on an int
               # is removed
@@ -236,6 +236,7 @@ class Chef
           content << (options[:target]).to_s
           content << "/#{MASK[options[:netmask].to_s]}" if options[:netmask]
           content << " via #{options[:gateway]}" if options[:gateway]
+          content << " dev #{options[:device]}" if options[:device]
           content << " metric #{options[:metric]}" if options[:metric]
           content << "\n"
         end


### PR DESCRIPTION
### Description

On RHEL/CentOS, we must specify dev when using metric at least

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
