### PR TITLE
[MSYS-817] fix for windows_task does not parse backslashes in the commad property

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -231,6 +231,7 @@ class Chef
 
         # seprated command arguments from :command property
         def set_command_and_arguments
+          new_resource.command = new_resource.command.gsub(/\\/, '\&\&')
           cmd, *args = Shellwords.split(new_resource.command)
           new_resource.command = cmd
           new_resource.command_arguments = args.join(" ")

--- a/spec/functional/resource/windows_task_spec.rb
+++ b/spec/functional/resource/windows_task_spec.rb
@@ -68,7 +68,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
         current_resource = call_for_load_current_resource
         expect(current_resource.exists).to eq(true)
         expect(current_resource.task.application_name).to eq("chef-client")
-        expect(current_resource.task.parameters).to eq("-W -L C:\\chef\\chef-ad-join.log")
+        expect(current_resource.task.parameters).to eq("-W -L C:\\\\chef\\\\chef-ad-join.log")
       end
 
       it "does not converge the resource if it is already converged" do


### PR DESCRIPTION
### Description
Fix for
The new windows_task in chef client v14 does not correctly parse backslashes in the command property- they end up being erased in the task on the node.

### Issues Resolved
#7277 

verified running with following recipes

```
windows_task 'chef-client-test' do
	task_name 'chef-client-test1'
	command 'chef-client -W -L "C:\\chef\\chef-ad-join.log"'
	user 'Administrator'
	password 'master#123'
	run_level :highest
	frequency :daily
end

windows_task 'chef-client-test' do
	task_name 'chef-client-test2'
	command 'chef-client -W'
	run_level :highest
	frequency :daily
end

windows_task 'chef-client-test' do
	task_name 'chef-client-test3'
	command 'chef-client'
	run_level :highest
	frequency :daily
end

windows_task 'chef-client-test' do
	task_name 'chef-client-test4' 
	command '"C:\\Program Files\\Git\\git-bash.exe"'
	run_level :highest
	frequency :daily
end

windows_task 'chef-client-test' do
	task_name 'chef-client-test5' 
	command '"C:\Program Files\Git\git-bash.exe" -arg1 -arg2'
	run_level :highest
	frequency :daily
end

windows_task 'chef-client-test' do
	task_name 'chef-client-test6'
	command 'ping "http://www.google.com"'
	run_level :highest
	frequency :daily
end

windows_task 'test1' do
  cwd 'C:\\'
  command 'Powershell.exe -ExecutionPolicy Bypass C:\foo bar\bar\blah\script.ps1'
  run_level :highest
  frequency :daily
end

windows_task 'test2' do
  cwd 'C:\\'
  command 'Powershell.exe -ExecutionPolicy Bypass C:\\foo bar\\bar\\blah\\script.ps1'
  run_level :highest
  frequency :daily
end

windows_task 'test3' do
  cwd 'C:\\'
  command 'Powershell.exe -ExecutionPolicy Bypass C:\foo\bar\blah\script.ps1'
  run_level :highest
  frequency :daily
end


windows_task 'chef-client-test' do
	task_name 'chef-client-test7'
	command "chef-client -W -L 'C:\\chef\\chef-ad-join.log'"
	user 'Administrator'
	password 'master#123'
	run_level :highest
	frequency :daily
end
````
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>