### PR TITLE
Allow specifying `ignore_failure :quiet` to disable the error spew

### DIFF
--- a/lib/chef/formatters/base.rb
+++ b/lib/chef/formatters/base.rb
@@ -137,7 +137,7 @@ class Chef
 
       def resource_failed(resource, action, exception)
         description = ErrorMapper.resource_failed(resource, action, exception)
-        display_error(description)
+        display_error(description) unless resource.ignore_failure && resource.ignore_failure.to_s == 'quiet'
       end
 
       # Generic callback for any attribute/library/lwrp/recipe file in a

--- a/lib/chef/formatters/base.rb
+++ b/lib/chef/formatters/base.rb
@@ -137,7 +137,7 @@ class Chef
 
       def resource_failed(resource, action, exception)
         description = ErrorMapper.resource_failed(resource, action, exception)
-        display_error(description) unless resource.ignore_failure && resource.ignore_failure.to_s == 'quiet'
+        display_error(description) unless resource.ignore_failure && resource.ignore_failure.to_s == "quiet"
       end
 
       # Generic callback for any attribute/library/lwrp/recipe file in a

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -524,7 +524,7 @@ class Chef
     # @param arg [Boolean, String, Symbol] Whether to ignore failures.
     # @return Whether this resource will ignore failures.
     #
-    property :ignore_failure, [ true, false, :quiet, 'quiet' ], default: false, desired_state: false
+    property :ignore_failure, [ true, false, :quiet, "quiet" ], default: false, desired_state: false
 
     #
     # Make this resource into an exact (shallow) copy of the other resource.

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -515,15 +515,16 @@ class Chef
     #
     # Whether to ignore failures.  If set to `true`, and this resource when an
     # action is run, the resource will be marked as failed but no exception will
-    # be thrown (and no error will be output).  Defaults to `false`.
+    # be thrown (and no error will be output).  Defaults to `false`. If set to
+    # `:quiet` or `'quiet'`, the normal error trace will be suppressed.
     #
     # TODO ignore_failure and retries seem to be mutually exclusive; I doubt
     # that was intended.
     #
-    # @param arg [Boolean] Whether to ignore failures.
+    # @param arg [Boolean, String, Symbol] Whether to ignore failures.
     # @return Whether this resource will ignore failures.
     #
-    property :ignore_failure, [ TrueClass, FalseClass ], default: false, desired_state: false
+    property :ignore_failure, [ true, false, :quiet, 'quiet' ], default: false, desired_state: false
 
     #
     # Make this resource into an exact (shallow) copy of the other resource.

--- a/spec/unit/formatters/base_spec.rb
+++ b/spec/unit/formatters/base_spec.rb
@@ -23,6 +23,14 @@ describe Chef::Formatters::Base do
   let(:out) { StringIO.new }
   let(:err) { StringIO.new }
   let(:formatter) { Chef::Formatters::Base.new(out, err) }
+  let(:exception) do
+    # An exception with a real backtrace.
+    begin
+      raise EOFError
+    rescue EOFError => exc
+    end
+    exc
+  end
 
   it "starts with an indentation of zero" do
     expect(formatter.output.indent).to eql(0)
@@ -45,27 +53,48 @@ describe Chef::Formatters::Base do
   end
 
   it "humanizes EOFError exceptions for #registration_failed" do
-    formatter.registration_failed("foo.example.com", EOFError.new, double("Chef::Config"))
+    formatter.registration_failed("foo.example.com", exception, double("Chef::Config"))
     expect(out.string).to match(/Received an EOF on transport socket/)
   end
 
   it "humanizes EOFError exceptions for #node_load_failed" do
-    formatter.node_load_failed("foo.example.com", EOFError.new, double("Chef::Config"))
+    formatter.node_load_failed("foo.example.com", exception, double("Chef::Config"))
     expect(out.string).to match(/Received an EOF on transport socket/)
   end
 
   it "humanizes EOFError exceptions for #run_list_expand_failed" do
