### PR TITLE
Deprecated the Chef::Provider::Package::Freebsd::Pkg provider

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -278,6 +278,16 @@ class Chef
       end
     end
 
+    class FreebsdPkgProvider < Base
+      def id
+        23
+      end
+
+      def target
+        "freebsd_pkg_provider.html"
+      end
+    end
+
     # id 3694 was deleted
 
     # Returned when using the deprecated option on a property

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -63,6 +63,8 @@ class Chef
                     elsif supports_pkgng?
                       Chef::Provider::Package::Freebsd::Pkgng
                     else
+                      Chef.deprecated(:freebsd_package_provider, "The freebsd_package provider for pkg (Chef::Provider::Package::Freebsd::Pkg) is deprecated and will be removed from Chef core in 15.0 (April 2019).")
+
                       Chef::Provider::Package::Freebsd::Pkg
                     end
       end

--- a/spec/unit/resource/freebsd_package_spec.rb
+++ b/spec/unit/resource/freebsd_package_spec.rb
@@ -93,6 +93,7 @@ describe Chef::Resource::FreebsdPackage do
 
         [1000016, 1000000, 901503, 902506, 802511].each do |freebsd_version|
           node.automatic_attrs[:os_version] = freebsd_version
+          expect(Chef).to receive(:deprecated).with(:freebsd_package_provider, kind_of(String))
           resource.after_created
           expect(resource.provider).to eq(Chef::Provider::Package::Freebsd::Pkg)
         end


### PR DESCRIPTION
FreeBSD 10 and later have pkgng and Chef will use that instead. This Oct even FreeBSD 10 goes fully EOL so we'll be supporting multiple EOL versions back come April. We should speed up this resource and simplify things by removing the unnecessary provider and the logic that decides which one to use.

Signed-off-by: Tim Smith <tsmith@chef.io>