### PR TITLE
Support for toml knife config settings

### DIFF
--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -156,10 +156,10 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
-      creds.each  do |key, value|
+      creds.each do |key, value|
         next unless key == "knife"
-        value.each do | k, v |
-          Config.knife[k.to_sym] = v
+        value.each do |k, v|
+          Config.knife.merge!({k.to_sym => v})
         end
       end
 

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -156,10 +156,10 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
-      creds.each do |cred|
-        knife_setting = /knife\[:(\w+)\]/.match(cred[0])
-        if knife_setting
-          Config.knife[knife_setting[1].to_sym] = cred[1]
+      creds.each  do |key, value|
+        next if key != "knife"
+        value.each do | k, v |
+          Config.knife[k.to_sym] = v
         end
       end
 

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -156,12 +156,7 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
-      creds.each do |key, value|
-        next unless key == "knife"
-        value.each do |k, v|
-          Config.knife.merge!({k.to_sym => v})
-        end
-      end
+      Config.knife.merge!(Hash[creds.fetch('knife', {}).map{|k, v| [k.to_sym, v]}])
 
       extract_key(creds, "validation_key", :validation_key, :validation_key_contents)
       extract_key(creds, "validator_key", :validation_key, :validation_key_contents)

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -156,7 +156,7 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
-      Config.knife.merge!(Hash[creds.fetch('knife', {}).map{|k, v| [k.to_sym, v]}])
+      Config.knife.merge!(Hash[creds.fetch('knife', {}).map { |k, v| [k.to_sym, v] }])
 
       extract_key(creds, "validation_key", :validation_key, :validation_key_contents)
       extract_key(creds, "validator_key", :validation_key, :validation_key_contents)

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -156,7 +156,7 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
-      Config.knife.merge!(Hash[creds.fetch('knife', {}).map { |k, v| [k.to_sym, v] }])
+      Config.knife.merge!(Hash[creds.fetch("knife", {}).map { |k, v| [k.to_sym, v] }])
 
       extract_key(creds, "validation_key", :validation_key, :validation_key_contents)
       extract_key(creds, "validator_key", :validation_key, :validation_key_contents)

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -157,7 +157,7 @@ module ChefConfig
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
       creds.each  do |key, value|
-        next if key != "knife"
+        next unless key == "knife"
         value.each do | k, v |
           Config.knife[k.to_sym] = v
         end

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -72,7 +72,7 @@ module ChefConfig
       load_credentials(profile)
       # Ignore it if there's no explicit_config_file and can't find one at a
       # default path.
-      if !config_location.nil?
+      unless config_location.nil?
         if explicit_config_file && !path_exists?(config_location)
           raise ChefConfig::ConfigurationError, "Specified config file #{config_location} does not exist"
         end
@@ -156,6 +156,13 @@ module ChefConfig
       Config.chef_server_url = creds.fetch("chef_server_url") if creds.key?("chef_server_url")
       Config.validation_client_name = creds.fetch("validation_client_name") if creds.key?("validation_client_name")
 
+      creds.each do |cred|
+        knife_setting = /knife\[:(\w+)\]/.match(cred[0])
+        if knife_setting
+          Config.knife[knife_setting[1].to_sym] = cred[1]
+        end
+      end
+
       extract_key(creds, "validation_key", :validation_key, :validation_key_contents)
       extract_key(creds, "validator_key", :validation_key, :validation_key_contents)
       extract_key(creds, "client_key", :client_key, :client_key_contents)
