### PR TITLE
Don't crash on non-existent credentials profile

### DIFF
--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -43,6 +43,12 @@ module ChefConfig
                   end
 
         config = Tomlrb.load_file(credentials_file)
+
+        if config[profile].nil?
+          return if profile == 'default'
+          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file}."
+        end
+
         apply_credentials(config[profile], profile)
       rescue ChefConfig::ConfigurationError
         raise


### PR DESCRIPTION
### Description

If a credentials file exists, but doesn't contain the profile in
CHEF_PROFILE (or a default profile is CHEF_PROFILE is unset and there is
no context file), then an "Unable to parse Credentials file" error is
shown.

This change simply detects if there isn't a matching profile in the
credentials file and returns without trying to load the credentials any
further (as is the case when a credentials file isn't present).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
