### PR TITLE
Convert shell_out_with_systems_locale to `default_env: true` API

### DIFF
--- a/lib/chef/guard_interpreter/default_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/default_guard_interpreter.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014-2017, Chef Software Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ class Chef
       public
 
       def evaluate
-        result = shell_out_with_systems_locale(@command, @command_opts)
+        result = shell_out(@command, default_env: false, **@command_opts)
         Chef::Log.debug "Command failed: #{result.stderr}" unless result.status.success?
         result.status.success?
       # Timeout fails command rather than chef-client run, see:

--- a/lib/chef/provider/service/freebsd.rb
+++ b/lib/chef/provider/service/freebsd.rb
@@ -83,7 +83,7 @@ class Chef
           if new_resource.start_command
             super
           else
-            shell_out_with_systems_locale!("#{init_command} faststart")
+            shell_out!("#{init_command} faststart", default_env: false)
           end
         end
 
@@ -91,7 +91,7 @@ class Chef
           if new_resource.stop_command
             super
           else
-            shell_out_with_systems_locale!("#{init_command} faststop")
+            shell_out!("#{init_command} faststop", default_env: false)
           end
         end
 
@@ -99,7 +99,7 @@ class Chef
           if new_resource.restart_command
             super
           elsif supports[:restart]
-            shell_out_with_systems_locale!("#{init_command} fastrestart")
+            shell_out!("#{init_command} fastrestart", default_env: false)
           else
             stop_service
             sleep 1

--- a/lib/chef/provider/service/init.rb
+++ b/lib/chef/provider/service/init.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ class Chef
           if @new_resource.start_command
             super
           else
-            shell_out_with_systems_locale!("#{default_init_command} start")
+            shell_out!("#{default_init_command} start", default_env: false)
           end
         end
 
@@ -64,7 +64,7 @@ class Chef
           if @new_resource.stop_command
             super
           else
-            shell_out_with_systems_locale!("#{default_init_command} stop")
+            shell_out!("#{default_init_command} stop", default_env: false)
           end
         end
 
@@ -72,7 +72,7 @@ class Chef
           if @new_resource.restart_command
             super
           elsif supports[:restart]
-            shell_out_with_systems_locale!("#{default_init_command} restart")
+            shell_out!("#{default_init_command} restart", default_env: false)
           else
             stop_service
             sleep 1
@@ -84,7 +84,7 @@ class Chef
           if @new_resource.reload_command
             super
           elsif supports[:reload]
-            shell_out_with_systems_locale!("#{default_init_command} reload")
+            shell_out!("#{default_init_command} reload", default_env: false)
           end
         end
       end

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -174,9 +174,9 @@ class Chef
 
         def shell_out_as_user(cmd)
           if @console_user
-            shell_out_with_systems_locale("#{@base_user_cmd} '#{cmd}'")
+            shell_out("#{@base_user_cmd} '#{cmd}'", default_env: false)
           else
-            shell_out_with_systems_locale(cmd)
+            shell_out(cmd, default_env: false)
 
           end
         end
@@ -224,8 +224,9 @@ class Chef
 
           # plist files can come in XML or Binary formats. this command
           # will make sure we get XML every time.
-          plist_xml = shell_out_with_systems_locale!(
-            "plutil -convert xml1 -o - #{@plist}"
+          plist_xml = shell_out!(
+            "plutil -convert xml1 -o - #{@plist}",
+            default_env: false
           ).stdout
 
           plist_doc = REXML::Document.new(plist_xml)

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -83,16 +83,16 @@ class Chef
         end
 
         def start_service
-          shell_out_with_systems_locale!(@new_resource.start_command)
+          shell_out!(@new_resource.start_command, default_env: false)
         end
 
         def stop_service
-          shell_out_with_systems_locale!(@new_resource.stop_command)
+          shell_out!(@new_resource.stop_command, default_env: false)
         end
 
         def restart_service
           if @new_resource.restart_command
-            shell_out_with_systems_locale!(@new_resource.restart_command)
+            shell_out!(@new_resource.restart_command, default_env: false)
           else
             stop_service
             sleep 1
@@ -101,7 +101,7 @@ class Chef
         end
 
         def reload_service
-          shell_out_with_systems_locale!(@new_resource.reload_command)
+          shell_out!(@new_resource.reload_command, default_env: false)
         end
 
         protected

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Stephen Haynes (<sh@nomitor.com>)
 # Author:: Davide Cavalca (<dcavalca@fb.com>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright 2011-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,7 +101,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} start #{Shellwords.escape(new_resource.service_name)}", options)
+        shell_out!("#{systemctl_path} #{args} start #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
       end
     end
   end
@@ -114,7 +114,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} stop #{Shellwords.escape(new_resource.service_name)}", options)
+        shell_out!("#{systemctl_path} #{args} stop #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
       end
     end
   end
@@ -124,7 +124,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       super
     else
       options, args = get_systemctl_options_args
-      shell_out_with_systems_locale!("#{systemctl_path} #{args} restart #{Shellwords.escape(new_resource.service_name)}", options)
+      shell_out!("#{systemctl_path} #{args} restart #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
     end
   end
 
@@ -134,7 +134,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     else
       if current_resource.running
         options, args = get_systemctl_options_args
-        shell_out_with_systems_locale!("#{systemctl_path} #{args} reload #{Shellwords.escape(new_resource.service_name)}", options)
+        shell_out!("#{systemctl_path} #{args} reload #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
       else
         start_service
       end
@@ -143,37 +143,37 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def enable_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} enable #{Shellwords.escape(new_resource.service_name)}", options)
+    shell_out!("#{systemctl_path} #{args} enable #{Shellwords.escape(new_resource.service_name)}", **options)
   end
 
   def disable_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} disable #{Shellwords.escape(new_resource.service_name)}", options)
+    shell_out!("#{systemctl_path} #{args} disable #{Shellwords.escape(new_resource.service_name)}", **options)
   end
 
   def mask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} mask #{Shellwords.escape(new_resource.service_name)}", options)
+    shell_out!("#{systemctl_path} #{args} mask #{Shellwords.escape(new_resource.service_name)}", **options)
   end
 
   def unmask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} unmask #{Shellwords.escape(new_resource.service_name)}", options)
