### PR TITLE
Don't always request lazy files

### DIFF
--- a/lib/chef/cookbook/remote_file_vendor.rb
+++ b/lib/chef/cookbook/remote_file_vendor.rb
@@ -62,7 +62,7 @@ class Chef
         # If the checksums are different between on-disk (current) and on-server
         # (remote, per manifest), do the update. This will also execute if there
         # is no current checksum.
-        if found_manifest_record[:lazy] || current_checksum != found_manifest_record["checksum"]
+        if current_checksum != found_manifest_record["checksum"]
           raw_file = @rest.streaming_request(found_manifest_record[:url])
 
           Chef::Log.trace("Storing updated #{cache_filename} in the cache.")


### PR DESCRIPTION
Testing with a single remote directory of 100 3 byte files, this drops a chef run from 40 secs to 5 secs when the files are already in the cache (identical to lazy load being disabled).