### PR TITLE
Mount: Fix errors on Windows when using the mount_point property

### DIFF
--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -40,10 +40,8 @@ class Chef
 
         def load_current_resource
           if is_volume(@new_resource.device)
-            @mount = Chef::Util::Windows::Volume.new(@new_resource.name)
-          elsif @new_resource.name.include?(":") && !@new_resource.mount_point #assume network drive
-            @mount = Chef::Util::Windows::NetUse.new(@new_resource.name)
-          else
+            @mount = Chef::Util::Windows::Volume.new(@new_resource.mount_point)
+          else #assume network drive
             @mount = Chef::Util::Windows::NetUse.new(@new_resource.mount_point)
           end
 

--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -41,7 +41,9 @@ class Chef
         def load_current_resource
           if is_volume(@new_resource.device)
             @mount = Chef::Util::Windows::Volume.new(@new_resource.name)
-          else #assume network drive
+          elsif @new_resource.name.include?(":") && !@new_resource.mount_point #assume network drive
+            @mount = Chef::Util::Windows::NetUse.new(@new_resource.name)
+          else
             @mount = Chef::Util::Windows::NetUse.new(@new_resource.mount_point)
           end
 

--- a/lib/chef/provider/mount/windows.rb
+++ b/lib/chef/provider/mount/windows.rb
@@ -42,7 +42,7 @@ class Chef
           if is_volume(@new_resource.device)
             @mount = Chef::Util::Windows::Volume.new(@new_resource.name)
           else #assume network drive
-            @mount = Chef::Util::Windows::NetUse.new(@new_resource.name)
+            @mount = Chef::Util::Windows::NetUse.new(@new_resource.mount_point)
           end
 
           @current_resource = Chef::Resource::Mount.new(@new_resource.name)

--- a/spec/unit/resource/mount_spec.rb
+++ b/spec/unit/resource/mount_spec.rb
@@ -44,6 +44,16 @@ describe Chef::Resource::Mount do
     expect(resource.device).to eql("/dev/sdb3")
   end
 
+  it "allows you to set mount_point property" do
+    resource.mount_point "U:"
+    expect(resource.mount_point).to eql("U:")
+  end
+
+  it "raises error when mount_point property is not set" do
+    resource.mount_point nil
+    expect { resource.mounted("poop") }.to raise_error(ArgumentError)
+  end
+
   it "sets fsck_device to '-' by default" do
     expect(resource.fsck_device).to eql("-")
   end


### PR DESCRIPTION
### Description
According to mount resource documentation for mount_type, "The directory (or path) in which the device is to be mounted. Default value: the name of the resource block. A customer had tried this and was getting errors when the name was anything but the mount_point. Looking at lib/chef/provider/mount/windows.rb, it shows that net_use is hard-wired to use only the resource name, which conflicts with the documentation. If we change it from name to mount_point, then it will work according to how the documentation specifies.

Windows mount uses `new_resource.name` instead of `new_resource.mount_point` when connecting to a CIFS share

### Resolved issue
https://getchef.zendesk.com/agent/tickets/18684