+    shell_out!("#{systemctl_path} #{args} unmask #{Shellwords.escape(new_resource.service_name)}", **options)
   end
 
   def is_active?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-active #{Shellwords.escape(new_resource.service_name)} --quiet", options).exitstatus == 0
+    shell_out("#{systemctl_path} #{args} is-active #{Shellwords.escape(new_resource.service_name)} --quiet", **options).exitstatus == 0
   end
 
   def is_enabled?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)} --quiet", options).exitstatus == 0
+    shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)} --quiet", **options).exitstatus == 0
   end
 
   def is_masked?
     options, args = get_systemctl_options_args
-    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", options)
+    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", **options)
     s.exitstatus != 0 && s.stdout.include?("masked")
   end
 

--- a/lib/chef/provider/service/upstart.rb
+++ b/lib/chef/provider/service/upstart.rb
@@ -169,7 +169,7 @@ class Chef
             if @new_resource.start_command
               super
             else
-              shell_out_with_systems_locale!("/sbin/start #{@job}")
+              shell_out!("/sbin/start #{@job}", default_env: false)
             end
           end
 
@@ -185,7 +185,7 @@ class Chef
             if @new_resource.stop_command
               super
             else
-              shell_out_with_systems_locale!("/sbin/stop #{@job}")
+              shell_out!("/sbin/stop #{@job}", default_env: false)
             end
           end
 
@@ -217,7 +217,7 @@ class Chef
             super
           else
             # upstart >= 0.6.3-4 supports reload (HUP)
-            shell_out_with_systems_locale!("/sbin/reload #{@job}")
+            shell_out!("/sbin/reload #{@job}", default_env: false)
           end
 
           @upstart_service_running = true

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -219,15 +219,15 @@ class Chef
       end
 
       def daemon_reload
-        shell_out_with_systems_locale!("#{systemctl_cmd} daemon-reload", systemctl_opts)
+        shell_out!("#{systemctl_cmd} daemon-reload", **systemctl_opts, default_env: false)
       end
 
       def systemctl_execute!(action, unit)
-        shell_out_with_systems_locale!("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", systemctl_opts)
+        shell_out!("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", **systemctl_opts, default_env: false)
       end
 
       def systemctl_execute(action, unit)
-        shell_out("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", systemctl_opts)
+        shell_out("#{systemctl_cmd} #{action} #{Shellwords.escape(unit)}", **systemctl_opts)
       end
 
       def systemctl_cmd

--- a/spec/functional/mixin/shell_out_spec.rb
+++ b/spec/functional/mixin/shell_out_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,32 @@ describe Chef::Mixin::ShellOut do
                 shell_out_with_systems_locale("echo %LC_ALL%", :environment => { "LC_ALL" => "POSIX" })
               else
                 shell_out_with_systems_locale("echo $LC_ALL", :environment => { "LC_ALL" => "POSIX" })
+              end
+
+        expect(cmd.stdout.chomp).to eq "POSIX"
+      end
+    end
+  end
+
+  describe "shell_out default_env: false" do
+    describe "when environment['LC_ALL'] is not set" do
+      it "should use the default shell_out setting" do
+        cmd = if windows?
+                shell_out("echo %LC_ALL%", default_env: false)
+              else
+                shell_out("echo $LC_ALL", default_env: false)
+              end
+
+        expect(cmd.stdout.chomp).to match_environment_variable("LC_ALL")
+      end
+    end
+
+    describe "when environment['LC_ALL'] is set" do
+      it "should use the option's setting" do
+        cmd = if windows?
+                shell_out("echo %LC_ALL%", :environment => { "LC_ALL" => "POSIX" }, default_env: false)
+              else
+                shell_out("echo $LC_ALL", :environment => { "LC_ALL" => "POSIX" }, default_env: false)
               end
 
         expect(cmd.stdout.chomp).to eq "POSIX"

--- a/spec/unit/dsl/recipe_spec.rb
+++ b/spec/unit/dsl/recipe_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,10 +52,6 @@ describe Chef::DSL::Recipe do
 
     it "responds to shell_out" do
       expect(recipe.respond_to?(:shell_out!)).to be true
-    end
-
-    it "responds to shell_out" do
-      expect(recipe.respond_to?(:shell_out_with_systems_locale)).to be true
     end
   end
 

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -232,5 +232,65 @@ describe Chef::Mixin::ShellOut do
       end
     end
 
+    describe "#shell_out default_env: false" do
+
+      describe "when the last argument is a Hash" do
+        describe "and environment is an option" do
+          it "should not change environment['LC_ALL'] when set to nil" do
+            options = { :environment => { "LC_ALL" => nil } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+
+          it "should not change environment['LC_ALL'] when set to non-nil" do
+            options = { :environment => { "LC_ALL" => "en_US.UTF-8" } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+
+          it "should no longer set environment['LC_ALL'] to nil when 'LC_ALL' not present" do
+            options = { :environment => { "HOME" => "/Users/morty" } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+        end
+
+        describe "and env is an option" do
+          it "should not change env when set to nil" do
+            options = { :env => { "LC_ALL" => nil } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+
+          it "should not change env when set to non-nil" do
+            options = { :env => { "LC_ALL" => "en_US.UTF-8" } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+
+          it "should no longer set env['LC_ALL'] to nil when 'LC_ALL' not present" do
+            options = { :env => { "HOME" => "/Users/morty" } }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+        end
+
+        describe "and no env/environment option is present" do
+          it "should no longer add environment option and set environment['LC_ALL'] to nil" do
+            options = { :user => "morty" }
+            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            shell_out_obj.shell_out(cmd, **options, default_env: false)
+          end
+        end
+      end
+
+      describe "when the last argument is not a Hash" do
+        it "should no longer add environment options and set environment['LC_ALL'] to nil" do
+          expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {}).and_return(true)
+          shell_out_obj.shell_out(cmd, default_env: false)
+        end
+      end
+    end
+
   end
 end

--- a/spec/unit/provider/service/arch_service_spec.rb
+++ b/spec/unit/provider/service/arch_service_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Jan Zimmek (<jan.zimmek@web.de>)
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -222,12 +222,12 @@ RUNNING_PS
 
       it "should call the start command if one is specified" do
         @new_resource.start_command("/etc/rc.d/chef startyousillysally")
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef startyousillysally")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/chef startyousillysally", default_env: false)
         @provider.start_service()
       end
 
       it "should call '/etc/rc.d/service_name start' if no start command is specified" do
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} start")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} start", default_env: false)
         @provider.start_service()
       end
     end
@@ -248,12 +248,12 @@ RUNNING_PS
 
       it "should call the stop command if one is specified" do
         @new_resource.stop_command("/etc/rc.d/chef itoldyoutostop")
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef itoldyoutostop")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/chef itoldyoutostop", default_env: false)
         @provider.stop_service()
       end
 
       it "should call '/etc/rc.d/service_name stop' if no stop command is specified" do
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} stop")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} stop", default_env: false)
         @provider.stop_service()
       end
     end
