### PR TITLE
Support windows_feature_powershell on Windows 2008 R2

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -20,6 +20,12 @@ class Chef
   class Platform
 
     class << self
+      # a simple helper to determine if we're on a windows release pre-2012 / 8
+      # @return [Boolean] Is the system older than Windows 8 / 2012
+      def older_than_win_2012_or_8?
+        node["platform_version"].to_f < 6.2
+      end
+
       def windows?
         ChefConfig.windows?
       end

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -30,7 +30,7 @@ class Chef
 
       property :feature_name, [Array, String],
                description: "The name of the feature/role(s) to install if it differs from the resource name.",
-               coerce: proc { |x| to_lowercase_array(x) },
+               coerce: proc { |x| to_formatted_array(x) },
                name_property: true
 
       property :source, String,
@@ -44,12 +44,18 @@ class Chef
                description: "Specifies a timeout (in seconds) for feature install.",
                default: 600
 
-      def to_lowercase_array(x)
+      # @return [Array] lowercase the array unless we're on < Windows 2012
+      def to_formatted_array(x)
         x = x.split(/\s*,\s*/) if x.is_a?(String) # split multiple forms of a comma separated list
 
-        # dism on windows < 2012 is case sensitive so only downcase when on 2012+
-        # @todo when we're really ready to remove support for Windows 2008 R2 this check can go away
-        node["platform_version"].to_f < 6.2 ? x : x.map(&:downcase)
+        # feature installs on windows < 2012 are case sensitive so only downcase when on 2012+
+        older_than_2012_or_8? ? x : x.map(&:downcase)
+      end
+
+      # a simple helper to determine if we're on a windows release pre-2012 / 8
+      # @return [Boolean] Is the system older than Windows 8 / 2012
+      def older_than_2012_or_8?
+        node["platform_version"].to_f < 6.2
       end
 
       action :install do
@@ -200,7 +206,7 @@ class Chef
           # dism on windows 2012+ isn't case sensitive so it's best to compare
           # lowercase lists so the user input doesn't need to be case sensitive
           # @todo when we're ready to remove windows 2008R2 the gating here can go away
-          feature_details.downcase! unless node["platform_version"].to_f < 6.2
+          feature_details.downcase! unless older_than_2012_or_8?
           node.override["dism_features_cache"][feature_type] << feature_details
         end
 
@@ -208,7 +214,7 @@ class Chef
         # @return [void]
         def fail_if_removed
           return if new_resource.source # if someone provides a source then all is well
-          if node["platform_version"].to_f > 6.2
+          if node["platform_version"].to_f > 6.2 # 2012R2 or later
             return if registry_key_exists?('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Servicing') && registry_value_exists?('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Servicing', name: "LocalSourcePath") # if source is defined in the registry, still fine
           end
           removed = new_resource.feature_name & node["dism_features_cache"]["removed"]

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -201,7 +201,7 @@ class Chef
           # dism on windows 2012+ isn't case sensitive so it's best to compare
           # lowercase lists so the user input doesn't need to be case sensitive
           # @todo when we're ready to remove windows 2008R2 the gating here can go away
-          feature_details.downcase! unless Chef::Platform.older_than_win_2012_or_8
+          feature_details.downcase! unless Chef::Platform.older_than_win_2012_or_8?
           node.override["dism_features_cache"][feature_type] << feature_details
         end
 
@@ -219,7 +219,7 @@ class Chef
         # Fail unless we're on windows 8+ / 2012+ where deleting a feature is supported
         # @return [void]
         def raise_if_delete_unsupported
-          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not support on Windows releases before Windows 8/2012. Cannot continue!" unless node["platform_version"].to_f >= 6.2
+          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not supported on Windows releases before Windows 8/2012. Cannot continue!" if Chef::Platform.older_than_win_2012_or_8?
         end
       end
     end

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource"
+require "chef/platform/query_helpers"
 
 class Chef
   class Resource
@@ -49,13 +50,7 @@ class Chef
         x = x.split(/\s*,\s*/) if x.is_a?(String) # split multiple forms of a comma separated list
 
         # feature installs on windows < 2012 are case sensitive so only downcase when on 2012+
-        older_than_2012_or_8? ? x : x.map(&:downcase)
-      end
-
-      # a simple helper to determine if we're on a windows release pre-2012 / 8
-      # @return [Boolean] Is the system older than Windows 8 / 2012
-      def older_than_2012_or_8?
-        node["platform_version"].to_f < 6.2
+        Chef::Platform.older_than_win_2012_or_8? ? x : x.map(&:downcase)
       end
 
       action :install do
