### PR TITLE
removing foodcritic from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,6 @@ matrix:
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
     rvm: 2.5.1
   - env:
-      TEST_GEM: foodcritic/foodcritic
-    script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake test
-    rvm: 2.5.1
-  - env:
       TEST_GEM: poise/halite
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
     rvm: 2.5.1


### PR DESCRIPTION
it doesn't depend on chef/chef so this test seems quite pointless.

