### PR TITLE
we removed the state default property in 13

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -23,6 +23,9 @@ github:
   # The file where our CHANGELOG is kept. This file is updated automatically with
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
+  # This will trigger an Omnibus build with EXPIRE_CACHE enabled after
+  # a pull request is merged into the release branch.
+  enable_expire_cache: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
   # The Github Team primarily responsible for handling incoming Pull Requests.

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -657,9 +657,9 @@ class Chef
       # as needed.
       return if Chef::Resource.properties.keys.include?(name)
 
-      # Special case for `supports` as it was moved in Chef 13 and this is causing
+      # Special case for `supports` and `state` as they were moved in Chef 13 and this is causing
       # some user confusion in cookbooks that need to support both 12 and 13.
-      return if name.to_s == "supports"
+      return if %w{ supports state }.include? name.to_s
 
       # Emit the deprecation.
       resource_name = declared_in.respond_to?(:resource_name) ? declared_in.resource_name : declared_in


### PR DESCRIPTION
This sucks for folk upgrading where a cookbook uses a property called state, like https://github.com/chef-cookbooks/openssl/pull/70