### PR TITLE
Pull in win32-taskscheduler 1.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ PATH
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
       win32-service (~> 0.8.7)
-      win32-taskscheduler (~> 0.4.0)
+      win32-taskscheduler (~> 1.0.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
 
@@ -339,7 +339,7 @@ GEM
     win32-service (0.8.10)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (0.4.1)
+    win32-taskscheduler (1.0.2)
       ffi
       structured_warnings
     windows-api (0.4.4)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -14,7 +14,7 @@ gemspec.add_dependency "win32-process", "~> 0.8.2"
 gemspec.add_dependency "win32-service", "~> 0.8.7"
 gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
-gemspec.add_dependency "win32-taskscheduler", "~> 0.4.0"
+gemspec.add_dependency "win32-taskscheduler", "~> 1.0.0"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += %w{ext/win32-eventlog/Rakefile ext/win32-eventlog/chef-log.man}
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.66)
-      aws-sdk-resources (= 2.11.66)
-    aws-sdk-core (2.11.66)
+    aws-sdk (2.11.67)
+      aws-sdk-resources (= 2.11.67)
+    aws-sdk-core (2.11.67)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.66)
-      aws-sdk-core (= 2.11.66)
+    aws-sdk-resources (2.11.67)
+      aws-sdk-core (= 2.11.67)
     aws-sigv4 (1.0.2)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -127,7 +127,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.6)
+    mixlib-config (2.2.8)
       tomlrb
     mixlib-install (3.10.0)
       mixlib-shellout
@@ -226,7 +226,7 @@ GEM
       hitimes
     toml-rb (1.1.1)
       citrus (~> 3.0, > 3.0)
-    tomlrb (1.2.6)
+    tomlrb (1.2.7)
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)


### PR DESCRIPTION
- Fixes tasks gets created when wrong username and password is provided and then it throws error for invalid username password.
- Fixes windows_task not idempotent when task_name includes parent folder

Signed-off-by: Tim Smith <tsmith@chef.io>