### PR TITLE
windows_feature_dism: Fix errors when specifying the source

### DIFF
--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -117,7 +117,7 @@ class Chef
         def features_to_install
           @install ||= begin
             # disabled features are always available to install
-            available_for_install = node["dism_features_cache"]["disabled"]
+            available_for_install = node["dism_features_cache"]["disabled"].dup
 
             # if the user passes a source then removed features are also available for installation
             available_for_install.concat(node["dism_features_cache"]["removed"]) if new_resource.source


### PR DESCRIPTION
Make sure we dupe the immutable array of the node attribute so we can
concat the additional array values into it later on.

Signed-off-by: Tim Smith <tsmith@chef.io>