@@ -275,13 +275,13 @@ RUNNING_PS
 
       it "should call 'restart' on the service_name if the resource supports it" do
         @new_resource.supports({ :restart => true })
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} restart")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} restart", default_env: false)
         @provider.restart_service()
       end
 
       it "should call the restart_command if one has been specified" do
         @new_resource.restart_command("/etc/rc.d/chef restartinafire")
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} restartinafire")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} restartinafire", default_env: false)
         @provider.restart_service()
       end
 
@@ -310,13 +310,13 @@ RUNNING_PS
 
       it "should call 'reload' on the service if it supports it" do
         @new_resource.supports({ :reload => true })
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} reload")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} reload", default_env: false)
         @provider.reload_service()
       end
 
       it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
         @new_resource.reload_command("/etc/rc.d/chef lollerpants")
-        expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{@new_resource.service_name} lollerpants")
+        expect(@provider).to receive(:shell_out!).with("/etc/rc.d/#{@new_resource.service_name} lollerpants", default_env: false)
         @provider.reload_service()
       end
     end

--- a/spec/unit/provider/service/freebsd_service_spec.rb
+++ b/spec/unit/provider/service/freebsd_service_spec.rb
@@ -444,12 +444,12 @@ EOF
     describe Chef::Provider::Service::Freebsd, "start_service" do
       it "should call the start command if one is specified" do
         new_resource.start_command("/etc/rc.d/chef startyousillysally")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef startyousillysally")
+        expect(provider).to receive(:shell_out!).with("/etc/rc.d/chef startyousillysally", default_env: false)
         provider.start_service()
       end
 
       it "should call '/usr/local/etc/rc.d/service_name faststart' if no start command is specified" do
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/usr/local/etc/rc.d/#{new_resource.service_name} faststart")
+        expect(provider).to receive(:shell_out!).with("/usr/local/etc/rc.d/#{new_resource.service_name} faststart", default_env: false)
         provider.start_service()
       end
     end
@@ -457,12 +457,12 @@ EOF
     describe Chef::Provider::Service::Freebsd, "stop_service" do
       it "should call the stop command if one is specified" do
         new_resource.stop_command("/etc/init.d/chef itoldyoutostop")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef itoldyoutostop")
+        expect(provider).to receive(:shell_out!).with("/etc/init.d/chef itoldyoutostop", default_env: false)
         provider.stop_service()
       end
 
       it "should call '/usr/local/etc/rc.d/service_name faststop' if no stop command is specified" do
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/usr/local/etc/rc.d/#{new_resource.service_name} faststop")
+        expect(provider).to receive(:shell_out!).with("/usr/local/etc/rc.d/#{new_resource.service_name} faststop", default_env: false)
         provider.stop_service()
       end
     end
@@ -470,13 +470,13 @@ EOF
     describe Chef::Provider::Service::Freebsd, "restart_service" do
       it "should call 'restart' on the service_name if the resource supports it" do
         new_resource.supports({ :restart => true })
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/usr/local/etc/rc.d/#{new_resource.service_name} fastrestart")
+        expect(provider).to receive(:shell_out!).with("/usr/local/etc/rc.d/#{new_resource.service_name} fastrestart", default_env: false)
         provider.restart_service()
       end
 
       it "should call the restart_command if one has been specified" do
         new_resource.restart_command("/etc/init.d/chef restartinafire")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef restartinafire")
+        expect(provider).to receive(:shell_out!).with("/etc/init.d/chef restartinafire", default_env: false)
         provider.restart_service()
       end
 

--- a/spec/unit/provider/service/init_service_spec.rb
+++ b/spec/unit/provider/service/init_service_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,7 +100,7 @@ PS
     end
 
     it "should use the init_command if one has been specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/opt/chef-server/service/erchef start")
+      expect(@provider).to receive(:shell_out!).with("/opt/chef-server/service/erchef start", default_env: false)
       @provider.start_service
     end
 
@@ -164,12 +164,12 @@ RUNNING_PS
   describe "when starting the service" do
     it "should call the start command if one is specified" do
       @new_resource.start_command("/etc/init.d/chef startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/chef startyousillysally", default_env: false)
       @provider.start_service()
     end
 
     it "should call '/etc/init.d/service_name start' if no start command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} start")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/#{@new_resource.service_name} start", default_env: false)
       @provider.start_service()
     end
   end
@@ -177,12 +177,12 @@ RUNNING_PS
   describe Chef::Provider::Service::Init, "stop_service" do
     it "should call the stop command if one is specified" do
       @new_resource.stop_command("/etc/init.d/chef itoldyoutostop")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef itoldyoutostop")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/chef itoldyoutostop", default_env: false)
       @provider.stop_service()
     end
 
     it "should call '/etc/init.d/service_name stop' if no stop command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} stop")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/#{@new_resource.service_name} stop", default_env: false)
       @provider.stop_service()
     end
   end
