### PR TITLE
Cookbook Version:  add host-<fqdn> to the error message for templates and files specificity

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -239,6 +239,7 @@ class Chef
                               filename.map { |name| "  #{File.join(segment.to_s, name)}" }
                             else
                               [
+                                "  #{segment}/host-#{node[:fqdn]}/#{filename}",
                                 "  #{segment}/#{node[:platform]}-#{node[:platform_version]}/#{filename}",
                                 "  #{segment}/#{node[:platform]}/#{filename}",
                                 "  #{segment}/default/#{filename}",


### PR DESCRIPTION
closes #1479

