### PR TITLE
Allow build_essential resource to be used without setting a name

### DIFF
--- a/kitchen-tests/cookbooks/base/recipes/default.rb
+++ b/kitchen-tests/cookbooks/base/recipes/default.rb
@@ -25,7 +25,7 @@ yum_repository "epel" do
   only_if { platform_family?("rhel") }
 end
 
-build_essential "install compilation tools"
+build_essential
 
 include_recipe "::packages"
 

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -25,6 +25,9 @@ class Chef
       description "Use the build_essential resource to install packages required for compiling C software from source"
       introduced "14.0"
 
+      # this allows us to use build_essential without setting a name
+      property :name, String, default: ""
+
       property :compile_time, [TrueClass, FalseClass],
                description: "Install build essential packages at compile time.",
                default: false

--- a/spec/unit/resource/build_essential_spec.rb
+++ b/spec/unit/resource/build_essential_spec.rb
@@ -28,4 +28,12 @@ describe Chef::Resource::BuildEssential do
   it "has a default action of install" do
     expect(resource.action).to eql([:install])
   end
+
+  context "when not settting a resource name" do
+    let(:resource) { Chef::Resource::BuildEssential.new(nil) }
+
+    it "the name defaults to an empty string" do
+      expect(resource.name).to eql("")
+    end
+  end
 end


### PR DESCRIPTION
This is the same as apt_update. It seems odd to use this resource with a name like this:

```ruby
build_essential "build-essential"
```

Signed-off-by: Tim Smith <tsmith@chef.io>