### PR TITLE
Make shell_out_compact automatically pull timeouts off the resource + remove uses of shell_out_compact_timeout

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -62,7 +62,7 @@ class Chef
       #
 
       def shell_out_compact(*args, **options)
-        options = Chef::Mixin::ShellOut.maybe_add_timeout(options)
+        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
         if options.empty?
           shell_out(*clean_array(*args))
         else
@@ -71,7 +71,7 @@ class Chef
       end
 
       def shell_out_compact!(*args, **options)
-        options = Chef::Mixin::ShellOut.maybe_add_timeout(options)
+        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
         if options.empty?
           shell_out!(*clean_array(*args))
         else
@@ -79,12 +79,13 @@ class Chef
         end
       end
 
+      # module method to not pollute namespaces, but that means we need self injected as an arg
       # @api private
-      def self.maybe_add_timeout(options)
-        if is_a?(Chef::Provider) && !new_resource.is_a?(Chef::Resource::LWRPBase) && new_resource.respond_to?(:timeout) && !options.key?(:timeout)
+      def self.maybe_add_timeout(obj, options)
+        if obj.is_a?(Chef::Provider) && !obj.new_resource.is_a?(Chef::Resource::LWRPBase) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
           options = options.dup
           # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
-          options[:timeout] = new_resource.timeout ? new_resource.timeout.to_f : 900
+          options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : 900
         end
         options
       end

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -62,6 +62,7 @@ class Chef
       #
 
       def shell_out_compact(*args, **options)
+        options = maybe_add_timeout(options)
         if options.empty?
           shell_out(*clean_array(*args))
         else
@@ -70,6 +71,7 @@ class Chef
       end
 
       def shell_out_compact!(*args, **options)
+        options = maybe_add_timeout(options)
         if options.empty?
           shell_out!(*clean_array(*args))
         else
@@ -77,22 +79,21 @@ class Chef
         end
       end
 
-      # helper sugar for resources that support passing timeouts to shell_out
+      def maybe_add_timeout(options)
+        if is_a?(Chef::Provider) && !new_resource.is_a?(Chef::Resource::LWRPBase) && new_resource.respond_to?(:timeout)
+          options = options.dup
+          options[:timeout] = new_resource.timeout if new_resource.timeout
+          options[:timeout] = 900 unless options.key?(:timeout)
+        end
+        options
+      end
 
       def shell_out_compact_timeout(*args, **options)
-        raise "object is not a resource that supports timeouts" unless respond_to?(:new_resource) && new_resource.respond_to?(:timeout)
-        options_dup = options.dup
-        options_dup[:timeout] = new_resource.timeout if new_resource.timeout
-        options_dup[:timeout] = 900 unless options_dup.key?(:timeout)
-        shell_out_compact(*args, **options_dup)
+        shell_out_compact(*args, **options)
       end
 
       def shell_out_compact_timeout!(*args, **options)
-        raise "object is not a resource that supports timeouts" unless respond_to?(:new_resource) && new_resource.respond_to?(:timeout)
-        options_dup = options.dup
-        options_dup[:timeout] = new_resource.timeout if new_resource.timeout
-        options_dup[:timeout] = 900 unless options_dup.key?(:timeout)
-        shell_out_compact!(*args, **options_dup)
+        shell_out_compact!(*args, **options)
       end
 
       # shell_out! runs a command on the system and will raise an error if the command fails, which is what you want

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -62,7 +62,7 @@ class Chef
       #
 
       def shell_out_compact(*args, **options)
-        options = maybe_add_timeout(options)
+        options = Chef::Mixin::ShellOut.maybe_add_timeout(options)
         if options.empty?
           shell_out(*clean_array(*args))
         else
@@ -71,7 +71,7 @@ class Chef
       end
 
       def shell_out_compact!(*args, **options)
-        options = maybe_add_timeout(options)
+        options = Chef::Mixin::ShellOut.maybe_add_timeout(options)
         if options.empty?
           shell_out!(*clean_array(*args))
         else
@@ -79,7 +79,8 @@ class Chef
         end
       end
 
-      def maybe_add_timeout(options)
+      # @api private
+      def self.maybe_add_timeout(options)
         if is_a?(Chef::Provider) && !new_resource.is_a?(Chef::Resource::LWRPBase) && new_resource.respond_to?(:timeout) && !options.key?(:timeout)
           options = options.dup
           # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -79,6 +79,8 @@ class Chef
         end
       end
 
+      # helper sugar for resources that support passing timeouts to shell_out
+      #
       # module method to not pollute namespaces, but that means we need self injected as an arg
       # @api private
       def self.maybe_add_timeout(obj, options)

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -80,10 +80,10 @@ class Chef
       end
 
       def maybe_add_timeout(options)
-        if is_a?(Chef::Provider) && !new_resource.is_a?(Chef::Resource::LWRPBase) && new_resource.respond_to?(:timeout)
+        if is_a?(Chef::Provider) && !new_resource.is_a?(Chef::Resource::LWRPBase) && new_resource.respond_to?(:timeout) && !options.key?(:timeout)
           options = options.dup
