### PR TITLE
windows_task: Don't allow bad username/password to be provided to a task which will fail later

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -133,10 +133,10 @@ class Chef
             converge_by("#{new_resource} task created") do
               task = TaskScheduler.new
               if new_resource.frequency == :none
-                task.new_work_item(new_resource.task_name, {})
+                task.new_work_item(new_resource.task_name, {}, { user: new_resource.user, password: new_resource.password })
                 task.activate(new_resource.task_name)
               else
-                task.new_work_item(new_resource.task_name, trigger)
+                task.new_work_item(new_resource.task_name, trigger, { user: new_resource.user, password: new_resource.password })
               end
               task.application_name = new_resource.command
               task.parameters = new_resource.command_arguments if new_resource.command_arguments


### PR DESCRIPTION
### Description
When wrong username and password provided in the windows_task recipe it creates the windows_task and raises the exception afterwards. It should not create task when username and password is incorrect.

### Issues Resolved
Updated win32-taskscheduler to set user information at the time of creation of task so that it will validate the user at that time and updated the method defination in windows_task provider.

Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>