### PR TITLE
package: Make sure to use the package_name name properties

### DIFF
--- a/lib/chef/provider/package/bff.rb
+++ b/lib/chef/provider/package/bff.rb
@@ -34,11 +34,11 @@ class Chef
           super
           requirements.assert(:install) do |a|
             a.assertion { new_resource.source }
-            a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.name} required for action install"
+            a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.package_name} required for action install"
           end
           requirements.assert(:all_actions) do |a|
             a.assertion { !new_resource.source || package_source_found? }
-            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.name} not found: #{new_resource.source}"
+            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.package_name} not found: #{new_resource.source}"
             a.whyrun "would assume #{new_resource.source} would be have previously been made available"
           end
         end

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -58,7 +58,7 @@ class Chef
         def load_current_resource
           @current_resource = Chef::Resource::IpsPackage.new(new_resource.name)
           current_resource.package_name(new_resource.package_name)
-          logger.trace("Checking package status for #{new_resource.name}")
+          logger.trace("Checking package status for #{new_resource.package_name}")
           current_resource.version(get_current_version)
           @candidate_version = get_candidate_version
           current_resource

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -16,7 +16,7 @@ class Chef
           @candidate_version = macports_candidate_version
 
           if !new_resource.version && !@candidate_version
-            raise Chef::Exceptions::Package, "Could not get a candidate version for this package -- #{new_resource.name} does not seem to be a valid package!"
+            raise Chef::Exceptions::Package, "Could not get a candidate version for this package -- #{new_resource.package_name} does not seem to be a valid package!"
           end
 
           logger.trace("#{new_resource} candidate version is #{@candidate_version}") if @candidate_version

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -116,7 +116,7 @@ class Chef
             when 1
               results[0]
             else
-              raise Chef::Exceptions::Package, "#{new_resource.name} has multiple matching candidates. Please use a more specific name" if results.length > 1
+              raise Chef::Exceptions::Package, "#{new_resource.package_name} has multiple matching candidates. Please use a more specific name" if results.length > 1
             end
           end
         end

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -33,13 +33,13 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             a.assertion { @package_source_exists }
-            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.name} not found: #{new_resource.source}"
-            a.whyrun "Assuming package #{new_resource.name} would have been made available."
+            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.package_name} not found: #{new_resource.source}"
+            a.whyrun "Assuming package #{new_resource.package_name} would have been made available."
           end
           requirements.assert(:all_actions) do |a|
             a.assertion { !@rpm_status.nil? && (@rpm_status.exitstatus == 0 || @rpm_status.exitstatus == 1) }
             a.failure_message Chef::Exceptions::Package, "Unable to determine current version due to RPM failure. Detail: #{@rpm_status.inspect}"
-            a.whyrun "Assuming current version would have been determined for package#{new_resource.name}."
+            a.whyrun "Assuming current version would have been determined for package #{new_resource.package_name}."
           end
         end
 

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -38,11 +38,11 @@ class Chef
           super
           requirements.assert(:install) do |a|
             a.assertion { new_resource.source }
-            a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.name} required for action install"
+            a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.package_name} required for action install"
           end
           requirements.assert(:all_actions) do |a|
             a.assertion { !new_resource.source || @package_source_found }
-            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.name} not found: #{new_resource.source}"
+            a.failure_message Chef::Exceptions::Package, "Package #{new_resource.package_name} not found: #{new_resource.source}"
             a.whyrun "would assume #{new_resource.source} would be have previously been made available"
           end
         end

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -37,13 +37,13 @@ class Chef
         def define_resource_requirements
           requirements.assert(:install) do |a|
             a.assertion { new_resource.source || msi? }
-            a.failure_message Chef::Exceptions::NoWindowsPackageSource, "Source for package #{new_resource.name} must be specified in the resource's source property for package to be installed because the package_name property is used to test for the package installation state for this package type."
+            a.failure_message Chef::Exceptions::NoWindowsPackageSource, "Source for package #{new_resource.package_name} must be specified in the resource's source property for package to be installed because the package_name property is used to test for the package installation state for this package type."
           end
 
           unless uri_scheme?(new_resource.source)
             requirements.assert(:install) do |a|
               a.assertion { ::File.exist?(new_resource.source) }
-              a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.name} does not exist"
+              a.failure_message Chef::Exceptions::Package, "Source for package #{new_resource.package_name} does not exist"
               a.whyrun "Assuming source file #{new_resource.source} would have been created."
             end
           end
@@ -121,7 +121,7 @@ class Chef
                 if basename == "setup.exe"
                   :installshield
                 else
-                  raise Chef::Exceptions::CannotDetermineWindowsInstallerType, "Installer type for Windows Package '#{new_resource.name}' not specified and cannot be determined from file extension '#{file_extension}'"
+                  raise Chef::Exceptions::CannotDetermineWindowsInstallerType, "Installer type for Windows Package '#{new_resource.package_name}' not specified and cannot be determined from file extension '#{file_extension}'"
                 end
               end
             end


### PR DESCRIPTION
We have a package_name name_property in package resources, but we weren't using it everywhere which makes for some super confusing errors / why-run messages

Signed-off-by: Tim Smith <tsmith@chef.io>