-          options[:timeout] = new_resource.timeout if new_resource.timeout
-          options[:timeout] = 900 unless options.key?(:timeout)
+          # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
+          options[:timeout] = new_resource.timeout ? new_resource.timeout.to_f : 900
         end
         options
       end

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -307,7 +307,7 @@ class Chef
       # used by subclasses.  deprecated.  use #a_to_s instead.
       def expand_options(options)
         # its deprecated but still work to do to deprecate it fully
-        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out_compact or shell_out_compact_timeout instead")
+        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out_compact or shell_out_compact instead")
         if options
           " #{options.is_a?(Array) ? Shellwords.join(options) : options}"
         else
@@ -678,7 +678,7 @@ class Chef
 
       def add_timeout_option(command_args)
         # this is deprecated but its not quite done yet
-        #Chef.deprecated(:package_misc, "shell_out_with_timeout and add_timeout_option are deprecated methods, use shell_out_compact_timeout instead")
+        #Chef.deprecated(:package_misc, "shell_out_with_timeout and add_timeout_option are deprecated methods, use shell_out_compact instead")
         args = command_args.dup
         if args.last.is_a?(Hash)
           options = args.pop.dup

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -307,7 +307,7 @@ class Chef
       # used by subclasses.  deprecated.  use #a_to_s instead.
       def expand_options(options)
         # its deprecated but still work to do to deprecate it fully
-        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out_compact or shell_out_compact instead")
+        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out_compact instead")
         if options
           " #{options.is_a?(Array) ? Shellwords.join(options) : options}"
         else

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -81,7 +81,7 @@ class Chef
         def locked_packages
           @locked_packages ||=
             begin
-              locked = shell_out_compact_timeout!("apt-mark", "showhold")
+              locked = shell_out_compact!("apt-mark", "showhold")
               locked.stdout.each_line.map do |line|
                 line.strip
               end
@@ -140,9 +140,9 @@ class Chef
         #
         # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
         def version_compare(v1, v2)
-          if !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
+          if !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
             1
-          elsif !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
+          elsif !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
             0
           else
             -1
