### PR TITLE
Avoid conflict with build_powershell_command from powershell_out mixin

### DIFF
--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -36,7 +36,7 @@ class Chef
 
         def define_resource_requirements
           super
-          if node['languages']['powershell']['version'].to_i < 5
+          if powershell_out("$PSVersionTable.PSVersion.Major").stdout.strip.to_i < 5
             raise "Minimum installed Powershell Version required is 5"
           end
           requirements.assert(:install) do |a|

--- a/spec/unit/provider/package/powershell_spec.rb
+++ b/spec/unit/provider/package/powershell_spec.rb
@@ -192,88 +192,88 @@ describe Chef::Provider::Package::Powershell do
 
   end
 
-  describe "#build_powershell_command" do
+  describe "#build_powershell_package_command" do
     it "can build a valid command from a single string" do
-      expect(provider.build_powershell_command("Get-Package posh-git")).to eql(generated_command)
+      expect(provider.build_powershell_package_command("Get-Package posh-git")).to eql(generated_command)
     end
 
     it "can build a valid command from an array" do
-      expect(provider.build_powershell_command(["Get-Package", "posh-git"])).to eql(generated_command)
+      expect(provider.build_powershell_package_command(["Get-Package", "posh-git"])).to eql(generated_command)
     end
 
     context "when source is nil" do
       it "build get commands correctly" do
-        expect(provider.build_powershell_command("Get-Package xNetworking")).to eql(generated_get_cmdlet)
+        expect(provider.build_powershell_package_command("Get-Package xNetworking")).to eql(generated_get_cmdlet)
       end
 
       it "build get commands correctly when a version is passed" do
-        expect(provider.build_powershell_command("Get-Package xNetworking", "1.0.0.0")).to eql(generated_get_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Get-Package xNetworking", "1.0.0.0")).to eql(generated_get_cmdlet_with_version)
       end
 
       it "builds find commands correctly" do
-        expect(provider.build_powershell_command("Find-Package xNetworking")).to eql(generated_find_cmdlet)
+        expect(provider.build_powershell_package_command("Find-Package xNetworking")).to eql(generated_find_cmdlet)
       end
 
       it "builds find commands correctly when a version is passed" do
-        expect(provider.build_powershell_command("Find-Package xNetworking", "1.0.0.0")).to eql(generated_find_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Find-Package xNetworking", "1.0.0.0")).to eql(generated_find_cmdlet_with_version)
       end
 
       it "build install commands correctly" do
-        expect(provider.build_powershell_command("Install-Package xNetworking")).to eql(generated_install_cmdlet)
+        expect(provider.build_powershell_package_command("Install-Package xNetworking")).to eql(generated_install_cmdlet)
       end
 
       it "build install commands correctly when a version is passed" do
-        expect(provider.build_powershell_command("Install-Package xNetworking", "1.0.0.0")).to eql(generated_install_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Install-Package xNetworking", "1.0.0.0")).to eql(generated_install_cmdlet_with_version)
       end
 
       it "build install commands correctly" do
-        expect(provider.build_powershell_command("Uninstall-Package xNetworking")).to eql(generated_uninstall_cmdlet)
+        expect(provider.build_powershell_package_command("Uninstall-Package xNetworking")).to eql(generated_uninstall_cmdlet)
       end
 
       it "build install commands correctly when a version is passed" do
-        expect(provider.build_powershell_command("Uninstall-Package xNetworking", "1.0.0.0")).to eql(generated_uninstall_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Uninstall-Package xNetworking", "1.0.0.0")).to eql(generated_uninstall_cmdlet_with_version)
       end
     end
 
     context "when source is set" do
       it "build get commands correctly" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Get-Package xNetworking")).to eql(generated_get_cmdlet)
+        expect(provider.build_powershell_package_command("Get-Package xNetworking")).to eql(generated_get_cmdlet)
       end
 
       it "build get commands correctly when a version is passed" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Get-Package xNetworking", "1.0.0.0")).to eql(generated_get_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Get-Package xNetworking", "1.0.0.0")).to eql(generated_get_cmdlet_with_version)
       end
 
       it "builds find commands correctly" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Find-Package xNetworking")).to eql(generated_find_cmdlet_with_source)
+        expect(provider.build_powershell_package_command("Find-Package xNetworking")).to eql(generated_find_cmdlet_with_source)
       end
 
       it "builds find commands correctly when a version is passed" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Find-Package xNetworking", "1.0.0.0")).to eql(generated_find_cmdlet_with_source_and_version)
+        expect(provider.build_powershell_package_command("Find-Package xNetworking", "1.0.0.0")).to eql(generated_find_cmdlet_with_source_and_version)
       end
 
       it "build install commands correctly" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Install-Package xNetworking")).to eql(generated_install_cmdlet_with_source)
+        expect(provider.build_powershell_package_command("Install-Package xNetworking")).to eql(generated_install_cmdlet_with_source)
       end
 
       it "build install commands correctly when a version is passed" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Install-Package xNetworking", "1.0.0.0")).to eql(generated_install_cmdlet_with_source_and_version)
+        expect(provider.build_powershell_package_command("Install-Package xNetworking", "1.0.0.0")).to eql(generated_install_cmdlet_with_source_and_version)
       end
 
       it "build install commands correctly" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Uninstall-Package xNetworking")).to eql(generated_uninstall_cmdlet)
+        expect(provider.build_powershell_package_command("Uninstall-Package xNetworking")).to eql(generated_uninstall_cmdlet)
       end
 
       it "build install commands correctly when a version is passed" do
         new_resource.source("MyGallery")
-        expect(provider.build_powershell_command("Uninstall-Package xNetworking", "1.0.0.0")).to eql(generated_uninstall_cmdlet_with_version)
+        expect(provider.build_powershell_package_command("Uninstall-Package xNetworking", "1.0.0.0")).to eql(generated_uninstall_cmdlet_with_version)
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

`powershell_out` wraps the command to run via calling a method `build_powershell_command`.  This method was also implemented with the same name in the `powershell_package` provider but for a different purpose and hence calling `powershell_out` from the provider resulted in incorrect parameters being passed to PowerShell for execution.

Renamed the method in the provider and associated references, and made a small optimization to the PowerShell version detection logic to use an ohai automatic attribute instead of attempting to execute PowerShell to retrieve the version.

### Issues Resolved

Fixes #7166 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
