### PR TITLE
Tg/clear gem sources option

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1086,6 +1086,9 @@ module ChefConfig
     # can be set to a string or array of strings for URIs to set as rubygems sources
     default :rubygems_url, "https://www.rubygems.org"
 
+    # globally sets the default of the clear_sources property on the gem_package and chef_gem resources
+    default :clear_gem_sources, false 
+
     # If installed via an omnibus installer, this gives the path to the
     # "embedded" directory which contains all of the software packaged with
     # omnibus. This is used to locate the cacert.pem file on windows.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -1087,7 +1087,7 @@ module ChefConfig
     default :rubygems_url, "https://www.rubygems.org"
 
     # globally sets the default of the clear_sources property on the gem_package and chef_gem resources
-    default :clear_gem_sources, false 
+    default :clear_gem_sources, false
 
     # If installed via an omnibus installer, this gives the path to the
     # "embedded" directory which contains all of the software packaged with

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -40,7 +40,7 @@ class Chef
       # FIXME? the array form of installing paths most likely does not work?
       #
       property :source, [ String, Array ]
-      property :clear_sources, [ TrueClass, FalseClass ], default: false, desired_state: false
+      property :clear_sources, [ TrueClass, FalseClass ], default: lazy {Chef::Config[:clear_gem_sources]}, desired_state: false
       # Sets a custom gem_binary to run for gem commands.
       property :gem_binary, String, desired_state: false
 

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -40,7 +40,7 @@ class Chef
       # FIXME? the array form of installing paths most likely does not work?
       #
       property :source, [ String, Array ]
-      property :clear_sources, [ TrueClass, FalseClass ], default: lazy {Chef::Config[:clear_gem_sources]}, desired_state: false
+      property :clear_sources, [ TrueClass, FalseClass ], default: lazy { Chef::Config[:clear_gem_sources] }, desired_state: false
       # Sets a custom gem_binary to run for gem commands.
       property :gem_binary, String, desired_state: false
 

--- a/spec/unit/resource/gem_package_spec.rb
+++ b/spec/unit/resource/gem_package_spec.rb
@@ -38,3 +38,16 @@ describe Chef::Resource::GemPackage, "gem_binary" do
     expect(resource.gem_binary).to eql("/opt/local/bin/gem")
   end
 end
+
+describe Chef::Resource::GemPackage, "clear_gem_sources" do
+  let(:resource) { Chef::Resource::GemPackage.new("foo") }
+
+  it "is false by default" do
+    expect(resource.clear_sources).to be false
+  end
+
+  it "sets the default of clear_sources to the config value" do
+    Chef::Config[:clear_gem_sources] = true
+    expect(resource.clear_sources).to be true
+  end
+end


### PR DESCRIPTION
### Description

Added a config option called clear_gem_sources and defaulted gem_package.clear_gem_sources to it. This supports airgapped environments that want to exclude implicit remote gem sources.
