### PR TITLE
Add skip_publisher_check property to powershell_package

### DIFF
--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -110,12 +110,14 @@ class Chef
 
         def build_powershell_package_command(command, version = nil)
           command = [command] unless command.is_a?(Array)
+          cmdlet_name = command.first
           command.unshift("(")
           %w{-Force -ForceBootstrap}.each do |arg|
             command.push(arg)
           end
           command.push("-RequiredVersion #{version}") if version
-          command.push("-Source #{new_resource.source}") if new_resource.source && command[1] =~ Regexp.union(/Install-Package/, /Find-Package/)
+          command.push("-Source #{new_resource.source}") if new_resource.source && cmdlet_name =~ Regexp.union(/Install-Package/, /Find-Package/)
+          command.push("-SkipPublisherCheck") if new_resource.skip_publisher_check && cmdlet_name !~ /Find-Package/
           command.push(").Version")
           command.join(" ")
         end

--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -53,7 +53,9 @@ class Chef
         # Installs the package specified with the version passed else latest version will be installed
         def install_package(names, versions)
           names.each_with_index do |name, index|
-            powershell_out(build_powershell_package_command("Install-Package '#{name}'", versions[index]), timeout: new_resource.timeout)
+            cmd = powershell_out(build_powershell_package_command("Install-Package '#{name}'", versions[index]), timeout: new_resource.timeout)
+            next if cmd.nil?
+            raise Chef::Exceptions::PowershellCmdletException, "Failed to install package due to catalog signing error, use skip_publisher_check to force install" if cmd.stderr =~ /SkipPublisherCheck/
           end
         end
 

--- a/lib/chef/resource/powershell_package.rb
+++ b/lib/chef/resource/powershell_package.rb
@@ -37,6 +37,7 @@ class Chef
       property :package_name, [String, Array], coerce: proc { |x| [x].flatten }
       property :version, [String, Array], coerce: proc { |x| [x].flatten }
       property :source, [String]
+      property :skip_publisher_check, [true, false], default: false
     end
   end
 end

--- a/lib/chef/resource/powershell_package.rb
+++ b/lib/chef/resource/powershell_package.rb
@@ -37,7 +37,7 @@ class Chef
       property :package_name, [String, Array], coerce: proc { |x| [x].flatten }
       property :version, [String, Array], coerce: proc { |x| [x].flatten }
       property :source, [String]
-      property :skip_publisher_check, [true, false], default: false
+      property :skip_publisher_check, [true, false], default: false, introduced: "14.2", description: "Skip validating module author"
     end
   end
 end

--- a/spec/unit/resource/powershell_package_spec.rb
+++ b/spec/unit/resource/powershell_package_spec.rb
@@ -72,4 +72,13 @@ describe Chef::Resource::PowershellPackage do
     resource.source("MyGallery")
     expect(resource.source).to eql("MyGallery")
   end
+
+  it "the skip_publisher_check default is false" do
+    expect(resource.skip_publisher_check).to eql(false)
+  end
+
+  it "the skip_publisher_check setter accepts booleans" do
+    resource.skip_publisher_check(true)
+    expect(resource.skip_publisher_check).to eql(true)
+  end
 end


### PR DESCRIPTION
### Description

Adds a `skip_publisher_check` property and fixes a bug where catalog signing errors would cause the install to fail silently.

### Issues Resolved

https://github.com/chef/chef/issues/7212

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>