### PR TITLE
Updating git resource to fail when checking out to non-empty directory

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -141,6 +141,7 @@ class Chef
     class IllegalChecksumRevert < RuntimeError; end
     class CookbookVersionNameMismatch < ArgumentError; end
     class MissingParentDirectory < RuntimeError; end
+    class DestinationAlreadyExists < RuntimeError; end
     class UnresolvableGitReference < RuntimeError; end
     class InvalidRemoteGitReference < RuntimeError; end
     class InvalidEnvironmentRunListSpecification < ArgumentError; end


### PR DESCRIPTION
### Description

The current behavior of the git resource is that it will silently fail to checkout if the destination directory is not empty. This change modifies the behavior in that situation to raise an explicit error.

### Issues Resolved

#7347 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
