### PR TITLE
Enable expire cache enabled builds for chef-13

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,6 +24,9 @@ github:
   # The file where our CHANGELOG is kept. This file is updated automatically with
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
+  # This will trigger an Omnibus build with EXPIRE_CACHE enabled after
+  # a pull request is merged into the release branch.
+  enable_expire_cache: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
   # The Github Team primarily responsible for handling incoming Pull Requests.


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Enable expire cache enabled release builds for chef-13

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