@@ -190,13 +190,13 @@ RUNNING_PS
   describe "when restarting a service" do
     it "should call 'restart' on the service_name if the resource supports it" do
       @new_resource.supports({ :restart => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restart")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/#{@new_resource.service_name} restart", default_env: false)
       @provider.restart_service()
     end
 
     it "should call the restart_command if one has been specified" do
       @new_resource.restart_command("/etc/init.d/chef restartinafire")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/#{@new_resource.service_name} restartinafire")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/#{@new_resource.service_name} restartinafire", default_env: false)
       @provider.restart_service()
     end
 
@@ -211,13 +211,13 @@ RUNNING_PS
   describe "when reloading a service" do
     it "should call 'reload' on the service if it supports it" do
       @new_resource.supports({ :reload => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef reload")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/chef reload", default_env: false)
       @provider.reload_service()
     end
 
     it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
       @new_resource.reload_command("/etc/init.d/chef lollerpants")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef lollerpants")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/chef lollerpants", default_env: false)
       @provider.reload_service()
     end
   end
@@ -225,7 +225,7 @@ RUNNING_PS
   describe "when a custom command has been specified" do
     before do
       @new_resource.start_command("/etc/init.d/chef startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef startyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/chef startyousillysally", default_env: false)
     end
 
     it "should still pass all why run assertions" do

--- a/spec/unit/provider/service/invokercd_service_spec.rb
+++ b/spec/unit/provider/service/invokercd_service_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@hjksolutions.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,12 +151,12 @@ RUNNING_PS
   describe "when starting the service" do
     it "should call the start command if one is specified" do
       @new_resource.start_command("/usr/sbin/invoke-rc.d chef startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d chef startyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d chef startyousillysally", default_env: false)
       @provider.start_service()
     end
 
     it "should call '/usr/sbin/invoke-rc.d service_name start' if no start command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} start")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} start", default_env: false)
       @provider.start_service()
     end
   end
@@ -164,12 +164,12 @@ RUNNING_PS
   describe Chef::Provider::Service::Invokercd, "stop_service" do
     it "should call the stop command if one is specified" do
       @new_resource.stop_command("/usr/sbin/invoke-rc.d chef itoldyoutostop")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d chef itoldyoutostop")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d chef itoldyoutostop", default_env: false)
       @provider.stop_service()
     end
 
     it "should call '/usr/sbin/invoke-rc.d service_name stop' if no stop command is specified" do
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} stop")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} stop", default_env: false)
       @provider.stop_service()
     end
   end
@@ -177,13 +177,13 @@ RUNNING_PS
   describe "when restarting a service" do
     it "should call 'restart' on the service_name if the resource supports it" do
       @new_resource.supports({ :restart => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} restart")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} restart", default_env: false)
       @provider.restart_service()
     end
 
     it "should call the restart_command if one has been specified" do
       @new_resource.restart_command("/usr/sbin/invoke-rc.d chef restartinafire")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} restartinafire")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d #{@new_resource.service_name} restartinafire", default_env: false)
       @provider.restart_service()
     end
 
@@ -198,13 +198,13 @@ RUNNING_PS
   describe "when reloading a service" do
     it "should call 'reload' on the service if it supports it" do
       @new_resource.supports({ :reload => true })
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d chef reload")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d chef reload", default_env: false)
       @provider.reload_service()
     end
 
     it "should should run the user specified reload command if one is specified and the service doesn't support reload" do
       @new_resource.reload_command("/usr/sbin/invoke-rc.d chef lollerpants")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/usr/sbin/invoke-rc.d chef lollerpants")
+      expect(@provider).to receive(:shell_out!).with("/usr/sbin/invoke-rc.d chef lollerpants", default_env: false)
       @provider.reload_service()
     end
   end

--- a/spec/unit/provider/service/macosx_spec.rb
+++ b/spec/unit/provider/service/macosx_spec.rb
@@ -82,13 +82,13 @@ XML
             allow(Etc).to receive(:getpwuid).and_return(@getpwuid)
             allow(node).to receive(:[]).with("platform_version").and_return(platform_version)
             cmd = "launchctl list #{service_label}"
