### PR TITLE
Convert :key property in registry_key to use property

### DIFF
--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -28,7 +28,6 @@ class Chef
       description "Use the registry_key resource to create and delete registry keys in Microsoft Windows."
       introduced "11.0"
 
-      identity_attr :key
       state_attrs :values
 
       default_action :create
@@ -67,17 +66,10 @@ class Chef
 
       def initialize(name, run_context = nil)
         super
-        @key = name
         @values, @unscrubbed_values = [], []
       end
 
-      def key(arg = nil)
-        set_or_return(
-          :key,
-          arg,
-          :kind_of => String
-        )
-      end
+      property :key, String, name_property: true, identity: true
 
       def values(arg = nil)
         if not arg.nil?

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -195,6 +195,6 @@ describe Chef::Resource::RegistryKey, "state" do
 
   it "returns scrubbed values" do
     resource.values([ { :name => "poosh", :type => :binary, :data => 255.chr * 1 } ])
-    expect(resource.state_for_resource_reporter).to eql( { :values => [{ :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" }] } )
+    expect(resource.state_for_resource_reporter[:values]).to eql( [{ :name => "poosh", :type => :binary, :data => "a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89" }] )
   end
 end


### PR DESCRIPTION
Convert this to a true property. It required updating the specs a tiny bit since key gets returned as a state value now (as it should).

Signed-off-by: Tim Smith <tsmith@chef.io>