@@ -196,7 +203,7 @@ module ChefConfig
       message << "#{e.class.name}: #{e.message}\n"
       filtered_trace = e.backtrace.grep(/#{Regexp.escape(config_file_path)}/)
       filtered_trace.each { |bt_line| message << "  " << bt_line << "\n" }
-      if !filtered_trace.empty?
+      unless filtered_trace.empty?
         line_nr = filtered_trace.first[/#{Regexp.escape(config_file_path)}:([\d]+)/, 1]
         message << highlight_config_error(config_file_path, line_nr.to_i)
       end

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -394,6 +394,8 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
 node_name = 'barney'
 client_key = "barney_rubble.pem"
 chef_server_url = "https://api.chef.io/organizations/bedrock"
+"knife[:ssh_user]" = 'knife_ssh_user'
+"knife[:secret_file]" = "/home/barney/.chef/encrypted_data_bag_secret.pem"
 EOH
           content
         end
@@ -402,6 +404,8 @@ EOH
           expect { config_loader.load_credentials }.not_to raise_error
           expect(ChefConfig::Config.chef_server_url).to eq("https://api.chef.io/organizations/bedrock")
           expect(ChefConfig::Config.client_key.to_s).to eq("#{home}/.chef/barney_rubble.pem")
+          expect(ChefConfig::Config.knife[:ssh_user].to_s).to eq('knife_ssh_user')
+          expect(ChefConfig::Config.knife[:secret_file].to_s).to eq('/home/barney/.chef/encrypted_data_bag_secret.pem')
           expect(ChefConfig::Config.profile.to_s).to eq("default")
         end
       end

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -394,6 +394,25 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
 node_name = 'barney'
 client_key = "barney_rubble.pem"
 chef_server_url = "https://api.chef.io/organizations/bedrock"
+EOH
+          content
+        end
+
+        it "applies the expected config" do
+          expect { config_loader.load_credentials }.not_to raise_error
+          expect(ChefConfig::Config.chef_server_url).to eq("https://api.chef.io/organizations/bedrock")
+          expect(ChefConfig::Config.client_key.to_s).to eq("#{home}/.chef/barney_rubble.pem")
+          expect(ChefConfig::Config.profile.to_s).to eq("default")
+        end
+      end
+
+      context "and has a default profile with knife settings" do
+        let(:content) do
+          content = <<EOH
+[default]
+node_name = 'barney'
+client_key = "barney_rubble.pem"
+chef_server_url = "https://api.chef.io/organizations/bedrock"
 knife = {
   secret_file = "/home/barney/.chef/encrypted_data_bag_secret.pem"
 }
@@ -403,7 +422,7 @@ EOH
           content
         end
 
-        it "applies the expected config" do
+        it "applies the expected knife config" do
           expect { config_loader.load_credentials }.not_to raise_error
           expect(ChefConfig::Config.chef_server_url).to eq("https://api.chef.io/organizations/bedrock")
           expect(ChefConfig::Config.client_key.to_s).to eq("#{home}/.chef/barney_rubble.pem")

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -404,8 +404,8 @@ EOH
           expect { config_loader.load_credentials }.not_to raise_error
           expect(ChefConfig::Config.chef_server_url).to eq("https://api.chef.io/organizations/bedrock")
           expect(ChefConfig::Config.client_key.to_s).to eq("#{home}/.chef/barney_rubble.pem")
-          expect(ChefConfig::Config.knife[:ssh_user].to_s).to eq('knife_ssh_user')
-          expect(ChefConfig::Config.knife[:secret_file].to_s).to eq('/home/barney/.chef/encrypted_data_bag_secret.pem')
+          expect(ChefConfig::Config.knife[:ssh_user].to_s).to eq("knife_ssh_user")
+          expect(ChefConfig::Config.knife[:secret_file].to_s).to eq("/home/barney/.chef/encrypted_data_bag_secret.pem")
           expect(ChefConfig::Config.profile.to_s).to eq("default")
         end
       end

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -394,8 +394,11 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
 node_name = 'barney'
 client_key = "barney_rubble.pem"
 chef_server_url = "https://api.chef.io/organizations/bedrock"
-"knife[:ssh_user]" = 'knife_ssh_user'
-"knife[:secret_file]" = "/home/barney/.chef/encrypted_data_bag_secret.pem"
+knife = {
+  secret_file = "/home/barney/.chef/encrypted_data_bag_secret.pem"
+}
+[default.knife]
+ssh_user = "knife_ssh_user"
 EOH
           content
         end


### PR DESCRIPTION
Support for toml knife config settings

### Description
Enable defining additional (knife) config settings via chef .credentials file.
The goal is that no conditional custom ruby code needs to exist in the client.rb or knife.rb files to support multiple chef organizations.

The new .credentials file has been fantastic and a huge improvement for maintaining one config file which can support multiple chef orgs.  See - https://chef.github.io/chef-rfc/rfc099-authentication-config-file.html
This new feature is limited in that it only currently supports setting the following config values:
node_name, chef_server_url, validation_client_name, validation_key, validator_key, client_key

There are other settings, namely the encrypted data bag secret file, which aren't yet supported.
This adds support for setting any knife configs via the .credentials file.
Inline table format can be used.

### Issues Resolved

https://github.com/chef/chef/issues/7168

### Check List

- [ X] New functionality includes tests
- [ X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
