### PR TITLE
[MSYS-814] - Manual cron job deletion

### DIFF
--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -155,46 +155,48 @@ class Chef
       end
 
       def action_delete
-        crontab = String.new
-        cron_found = false
-        cron_job_found = false
-        manual_job_found = false
-        read_crontab.each_line do |line|
-          case line.chomp
-          when "# Chef Name: #{new_resource.name}"
-            cron_job_found = true
-            cron_found = true
-            next
-          when ENV_PATTERN
-            next if cron_found
-          when SPECIAL_PATTERN
-            if cron_found
+        if crontab_content = read_crontab
+          crontab = String.new
+          cron_job_found = false
+          manual_job_found = false
+          cron_found = false
+          crontab_content.each_line do |line|
+            case line.chomp
+            when "# Chef Name: #{new_resource.name}"
+              cron_job_found = true
+              cron_found = true
+              next
+            when ENV_PATTERN
+              next if cron_found
+            when SPECIAL_PATTERN
+              if cron_found
+                cron_found = false
+                next
+              end
+            when CRON_PATTERN
+              if cron_found
+                cron_found = false
+                next
+              elsif resource_details == line.split(CRON_PATTERN)[1..-2]
+                # Deletion of Manually created task
+                manual_job_found = true
+                next
+              end
+            else
+              # We've got a Chef comment with no following crontab line
               cron_found = false
-              next
             end
-          when CRON_PATTERN
-            if cron_found
-              cron_found = false
-              next
-            elsif resource_details == line.split(CRON_PATTERN)[1..-2]
-              # Deletion of Manually created task
-              manual_job_found = true
-              next
-            end
-          else
-            # We've got a Chef comment with no following crontab line
-            cron_found = false
+            crontab << line
           end
-          crontab << line
-        end
-        description = Array.new
-        description << "remove #{new_resource.name} from crontab" if cron_job_found
-        description << "remove manual job from crontab" if manual_job_found
-        description << "save unmodified crontab" if description.empty?
-        description = description.join("\n - ")
-        converge_by(description) do
-          write_crontab crontab
-          Chef::Log.info("#{new_resource} deleted crontab entry")
+          description = Array.new
+          description << "remove #{new_resource.name} from crontab" if cron_job_found
+          description << "remove manual job from crontab" if manual_job_found
+          description << "save unmodified crontab" if description.empty?
+          description = description.join("\n - ")
+          converge_by(description) do
+            write_crontab crontab
+            logger.info("#{new_resource} deleted crontab entry")
+          end
         end
       end
 

--- a/lib/chef/provider/cron.rb
+++ b/lib/chef/provider/cron.rb
@@ -155,37 +155,46 @@ class Chef
       end
 
       def action_delete
-        if @cron_exists
-          crontab = ""
-          cron_found = false
-          read_crontab.each_line do |line|
-            case line.chomp
-            when "# Chef Name: #{new_resource.name}"
-              cron_found = true
-              next
-            when ENV_PATTERN
-              next if cron_found
-            when SPECIAL_PATTERN
-              if cron_found
-                cron_found = false
-                next
-              end
-            when CRON_PATTERN
-              if cron_found
-                cron_found = false
-                next
-              end
-            else
-              # We've got a Chef comment with no following crontab line
+        crontab = String.new
+        cron_found = false
+        cron_job_found = false
+        manual_job_found = false
+        read_crontab.each_line do |line|
+          case line.chomp
+          when "# Chef Name: #{new_resource.name}"
+            cron_job_found = true
+            cron_found = true
+            next
+          when ENV_PATTERN
+            next if cron_found
+          when SPECIAL_PATTERN
+            if cron_found
               cron_found = false
+              next
             end
-            crontab << line
+          when CRON_PATTERN
+            if cron_found
+              cron_found = false
+              next
+            elsif resource_details == line.split(CRON_PATTERN)[1..-2]
+              # Deletion of Manually created task
+              manual_job_found = true
+              next
+            end
+          else
+            # We've got a Chef comment with no following crontab line
+            cron_found = false
           end
-          description = cron_found ? "remove #{new_resource.name} from crontab" : "save unmodified crontab"
-          converge_by(description) do
-            write_crontab crontab
-            logger.info("#{new_resource} deleted crontab entry")
-          end
+          crontab << line
+        end
+        description = Array.new
+        description << "remove #{new_resource.name} from crontab" if cron_job_found
+        description << "remove manual job from crontab" if manual_job_found
+        description << "save unmodified crontab" if description.empty?
+        description = description.join("\n - ")
+        converge_by(description) do
+          write_crontab crontab
+          Chef::Log.info("#{new_resource} deleted crontab entry")
         end
       end
 
@@ -238,6 +247,15 @@ class Chef
         else
           weekday_in_crontab.to_s
         end
+      end
+
+      def resource_details
+        [ new_resource.minute,
+          new_resource.hour,
+          new_resource.day,
+          new_resource.month,
+          new_resource.weekday,
+          new_resource.command ]
       end
     end
   end


### PR DESCRIPTION
- Commit to handle deletion of manually created cron jobs, other than chef
- Also fixed an existing issue: If chef created job is not the last job written in crontab, then even after its deletion, message was: `save unmodified crontab`

Signed-off-by: nimesh-msys <nimesh.patni@msystechnologies.com>

### Description

Cron Job Deletion process: Iteration over each line of crontab and insert the contents(line) into a local string 'crontab'.  When we found "# Chef Name: #{new_resource.name}", this line(the header comment) and the next line(with cron job) will be skipped. Hence 'crontab' string only contains the remaining line of codes. This 'crontab' then completely overwrites crontab file. Thus we were only deleting the jobs which were created by chef (by header search)
Following code changes includes: during iteration if we encounter a 'cron job pattern', which is exactly similar to what user has passed(for deletion), skip that line too. This skipping will be irrespective of resource name, hence the given job could also be deleted which was created manually.

### Issues Resolved
[MSYS-814](https://chefio.atlassian.net/browse/MSYS-814)

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
