### PR TITLE
Ensure we have a sane PATH when calling sysctl -p

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -84,7 +84,10 @@ class Chef
             content "#{new_resource.key} = #{new_resource.value}"
           end
 
-          execute "sysctl -p"
+          execute "sysctl -p" do
+            environment ({"PATH" => "/sbin:/bin:/usr/sbin:/usr/bin"})
+            command "sysctl -p"
+          end
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

### Description

Fixes issue on RHEL 6/7 where sysctl isn't on PATH when chef-client is called via cron

### Issues Resolved

#7180

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
