### PR TITLE
Fix manifest entries for root files

### DIFF
--- a/lib/chef/cookbook/manifest_v0.rb
+++ b/lib/chef/cookbook/manifest_v0.rb
@@ -31,7 +31,7 @@ class Chef
         response[:all_files] = COOKBOOK_SEGMENTS.inject([]) do |memo, segment|
           next memo if hash[segment].nil? || hash[segment].empty?
           hash[segment].each do |file|
-            file["name"] = "#{segment}/#{file["name"]}" unless segment == "root_files"
+            file["name"] = "#{segment}/#{file["name"]}"
             memo << file
           end
           response.delete(segment)
@@ -49,7 +49,7 @@ class Chef
           if COOKBOOK_SEGMENTS.include?(parent)
             memo[parent] ||= []
             files[parent].each do |file|
-              file["name"] = file["name"].split("/")[1] unless parent == "root_files"
+              file["name"] = file["name"].split("/")[1]
               file.delete("full_path")
               memo[parent] << file
             end

--- a/lib/chef/cookbook_manifest.rb
+++ b/lib/chef/cookbook_manifest.rb
@@ -204,7 +204,8 @@ class Chef
 
     def root_files
       manifest[:all_files].select do |file|
-        file[:name].split("/").length == 1
+        segment, name = file[:name].split("/")
+        name.nil? || segment == "root_files"
       end
     end
 
@@ -271,7 +272,7 @@ class Chef
         next if parts[0] == ".."
 
         # if we have a root_file, such as metadata.rb, the first part will be "."
-        return [ pathname.to_s, pathname.to_s, "default" ] if parts.length == 1
+        return [ "root_files/#{pathname}", pathname.to_s, "default" ] if parts.length == 1
 
         segment = parts[0]
 

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -131,7 +131,7 @@ class Chef
     def attribute_filenames_by_short_filename
       @attribute_filenames_by_short_filename ||= begin
         name_map = filenames_by_name(files_for("attributes"))
-        root_alias = cookbook_manifest.root_files.find { |record| record[:name] == "attributes.rb" }
+        root_alias = cookbook_manifest.root_files.find { |record| record[:name] == "root_files/attributes.rb" }
         name_map["default"] = root_alias[:full_path] if root_alias
         name_map
       end
@@ -140,7 +140,7 @@ class Chef
     def recipe_filenames_by_name
       @recipe_filenames_by_name ||= begin
         name_map = filenames_by_name(files_for("recipes"))
-        root_alias = cookbook_manifest.root_files.find { |record| record[:name] == "recipe.rb" }
+        root_alias = cookbook_manifest.root_files.find { |record| record[:name] == "root_files/recipe.rb" }
         if root_alias
           Chef::Log.error("Cookbook #{name} contains both recipe.rb and and recipes/default.rb, ignoring recipes/default.rb") if name_map["default"]
           name_map["default"] = root_alias[:full_path]

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -191,7 +191,7 @@ class Chef
 
       def load_attributes_from_cookbook(cookbook_name)
         list_of_attr_files = files_in_cookbook_by_segment(cookbook_name, :attributes).dup
-        root_alias = cookbook_collection[cookbook_name].files_for(:root_files).find { |record| record[:name] == "attributes.rb" }
+        root_alias = cookbook_collection[cookbook_name].files_for(:root_files).find { |record| record[:name] == "root_files/attributes.rb" }
         default_file = list_of_attr_files.find { |path| File.basename(path) == "default.rb" }
         if root_alias
           if default_file

--- a/spec/unit/cookbook/manifest_v0_spec.rb
+++ b/spec/unit/cookbook/manifest_v0_spec.rb
@@ -82,7 +82,7 @@ describe Chef::Cookbook::ManifestV0 do
 
     it "creates an all_files key and populates it" do
       result = described_class.from_hash(source_hash)
-      expect(result[:all_files].map { |f| f["name"] }).to match_array %w{ recipes/default.rb attributes/default.rb README.rdoc }
+      expect(result[:all_files].map { |f| f["name"] }).to match_array %w{ recipes/default.rb attributes/default.rb root_files/README.rdoc }
     end
 
     it "deletes unwanted segment types" do

--- a/spec/unit/cookbook_manifest_spec.rb
+++ b/spec/unit/cookbook_manifest_spec.rb
@@ -122,6 +122,8 @@ describe Chef::CookbookManifest do
         parts = relative_path.split("/")
         name = if %w{templates files}.include?(parts[0]) && parts.length == 3
                  File.join(parts[0], parts[2])
+               elsif parts.length == 1
+                 "root_files/#{parts[0]}"
                else
                  relative_path
                end


### PR DESCRIPTION
We weren't consistently naming root files; in some places in the spec
the names contained the `root_files` segment and in other places they
didn't. This now always uses `root_files`.