### PR TITLE
remote_directory: restore overwrite default

### DIFF
--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -56,7 +56,7 @@ class Chef
       property :source, String, default: lazy { ::File.basename(path) }
       property :files_backup, [ Integer, FalseClass ], default: 5, desired_state: false
       property :purge, [ TrueClass, FalseClass ], default: false, desired_state: false
-      property :overwrite, [ TrueClass, FalseClass ], default: false
+      property :overwrite, [ TrueClass, FalseClass ], default: true
       property :cookbook, String
 
       def files_group(arg = nil)

--- a/spec/unit/resource/remote_directory_spec.rb
+++ b/spec/unit/resource/remote_directory_spec.rb
@@ -67,6 +67,10 @@ describe Chef::Resource::RemoteDirectory do
     expect(resource.files_owner).to eql(1000)
   end
 
+  it "overwrites by default" do
+    expect(resource.overwrite).to be true
+  end
+
   describe "when it has cookbook, files owner, files mode, and source" do
     before do
       resource.path("/var/path/")


### PR DESCRIPTION
### Description

`remote_directory` used to overwrite files by default. When converting to properties, the default was changed to false in PR #7204 probably unintentionally. This PR restores the default and also provides a test case.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
