### PR TITLE
Allow securable resource tests to work on Windows 10 machines connected to an Azure Active Directory

### DIFF
--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -313,7 +313,7 @@ shared_examples_for "a securable resource without existing target" do
     end
 
     it "sets owner when owner is specified with a \\" do
-      resource.owner "#{ENV['USERDOMAIN']}\\Guest"
+      resource.owner "#{ENV['COMPUTERNAME']}\\Guest"
       resource.run_action(:create)
       expect(descriptor.owner).to eq(SID.Guest)
     end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This change allows users of Windows 10 machines connected to an Azure Active Directory (AAD) to execute our securable resource tests.  In this scenario, USERDOMAIN is set to the NetBIOS domain name for the AAD (e.g. OPSCODECORP),  but no domain controller is reachable so commands that use USERDOMAIN generally fail.

In non-domain-connected machines (such as Appveyor) USERDOMAIN and COMPUTERNAME should be identical so this change should only have a positive effect of allowing Windows 10 users to run the tests successfully.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