@@ -206,7 +201,7 @@ class Chef
           # dism on windows 2012+ isn't case sensitive so it's best to compare
           # lowercase lists so the user input doesn't need to be case sensitive
           # @todo when we're ready to remove windows 2008R2 the gating here can go away
-          feature_details.downcase! unless older_than_2012_or_8?
+          feature_details.downcase! unless Chef::Platform.older_than_win_2012_or_8
           node.override["dism_features_cache"][feature_type] << feature_details
         end
 

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -259,7 +259,7 @@ class Chef
 
         # Fail unless we're on windows 8+ / 2012+ where deleting a feature is supported
         def raise_if_delete_unsupported
-          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not support on Windows releases before Windows 8/2012. Cannot continue!" if Chef::Platform.older_than_win_2012_or_8
+          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not supported on Windows releases before Windows 8/2012. Cannot continue!" if Chef::Platform.older_than_win_2012_or_8?
         end
       end
     end

--- a/spec/unit/resource/windows_feature_dism.rb
+++ b/spec/unit/resource/windows_feature_dism.rb
@@ -32,7 +32,7 @@ describe Chef::Resource::WindowsFeatureDism do
   end
 
   it "the feature_name property is the name_property" do
-    node.automatic[:platform_version] = "6.2"
+    node.automatic[:platform_version] = "6.2.9200"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
@@ -47,25 +47,25 @@ describe Chef::Resource::WindowsFeatureDism do
   end
 
   it "coerces comma separated lists of features to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2"
+    node.automatic[:platform_version] = "6.2.9200"
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
   it "coerces a single feature as a String to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2"
+    node.automatic[:platform_version] = "6.2.9200"
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["snmp"])
   end
 
   it "coerces comma separated lists of features to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1"
+    node.automatic[:platform_version] = "6.1.7601"
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{SNMP DHCP})
   end
 
   it "coerces a single feature as a String to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1"
+    node.automatic[:platform_version] = "6.1.7601"
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["SNMP"])
   end

--- a/spec/unit/resource/windows_feature_powershell.rb
+++ b/spec/unit/resource/windows_feature_powershell.rb
@@ -18,10 +18,22 @@
 require "spec_helper"
 
 describe Chef::Resource::WindowsFeaturePowershell do
-  let(:resource) { Chef::Resource::WindowsFeaturePowershell.new(%w{SNMP DHCP}) }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::WindowsFeaturePowershell.new(%w{SNMP DHCP}, run_context) }
 
   it "sets resource name as :windows_feature_powershell" do
     expect(resource.resource_name).to eql(:windows_feature_powershell)
+  end
+
+  it "sets the default action as :install" do
+    expect(resource.action).to eql([:install])
+  end
+
+  it "the feature_name property is the name_property" do
+    node.automatic[:platform_version] = "6.2.9200"
+    expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
   it "sets the default action as :install" do
@@ -34,18 +46,27 @@ describe Chef::Resource::WindowsFeaturePowershell do
     expect { resource.action :remove }.not_to raise_error
   end
 
-  it "sets the feature_name property as its name_property" do
-    expect(resource.feature_name).to eql(%w{SNMP DHCP})
+  it "coerces comma separated lists of features to a lowercase array on 2012+" do
+    node.automatic[:platform_version] = "6.2.9200"
+    resource.feature_name "SNMP, DHCP"
+    expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces comma separated lists of features to arrays" do
+  it "coerces a single feature as a String to a lowercase array on 2012+" do
+    node.automatic[:platform_version] = "6.2.9200"
+    resource.feature_name "SNMP"
+    expect(resource.feature_name).to eql(["snmp"])
+  end
+
+  it "coerces comma separated lists of features to an array, but preserves case on < 2012" do
+    node.automatic[:platform_version] = "6.1.7601"
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{SNMP DHCP})
   end
 
-  it "coerces a single feature as a String into an array" do
+  it "coerces a single feature as a String to an array, but preserves case on < 2012" do
+    node.automatic[:platform_version] = "6.1.7601"
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["SNMP"])
   end
-
 end


### PR DESCRIPTION
So this one was a few layers deep:

1) We didn't actually need to import the ServerManager module. This was a powershell 2.0 thing, but since we use ConvertTo-Json  we require Powershell 3.0 where this module is autoloaded.
2) Features are only case insensitive on Windows 8 / 2012+. That means we can't lowercase the features on these platforms. We still want to lowercase the features everywhere else because case shouldn't matter and that would be a breaking change.
3) Windows 2008 R2 doesn't have a concept of a removed feature (where the source is gone) so they don't return data the same way when you request features. They just return: Installed: true/false. This means we need to coerce the returned data from 2008 R2 to look like a later Windows release.

Signed-off-by: Tim Smith <tsmith@chef.io>