@@ -153,7 +153,7 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(*args)
-          shell_out_compact_timeout!(*args, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+          shell_out_compact!(*args, env: { "DEBIAN_FRONTEND" => "noninteractive" })
         end
 
         def default_release_options

--- a/lib/chef/provider/package/bff.rb
+++ b/lib/chef/provider/package/bff.rb
@@ -49,7 +49,7 @@ class Chef
 
           if package_source_found?
             logger.trace("#{new_resource} checking pkg status")
-            ret = shell_out_compact_timeout("installp", "-L", "-d", new_resource.source)
+            ret = shell_out_compact("installp", "-L", "-d", new_resource.source)
             ret.stdout.each_line do |line|
               case line
               when /:#{new_resource.package_name}:/
@@ -65,7 +65,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          ret = shell_out_compact_timeout("lslpp", "-lcq", current_resource.package_name)
+          ret = shell_out_compact("lslpp", "-lcq", current_resource.package_name)
           ret.stdout.each_line do |line|
             case line
             when /#{current_resource.package_name}/
@@ -85,7 +85,7 @@ class Chef
         def candidate_version
           return @candidate_version if @candidate_version
           if package_source_found?
-            ret = shell_out_compact_timeout("installp", "-L", "-d", new_resource.source)
+            ret = shell_out_compact("installp", "-L", "-d", new_resource.source)
             ret.stdout.each_line do |line|
               case line
               when /\w:#{Regexp.escape(new_resource.package_name)}:(.*)/
@@ -112,10 +112,10 @@ class Chef
         def install_package(name, version)
           logger.trace("#{new_resource} package install options: #{options}")
           if options.nil?
-            shell_out_compact_timeout!("installp", "-aYF", "-d", new_resource.source, new_resource.package_name)
+            shell_out_compact!("installp", "-aYF", "-d", new_resource.source, new_resource.package_name)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
-            shell_out_compact_timeout!("installp", "-aYF", options, "-d", new_resource.source, new_resource.package_name)
+            shell_out_compact!("installp", "-aYF", options, "-d", new_resource.source, new_resource.package_name)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           end
         end
@@ -124,10 +124,10 @@ class Chef
 
         def remove_package(name, version)
           if options.nil?
-            shell_out_compact_timeout!("installp", "-u", name)
+            shell_out_compact!("installp", "-u", name)
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           else
-            shell_out_compact_timeout!("installp", "-u", options, name)
+            shell_out_compact!("installp", "-u", options, name)
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -167,7 +167,7 @@ class Chef
         end
 
         def dnf(*args)
-          shell_out_compact_timeout!("dnf", *args)
+          shell_out_compact!("dnf", *args)
         end
 
         def safe_version_array

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -113,9 +113,9 @@ class Chef
         #
         # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
         def version_compare(v1, v2)
-          if !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
+          if !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
             1
-          elsif !shell_out_compact_timeout("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
+          elsif !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
             0
           else
             -1
@@ -124,7 +124,7 @@ class Chef
 
         def read_current_version_of_package(package_name)
           logger.trace("#{new_resource} checking install state of #{package_name}")
-          status = shell_out_compact_timeout!("dpkg", "-s", package_name, returns: [0, 1])
+          status = shell_out_compact!("dpkg", "-s", package_name, returns: [0, 1])
           package_installed = false
           status.stdout.each_line do |line|
             case line
@@ -152,7 +152,7 @@ class Chef
         # Runs command via shell_out_with_timeout with magic environment to disable
         # interactive prompts.
         def run_noninteractive(*command)
-          shell_out_compact_timeout!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+          shell_out_compact!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
         end
 
         # Returns true if all sources exist.  Returns false if any do not, or if no
@@ -192,7 +192,7 @@ class Chef
             begin
               pkginfos = resolved_source_array.map do |src|
                 logger.trace("#{new_resource} checking #{src} dpkg status")
-                status = shell_out_compact_timeout!("dpkg-deb", "-W", src)
+                status = shell_out_compact!("dpkg-deb", "-W", src)
                 status.stdout
               end
               Hash[*package_name_array.zip(pkginfos).flatten]

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -47,7 +47,7 @@ class Chef
 
             # Otherwise look up the path to the ports directory using 'whereis'
             else
-              whereis = shell_out_compact_timeout!("whereis", "-s", port, env: nil)
+              whereis = shell_out_compact!("whereis", "-s", port, env: nil)
               unless path = whereis.stdout[/^#{Regexp.escape(port)}:\s+(.+)$/, 1]
                 raise Chef::Exceptions::Package, "Could not find port with the name #{port}"
               end
@@ -57,7 +57,7 @@ class Chef
 
           def makefile_variable_value(variable, dir = nil)
             options = dir ? { cwd: dir } : {}
-            make_v = shell_out_compact_timeout!("make", "-V", variable, options.merge!(env: nil, returns: [0, 1]))
+            make_v = shell_out_compact!("make", "-V", variable, options.merge!(env: nil, returns: [0, 1]))
             make_v.exitstatus == 0 ? make_v.stdout.strip.split($OUTPUT_RECORD_SEPARATOR).first : nil # $\ is the line separator, i.e. newline.
           end
         end

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -34,24 +34,24 @@ class Chef
               case new_resource.source
               when /^http/, /^ftp/
                 if new_resource.source =~ /\/$/
-                  shell_out_compact_timeout!("pkg_add", "-r", package_name, env: { "PACKAGESITE" => new_resource.source, "LC_ALL" => nil }).status
+                  shell_out_compact!("pkg_add", "-r", package_name, env: { "PACKAGESITE" => new_resource.source, "LC_ALL" => nil }).status
                 else
-                  shell_out_compact_timeout!("pkg_add", "-r", package_name, env: { "PACKAGEROOT" => new_resource.source, "LC_ALL" => nil }).status
+                  shell_out_compact!("pkg_add", "-r", package_name, env: { "PACKAGEROOT" => new_resource.source, "LC_ALL" => nil }).status
                 end
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
 
               when /^\//
-                shell_out_compact_timeout!("pkg_add", file_candidate_version_path, env: { "PKG_PATH" => new_resource.source, "LC_ALL" => nil }).status
+                shell_out_compact!("pkg_add", file_candidate_version_path, env: { "PKG_PATH" => new_resource.source, "LC_ALL" => nil }).status
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
 
               else
-                shell_out_compact_timeout!("pkg_add", "-r", latest_link_name, env: nil).status
+                shell_out_compact!("pkg_add", "-r", latest_link_name, env: nil).status
               end
             end
           end
 
           def remove_package(name, version)
-            shell_out_compact_timeout!("pkg_delete", "#{package_name}-#{version || current_resource.version}", env: nil).status
+            shell_out_compact!("pkg_delete", "#{package_name}-#{version || current_resource.version}", env: nil).status
           end
 
           # The name of the package (without the version number) as understood by pkg_add and pkg_info.
@@ -72,7 +72,7 @@ class Chef
           end
 
           def current_installed_version
-            pkg_info = shell_out_compact_timeout!("pkg_info", "-E", "#{package_name}*", env: nil, returns: [0, 1])
+            pkg_info = shell_out_compact!("pkg_info", "-E", "#{package_name}*", env: nil, returns: [0, 1])
             pkg_info.stdout[/^#{Regexp.escape(package_name)}-(.+)/, 1]
           end
 

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -28,21 +28,21 @@ class Chef
             unless current_resource.version
               case new_resource.source
               when /^(http|ftp|\/)/
-                shell_out_compact_timeout!("pkg", "add", options, new_resource.source, env: { "LC_ALL" => nil }).status
+                shell_out_compact!("pkg", "add", options, new_resource.source, env: { "LC_ALL" => nil }).status
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
               else
-                shell_out_compact_timeout!("pkg", "install", "-y", options, name, env: { "LC_ALL" => nil }).status
+                shell_out_compact!("pkg", "install", "-y", options, name, env: { "LC_ALL" => nil }).status
               end
             end
           end
 
           def remove_package(name, version)
             options_dup = options && options.map { |str| str.sub(repo_regex, "") }.reject!(&:empty?)
-            shell_out_compact_timeout!("pkg", "delete", "-y", options_dup, "#{name}#{version ? '-' + version : ''}", env: nil).status
+            shell_out_compact!("pkg", "delete", "-y", options_dup, "#{name}#{version ? '-' + version : ''}", env: nil).status
           end
 
           def current_installed_version
-            pkg_info = shell_out_compact_timeout!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
+            pkg_info = shell_out_compact!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
             pkg_info.stdout[/^Version +: (.+)$/, 1]
           end
 
@@ -61,7 +61,7 @@ class Chef
               options = $1.split(" ")
             end
 
-            pkg_query = shell_out_compact_timeout!("pkg", "rquery", options, "%v", new_resource.package_name, env: nil)
+            pkg_query = shell_out_compact!("pkg", "rquery", options, "%v", new_resource.package_name, env: nil)
             pkg_query.exitstatus == 0 ? pkg_query.stdout.strip.split(/\n/).last : nil
           end
 

--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -26,18 +26,18 @@ class Chef
           include PortsHelper
 
           def install_package(name, version)
-            shell_out_compact_timeout!("make", "-DBATCH", "install", "clean", timeout: 1800, env: nil, cwd: port_dir).status
+            shell_out_compact!("make", "-DBATCH", "install", "clean", timeout: 1800, env: nil, cwd: port_dir).status
           end
 
           def remove_package(name, version)
-            shell_out_compact_timeout!("make", "deinstall", timeout: 300, env: nil, cwd: port_dir).status
+            shell_out_compact!("make", "deinstall", timeout: 300, env: nil, cwd: port_dir).status
           end
 
           def current_installed_version
             pkg_info = if new_resource.supports_pkgng?
-                         shell_out_compact_timeout!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
+                         shell_out_compact!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
                        else
-                         shell_out_compact_timeout!("pkg_info", "-E", "#{new_resource.package_name}*", env: nil, returns: [0, 1])
+                         shell_out_compact!("pkg_info", "-E", "#{new_resource.package_name}*", env: nil, returns: [0, 1])
                        end
             pkg_info.stdout[/^#{Regexp.escape(new_resource.package_name)}-(.+)/, 1]
           end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -128,7 +128,7 @@ class Chef
 
           logger.trace "Executing '#{command.join(' ')}' as user '#{homebrew_user.name}'"
           # FIXME: this 1800 second default timeout should be deprecated
-          output = shell_out_compact_timeout!(*command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
+          output = shell_out_compact!(*command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
           output.stdout.chomp
         end
 

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -42,14 +42,14 @@ class Chef
         end
 
         def get_current_version
-          shell_out_compact_timeout("pkg", "info", new_resource.package_name).stdout.each_line do |line|
+          shell_out_compact("pkg", "info", new_resource.package_name).stdout.each_line do |line|
             return $1.split[0] if line =~ /^\s+Version: (.*)/
           end
           nil
         end
 
         def get_candidate_version
-          shell_out_compact_timeout!("pkg", "info", "-r", new_resource.package_name).stdout.each_line do |line|
+          shell_out_compact!("pkg", "info", "-r", new_resource.package_name).stdout.each_line do |line|
             return $1.split[0] if line =~ /Version: (.*)/
           end
           nil
@@ -68,7 +68,7 @@ class Chef
           command = [ "pkg", options, "install", "-q" ]
           command << "--accept" if new_resource.accept_license
           command << "#{name}@#{version}"
-          shell_out_compact_timeout!(command)
+          shell_out_compact!(command)
         end
 
         def upgrade_package(name, version)
@@ -77,7 +77,7 @@ class Chef
 
         def remove_package(name, version)
           package_name = "#{name}@#{version}"
-          shell_out_compact_timeout!( "pkg", options, "uninstall", "-q", package_name )
+          shell_out_compact!( "pkg", options, "uninstall", "-q", package_name )
         end
       end
     end

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -49,21 +49,21 @@ class Chef
           unless current_resource.version == version
             command = [ "port", options, "install", name ]
             command << "@#{version}" if version && !version.empty?
-            shell_out_compact_timeout!(command)
+            shell_out_compact!(command)
           end
         end
 
         def purge_package(name, version)
           command = [ "port", options, "uninstall", name ]
           command << "@#{version}" if version && !version.empty?
-          shell_out_compact_timeout!(command)
+          shell_out_compact!(command)
         end
 
         def remove_package(name, version)
           command = [ "port", options, "deactivate", name ]
           command << "@#{version}" if version && !version.empty?
 
-          shell_out_compact_timeout!(command)
+          shell_out_compact!(command)
         end
 
         def upgrade_package(name, version)
@@ -76,7 +76,7 @@ class Chef
             # that hasn't been installed.
             install_package(name, version)
           elsif current_version != version
-            shell_out_compact_timeout!( "port", options, "upgrade", name, "@#{version}" )
+            shell_out_compact!( "port", options, "upgrade", name, "@#{version}" )
           end
         end
 
@@ -84,7 +84,7 @@ class Chef
 
         def get_response_from_command(command)
           output = nil
-          status = shell_out_compact_timeout(command)
+          status = shell_out_compact(command)
           begin
             output = status.stdout
           rescue Exception

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -72,7 +72,7 @@ class Chef
             if parts = name.match(/^(.+?)--(.+)/) # use double-dash for stems with flavors, see man page for pkg_add
               name = parts[1]
             end
-            shell_out_compact_timeout!("pkg_add", "-r", package_string(name, version), env: { "PKG_PATH" => pkg_path }).status
+            shell_out_compact!("pkg_add", "-r", package_string(name, version), env: { "PKG_PATH" => pkg_path }).status
             logger.trace("#{new_resource.package_name} installed")
           end
         end
@@ -81,7 +81,7 @@ class Chef
           if parts = name.match(/^(.+?)--(.+)/)
             name = parts[1]
           end
-          shell_out_compact_timeout!("pkg_delete", package_string(name, version), env: nil).status
+          shell_out_compact!("pkg_delete", package_string(name, version), env: nil).status
         end
 
         private
@@ -92,7 +92,7 @@ class Chef
                  else
                    new_resource.package_name
                  end
-          pkg_info = shell_out_compact_timeout!("pkg_info", "-e", "#{name}->0", env: nil, returns: [0, 1])
+          pkg_info = shell_out_compact!("pkg_info", "-e", "#{name}->0", env: nil, returns: [0, 1])
           result = pkg_info.stdout[/^inst:#{Regexp.escape(name)}-(.+?)\s/, 1]
           logger.trace("installed_version of '#{new_resource.package_name}' is '#{result}'")
           result
@@ -101,7 +101,7 @@ class Chef
         def candidate_version
           @candidate_version ||= begin
             results = []
-            shell_out_compact_timeout!("pkg_info", "-I", package_string(new_resource.package_name, new_resource.version), env: nil, returns: [0, 1]).stdout.each_line do |line|
+            shell_out_compact!("pkg_info", "-I", package_string(new_resource.package_name, new_resource.version), env: nil, returns: [0, 1]).stdout.each_line do |line|
               results << if parts = new_resource.package_name.match(/^(.+?)--(.+)/)
                            line[/^#{Regexp.escape(parts[1])}-(.+?)\s/, 1]
                          else

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -32,7 +32,7 @@ class Chef
           current_resource.package_name(new_resource.package_name)
 
           logger.trace("#{new_resource} checking pacman for #{new_resource.package_name}")
-          status = shell_out_compact_timeout("pacman", "-Qi", new_resource.package_name)
+          status = shell_out_compact("pacman", "-Qi", new_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /^Version(\s?)*: (.+)$/
@@ -60,7 +60,7 @@ class Chef
 
           package_repos = repos.map { |r| Regexp.escape(r) }.join("|")
 
-          status = shell_out_compact_timeout("pacman", "-Sl")
+          status = shell_out_compact("pacman", "-Sl")
           status.stdout.each_line do |line|
             case line
             when /^(#{package_repos}) #{Regexp.escape(new_resource.package_name)} (.+)$/
@@ -82,7 +82,7 @@ class Chef
         end
 
         def install_package(name, version)
-          shell_out_compact_timeout!( "pacman", "--sync", "--noconfirm", "--noprogressbar", options, name)
+          shell_out_compact!( "pacman", "--sync", "--noconfirm", "--noprogressbar", options, name)
         end
 
         def upgrade_package(name, version)
@@ -90,7 +90,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          shell_out_compact_timeout!( "pacman", "--remove", "--noconfirm", "--noprogressbar", options, name )
+          shell_out_compact!( "pacman", "--remove", "--noconfirm", "--noprogressbar", options, name )
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/paludis.rb
+++ b/lib/chef/provider/package/paludis.rb
@@ -58,7 +58,7 @@ class Chef
                 else
                   new_resource.package_name.to_s
                 end
-          shell_out_compact_timeout!("cave", "-L", "warning", "resolve", "-x", options, pkg)
+          shell_out_compact!("cave", "-L", "warning", "resolve", "-x", options, pkg)
         end
 
         def upgrade_package(name, version)

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Ezra Zygmuntowicz (<ezra@engineyard.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ class Chef
         PACKAGE_NAME_PATTERN = %r{(?:([^/]+)/)?([^/]+)}
 
         def load_current_resource
-          @current_resource = Chef::Resource::Package.new(new_resource.name)
+          @current_resource = Chef::Resource::PortagePackage.new(new_resource.name)
           current_resource.package_name(new_resource.package_name)
 
           category, pkg = /^#{PACKAGE_NAME_PATTERN}$/.match(new_resource.package_name)[1, 2]

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -57,7 +57,7 @@ class Chef
             end
 
             logger.trace("#{new_resource} checking rpm status")
-            shell_out_compact_timeout!("rpm", "-qp", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", new_resource.source).stdout.each_line do |line|
+            shell_out_compact!("rpm", "-qp", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", new_resource.source).stdout.each_line do |line|
               case line
               when /^(\S+)\s(\S+)$/
                 current_resource.package_name($1)
@@ -73,7 +73,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          @rpm_status = shell_out_compact_timeout("rpm", "-q", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", current_resource.package_name)
+          @rpm_status = shell_out_compact("rpm", "-q", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", current_resource.package_name)
           @rpm_status.stdout.each_line do |line|
             case line
             when /^(\S+)\s(\S+)$/
@@ -88,12 +88,12 @@ class Chef
         def install_package(name, version)
           if current_resource.version
             if allow_downgrade
-              shell_out_compact_timeout!("rpm", options, "-U", "--oldpackage", new_resource.source)
+              shell_out_compact!("rpm", options, "-U", "--oldpackage", new_resource.source)
             else
-              shell_out_compact_timeout!("rpm", options, "-U", new_resource.source)
+              shell_out_compact!("rpm", options, "-U", new_resource.source)
             end
           else
-            shell_out_compact_timeout!("rpm", options, "-i", new_resource.source)
+            shell_out_compact!("rpm", options, "-i", new_resource.source)
           end
         end
 
@@ -101,9 +101,9 @@ class Chef
 
         def remove_package(name, version)
           if version
-            shell_out_compact_timeout!("rpm", options, "-e", "#{name}-#{version}")
+            shell_out_compact!("rpm", options, "-e", "#{name}-#{version}")
           else
-            shell_out_compact_timeout!("rpm", options, "-e", name)
+            shell_out_compact!("rpm", options, "-e", name)
           end
         end
 

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -43,7 +43,7 @@ class Chef
         def check_package_state(name)
           logger.trace("#{new_resource} checking package #{name}")
           version = nil
-          info = shell_out_compact_timeout!("/opt/local/sbin/pkg_info", "-E", "#{name}*", env: nil, returns: [0, 1])
+          info = shell_out_compact!("/opt/local/sbin/pkg_info", "-E", "#{name}*", env: nil, returns: [0, 1])
 
           if info.stdout
             version = info.stdout[/^#{new_resource.package_name}-(.+)/, 1]
@@ -58,7 +58,7 @@ class Chef
           return @candidate_version if @candidate_version
           name = nil
           version = nil
-          pkg = shell_out_compact_timeout!("/opt/local/bin/pkgin", "se", new_resource.package_name, env: nil, returns: [0, 1])
+          pkg = shell_out_compact!("/opt/local/bin/pkgin", "se", new_resource.package_name, env: nil, returns: [0, 1])
           pkg.stdout.each_line do |line|
             case line
             when /^#{new_resource.package_name}/
@@ -72,7 +72,7 @@ class Chef
         def install_package(name, version)
           logger.trace("#{new_resource} installing package #{name} version #{version}")
           package = "#{name}-#{version}"
-          out = shell_out_compact_timeout!("/opt/local/bin/pkgin", "-y", "install", package, env: nil)
+          out = shell_out_compact!("/opt/local/bin/pkgin", "-y", "install", package, env: nil)
         end
 
         def upgrade_package(name, version)
@@ -83,7 +83,7 @@ class Chef
         def remove_package(name, version)
           logger.trace("#{new_resource} removing package #{name} version #{version}")
           package = name.to_s
-          out = shell_out_compact_timeout!("/opt/local/bin/pkgin", "-y", "remove", package, env: nil)
+          out = shell_out_compact!("/opt/local/bin/pkgin", "-y", "remove", package, env: nil)
         end
 
       end

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -55,7 +55,7 @@ class Chef
             @package_source_found = ::File.exist?(new_resource.source)
             if @package_source_found
               logger.trace("#{new_resource} checking pkg status")
-              shell_out_compact_timeout("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name).stdout.each_line do |line|
+              shell_out_compact("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name).stdout.each_line do |line|
                 case line
                 when /VERSION:\s+(.+)/
                   new_resource.version($1)
@@ -65,7 +65,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          status = shell_out_compact_timeout("pkginfo", "-l", current_resource.package_name)
+          status = shell_out_compact("pkginfo", "-l", current_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -83,7 +83,7 @@ class Chef
 
         def candidate_version
           return @candidate_version if @candidate_version
-          status = shell_out_compact_timeout("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name)
+          status = shell_out_compact("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -106,7 +106,7 @@ class Chef
                       else
                         [ "pkgadd", "-n", "-d", new_resource.source, "all" ]
                       end
-            shell_out_compact_timeout!(command)
+            shell_out_compact!(command)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
             command = if ::File.directory?(new_resource.source) # CHEF-4469
@@ -114,7 +114,7 @@ class Chef
                       else
                         [ "pkgadd", "-n", options, "-d", new_resource.source, "all" ]
                       end
-            shell_out_compact_timeout!(*command)
+            shell_out_compact!(*command)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           end
         end
@@ -123,10 +123,10 @@ class Chef
 
         def remove_package(name, version)
           if options.nil?
-            shell_out_compact_timeout!( "pkgrm", "-n", name )
+            shell_out_compact!( "pkgrm", "-n", name )
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           else
-            shell_out_compact_timeout!( "pkgrm", "-n", options, name )
+            shell_out_compact!( "pkgrm", "-n", options, name )
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -260,7 +260,7 @@ class Chef
         end
 
         def yum(*args)
-          shell_out_compact_timeout!(yum_binary, *args)
+          shell_out_compact!(yum_binary, *args)
         end
 
         def safe_version_array

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -35,7 +35,7 @@ class Chef
           candidate_version = current_version = nil
           is_installed = false
           logger.trace("#{new_resource} checking zypper")
-          status = shell_out_compact_timeout!("zypper", "--non-interactive", "info", package_name)
+          status = shell_out_compact!("zypper", "--non-interactive", "info", package_name)
           status.stdout.each_line do |line|
             case line
             when /^Version *: (.+) *$/
@@ -86,7 +86,7 @@ class Chef
         def locked_packages
           @locked_packages ||=
             begin
-              locked = shell_out_compact_timeout!("zypper", "locks")
+              locked = shell_out_compact!("zypper", "locks")
               locked.stdout.each_line.map do |line|
                 line.split("|").shift(2).last.strip
               end
@@ -144,9 +144,9 @@ class Chef
         def zypper_package(command, *options, names, versions)
           zipped_names = zip(names, versions)
           if zypper_version < 1.0
-            shell_out_compact_timeout!("zypper", gpg_checks, command, *options, "-y", names)
+            shell_out_compact!("zypper", gpg_checks, command, *options, "-y", names)
           else
-            shell_out_compact_timeout!("zypper", "--non-interactive", gpg_checks, command, *options, zipped_names)
+            shell_out_compact!("zypper", "--non-interactive", gpg_checks, command, *options, zipped_names)
           end
         end
 

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Vasiliy Tolstov (<v.tolstov@selfip.ru>)
-# Copyright:: Copyright 2014-2016, Chef Software Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/resource/portage_package.rb
+++ b/lib/chef/resource/portage_package.rb
@@ -25,6 +25,8 @@ class Chef
       provides :portage_package
 
       description "Use the portage_package resource to manage packages for the Gentoo platform."
+
+      property :timeout, default: 3600
     end
   end
 end

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -415,7 +415,7 @@ mpg123 1.12.1-0ubuntu1
         @provider.lock_package("irssi", "0.8.12-7")
       end
       it "should not lock if the package is already locked" do
-        allow(@provider).to receive(:shell_out_compact_timeout!).with(
+        allow(@provider).to receive(:shell_out_compact!).with(
           "apt-mark", "showhold"
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: "irssi")
@@ -436,7 +436,7 @@ mpg123 1.12.1-0ubuntu1
         @provider.unlock_package("irssi", "0.8.12-7")
       end
       it "should not unlock if the package is already unlocked" do
-        allow(@provider).to receive(:shell_out_compact_timeout!).with(
+        allow(@provider).to receive(:shell_out_compact!).with(
           "apt-mark", "showhold"
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: "")
@@ -499,7 +499,7 @@ mpg123 1.12.1-0ubuntu1
       it "should run dpkg to compare versions if an existing version is installed" do
         allow(@provider).to receive(:get_current_versions).and_return("1.4.0")
         allow(@new_resource).to receive(:allow_downgrade).and_return(false)
-        expect(@provider).to receive(:shell_out_compact_timeout).with(
+        expect(@provider).to receive(:shell_out_compact).with(
           "dpkg", "--compare-versions", "1.4.0", "gt", "0.8.12-7"
         ).and_return(double(error?: false))
         @provider.run_action(:upgrade)

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -207,7 +207,7 @@ Section: ruby
 
     it "should raise an exception if dpkg-deb -W fails to run" do
       status = double(:stdout => "", :exitstatus => -1)
-      expect(provider).to receive(:shell_out_compact_timeout!).with("dpkg-deb", "-W", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb").and_raise(Mixlib::ShellOut::ShellCommandFailed)
+      expect(provider).to receive(:shell_out_compact!).with("dpkg-deb", "-W", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb").and_raise(Mixlib::ShellOut::ShellCommandFailed)
       expect { provider.load_current_resource }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
   end

--- a/spec/unit/provider/package/paludis_spec.rb
+++ b/spec/unit/provider/package/paludis_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Vasiliy Tolstov <v.tolstov@selfip.ru>
-# Copyright:: Copyright 2014-2016, Chef Software Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,7 +59,7 @@ PKG_STATUS
     end
 
     it "should run pkg info with the package name" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "print-ids", "-M", "none", "-m", @new_resource.package_name, "-f", "%c/%p %v %r\n").and_return(@shell_out)
+      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "print-ids", "-M", "none", "-m", @new_resource.package_name, "-f", "%c/%p %v %r\n", timeout: 900).and_return(@shell_out)
       @provider.load_current_resource
     end
 
@@ -126,7 +126,7 @@ PKG_STATUS
 
   context "when uninstalling a package" do
     it "should run pkg uninstall with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "uninstall", "-x", "=net/ntp-4.2.6_p5-r2")
+      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "uninstall", "-x", "=net/ntp-4.2.6_p5-r2", timeout: 900)
       @provider.remove_package("net/ntp", "4.2.6_p5-r2")
     end
 

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Caleb Tennis (<caleb.tennis@gmail.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,19 +22,19 @@ describe Chef::Provider::Package::Portage, "load_current_resource" do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::Package.new("dev-util/git")
-    @new_resource_without_category = Chef::Resource::Package.new("git")
-    @current_resource = Chef::Resource::Package.new("dev-util/git")
+    @new_resource = Chef::Resource::PortagePackage.new("dev-util/git")
+    @new_resource_without_category = Chef::Resource::PortagePackage.new("git")
+    @current_resource = Chef::Resource::PortagePackage.new("dev-util/git")
 
     @provider = Chef::Provider::Package::Portage.new(@new_resource, @run_context)
-    allow(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
+    allow(Chef::Resource::PortagePackage).to receive(:new).and_return(@current_resource)
   end
 
   describe "when determining the current state of the package" do
 
     it "should create a current resource with the name of new_resource" do
       allow(::Dir).to receive(:[]).with("/var/db/pkg/dev-util/git-*").and_return(["/var/db/pkg/dev-util/git-1.0.0"])
-      expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
+      expect(Chef::Resource::PortagePackage).to receive(:new).and_return(@current_resource)
       @provider.load_current_resource
     end
 
@@ -148,17 +148,17 @@ EOF
 
     describe Chef::Provider::Package::Portage, "install_package" do
       it "should install a normally versioned package using portage" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0")
+        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
         @provider.install_package("dev-util/git", "1.0.0")
       end
 
       it "should install a tilde versioned package using portage" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "~dev-util/git-1.0.0")
+        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "~dev-util/git-1.0.0", timeout: 3600)
         @provider.install_package("dev-util/git", "~1.0.0")
       end
 
       it "should add options to the emerge command when specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "--oneshot", "=dev-util/git-1.0.0")
+        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "--oneshot", "=dev-util/git-1.0.0", timeout: 3600)
         @new_resource.options "--oneshot"
         @provider.install_package("dev-util/git", "1.0.0")
       end
@@ -166,12 +166,12 @@ EOF
 
     describe Chef::Provider::Package::Portage, "remove_package" do
       it "should un-emerge the package with no version specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "dev-util/git")
+        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "dev-util/git", timeout: 3600)
         @provider.remove_package("dev-util/git", nil)
       end
 
       it "should un-emerge the package with a version specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0")
+        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
         @provider.remove_package("dev-util/git", "1.0.0")
       end
     end

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -270,10 +270,10 @@ describe Chef::Provider::Package::Zypper do
   describe "action_lock" do
     it "should lock if the package is not already locked" do
       prov = provider
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "--non-interactive", "info", new_resource.package_name
       ).and_return(status)
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "locks"
       ).and_return(instance_double(
         Mixlib::ShellOut, stdout: "1 | somethingelse | package | (any)"
@@ -286,10 +286,10 @@ describe Chef::Provider::Package::Zypper do
 
     it "should not lock if the package is already locked" do
       prov = provider
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "--non-interactive", "info", new_resource.package_name
       ).and_return(status)
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "locks"
       ).and_return(instance_double(
         Mixlib::ShellOut, stdout: "1 | cups | package | (any)"
@@ -327,10 +327,10 @@ describe Chef::Provider::Package::Zypper do
   describe "action_unlock" do
     it "should unlock if the package is not already unlocked" do
       prov = provider
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "--non-interactive", "info", new_resource.package_name
       ).and_return(status)
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "locks"
       ).and_return(instance_double(
         Mixlib::ShellOut, stdout: "1 | cups | package | (any)"
@@ -342,10 +342,10 @@ describe Chef::Provider::Package::Zypper do
     end
     it "should not unlock if the package is already unlocked" do
       prov = provider
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "--non-interactive", "info", new_resource.package_name
       ).and_return(status)
-      allow(prov).to receive(:shell_out_compact_timeout!).with(
+      allow(prov).to receive(:shell_out_compact!).with(
         "zypper", "locks"
       ).and_return(instance_double(
         Mixlib::ShellOut, stdout: "1 | somethingelse | package | (any)"


### PR DESCRIPTION
Collapses down the API a bit better.

I've got some possibly overly paranoid gating to make sure this wouldn't affect anyone's cookbooks, but at the same time this only affects shell_out_compact(), not shell_out() itself.

It found and fixed at least one reported bug:  #6288

Since portage is a compile-from-source I bumped the default timeout up to 3600 on that one and it now should obey user-set timeouts.

Code timeouts always take precedence now, then the new_resource.timeout, then it applies the 900 timeout if that is nil.

closes #6288