### PR TITLE
Unification of shell_out APIs

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -125,6 +125,9 @@ class Chef
       # module method to not pollute namespaces, but that means we need self injected as an arg
       # @api private
       def self.maybe_add_timeout(obj, options)
+        # note that we can't define an empty Chef::Resource::LWRPBase because that breaks descendants tracker, so we'd have to instead require the file here, which would pull in half
+        # of chef, so instead convert to using strings.  once descendants tracker is gone, we can just declare the empty classes instead and use `is_a?` against the symbols.
+        # (be nice if ruby supported strings in `is_a?` for looser coupling).
         if obj.class.ancestors.map(&:to_s).include?("Chef::Provider") && !obj.class.ancestors.map(&:to_s).include?("Chef::Resource::LWRPBase") && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
           options = options.dup
           # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -48,33 +48,33 @@ class Chef
 
       def shell_out_compact(*args, **options) # FIXME: deprecate
         if options.empty?
-          shell_out_compact(*args)
+          shell_out(*args)
         else
-          shell_out_compact(*args, **options)
+          shell_out(*args, **options)
         end
       end
 
       def shell_out_compact!(*args, **options) # FIXME: deprecate
         if options.empty?
-          shell_out_compact!(*args)
+          shell_out!(*args)
         else
-          shell_out_compact!(*args, **options)
+          shell_out!(*args, **options)
         end
       end
 
       def shell_out_compact_timeout(*args, **options) # FIXME: deprecate
         if options.empty?
-          shell_out_compact(*args)
+          shell_out(*args)
         else
-          shell_out_compact(*args, **options)
+          shell_out(*args, **options)
         end
       end
 
       def shell_out_compact_timeout!(*args, **options) # FIXME: deprecate
         if options.empty?
-          shell_out_compact!(*args)
+          shell_out!(*args)
         else
-          shell_out_compact!(*args, **options)
+          shell_out!(*args, **options)
         end
       end
 

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -21,61 +21,102 @@ require "chef/mixin/path_sanity"
 class Chef
   module Mixin
     module ShellOut
-      include Chef::Mixin::PathSanity
+      extend Chef::Mixin::PathSanity
 
       # PREFERRED APIS:
       #
-      # shell_out_compact and shell_out_compact! flatten their array arguments and remove nils and pass
-      # the resultant array to shell_out.  this actually eliminates spaces-in-args bugs because this:
+      # all consumers should now call shell_out!/shell_out.
       #
-      # shell_out!("command #{arg}")
+      # on unix the shell_out API supports the clean_array() kind of syntax (below) so that
+      # array args are flat/compact/to_s'd.  on windows, array args aren't supported to its
+      # up to the caller to join(" ") on arrays of strings.
       #
-      # becomes two arguments if arg has spaces and requires quotations:
+      # the shell_out_compacted/shell_out_compacted! APIs are private but are intended for use
+      # in rspec tests, and should ideally always be used to make code refactorings that do not
+      # change behavior easier:
       #
-      # shell_out!("command '#{arg}'")
+      # allow(provider).to receive(:shell_out_compacted!).with("foo", "bar", "baz")
+      # provider.shell_out!("foo", [ "bar", nil, "baz"])
+      # provider.shell_out!(["foo", nil, "bar" ], ["baz"])
       #
-      # using shell_out_compact! this becomes:
-      #
-      # shell_out_compact!("command", arg)
-      #
-      # and spaces in the arg just works and it does not become two arguments (and the shell quoting around
-      # the argument must actually be removed).
-      #
-      # there's also an implicit join between all the array elements, and nested arrays are flattened which
-      # means that odd where-do-i-put-the-spaces options handling just works, and instead of this:
-      #
-      #    opts = ""                     # needs to be empty string for when foo and bar are both missing
-      #    opts << " -foo" if needs_foo? # needs the leading space on both of these
-      #    opts << " -bar" if needs_bar?
-      #    shell_out!("cmd#{opts}")      # have to think way too hard about why there's no space here
-      #
-      # becomes:
-      #
-      #    opts = []
-      #    opts << "-foo" if needs_foo?
-      #    opts << "-bar" if needs_bar?
-      #    shell_out_compact!("cmd", opts)
-      #
-      # and opts can be an empty array or nil and it'll work out fine.
-      #
-      # generally its best to use shell_out_compact! in code and setup expectations on shell_out! in tests
+      # note that shell_out_compacted also includes adding the magical timeout option to force
+      # people to setup expectations on that value explicitly.  it does not include the default_env
+      # mangling in order to avoid users having to setup an expectation on anything other than
+      # setting `default_env: false` and allow us to make tweak to the default_env without breaking
+      # a thousand unit tests.
       #
 
-      def shell_out_compact(*args, **options)
-        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
+      def shell_out_compact(*args, **options) # FIXME: deprecate
         if options.empty?
-          shell_out(*clean_array(*args))
+          shell_out_compact(*args)
         else
-          shell_out(*clean_array(*args), **options)
+          shell_out_compact(*args, **options)
         end
       end
 
-      def shell_out_compact!(*args, **options)
+      def shell_out_compact!(*args, **options) # FIXME: deprecate
+        if options.empty?
+          shell_out_compact!(*args)
+        else
+          shell_out_compact!(*args, **options)
+        end
+      end
+
+      def shell_out_compact_timeout(*args, **options) # FIXME: deprecate
+        if options.empty?
+          shell_out_compact(*args)
+        else
+          shell_out_compact(*args, **options)
+        end
+      end
+
+      def shell_out_compact_timeout!(*args, **options) # FIXME: deprecate
+        if options.empty?
+          shell_out_compact!(*args)
+        else
+          shell_out_compact!(*args, **options)
+        end
+      end
+
+      def shell_out_with_systems_locale(*args, **options) # FIXME: deprecate
+        if options.empty?
+          shell_out(*args, default_env: false)
+        else
+          shell_out(*args, default_env: false, **options)
+        end
+      end
+
+      def shell_out_with_systems_locale!(*args, **options) # FIXME: deprecate
+        if options.empty?
+          shell_out!(*args, default_env: false)
+        else
+          shell_out!(*args, default_env: false, **options)
+        end
+      end
+
+      def a_to_s(*args) # FIXME: deprecate
+        # can't quite deprecate this yet
+        #Chef.deprecated(:package_misc, "a_to_s is deprecated use shell_out_compact or shell_out_compact_timeout instead")
+        args.flatten.reject { |i| i.nil? || i == "" }.map(&:to_s).join(" ")
+      end
+
+      def shell_out(*args, **options)
+        options = options.dup
         options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
         if options.empty?
-          shell_out!(*clean_array(*args))
+          shell_out_compacted(*Chef::Mixin::ShellOut.clean_array(*args))
         else
-          shell_out!(*clean_array(*args), **options)
+          shell_out_compacted(*Chef::Mixin::ShellOut.clean_array(*args), **options)
+        end
+      end
+
+      def shell_out!(*args, **options)
+        options = options.dup
+        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
+        if options.empty?
+          shell_out_compacted!(*Chef::Mixin::ShellOut.clean_array(*args))
+        else
+          shell_out_compacted!(*Chef::Mixin::ShellOut.clean_array(*args), **options)
         end
       end
 
@@ -84,7 +125,7 @@ class Chef
       # module method to not pollute namespaces, but that means we need self injected as an arg
       # @api private
       def self.maybe_add_timeout(obj, options)
-        if obj.is_a?(Chef::Provider) && !obj.new_resource.is_a?(Chef::Resource::LWRPBase) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
+        if obj.class.ancestors.map(&:to_s).include?("Chef::Provider") && !obj.class.ancestors.map(&:to_s).include?("Chef::Resource::LWRPBase") && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
           options = options.dup
           # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
           options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : 900
@@ -92,22 +133,10 @@ class Chef
         options
       end
 
-      def shell_out_compact_timeout(*args, **options)
-        shell_out_compact(*args, **options)
-      end
-
-      def shell_out_compact_timeout!(*args, **options)
-        shell_out_compact!(*args, **options)
-      end
-
-      # shell_out! runs a command on the system and will raise an error if the command fails, which is what you want
-      # for debugging, shell_out and shell_out! both will display command output to the tty when the log level is debug
-      # Generally speaking, 'extend Chef::Mixin::ShellOut' in your recipes and include 'Chef::Mixin::ShellOut' in your LWRPs
-      # You can also call Mixlib::Shellout.new directly, but you lose all of the above functionality
-
-      # we use 'en_US.UTF-8' by default because we parse localized strings in English as an API and
-      # generally must support UTF-8 unicode.
-      def shell_out(*args, **options)
+      # helper function to mangle options when `default_env` is true
+      #
+      # @api private
+      def self.apply_default_env(options)
         options = options.dup
         default_env = options.delete(:default_env)
         default_env = true if default_env.nil?
@@ -120,34 +149,37 @@ class Chef
             env_path => sanitized_path,
           }.update(options[env_key] || {})
         end
-        shell_out_command(*args, **options)
+        options
       end
 
-      # call shell_out (using en_US.UTF-8) and raise errors
-      def shell_out!(*command_args)
-        cmd = shell_out(*command_args)
+      private
+
+      # this SHOULD be used for setting up expectations in rspec, see banner comment at top.
+      #
+      # the private constraint is meant to avoid code calling this directly, rspec expectations are fine.
+      #
+      def shell_out_compacted(*args, **options)
+        options = Chef::Mixin::ShellOut.apply_default_env(options)
+        if options.empty?
+          Chef::Mixin::ShellOut.shell_out_command(*args)
+        else
+          Chef::Mixin::ShellOut.shell_out_command(*args, **options)
+        end
+      end
+
+      # this SHOULD be used for setting up expectations in rspec, see banner comment at top.
+      #
+      # the private constraint is meant to avoid code calling this directly, rspec expectations are fine.
+      #
+      def shell_out_compacted!(*args, **options)
+        options = Chef::Mixin::ShellOut.apply_default_env(options)
+        cmd = if options.empty?
+                Chef::Mixin::ShellOut.shell_out_command(*args)
+              else
+                Chef::Mixin::ShellOut.shell_out_command(*args, **options)
+              end
         cmd.error!
         cmd
-      end
-
-      def shell_out_with_systems_locale(*args, **options) # FIXME: deprecate
-        shell_out(*args, default_env: false, **options)
-      end
-
-      def shell_out_with_systems_locale!(*args, **options) # FIXME: deprecate
-        shell_out!(*args, default_env: false, **options)
-      end
-
-      # Helper for subclasses to convert an array of string args into a string.  It
-      # will compact nil or empty strings in the array and will join the array elements
-      # with spaces, without introducing any double spaces for nil/empty elements.
-      #
-      # @param args [String] variable number of string arguments
-      # @return [String] nicely concatenated string or empty string
-      def a_to_s(*args)
-        # can't quite deprecate this yet
-        #Chef.deprecated(:package_misc, "a_to_s is deprecated use shell_out_compact or shell_out_compact_timeout instead")
-        args.flatten.reject { |i| i.nil? || i == "" }.map(&:to_s).join(" ")
       end
 
       # Helper for subclasses to reject nil out of an array.  It allows
@@ -166,20 +198,23 @@ class Chef
       #
       # @param args [String] variable number of string arguments
       # @return [Array] array of strings with nil and null string rejection
-      def clean_array(*args)
+
+      def self.clean_array(*args)
         args.flatten.compact.map(&:to_s)
       end
 
-      private
-
-      def shell_out_command(*command_args)
-        cmd = Mixlib::ShellOut.new(*command_args)
+      def self.shell_out_command(*args, **options)
+        cmd = if options.empty?
+                Mixlib::ShellOut.new(*args)
+              else
+                Mixlib::ShellOut.new(*args, **options)
+              end
         cmd.live_stream ||= io_for_live_stream
         cmd.run_command
         cmd
       end
 
-      def io_for_live_stream
+      def self.io_for_live_stream
         if STDOUT.tty? && !Chef::Config[:daemon] && Chef::Log.debug?
           STDOUT
         else
@@ -187,7 +222,7 @@ class Chef
         end
       end
 
-      def env_path
+      def self.env_path
         if Chef::Platform.windows?
           "Path"
         else

--- a/lib/chef/provider/group/aix.rb
+++ b/lib/chef/provider/group/aix.rb
@@ -32,33 +32,33 @@ class Chef
         end
 
         def create_group
-          shell_out_compact!("mkgroup", set_options, new_resource.group_name)
+          shell_out!("mkgroup", set_options, new_resource.group_name)
           modify_group_members
         end
 
         def manage_group
           options = set_options
           if options.size > 0
-            shell_out_compact!("chgroup", options, new_resource.group_name)
+            shell_out!("chgroup", options, new_resource.group_name)
           end
           modify_group_members
         end
 
         def remove_group
-          shell_out_compact!("rmgroup", new_resource.group_name)
+          shell_out!("rmgroup", new_resource.group_name)
         end
 
         def add_member(member)
-          shell_out_compact!("chgrpmem", "-m", "+", member, new_resource.group_name)
+          shell_out!("chgrpmem", "-m", "+", member, new_resource.group_name)
         end
 
         def set_members(members)
           return if members.empty?
-          shell_out_compact!("chgrpmem", "-m", "=", members.join(","), new_resource.group_name)
+          shell_out!("chgrpmem", "-m", "=", members.join(","), new_resource.group_name)
         end
 
         def remove_member(member)
-          shell_out_compact!("chgrpmem", "-m", "-", member, new_resource.group_name)
+          shell_out!("chgrpmem", "-m", "-", member, new_resource.group_name)
         end
 
         def set_options

--- a/lib/chef/provider/group/dscl.rb
+++ b/lib/chef/provider/group/dscl.rb
@@ -27,7 +27,7 @@ class Chef
           argdup = args.dup
           cmd = argdup.shift
           shellcmd = [ "dscl", ".", "-#{cmd}", argdup ]
-          status = shell_out_compact(shellcmd)
+          status = shell_out(shellcmd)
           stdout_result = ""
           stderr_result = ""
           status.stdout.each_line { |line| stdout_result << line }

--- a/lib/chef/provider/group/gpasswd.rb
+++ b/lib/chef/provider/group/gpasswd.rb
@@ -39,18 +39,18 @@ class Chef
 
         def set_members(members)
           if members.empty?
-            shell_out_compact!("gpasswd", "-M", "", new_resource.group_name)
+            shell_out!("gpasswd", "-M", "", new_resource.group_name)
           else
-            shell_out_compact!("gpasswd", "-M", members.join(","), new_resource.group_name)
+            shell_out!("gpasswd", "-M", members.join(","), new_resource.group_name)
           end
         end
 
         def add_member(member)
-          shell_out_compact!("gpasswd", "-a", member, new_resource.group_name)
+          shell_out!("gpasswd", "-a", member, new_resource.group_name)
         end
 
         def remove_member(member)
-          shell_out_compact!("gpasswd", "-d", member, new_resource.group_name)
+          shell_out!("gpasswd", "-d", member, new_resource.group_name)
         end
       end
     end

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -44,19 +44,19 @@ class Chef
 
         # Create the group
         def create_group
-          shell_out_compact!("groupadd", set_options, groupadd_options)
+          shell_out!("groupadd", set_options, groupadd_options)
           modify_group_members
         end
 
         # Manage the group when it already exists
         def manage_group
-          shell_out_compact!("groupmod", set_options)
+          shell_out!("groupmod", set_options)
           modify_group_members
         end
 
         # Remove the group
         def remove_group
-          shell_out_compact!("groupdel", new_resource.group_name)
+          shell_out!("groupdel", new_resource.group_name)
         end
 
         def modify_group_members

--- a/lib/chef/provider/group/groupmod.rb
+++ b/lib/chef/provider/group/groupmod.rb
@@ -32,7 +32,7 @@ class Chef
 
         # Create the group
         def create_group
-          shell_out_compact!("group", "add", set_options)
+          shell_out!("group", "add", set_options)
 
           add_group_members(new_resource.members)
         end
@@ -79,14 +79,14 @@ class Chef
 
         # Remove the group
         def remove_group
-          shell_out_compact!("group", "del", new_resource.group_name)
+          shell_out!("group", "del", new_resource.group_name)
         end
 
         # Adds a list of usernames to the group using `user mod`
         def add_group_members(members)
           logger.trace("#{new_resource} adding members #{members.join(', ')}") unless members.empty?
           members.each do |user|
-            shell_out_compact!("user", "mod", "-G", new_resource.group_name, user)
+            shell_out!("user", "mod", "-G", new_resource.group_name, user)
           end
         end
 
@@ -94,11 +94,11 @@ class Chef
         # "<name>_bak", create a new group with the same GID and
         # "<name>", then set correct members on that group
         def reset_group_membership
-          shell_out_compact!("group", "mod", "-n", "#{new_resource.group_name}_bak", new_resource.group_name)
+          shell_out!("group", "mod", "-n", "#{new_resource.group_name}_bak", new_resource.group_name)
 
-          shell_out_compact!("group", "add", set_options(overwrite_gid: true))
+          shell_out!("group", "add", set_options(overwrite_gid: true))
 
-          shell_out_compact!("group", "del", "#{new_resource.group_name}_bak")
+          shell_out!("group", "del", "#{new_resource.group_name}_bak")
         end
 
         # Little bit of magic as per Adam's useradd provider to pull and assign the command line flags

--- a/lib/chef/provider/group/pw.rb
+++ b/lib/chef/provider/group/pw.rb
@@ -48,24 +48,24 @@ class Chef
             command += [ "-M", new_resource.members.join(",") ]
           end
 
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         # Manage the group when it already exists
         def manage_group
           member_options = set_members_options
           if member_options.empty?
-            shell_out_compact!("pw", "groupmod", set_options)
+            shell_out!("pw", "groupmod", set_options)
           else
             member_options.each do |option|
-              shell_out_compact!("pw", "groupmod", set_options, option)
+              shell_out!("pw", "groupmod", set_options, option)
             end
           end
         end
 
         # Remove the group
         def remove_group
-          shell_out_compact!("pw", "groupdel", new_resource.group_name)
+          shell_out!("pw", "groupdel", new_resource.group_name)
         end
 
         # Little bit of magic as per Adam's useradd provider to pull and assign the command line flags

--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -66,7 +66,7 @@ class Chef
         end
 
         def add_member(member)
-          shell_out_compact!("groupmod", "-A", member, new_resource.group_name)
+          shell_out!("groupmod", "-A", member, new_resource.group_name)
         end
 
         def to_remove(members)
@@ -74,7 +74,7 @@ class Chef
         end
 
         def remove_member(member)
-          shell_out_compact!("groupmod", "-R", member, new_resource.group_name)
+          shell_out!("groupmod", "-R", member, new_resource.group_name)
         end
 
       end

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -66,7 +66,7 @@ class Chef
         end
 
         def add_member(member)
-          shell_out_compact!("usermod", append_flags, new_resource.group_name, member)
+          shell_out!("usermod", append_flags, new_resource.group_name, member)
         end
 
         def remove_member(member)

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -163,7 +163,7 @@ class Chef
           unless new_resource.device == loopback_device
             command = add_command
             converge_by("run #{command.join(' ')} to add #{new_resource}") do
-              shell_out_compact!(command)
+              shell_out!(command)
               logger.info("#{new_resource} added")
             end
           end
@@ -179,7 +179,7 @@ class Chef
         return if new_resource.device == loopback_device
         command = enable_command
         converge_by("run #{command.join(' ')} to enable #{new_resource}") do
-          shell_out_compact!(command)
+          shell_out!(command)
           logger.info("#{new_resource} enabled")
         end
       end
@@ -189,7 +189,7 @@ class Chef
         if current_resource.device
           command = delete_command
           converge_by("run #{command.join(' ')} to delete #{new_resource}") do
-            shell_out_compact!(command)
+            shell_out!(command)
             logger.info("#{new_resource} deleted")
           end
         else
@@ -204,7 +204,7 @@ class Chef
         if current_resource.device
           command = disable_command
           converge_by("run #{command.join(' ')} to disable #{new_resource}") do
-            shell_out_compact!(command)
+            shell_out!(command)
             logger.info("#{new_resource} disabled")
           end
         else

--- a/lib/chef/provider/ifconfig/aix.rb
+++ b/lib/chef/provider/ifconfig/aix.rb
@@ -31,7 +31,7 @@ class Chef
           found_interface = false
           interface = {}
 
-          @status = shell_out_compact("ifconfig", "-a")
+          @status = shell_out("ifconfig", "-a")
           @status.stdout.each_line do |line|
             if !found_interface
               if line =~ /^(\S+):\sflags=(\S+)/

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -307,7 +307,7 @@ class Chef
       # used by subclasses.  deprecated.  use #a_to_s instead.
       def expand_options(options)
         # its deprecated but still work to do to deprecate it fully
-        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out_compact instead")
+        #Chef.deprecated(:package_misc, "expand_options is deprecated, use shell_out instead")
         if options
           " #{options.is_a?(Array) ? Shellwords.join(options) : options}"
         else
@@ -668,17 +668,17 @@ class Chef
         end
       end
 
-      def shell_out_with_timeout(*command_args)
+      def shell_out_with_timeout(*command_args) # FIXME: deprecated
         shell_out(*add_timeout_option(command_args))
       end
 
-      def shell_out_with_timeout!(*command_args)
+      def shell_out_with_timeout!(*command_args) # FIXME: deprecated
         shell_out!(*add_timeout_option(command_args))
       end
 
       def add_timeout_option(command_args)
         # this is deprecated but its not quite done yet
-        #Chef.deprecated(:package_misc, "shell_out_with_timeout and add_timeout_option are deprecated methods, use shell_out_compact instead")
+        #Chef.deprecated(:package_misc, "shell_out_with_timeout and add_timeout_option are deprecated methods, use shell_out instead")
         args = command_args.dup
         if args.last.is_a?(Hash)
           options = args.pop.dup

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -81,7 +81,7 @@ class Chef
         def locked_packages
           @locked_packages ||=
             begin
-              locked = shell_out_compact!("apt-mark", "showhold")
+              locked = shell_out!("apt-mark", "showhold")
               locked.stdout.each_line.map do |line|
                 line.strip
               end
@@ -140,9 +140,9 @@ class Chef
         #
         # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
         def version_compare(v1, v2)
