### PR TITLE
Run all tests in CI

### DIFF
--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -118,5 +118,5 @@ if [ "x$ACCEPTANCE" != "x" ]; then
 else
   cd $CHEF_GEM
 
-  sudo bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional
+  sudo bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation
 fi


### PR DESCRIPTION
Previously, we ran only integration tests. But many of our unit tests
are constrained by rootyness and platform, and this means the first time
they get run is during the ChefDK verification stage, which uses the
released Chef build. So we have no way of fixing test failures short of
a new Chef release.

For those that can see this, http://manhattan.cd.chef.co/job/chefdk-test/architecture=x86_64,platform=el-7,project=chefdk,role=tester/25//console is a perfect example.