### PR TITLE
windows_task: Fix for task is not idempotent when task name includes parent folder

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -100,15 +100,13 @@ class Chef
 
         def load_current_resource
           @current_resource = Chef::Resource::WindowsTask.new(new_resource.name)
-          task = TaskScheduler.new
-          if task.exists?(new_resource.task_name)
-            @current_resource.exists = true
+          task = TaskScheduler.new(new_resource.task_name, nil, "\\", false)
+          @current_resource.exists = task.exists?(new_resource.task_name)
+          if @current_resource.exists
             task.get_task(new_resource.task_name)
             @current_resource.task = task
             pathed_task_name = new_resource.task_name.start_with?('\\') ? new_resource.task_name : "\\#{new_resource.task_name}"
             @current_resource.task_name(pathed_task_name)
-          else
-            @current_resource.exists = false
           end
           @current_resource
         end


### PR DESCRIPTION
### Description
The windows_task not idempotent when task_name includes parent folder. The resource will converge every time as a result, even when properties have not changed.

```
windows_task 'MyTask Under MyOrg' do
task_name '\MyOrg\MyTask'
command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName 
 Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
 run_level :highest
 frequency :daily
 start_time '03:00'
 action :create
end
```

### Issues Resolved
Fixes #7291

Tested with following recipes

```
windows_task 'MyTask Under MyOrg' do
  task_name '\MyOrg\MyTask'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '04:00'
  action :create
end

windows_task 'MyTask Under MyOrg' do
  task_name '\MyOrg\MyTask'
  action :delete
end

windows_task 'MyTask Under MyOrg' do
  task_name '\MyOrg\MyTask1'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '04:00'
  action :create
end

windows_task 'MyTask Under MyOrg' do
  task_name '\MyOrg\MyTask1'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :once
  start_time '07:00'
  action :create
end

windows_task 'MyTask MyFolder MyOrg' do
  task_name '\MyOrg\MyFolder\MyTask'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '03:00'
  action :create
end

windows_task 'MyTask Under MyOrg' do
  task_name '\MyOrg\MyFolder\MyTask'
  action :delete
end

windows_task 'MyTask1 MyFolder MyOrg' do
  task_name '\MyOrg\MyFolder\MyTask1'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '07:00'
  action :create
end

windows_task 'MyTask1 MyFolder MyOrg' do
  task_name '\MyOrg\MyFolder\MyTask1'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '09:00'
  action :create
end

windows_task 'foo bar MyTask1' do
  task_name '\foo\bar\MyTask1'
  command 'powershell -NoLogo -NonInteractive -ExecutionPolicy Bypass "Write-EventLog -LogName Application -EventID 10000 -Source Chef -EntryType Information -Message MyTask_Under_MyOrg"'
  run_level :highest
  frequency :daily
  start_time '09:00'
  action :create
end

windows_task 'chef-client-test' do
 task_name 'chef-client-test11' # 1http://bit.ly/1WDZ1kn
 command "chef-client -W -L 'C:\\chef\\chef-ad-join.log'"
 run_level :highest
 frequency :daily
end
```
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>
