### PR TITLE
Disable testing of poise in travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,10 +112,11 @@ matrix:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
     rvm: 2.5.1
-  - env:
-      TEST_GEM: poise/poise
-    script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.1
+  # disable this pending a Chef 14 compat version of poise
+  # - env:
+  #     TEST_GEM: poise/poise
+  #   script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
+  #   rvm: 2.5.1
   ### START TEST KITCHEN ONLY ###
   #
   - rvm: 2.4.4


### PR DESCRIPTION
Disable this pending a Chef 14 compatible version of poise

Signed-off-by: Tim Smith <tsmith@chef.io>