-            allow(provider).to receive(:shell_out_with_systems_locale).
-              with(/(#{su_cmd} '#{cmd}'|#{cmd})/).
+            allow(provider).to receive(:shell_out).
+              with(/(#{su_cmd} '#{cmd}'|#{cmd})/, default_env: false).
               and_return(double("Status",
                                     :stdout => launchctl_stdout, :exitstatus => 0))
             allow(File).to receive(:exists?).and_return([true], [])
-            allow(provider).to receive(:shell_out_with_systems_locale!).
-              with(/plutil -convert xml1 -o/).
+            allow(provider).to receive(:shell_out!).
+              with(/plutil -convert xml1 -o/, default_env: false).
               and_return(double("Status", :stdout => plutil_stdout))
           end
 
@@ -256,7 +256,7 @@ SVC_LIST
               it "calls the start command if one is specified and service is not running" do
                 allow(new_resource).to receive(:start_command).and_return("cowsay dirty")
 
-                expect(provider).to receive(:shell_out_with_systems_locale!).with("cowsay dirty")
+                expect(provider).to receive(:shell_out!).with("cowsay dirty", default_env: false)
                 provider.start_service
               end
 
@@ -269,8 +269,8 @@ SVC_LIST
 
               it "starts service via launchctl if service found" do
                 cmd = "launchctl load -w " + session + plist
-                expect(provider).to receive(:shell_out_with_systems_locale).
-                  with(/(#{su_cmd} .#{cmd}.|#{cmd})/).
+                expect(provider).to receive(:shell_out).
+                  with(/(#{su_cmd} .#{cmd}.|#{cmd})/, default_env: false).
                   and_return(0)
 
                 provider.start_service
@@ -288,7 +288,7 @@ SVC_LIST
               it "calls the stop command if one is specified and service is running" do
                 allow(new_resource).to receive(:stop_command).and_return("kill -9 123")
 
-                expect(provider).to receive(:shell_out_with_systems_locale!).with("kill -9 123")
+                expect(provider).to receive(:shell_out!).with("kill -9 123", default_env: false)
                 provider.stop_service
               end
 
@@ -301,8 +301,8 @@ SVC_LIST
 
               it "stops the service via launchctl if service found" do
                 cmd = "launchctl unload -w " + plist
-                expect(provider).to receive(:shell_out_with_systems_locale).
-                  with(/(#{su_cmd} .#{cmd}.|#{cmd})/).
+                expect(provider).to receive(:shell_out).
+                  with(/(#{su_cmd} .#{cmd}.|#{cmd})/, default_env: false).
                   and_return(0)
 
                 provider.stop_service
@@ -321,7 +321,7 @@ SVC_LIST
               it "issues a command if given" do
                 allow(new_resource).to receive(:restart_command).and_return("reload that thing")
 
-                expect(provider).to receive(:shell_out_with_systems_locale!).with("reload that thing")
+                expect(provider).to receive(:shell_out!).with("reload that thing", default_env: false)
                 provider.restart_service
               end
 

--- a/spec/unit/provider/service/openbsd_service_spec.rb
+++ b/spec/unit/provider/service/openbsd_service_spec.rb
@@ -285,12 +285,12 @@ describe Chef::Provider::Service::Openbsd do
     describe Chef::Provider::Service::Openbsd, "start_service" do
       it "should call the start command if one is specified" do
         new_resource.start_command("/etc/rc.d/chef startyousillysally")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/chef startyousillysally")
+        expect(provider).to receive(:shell_out!).with("/etc/rc.d/chef startyousillysally", default_env: false)
         provider.start_service()
       end
 
       it "should call '/usr/local/etc/rc.d/service_name start' if no start command is specified" do
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{new_resource.service_name} start")
+        expect(provider).to receive(:shell_out!).with("/etc/rc.d/#{new_resource.service_name} start", default_env: false)
         provider.start_service()
       end
     end
@@ -298,12 +298,12 @@ describe Chef::Provider::Service::Openbsd do
     describe Chef::Provider::Service::Openbsd, "stop_service" do
       it "should call the stop command if one is specified" do
         new_resource.stop_command("/etc/init.d/chef itoldyoutostop")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef itoldyoutostop")
+        expect(provider).to receive(:shell_out!).with("/etc/init.d/chef itoldyoutostop", default_env: false)
         provider.stop_service()
       end
 
       it "should call '/usr/local/etc/rc.d/service_name stop' if no stop command is specified" do
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{new_resource.service_name} stop")
+        expect(provider).to receive(:shell_out!).with("/etc/rc.d/#{new_resource.service_name} stop", default_env: false)
         provider.stop_service()
       end
     end
@@ -312,14 +312,14 @@ describe Chef::Provider::Service::Openbsd do
       context "when the new_resource supports restart" do
         let(:supports) { { restart: true } }
         it "should call 'restart' on the service_name if the resource supports it" do
-          expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/rc.d/#{new_resource.service_name} restart")
+          expect(provider).to receive(:shell_out!).with("/etc/rc.d/#{new_resource.service_name} restart", default_env: false)
           provider.restart_service()
         end
       end
 
       it "should call the restart_command if one has been specified" do
         new_resource.restart_command("/etc/init.d/chef restartinafire")
-        expect(provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/chef restartinafire")
+        expect(provider).to receive(:shell_out!).with("/etc/init.d/chef restartinafire", default_env: false)
         provider.restart_service()
       end
 

--- a/spec/unit/provider/service/simple_service_spec.rb
+++ b/spec/unit/provider/service/simple_service_spec.rb
@@ -107,7 +107,7 @@ NOMOCKINGSTRINGSPLZ
   describe "when starting the service" do
     it "should call the start command if one is specified" do
       @new_resource.start_command("#{@new_resource.start_command}")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("#{@new_resource.start_command}")
+      expect(@provider).to receive(:shell_out!).with("#{@new_resource.start_command}", default_env: false)
       @provider.start_service()
     end
 
@@ -121,7 +121,7 @@ NOMOCKINGSTRINGSPLZ
   describe "when stopping a service" do
     it "should call the stop command if one is specified" do
       @new_resource.stop_command("/etc/init.d/themadness stop")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/themadness stop")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/themadness stop", default_env: false)
       @provider.stop_service()
     end
 
@@ -135,7 +135,7 @@ NOMOCKINGSTRINGSPLZ
   describe Chef::Provider::Service::Simple, "restart_service" do
     it "should call the restart command if one has been specified" do
       @new_resource.restart_command("/etc/init.d/foo restart")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/etc/init.d/foo restart")
+      expect(@provider).to receive(:shell_out!).with("/etc/init.d/foo restart", default_env: false)
       @provider.restart_service()
     end
 
@@ -162,7 +162,7 @@ NOMOCKINGSTRINGSPLZ
 
     it "should should run the user specified reload command if one is specified" do
       @new_resource.reload_command("kill -9 1")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("kill -9 1")
+      expect(@provider).to receive(:shell_out!).with("kill -9 1", default_env: false)
       @provider.reload_service()
     end
   end

--- a/spec/unit/provider/service/upstart_service_spec.rb
+++ b/spec/unit/provider/service/upstart_service_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::Provider::Service::Upstart do
   let(:shell_out_success) do
-    double("shell_out_with_systems_locale", :exitstatus => 0, :error? => false)
+    double("shell_out", :exitstatus => 0, :error? => false)
   end
 
   before(:each) do
@@ -267,19 +267,19 @@ describe Chef::Provider::Service::Upstart do
     it "should call the start command if one is specified" do
       @provider.upstart_service_running = false
       @new_resource.start_command("/sbin/rsyslog startyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog startyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/sbin/rsyslog startyousillysally", default_env: false)
       @provider.start_service()
     end
 
     it "should call '/sbin/start service_name' if no start command is specified" do
       @provider.upstart_service_running = false
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out!).with("/sbin/start #{@new_resource.service_name}", default_env: false).and_return(shell_out_success)
       @provider.start_service()
     end
 
     it "should not call '/sbin/start service_name' if it is already running" do
       @provider.upstart_service_running = true
-      expect(@provider).not_to receive(:shell_out_with_systems_locale!)
+      expect(@provider).not_to receive(:shell_out!)
       @provider.start_service()
     end
 
@@ -288,14 +288,14 @@ describe Chef::Provider::Service::Upstart do
       @new_resource.parameters({ "OSD_ID" => "2" })
       @provider = Chef::Provider::Service::Upstart.new(@new_resource, @run_context)
       @provider.current_resource = @current_resource
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start rsyslog OSD_ID=2").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out!).with("/sbin/start rsyslog OSD_ID=2", default_env: false).and_return(shell_out_success)
       @provider.start_service()
     end
 
     it "should call the restart command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
       @new_resource.restart_command("/sbin/rsyslog restartyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog restartyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/sbin/rsyslog restartyousillysally", default_env: false)
       @provider.restart_service()
     end
 
@@ -310,40 +310,40 @@ describe Chef::Provider::Service::Upstart do
     it "should call '/sbin/start service_name' if restart_service is called for a stopped service" do
       @provider.upstart_service_running = false
       allow(@current_resource).to receive(:running).and_return(false)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/start #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out!).with("/sbin/start #{@new_resource.service_name}", default_env: false).and_return(shell_out_success)
       @provider.restart_service()
     end
 
     it "should call the reload command if one is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
       @new_resource.reload_command("/sbin/rsyslog reloadyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog reloadyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/sbin/rsyslog reloadyousillysally", default_env: false)
       @provider.reload_service()
     end
 
     it "should call '/sbin/reload service_name' if no reload command is specified" do
       allow(@current_resource).to receive(:running).and_return(true)
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/reload #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out!).with("/sbin/reload #{@new_resource.service_name}", default_env: false).and_return(shell_out_success)
       @provider.reload_service()
     end
 
     it "should call the stop command if one is specified" do
       @provider.upstart_service_running = true
       @new_resource.stop_command("/sbin/rsyslog stopyousillysally")
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/rsyslog stopyousillysally")
+      expect(@provider).to receive(:shell_out!).with("/sbin/rsyslog stopyousillysally", default_env: false)
       @provider.stop_service()
     end
 
     it "should call '/sbin/stop service_name' if no stop command is specified" do
       @provider.upstart_service_running = true
-      expect(@provider).to receive(:shell_out_with_systems_locale!).with("/sbin/stop #{@new_resource.service_name}").and_return(shell_out_success)
+      expect(@provider).to receive(:shell_out!).with("/sbin/stop #{@new_resource.service_name}", default_env: false).and_return(shell_out_success)
       @provider.stop_service()
     end
 
     it "should not call '/sbin/stop service_name' if it is already stopped" do
       @provider.upstart_service_running = false
       allow(@current_resource).to receive(:running).and_return(false)
-      expect(@provider).not_to receive(:shell_out_with_systems_locale!).with("/sbin/stop #{@new_resource.service_name}")
+      expect(@provider).not_to receive(:shell_out!).with("/sbin/stop #{@new_resource.service_name}", default_env: false)
       @provider.stop_service()
       expect(@upstart_service_running).to be_falsey
     end

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -58,19 +58,19 @@ describe Chef::Provider::SystemdUnit do
   end
 
   let(:shell_out_success) do
-    double("shell_out_with_systems_locale", :exitstatus => 0, :error? => false)
+    double("shell_out", :exitstatus => 0, :error? => false)
   end
 
   let(:shell_out_failure) do
-    double("shell_out_with_systems_locale", :exitstatus => 1, :error? => true)
+    double("shell_out", :exitstatus => 1, :error? => true)
   end
 
   let(:shell_out_masked) do
-    double("shell_out_with_systems_locale", :exit_status => 0, :error? => false, :stdout => "masked")
+    double("shell_out", :exit_status => 0, :error? => false, :stdout => "masked")
   end
 
   let(:shell_out_static) do
-    double("shell_out_with_systems_locale", :exit_status => 0, :error? => false, :stdout => "static")
+    double("shell_out", :exit_status => 0, :error? => false, :stdout => "static")
   end
 
   before(:each) do
@@ -285,9 +285,9 @@ describe Chef::Provider::SystemdUnit do
             new_resource.user("joe")
             allow(provider).to receive(:manage_unit_file).with(:create)
             expect(new_resource.triggers_reload).to eq true
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user daemon-reload", user_cmd_opts)
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user daemon-reload", **user_cmd_opts, default_env: false)
             provider.action_create
           end
 
@@ -298,9 +298,9 @@ describe Chef::Provider::SystemdUnit do
                              .and_return(true)
             allow(provider).to receive(:manage_unit_file).with(:delete)
             expect(new_resource.triggers_reload).to eq true
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user daemon-reload", user_cmd_opts)
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user daemon-reload", **user_cmd_opts, default_env: false)
             provider.action_delete
           end
 
@@ -308,9 +308,9 @@ describe Chef::Provider::SystemdUnit do
             new_resource.user("joe")
             new_resource.triggers_reload(false)
             allow(provider).to receive(:manage_unit_file).with(:create)
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to_not receive(:shell_out_with_systems_locale!)
-                                      .with("#{systemctl_path} --user daemon-reload", user_cmd_opts)
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to_not receive(:shell_out!)
+                                      .with("#{systemctl_path} --user daemon-reload", **user_cmd_opts, default_env: false)
             provider.action_create
           end
 
@@ -321,9 +321,9 @@ describe Chef::Provider::SystemdUnit do
                              .with(unit_path_user)
                              .and_return(true)
             allow(provider).to receive(:manage_unit_file).with(:delete)
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to_not receive(:shell_out_with_systems_locale!)
-                                      .with("#{systemctl_path} --user daemon-reload", user_cmd_opts)
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to_not receive(:shell_out!)
+                                      .with("#{systemctl_path} --user daemon-reload", **user_cmd_opts, default_env: false)
             provider.action_delete
           end
 
@@ -352,16 +352,16 @@ describe Chef::Provider::SystemdUnit do
 
           it "presets the unit" do
             new_resource.user("joe")
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user preset #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user preset #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_preset
           end
 
           it "reverts the unit" do
             new_resource.user("joe")
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user revert #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user revert #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_revert
           end
@@ -371,9 +371,9 @@ describe Chef::Provider::SystemdUnit do
           it "triggers a daemon-reload when creating a unit with triggers_reload" do
             allow(provider).to receive(:manage_unit_file).with(:create)
             expect(new_resource.triggers_reload).to eq true
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system daemon-reload", {})
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system daemon-reload", default_env: false)
             provider.action_create
           end
 
@@ -383,18 +383,18 @@ describe Chef::Provider::SystemdUnit do
                              .and_return(true)
             allow(provider).to receive(:manage_unit_file).with(:delete)
             expect(new_resource.triggers_reload).to eq true
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system daemon-reload", {})
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system daemon-reload", default_env: false)
             provider.action_delete
           end
 
           it "does not trigger a daemon-reload when creating a unit without triggers_reload" do
             new_resource.triggers_reload(false)
             allow(provider).to receive(:manage_unit_file).with(:create)
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to_not receive(:shell_out_with_systems_locale!)
-                                      .with("#{systemctl_path} --system daemon-reload", {})
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to_not receive(:shell_out!)
+                                      .with("#{systemctl_path} --system daemon-reload", default_env: false)
             provider.action_create
           end
 
@@ -404,9 +404,9 @@ describe Chef::Provider::SystemdUnit do
                              .with(unit_path_system)
                              .and_return(true)
             allow(provider).to receive(:manage_unit_file).with(:delete)
-            allow(provider).to receive(:shell_out_with_systems_locale!)
-            expect(provider).to_not receive(:shell_out_with_systems_locale!)
-                                      .with("#{systemctl_path} --system daemon-reload", {})
+            allow(provider).to receive(:shell_out!)
+            expect(provider).to_not receive(:shell_out!)
+                                      .with("#{systemctl_path} --system daemon-reload", default_env: false)
             provider.action_delete
           end
           it "deletes the file when it exists" do
@@ -431,15 +431,15 @@ describe Chef::Provider::SystemdUnit do
           end
 
           it "presets the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system preset #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system preset #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_preset
           end
 
           it "reverts the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system revert #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system revert #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_revert
           end
@@ -450,8 +450,8 @@ describe Chef::Provider::SystemdUnit do
         context "when a user is specified" do
           it "reenables the unit" do
             current_resource.user(user_name)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reenable #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user reenable #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reenable
           end
@@ -459,8 +459,8 @@ describe Chef::Provider::SystemdUnit do
           it "enables the unit when it is disabled" do
             current_resource.user(user_name)
             current_resource.enabled(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user enable #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user enable #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_enable
           end
@@ -468,22 +468,22 @@ describe Chef::Provider::SystemdUnit do
           it "does not enable the unit when it is enabled" do
             current_resource.user(user_name)
             current_resource.enabled(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_enable
           end
 
           it "does not enable the unit when it is static" do
             current_resource.user(user_name)
             current_resource.static(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_enable
           end
 
           it "disables the unit when it is enabled" do
             current_resource.user(user_name)
             current_resource.enabled(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user disable #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user disable #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_disable
           end
@@ -491,64 +491,64 @@ describe Chef::Provider::SystemdUnit do
           it "does not disable the unit when it is disabled" do
             current_resource.user(user_name)
             current_resource.enabled(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_disable
           end
 
           it "does not disable the unit when it is static" do
             current_resource.user(user_name)
             current_resource.static(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_disable
           end
         end
 
         context "when no user is specified" do
           it "reenables the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reenable #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system reenable #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reenable
           end
 
           it "enables the unit when it is disabled" do
             current_resource.enabled(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system enable #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system enable #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_enable
           end
 
           it "does not enable the unit when it is enabled" do
             current_resource.enabled(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_enable
           end
 
           it "does not enable the unit when it is static" do
             current_resource.static(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_enable
           end
 
           it "disables the unit when it is enabled" do
             current_resource.enabled(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system disable #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system disable #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_disable
           end
 
           it "does not disable the unit when it is disabled" do
             current_resource.enabled(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_disable
           end
 
           it "does not disable the unit when it is static" do
             current_resource.user(user_name)
             current_resource.static(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_disable
           end
         end
@@ -559,8 +559,8 @@ describe Chef::Provider::SystemdUnit do
           it "masks the unit when it is unmasked" do
             current_resource.user(user_name)
             current_resource.masked(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user mask #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user mask #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_mask
           end
@@ -568,15 +568,15 @@ describe Chef::Provider::SystemdUnit do
           it "does not mask the unit when it is masked" do
             current_resource.user(user_name)
             current_resource.masked(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_mask
           end
 
           it "unmasks the unit when it is masked" do
             current_resource.user(user_name)
             current_resource.masked(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user unmask #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user unmask #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_unmask
           end
@@ -584,7 +584,7 @@ describe Chef::Provider::SystemdUnit do
           it "does not unmask the unit when it is unmasked" do
             current_resource.user(user_name)
             current_resource.masked(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_unmask
           end
         end
@@ -592,29 +592,29 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "masks the unit when it is unmasked" do
             current_resource.masked(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system mask #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system mask #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_mask
           end
 
           it "does not mask the unit when it is masked" do
             current_resource.masked(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_mask
           end
 
           it "unmasks the unit when it is masked" do
             current_resource.masked(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system unmask #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system unmask #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_unmask
           end
 
           it "does not unmask the unit when it is unmasked" do
             current_resource.masked(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_unmask
           end
         end
@@ -625,8 +625,8 @@ describe Chef::Provider::SystemdUnit do
           it "starts the unit when it is inactive" do
             current_resource.user(user_name)
             current_resource.active(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user start #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user start #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_start
           end
@@ -634,15 +634,15 @@ describe Chef::Provider::SystemdUnit do
           it "does not start the unit when it is active" do
             current_resource.user(user_name)
             current_resource.active(true)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_start
           end
 
           it "stops the unit when it is active" do
             current_resource.user(user_name)
             current_resource.active(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user stop #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user stop #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_stop
           end
@@ -650,7 +650,7 @@ describe Chef::Provider::SystemdUnit do
           it "does not stop the unit when it is inactive" do
             current_resource.user(user_name)
             current_resource.active(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_stop
           end
         end
@@ -658,29 +658,29 @@ describe Chef::Provider::SystemdUnit do
         context "when no user is specified" do
           it "starts the unit when it is inactive" do
             current_resource.active(false)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system start #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system start #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_start
           end
 
           it "does not start the unit when it is active" do
             current_resource.active(true)
-            expect(provider).to_not receive(:shell_out_with_systems_locale!)
+            expect(provider).to_not receive(:shell_out!)
             provider.action_start
           end
 
           it "stops the unit when it is active" do
             current_resource.active(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system stop #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system stop #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_stop
           end
 
           it "does not stop the unit when it is inactive" do
             current_resource.active(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_stop
           end
         end
@@ -690,8 +690,8 @@ describe Chef::Provider::SystemdUnit do
         context "when a user is specified" do
           it "restarts the unit" do
             current_resource.user(user_name)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user restart #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user restart #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_restart
           end
@@ -699,8 +699,8 @@ describe Chef::Provider::SystemdUnit do
           it "reloads the unit if active" do
             current_resource.user(user_name)
             current_resource.active(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user reload #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload
           end
@@ -708,30 +708,30 @@ describe Chef::Provider::SystemdUnit do
           it "does not reload if the unit is inactive" do
             current_resource.user(user_name)
             current_resource.active(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_reload
           end
         end
 
         context "when no user is specified" do
           it "restarts the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system restart #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system restart #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_restart
           end
 
           it "reloads the unit if active" do
             current_resource.active(true)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system reload #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload
           end
 
           it "does not reload the unit if inactive" do
             current_resource.active(false)
-            expect(provider).not_to receive(:shell_out_with_systems_locale!)
+            expect(provider).not_to receive(:shell_out!)
             provider.action_reload
           end
         end
@@ -741,8 +741,8 @@ describe Chef::Provider::SystemdUnit do
         context "when a user is specified" do
           it "try-restarts the unit" do
             current_resource.user(user_name)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user try-restart #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user try-restart #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_try_restart
           end
@@ -750,8 +750,8 @@ describe Chef::Provider::SystemdUnit do
 
         context "when no user is specified" do
           it "try-restarts the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system try-restart #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system try-restart #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_try_restart
           end
@@ -762,8 +762,8 @@ describe Chef::Provider::SystemdUnit do
         context "when a user is specified" do
           it "reload-or-restarts the unit" do
             current_resource.user(user_name)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload-or-restart #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user reload-or-restart #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload_or_restart
           end
@@ -771,8 +771,8 @@ describe Chef::Provider::SystemdUnit do
 
         context "when no user is specified" do
           it "reload-or-restarts the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload-or-restart #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system reload-or-restart #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload_or_restart
           end
@@ -783,8 +783,8 @@ describe Chef::Provider::SystemdUnit do
         context "when a user is specified" do
           it "reload-or-try-restarts the unit" do
             current_resource.user(user_name)
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --user reload-or-try-restart #{unit_name_escaped}", user_cmd_opts)
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --user reload-or-try-restart #{unit_name_escaped}", **user_cmd_opts, default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload_or_try_restart
           end
@@ -792,8 +792,8 @@ describe Chef::Provider::SystemdUnit do
 
         context "when no user is specified" do
           it "reload-or-try-restarts the unit" do
-            expect(provider).to receive(:shell_out_with_systems_locale!)
-                                  .with("#{systemctl_path} --system reload-or-try-restart #{unit_name_escaped}", {})
+            expect(provider).to receive(:shell_out!)
+                                  .with("#{systemctl_path} --system reload-or-try-restart #{unit_name_escaped}", default_env: false)
                                   .and_return(shell_out_success)
             provider.action_reload_or_try_restart
           end

--- a/spec/unit/provider/zypper_repository_spec.rb
+++ b/spec/unit/provider/zypper_repository_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: 2017, Chef Software, Inc.
+# Copyright:: 2017-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,11 +45,11 @@ describe Chef::Provider::ZypperRepository do
   end
 
   let(:rpm_key_finger) do
-    double("shell_out_with_systems_locale", stdout: RPM_KEYS, exitstatus: 0, error?: false)
+    double("shell_out", stdout: RPM_KEYS, exitstatus: 0, error?: false)
   end
 
   let(:gpg_finger) do
-    double("shell_out_with_systems_locale", stdout: GPG_FINGER, exitstatus: 0, error?: false)
+    double("shell_out", stdout: GPG_FINGER, exitstatus: 0, error?: false)
   end
 
   it "responds to load_current_resource" do

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,10 +73,6 @@ describe Chef::Provider do
 
   it "should mixin shell_out!" do
     expect(@provider.respond_to?(:shell_out!)).to be true
-  end
-
-  it "should mixin shell_out_with_systems_locale" do
-    expect(@provider.respond_to?(:shell_out_with_systems_locale)).to be true
   end
 
   it "should store the resource passed to new as new_resource" do

--- a/spec/unit/resource/conditional_spec.rb
+++ b/spec/unit/resource/conditional_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2011-2017, Chef Software Inc.
+# Copyright:: Copyright 2011-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,7 +92,7 @@ describe Chef::Resource::Conditional do
     describe "after running a command which timed out" do
       before do
         @conditional = Chef::Resource::Conditional.only_if(@parent_resource, "false")
-        allow_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:shell_out_with_systems_locale).and_raise(Chef::Exceptions::CommandTimeout)
+        allow_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:shell_out).and_raise(Chef::Exceptions::CommandTimeout)
       end
 
       it "indicates that resource convergence should not continue" do
@@ -195,7 +195,7 @@ describe Chef::Resource::Conditional do
     describe "after running a command which timed out" do
       before do
         @conditional = Chef::Resource::Conditional.not_if(@parent_resource, "false")
-        allow_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:shell_out_with_systems_locale).and_raise(Chef::Exceptions::CommandTimeout)
+        allow_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:shell_out).and_raise(Chef::Exceptions::CommandTimeout)
       end
 
       it "indicates that resource convergence should continue" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,10 +36,6 @@ describe Chef::Resource do
 
   it "should mixin shell_out!" do
     expect(resource.respond_to?(:shell_out!)).to be true
-  end
-
-  it "should mixin shell_out_with_systems_locale" do
-    expect(resource.respond_to?(:shell_out_with_systems_locale)).to be true
   end
 
   describe "when inherited" do


### PR DESCRIPTION
Somewhat mechanically converts old `shell_out_with_systems_locale` to the new API.