### PR TITLE
deprecate old shell_out APIs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes.
 
+## Simplification of `shell_out` APIs
+
+The following methods are deprecated:
+
+- `shell_out_with_systems_locale`
+- `shell_out_with_timeout`
+- `shell_out_compact`
+- `shell_out_compact_timeout`
+- `shell_out_with_systems_locale!`
+- `shell_out_with_timeout!`
+- `shell_out_compact!`
+- `shell_out_compact_timeout!`
+
+The functionality of `shell_out_with_systems_locale` has been implemented using the `default_env: false`
+option that removes the PATH and locale mangling that has been the default behavior of `shell_out`.
+
+The functionality of `shell_out_compact` has been folded into `shell_out`.  The `shell_out` API when called
+with varargs has its arguments flatted, compacted and coerced to strings.  This style of calling is encouraged
+over using strings and building up commands using `join(" ")` since it avoids shell interpolation and edge
+conditions in the construction of spaces between arguments.  The varargs form is still not supported on
+Windows.
+
+The functionality of `shell_out*timeout` has also been folded into `shell_out`.  Users writing Custom Resources
+should be explicit for Chef-14:  `shell_out!("whatever", timeout: new_resource.timeout)` which will become
+automatic in Chef-15.
+
 ## Silencing deprecation warnings
 
 While deprecation warnings have been great for the Chef community to ensure

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -215,6 +215,10 @@ class Chef
       def to_s
         "Deprecated resource property used from #{location}\n\n  #{message}\n\nPlease consult the resource documentation for more information."
       end
+    end
+
+    class ShellOut < Base
+      target 26
     end
 
     class Generic < Base

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -131,15 +131,20 @@ class Chef
       # @api private
       def self.maybe_add_timeout(obj, options)
         options = options.dup
-        force = options.delete(:argument_that_will_go_away_in_chef_15_so_do_not_use_it)
-        return options if options.key?(:timeout)
+        force = options.delete(:argument_that_will_go_away_in_chef_15_so_do_not_use_it) # remove in Chef-15
+        # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
+        default_val = 900
+        if !force
+          return options if options.key?(:timeout) # leave this line in Chef-15, delete the rest of the conditional
+        else
+          default_val = options[:timeout] if options.key?(:timeout) # delete in Chef-15
+        end
         # note that we can't define an empty Chef::Resource::LWRPBase because that breaks descendants tracker, so we'd have to instead require the file here, which would pull in half
         # of chef, so instead convert to using strings.  once descendants tracker is gone, we can just declare the empty classes instead and use `is_a?` against the symbols.
         # (be nice if ruby supported strings in `is_a?` for looser coupling).
+        # FIXME: just use `if obj.respond_to?(:new_resource) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)` in Chef 15
         if obj.respond_to?(:new_resource) && ( force || ( obj.class.ancestors.map(&:name).include?("Chef::Provider") && !obj.class.ancestors.map(&:name).include?("Chef::Resource::LWRPBase") && !obj.class.ancestors.map(&:name).include?("Chef::Resource::ActionClass") && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout) ) )
-          # FIXME: just use `obj.respond_to?(:new_resource) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)` in Chef 15
-          # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
-          options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : 900
+          options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : default_val
         end
         options
       end

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -46,7 +46,8 @@ class Chef
       # a thousand unit tests.
       #
 
