### PR TITLE
Trying to use --recipe-url on Windows with local file fails

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -534,9 +534,13 @@ class Chef::Application::Client < Chef::Application
 
   def fetch_recipe_tarball(url, path)
     Chef::Log.trace("Download recipes tarball from #{url} to #{path}")
-    File.open(path, "wb") do |f|
-      open(url) do |r|
-        f.write(r.read)
+    if File.exist?(url)
+      FileUtils.cp(url, path)
+    else
+      File.open(path, "wb") do |f|
+        open(url) do |r|
+          f.write(r.read)
+        end
       end
     end
   end

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -28,6 +28,7 @@ require "chef/workstation_config_loader"
 require "chef/mixin/shell_out"
 require "chef-config/mixin/dot_d"
 require "mixlib/archive"
+require "uri"
 
 class Chef::Application::Client < Chef::Application
   include Chef::Mixin::ShellOut
@@ -534,14 +535,17 @@ class Chef::Application::Client < Chef::Application
 
   def fetch_recipe_tarball(url, path)
     Chef::Log.trace("Download recipes tarball from #{url} to #{path}")
-    if File.exist?(url)
-      FileUtils.cp(url, path)
-    else
+    if url =~ URI.regexp
       File.open(path, "wb") do |f|
         open(url) do |r|
           f.write(r.read)
         end
       end
+    elsif File.exist?(url)
+      FileUtils.cp(url, path)
+    else
+      Chef::Application.fatal! "You specified --recipe-url but the value is neither a valid URL nor a path to a file that exists on disk." +
+        "Please confirm the location of the tarball and try again."
     end
   end
 end

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -553,6 +553,12 @@ EOM
       result = shell_out("#{chef_client} --recipe-url=http://localhost:9000/recipes.tgz", :cwd => tmp_dir)
       expect(result.exitstatus).not_to eq(0)
     end
+
+    it "should fail when passed --recipe-url with a file that doesn't exist" do
+      broken_path = File.join(CHEF_SPEC_DATA, "recipes_dont_exist.tgz")
+      result = shell_out("#{chef_client} --recipe-url=#{broken_path}", :cwd => tmp_dir)
+      expect(result.exitstatus).not_to eq(0)
+    end
   end
 
   when_the_repository "has a cookbook with broken metadata.rb, but has metadata.json" do


### PR DESCRIPTION
### Description

Trying to use --recipe-url on Windows with local file fails, but succeeds on Linux. I'm guessing open-uri doesn't handle local file paths well with `open`? Either way this fixes the issue.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tyleraball@gmail.com>