### PR TITLE
repo_name property should be part of new_resource object

### DIFF
--- a/lib/chef/resource/rhsm_repo.rb
+++ b/lib/chef/resource/rhsm_repo.rb
@@ -34,20 +34,20 @@ class Chef
       action :enable do
         description "Enable a RHSM repository"
 
-        execute "Enable repository #{repo_name}" do
-          command "subscription-manager repos --enable=#{repo_name}"
+        execute "Enable repository #{new_resource.repo_name}" do
+          command "subscription-manager repos --enable=#{new_resource.repo_name}"
           action :run
-          not_if { repo_enabled?(repo_name) }
+          not_if { repo_enabled?(new_resource.repo_name) }
         end
       end
 
       action :disable do
         description "Disable a RHSM repository"
 
-        execute "Enable repository #{repo_name}" do
-          command "subscription-manager repos --disable=#{repo_name}"
+        execute "Enable repository #{new_resource.repo_name}" do
+          command "subscription-manager repos --disable=#{new_resource.repo_name}"
           action :run
-          only_if { repo_enabled?(repo_name) }
+          only_if { repo_enabled?(new_resource.repo_name) }
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Thomas Anderson <thomas@tjanderson.net>

### Description

Makes rhsm_repo resource work in a chef converge

### Issues Resolved

#7251 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