-      def shell_out_compact(*args, **options) # FIXME: deprecate
+      def shell_out_compact(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_compact should be replaced by shell_out")
         if options.empty?
           shell_out(*args)
         else
@@ -54,7 +55,8 @@ class Chef
         end
       end
 
-      def shell_out_compact!(*args, **options) # FIXME: deprecate
+      def shell_out_compact!(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_compact! should be replaced by shell_out!")
         if options.empty?
           shell_out!(*args)
         else
@@ -62,23 +64,26 @@ class Chef
         end
       end
 
-      def shell_out_compact_timeout(*args, **options) # FIXME: deprecate
+      def shell_out_compact_timeout(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_compact_timeout should be replaced by shell_out")
         if options.empty?
-          shell_out(*args)
+          shell_out(*args, argument_that_will_go_away_in_chef_15_so_do_not_use_it: true)
         else
-          shell_out(*args, **options)
+          shell_out(*args, argument_that_will_go_away_in_chef_15_so_do_not_use_it: true, **options)
         end
       end
 
-      def shell_out_compact_timeout!(*args, **options) # FIXME: deprecate
+      def shell_out_compact_timeout!(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_compact_timeout! should be replaced by shell_out!")
         if options.empty?
-          shell_out!(*args)
+          shell_out!(*args, argument_that_will_go_away_in_chef_15_so_do_not_use_it: true)
         else
-          shell_out!(*args, **options)
+          shell_out!(*args, argument_that_will_go_away_in_chef_15_so_do_not_use_it: true, **options)
         end
       end
 
-      def shell_out_with_systems_locale(*args, **options) # FIXME: deprecate
+      def shell_out_with_systems_locale(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_with_systems_locale should be replaced by shell_out with the default_env option set to false")
         if options.empty?
           shell_out(*args, default_env: false)
         else
@@ -86,7 +91,8 @@ class Chef
         end
       end
 
-      def shell_out_with_systems_locale!(*args, **options) # FIXME: deprecate
+      def shell_out_with_systems_locale!(*args, **options)
+        Chef.deprecated(:shell_out, "shell_out_with_systems_locale! should be replaced by shell_out! with the default_env option set to false")
         if options.empty?
           shell_out!(*args, default_env: false)
         else
@@ -94,9 +100,8 @@ class Chef
         end
       end
 
-      def a_to_s(*args) # FIXME: deprecate
-        # can't quite deprecate this yet
-        #Chef.deprecated(:package_misc, "a_to_s is deprecated use shell_out_compact or shell_out_compact_timeout instead")
+      def a_to_s(*args)
+        Chef.deprecated(:shell_out, "a_to_s is deprecated use shell_out with splat-args")
         args.flatten.reject { |i| i.nil? || i == "" }.map(&:to_s).join(" ")
       end
 
@@ -125,11 +130,14 @@ class Chef
       # module method to not pollute namespaces, but that means we need self injected as an arg
       # @api private
       def self.maybe_add_timeout(obj, options)
+        options = options.dup
+        force = options.delete(:argument_that_will_go_away_in_chef_15_so_do_not_use_it)
+        return options if options.key?(:timeout)
         # note that we can't define an empty Chef::Resource::LWRPBase because that breaks descendants tracker, so we'd have to instead require the file here, which would pull in half
         # of chef, so instead convert to using strings.  once descendants tracker is gone, we can just declare the empty classes instead and use `is_a?` against the symbols.
         # (be nice if ruby supported strings in `is_a?` for looser coupling).
-        if obj.class.ancestors.map(&:to_s).include?("Chef::Provider") && !obj.class.ancestors.map(&:to_s).include?("Chef::Resource::LWRPBase") && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
-          options = options.dup
+        if obj.respond_to?(:new_resource) && ( force || ( obj.class.ancestors.map(&:name).include?("Chef::Provider") && !obj.class.ancestors.map(&:name).include?("Chef::Resource::LWRPBase") && !obj.class.ancestors.map(&:name).include?("Chef::Resource::ActionClass") && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout) ) )
+          # FIXME: just use `obj.respond_to?(:new_resource) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)` in Chef 15
           # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
           options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : 900
         end

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -668,27 +668,12 @@ class Chef
         end
       end
 
-      def shell_out_with_timeout(*command_args) # FIXME: deprecated
-        shell_out(*add_timeout_option(command_args))
+      def shell_out_with_timeout(*command_args)
+        shell_out_compact_timeout(*command_args)
       end
 
-      def shell_out_with_timeout!(*command_args) # FIXME: deprecated
-        shell_out!(*add_timeout_option(command_args))
-      end
-
-      def add_timeout_option(command_args)
-        # this is deprecated but its not quite done yet
-        #Chef.deprecated(:package_misc, "shell_out_with_timeout and add_timeout_option are deprecated methods, use shell_out instead")
-        args = command_args.dup
-        if args.last.is_a?(Hash)
-          options = args.pop.dup
-          options[:timeout] = new_resource.timeout if new_resource.timeout
-          options[:timeout] = 900 unless options.key?(:timeout)
-          args << options
-        else
-          args << { timeout: new_resource.timeout ? new_resource.timeout : 900 }
-        end
-        args
+      def shell_out_with_timeout!(*command_args)
+        shell_out_compact_timeout!(*command_args)
       end
     end
   end

--- a/spec/functional/mixin/shell_out_spec.rb
+++ b/spec/functional/mixin/shell_out_spec.rb
@@ -21,6 +21,10 @@ describe Chef::Mixin::ShellOut do
   include Chef::Mixin::ShellOut
 
   describe "shell_out_with_systems_locale" do
+    before do
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
+    end
+
     describe "when environment['LC_ALL'] is not set" do
       it "should use the default shell_out setting" do
         cmd = if windows?

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -408,7 +408,7 @@ describe Chef::Mixin::ShellOut do
       end
     end
 
-    describe "deprecated timeouts" do
+    describe "deprecated timeouts" do # Chef 15: delete me
       let(:new_resource) { Chef::Resource::Package.new("foo") }
       let(:provider) { new_resource.provider_for_action(:install) }
 
@@ -428,7 +428,7 @@ describe Chef::Mixin::ShellOut do
         end
         it "#{method} overrides the new_resource.timeout with the timeout option" do
           new_resource.timeout(99)
-          expect(provider).to receive(stubbed_method).with("foo", timeout: 1)
+          expect(provider).to receive(stubbed_method).with("foo", timeout: 99)
           provider.send(method, "foo", timeout: 1)
         end
         it "#{method} defaults to 900 seconds and preserves options" do
@@ -441,7 +441,7 @@ describe Chef::Mixin::ShellOut do
         end
         it "#{method} overrides the new_resource.timeout with the timeout option and preseves options" do
           new_resource.timeout(99)
-          expect(provider).to receive(stubbed_method).with("foo", timeout: 1, env: nil)
+          expect(provider).to receive(stubbed_method).with("foo", timeout: 99, env: nil)
           provider.send(method, "foo", timeout: 1, env: nil)
         end
       end

--- a/spec/unit/provider/package_spec.rb
+++ b/spec/unit/provider/package_spec.rb
@@ -942,7 +942,7 @@ describe "Chef::Provider::Package - Multi" do
     end
 
     [ :shell_out_with_timeout, :shell_out_with_timeout! ].each do |method|
-      stubbed_method = method == :shell_out_with_timeout! ? :shell_out! : :shell_out
+      stubbed_method = method == :shell_out_with_timeout! ? :shell_out_compacted! : :shell_out_compacted
       [ %w{command arg1 arg2}, "command arg1 arg2" ].each do |command|
         it "#{method} defaults to 900 seconds" do
           expect(provider).to receive(stubbed_method).with(*command, timeout: 900)


### PR DESCRIPTION
note that this restores the behavior of shell_out_with_timeout()
which downstream consumers may be using, and correctly treats
custom resources and LWRPs the same, along with setting up
removing all this backcompat weirdness in Chef-15.
