### PR TITLE
actually test against cheffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,10 @@ matrix:
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
     rvm: 2.5.1
   - env:
-      PEDANT_OPTS: --skip-oc_id
-      TEST_GEM: chef/chef-zero
-    script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec cheffs
+      - PEDANT_OPTS=--skip-oc_id
+      - TEST_GEM=chef/chef-zero
+      - CHEF_FS=true
+    script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake pedant
     rvm: 2.5.1
   - env:
       TEST_GEM: chef/cheffish

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2012-2018, Chef Software Inc.
+# Copyright:: Copyright 2012-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -307,14 +307,25 @@ class Chef
 
         # GET /cookbooks/NAME/VERSION or /cookbook_artifacts/NAME/IDENTIFIER
         elsif %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length == 3
-          with_cookbook_manifest(path) do |manifest, entry|
+          with_entry([path[0]]) do |entry|
             cookbook_type = path[0]
+            cookbook_entry = entry.children.select do |child|
+              child.chef_object.full_name == "#{path[1]}-#{path[2]}" ||
+                (child.chef_object.name.to_s == path[1] && child.chef_object.identifier == path[2])
+            end[0]
+            raise ChefZero::DataStore::DataNotFoundError.new(path) if cookbook_entry.nil?
+            result = nil
+            begin
+              result = Chef::CookbookManifest.new(cookbook_entry.chef_object, policy_mode: cookbook_type == "cookbook_artifacts").to_hash
+            rescue Chef::ChefFS::FileSystem::NotFoundError => e
+              raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+            end
 
-            manifest.each_pair do |key, value|
+            result.each_pair do |key, value|
               if value.is_a?(Array)
                 value.each do |file|
                   if file.is_a?(Hash) && file.has_key?("checksum")
-                    relative = ["file_store", "repo", cookbook_type, entry.name ]
+                    relative = ["file_store", "repo", cookbook_type, cookbook_entry.name ]
                     relative += file[:path].split("/")
                     file["url"] = ChefZero::RestBase.build_uri(request.base_uri, relative)
                   end
@@ -323,8 +334,8 @@ class Chef
             end
 
             if cookbook_type == "cookbook_artifacts"
-              manifest["metadata"] = manifest["metadata"].to_hash
-              manifest["metadata"].delete_if do |key, value|
+              result["metadata"] = result["metadata"].to_hash
+              result["metadata"].delete_if do |key, value|
                 value == [] ||
                   (value == {} && !%w{dependencies attributes recipes}.include?(key)) ||
                   (value == "" && %w{source_url issues_url}.include?(key)) ||
@@ -332,8 +343,9 @@ class Chef
               end
             end
 
-            Chef::JSONCompat.to_json_pretty(manifest)
+            Chef::JSONCompat.to_json_pretty(result)
           end
+
         else
           with_entry(path) do |entry|
             begin
@@ -754,26 +766,6 @@ class Chef
 
       def path_always_exists?(path)
         path.length == 1 && BASE_DIRNAMES.include?(path[0])
-      end
-
-      def with_cookbook_manifest(path)
-        cookbook_type = path[0]
-        begin
-          # this is fast and equivalent to with_entry() that also returns the cb manifest
-          entry = Chef::ChefFS::FileSystem.resolve_path(chef_fs, to_chef_fs_path(path))
-          yield Chef::CookbookManifest.new(entry.chef_object, policy_mode: cookbook_type == "cookbook_artifacts").to_hash, entry
-        rescue Chef::ChefFS::FileSystem::NotFoundError, ChefZero::DataStore::DataNotFoundError => e
-          # this is very slow and we walk through all the cookbook versions to find ones that have the correct name in the metadata
-          dir = Chef::ChefFS::FileSystem.resolve_path(chef_fs, to_chef_fs_path([path[0]]))
-          entry = dir.children.select do |child|
-            child.chef_object.full_name == "#{path[1]}-#{path[2]}" ||
-              (child.chef_object.name.to_s == path[1] && child.chef_object.identifier == path[2])
-          end[0]
-          raise ChefZero::DataStore::DataNotFoundError.new(path) if entry.nil?
-          yield Chef::CookbookManifest.new(entry.chef_object, policy_mode: cookbook_type == "cookbook_artifacts").to_hash, entry
-        end
-      rescue Chef::ChefFS::FileSystem::NotFoundError => e
-        raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
       end
 
       def with_entry(path)

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -28,7 +28,6 @@ describe "ChefFSDataStore tests", :workstation do
 
   let(:cookbook_x_100_metadata_rb) { cb_metadata("x", "1.0.0") }
   let(:cookbook_z_100_metadata_rb) { cb_metadata("z", "1.0.0") }
