### PR TITLE
HTTP remote file provider should not fetch the file in --why-run mode

### DIFF
--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -68,7 +68,7 @@ class Chef
 
         # Given a source uri, return a Tempfile, or a File that acts like a Tempfile (close! method)
         def grab_file_from_uri(uri)
-          Chef::Provider::RemoteFile::Fetcher.for_resource(uri, @new_resource, @current_resource).fetch
+          Chef::Provider::RemoteFile::Fetcher.for_resource(uri, @new_resource, @current_resource).fetch unless Chef::Config[:why_run]
         end
 
         def current_resource_matches_target_checksum?

--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -68,7 +68,7 @@ class Chef
 
         # Given a source uri, return a Tempfile, or a File that acts like a Tempfile (close! method)
         def grab_file_from_uri(uri)
-          Chef::Provider::RemoteFile::Fetcher.for_resource(uri, @new_resource, @current_resource).fetch unless Chef::Config[:why_run]
+          Chef::Provider::RemoteFile::Fetcher.for_resource(uri, @new_resource, @current_resource).fetch
         end
 
         def current_resource_matches_target_checksum?

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -70,7 +70,7 @@ class Chef
             end
           else
             tempfile = http.streaming_request(uri, headers, orig_tempfile)
-          end
+          end unless Chef::Config[:why_run]
           if tempfile
             update_cache_control_data(tempfile, http.last_response)
             tempfile.close

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -64,13 +64,15 @@ class Chef
         def fetch
           http = Chef::HTTP::Simple.new(uri, http_client_opts)
           orig_tempfile = Chef::FileContentManagement::Tempfile.new(@new_resource).tempfile
-          if want_progress?
-            tempfile = http.streaming_request_with_progress(uri, headers, orig_tempfile) do |size, total|
-              events.resource_update_progress(new_resource, size, total, progress_interval)
+          unless Chef::Config[:why_run]
+            if want_progress?
+              tempfile = http.streaming_request_with_progress(uri, headers, orig_tempfile) do |size, total|
+                events.resource_update_progress(new_resource, size, total, progress_interval)
+              end
+            else
+              tempfile = http.streaming_request(uri, headers, orig_tempfile)
             end
-          else
-            tempfile = http.streaming_request(uri, headers, orig_tempfile)
-          end unless Chef::Config[:why_run]
+          end
           if tempfile
             update_cache_control_data(tempfile, http.last_response)
             tempfile.close

--- a/spec/functional/resource/remote_file_spec.rb
+++ b/spec/functional/resource/remote_file_spec.rb
@@ -66,6 +66,20 @@ describe Chef::Resource::RemoteFile do
       stop_tiny_server
     end
 
+    context "when why-run is enabled", :whyrun_only do
+      let(:source) { "http://localhost:9000/nyan_cat.png" }
+
+      before do
+        Chef::Config[:why_run] = true
+        expect(File).not_to exist(path)
+        resource.run_action(:create)
+      end
+
+      it "does not fetch the remote file" do
+        expect(File).not_to exist(path)
+      end
+    end
+
     describe "when redownload isn't necessary" do
       let(:source) { "http://localhost:9000/seattle_capo.png" }
 


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This change bypasses the logic that retrieves the content for remote files when used in --why-run mode.  Instead, just the outer converge_by message will be shown, i.e.:

```
Recipe: @recipe_files::C:/projects/repro/why_run_remote_file/repro.rb
  * remote_file[C:/Users/spreston\.chef\local-mode-cache\cache/push-jobs-client-2.5.0-1-x64.msi] action create
    - Would create new file C:/Users/spreston\.chef\local-mode-cache\cache/push-jobs-client-2.5.0-1-x64.msi
    - Would change dacl
    - Would change owner
    - Would change group
```

### Issues Resolved

Previously, the remote file was retrieved anyway for a checksum comparison even though it was not necessary to retrieve the whole file.  A number of cookbooks use remote_file internally to retrieve Chef installation files from our CDN and so this change benefits both Chef Software as well as customer bandwidth charges.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
