### PR TITLE
Check local file exists before installing a windows package

### DIFF
--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -39,6 +39,13 @@ class Chef
             a.assertion { new_resource.source || msi? }
             a.failure_message Chef::Exceptions::NoWindowsPackageSource, "Source for package #{new_resource.name} must be specified in the resource's source property for package to be installed because the package_name property is used to test for the package installation state for this package type."
           end
+
+          unless uri_scheme?(new_resource.source)
+            requirements.assert(:install) do |a|
+              a.assertion { ::File.exist?(new_resource.source) }
+              a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.name} does not exist"
+            end
+          end
         end
 
         # load_current_resource is run in Chef::Provider#run_action when not in whyrun_mode?

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -44,6 +44,7 @@ class Chef
             requirements.assert(:install) do |a|
               a.assertion { ::File.exist?(new_resource.source) }
               a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.name} does not exist"
+              a.whyrun "Assuming source file #{new_resource.source} would have been created."
             end
           end
         end

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -394,6 +394,18 @@ describe Chef::Provider::Package::Windows, :windows_only do
         end
       end
     end
+
+    context "a missing local file is given" do
+      let(:resource_source) { "C:/a_missing_file.exe" }
+      let(:installer_type) { nil }
+
+      it "raises a Package error" do
+        allow(::File).to receive(:exist?).with(provider.new_resource.source).and_return(false)
+
+        provider.load_current_resource
+        expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+      end
+    end
   end
 
   shared_context "valid checksum" do

--- a/spec/unit/provider/package/windows_spec.rb
+++ b/spec/unit/provider/package/windows_spec.rb
@@ -398,12 +398,19 @@ describe Chef::Provider::Package::Windows, :windows_only do
     context "a missing local file is given" do
       let(:resource_source) { "C:/a_missing_file.exe" }
       let(:installer_type) { nil }
+      before do
+        allow(::File).to receive(:exist?).with(provider.new_resource.source).and_return(false)
+        provider.load_current_resource
+      end
 
       it "raises a Package error" do
-        allow(::File).to receive(:exist?).with(provider.new_resource.source).and_return(false)
-
-        provider.load_current_resource
         expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
+      end
+
+      it "why_run mode doesn't raise an error" do
+        Chef::Config[:why_run] = true
+        expect { provider.run_action(:install) }.not_to raise_error
+        Chef::Config[:why_run] = false
       end
     end
   end


### PR DESCRIPTION
### Description

Raises an error if a local file does not exist when attempting to install a windows_package

Cherry-picked from #7299 

### Issues Resolved

Fixes #7290 

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