-          if !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
+          if !shell_out("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
             1
-          elsif !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
+          elsif !shell_out("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
             0
           else
             -1
@@ -153,7 +153,7 @@ class Chef
         # interactive prompts. Command is run with default localization rather
         # than forcing locale to "C", so command output may not be stable.
         def run_noninteractive(*args)
-          shell_out_compact!(*args, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+          shell_out!(*args, env: { "DEBIAN_FRONTEND" => "noninteractive" })
         end
 
         def default_release_options

--- a/lib/chef/provider/package/bff.rb
+++ b/lib/chef/provider/package/bff.rb
@@ -49,7 +49,7 @@ class Chef
 
           if package_source_found?
             logger.trace("#{new_resource} checking pkg status")
-            ret = shell_out_compact("installp", "-L", "-d", new_resource.source)
+            ret = shell_out("installp", "-L", "-d", new_resource.source)
             ret.stdout.each_line do |line|
               case line
               when /:#{new_resource.package_name}:/
@@ -65,7 +65,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          ret = shell_out_compact("lslpp", "-lcq", current_resource.package_name)
+          ret = shell_out("lslpp", "-lcq", current_resource.package_name)
           ret.stdout.each_line do |line|
             case line
             when /#{current_resource.package_name}/
@@ -85,7 +85,7 @@ class Chef
         def candidate_version
           return @candidate_version if @candidate_version
           if package_source_found?
-            ret = shell_out_compact("installp", "-L", "-d", new_resource.source)
+            ret = shell_out("installp", "-L", "-d", new_resource.source)
             ret.stdout.each_line do |line|
               case line
               when /\w:#{Regexp.escape(new_resource.package_name)}:(.*)/
@@ -112,10 +112,10 @@ class Chef
         def install_package(name, version)
           logger.trace("#{new_resource} package install options: #{options}")
           if options.nil?
-            shell_out_compact!("installp", "-aYF", "-d", new_resource.source, new_resource.package_name)
+            shell_out!("installp", "-aYF", "-d", new_resource.source, new_resource.package_name)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
-            shell_out_compact!("installp", "-aYF", options, "-d", new_resource.source, new_resource.package_name)
+            shell_out!("installp", "-aYF", options, "-d", new_resource.source, new_resource.package_name)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           end
         end
@@ -124,10 +124,10 @@ class Chef
 
         def remove_package(name, version)
           if options.nil?
-            shell_out_compact!("installp", "-u", name)
+            shell_out!("installp", "-u", name)
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           else
-            shell_out_compact!("installp", "-u", options, name)
+            shell_out!("installp", "-u", options, name)
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -171,7 +171,7 @@ EOS
         # @param args [String] variable number of string arguments
         # @return [Mixlib::ShellOut] object returned from shell_out!
         def choco_command(*args)
-          shell_out_with_timeout!(args_to_string(choco_exe, *args), returns: new_resource.returns)
+          shell_out!(args_to_string(choco_exe, *args), returns: new_resource.returns)
         end
 
         # Use the available_packages Hash helper to create an array suitable for

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -121,7 +121,7 @@ class Chef
         private
 
         def resolve_source_to_version_obj
-          shell_out_with_timeout!("rpm -qp --queryformat '%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n' #{new_resource.source}").stdout.each_line do |line|
+          shell_out!("rpm -qp --queryformat '%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n' #{new_resource.source}").stdout.each_line do |line|
             # this is another case of committing the sin of doing some lightweight mangling of RPM versions in ruby -- but the output of the rpm command
             # does not match what the dnf library accepts.
             case line
@@ -167,7 +167,7 @@ class Chef
         end
 
         def dnf(*args)
-          shell_out_compact!("dnf", *args)
+          shell_out!("dnf", *args)
         end
 
         def safe_version_array

--- a/lib/chef/provider/package/dpkg.rb
+++ b/lib/chef/provider/package/dpkg.rb
@@ -113,9 +113,9 @@ class Chef
         #
         # @return [Integer] 1 if v1 > v2. 0 if they're equal. -1 if v1 < v2
         def version_compare(v1, v2)
-          if !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
+          if !shell_out("dpkg", "--compare-versions", v1.to_s, "gt", v2.to_s).error?
             1
-          elsif !shell_out_compact("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
+          elsif !shell_out("dpkg", "--compare-versions", v1.to_s, "eq", v2.to_s).error?
             0
           else
             -1
@@ -124,7 +124,7 @@ class Chef
 
         def read_current_version_of_package(package_name)
           logger.trace("#{new_resource} checking install state of #{package_name}")
-          status = shell_out_compact!("dpkg", "-s", package_name, returns: [0, 1])
+          status = shell_out!("dpkg", "-s", package_name, returns: [0, 1])
           package_installed = false
           status.stdout.each_line do |line|
             case line
@@ -149,10 +149,10 @@ class Chef
           end
         end
 
-        # Runs command via shell_out_with_timeout with magic environment to disable
+        # Runs command via shell_out with magic environment to disable
         # interactive prompts.
         def run_noninteractive(*command)
-          shell_out_compact!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+          shell_out!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
         end
 
         # Returns true if all sources exist.  Returns false if any do not, or if no
@@ -192,7 +192,7 @@ class Chef
             begin
               pkginfos = resolved_source_array.map do |src|
                 logger.trace("#{new_resource} checking #{src} dpkg status")
-                status = shell_out_compact!("dpkg-deb", "-W", src)
+                status = shell_out!("dpkg-deb", "-W", src)
                 status.stdout
               end
               Hash[*package_name_array.zip(pkginfos).flatten]

--- a/lib/chef/provider/package/freebsd/base.rb
+++ b/lib/chef/provider/package/freebsd/base.rb
@@ -47,7 +47,7 @@ class Chef
 
             # Otherwise look up the path to the ports directory using 'whereis'
             else
-              whereis = shell_out_compact!("whereis", "-s", port, env: nil)
+              whereis = shell_out!("whereis", "-s", port, env: nil)
               unless path = whereis.stdout[/^#{Regexp.escape(port)}:\s+(.+)$/, 1]
                 raise Chef::Exceptions::Package, "Could not find port with the name #{port}"
               end
@@ -57,7 +57,7 @@ class Chef
 
           def makefile_variable_value(variable, dir = nil)
             options = dir ? { cwd: dir } : {}
-            make_v = shell_out_compact!("make", "-V", variable, options.merge!(env: nil, returns: [0, 1]))
+            make_v = shell_out!("make", "-V", variable, options.merge!(env: nil, returns: [0, 1]))
             make_v.exitstatus == 0 ? make_v.stdout.strip.split($OUTPUT_RECORD_SEPARATOR).first : nil # $\ is the line separator, i.e. newline.
           end
         end

--- a/lib/chef/provider/package/freebsd/pkg.rb
+++ b/lib/chef/provider/package/freebsd/pkg.rb
@@ -34,24 +34,24 @@ class Chef
               case new_resource.source
               when /^http/, /^ftp/
                 if new_resource.source =~ /\/$/
-                  shell_out_compact!("pkg_add", "-r", package_name, env: { "PACKAGESITE" => new_resource.source, "LC_ALL" => nil }).status
+                  shell_out!("pkg_add", "-r", package_name, env: { "PACKAGESITE" => new_resource.source, "LC_ALL" => nil }).status
                 else
-                  shell_out_compact!("pkg_add", "-r", package_name, env: { "PACKAGEROOT" => new_resource.source, "LC_ALL" => nil }).status
+                  shell_out!("pkg_add", "-r", package_name, env: { "PACKAGEROOT" => new_resource.source, "LC_ALL" => nil }).status
                 end
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
 
               when /^\//
-                shell_out_compact!("pkg_add", file_candidate_version_path, env: { "PKG_PATH" => new_resource.source, "LC_ALL" => nil }).status
+                shell_out!("pkg_add", file_candidate_version_path, env: { "PKG_PATH" => new_resource.source, "LC_ALL" => nil }).status
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
 
               else
-                shell_out_compact!("pkg_add", "-r", latest_link_name, env: nil).status
+                shell_out!("pkg_add", "-r", latest_link_name, env: nil).status
               end
             end
           end
 
           def remove_package(name, version)
-            shell_out_compact!("pkg_delete", "#{package_name}-#{version || current_resource.version}", env: nil).status
+            shell_out!("pkg_delete", "#{package_name}-#{version || current_resource.version}", env: nil).status
           end
 
           # The name of the package (without the version number) as understood by pkg_add and pkg_info.
@@ -72,7 +72,7 @@ class Chef
           end
 
           def current_installed_version
-            pkg_info = shell_out_compact!("pkg_info", "-E", "#{package_name}*", env: nil, returns: [0, 1])
+            pkg_info = shell_out!("pkg_info", "-E", "#{package_name}*", env: nil, returns: [0, 1])
             pkg_info.stdout[/^#{Regexp.escape(package_name)}-(.+)/, 1]
           end
 

--- a/lib/chef/provider/package/freebsd/pkgng.rb
+++ b/lib/chef/provider/package/freebsd/pkgng.rb
@@ -28,21 +28,21 @@ class Chef
             unless current_resource.version
               case new_resource.source
               when /^(http|ftp|\/)/
-                shell_out_compact!("pkg", "add", options, new_resource.source, env: { "LC_ALL" => nil }).status
+                shell_out!("pkg", "add", options, new_resource.source, env: { "LC_ALL" => nil }).status
                 logger.trace("#{new_resource} installed from: #{new_resource.source}")
               else
-                shell_out_compact!("pkg", "install", "-y", options, name, env: { "LC_ALL" => nil }).status
+                shell_out!("pkg", "install", "-y", options, name, env: { "LC_ALL" => nil }).status
               end
             end
           end
 
           def remove_package(name, version)
             options_dup = options && options.map { |str| str.sub(repo_regex, "") }.reject!(&:empty?)
-            shell_out_compact!("pkg", "delete", "-y", options_dup, "#{name}#{version ? '-' + version : ''}", env: nil).status
+            shell_out!("pkg", "delete", "-y", options_dup, "#{name}#{version ? '-' + version : ''}", env: nil).status
           end
 
           def current_installed_version
-            pkg_info = shell_out_compact!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
+            pkg_info = shell_out!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
             pkg_info.stdout[/^Version +: (.+)$/, 1]
           end
 
@@ -61,7 +61,7 @@ class Chef
               options = $1.split(" ")
             end
 
-            pkg_query = shell_out_compact!("pkg", "rquery", options, "%v", new_resource.package_name, env: nil)
+            pkg_query = shell_out!("pkg", "rquery", options, "%v", new_resource.package_name, env: nil)
             pkg_query.exitstatus == 0 ? pkg_query.stdout.strip.split(/\n/).last : nil
           end
 

--- a/lib/chef/provider/package/freebsd/port.rb
+++ b/lib/chef/provider/package/freebsd/port.rb
@@ -26,18 +26,18 @@ class Chef
           include PortsHelper
 
           def install_package(name, version)
-            shell_out_compact!("make", "-DBATCH", "install", "clean", timeout: 1800, env: nil, cwd: port_dir).status
+            shell_out!("make", "-DBATCH", "install", "clean", timeout: 1800, env: nil, cwd: port_dir).status
           end
 
           def remove_package(name, version)
-            shell_out_compact!("make", "deinstall", timeout: 300, env: nil, cwd: port_dir).status
+            shell_out!("make", "deinstall", timeout: 300, env: nil, cwd: port_dir).status
           end
 
           def current_installed_version
             pkg_info = if new_resource.supports_pkgng?
-                         shell_out_compact!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
+                         shell_out!("pkg", "info", new_resource.package_name, env: nil, returns: [0, 70])
                        else
-                         shell_out_compact!("pkg_info", "-E", "#{new_resource.package_name}*", env: nil, returns: [0, 1])
+                         shell_out!("pkg_info", "-E", "#{new_resource.package_name}*", env: nil, returns: [0, 1])
                        end
             pkg_info.stdout[/^#{Regexp.escape(new_resource.package_name)}-(.+)/, 1]
           end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -128,7 +128,7 @@ class Chef
 
           logger.trace "Executing '#{command.join(' ')}' as user '#{homebrew_user.name}'"
           # FIXME: this 1800 second default timeout should be deprecated
-          output = shell_out_compact!(*command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
+          output = shell_out!(*command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
           output.stdout.chomp
         end
 

--- a/lib/chef/provider/package/ips.rb
+++ b/lib/chef/provider/package/ips.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Jason J. W. Williams (<williamsjj@digitar.com>)
 # Author:: Stephen Nelson-Smith (<sns@chef.io>)
-# Copyright:: Copyright 2011-2017, Chef Software Inc.
+# Copyright:: Copyright 2011-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,14 +42,14 @@ class Chef
         end
 
         def get_current_version
-          shell_out_compact("pkg", "info", new_resource.package_name).stdout.each_line do |line|
+          shell_out("pkg", "info", new_resource.package_name).stdout.each_line do |line|
             return $1.split[0] if line =~ /^\s+Version: (.*)/
           end
           nil
         end
 
         def get_candidate_version
-          shell_out_compact!("pkg", "info", "-r", new_resource.package_name).stdout.each_line do |line|
+          shell_out!("pkg", "info", "-r", new_resource.package_name).stdout.each_line do |line|
             return $1.split[0] if line =~ /Version: (.*)/
           end
           nil
@@ -68,7 +68,7 @@ class Chef
           command = [ "pkg", options, "install", "-q" ]
           command << "--accept" if new_resource.accept_license
           command << "#{name}@#{version}"
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def upgrade_package(name, version)
@@ -77,7 +77,7 @@ class Chef
 
         def remove_package(name, version)
           package_name = "#{name}@#{version}"
-          shell_out_compact!( "pkg", options, "uninstall", "-q", package_name )
+          shell_out!( "pkg", options, "uninstall", "-q", package_name )
         end
       end
     end

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -49,21 +49,21 @@ class Chef
           unless current_resource.version == version
             command = [ "port", options, "install", name ]
             command << "@#{version}" if version && !version.empty?
-            shell_out_compact!(command)
+            shell_out!(command)
           end
         end
 
         def purge_package(name, version)
           command = [ "port", options, "uninstall", name ]
           command << "@#{version}" if version && !version.empty?
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def remove_package(name, version)
           command = [ "port", options, "deactivate", name ]
           command << "@#{version}" if version && !version.empty?
 
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def upgrade_package(name, version)
@@ -76,7 +76,7 @@ class Chef
             # that hasn't been installed.
             install_package(name, version)
           elsif current_version != version
-            shell_out_compact!( "port", options, "upgrade", name, "@#{version}" )
+            shell_out!( "port", options, "upgrade", name, "@#{version}" )
           end
         end
 
@@ -84,7 +84,7 @@ class Chef
 
         def get_response_from_command(command)
           output = nil
-          status = shell_out_compact(command)
+          status = shell_out(command)
           begin
             output = status.stdout
           rescue Exception

--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -125,7 +125,7 @@ class Chef
 
         def extract_msu_contents(msu_file, destination)
           with_os_architecture(nil) do
-            shell_out_with_timeout!("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* #{msu_file} #{destination}")
+            shell_out!("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* #{msu_file} #{destination}")
           end
         end
 

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -72,7 +72,7 @@ class Chef
             if parts = name.match(/^(.+?)--(.+)/) # use double-dash for stems with flavors, see man page for pkg_add
               name = parts[1]
             end
-            shell_out_compact!("pkg_add", "-r", package_string(name, version), env: { "PKG_PATH" => pkg_path }).status
+            shell_out!("pkg_add", "-r", package_string(name, version), env: { "PKG_PATH" => pkg_path }).status
             logger.trace("#{new_resource.package_name} installed")
           end
         end
@@ -81,7 +81,7 @@ class Chef
           if parts = name.match(/^(.+?)--(.+)/)
             name = parts[1]
           end
-          shell_out_compact!("pkg_delete", package_string(name, version), env: nil).status
+          shell_out!("pkg_delete", package_string(name, version), env: nil).status
         end
 
         private
@@ -92,7 +92,7 @@ class Chef
                  else
                    new_resource.package_name
                  end
-          pkg_info = shell_out_compact!("pkg_info", "-e", "#{name}->0", env: nil, returns: [0, 1])
+          pkg_info = shell_out!("pkg_info", "-e", "#{name}->0", env: nil, returns: [0, 1])
           result = pkg_info.stdout[/^inst:#{Regexp.escape(name)}-(.+?)\s/, 1]
           logger.trace("installed_version of '#{new_resource.package_name}' is '#{result}'")
           result
@@ -101,7 +101,7 @@ class Chef
         def candidate_version
           @candidate_version ||= begin
             results = []
-            shell_out_compact!("pkg_info", "-I", package_string(new_resource.package_name, new_resource.version), env: nil, returns: [0, 1]).stdout.each_line do |line|
+            shell_out!("pkg_info", "-I", package_string(new_resource.package_name, new_resource.version), env: nil, returns: [0, 1]).stdout.each_line do |line|
               results << if parts = new_resource.package_name.match(/^(.+?)--(.+)/)
                            line[/^#{Regexp.escape(parts[1])}-(.+?)\s/, 1]
                          else

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -32,7 +32,7 @@ class Chef
           current_resource.package_name(new_resource.package_name)
 
           logger.trace("#{new_resource} checking pacman for #{new_resource.package_name}")
-          status = shell_out_compact("pacman", "-Qi", new_resource.package_name)
+          status = shell_out("pacman", "-Qi", new_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /^Version(\s?)*: (.+)$/
@@ -60,7 +60,7 @@ class Chef
 
           package_repos = repos.map { |r| Regexp.escape(r) }.join("|")
 
-          status = shell_out_compact("pacman", "-Sl")
+          status = shell_out("pacman", "-Sl")
           status.stdout.each_line do |line|
             case line
             when /^(#{package_repos}) #{Regexp.escape(new_resource.package_name)} (.+)$/
@@ -82,7 +82,7 @@ class Chef
         end
 
         def install_package(name, version)
-          shell_out_compact!( "pacman", "--sync", "--noconfirm", "--noprogressbar", options, name)
+          shell_out!( "pacman", "--sync", "--noconfirm", "--noprogressbar", options, name)
         end
 
         def upgrade_package(name, version)
@@ -90,7 +90,7 @@ class Chef
         end
 
         def remove_package(name, version)
-          shell_out_compact!( "pacman", "--remove", "--noconfirm", "--noprogressbar", options, name )
+          shell_out!( "pacman", "--remove", "--noconfirm", "--noprogressbar", options, name )
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/paludis.rb
+++ b/lib/chef/provider/package/paludis.rb
@@ -35,7 +35,7 @@ class Chef
           installed = false
           re = Regexp.new("(.*)[[:blank:]](.*)[[:blank:]](.*)$")
 
-          shell_out_compact!("cave", "-L", "warning", "print-ids", "-M", "none", "-m", new_resource.package_name, "-f", "%c/%p %v %r\n").stdout.each_line do |line|
+          shell_out!("cave", "-L", "warning", "print-ids", "-M", "none", "-m", new_resource.package_name, "-f", "%c/%p %v %r\n").stdout.each_line do |line|
             res = re.match(line)
             next if res.nil?
             case res[3]
@@ -58,7 +58,7 @@ class Chef
                 else
                   new_resource.package_name.to_s
                 end
-          shell_out_compact!("cave", "-L", "warning", "resolve", "-x", options, pkg)
+          shell_out!("cave", "-L", "warning", "resolve", "-x", options, pkg)
         end
 
         def upgrade_package(name, version)
@@ -72,7 +72,7 @@ class Chef
                   new_resource.package_name.to_s
                 end
 
-          shell_out_compact!("cave", "-L", "warning", "uninstall", "-x", options, pkg)
+          shell_out!("cave", "-L", "warning", "uninstall", "-x", options, pkg)
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/portage.rb
+++ b/lib/chef/provider/package/portage.rb
@@ -66,7 +66,7 @@ class Chef
         def candidate_version
           return @candidate_version if @candidate_version
 
-          pkginfo = shell_out_compact("portageq", "best_visible", "/", new_resource.package_name)
+          pkginfo = shell_out("portageq", "best_visible", "/", new_resource.package_name)
 
           if pkginfo.exitstatus != 0
             pkginfo.stderr.each_line do |line|
@@ -106,7 +106,7 @@ class Chef
             pkg = "~#{name}-#{$1}"
           end
 
-          shell_out_compact!( "emerge", "-g", "--color", "n", "--nospinner", "--quiet", options, pkg )
+          shell_out!( "emerge", "-g", "--color", "n", "--nospinner", "--quiet", options, pkg )
         end
 
         def upgrade_package(name, version)
@@ -120,7 +120,7 @@ class Chef
                   new_resource.package_name.to_s
                 end
 
-          shell_out_compact!( "emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", options, pkg )
+          shell_out!( "emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", options, pkg )
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/rpm.rb
+++ b/lib/chef/provider/package/rpm.rb
@@ -57,7 +57,7 @@ class Chef
             end
 
             logger.trace("#{new_resource} checking rpm status")
-            shell_out_compact!("rpm", "-qp", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", new_resource.source).stdout.each_line do |line|
+            shell_out!("rpm", "-qp", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", new_resource.source).stdout.each_line do |line|
               case line
               when /^(\S+)\s(\S+)$/
                 current_resource.package_name($1)
@@ -73,7 +73,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          @rpm_status = shell_out_compact("rpm", "-q", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", current_resource.package_name)
+          @rpm_status = shell_out("rpm", "-q", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", current_resource.package_name)
           @rpm_status.stdout.each_line do |line|
             case line
             when /^(\S+)\s(\S+)$/
@@ -88,12 +88,12 @@ class Chef
         def install_package(name, version)
           if current_resource.version
             if allow_downgrade
-              shell_out_compact!("rpm", options, "-U", "--oldpackage", new_resource.source)
+              shell_out!("rpm", options, "-U", "--oldpackage", new_resource.source)
             else
-              shell_out_compact!("rpm", options, "-U", new_resource.source)
+              shell_out!("rpm", options, "-U", new_resource.source)
             end
           else
-            shell_out_compact!("rpm", options, "-i", new_resource.source)
+            shell_out!("rpm", options, "-i", new_resource.source)
           end
         end
 
@@ -101,9 +101,9 @@ class Chef
 
         def remove_package(name, version)
           if version
-            shell_out_compact!("rpm", options, "-e", "#{name}-#{version}")
+            shell_out!("rpm", options, "-e", "#{name}-#{version}")
           else
-            shell_out_compact!("rpm", options, "-e", name)
+            shell_out!("rpm", options, "-e", name)
           end
         end
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -547,9 +547,9 @@ class Chef
           end
           src_str = src.empty? ? "" : " #{src.join(" ")}"
           if !version.nil? && !version.empty?
-            shell_out_with_timeout!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src_str}#{opts}", env: nil)
+            shell_out!("#{gem_binary_path} install #{name} -q --no-rdoc --no-ri -v \"#{version}\"#{src_str}#{opts}", env: nil)
           else
-            shell_out_with_timeout!("#{gem_binary_path} install \"#{name}\" -q --no-rdoc --no-ri #{src_str}#{opts}", env: nil)
+            shell_out!("#{gem_binary_path} install \"#{name}\" -q --no-rdoc --no-ri #{src_str}#{opts}", env: nil)
           end
         end
 
@@ -573,9 +573,9 @@ class Chef
 
         def uninstall_via_gem_command(name, version)
           if version
-            shell_out_with_timeout!("#{gem_binary_path} uninstall #{name} -q -x -I -v \"#{version}\"#{opts}", env: nil)
+            shell_out!("#{gem_binary_path} uninstall #{name} -q -x -I -v \"#{version}\"#{opts}", env: nil)
           else
-            shell_out_with_timeout!("#{gem_binary_path} uninstall #{name} -q -x -I -a#{opts}", env: nil)
+            shell_out!("#{gem_binary_path} uninstall #{name} -q -x -I -a#{opts}", env: nil)
           end
         end
 

--- a/lib/chef/provider/package/smartos.rb
+++ b/lib/chef/provider/package/smartos.rb
@@ -43,7 +43,7 @@ class Chef
         def check_package_state(name)
           logger.trace("#{new_resource} checking package #{name}")
           version = nil
-          info = shell_out_compact!("/opt/local/sbin/pkg_info", "-E", "#{name}*", env: nil, returns: [0, 1])
+          info = shell_out!("/opt/local/sbin/pkg_info", "-E", "#{name}*", env: nil, returns: [0, 1])
 
           if info.stdout
             version = info.stdout[/^#{new_resource.package_name}-(.+)/, 1]
@@ -58,7 +58,7 @@ class Chef
           return @candidate_version if @candidate_version
           name = nil
           version = nil
-          pkg = shell_out_compact!("/opt/local/bin/pkgin", "se", new_resource.package_name, env: nil, returns: [0, 1])
+          pkg = shell_out!("/opt/local/bin/pkgin", "se", new_resource.package_name, env: nil, returns: [0, 1])
           pkg.stdout.each_line do |line|
             case line
             when /^#{new_resource.package_name}/
@@ -72,7 +72,7 @@ class Chef
         def install_package(name, version)
           logger.trace("#{new_resource} installing package #{name} version #{version}")
           package = "#{name}-#{version}"
-          out = shell_out_compact!("/opt/local/bin/pkgin", "-y", "install", package, env: nil)
+          out = shell_out!("/opt/local/bin/pkgin", "-y", "install", package, env: nil)
         end
 
         def upgrade_package(name, version)
@@ -83,7 +83,7 @@ class Chef
         def remove_package(name, version)
           logger.trace("#{new_resource} removing package #{name} version #{version}")
           package = name.to_s
-          out = shell_out_compact!("/opt/local/bin/pkgin", "-y", "remove", package, env: nil)
+          out = shell_out!("/opt/local/bin/pkgin", "-y", "remove", package, env: nil)
         end
 
       end

--- a/lib/chef/provider/package/solaris.rb
+++ b/lib/chef/provider/package/solaris.rb
@@ -55,7 +55,7 @@ class Chef
             @package_source_found = ::File.exist?(new_resource.source)
             if @package_source_found
               logger.trace("#{new_resource} checking pkg status")
-              shell_out_compact("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name).stdout.each_line do |line|
+              shell_out("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name).stdout.each_line do |line|
                 case line
                 when /VERSION:\s+(.+)/
                   new_resource.version($1)
@@ -65,7 +65,7 @@ class Chef
           end
 
           logger.trace("#{new_resource} checking install state")
-          status = shell_out_compact("pkginfo", "-l", current_resource.package_name)
+          status = shell_out("pkginfo", "-l", current_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -83,7 +83,7 @@ class Chef
 
         def candidate_version
           return @candidate_version if @candidate_version
-          status = shell_out_compact("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name)
+          status = shell_out("pkginfo", "-l", "-d", new_resource.source, new_resource.package_name)
           status.stdout.each_line do |line|
             case line
             when /VERSION:\s+(.+)/
@@ -106,7 +106,7 @@ class Chef
                       else
                         [ "pkgadd", "-n", "-d", new_resource.source, "all" ]
                       end
-            shell_out_compact!(command)
+            shell_out!(command)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           else
             command = if ::File.directory?(new_resource.source) # CHEF-4469
@@ -114,7 +114,7 @@ class Chef
                       else
                         [ "pkgadd", "-n", options, "-d", new_resource.source, "all" ]
                       end
-            shell_out_compact!(*command)
+            shell_out!(*command)
             logger.trace("#{new_resource} installed version #{new_resource.version} from: #{new_resource.source}")
           end
         end
@@ -123,10 +123,10 @@ class Chef
 
         def remove_package(name, version)
           if options.nil?
-            shell_out_compact!( "pkgrm", "-n", name )
+            shell_out!( "pkgrm", "-n", name )
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           else
-            shell_out_compact!( "pkgrm", "-n", options, name )
+            shell_out!( "pkgrm", "-n", options, name )
             logger.trace("#{new_resource} removed version #{new_resource.version}")
           end
         end

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -210,7 +210,7 @@ class Chef
         end
 
         def resolve_source_to_version_obj
-          shell_out_with_timeout!("rpm -qp --queryformat '%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n' #{new_resource.source}").stdout.each_line do |line|
+          shell_out!("rpm -qp --queryformat '%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n' #{new_resource.source}").stdout.each_line do |line|
             # this is another case of committing the sin of doing some lightweight mangling of RPM versions in ruby -- but the output of the rpm command
             # does not match what the yum library accepts.
             case line
@@ -260,7 +260,7 @@ class Chef
         end
 
         def yum(*args)
-          shell_out_compact!(yum_binary, *args)
+          shell_out!(yum_binary, *args)
         end
 
         def safe_version_array

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -35,7 +35,7 @@ class Chef
           candidate_version = current_version = nil
           is_installed = false
           logger.trace("#{new_resource} checking zypper")
-          status = shell_out_compact!("zypper", "--non-interactive", "info", package_name)
+          status = shell_out!("zypper", "--non-interactive", "info", package_name)
           status.stdout.each_line do |line|
             case line
             when /^Version *: (.+) *$/
@@ -86,7 +86,7 @@ class Chef
         def locked_packages
           @locked_packages ||=
             begin
-              locked = shell_out_compact!("zypper", "locks")
+              locked = shell_out!("zypper", "locks")
               locked.stdout.each_line.map do |line|
                 line.split("|").shift(2).last.strip
               end
@@ -144,9 +144,9 @@ class Chef
         def zypper_package(command, *options, names, versions)
           zipped_names = zip(names, versions)
           if zypper_version < 1.0
-            shell_out_compact!("zypper", gpg_checks, command, *options, "-y", names)
+            shell_out!("zypper", gpg_checks, command, *options, "-y", names)
           else
-            shell_out_compact!("zypper", "--non-interactive", gpg_checks, command, *options, zipped_names)
+            shell_out!("zypper", "--non-interactive", gpg_checks, command, *options, zipped_names)
           end
         end
 

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -133,7 +133,7 @@ class Chef
         else
           command = generate_command(:add)
           converge_by("run #{command.join(' ')} to add route") do
-            shell_out_compact!(command)
+            shell_out!(command)
             logger.info("#{new_resource} added")
           end
         end
@@ -146,7 +146,7 @@ class Chef
         if is_running
           command = generate_command(:delete)
           converge_by("run #{command.join(' ')} to delete route ") do
-            shell_out_compact!(command)
+            shell_out!(command)
             logger.info("#{new_resource} removed")
           end
         else

--- a/lib/chef/provider/service/simple.rb
+++ b/lib/chef/provider/service/simple.rb
@@ -163,6 +163,7 @@ class Chef
         end
 
         def ps_cmd
+          # XXX: magic attributes are a shitty api, need something better here and deprecate this attribute
           @run_context.node[:command] && @run_context.node[:command][:ps]
         end
       end

--- a/lib/chef/provider/user/aix.rb
+++ b/lib/chef/provider/user/aix.rb
@@ -24,7 +24,7 @@ class Chef
         provides :aix_user
 
         def create_user
-          shell_out_compact!("useradd", universal_options, useradd_options, new_resource.username)
+          shell_out!("useradd", universal_options, useradd_options, new_resource.username)
           add_password
         end
 
@@ -32,11 +32,11 @@ class Chef
           add_password
           manage_home
           return if universal_options.empty? && usermod_options.empty?
-          shell_out_compact!("usermod", universal_options, usermod_options, new_resource.username)
+          shell_out!("usermod", universal_options, usermod_options, new_resource.username)
         end
 
         def remove_user
-          shell_out_compact!("userdel", userdel_options, new_resource.username)
+          shell_out!("userdel", userdel_options, new_resource.username)
         end
 
         # Aix does not support -r like other unix, sytem account is created by adding to 'system' group
@@ -66,7 +66,7 @@ class Chef
         end
 
         def check_lock
-          lock_info = shell_out_compact!("lsuser", "-a", "account_locked", new_resource.username)
+          lock_info = shell_out!("lsuser", "-a", "account_locked", new_resource.username)
           if whyrun_mode? && passwd_s.stdout.empty? && lock_info.stderr.match(/does not exist/)
             # if we're in whyrun mode and the user is not yet created we assume it would be
             return false
@@ -85,11 +85,11 @@ class Chef
         end
 
         def lock_user
-          shell_out_compact!("chuser", "account_locked=true", new_resource.username)
+          shell_out!("chuser", "account_locked=true", new_resource.username)
         end
 
         def unlock_user
-          shell_out_compact!("chuser", "account_locked=false", new_resource.username)
+          shell_out!("chuser", "account_locked=false", new_resource.username)
         end
 
         def universal_options

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -326,7 +326,7 @@ user password using shadow hash.")
         end
 
         def ditto_home
-          shell_out_compact!("/usr/sbin/createhomedir", "-c", "-u", "#{new_resource.username}")
+          shell_out!("/usr/sbin/createhomedir", "-c", "-u", "#{new_resource.username}")
         end
 
         def move_home
@@ -364,7 +364,7 @@ user password using shadow hash.")
 
           # Shadow info is saved as binary plist. Convert the info to binary plist.
           shadow_info_binary = StringIO.new
-          shell_out_compact("plutil", "-convert", "binary1", "-o", "-", "-",
+          shell_out("plutil", "-convert", "binary1", "-o", "-", "-",
                             input: shadow_info.to_plist, live_stream: shadow_info_binary)
 
           if user_info.nil?
@@ -586,7 +586,7 @@ user password using shadow hash.")
 
           # We flush the cache here in order to make sure that we read fresh information
           # for the user.
-          shell_out_compact("dscacheutil", "-flushcache") # FIXME: this is MacOS version dependent
+          shell_out("dscacheutil", "-flushcache") # FIXME: this is MacOS version dependent
 
           begin
             user_plist_file = "#{USER_PLIST_DIRECTORY}/#{new_resource.username}.plist"
@@ -654,7 +654,7 @@ user password using shadow hash.")
         end
 
         def run_dscl(*args)
-          result = shell_out_compact("dscl", ".", "-#{args[0]}", args[1..-1])
+          result = shell_out("dscl", ".", "-#{args[0]}", args[1..-1])
           return "" if ( args.first =~ /^delete/ ) && ( result.exitstatus != 0 )
           raise(Chef::Exceptions::DsclCommandFailed, "dscl error: #{result.inspect}") unless result.exitstatus == 0
           raise(Chef::Exceptions::DsclCommandFailed, "dscl error: #{result.inspect}") if result.stdout =~ /No such key: /
@@ -662,7 +662,7 @@ user password using shadow hash.")
         end
 
         def run_plutil(*args)
-          result = shell_out_compact("plutil", "-#{args[0]}", args[1..-1])
+          result = shell_out("plutil", "-#{args[0]}", args[1..-1])
           raise(Chef::Exceptions::PlistUtilCommandFailed, "plutil error: #{result.inspect}") unless result.exitstatus == 0
           if result.stdout.encoding == Encoding::ASCII_8BIT
             result.stdout.encode("utf-8", "binary", undef: :replace, invalid: :replace, replace: "?")
@@ -672,7 +672,7 @@ user password using shadow hash.")
         end
 
         def convert_binary_plist_to_xml(binary_plist_string)
-          shell_out_compact("plutil", "-convert", "xml1", "-o", "-", "-", input: binary_plist_string).stdout
+          shell_out("plutil", "-convert", "xml1", "-o", "-", "-", input: binary_plist_string).stdout
         end
 
         def convert_to_binary(string)

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -24,23 +24,23 @@ class Chef
         provides :user, os: "linux"
 
         def create_user
-          shell_out_compact!("useradd", universal_options, useradd_options, new_resource.username)
+          shell_out!("useradd", universal_options, useradd_options, new_resource.username)
         end
 
         def manage_user
-          shell_out_compact!("usermod", universal_options, usermod_options, new_resource.username)
+          shell_out!("usermod", universal_options, usermod_options, new_resource.username)
         end
 
         def remove_user
-          shell_out_compact!("userdel", userdel_options, new_resource.username)
+          shell_out!("userdel", userdel_options, new_resource.username)
         end
 
         def lock_user
-          shell_out_compact!("usermod", "-L", new_resource.username)
+          shell_out!("usermod", "-L", new_resource.username)
         end
 
         def unlock_user
-          shell_out_compact!("usermod", "-U", new_resource.username)
+          shell_out!("usermod", "-U", new_resource.username)
         end
 
         # common to usermod and useradd
@@ -88,7 +88,7 @@ class Chef
         def check_lock
           # there's an old bug in rhel (https://bugzilla.redhat.com/show_bug.cgi?id=578534)
           # which means that both 0 and 1 can be success.
-          passwd_s = shell_out_compact("passwd", "-S", new_resource.username, returns: [ 0, 1 ])
+          passwd_s = shell_out("passwd", "-S", new_resource.username, returns: [ 0, 1 ])
 
           # checking "does not exist" has to come before exit code handling since centos and ubuntu differ in exit codes
           if passwd_s.stderr =~ /does not exist/

--- a/lib/chef/provider/user/pw.rb
+++ b/lib/chef/provider/user/pw.rb
@@ -31,19 +31,19 @@ class Chef
         end
 
         def create_user
-          shell_out_compact!("pw", "useradd", set_options)
+          shell_out!("pw", "useradd", set_options)
           modify_password
         end
 
         def manage_user
-          shell_out_compact!("pw", "usermod", set_options)
+          shell_out!("pw", "usermod", set_options)
           modify_password
         end
 
         def remove_user
           command = [ "pw", "userdel", new_resource.username ]
           command << "-r" if new_resource.manage_home
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def check_lock
@@ -57,11 +57,11 @@ class Chef
         end
 
         def lock_user
-          shell_out_compact!("pw", "lock", new_resource.username)
+          shell_out!("pw", "lock", new_resource.username)
         end
 
         def unlock_user
-          shell_out_compact!("pw", "unlock", new_resource.username)
+          shell_out!("pw", "unlock", new_resource.username)
         end
 
         def set_options

--- a/lib/chef/provider/user/solaris.rb
+++ b/lib/chef/provider/user/solaris.rb
@@ -30,18 +30,18 @@ class Chef
         PASSWORD_FILE = "/etc/shadow"
 
         def create_user
-          shell_out_compact!("useradd", universal_options, useradd_options, new_resource.username)
+          shell_out!("useradd", universal_options, useradd_options, new_resource.username)
           manage_password
         end
 
         def manage_user
           manage_password
           return if universal_options.empty? && usermod_options.empty?
-          shell_out_compact!("usermod", universal_options, usermod_options, new_resource.username)
+          shell_out!("usermod", universal_options, usermod_options, new_resource.username)
         end
 
         def remove_user
-          shell_out_compact!("userdel", userdel_options, new_resource.username)
+          shell_out!("userdel", userdel_options, new_resource.username)
         end
 
         def check_lock
@@ -56,11 +56,11 @@ class Chef
         end
 
         def lock_user
-          shell_out_compact!("passwd", "-l", new_resource.username)
+          shell_out!("passwd", "-l", new_resource.username)
         end
 
         def unlock_user
-          shell_out_compact!("passwd", "-u", new_resource.username)
+          shell_out!("passwd", "-u", new_resource.username)
         end
 
         private

--- a/lib/chef/provider/user/useradd.rb
+++ b/lib/chef/provider/user/useradd.rb
@@ -36,7 +36,7 @@ class Chef
             useradd.concat(universal_options)
             useradd.concat(useradd_options)
           end
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def manage_user
@@ -44,7 +44,7 @@ class Chef
           command = compile_command("usermod") do |u|
             u.concat(universal_options)
           end
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def remove_user
@@ -52,13 +52,13 @@ class Chef
           command << "-r" if new_resource.manage_home
           command << "-f" if new_resource.force
           command << new_resource.username
-          shell_out_compact!(command)
+          shell_out!(command)
         end
 
         def check_lock
           # we can get an exit code of 1 even when it's successful on
           # rhel/centos (redhat bug 578534). See additional error checks below.
-          passwd_s = shell_out_compact!("passwd", "-S", new_resource.username, returns: [0, 1])
+          passwd_s = shell_out!("passwd", "-S", new_resource.username, returns: [0, 1])
           if whyrun_mode? && passwd_s.stdout.empty? && passwd_s.stderr.match(/does not exist/)
             # if we're in whyrun mode and the user is not yet created we assume it would be
             return false
@@ -79,7 +79,7 @@ class Chef
           unless passwd_s.exitstatus == 0
             raise_lock_error = false
             if %w{redhat centos}.include?(node[:platform])
-              passwd_version_check = shell_out_compact!("rpm", "-q", "passwd")
+              passwd_version_check = shell_out!("rpm", "-q", "passwd")
               passwd_version = passwd_version_check.stdout.chomp
 
               unless passwd_version == "passwd-0.73-1"
@@ -96,11 +96,11 @@ class Chef
         end
 
         def lock_user
-          shell_out_compact!("usermod", "-L", new_resource.username)
+          shell_out!("usermod", "-L", new_resource.username)
         end
 
         def unlock_user
-          shell_out_compact!("usermod", "-U", new_resource.username)
+          shell_out!("usermod", "-U", new_resource.username)
         end
 
         def compile_command(base_command)

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -46,7 +46,7 @@ class Chef
       #
       # @return [Boolean] do we support pkgng
       def supports_pkgng?
-        ships_with_pkgng? || !!shell_out_compact!("make", "-V", "WITH_PKGNG", :env => nil).stdout.match(/yes/i)
+        ships_with_pkgng? || !!shell_out!("make", "-V", "WITH_PKGNG", :env => nil).stdout.match(/yes/i)
       end
 
       private

--- a/lib/chef/util/selinux.rb
+++ b/lib/chef/util/selinux.rb
@@ -52,7 +52,7 @@ class Chef
           restorecon_flags << "-r" if recursive
           restorecon_flags << file_path
           Chef::Log.trace("Restoring selinux security content with #{restorecon_path}")
-          shell_out_compact!(restorecon_path, restorecon_flags)
+          shell_out!(restorecon_path, restorecon_flags)
         else
           Chef::Log.warn "Can not find 'restorecon' on the system. Skipping selinux security context restore."
         end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -160,7 +160,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-d", "/Users/mud",
                        "-m",
                        "adam" ])
-      expect(provider).to receive(:shell_out!).with(*command).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
 
@@ -181,7 +181,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                          "-u", "1000",
                          "-r", "-m",
                          "adam" ])
-        expect(provider).to receive(:shell_out!).with(*command).and_return(true)
+        expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
         provider.create_user
       end
 
@@ -204,7 +204,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam" ]
-      expect(provider).to receive(:shell_out!).with(*command).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
 
@@ -215,7 +215,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam" ]
-      expect(provider).to receive(:shell_out!).with(*command).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
 
@@ -224,7 +224,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       command = ["usermod",
                   "-g", "23",
                   "adam" ]
-      expect(provider).to receive(:shell_out!).with(*command).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
   end
@@ -232,24 +232,24 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   describe "when removing a user" do
 
     it "should run userdel with the new resources user name" do
-      expect(provider).to receive(:shell_out!).with("userdel", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -r if manage_home is true" do
       @new_resource.manage_home true
-      expect(provider).to receive(:shell_out!).with("userdel", "-r", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name if non_unique is true" do
-      expect(provider).to receive(:shell_out!).with("userdel", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -f if force is true" do
       @new_resource.force(true)
-      expect(provider).to receive(:shell_out!).with("userdel", "-f", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username).and_return(true)
       provider.remove_user
     end
   end
@@ -335,14 +335,14 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
 
   describe "when locking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out!).with("usermod", "-L", @new_resource.username)
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username)
       provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out!).with("usermod", "-U", @new_resource.username)
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username)
       provider.unlock_user
     end
   end

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2009-2017, Chef Software Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -56,19 +56,19 @@ describe Chef::Mixin::ShellOut do
         describe "and environment is an option" do
           it "should not change environment language settings when they are set to nil" do
             options = { :environment => { "LC_ALL" => nil, "LANGUAGE" => nil, "LANG" => nil, env_path => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should not change environment language settings when they are set to non-nil" do
             options = { :environment => { "LC_ALL" => "en_US.UTF-8", "LANGUAGE" => "en_US.UTF-8", "LANG" => "en_US.UTF-8", env_path => "foo:bar:baz" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should set environment language settings to the configured internal locale when they are not present" do
             options = { :environment => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
               :environment => {
                 "HOME"     => "/Users/morty",
                 "LC_ALL"   => Chef::Config[:internal_locale],
@@ -82,7 +82,7 @@ describe Chef::Mixin::ShellOut do
 
           it "should not mutate the options hash when it adds language settings" do
             options = { :environment => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
               :environment => {
                 "HOME"     => "/Users/morty",
                 "LC_ALL"   => Chef::Config[:internal_locale],
@@ -99,19 +99,19 @@ describe Chef::Mixin::ShellOut do
         describe "and env is an option" do
           it "should not change env when langauge options are set to nil" do
             options = { :env => { "LC_ALL" => nil, "LANG" => nil, "LANGUAGE" => nil, env_path => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should not change env when language options are set to non-nil" do
             options = { :env => { "LC_ALL" => "de_DE.UTF-8", "LANG" => "de_DE.UTF-8", "LANGUAGE" => "de_DE.UTF-8", env_path => "foo:bar:baz" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, options)
           end
 
           it "should set environment language settings to the configured internal locale when they are not present" do
             options = { :env => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
               :env => {
                 "HOME"     => "/Users/morty",
                 "LC_ALL"   => Chef::Config[:internal_locale],
@@ -125,7 +125,7 @@ describe Chef::Mixin::ShellOut do
 
           it "should not mutate the options hash when it adds language settings" do
             options = { :env => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
               :env => {
                 "HOME"     => "/Users/morty",
                 "LC_ALL"   => Chef::Config[:internal_locale],
@@ -142,7 +142,7 @@ describe Chef::Mixin::ShellOut do
         describe "and no env/environment option is present" do
           it "should set environment language settings to the configured internal locale" do
             options = { :user => "morty" }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
               :user => "morty",
               :environment => {
                 "LC_ALL"   => Chef::Config[:internal_locale],
@@ -158,7 +158,7 @@ describe Chef::Mixin::ShellOut do
 
       describe "when the last argument is not a Hash" do
         it "should set environment language settings to the configured internal locale" do
-          expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {
+          expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, {
             :environment => {
               "LC_ALL"   => Chef::Config[:internal_locale],
               "LANG"     => Chef::Config[:internal_locale],
@@ -178,19 +178,19 @@ describe Chef::Mixin::ShellOut do
         describe "and environment is an option" do
           it "should not change environment['LC_ALL'] when set to nil" do
             options = { :environment => { "LC_ALL" => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
 
           it "should not change environment['LC_ALL'] when set to non-nil" do
             options = { :environment => { "LC_ALL" => "en_US.UTF-8" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
 
           it "should no longer set environment['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { :environment => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
         end
@@ -198,19 +198,19 @@ describe Chef::Mixin::ShellOut do
         describe "and env is an option" do
           it "should not change env when set to nil" do
             options = { :env => { "LC_ALL" => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
 
           it "should not change env when set to non-nil" do
             options = { :env => { "LC_ALL" => "en_US.UTF-8" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
 
           it "should no longer set env['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { :env => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
         end
@@ -218,7 +218,7 @@ describe Chef::Mixin::ShellOut do
         describe "and no env/environment option is present" do
           it "should no longer add environment option and set environment['LC_ALL'] to nil" do
             options = { :user => "morty" }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out_with_systems_locale(cmd, options)
           end
         end
@@ -226,7 +226,7 @@ describe Chef::Mixin::ShellOut do
 
       describe "when the last argument is not a Hash" do
         it "should no longer add environment options and set environment['LC_ALL'] to nil" do
-          expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {}).and_return(true)
+          expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd).and_return(true)
           shell_out_obj.shell_out_with_systems_locale(cmd)
         end
       end
@@ -238,19 +238,19 @@ describe Chef::Mixin::ShellOut do
         describe "and environment is an option" do
           it "should not change environment['LC_ALL'] when set to nil" do
             options = { :environment => { "LC_ALL" => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should not change environment['LC_ALL'] when set to non-nil" do
             options = { :environment => { "LC_ALL" => "en_US.UTF-8" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should no longer set environment['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { :environment => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -258,19 +258,19 @@ describe Chef::Mixin::ShellOut do
         describe "and env is an option" do
           it "should not change env when set to nil" do
             options = { :env => { "LC_ALL" => nil } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should not change env when set to non-nil" do
             options = { :env => { "LC_ALL" => "en_US.UTF-8" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should no longer set env['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { :env => { "HOME" => "/Users/morty" } }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -278,7 +278,7 @@ describe Chef::Mixin::ShellOut do
         describe "and no env/environment option is present" do
           it "should no longer add environment option and set environment['LC_ALL'] to nil" do
             options = { :user => "morty" }
-            expect(shell_out_obj).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -286,7 +286,7 @@ describe Chef::Mixin::ShellOut do
 
       describe "when the last argument is not a Hash" do
         it "should no longer add environment options and set environment['LC_ALL'] to nil" do
-          expect(shell_out_obj).to receive(:shell_out_command).with(cmd, {}).and_return(true)
+          expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd).and_return(true)
           shell_out_obj.shell_out(cmd, default_env: false)
         end
       end

--- a/spec/unit/provider/group/dscl_spec.rb
+++ b/spec/unit/provider/group/dscl_spec.rb
@@ -32,11 +32,11 @@ describe Chef::Provider::Group::Dscl do
     @provider.current_resource = @current_resource
 
     @status = double(stdout: "\n", stderr: "", exitstatus: 0)
-    allow(@provider).to receive(:shell_out).and_return(@status)
+    allow(@provider).to receive(:shell_out_compacted).and_return(@status)
   end
 
   it "should run shell_out with the supplied array of arguments appended to the dscl command" do
-    expect(@provider).to receive(:shell_out).with("dscl", ".", "-cmd", "/Path", "arg1", "arg2")
+    expect(@provider).to receive(:shell_out_compacted).with("dscl", ".", "-cmd", "/Path", "arg1", "arg2")
     @provider.dscl("cmd", "/Path", "arg1", "arg2")
   end
 

--- a/spec/unit/provider/group/gpasswd_spec.rb
+++ b/spec/unit/provider/group/gpasswd_spec.rb
@@ -69,7 +69,7 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
 
       it "logs a message and sets group's members to 'none'" do
         expect(logger).to receive(:trace).with("group[wheel] setting group members to: none")
-        expect(@provider).to receive(:shell_out!).with("gpasswd", "-M", "", "wheel")
+        expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-M", "", "wheel")
         @provider.modify_group_members
       end
     end
@@ -81,7 +81,7 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
       end
 
       it "does not modify group membership" do
-        expect(@provider).not_to receive(:shell_out!)
+        expect(@provider).not_to receive(:shell_out_compacted!)
         @provider.modify_group_members
       end
     end
@@ -89,12 +89,12 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
     describe "when the resource specifies group members" do
       it "should log an appropriate debug message" do
         expect(logger).to receive(:trace).with("group[wheel] setting group members to: lobster, rage, fist")
-        allow(@provider).to receive(:shell_out!)
+        allow(@provider).to receive(:shell_out_compacted!)
         @provider.modify_group_members
       end
 
       it "should run gpasswd with the members joined by ',' followed by the target group" do
-        expect(@provider).to receive(:shell_out!).with("gpasswd", "-M", "lobster,rage,fist", "wheel")
+        expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-M", "lobster,rage,fist", "wheel")
         @provider.modify_group_members
       end
 
@@ -107,9 +107,9 @@ describe Chef::Provider::Group::Gpasswd, "modify_group_members" do
 
         it "should run gpasswd individually for each user when the append option is set" do
           @new_resource.append(true)
-          expect(@provider).to receive(:shell_out!).with("gpasswd", "-a", "lobster", "wheel")
-          expect(@provider).to receive(:shell_out!).with("gpasswd", "-a", "rage", "wheel")
-          expect(@provider).to receive(:shell_out!).with("gpasswd", "-a", "fist", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-a", "lobster", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-a", "rage", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("gpasswd", "-a", "fist", "wheel")
           @provider.modify_group_members
         end
       end

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -108,14 +108,14 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "#create_group" do
     before do
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       allow(provider).to receive(:set_options).and_return("monkey")
       allow(provider).to receive(:groupadd_options).and_return([])
       allow(provider).to receive(:modify_group_members).and_return(true)
     end
 
     it "should run groupadd with the return of set_options" do
-      expect(provider).to receive(:shell_out!).with("groupadd", "monkey").and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("groupadd", "monkey").and_return(true)
       provider.create_group
     end
 
@@ -127,13 +127,13 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "#manage_group" do
     before do
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       allow(provider).to receive(:set_options).and_return("monkey")
     end
 
     it "should run groupmod with the return of set_options" do
       allow(provider).to receive(:modify_group_members).and_return(true)
-      expect(provider).to receive(:shell_out!).with("groupmod", "monkey").and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("groupmod", "monkey").and_return(true)
       provider.manage_group
     end
 
@@ -145,12 +145,12 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "#remove_group" do
     before do
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       allow(provider).to receive(:set_options).and_return("monkey")
     end
 
     it "should run groupdel with the new resources group name" do
-      expect(provider).to receive(:shell_out!).with("groupdel", "aj").and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("groupdel", "aj").and_return(true)
       provider.remove_group
     end
   end
@@ -163,7 +163,7 @@ describe Chef::Provider::Group::Groupadd do
 
   describe "#load_current_resource" do
     before do
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       allow(provider).to receive(:set_options).and_return("monkey")
     end
 

--- a/spec/unit/provider/group/groupmod_spec.rb
+++ b/spec/unit/provider/group/groupmod_spec.rb
@@ -65,9 +65,9 @@ describe Chef::Provider::Group::Groupmod do
 
         it "logs a message and sets group's members to 'none', then removes existing group members" do
           expect(logger).to receive(:trace).with("group[wheel] setting group members to: none")
-          expect(@provider).to receive(:shell_out!).with("group", "mod", "-n", "wheel_bak", "wheel")
-          expect(@provider).to receive(:shell_out!).with("group", "add", "-g", "123", "-o", "wheel")
-          expect(@provider).to receive(:shell_out!).with("group", "del", "wheel_bak")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "mod", "-n", "wheel_bak", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "add", "-g", "123", "-o", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "del", "wheel_bak")
           @provider.manage_group
         end
       end
@@ -80,7 +80,7 @@ describe Chef::Provider::Group::Groupmod do
 
         it "logs a message and does not modify group membership" do
           expect(logger).to receive(:trace).with("group[wheel] not changing group members, the group has no members to add")
-          expect(@provider).not_to receive(:shell_out!)
+          expect(@provider).not_to receive(:shell_out_compacted!)
           @provider.manage_group
         end
       end
@@ -93,10 +93,10 @@ describe Chef::Provider::Group::Groupmod do
 
         it "updates group membership correctly" do
           allow(logger).to receive(:trace)
-          expect(@provider).to receive(:shell_out!).with("group", "mod", "-n", "wheel_bak", "wheel")
-          expect(@provider).to receive(:shell_out!).with("user", "mod", "-G", "wheel", "lobster")
-          expect(@provider).to receive(:shell_out!).with("group", "add", "-g", "123", "-o", "wheel")
-          expect(@provider).to receive(:shell_out!).with("group", "del", "wheel_bak")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "mod", "-n", "wheel_bak", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("user", "mod", "-G", "wheel", "lobster")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "add", "-g", "123", "-o", "wheel")
+          expect(@provider).to receive(:shell_out_compacted!).with("group", "del", "wheel_bak")
           @provider.manage_group
         end
       end
@@ -111,10 +111,10 @@ describe Chef::Provider::Group::Groupmod do
       end
 
       it "should run a group add command and some user mod commands" do
-        expect(@provider).to receive(:shell_out!).with("group", "add", "-g", "123", "wheel")
-        expect(@provider).to receive(:shell_out!).with("user", "mod", "-G", "wheel", "lobster")
-        expect(@provider).to receive(:shell_out!).with("user", "mod", "-G", "wheel", "rage")
-        expect(@provider).to receive(:shell_out!).with("user", "mod", "-G", "wheel", "fist")
+        expect(@provider).to receive(:shell_out_compacted!).with("group", "add", "-g", "123", "wheel")
+        expect(@provider).to receive(:shell_out_compacted!).with("user", "mod", "-G", "wheel", "lobster")
+        expect(@provider).to receive(:shell_out_compacted!).with("user", "mod", "-G", "wheel", "rage")
+        expect(@provider).to receive(:shell_out_compacted!).with("user", "mod", "-G", "wheel", "fist")
         @provider.create_group
       end
     end
@@ -128,7 +128,7 @@ describe Chef::Provider::Group::Groupmod do
       end
 
       it "should run a group del command" do
-        expect(@provider).to receive(:shell_out!).with("group", "del", "wheel")
+        expect(@provider).to receive(:shell_out_compacted!).with("group", "del", "wheel")
         @provider.remove_group
       end
     end

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Provider::Group::Pw do
   describe "when creating a group" do
     it "should run pw groupadd with the return of set_options and set_members_option" do
       @new_resource.gid(23)
-      expect(@provider).to receive(:shell_out!).with("pw", "groupadd", "wheel", "-g", "23", "-M", "root,aj").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with("pw", "groupadd", "wheel", "-g", "23", "-M", "root,aj").and_return(true)
       @provider.create_group
     end
   end
@@ -62,8 +62,8 @@ describe Chef::Provider::Group::Pw do
     it "should run pw groupmod with the return of set_options" do
       @new_resource.gid(42)
       @new_resource.members(["someone"])
-      expect(@provider).to receive(:shell_out!).with("pw", "groupmod", "wheel", "-g", "42", "-m", "someone").and_return(true)
-      expect(@provider).to receive(:shell_out!).with("pw", "groupmod", "wheel", "-g", "42", "-d", "root,aj").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with("pw", "groupmod", "wheel", "-g", "42", "-m", "someone").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with("pw", "groupmod", "wheel", "-g", "42", "-d", "root,aj").and_return(true)
       @provider.manage_group
     end
 
@@ -71,7 +71,7 @@ describe Chef::Provider::Group::Pw do
 
   describe "when removing the group" do
     it "should run pw groupdel with the new resources group name" do
-      expect(@provider).to receive(:shell_out!).with("pw", "groupdel", "wheel").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with("pw", "groupdel", "wheel").and_return(true)
       @provider.remove_group
     end
   end

--- a/spec/unit/provider/group/suse_spec.rb
+++ b/spec/unit/provider/group/suse_spec.rb
@@ -76,14 +76,14 @@ describe Chef::Provider::Group::Suse do
 
   describe "#add_member" do
     it "should call out to groupmod to add user" do
-      expect(provider).to receive(:shell_out!).with("groupmod", "-A", "new_user", "new_group")
+      expect(provider).to receive(:shell_out_compacted!).with("groupmod", "-A", "new_user", "new_group")
       provider.add_member("new_user")
     end
   end
 
   describe "#remove_member" do
     it "should call out to groupmod to remove user" do
-      expect(provider).to receive(:shell_out!).with("groupmod", "-R", "new_user", "new_group")
+      expect(provider).to receive(:shell_out_compacted!).with("groupmod", "-R", "new_user", "new_group")
       provider.remove_member("new_user")
     end
   end

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -39,7 +39,7 @@ describe Chef::Provider::Group::Usermod do
       end
 
       it "should log an appropriate message" do
-        expect(@provider).not_to receive(:shell_out!)
+        expect(@provider).not_to receive(:shell_out_compacted!)
         @provider.modify_group_members
       end
     end
@@ -85,9 +85,9 @@ describe Chef::Provider::Group::Usermod do
           @provider.current_resource = current_resource
           @node.automatic_attrs[:platform] = platform
           @new_resource.append(true)
-          expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "all")
-          expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "your")
-          expect(@provider).to receive(:shell_out!).with("usermod", *flags, "wheel", "base")
+          expect(@provider).to receive(:shell_out_compacted!).with("usermod", *flags, "wheel", "all")
+          expect(@provider).to receive(:shell_out_compacted!).with("usermod", *flags, "wheel", "your")
+          expect(@provider).to receive(:shell_out_compacted!).with("usermod", *flags, "wheel", "base")
           @provider.modify_group_members
         end
       end

--- a/spec/unit/provider/ifconfig/aix_spec.rb
+++ b/spec/unit/provider/ifconfig/aix_spec.rb
@@ -49,7 +49,7 @@ IFCONFIG
   describe "#load_current_resource" do
     before do
       @status = double(stdout: @ifconfig_output, exitstatus: 0)
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       @new_resource.device "en0"
     end
 
@@ -72,7 +72,7 @@ IFCONFIG
         @provider.instance_variable_set("@current_resource", Chef::Resource::Ifconfig.new("10.0.0.1", @run_context))
       end
       command = "chdev -l #{@new_resource.device} -a netaddr=#{@new_resource.name}"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
       @provider.run_action(:add)
       expect(@new_resource).to be_updated
@@ -98,7 +98,7 @@ IFCONFIG
         @provider.instance_variable_set("@current_resource", Chef::Resource::Ifconfig.new("10.0.0.1", @run_context))
       end
       command = "ifconfig #{@new_resource.device} #{@new_resource.name}"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
       @provider.run_action(:enable)
       expect(@new_resource).to be_updated
@@ -114,7 +114,7 @@ IFCONFIG
         @provider.instance_variable_set("@current_resource", Chef::Resource::Ifconfig.new("10.0.0.1", @run_context))
       end
 
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
 
       @provider.run_action(:disable)
       expect(@new_resource).not_to be_updated
@@ -133,7 +133,7 @@ IFCONFIG
 
       it "should disable an interface if it exists" do
         command = "ifconfig #{@new_resource.device} down"
-        expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+        expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
         @provider.run_action(:disable)
         expect(@new_resource).to be_updated
@@ -151,7 +151,7 @@ IFCONFIG
         @provider.instance_variable_set("@current_resource", Chef::Resource::Ifconfig.new("10.0.0.1", @run_context))
       end
 
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
 
       @provider.run_action(:delete)
       expect(@new_resource).not_to be_updated
@@ -170,7 +170,7 @@ IFCONFIG
 
       it "should delete an interface if it exists" do
         command = "chdev -l #{@new_resource.device} -a state=down"
-        expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+        expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
         @provider.run_action(:delete)
         expect(@new_resource).to be_updated

--- a/spec/unit/provider/ifconfig_spec.rb
+++ b/spec/unit/provider/ifconfig_spec.rb
@@ -48,9 +48,9 @@ EOS
 
     before do
       ifconfig = double(stdout: "", exitstatus: 1)
-      allow(@provider).to receive(:shell_out).and_return(ifconfig)
+      allow(@provider).to receive(:shell_out_compacted).and_return(ifconfig)
       ifconfig_version = double(stdout: "", stderr: net_tools_version, exitstatus: 4)
-      allow(@provider).to receive(:shell_out).with("ifconfig --version").and_return(ifconfig_version)
+      allow(@provider).to receive(:shell_out_compacted).with("ifconfig --version").and_return(ifconfig_version)
       @provider.load_current_resource
     end
     it "should track state of ifconfig failure" do
@@ -67,7 +67,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @current_resource.inet_addr nil
       command = "ifconfig eth0 10.0.0.1 netmask 255.255.254.0 metric 1 mtu 1500"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
       expect(@provider).to receive(:generate_config)
 
       @provider.run_action(:add)
@@ -78,7 +78,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @new_resource.target "172.16.32.2"
       command = "ifconfig eth0 172.16.32.2 netmask 255.255.254.0 metric 1 mtu 1500"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
       @provider.run_action(:add)
       expect(@new_resource).to be_updated
@@ -86,7 +86,7 @@ EOS
 
     it "should not add an interface if it already exists" do
       allow(@provider).to receive(:load_current_resource)
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
       @current_resource.inet_addr "10.0.0.1"
       expect(@provider).to receive(:generate_config)
 
@@ -105,7 +105,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @current_resource.inet_addr nil
       command = "ifconfig eth0 10.0.0.1 netmask 255.255.254.0 metric 1 mtu 1500"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
       expect(@provider).not_to receive(:generate_config)
 
       @provider.run_action(:enable)
@@ -116,7 +116,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @new_resource.target "172.16.32.2"
       command = "ifconfig eth0 172.16.32.2 netmask 255.255.254.0 metric 1 mtu 1500"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
 
       @provider.run_action(:enable)
       expect(@new_resource).to be_updated
@@ -139,7 +139,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @current_resource.device "eth0"
       command = "ifconfig #{@new_resource.device} down"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
       expect(@provider).to receive(:delete_config)
 
       @provider.run_action(:delete)
@@ -148,7 +148,7 @@ EOS
 
     it "should not delete interface if it does not exist" do
       allow(@provider).to receive(:load_current_resource)
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
       expect(@provider).to receive(:delete_config)
 
       @provider.run_action(:delete)
@@ -162,7 +162,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @current_resource.device "eth0"
       command = "ifconfig #{@new_resource.device} down"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
       expect(@provider).not_to receive(:delete_config)
 
       @provider.run_action(:disable)
@@ -171,7 +171,7 @@ EOS
 
     it "should not delete interface if it does not exist" do
       allow(@provider).to receive(:load_current_resource)
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
       expect(@provider).not_to receive(:delete_config)
 
       @provider.run_action(:disable)
@@ -185,7 +185,7 @@ EOS
       allow(@provider).to receive(:load_current_resource)
       @current_resource.device "eth0"
       command = "ifconfig #{@new_resource.device} down"
-      expect(@provider).to receive(:shell_out!).with(*command.split(" "))
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
       expect(@provider).to receive(:delete_config)
 
       @provider.run_action(:delete)
@@ -196,7 +196,7 @@ EOS
       # This is so that our fake values do not get overwritten
       allow(@provider).to receive(:load_current_resource)
       # This is so that nothing actually runs
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
       expect(@provider).to receive(:delete_config)
 
       @provider.run_action(:delete)

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ irssi:
   describe "when loading current resource" do
 
     it "should create a current resource with the name of the new_resource" do
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", @new_resource.package_name,
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -77,7 +77,7 @@ sudo:
      1.7.2p1-1ubuntu5 0
         500 http://us.archive.ubuntu.com/ubuntu/ lucid/main Packages
       INSTALLED
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq(["1.7.2p1-1ubuntu5.3"])
       expect(@provider.candidate_version).to eql(["1.7.2p1-1ubuntu5.3"])
@@ -90,7 +90,7 @@ sudo:
 N: Unable to locate package conic-smarms
       POLICY_STDOUT
       policy = double(:stdout => policy_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", "conic-smarms",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -99,7 +99,7 @@ N: Unable to locate package conic-smarms
 N: Unable to locate package conic-smarms
       SHOWPKG_STDOUT
       showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "showpkg", "conic-smarms",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -118,7 +118,7 @@ libmysqlclient15-dev:
   Version table:
       VPKG_STDOUT
       virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", "libmysqlclient15-dev",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -142,7 +142,7 @@ libmysqlclient-dev 5.1.41-3ubuntu12.10
 libmysqlclient-dev 5.1.41-3ubuntu12
       SHOWPKG_STDOUT
       showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "showpkg", "libmysqlclient15-dev",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -161,7 +161,7 @@ libmysqlclient-dev:
         500 http://us.archive.ubuntu.com/ubuntu/ lucid/main Packages
       RPKG_STDOUT
       real_package = double(:stdout => real_package_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", "libmysqlclient-dev",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -178,7 +178,7 @@ mp3-decoder:
   Version table:
       VPKG_STDOUT
       virtual_package = double(:stdout => virtual_package_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", "mp3-decoder",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -205,7 +205,7 @@ mpg321 0.2.10.6
 mpg123 1.12.1-0ubuntu1
       SHOWPKG_STDOUT
       showpkg = double(:stdout => showpkg_out, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "showpkg", "mp3-decoder",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -219,7 +219,7 @@ mpg123 1.12.1-0ubuntu1
 
       @new_resource.default_release("lenny-backports")
       @new_resource.provider(nil)
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "-o", "APT::Default-Release=lenny-backports", "policy", "irssi",
         :env => { "DEBIAN_FRONTEND" => "noninteractive" },
         :timeout => @timeout
@@ -229,7 +229,7 @@ mpg123 1.12.1-0ubuntu1
 
     it "raises an exception if a source is specified (CHEF-5113)" do
       @new_resource.source "pluto"
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "apt-cache", "policy", @new_resource.package_name,
         :env => { "DEBIAN_FRONTEND" => "noninteractive" } ,
         :timeout => @timeout
@@ -258,7 +258,7 @@ mpg123 1.12.1-0ubuntu1
 
     describe "install_package" do
       it "should run apt-get install with the package name and version" do
-        expect(@provider).to receive(:shell_out!). with(
+        expect(@provider).to receive(:shell_out_compacted!). with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -267,7 +267,7 @@ mpg123 1.12.1-0ubuntu1
       end
 
       it "should run apt-get install with the package name and version and options if specified" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "--force-yes", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -283,7 +283,7 @@ mpg123 1.12.1-0ubuntu1
         @new_resource.provider = nil
         @provider.new_resource = @new_resource
 
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "-o", "APT::Default-Release=lenny-backports", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -293,7 +293,7 @@ mpg123 1.12.1-0ubuntu1
       end
 
       it "should run apt-get install with the package name and quotes options if specified" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "--force-yes", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confnew", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -314,7 +314,7 @@ mpg123 1.12.1-0ubuntu1
     describe Chef::Resource::AptPackage, "remove_package" do
 
       it "should run apt-get remove with the package name" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "remove", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -323,7 +323,7 @@ mpg123 1.12.1-0ubuntu1
       end
 
       it "should run apt-get remove with the package name and options if specified" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "--force-yes", "remove", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -337,7 +337,7 @@ mpg123 1.12.1-0ubuntu1
     describe "when purging a package" do
 
       it "should run apt-get purge with the package name" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "purge", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -346,7 +346,7 @@ mpg123 1.12.1-0ubuntu1
       end
 
       it "should run apt-get purge with the package name and options if specified" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "--force-yes", "purge", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -365,7 +365,7 @@ mpg123 1.12.1-0ubuntu1
       it "should get the full path to the preseed response file" do
         file = "/tmp/irssi-0.8.12-7.seed"
 
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "debconf-set-selections", "/tmp/irssi-0.8.12-7.seed",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -375,7 +375,7 @@ mpg123 1.12.1-0ubuntu1
       end
 
       it "should run debconf-set-selections on the preseed file if it has changed" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "debconf-set-selections", "/tmp/irssi-0.8.12-7.seed",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -389,14 +389,14 @@ mpg123 1.12.1-0ubuntu1
         @current_resource.version "0.8.11"
         @new_resource.response_file "/tmp/file"
         allow(@provider).to receive(:get_preseed_file).and_return(false)
-        expect(@provider).not_to receive(:shell_out!)
+        expect(@provider).not_to receive(:shell_out_compacted!)
         @provider.run_action(:reconfig)
       end
     end
 
     describe "when reconfiguring a package" do
       it "should run dpkg-reconfigure package" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "dpkg-reconfigure", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -407,7 +407,7 @@ mpg123 1.12.1-0ubuntu1
 
     describe "when locking a package" do
       it "should run apt-mark hold package" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-mark", "hold", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -415,8 +415,8 @@ mpg123 1.12.1-0ubuntu1
         @provider.lock_package("irssi", "0.8.12-7")
       end
       it "should not lock if the package is already locked" do
-        allow(@provider).to receive(:shell_out_compact!).with(
-          "apt-mark", "showhold"
+        allow(@provider).to receive(:shell_out_compacted!).with(
+          "apt-mark", "showhold", timeout: 900
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: "irssi")
                     )
@@ -428,7 +428,7 @@ mpg123 1.12.1-0ubuntu1
 
     describe "when unlocking a package" do
       it "should run apt-mark unhold package" do
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-mark", "unhold", "irssi",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -436,8 +436,8 @@ mpg123 1.12.1-0ubuntu1
         @provider.unlock_package("irssi", "0.8.12-7")
       end
       it "should not unlock if the package is already unlocked" do
-        allow(@provider).to receive(:shell_out_compact!).with(
-          "apt-mark", "showhold"
+        allow(@provider).to receive(:shell_out_compacted!).with(
+          "apt-mark", "showhold", timeout: 900
         ).and_return(instance_double(
           Mixlib::ShellOut, stdout: "")
                     )
@@ -450,7 +450,7 @@ mpg123 1.12.1-0ubuntu1
     describe "when installing a virtual package" do
       it "should install the package without specifying a version" do
         @provider.package_data["libmysqlclient15-dev"][:virtual] = true
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "libmysqlclient15-dev",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -462,7 +462,7 @@ mpg123 1.12.1-0ubuntu1
     describe "when removing a virtual package" do
       it "should remove the resolved name instead of the virtual package name" do
         expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "remove", "libmysqlclient-dev",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -474,7 +474,7 @@ mpg123 1.12.1-0ubuntu1
     describe "when purging a virtual package" do
       it "should purge the resolved name instead of the virtual package name" do
         expect(@provider).to receive(:resolve_virtual_package_name).with("libmysqlclient15-dev").and_return("libmysqlclient-dev")
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "purge", "libmysqlclient-dev",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -486,7 +486,7 @@ mpg123 1.12.1-0ubuntu1
     describe "when installing multiple packages" do
       it "can install a virtual package followed by a non-virtual package" do
         # https://github.com/chef/chef/issues/2914
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "libmysqlclient15-dev", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -499,8 +499,8 @@ mpg123 1.12.1-0ubuntu1
       it "should run dpkg to compare versions if an existing version is installed" do
         allow(@provider).to receive(:get_current_versions).and_return("1.4.0")
         allow(@new_resource).to receive(:allow_downgrade).and_return(false)
-        expect(@provider).to receive(:shell_out_compact).with(
-          "dpkg", "--compare-versions", "1.4.0", "gt", "0.8.12-7"
+        expect(@provider).to receive(:shell_out_compacted).with(
+          "dpkg", "--compare-versions", "1.4.0", "gt", "0.8.12-7", timeout: 900
         ).and_return(double(error?: false))
         @provider.run_action(:upgrade)
       end
@@ -509,7 +509,7 @@ mpg123 1.12.1-0ubuntu1
         allow(@provider).to receive(:get_current_versions).and_return("0.4.0")
         allow(@new_resource).to receive(:allow_downgrade).and_return(false)
         expect(@provider).to receive(:version_compare).and_return(-1)
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout
@@ -521,7 +521,7 @@ mpg123 1.12.1-0ubuntu1
         allow(@provider).to receive(:get_current_versions).and_return(nil)
         allow(@new_resource).to receive(:allow_downgrade).and_return(false)
         expect(@provider).not_to receive(:version_compare)
-        expect(@provider).to receive(:shell_out!).with(
+        expect(@provider).to receive(:shell_out_compacted!).with(
           "apt-get", "-q", "-y", "-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "install", "irssi=0.8.12-7",
           :env => { "DEBIAN_FRONTEND" => "noninteractive" },
           :timeout => @timeout

--- a/spec/unit/provider/package/bff_spec.rb
+++ b/spec/unit/provider/package/bff_spec.rb
@@ -43,22 +43,22 @@ describe Chef::Provider::Package::Bff do
 
     it "should create a current resource with the name of new_resource" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("samba.base")
     end
 
     it "should set the current resource bff package name to the new resource bff package name" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("samba.base")
     end
 
     it "should raise an exception if a source is supplied but not found" do
-      allow(@provider).to receive(:shell_out).and_return(@empty_status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@empty_status)
       allow(::File).to receive(:exist?).with(@new_resource.source).and_return(false)
       @provider.load_current_resource
       @provider.define_resource_requirements
@@ -67,8 +67,8 @@ describe Chef::Provider::Package::Bff do
 
     it "should get the source package version from lslpp if provided" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("samba.base")
@@ -79,8 +79,8 @@ describe Chef::Provider::Package::Bff do
       info = "samba.base:samba.base.samples:3.3.12.0::COMMITTED:I:Samba for AIX:
   /etc/objrepos:samba.base:3.3.12.0::COMMITTED:I:Samba for AIX:"
       status = double("Status", :stdout => info, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
       expect(logger).to receive(:warn).once.with(%r{bff package by product name})
       @provider.load_current_resource
 
@@ -92,8 +92,8 @@ describe Chef::Provider::Package::Bff do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
       @stdout = StringIO.new(@bffinfo)
       @stdin, @stderr = StringIO.new, StringIO.new
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("3.3.12.0")
     end
@@ -102,20 +102,20 @@ describe Chef::Provider::Package::Bff do
       status = double("Status", :stdout => "", :exitstatus => 1, :format_for_exception => "")
       @new_resource = Chef::Resource::Package.new("samba.base")
       @provider = Chef::Provider::Package::Bff.new(@new_resource, @run_context)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should raise an exception if installp/lslpp fails to run" do
       status = double(:stdout => "", :exitstatus => -1, :format_for_exception => "")
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should return a current resource with a nil version if the package is not found" do
       status = double("Status", :stdout => @bffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
-      expect(@provider).to receive(:shell_out).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("lslpp", "-lcq", "samba.base", timeout: 900).and_return(@empty_status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
     end
@@ -124,7 +124,7 @@ describe Chef::Provider::Package::Bff do
       wrongbffinfo = "/usr/lib/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:
 /etc/objrepos:openssl.base:0.9.8.2400::COMMITTED:I:Open Secure Socket Layer:"
       status = double("Status", :stdout => wrongbffinfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("installp", "-L", "-d", "/tmp/samba.base", timeout: 900).and_return(status)
       expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
   end
@@ -132,19 +132,19 @@ describe Chef::Provider::Package::Bff do
   describe "candidate_version" do
     it "should return the candidate_version variable if already setup" do
       @provider.candidate_version = "3.3.12.0"
-      expect(@provider).not_to receive(:shell_out)
+      expect(@provider).not_to receive(:shell_out_compacted)
       @provider.candidate_version
     end
 
     it "should lookup the candidate_version if the variable is not already set" do
       status = double(:stdout => "", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).and_return(status)
       @provider.candidate_version
     end
 
     it "should throw and exception if the exitstatus is not 0" do
       @status = double(:stdout => "", :exitstatus => 1, :format_for_exception => "")
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
     end
 
@@ -152,7 +152,7 @@ describe Chef::Provider::Package::Bff do
 
   describe "install and upgrade" do
     it "should run installp -aYF -d with the package source to install" do
-      expect(@provider).to receive(:shell_out!).with("installp", "-aYF", "-d", "/tmp/samba.base", "samba.base", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("installp", "-aYF", "-d", "/tmp/samba.base", "samba.base", timeout: 900)
       @provider.install_package("samba.base", "3.3.12.0")
     end
 
@@ -160,26 +160,26 @@ describe Chef::Provider::Package::Bff do
       @new_resource = Chef::Resource::Package.new("/tmp/samba.base")
       @provider = Chef::Provider::Package::Bff.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/samba.base")
-      expect(@provider).to receive(:shell_out!).with("installp", "-aYF", "-d", "/tmp/samba.base", "/tmp/samba.base", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("installp", "-aYF", "-d", "/tmp/samba.base", "/tmp/samba.base", timeout: 900)
       @provider.install_package("/tmp/samba.base", "3.3.12.0")
     end
 
     it "should run installp with -eLogfile option." do
       @new_resource.options("-e/tmp/installp.log")
-      expect(@provider).to receive(:shell_out!).with("installp", "-aYF", "-e/tmp/installp.log", "-d", "/tmp/samba.base", "samba.base", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("installp", "-aYF", "-e/tmp/installp.log", "-d", "/tmp/samba.base", "samba.base", timeout: 900)
       @provider.install_package("samba.base", "3.3.12.0")
     end
   end
 
   describe "remove" do
     it "should run installp -u samba.base to remove the package" do
-      expect(@provider).to receive(:shell_out!).with("installp", "-u", "samba.base", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("installp", "-u", "samba.base", timeout: 900)
       @provider.remove_package("samba.base", "3.3.12.0")
     end
 
     it "should run installp -u -e/tmp/installp.log  with options -e/tmp/installp.log" do
       @new_resource.options("-e/tmp/installp.log")
-      expect(@provider).to receive(:shell_out!).with("installp", "-u", "-e/tmp/installp.log", "samba.base", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("installp", "-u", "-e/tmp/installp.log", "samba.base", timeout: 900)
       @provider.remove_package("samba.base", "3.3.12.0")
     end
 

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -46,7 +46,7 @@ ConEmu|15.10.25.0
     allow(provider).to receive(:choco_install_path).and_return(choco_install_path)
     allow(provider).to receive(:choco_exe).and_return(choco_exe)
     local_list_obj = double(:stdout => local_list_stdout)
-    allow(provider).to receive(:shell_out!).with("#{choco_exe} list -l -r", { :returns => [0], :timeout => timeout }).and_return(local_list_obj)
+    allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -l -r", { :returns => [0], :timeout => timeout }).and_return(local_list_obj)
   end
 
   def allow_remote_list(package_names, args = nil)
@@ -60,7 +60,7 @@ munin-node|1.6.1.20130823
     EOF
     remote_list_obj = double(stdout: remote_list_stdout)
     package_names.each do |pkg|
-      allow(provider).to receive(:shell_out!).with("#{choco_exe} list -r #{pkg}#{args}", { :returns => [0], timeout: timeout }).and_return(remote_list_obj)
+      allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -r #{pkg}#{args}", { :returns => [0], timeout: timeout }).and_return(remote_list_obj)
     end
   end
 
@@ -182,7 +182,7 @@ munin-node|1.6.1.20130823
     it "should install a single package" do
       allow_remote_list(["git"])
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -193,7 +193,7 @@ munin-node|1.6.1.20130823
         allow_remote_list(["git"])
         new_resource.timeout(timeout)
         provider.load_current_resource
-        expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
+        expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
         provider.run_action(:install)
         expect(new_resource).to be_updated_by_last_action
       end
@@ -222,7 +222,7 @@ munin-node|1.6.1.20130823
       new_resource.package_name("ConEmu")
       new_resource.version("15.10.25.1")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -235,7 +235,7 @@ munin-node|1.6.1.20130823
       new_resource.package_name(%w{chocolatey ConEmu})
       new_resource.version([nil, "15.10.25.1"])
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -245,7 +245,7 @@ munin-node|1.6.1.20130823
       new_resource.package_name("conemu")
       new_resource.version("15.10.25.1")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -255,8 +255,8 @@ munin-node|1.6.1.20130823
       new_resource.package_name(%w{ConEmu git})
       new_resource.version(["15.10.25.1", nil])
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y --version 15.10.25.1 conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y git", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -265,7 +265,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git", "munin-node"])
       new_resource.package_name(["git", "munin-node"])
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y git munin-node", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y git munin-node", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -275,7 +275,7 @@ munin-node|1.6.1.20130823
         allow_remote_list(["git"], " -source localpackages")
         new_resource.source("localpackages")
         provider.load_current_resource
-        expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y -source localpackages git", { :returns => [0], :timeout => timeout }).and_return(double)
+        expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y -source localpackages git", { :returns => [0], :timeout => timeout }).and_return(double)
         provider.run_action(:install)
         expect(new_resource).to be_updated_by_last_action
       end
@@ -285,7 +285,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git"])
       new_resource.options("-force")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} install -y -force git", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y -force git", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -319,7 +319,7 @@ munin-node|1.6.1.20130823
     it "should install a package that is not installed" do
       allow_remote_list(["git"])
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} upgrade -y git", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y git", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -328,7 +328,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["ConEmu"])
       new_resource.package_name("ConEmu")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} upgrade -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -337,7 +337,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["conemu"])
       new_resource.package_name("conemu")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} upgrade -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -346,7 +346,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["chocolatey"])
       new_resource.package_name("chocolatey")
       provider.load_current_resource
-      expect(provider).not_to receive(:shell_out!).with("#{choco_exe} upgrade -y chocolatey", { :returns => [0], :timeout => timeout })
+      expect(provider).not_to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y chocolatey", { :returns => [0], :timeout => timeout })
       provider.run_action(:upgrade)
       expect(new_resource).not_to be_updated_by_last_action
     end
@@ -355,7 +355,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["git"])
       new_resource.version("2.6.2")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} upgrade -y --version 2.6.2 git", { :returns => [0], :timeout => timeout })
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y --version 2.6.2 git", { :returns => [0], :timeout => timeout })
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -363,7 +363,7 @@ munin-node|1.6.1.20130823
     it "upgrading multiple packages uses a single command" do
       allow_remote_list(%w{conemu git})
       new_resource.package_name(%w{conemu git})
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} upgrade -y conemu git", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} upgrade -y conemu git", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:upgrade)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -415,7 +415,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["ConEmu"])
       new_resource.package_name("ConEmu")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} uninstall -y ConEmu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} uninstall -y ConEmu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -424,7 +424,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(["conemu"])
       new_resource.package_name("conemu")
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} uninstall -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} uninstall -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -434,7 +434,7 @@ munin-node|1.6.1.20130823
       allow_remote_list(%w{git conemu})
       new_resource.package_name(%w{git conemu})
       provider.load_current_resource
-      expect(provider).to receive(:shell_out!).with("#{choco_exe} uninstall -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
+      expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} uninstall -y conemu", { :returns => [0], :timeout => timeout }).and_return(double)
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -457,7 +457,7 @@ describe "behavior when Chocolatey is not installed" do
     provider.instance_variable_set("@choco_install_path", nil)
 
     # we don't care what this returns, but we have to let it be called.
-    allow(provider).to receive(:shell_out!).and_return(double(:stdout => ""))
+    allow(provider).to receive(:shell_out_compacted!).and_return(double(:stdout => ""))
   end
 
   let(:error_regex) do

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -51,8 +51,8 @@ Conflicts: wget-ssl
   end
 
   before(:each) do
-    allow(provider).to receive(:shell_out!).with("dpkg-deb", "-W", source, timeout: 900).and_return(dpkg_deb_status)
-    allow(provider).to receive(:shell_out!).with("dpkg", "-s", package, timeout: 900, returns: [0, 1]).and_return(double(stdout: "", exitstatus: 1))
+    allow(provider).to receive(:shell_out_compacted!).with("dpkg-deb", "-W", source, timeout: 900).and_return(dpkg_deb_status)
+    allow(provider).to receive(:shell_out_compacted!).with("dpkg", "-s", package, timeout: 900, returns: [0, 1]).and_return(double(stdout: "", exitstatus: 1))
     allow(::File).to receive(:exist?).with(source).and_return(true)
   end
 
@@ -113,7 +113,7 @@ Conflicts: wget-ssl
     describe "gets the source package version from dpkg-deb" do
       def check_version(version)
         status = double(:stdout => "wget\t#{version}", :exitstatus => 0)
-        expect(provider).to receive(:shell_out!).with("dpkg-deb", "-W", source, timeout: 900).and_return(status)
+        expect(provider).to receive(:shell_out_compacted!).with("dpkg-deb", "-W", source, timeout: 900).and_return(status)
         provider.load_current_resource
         expect(provider.current_resource.package_name).to eq(["wget"])
         expect(provider.candidate_version).to eq([version])
@@ -165,7 +165,7 @@ Conflicts: wget-ssl
     end
 
     it "should return the current version installed if found by dpkg" do
-      allow(provider).to receive(:shell_out!).with("dpkg", "-s", package, timeout: 900, returns: [0, 1]).and_return(dpkg_s_status)
+      allow(provider).to receive(:shell_out_compacted!).with("dpkg", "-s", package, timeout: 900, returns: [0, 1]).and_return(dpkg_s_status)
       provider.load_current_resource
       expect(provider.current_resource.version).to eq(["1.11.4-1ubuntu1"])
     end
@@ -178,7 +178,7 @@ Use dpkg --info (= dpkg-deb --info) to examine archive files,
 and dpkg --contents (= dpkg-deb --contents) to list their contents.
         EOF
       )
-      expect(provider).to receive(:shell_out!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_return(dpkg_s_status)
+      expect(provider).to receive(:shell_out_compacted!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_return(dpkg_s_status)
       provider.load_current_resource
       expect(provider.current_resource.version).to eq([nil])
     end
@@ -192,7 +192,7 @@ Priority: extra
 Section: ruby
         EOF
       )
-      expect(provider).to receive(:shell_out!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_return(dpkg_s_status)
+      expect(provider).to receive(:shell_out_compacted!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_return(dpkg_s_status)
       provider.load_current_resource
       expect(provider.current_resource.version).to eq([nil])
     end
@@ -201,13 +201,13 @@ Section: ruby
       dpkg_s_status = double(
         exitstatus: 3, stderr: "i am very, very angry with you.  i'm very, very cross.  go to your room.", stdout: ""
       )
-      expect(provider).to receive(:shell_out!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
+      expect(provider).to receive(:shell_out_compacted!).with("dpkg", "-s", package, returns: [0, 1], timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
       expect { provider.load_current_resource }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 
     it "should raise an exception if dpkg-deb -W fails to run" do
       status = double(:stdout => "", :exitstatus => -1)
-      expect(provider).to receive(:shell_out_compact!).with("dpkg-deb", "-W", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb").and_raise(Mixlib::ShellOut::ShellCommandFailed)
+      expect(provider).to receive(:shell_out_compacted!).with("dpkg-deb", "-W", "/tmp/wget_1.11.4-1ubuntu1_amd64.deb", timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
       expect { provider.load_current_resource }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
   end

--- a/spec/unit/provider/package/freebsd/pkg_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkg_spec.rb
@@ -79,21 +79,21 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should return the version number when it is installed" do
       pkg_info = OpenStruct.new(:stdout => "zsh-4.3.6_7")
-      expect(@provider).to receive(:shell_out!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
       allow(@provider).to receive(:package_name).and_return("zsh")
       expect(@provider.current_installed_version).to eq("4.3.6_7")
     end
 
     it "does not set the current version number when the package is not installed" do
       pkg_info = OpenStruct.new(:stdout => "")
-      expect(@provider).to receive(:shell_out!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
       allow(@provider).to receive(:package_name).and_return("zsh")
       expect(@provider.current_installed_version).to be_nil
     end
 
     it "should return the port path for a valid port name" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
+      expect(@provider).to receive(:shell_out_compacted!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
       allow(@provider).to receive(:port_name).and_return("zsh")
       expect(@provider.port_path).to eq("/usr/ports/shells/zsh")
     end
@@ -102,7 +102,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     it "should return the ports candidate version when given a valid port path" do
       allow(@provider).to receive(:port_path).and_return("/usr/ports/shells/zsh")
       make_v = OpenStruct.new(:stdout => "4.3.6\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("make", "-V", "PORTVERSION", { cwd: "/usr/ports/shells/zsh", returns: [0, 1], env: nil, timeout: 900 }).and_return(make_v)
+      expect(@provider).to receive(:shell_out_compacted!).with("make", "-V", "PORTVERSION", { cwd: "/usr/ports/shells/zsh", returns: [0, 1], env: nil, timeout: 900 }).and_return(make_v)
       expect(@provider.ports_candidate_version).to eq("4.3.6")
     end
 
@@ -110,7 +110,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(::File).to receive(:exist?).with("/usr/ports/Makefile").and_return(true)
       allow(@provider).to receive(:port_path).and_return("/usr/ports/shells/zsh")
       make_v = OpenStruct.new(:stdout => "zsh-4.3.6_7\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("make", "-V", "PKGNAME", { cwd: "/usr/ports/shells/zsh", env: nil, returns: [0, 1], timeout: 900 }).and_return(make_v)
+      expect(@provider).to receive(:shell_out_compacted!).with("make", "-V", "PKGNAME", { cwd: "/usr/ports/shells/zsh", env: nil, returns: [0, 1], timeout: 900 }).and_return(make_v)
       #@provider.should_receive(:ports_makefile_variable_value).with("PKGNAME").and_return("zsh-4.3.6_7")
       expect(@provider.package_name).to eq("zsh")
     end
@@ -127,7 +127,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_add -r with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pkg_add", "-r", "zsh", env: nil, timeout: 900).and_return(@cmd_result)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_add", "-r", "zsh", env: nil, timeout: 900).and_return(@cmd_result)
       @provider.install_package("zsh", "4.3.6_7")
     end
   end
@@ -142,7 +142,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should figure out the port path from the package_name using whereis" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
+      expect(@provider).to receive(:shell_out_compacted!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
       expect(@provider.port_path).to eq("/usr/ports/shells/zsh")
     end
 
@@ -178,7 +178,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_add -r with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pkg_add", "-r", "ruby18-iconv", env: nil, timeout: 900).and_return(@install_result)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_add", "-r", "ruby18-iconv", env: nil, timeout: 900).and_return(@install_result)
       @provider.install_package("ruby-iconv", "1.0")
     end
   end
@@ -193,7 +193,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
     end
 
     it "should run pkg_delete with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pkg_delete", "zsh-4.3.6_7", env: nil, timeout: 900).and_return(@pkg_delete)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_delete", "zsh-4.3.6_7", env: nil, timeout: 900).and_return(@pkg_delete)
       @provider.remove_package("zsh", "4.3.6_7")
     end
   end
@@ -213,14 +213,14 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
 
     it "should return the port path for a valid port name" do
       whereis = OpenStruct.new(:stdout => "bonnie++: /usr/ports/benchmarks/bonnie++")
-      expect(@provider).to receive(:shell_out!).with("whereis", "-s", "bonnie++", env: nil, timeout: 900).and_return(whereis)
+      expect(@provider).to receive(:shell_out_compacted!).with("whereis", "-s", "bonnie++", env: nil, timeout: 900).and_return(whereis)
       allow(@provider).to receive(:port_name).and_return("bonnie++")
       expect(@provider.port_path).to eq("/usr/ports/benchmarks/bonnie++")
     end
 
     it "should return the version number when it is installed" do
       pkg_info = OpenStruct.new(:stdout => "bonnie++-1.96")
-      expect(@provider).to receive(:shell_out!).with("pkg_info", "-E", "bonnie++*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_info", "-E", "bonnie++*", env: nil, returns: [0, 1], timeout: 900).and_return(pkg_info)
       allow(@provider).to receive(:package_name).and_return("bonnie++")
       expect(@provider.current_installed_version).to eq("1.96")
     end
@@ -253,7 +253,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(@provider).to receive(:latest_link_name).and_return("perl")
 
       cmd = OpenStruct.new(:status => true)
-      expect(@provider).to receive(:shell_out!).with("pkg_add", "-r", "perl", env: nil, timeout: 900).and_return(cmd)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_add", "-r", "perl", env: nil, timeout: 900).and_return(cmd)
       @provider.install_package("perl5.8", "5.8.8_1")
     end
 
@@ -267,7 +267,7 @@ describe Chef::Provider::Package::Freebsd::Pkg, "load_current_resource" do
       allow(@provider).to receive(:latest_link_name).and_return("mysql50-server")
 
       cmd = OpenStruct.new(:status => true)
-      expect(@provider).to receive(:shell_out!).with("pkg_add", "-r", "mysql50-server", env: nil, timeout: 900).and_return(cmd)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_add", "-r", "mysql50-server", env: nil, timeout: 900).and_return(cmd)
       @provider.install_package("mysql50-server", "5.0.45_1")
     end
   end

--- a/spec/unit/provider/package/freebsd/pkgng_spec.rb
+++ b/spec/unit/provider/package/freebsd/pkgng_spec.rb
@@ -67,7 +67,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     end
 
     it "should query pkg database" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
   end
@@ -75,14 +75,14 @@ describe Chef::Provider::Package::Freebsd::Port do
   describe "determining candidate version" do
     it "should query repository" do
       pkg_query = OpenStruct.new(:stdout => "5.0.5\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("pkg", "rquery", "%v", "zsh", env: nil, timeout: 900).and_return(pkg_query)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "rquery", "%v", "zsh", env: nil, timeout: 900).and_return(pkg_query)
       expect(@provider.candidate_version).to eq("5.0.5")
     end
 
     it "should query specified repository when given option" do
       @provider.new_resource.options("-r LocalMirror") # This requires LocalMirror repo configuration.
       pkg_query = OpenStruct.new(:stdout => "5.0.3\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out!).with("pkg", "rquery", "-r", "LocalMirror", "%v", "zsh", env: nil, timeout: 900).and_return(pkg_query)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "rquery", "-r", "LocalMirror", "%v", "zsh", env: nil, timeout: 900).and_return(pkg_query)
       expect(@provider.candidate_version).to eq("5.0.3")
     end
 
@@ -99,7 +99,7 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should handle package source from file" do
       @provider.new_resource.source("/nas/pkg/repo/zsh-5.0.1.txz")
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "add", "/nas/pkg/repo/zsh-5.0.1.txz", env: { "LC_ALL" => nil }, timeout: 900).
         and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
@@ -107,21 +107,21 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should handle package source over ftp or http" do
       @provider.new_resource.source("http://repo.example.com/zsh-5.0.1.txz")
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "add", "http://repo.example.com/zsh-5.0.1.txz", env: { "LC_ALL" => nil }, timeout: 900).
         and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
 
     it "should handle a package name" do
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "install", "-y", "zsh", env: { "LC_ALL" => nil }, timeout: 900).and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
 
     it "should handle a package name with a specified repo" do
       @provider.new_resource.options("-r LocalMirror") # This requires LocalMirror repo configuration.
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "install", "-y", "-r", "LocalMirror", "zsh", env: { "LC_ALL" => nil }, timeout: 900).and_return(@install_result)
       @provider.install_package("zsh", "5.0.1")
     end
@@ -133,14 +133,14 @@ describe Chef::Provider::Package::Freebsd::Port do
     end
 
     it "should call pkg delete" do
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "delete", "-y", "zsh-5.0.1", env: nil, timeout: 900).and_return(@install_result)
       @provider.remove_package("zsh", "5.0.1")
     end
 
     it "should not include repo option in pkg delete" do
       @provider.new_resource.options("-r LocalMirror") # This requires LocalMirror repo configuration.
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("pkg", "delete", "-y", "zsh-5.0.1", env: nil, timeout: 900).and_return(@install_result)
       @provider.remove_package("zsh", "5.0.1")
     end

--- a/spec/unit/provider/package/freebsd/port_spec.rb
+++ b/spec/unit/provider/package/freebsd/port_spec.rb
@@ -68,7 +68,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should check 'pkg_info' if system uses pkg_* tools" do
       allow(@new_resource).to receive(:supports_pkgng?)
       expect(@new_resource).to receive(:supports_pkgng?).and_return(false)
-      expect(@provider).to receive(:shell_out!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg_info", "-E", "zsh*", env: nil, returns: [0, 1], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
 
@@ -76,8 +76,8 @@ describe Chef::Provider::Package::Freebsd::Port do
       pkg_enabled = OpenStruct.new(:stdout => "yes\n")
       [1000016, 1000000, 901503, 902506, 802511].each do |freebsd_version|
         @node.automatic_attrs[:os_version] = freebsd_version
-        expect(@new_resource).to receive(:shell_out!).with("make", "-V", "WITH_PKGNG", env: nil).and_return(pkg_enabled)
-        expect(@provider).to receive(:shell_out!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
+        expect(@new_resource).to receive(:shell_out_compacted!).with("make", "-V", "WITH_PKGNG", env: nil).and_return(pkg_enabled)
+        expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
         expect(@provider.current_installed_version).to eq("3.1.7")
       end
     end
@@ -85,7 +85,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should check 'pkg info' if the freebsd version is greater than or equal to 1000017" do
       freebsd_version = 1000017
       @node.automatic_attrs[:os_version] = freebsd_version
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "zsh", env: nil, returns: [0, 70], timeout: 900).and_return(@pkg_info)
       expect(@provider.current_installed_version).to eq("3.1.7")
     end
   end
@@ -98,7 +98,7 @@ describe Chef::Provider::Package::Freebsd::Port do
     it "should return candidate version if port exists" do
       allow(::File).to receive(:exist?).with("/usr/ports/Makefile").and_return(true)
       allow(@provider).to receive(:port_dir).and_return("/usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).with("make", "-V", "PORTVERSION", cwd: "/usr/ports/shells/zsh", env: nil, returns: [0, 1], timeout: 900).
+      expect(@provider).to receive(:shell_out_compacted!).with("make", "-V", "PORTVERSION", cwd: "/usr/ports/shells/zsh", env: nil, returns: [0, 1], timeout: 900).
         and_return(@port_version)
       expect(@provider.candidate_version).to eq("5.0.5")
     end
@@ -122,13 +122,13 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should query system for path given just a name" do
       whereis = OpenStruct.new(:stdout => "zsh: /usr/ports/shells/zsh\n")
-      expect(@provider).to receive(:shell_out!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
+      expect(@provider).to receive(:shell_out_compacted!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
       expect(@provider.port_dir).to eq("/usr/ports/shells/zsh")
     end
 
     it "should raise exception if not found" do
       whereis = OpenStruct.new(:stdout => "zsh:\n")
-      expect(@provider).to receive(:shell_out!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
+      expect(@provider).to receive(:shell_out_compacted!).with("whereis", "-s", "zsh", env: nil, timeout: 900).and_return(whereis)
       expect { @provider.port_dir }.to raise_error(Chef::Exceptions::Package, "Could not find port with the name zsh")
     end
   end
@@ -140,7 +140,7 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should run make install in port directory" do
       allow(@provider).to receive(:port_dir).and_return("/usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("make", "-DBATCH", "install", "clean", :timeout => 1800, :cwd => "/usr/ports/shells/zsh", :env => nil).
         and_return(@install_result)
       @provider.install_package("zsh", "5.0.5")
@@ -154,7 +154,7 @@ describe Chef::Provider::Package::Freebsd::Port do
 
     it "should run make deinstall in port directory" do
       allow(@provider).to receive(:port_dir).and_return("/usr/ports/shells/zsh")
-      expect(@provider).to receive(:shell_out!).
+      expect(@provider).to receive(:shell_out_compacted!).
         with("make", "deinstall", :timeout => 300, :cwd => "/usr/ports/shells/zsh", :env => nil).
         and_return(@install_result)
       @provider.remove_package("zsh", "5.0.5")

--- a/spec/unit/provider/package/ips_spec.rb
+++ b/spec/unit/provider/package/ips_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@chef.io>
-# Copyright:: Copyright 2012-2017, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,28 +64,28 @@ PKG_STATUS
 
   context "when loading current resource" do
     it "should create a current resource with the name of the new_resource" do
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       expect(Chef::Resource::IpsPackage).to receive(:new).and_return(@current_resource)
       @provider.load_current_resource
     end
 
     it "should set the current resources package name to the new resources package name" do
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.package_name).to eq(@new_resource.package_name)
     end
 
     it "should run pkg info with the package name" do
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       @provider.load_current_resource
     end
 
     it "should set the installed version to nil on the current resource if package state is not installed" do
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.version).to be_nil
     end
@@ -107,33 +107,33 @@ Packaging Date: October 19, 2011 09:14:50 AM
           Size: 8.07 MB
           FMRI: pkg://solaris/crypto/gnupg@2.0.17,5.11-0.175.0.0.0.2.537:20111019T091450Z
 INSTALLED
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       @provider.load_current_resource
       expect(@current_resource.version).to eq("2.0.17")
     end
 
     it "should return the current resource" do
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote_output)
       expect(@provider.load_current_resource).to eql(@current_resource)
     end
   end
 
   context "when installing a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900)
       @provider.install_package("crypto/gnupg", "2.0.17")
     end
 
     it "should run pkg install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "--no-refresh", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "--no-refresh", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900)
       @new_resource.options "--no-refresh"
       @provider.install_package("crypto/gnupg", "2.0.17")
     end
 
     it "raises an error if package fails to install" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "--no-refresh", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "--no-refresh", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900).and_raise(Mixlib::ShellOut::ShellCommandFailed)
       @new_resource.options("--no-refresh")
       expect { @provider.install_package("crypto/gnupg", "2.0.17") }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
@@ -152,8 +152,8 @@ Packaging Date: April  1, 2012 05:55:52 PM
           Size: 2.57 MB
           FMRI: pkg://omnios/security/sudo@1.8.4.1,5.11-0.151002:20120401T175552Z
 PKG_STATUS
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote)
       @provider.load_current_resource
       expect(@current_resource.version).to be_nil
       expect(@provider.candidate_version).to eql("1.8.4.1")
@@ -193,8 +193,8 @@ Packaging Date: October 19, 2011 09:14:50 AM
           FMRI: pkg://solaris/crypto/gnupg@2.0.18,5.11-0.175.0.0.0.2.537:20111019T091450Z
 REMOTE
 
-      expect(@provider).to receive(:shell_out).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local)
-      expect(@provider).to receive(:shell_out!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote)
+      expect(@provider).to receive(:shell_out_compacted).with("pkg", "info", @new_resource.package_name, timeout: 900).and_return(local)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "info", "-r", @new_resource.package_name, timeout: 900).and_return(remote)
       expect(@provider).to receive(:install_package).exactly(0).times
       @provider.run_action(:install)
     end
@@ -205,7 +205,7 @@ REMOTE
       end
 
       it "should run pkg install with the --accept flag" do
-        expect(@provider).to receive(:shell_out).with("pkg", "install", "-q", "--accept", "crypto/gnupg@2.0.17", timeout: 900).and_return(local_output)
+        expect(@provider).to receive(:shell_out_compacted!).with("pkg", "install", "-q", "--accept", "crypto/gnupg@2.0.17", timeout: 900).and_return(local_output)
         @provider.install_package("crypto/gnupg", "2.0.17")
       end
     end
@@ -213,19 +213,19 @@ REMOTE
 
   context "when upgrading a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out).with("pkg", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900).and_return(local_output)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "install", "-q", "crypto/gnupg@2.0.17", timeout: 900).and_return(local_output)
       @provider.upgrade_package("crypto/gnupg", "2.0.17")
     end
   end
 
   context "when uninstalling a package" do
     it "should run pkg uninstall with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "uninstall", "-q", "crypto/gnupg@2.0.17", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "uninstall", "-q", "crypto/gnupg@2.0.17", timeout: 900)
       @provider.remove_package("crypto/gnupg", "2.0.17")
     end
 
     it "should run pkg uninstall with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pkg", "--no-refresh", "uninstall", "-q", "crypto/gnupg@2.0.17", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("pkg", "--no-refresh", "uninstall", "-q", "crypto/gnupg@2.0.17", timeout: 900)
       @new_resource.options "--no-refresh"
       @provider.remove_package("crypto/gnupg", "2.0.17")
     end

--- a/spec/unit/provider/package/macports_spec.rb
+++ b/spec/unit/provider/package/macports_spec.rb
@@ -76,13 +76,13 @@ The following ports are currently installed:
 EOF
 
       status = double(:stdout => stdout, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).and_return(status)
       expect(@provider.current_installed_version).to eq("0.9.8k_0")
     end
 
     it "should return nil if a package is not currently installed" do
       status = double(:stdout => "       \n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).and_return(status)
       expect(@provider.current_installed_version).to be_nil
     end
   end
@@ -90,13 +90,13 @@ EOF
   describe "macports_candidate_version" do
     it "should return the latest available version of a given package" do
       status = double(:stdout => "version: 4.2.7\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).and_return(status)
       expect(@provider.macports_candidate_version).to eq("4.2.7")
     end
 
     it "should return nil if there is no version for a given package" do
       status = double(:stdout => "Error: port fadsfadsfads not found\n", :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).and_return(status)
       expect(@provider.macports_candidate_version).to be_nil
     end
   end
@@ -105,7 +105,7 @@ EOF
     it "should run the port install command with the correct version" do
       expect(@current_resource).to receive(:version).and_return("4.1.6")
       @provider.current_resource = @current_resource
-      expect(@provider).to receive(:shell_out!).with("port", "install", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "install", "zsh", "@4.2.7", timeout: 900)
 
       @provider.install_package("zsh", "4.2.7")
     end
@@ -113,7 +113,7 @@ EOF
     it "should not do anything if a package already exists with the same version" do
       expect(@current_resource).to receive(:version).and_return("4.2.7")
       @provider.current_resource = @current_resource
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
 
       @provider.install_package("zsh", "4.2.7")
     end
@@ -122,7 +122,7 @@ EOF
       expect(@current_resource).to receive(:version).and_return("4.1.6")
       @provider.current_resource = @current_resource
       @new_resource.options("-f")
-      expect(@provider).to receive(:shell_out!).with("port", "-f", "install", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "-f", "install", "zsh", "@4.2.7", timeout: 900)
 
       @provider.install_package("zsh", "4.2.7")
     end
@@ -130,36 +130,36 @@ EOF
 
   describe "purge_package" do
     it "should run the port uninstall command with the correct version" do
-      expect(@provider).to receive(:shell_out!).with("port", "uninstall", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "uninstall", "zsh", "@4.2.7", timeout: 900)
       @provider.purge_package("zsh", "4.2.7")
     end
 
     it "should purge the currently active version if no explicit version is passed in" do
-      expect(@provider).to receive(:shell_out!).with("port", "uninstall", "zsh", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "uninstall", "zsh", timeout: 900)
       @provider.purge_package("zsh", nil)
     end
 
     it "should add options to the port command when specified" do
       @new_resource.options("-f")
-      expect(@provider).to receive(:shell_out!).with("port", "-f", "uninstall", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "-f", "uninstall", "zsh", "@4.2.7", timeout: 900)
       @provider.purge_package("zsh", "4.2.7")
     end
   end
 
   describe "remove_package" do
     it "should run the port deactivate command with the correct version" do
-      expect(@provider).to receive(:shell_out!).with("port", "deactivate", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "deactivate", "zsh", "@4.2.7", timeout: 900)
       @provider.remove_package("zsh", "4.2.7")
     end
 
     it "should remove the currently active version if no explicit version is passed in" do
-      expect(@provider).to receive(:shell_out!).with("port", "deactivate", "zsh", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "deactivate", "zsh", timeout: 900)
       @provider.remove_package("zsh", nil)
     end
 
     it "should add options to the port command when specified" do
       @new_resource.options("-f")
-      expect(@provider).to receive(:shell_out!).with("port", "-f", "deactivate", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "-f", "deactivate", "zsh", "@4.2.7", timeout: 900)
       @provider.remove_package("zsh", "4.2.7")
     end
   end
@@ -169,7 +169,7 @@ EOF
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.1.6")
       @provider.current_resource = @current_resource
 
-      expect(@provider).to receive(:shell_out!).with("port", "upgrade", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "upgrade", "zsh", "@4.2.7", timeout: 900)
 
       @provider.upgrade_package("zsh", "4.2.7")
     end
@@ -177,7 +177,7 @@ EOF
     it "should not run the port upgrade command if the version is already installed" do
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.2.7")
       @provider.current_resource = @current_resource
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
 
       @provider.upgrade_package("zsh", "4.2.7")
     end
@@ -195,7 +195,7 @@ EOF
       expect(@current_resource).to receive(:version).at_least(:once).and_return("4.1.6")
       @provider.current_resource = @current_resource
 
-      expect(@provider).to receive(:shell_out!).with("port", "-f", "upgrade", "zsh", "@4.2.7", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("port", "-f", "upgrade", "zsh", "@4.2.7", timeout: 900)
 
       @provider.upgrade_package("zsh", "4.2.7")
     end

--- a/spec/unit/provider/package/msu_spec.rb
+++ b/spec/unit/provider/package/msu_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -243,7 +243,7 @@ The operation completed successfully.
 
   describe "#extract_msu_contents" do
     it "extracts the msu contents by using mixlib shellout" do
-      expect(provider).to receive(:shell_out_with_timeout!).with("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* msu_file destination")
+      expect(provider).to receive(:shell_out!).with("#{ENV['SYSTEMROOT']}\\system32\\expand.exe -f:* msu_file destination")
       provider.extract_msu_contents("msu_file", "destination")
     end
   end

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -45,16 +45,16 @@ describe Chef::Provider::Package::Openbsd do
 
     context "when not already installed" do
       before do
-        allow(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
+        allow(provider).to receive(:shell_out_compacted!).with("pkg_info", "-e", "#{name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
       end
 
       context "when there is a single candidate" do
 
         context "when source is not provided" do
           it "should run the installation command" do
-            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything()).and_return(
+            expect(provider).to receive(:shell_out_compacted!).with("pkg_info", "-I", name, anything()).and_return(
               instance_double("shellout", :stdout => "#{name}-#{version}\n"))
-            expect(provider).to receive(:shell_out!).with(
+            expect(provider).to receive(:shell_out_compacted!).with(
               "pkg_add", "-r", "#{name}-#{version}",
               { :env => { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
             ) { OpenStruct.new :status => true }
@@ -69,7 +69,7 @@ describe Chef::Provider::Package::Openbsd do
 
         context "if no version is specified" do
           it "should raise an exception" do
-            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything()).and_return(
+            expect(provider).to receive(:shell_out_compacted!).with("pkg_info", "-I", name, anything()).and_return(
               instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor_a}\n#{name}-#{version}-#{flavor_b}\n"))
             expect { provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /multiple matching candidates/)
           end
@@ -83,10 +83,10 @@ describe Chef::Provider::Package::Openbsd do
 
           context "if no version is specified" do
             it "should run the installation command" do
-              expect(provider).to receive(:shell_out!).with("pkg_info", "-e", "#{package_name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
-              expect(provider).to receive(:shell_out!).with("pkg_info", "-I", name, anything()).and_return(
+              expect(provider).to receive(:shell_out_compacted!).with("pkg_info", "-e", "#{package_name}->0", anything()).and_return(instance_double("shellout", :stdout => ""))
+              expect(provider).to receive(:shell_out_compacted!).with("pkg_info", "-I", name, anything()).and_return(
                 instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor}\n"))
-              expect(provider).to receive(:shell_out!).with(
+              expect(provider).to receive(:shell_out_compacted!).with(
                 "pkg_add", "-r", "#{name}-#{version}-#{flavor}",
                 { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
               ) { OpenStruct.new :status => true }
@@ -98,11 +98,11 @@ describe Chef::Provider::Package::Openbsd do
 
         context "if a version is specified" do
           it "should use the flavor from the version" do
-            expect(provider).to receive(:shell_out!).with("pkg_info", "-I", "#{name}-#{version}-#{flavor_b}", anything()).and_return(
+            expect(provider).to receive(:shell_out_compacted!).with("pkg_info", "-I", "#{name}-#{version}-#{flavor_b}", anything()).and_return(
               instance_double("shellout", :stdout => "#{name}-#{version}-#{flavor_a}\n"))
 
             new_resource.version("#{version}-#{flavor_b}")
-            expect(provider).to receive(:shell_out!).with(
+            expect(provider).to receive(:shell_out_compacted!).with(
               "pkg_add", "-r", "#{name}-#{version}-#{flavor_b}",
               { env: { "PKG_PATH" => "http://ftp.OpenBSD.org/pub/OpenBSD/5.5/packages/amd64/" }, timeout: 900 }
             ) { OpenStruct.new :status => true }
@@ -122,7 +122,7 @@ describe Chef::Provider::Package::Openbsd do
       @provider.current_resource = @current_resource
     end
     it "should run the command to delete the installed package" do
-      expect(@provider).to receive(:shell_out!).with(
+      expect(@provider).to receive(:shell_out_compacted!).with(
         "pkg_delete", @name, env: nil, timeout: 900
       ) { OpenStruct.new :status => true }
       @provider.remove_package(@name, nil)

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Provider::Package::Pacman do
     @provider = Chef::Provider::Package::Pacman.new(@new_resource, @run_context)
     allow(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
 
-    allow(@provider).to receive(:shell_out).and_return(@status)
+    allow(@provider).to receive(:shell_out_compacted).and_return(@status)
     @stdin = StringIO.new
     @stdout = StringIO.new(<<-ERR)
 error: package "nano" not found
@@ -51,17 +51,17 @@ ERR
     end
 
     it "should run pacman query with the package name" do
-      expect(@provider).to receive(:shell_out).with("pacman", "-Qi", @new_resource.package_name, { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out_compacted).with("pacman", "-Qi", @new_resource.package_name, { timeout: 900 }).and_return(@status)
       @provider.load_current_resource
     end
 
     it "should read stdout on pacman" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       @provider.load_current_resource
     end
 
     it "should set the installed version to nil on the current resource if pacman installed version not exists" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       @provider.load_current_resource
     end
 
@@ -89,14 +89,14 @@ Description    : Pico editor clone with enhancements
 PACMAN
 
       status = double(:stdout => stdout, :exitstatus => 0)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       @provider.load_current_resource
       expect(@current_resource.version).to eq("2.2.2-1")
     end
 
     it "should set the candidate version if pacman has one" do
       status = double(:stdout => "core nano 2.2.3-1", :exitstatus => 0)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       @provider.load_current_resource
       expect(@provider.candidate_version).to eql("2.2.3-1")
     end
@@ -123,7 +123,7 @@ PACMAN_CONF
       status = double(:stdout => "customrepo nano 1.2.3-4", :exitstatus => 0)
       allow(::File).to receive(:exist?).with("/etc/pacman.conf").and_return(true)
       allow(::File).to receive(:read).with("/etc/pacman.conf").and_return(@pacman_conf)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
 
       @provider.load_current_resource
       expect(@provider.candidate_version).to eql("1.2.3-4")
@@ -140,7 +140,7 @@ PACMAN_CONF
     end
 
     it "should raise an exception if pacman does not return a candidate version" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
     end
 
@@ -151,12 +151,12 @@ PACMAN_CONF
 
   describe Chef::Provider::Package::Pacman, "install_package" do
     it "should run pacman install with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
       @provider.install_package("nano", "1.0")
     end
 
     it "should run pacman install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
       @new_resource.options("--debug")
 
       @provider.install_package("nano", "1.0")
@@ -172,12 +172,12 @@ PACMAN_CONF
 
   describe Chef::Provider::Package::Pacman, "remove_package" do
     it "should run pacman remove with the package name" do
-      expect(@provider).to receive(:shell_out!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
       @provider.remove_package("nano", "1.0")
     end
 
     it "should run pacman remove with the package name and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
       @new_resource.options("--debug")
 
       @provider.remove_package("nano", "1.0")

--- a/spec/unit/provider/package/paludis_spec.rb
+++ b/spec/unit/provider/package/paludis_spec.rb
@@ -47,19 +47,19 @@ PKG_STATUS
 
   context "when loading current resource" do
     it "should create a current resource with the name of the new_resource" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
       @provider.load_current_resource
     end
 
     it "should set the current resources package name to the new resources package name" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       expect(@current_resource).to receive(:package_name).with(@new_resource.package_name)
       @provider.load_current_resource
     end
 
     it "should run pkg info with the package name" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "print-ids", "-M", "none", "-m", @new_resource.package_name, "-f", "%c/%p %v %r\n", timeout: 900).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "print-ids", "-M", "none", "-m", @new_resource.package_name, "-f", "%c/%p %v %r\n", timeout: 900).and_return(@shell_out)
       @provider.load_current_resource
     end
 
@@ -72,26 +72,26 @@ user/ntp 0 accounts
 user/ntp 0 installed-accounts
 net/ntp 4.2.6_p5-r1 installed
 INSTALLED
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       @provider.load_current_resource
       expect(@current_resource.version).to eq("4.2.6_p5-r1")
       expect(@provider.candidate_version).to eql("4.2.6_p5-r2")
     end
 
     it "should return the current resource" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       expect(@provider.load_current_resource).to eql(@current_resource)
     end
   end
 
   context "when installing a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "resolve", "-x", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "resolve", "-x", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
       @provider.install_package("net/ntp", "4.2.6_p5-r2")
     end
 
     it "should run pkg install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "resolve", "-x", "--preserve-world", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "resolve", "-x", "--preserve-world", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
       @new_resource.options "--preserve-world"
       @provider.install_package("net/ntp", "4.2.6_p5-r2")
     end
@@ -101,7 +101,7 @@ INSTALLED
 sys-process/lsof 4.87 arbor
 sys-process/lsof 4.87 x86_64
 PKG_STATUS
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "resolve", "-x", "=sys-process/lsof-4.87", { :timeout => @new_resource.timeout || 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "resolve", "-x", "=sys-process/lsof-4.87", { :timeout => @new_resource.timeout || 900 })
       @provider.install_package("sys-process/lsof", "4.87")
     end
 
@@ -110,7 +110,7 @@ PKG_STATUS
 sys-process/lsof 4.87 arbor
 sys-process/lsof 4.87 x86_64
 PKG_STATUS
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       @provider.load_current_resource
       expect(@current_resource.version).to be_nil
       expect(@provider.candidate_version).to eql("4.87")
@@ -119,14 +119,14 @@ PKG_STATUS
 
   context "when upgrading a package" do
     it "should run pkg install with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "resolve", "-x", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "resolve", "-x", "=net/ntp-4.2.6_p5-r2", { :timeout => @new_resource.timeout || 900 })
       @provider.upgrade_package("net/ntp", "4.2.6_p5-r2")
     end
   end
 
   context "when uninstalling a package" do
     it "should run pkg uninstall with the package name and version" do
-      expect(@provider).to receive(:shell_out!).with("cave", "-L", "warning", "uninstall", "-x", "=net/ntp-4.2.6_p5-r2", timeout: 900)
+      expect(@provider).to receive(:shell_out_compacted!).with("cave", "-L", "warning", "uninstall", "-x", "=net/ntp-4.2.6_p5-r2", timeout: 900)
       @provider.remove_package("net/ntp", "4.2.6_p5-r2")
     end
 

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -108,26 +108,26 @@ describe Chef::Provider::Package::Portage, "load_current_resource" do
     describe Chef::Provider::Package::Portage, "candidate_version" do
       it "should return the candidate_version variable if already set" do
         @provider.candidate_version = "1.0.0"
-        expect(@provider).not_to receive(:shell_out)
+        expect(@provider).not_to receive(:shell_out_compacted)
         @provider.candidate_version
       end
 
       it "should throw an exception if the exitstatus is not 0" do
         status = double(:stdout => "", :stderr => "", :exitstatus => 1)
-        allow(@provider).to receive(:shell_out).and_return(status)
+        allow(@provider).to receive(:shell_out_compacted).and_return(status)
         expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
       end
 
       it "should find the candidate_version if a category is specifed and there are no duplicates" do
         status = double(:stdout => "dev-vcs/git-2.16.2", :exitstatus => 0)
-        expect(@provider).to receive(:shell_out).and_return(status)
+        expect(@provider).to receive(:shell_out_compacted).and_return(status)
         expect(@provider.candidate_version).to eq("2.16.2")
       end
 
       it "should find the candidate_version if a category is not specifed and there are no duplicates" do
         status = double(:stdout => "dev-vcs/git-2.16.2", :exitstatus => 0)
         @provider = Chef::Provider::Package::Portage.new(@new_resource_without_category, @run_context)
-        expect(@provider).to receive(:shell_out).and_return(status)
+        expect(@provider).to receive(:shell_out_compacted).and_return(status)
         expect(@provider.candidate_version).to eq("2.16.2")
       end
 
@@ -141,24 +141,24 @@ Please use a more specific atom.
 EOF
         status = double(:stdout => "", :stderr => stderr_output, :exitstatus => 1)
         @provider = Chef::Provider::Package::Portage.new(@new_resource_without_category, @run_context)
-        expect(@provider).to receive(:shell_out).and_return(status)
+        expect(@provider).to receive(:shell_out_compacted).and_return(status)
         expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
       end
     end
 
     describe Chef::Provider::Package::Portage, "install_package" do
       it "should install a normally versioned package using portage" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
+        expect(@provider).to receive(:shell_out_compacted!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
         @provider.install_package("dev-util/git", "1.0.0")
       end
 
       it "should install a tilde versioned package using portage" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "~dev-util/git-1.0.0", timeout: 3600)
+        expect(@provider).to receive(:shell_out_compacted!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "~dev-util/git-1.0.0", timeout: 3600)
         @provider.install_package("dev-util/git", "~1.0.0")
       end
 
       it "should add options to the emerge command when specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "--oneshot", "=dev-util/git-1.0.0", timeout: 3600)
+        expect(@provider).to receive(:shell_out_compacted!).with("emerge", "-g", "--color", "n", "--nospinner", "--quiet", "--oneshot", "=dev-util/git-1.0.0", timeout: 3600)
         @new_resource.options "--oneshot"
         @provider.install_package("dev-util/git", "1.0.0")
       end
@@ -166,12 +166,12 @@ EOF
 
     describe Chef::Provider::Package::Portage, "remove_package" do
       it "should un-emerge the package with no version specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "dev-util/git", timeout: 3600)
+        expect(@provider).to receive(:shell_out_compacted!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "dev-util/git", timeout: 3600)
         @provider.remove_package("dev-util/git", nil)
       end
 
       it "should un-emerge the package with a version specified" do
-        expect(@provider).to receive(:shell_out!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
+        expect(@provider).to receive(:shell_out_compacted!).with("emerge", "--unmerge", "--color", "n", "--nospinner", "--quiet", "=dev-util/git-1.0.0", timeout: 3600)
         @provider.remove_package("dev-util/git", "1.0.0")
       end
     end

--- a/spec/unit/provider/package/rpm_spec.rb
+++ b/spec/unit/provider/package/rpm_spec.rb
@@ -44,8 +44,8 @@ describe Chef::Provider::Package::Rpm do
     allow(::File).to receive(:exist?).with("PLEASE STUB File.exists? EXACTLY").and_return(true)
 
     # Ensure all shell out usage is stubbed with exact arguments
-    allow(provider).to receive(:shell_out!).with("PLEASE STUB YOUR SHELLOUT CALLS").and_return(nil)
-    allow(provider).to receive(:shell_out).with("PLEASE STUB YOUR SHELLOUT CALLS").and_return(nil)
+    allow(provider).to receive(:shell_out_compacted!).with("PLEASE STUB YOUR SHELLOUT CALLS").and_return(nil)
+    allow(provider).to receive(:shell_out_compacted).with("PLEASE STUB YOUR SHELLOUT CALLS").and_return(nil)
   end
 
   describe "when the package source is not valid" do
@@ -85,11 +85,11 @@ describe Chef::Provider::Package::Rpm do
   describe "when the package source is valid" do
 
     before do
-      expect(provider).to receive(:shell_out!).
+      expect(provider).to receive(:shell_out_compacted!).
         with("rpm", "-qp", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", package_source, timeout: 900).
         and_return(rpm_qp_status)
 
-      expect(provider).to receive(:shell_out).
+      expect(provider).to receive(:shell_out_compacted).
         with("rpm", "-q", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n", package_name, timeout: 900).
         and_return(rpm_q_status)
     end
@@ -151,7 +151,7 @@ describe Chef::Provider::Package::Rpm do
 
           context "when at the desired version already" do
             it "does nothing when the correct version is installed" do
-              expect(provider).to_not receive(:shell_out!).with("rpm", "-i", "/tmp/imagemagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to_not receive(:shell_out_compacted!).with("rpm", "-i", "/tmp/imagemagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
 
               provider.action_install
             end
@@ -162,7 +162,7 @@ describe Chef::Provider::Package::Rpm do
             let(:rpm_q_stdout) { "imagemagick-c++ 0.5.4.7-7.el6_5" }
 
             it "runs rpm -u with the package source to upgrade" do
-              expect(provider).to receive(:shell_out!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to receive(:shell_out_compacted!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
               provider.action_install
             end
           end
@@ -178,7 +178,7 @@ describe Chef::Provider::Package::Rpm do
             let(:rpm_q_stdout) { "imagemagick-c++ 21.4-19.el6_5" }
 
             it "should run rpm -u --oldpackage with the package source to downgrade" do
-              expect(provider).to receive(:shell_out!).with("rpm", "-U", "--oldpackage", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to receive(:shell_out_compacted!).with("rpm", "-U", "--oldpackage", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
               provider.action_install
             end
 
@@ -192,7 +192,7 @@ describe Chef::Provider::Package::Rpm do
 
           context "when at the desired version already" do
             it "does nothing when the correct version is installed" do
-              expect(provider).to_not receive(:shell_out!).with("rpm", "-i", "/tmp/imagemagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to_not receive(:shell_out_compacted!).with("rpm", "-i", "/tmp/imagemagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
 
               provider.action_upgrade
             end
@@ -203,7 +203,7 @@ describe Chef::Provider::Package::Rpm do
             let(:rpm_q_stdout) { "imagemagick-c++ 0.5.4.7-7.el6_5" }
 
             it "runs rpm -u with the package source to upgrade" do
-              expect(provider).to receive(:shell_out!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to receive(:shell_out_compacted!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
               provider.action_upgrade
             end
           end
@@ -219,7 +219,7 @@ describe Chef::Provider::Package::Rpm do
             let(:rpm_q_stdout) { "imagemagick-c++ 21.4-19.el6_5" }
 
             it "should run rpm -u --oldpackage with the package source to downgrade" do
-              expect(provider).to receive(:shell_out!).with("rpm", "-U", "--oldpackage", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+              expect(provider).to receive(:shell_out_compacted!).with("rpm", "-U", "--oldpackage", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
               provider.action_upgrade
             end
 
@@ -231,7 +231,7 @@ describe Chef::Provider::Package::Rpm do
           let(:action) { :remove }
 
           it "should remove the package" do
-            expect(provider).to receive(:shell_out!).with("rpm", "-e", "ImageMagick-c++-6.5.4.7-7.el6_5", timeout: 900)
+            expect(provider).to receive(:shell_out_compacted!).with("rpm", "-e", "ImageMagick-c++-6.5.4.7-7.el6_5", timeout: 900)
             provider.action_remove
           end
         end
@@ -357,7 +357,7 @@ describe Chef::Provider::Package::Rpm do
         describe "action install" do
 
           it "installs the package" do
-            expect(provider).to receive(:shell_out!).with("rpm", "-i", package_source, timeout: 900)
+            expect(provider).to receive(:shell_out_compacted!).with("rpm", "-i", package_source, timeout: 900)
 
             provider.action_install
           end
@@ -365,7 +365,7 @@ describe Chef::Provider::Package::Rpm do
           context "when custom resource options are given" do
             it "installs with custom options specified in the resource" do
               new_resource.options("--dbpath /var/lib/rpm")
-              expect(provider).to receive(:shell_out!).with("rpm", "--dbpath", "/var/lib/rpm", "-i", package_source, timeout: 900)
+              expect(provider).to receive(:shell_out_compacted!).with("rpm", "--dbpath", "/var/lib/rpm", "-i", package_source, timeout: 900)
               provider.action_install
             end
           end
@@ -376,7 +376,7 @@ describe Chef::Provider::Package::Rpm do
           let(:action) { :upgrade }
 
           it "installs the package" do
-            expect(provider).to receive(:shell_out!).with("rpm", "-i", package_source, timeout: 900)
+            expect(provider).to receive(:shell_out_compacted!).with("rpm", "-i", package_source, timeout: 900)
 
             provider.action_upgrade
           end
@@ -387,7 +387,7 @@ describe Chef::Provider::Package::Rpm do
           let(:action) { :remove }
 
           it "should do nothing" do
-            expect(provider).to_not receive(:shell_out!).with("rpm", "-e", "ImageMagick-c++-6.5.4.7-7.el6_5", timeout: 900)
+            expect(provider).to_not receive(:shell_out_compacted!).with("rpm", "-e", "ImageMagick-c++-6.5.4.7-7.el6_5", timeout: 900)
             provider.action_remove
           end
         end
@@ -413,7 +413,7 @@ describe Chef::Provider::Package::Rpm do
     it "should install from a path when the package is a path and the source is nil" do
       expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
       provider.current_resource = current_resource
-      expect(provider).to receive(:shell_out!).with("rpm", "-i", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+      expect(provider).to receive(:shell_out_compacted!).with("rpm", "-i", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
       provider.install_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
     end
 
@@ -421,7 +421,7 @@ describe Chef::Provider::Package::Rpm do
       expect(new_resource.source).to eq("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm")
       current_resource.version("21.4-19.el5")
       provider.current_resource = current_resource
-      expect(provider).to receive(:shell_out!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
+      expect(provider).to receive(:shell_out_compacted!).with("rpm", "-U", "/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", timeout: 900)
       provider.upgrade_package("/tmp/ImageMagick-c++-6.5.4.7-7.el6_5.x86_64.rpm", "6.5.4.7-7.el6_5")
     end
   end

--- a/spec/unit/provider/package/smartos_spec.rb
+++ b/spec/unit/provider/package/smartos_spec.rb
@@ -41,26 +41,26 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
   describe "when loading current resource" do
 
     it "should create a current resource with the name of the new_resource" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
       @provider.load_current_resource
     end
 
     it "should set the current resource package name" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       expect(@current_resource).to receive(:package_name).with(@new_resource.package_name)
       @provider.load_current_resource
     end
 
     it "should set the installed version if it is installed" do
-      expect(@provider).to receive(:shell_out!).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(@shell_out)
       @provider.load_current_resource
       expect(@current_resource.version).to eq("2.1.5nb2")
     end
 
     it "should set the installed version to nil if it's not installed" do
       out = OpenStruct.new(:stdout => nil)
-      expect(@provider).to receive(:shell_out!).and_return(out)
+      expect(@provider).to receive(:shell_out_compacted!).and_return(out)
       @provider.load_current_resource
       expect(@current_resource.version).to eq(nil)
     end
@@ -70,7 +70,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
   describe "candidate_version" do
     it "should return the candidate_version variable if already setup" do
       @provider.candidate_version = "2.1.1"
-      expect(@provider).not_to receive(:shell_out!)
+      expect(@provider).not_to receive(:shell_out_compacted!)
       @provider.candidate_version
     end
 
@@ -80,7 +80,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
         and_yield("something-varnish-1.1.1   something varnish like\n").
         and_yield("varnish-2.3.4             actual varnish\n")
       @shell_out = double("shell_out!", :stdout => search)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/bin/pkgin", "se", "varnish", :env => nil, :returns => [0, 1], :timeout => 900).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).with("/opt/local/bin/pkgin", "se", "varnish", :env => nil, :returns => [0, 1], :timeout => 900).and_return(@shell_out)
       expect(@provider.candidate_version).to eq("2.3.4")
     end
 
@@ -90,7 +90,7 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
         and_yield("something-varnish-1.1.1;;something varnish like\n").
         and_yield("varnish-2.3.4;;actual varnish\n")
       @shell_out = double("shell_out!", :stdout => search)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/bin/pkgin", "se", "varnish", :env => nil, :returns => [0, 1], :timeout => 900).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).with("/opt/local/bin/pkgin", "se", "varnish", :env => nil, :returns => [0, 1], :timeout => 900).and_return(@shell_out)
       expect(@provider.candidate_version).to eq("2.3.4")
     end
   end
@@ -99,8 +99,8 @@ describe Chef::Provider::Package::SmartOS, "load_current_resource" do
 
     it "run pkgin and install the package" do
       out = OpenStruct.new(:stdout => nil)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/sbin/pkg_info", "-E", "varnish*", { :env => nil, :returns => [0, 1], :timeout => 900 }).and_return(@shell_out)
-      expect(@provider).to receive(:shell_out!).with("/opt/local/bin/pkgin", "-y", "install", "varnish-2.1.5nb2", { :env => nil, :timeout => 900 }).and_return(out)
+      expect(@provider).to receive(:shell_out_compacted!).with("/opt/local/sbin/pkg_info", "-E", "varnish*", { :env => nil, :returns => [0, 1], :timeout => 900 }).and_return(@shell_out)
+      expect(@provider).to receive(:shell_out_compacted!).with("/opt/local/bin/pkgin", "-y", "install", "varnish-2.1.5nb2", { :env => nil, :timeout => 900 }).and_return(out)
       @provider.load_current_resource
       @provider.install_package("varnish", "2.1.5nb2")
     end

--- a/spec/unit/provider/package/solaris_spec.rb
+++ b/spec/unit/provider/package/solaris_spec.rb
@@ -50,19 +50,19 @@ PKGINFO
     end
 
     it "should create a current resource with the name of new_resource" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.name).to eq("SUNWbash")
     end
 
     it "should set the current reource package name to the new resource package name" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.package_name).to eq("SUNWbash")
     end
 
     it "should raise an exception if a source is supplied but not found" do
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       allow(::File).to receive(:exist?).and_return(false)
       @provider.load_current_resource
       @provider.define_resource_requirements
@@ -71,8 +71,8 @@ PKGINFO
 
     it "should get the source package version from pkginfo if provided" do
       status = double(:stdout => @pkginfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(status)
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(@status)
       @provider.load_current_resource
 
       expect(@provider.current_resource.package_name).to eq("SUNWbash")
@@ -81,8 +81,8 @@ PKGINFO
 
     it "should return the current version installed if found by pkginfo" do
       status = double(:stdout => @pkginfo, :exitstatus => 0)
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(@status)
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to eq("11.10.0,REV=2005.01.08.05.16")
     end
@@ -90,19 +90,19 @@ PKGINFO
     it "should raise an exception if the source is not set but we are installing" do
       @new_resource = Chef::Resource::Package.new("SUNWbash")
       @provider = Chef::Provider::Package::Solaris.new(@new_resource, @run_context)
-      allow(@provider).to receive(:shell_out).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
       expect { @provider.run_action(:install) }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should raise an exception if pkginfo fails to run" do
       status = double(:stdout => "", :exitstatus => -1)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
     end
 
     it "should return a current resource with a nil version if the package is not found" do
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(@status)
-      expect(@provider).to receive(:shell_out).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "-d", "/tmp/bash.pkg", "SUNWbash", { timeout: 900 }).and_return(@status)
+      expect(@provider).to receive(:shell_out_compacted).with("pkginfo", "-l", "SUNWbash", { timeout: 900 }).and_return(@status)
       @provider.load_current_resource
       expect(@provider.current_resource.version).to be_nil
     end
@@ -111,20 +111,20 @@ PKGINFO
   describe "candidate_version" do
     it "should return the candidate_version variable if already setup" do
       @provider.candidate_version = "11.10.0,REV=2005.01.08.05.16"
-      expect(@provider).not_to receive(:shell_out)
+      expect(@provider).not_to receive(:shell_out_compacted)
       @provider.candidate_version
     end
 
     it "should lookup the candidate_version if the variable is not already set" do
       status = double(:stdout => "", :exitstatus => 0)
-      allow(@provider).to receive(:shell_out).and_return(status)
-      expect(@provider).to receive(:shell_out)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
+      expect(@provider).to receive(:shell_out_compacted)
       @provider.candidate_version
     end
 
     it "should throw and exception if the exitstatus is not 0" do
       status = double(:stdout => "", :exitstatus => 1)
-      allow(@provider).to receive(:shell_out).and_return(status)
+      allow(@provider).to receive(:shell_out_compacted).and_return(status)
       expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
     end
 
@@ -132,7 +132,7 @@ PKGINFO
 
   describe "install and upgrade" do
     it "should run pkgadd -n -d with the package source to install" do
-      expect(@provider).to receive(:shell_out!).with("pkgadd", "-n", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pkgadd", "-n", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
       @provider.install_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 
@@ -140,26 +140,26 @@ PKGINFO
       @new_resource = Chef::Resource::Package.new("/tmp/bash.pkg")
       @provider = Chef::Provider::Package::Solaris.new(@new_resource, @run_context)
       expect(@new_resource.source).to eq("/tmp/bash.pkg")
-      expect(@provider).to receive(:shell_out!).with("pkgadd", "-n", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pkgadd", "-n", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
       @provider.install_package("/tmp/bash.pkg", "11.10.0,REV=2005.01.08.05.16")
     end
 
     it "should run pkgadd -n -a /tmp/myadmin -d with the package options -a /tmp/myadmin" do
       @new_resource.options "-a /tmp/myadmin"
-      expect(@provider).to receive(:shell_out!).with("pkgadd", "-n", "-a", "/tmp/myadmin", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pkgadd", "-n", "-a", "/tmp/myadmin", "-d", "/tmp/bash.pkg", "all", { timeout: 900 })
       @provider.install_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
   end
 
   describe "remove" do
     it "should run pkgrm -n to remove the package" do
-      expect(@provider).to receive(:shell_out!).with("pkgrm", "-n", "SUNWbash", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pkgrm", "-n", "SUNWbash", { timeout: 900 })
       @provider.remove_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 
     it "should run pkgrm -n -a /tmp/myadmin with options -a /tmp/myadmin" do
       @new_resource.options "-a /tmp/myadmin"
-      expect(@provider).to receive(:shell_out!).with("pkgrm", "-n", "-a", "/tmp/myadmin", "SUNWbash", { timeout: 900 })
+      expect(@provider).to receive(:shell_out_compacted!).with("pkgrm", "-n", "-a", "/tmp/myadmin", "SUNWbash", { timeout: 900 })
       @provider.remove_package("SUNWbash", "11.10.0,REV=2005.01.08.05.16")
     end
 

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -52,7 +52,7 @@ describe Chef::Provider::User::Aix do
     end
 
     it "should call chpasswd correctly" do
-      expect(provider).to receive(:shell_out!).with("echo 'adam:Ostagazuzulum' | chpasswd -e").and_return true
+      expect(provider).to receive(:shell_out_compacted!).with("echo 'adam:Ostagazuzulum' | chpasswd -e").and_return true
       provider.manage_user
     end
   end
@@ -61,7 +61,7 @@ describe Chef::Provider::User::Aix do
     context "with a system user" do
       before { new_resource.system(true) }
       it "should add the user to the system group" do
-        expect(provider).to receive(:shell_out!).with("useradd", "-g", "system", "adam")
+        expect(provider).to receive(:shell_out_compacted!).with("useradd", "-g", "system", "adam")
         provider.create_user
       end
     end
@@ -74,13 +74,13 @@ describe Chef::Provider::User::Aix do
       end
 
       it "should create the home directory" do
-        allow(provider).to receive(:shell_out!).with("usermod", "-d", "/home/adam", "adam")
+        allow(provider).to receive(:shell_out_compacted!).with("usermod", "-d", "/home/adam", "adam")
         expect(FileUtils).to receive(:mkdir_p).and_return(true)
         provider.manage_user
       end
 
       it "should move an existing home dir" do
-        allow(provider).to receive(:shell_out!).with("usermod", "-d", "/mnt/home/adam", "adam")
+        allow(provider).to receive(:shell_out_compacted!).with("usermod", "-d", "/mnt/home/adam", "adam")
         new_resource.home("/mnt/home/adam")
         allow(File).to receive(:directory?).with("/home/adam").and_return(true)
         expect(FileUtils).to receive(:mv).with("/home/adam", "/mnt/home/adam")
@@ -89,7 +89,7 @@ describe Chef::Provider::User::Aix do
 
       it "should not pass -m" do
         allow(FileUtils).to receive(:mkdir_p).and_return(true)
-        expect(provider).to receive(:shell_out!).with("usermod", "-d", "/home/adam", "adam")
+        expect(provider).to receive(:shell_out_compacted!).with("usermod", "-d", "/home/adam", "adam")
         provider.manage_user
       end
     end

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -116,31 +116,31 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
   describe "when shelling out to dscl" do
     it "should run dscl with the supplied cmd /Path args" do
       shell_return = shellcmdresult.new("stdout", "err", 0)
-      expect(provider).to receive(:shell_out).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
+      expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
       expect(provider.run_dscl("cmd", "/Path", "args")).to eq("stdout")
     end
 
     it "returns an empty string from delete commands" do
       shell_return = shellcmdresult.new("out", "err", 23)
-      expect(provider).to receive(:shell_out).with("dscl", ".", "-delete", "/Path", "args").and_return(shell_return)
+      expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-delete", "/Path", "args").and_return(shell_return)
       expect(provider.run_dscl("delete", "/Path", "args")).to eq("")
     end
 
     it "should raise an exception for any other command" do
       shell_return = shellcmdresult.new("out", "err", 23)
-      expect(provider).to receive(:shell_out).with("dscl", ".", "-cmd", "/Path", "arguments").and_return(shell_return)
+      expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-cmd", "/Path", "arguments").and_return(shell_return)
       expect { provider.run_dscl("cmd", "/Path", "arguments") }.to raise_error(Chef::Exceptions::DsclCommandFailed)
     end
 
     it "raises an exception when dscl reports 'no such key'" do
       shell_return = shellcmdresult.new("No such key: ", "err", 23)
-      expect(provider).to receive(:shell_out).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
+      expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
       expect { provider.run_dscl("cmd", "/Path", "args") }.to raise_error(Chef::Exceptions::DsclCommandFailed)
     end
 
     it "raises an exception when dscl reports 'eDSRecordNotFound'" do
       shell_return = shellcmdresult.new("<dscl_cmd> DS Error: -14136 (eDSRecordNotFound)", "err", -14136)
-      expect(provider).to receive(:shell_out).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
+      expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-cmd", "/Path", "args").and_return(shell_return)
       expect { provider.run_dscl("cmd", "/Path", "args") }.to raise_error(Chef::Exceptions::DsclCommandFailed)
     end
   end
@@ -284,7 +284,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
     end
 
     it "should run createhomedir to create the user's new home folder" do
-      expect(provider).to receive(:shell_out!).with("/usr/sbin/createhomedir", "-c", "-u", "toor")
+      expect(provider).to receive(:shell_out_compacted!).with("/usr/sbin/createhomedir", "-c", "-u", "toor")
       provider.ditto_home
     end
 
@@ -399,8 +399,8 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30"
     let(:user_plist_file) { nil }
 
     before do
-      expect(provider).to receive(:shell_out).with("dscacheutil", "-flushcache")
-      expect(provider).to receive(:shell_out).with("plutil", "-convert", "xml1", "-o", "-", "/var/db/dslocal/nodes/Default/users/toor.plist") do
+      expect(provider).to receive(:shell_out_compacted).with("dscacheutil", "-flushcache")
+      expect(provider).to receive(:shell_out_compacted).with("plutil", "-convert", "xml1", "-o", "-", "/var/db/dslocal/nodes/Default/users/toor.plist") do
         if user_plist_file.nil?
           shellcmdresult.new("Can not find the file", "Sorry!!", 1)
         else
@@ -743,7 +743,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
       expect(provider).to receive(:prepare_password_shadow_info).and_return({})
       mock_shellout = double("Mock::Shellout")
       allow(mock_shellout).to receive(:run_command)
-      expect(provider).to receive(:shell_out).and_return(mock_shellout)
+      expect(provider).to receive(:shell_out_compacted).and_return(mock_shellout)
       expect(provider).to receive(:read_user_info)
       expect(provider).to receive(:dscl_set)
       expect(provider).to receive(:sleep).with(3)
@@ -812,7 +812,7 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
 
       it "should raise an exception when the group does not exist" do
         shell_return = shellcmdresult.new("<dscl_cmd> DS Error: -14136 (eDSRecordNotFound)", "err", -14136)
-        expect(provider).to receive(:shell_out).with("dscl", ".", "-read", "/Groups/newgroup", "PrimaryGroupID").and_return(shell_return)
+        expect(provider).to receive(:shell_out_compacted).with("dscl", ".", "-read", "/Groups/newgroup", "PrimaryGroupID").and_return(shell_return)
         expect { provider.dscl_set_gid }.to raise_error(Chef::Exceptions::GroupIDNotFound)
       end
     end
@@ -867,8 +867,8 @@ ea18e18b720e358e7fbe3cfbeaa561456f6ba008937a30")
 
   describe "when the user exists" do
     before do
-      expect(provider).to receive(:shell_out).with("dscacheutil", "-flushcache")
-      expect(provider).to receive(:shell_out).with("plutil", "-convert", "xml1", "-o", "-", "/var/db/dslocal/nodes/Default/users/toor.plist") do
+      expect(provider).to receive(:shell_out_compacted).with("dscacheutil", "-flushcache")
+      expect(provider).to receive(:shell_out_compacted).with("plutil", "-convert", "xml1", "-o", "-", "/var/db/dslocal/nodes/Default/users/toor.plist") do
         shellcmdresult.new(File.read(File.join(CHEF_SPEC_DATA, "mac_users/10.9.plist.xml")), "", 0)
       end
       provider.load_current_resource

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Stephen Haynes (<sh@nomitor.com>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,12 +81,12 @@ describe Chef::Provider::User::Pw do
 
   describe "create_user" do
     before(:each) do
-      allow(@provider).to receive(:shell_out!).and_return(true)
+      allow(@provider).to receive(:shell_out_compacted!).and_return(true)
       allow(@provider).to receive(:modify_password).and_return(true)
     end
 
     it "should run pw useradd with the return of set_options" do
-      expect(@provider).to receive(:shell_out!).with("pw", "useradd", "adam", "-m").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "useradd", "adam", "-m").and_return(true)
       @provider.create_user
     end
 
@@ -98,12 +98,12 @@ describe Chef::Provider::User::Pw do
 
   describe "manage_user" do
     before(:each) do
-      allow(@provider).to receive(:shell_out!).and_return(true)
+      allow(@provider).to receive(:shell_out_compacted!).and_return(true)
       allow(@provider).to receive(:modify_password).and_return(true)
     end
 
     it "should run pw usermod with the return of set_options" do
-      expect(@provider).to receive(:shell_out!).with("pw", "usermod", "adam", "-m").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "usermod", "adam", "-m").and_return(true)
       @provider.manage_user
     end
 
@@ -116,12 +116,12 @@ describe Chef::Provider::User::Pw do
   describe "remove_user" do
     it "should run pw userdel with the new resources user name" do
       @new_resource.manage_home false
-      expect(@provider).to receive(:shell_out!).with("pw", "userdel", @new_resource.username).and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "userdel", @new_resource.username).and_return(true)
       @provider.remove_user
     end
 
     it "should run pw userdel with the new resources user name and -r if manage_home is true" do
-      expect(@provider).to receive(:shell_out!).with("pw", "userdel", @new_resource.username, "-r").and_return(true)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "userdel", @new_resource.username, "-r").and_return(true)
       @provider.remove_user
     end
   end
@@ -140,14 +140,14 @@ describe Chef::Provider::User::Pw do
 
   describe "when locking the user" do
     it "should run pw lock with the new resources username" do
-      expect(@provider).to receive(:shell_out!).with("pw", "lock", @new_resource.username)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "lock", @new_resource.username)
       @provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
     it "should run pw unlock with the new resources username" do
-      expect(@provider).to receive(:shell_out!).with("pw", "unlock", @new_resource.username)
+      expect(@provider).to receive(:shell_out_compacted!).with( "pw", "unlock", @new_resource.username)
       @provider.unlock_user
     end
   end
@@ -155,7 +155,7 @@ describe Chef::Provider::User::Pw do
   describe "when modifying the password" do
     before(:each) do
       @status = double("Status", exitstatus: 0)
-      allow(@provider).to receive(:shell_out!).and_return(@status)
+      allow(@provider).to receive(:shell_out_compacted!).and_return(@status)
     end
 
     describe "and the new password has not been specified" do
@@ -202,12 +202,12 @@ describe Chef::Provider::User::Pw do
       end
 
       it "should run pw usermod with the username and the option -H 0" do
-        expect(@provider).to receive(:shell_out!).with("pw usermod adam -H 0", { :input => "abracadabra" }).and_return(@status)
+        expect(@provider).to receive(:shell_out_compacted!).with( "pw usermod adam -H 0", { :input => "abracadabra" }).and_return(@status)
         @provider.modify_password
       end
 
       it "should raise an exception if pw usermod fails" do
-        expect(@provider).to receive(:shell_out!).and_raise(Mixlib::ShellOut::ShellCommandFailed)
+        expect(@provider).to receive(:shell_out_compacted!).and_raise(Mixlib::ShellOut::ShellCommandFailed)
         expect { @provider.modify_password }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
       end
 

--- a/spec/unit/provider/user/solaris_spec.rb
+++ b/spec/unit/provider/user/solaris_spec.rb
@@ -58,7 +58,7 @@ describe Chef::Provider::User::Solaris do
 
     it "should use its own shadow file writer to set the password" do
       expect(provider).to receive(:write_shadow_file)
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       provider.manage_user
     end
 
@@ -69,7 +69,7 @@ describe Chef::Provider::User::Solaris do
       password_file.puts "adam:existingpassword:15441::::::"
       password_file.close
       stub_const("Chef::Provider::User::Solaris::PASSWORD_FILE", password_file.path)
-      allow(provider).to receive(:shell_out!).and_return(true)
+      allow(provider).to receive(:shell_out_compacted!).and_return(true)
       # may not be able to write to /etc for tests...
       temp_file = Tempfile.new("shadow")
       allow(Tempfile).to receive(:new).with("shadow", "/etc").and_return(temp_file)
@@ -84,7 +84,7 @@ describe Chef::Provider::User::Solaris do
     context "with a system user" do
       before { new_resource.system(true) }
       it "should not pass -r" do
-        expect(provider).to receive(:shell_out!).with("useradd", "adam")
+        expect(provider).to receive(:shell_out_compacted!).with( "useradd", "adam")
         provider.create_user
       end
     end
@@ -92,7 +92,7 @@ describe Chef::Provider::User::Solaris do
     context "with manage_home" do
       before { new_resource.manage_home(true) }
       it "should not pass -r" do
-        expect(provider).to receive(:shell_out!).with("useradd", "-m", "adam")
+        expect(provider).to receive(:shell_out_compacted!).with( "useradd", "-m", "adam")
         provider.create_user
       end
     end
@@ -162,7 +162,7 @@ describe Chef::Provider::User::Solaris do
     describe "when locking the user" do
       it "should run passwd -l with the new resources username" do
         shell_return = shellcmdresult.new("", "", 0)
-        expect(provider).to receive(:shell_out!).with("passwd", "-l", "adam").and_return(shell_return)
+        expect(provider).to receive(:shell_out_compacted!).with("passwd", "-l", "adam").and_return(shell_return)
         provider.lock_user
       end
     end
@@ -170,7 +170,7 @@ describe Chef::Provider::User::Solaris do
     describe "when unlocking the user" do
       it "should run passwd -u with the new resources username" do
         shell_return = shellcmdresult.new("", "", 0)
-        expect(provider).to receive(:shell_out!).with("passwd", "-u", "adam").and_return(shell_return)
+        expect(provider).to receive(:shell_out_compacted!).with("passwd", "-u", "adam").and_return(shell_return)
         provider.unlock_user
       end
     end

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Serdar Sutay (<serdar@chef.io>)
-# Copyright:: Copyright 2013-2017, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -124,21 +124,21 @@ describe Chef::Util::Selinux do
     end
 
     it "should call restorecon non-recursive by default" do
-      expect(@test_instance).to receive(:shell_out_compact!).twice.with(@restorecon_enabled_path, [ "-R", path ])
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", path).twice
       @test_instance.restore_security_context(path)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path)
     end
 
     it "should call restorecon recursive when recursive is set" do
-      expect(@test_instance).to receive(:shell_out_compact!).twice.with(@restorecon_enabled_path, [ "-R", "-r", path ])
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", "-r", path).twice
       @test_instance.restore_security_context(path, true)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path, true)
     end
 
     it "should call restorecon non-recursive when recursive is not set" do
-      expect(@test_instance).to receive(:shell_out_compact!).twice.with(@restorecon_enabled_path, [ "-R", path ])
+      expect(@test_instance).to receive(:shell_out_compacted!).with(@restorecon_enabled_path, "-R", path).twice
       @test_instance.restore_security_context(path)
       expect(File).not_to receive(:executable?)
       @test_instance.restore_security_context(path)


### PR DESCRIPTION
shell_out_compact / shell_out_with_timeout / shell_out_compact_timeout are now all collapsed into simply shell_out

the `shell_out_compacted` API is a private method which can be used to setup expectations on in rspec post-flat/compaction -- so meaningless changes to the shell_out won't cause churn in the specs.

formal deprecation of the APIs comes next.