### PR TITLE
Remove redundant "?" in knife configure

### DIFF
--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -75,7 +75,7 @@ class Chef
 
         config_file = File.expand_path(config_file)
         if File.exist?(config_file)
-          confirm("Overwrite #{config_file}?")
+          confirm("Overwrite #{config_file}")
         end
         ::File.open(config_file, "w") do |f|
           f.puts <<-EOH


### PR DESCRIPTION
### Description

This is already provided by `def confirmation_instructions` in `chef/lib/chef/knife/core/ui.rb`, currently this results in 
```
Overwrite /Users/alexymik/.chef/credentials?? (Y/N)
```

### Issues Resolved

Fixes typo

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