-  let(:cookbook_y_102_metadata_rb) { cb_metadata("z", "1.0.2") }
 
   describe "with repo mode 'hosted_everything' (default)" do
     before do
@@ -40,8 +39,6 @@ describe "ChefFSDataStore tests", :workstation do
         file "clients/x.json", {}
         file "cookbook_artifacts/x-111/metadata.rb", cookbook_x_100_metadata_rb
         file "cookbooks/x/metadata.rb", cookbook_x_100_metadata_rb
-        file "cookbooks/y/metadata.rb", cookbook_y_102_metadata_rb
-        file "cookbooks/z/metadata.rb", cookbook_z_100_metadata_rb
         file "data_bags/x/y.json", {}
         file "environments/x.json", {}
         file "nodes/x.json", {}
@@ -67,7 +64,6 @@ describe "ChefFSDataStore tests", :workstation do
 /acls/cookbook_artifacts/x.json
 /acls/cookbooks/
 /acls/cookbooks/x.json
-/acls/cookbooks/z.json
 /acls/data_bags/
 /acls/data_bags/x.json
 /acls/environments/
@@ -88,13 +84,11 @@ describe "ChefFSDataStore tests", :workstation do
 /containers/
 /containers/x.json
 /cookbook_artifacts/
-/cookbook_artifacts/x-1.0.0/
-/cookbook_artifacts/x-1.0.0/metadata.rb
+/cookbook_artifacts/x-111/
+/cookbook_artifacts/x-111/metadata.rb
 /cookbooks/
 /cookbooks/x/
 /cookbooks/x/metadata.rb
-/cookbooks/z/
-/cookbooks/z/metadata.rb
 /data_bags/
 /data_bags/x/
 /data_bags/x/y.json
@@ -117,12 +111,6 @@ EOM
         end
       end
 
-      context "LIST /TYPE/NAME" do
-        it "knife cookbook show -z z" do
-          knife("cookbook show -z z").should_succeed "z   1.0.2  1.0.0\n"
-        end
-      end
-
       context "DELETE /TYPE/NAME" do
         it "knife delete -z /clients/x.json works" do
           knife("delete -z /clients/x.json").should_succeed "Deleted /clients/x.json\n"
@@ -131,7 +119,7 @@ EOM
 
         it "knife delete -z -r /cookbooks/x works" do
           knife("delete -z -r /cookbooks/x").should_succeed "Deleted /cookbooks/x\n"
-          knife("list -z -Rfp /cookbooks").should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
+          knife("list -z -Rfp /cookbooks").should_succeed ""
         end
 
         it "knife delete -z -r /data_bags/x works" do
@@ -206,14 +194,7 @@ EOM
 Uploading x              [1.0.0]
 Uploaded 1 cookbook.
 EOM
-          knife("list --local -Rfp /cookbooks").should_succeed <<EOM
-/cookbooks/x/
-/cookbooks/x/metadata.rb
-/cookbooks/y/
-/cookbooks/y/metadata.rb
-/cookbooks/z/
-/cookbooks/z/metadata.rb
-EOM
+          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
         end
 
         it "knife raw -z -i empty.json -m PUT /data/x/y" do

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2018, Chef Software Inc.
+# Copyright:: Copyright 2013-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -11,6 +11,10 @@ include Chef::Mixin::ShellOut
 github_repo = ARGV.shift
 git_thing = ARGV.shift
 
+build_dir = File.expand_path(ENV["TRAVIS_BUILD_DIR"] || Dir.pwd)
+
+env = { "GEMFILE_MOD" => "gem 'chef', path: '#{build_dir}'" }
+
 Dir.mktmpdir("chef-external-test") do |dir|
   git_url = "https://github.com/#{github_repo}"
   Dir.rmdir dir
@@ -18,8 +22,8 @@ Dir.mktmpdir("chef-external-test") do |dir|
   Dir.chdir(dir) do
     shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
     Bundler.with_clean_env do
-      shell_out!("bundle install", live_stream: STDOUT)
-      shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT)
+      shell_out!("bundle install", live_stream: STDOUT, env: env)
+      shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
     end
   end
 end


### PR DESCRIPTION
- revert the changes to try to lookup chef-zero cookbook using name property.  even after the perf fixes, it caused chef-zero to fail lots of pedant tests, which were masked by the fact that this repo was testing the released version of chef, and pulling master of chef-zero which was still pinned to chef 13.

- test chef-zero and cheffish correctly against PRs and against master.

this reverts the changes in #7143 and #6471

