### PR TITLE
fix git provider: -prune-tags is not available with old git versions, fixes #7233

### DIFF
--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -195,7 +195,7 @@ class Chef
           # since we're in a local branch already, just reset to specified revision rather than merge
           logger.trace "Fetching updates from #{new_resource.remote} and resetting to revision #{target_revision}"
           git("fetch", "--prune", new_resource.remote, cwd: cwd)
-          git("fetch", "--prune-tags", new_resource.remote, "--tags", cwd: cwd)
+          git("fetch", new_resource.remote, "--tags", cwd: cwd)
           git("reset", "--hard", target_revision, cwd: cwd)
         end
       end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -427,7 +427,7 @@ SHAS
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
     expected_cmd1 = "git fetch --prune origin"
     expect(@provider).to receive(:shell_out!).with(expected_cmd1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    expected_cmd2 = "git fetch --prune-tags origin --tags"
+    expected_cmd2 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     expected_cmd3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(expected_cmd3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
@@ -445,7 +445,7 @@ SHAS
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
                                                                   :environment => { "HOME" => "/home/whois" })
-    expected_cmd2 = "git fetch --prune-tags origin --tags"
+    expected_cmd2 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(expected_cmd2, :cwd => "/my/deploy/dir",
                                                                   :user => "whois", :group => "thisis",
                                                                   :log_tag => "git[web2.0 app]",
@@ -463,7 +463,7 @@ SHAS
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
     fetch_command1 = "git fetch --prune origin"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch --prune-tags origin --tags"
+    fetch_command2 = "git fetch origin --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
@@ -475,7 +475,7 @@ SHAS
     expect(@provider).to receive(:setup_remote_tracking_branches).with(@resource.remote, @resource.repository)
     fetch_command1 = "git fetch --prune opscode"
     expect(@provider).to receive(:shell_out!).with(fetch_command1, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
-    fetch_command2 = "git fetch --prune-tags opscode --tags"
+    fetch_command2 = "git fetch opscode --tags"
     expect(@provider).to receive(:shell_out!).with(fetch_command2, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")
     fetch_command3 = "git reset --hard d35af14d41ae22b19da05d7d03a0bafc321b244c"
     expect(@provider).to receive(:shell_out!).with(fetch_command3, :cwd => "/my/deploy/dir", :log_tag => "git[web2.0 app]")


### PR DESCRIPTION
### Description

Fix git provider which currently breaks when used with an old git version.

### Issues Resolved

`--prune-tags` was introduced by a very recent git version ([2.17.0](https://github.com/git/git/blob/master/Documentation/RelNotes/2.17.0.txt#L32)) but most supported distros come with rather old git versions which do not have this option and break the git resource.

This PR removes the pruning of tags. Pruning of branches works even with older git versions and should be the most common use case (e.g. when using feature branches) anyway.

This issue is related to the merged PR #7129

### Check List

- [X ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