-    formatter.run_list_expand_failed(double("Chef::Node"), EOFError.new)
+    formatter.run_list_expand_failed(double("Chef::Node"), exception)
     expect(out.string).to match(/Received an EOF on transport socket/)
   end
 
   it "humanizes EOFError exceptions for #cookbook_resolution_failed" do
-    formatter.run_list_expand_failed(double("Expanded Run List"), EOFError.new)
+    formatter.run_list_expand_failed(double("Expanded Run List"), exception)
     expect(out.string).to match(/Received an EOF on transport socket/)
   end
 
   it "humanizes EOFError exceptions for #cookbook_sync_failed" do
-    formatter.cookbook_sync_failed("foo.example.com", EOFError.new)
+    formatter.cookbook_sync_failed("foo.example.com", exception)
     expect(out.string).to match(/Received an EOF on transport socket/)
+  end
+
+  it "outputs error information for failed resources with ignore_failure true" do
+    resource = Chef::Resource::RubyBlock.new('test')
+    resource.ignore_failure(true)
+    formatter.resource_failed(resource, :run, exception)
+    expect(out.string).to match(/Error executing action `run` on resource 'ruby_block\[test\]'/)
+  end
+
+  it "does not output error information for failed resources with ignore_failure :quiet" do
+    resource = Chef::Resource::RubyBlock.new('test')
+    resource.ignore_failure(:quiet)
+    formatter.resource_failed(resource, :run, exception)
+    expect(out.string).to eq('')
+  end
+
+  it "does not output error information for failed resources with ignore_failure 'quiet'" do
+    resource = Chef::Resource::RubyBlock.new('test')
+    resource.ignore_failure('quiet')
+    formatter.resource_failed(resource, :run, exception)
+    expect(out.string).to eq('')
   end
 end

--- a/spec/unit/formatters/base_spec.rb
+++ b/spec/unit/formatters/base_spec.rb
@@ -78,23 +78,23 @@ describe Chef::Formatters::Base do
   end
 
   it "outputs error information for failed resources with ignore_failure true" do
-    resource = Chef::Resource::RubyBlock.new('test')
+    resource = Chef::Resource::RubyBlock.new("test")
     resource.ignore_failure(true)
     formatter.resource_failed(resource, :run, exception)
     expect(out.string).to match(/Error executing action `run` on resource 'ruby_block\[test\]'/)
   end
 
   it "does not output error information for failed resources with ignore_failure :quiet" do
-    resource = Chef::Resource::RubyBlock.new('test')
+    resource = Chef::Resource::RubyBlock.new("test")
     resource.ignore_failure(:quiet)
     formatter.resource_failed(resource, :run, exception)
-    expect(out.string).to eq('')
+    expect(out.string).to eq("")
   end
 
   it "does not output error information for failed resources with ignore_failure 'quiet'" do
-    resource = Chef::Resource::RubyBlock.new('test')
-    resource.ignore_failure('quiet')
+    resource = Chef::Resource::RubyBlock.new("test")
+    resource.ignore_failure("quiet")
     formatter.resource_failed(resource, :run, exception)
-    expect(out.string).to eq('')
+    expect(out.string).to eq("")
   end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -555,6 +555,16 @@ end
       resource.ignore_failure(true)
       expect(resource.ignore_failure).to eq(true)
     end
+
+    it "should allow you to set quiet ignore_failure as a symbol" do
+      resource.ignore_failure(:quiet)
+      expect(resource.ignore_failure).to eq(:quiet)
+    end
+
+    it "should allow you to set quiet ignore_failure as a string" do
+      resource.ignore_failure('quiet')
+      expect(resource.ignore_failure).to eq('quiet')
+    end
   end
 
   describe "retries" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -562,8 +562,8 @@ end
     end
 
     it "should allow you to set quiet ignore_failure as a string" do
-      resource.ignore_failure('quiet')
-      expect(resource.ignore_failure).to eq('quiet')
+      resource.ignore_failure("quiet")
+      expect(resource.ignore_failure).to eq("quiet")
     end
   end
 


### PR DESCRIPTION
Directly inspired by https://github.com/sous-chefs/sysctl/pull/127 but more generally people have been asking for this forever so why not?