### PR TITLE
pin kitchen tests to chef-13 on chef-13 branch

### DIFF
--- a/kitchen-tests/.kitchen.travis.yml
+++ b/kitchen-tests/.kitchen.travis.yml
@@ -13,11 +13,11 @@ provisioner:
   root_path: /opt/kitchen
   require_chef_omnibus: latest
   chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
-  chef_omnibus_install_options: "-c current"
+  chef_omnibus_install_options: "-c current -v 13"
   github_owner: "chef"
   github_repo: "chef"
   refname: <%= ENV['TRAVIS_COMMIT'] %>
-  ohai_refname: "master"
+  ohai_refname: "13-stable"
   github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
   data_path: test/fixtures
 # disable file provider diffs so we don't overflow travis' line limit

--- a/kitchen-tests/.kitchen.yml
+++ b/kitchen-tests/.kitchen.yml
@@ -12,10 +12,10 @@ verifier:
 provisioner:
   name: chef_github
   chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
-  chef_omnibus_install_options: "-c current"
+  chef_omnibus_install_options: "-c current -v 13"
   github_owner: "chef"
   github_repo: "chef"
-  ohai_refname: "master"
+  ohai_refname: "13-stable"
   refname: <%= %x(git rev-parse HEAD) %>
   client_rb:
     diff_disabled: true


### PR DESCRIPTION
stop pulling down ohai master / chef-14 current / ruby-2.5

