### PR TITLE
Remove sudo/gcc-c++ package installs from kitchen tests

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -4,7 +4,7 @@ gem "rake" # required to build some native extensions
 gem "chef", path: ".."
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master" # avoids failures when we bump chef major
 gem "berkshelf", git: "https://github.com/berkshelf/berkshelf.git", branch: "master"
-gem "kitchen-appbundle-updater", git: "https://github.com/chef/kitchen-appbundle-updater", branch: "master"
+gem "kitchen-appbundle-updater"
 gem "kitchen-dokken", "< 2.0" # 2.x fails atm: https://travis-ci.org/chef/chef/jobs/199125787
 gem "kitchen-inspec", git: "https://github.com/chef/kitchen-inspec.git", branch: "master"
 gem "kitchen-vagrant", git: "https://github.com/test-kitchen/kitchen-vagrant.git", branch: "master"

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -34,8 +34,6 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
     intermediate_instructions:
-      # TODO: inspec 2.0 requires gcc-c++, adding here until it can be added to appbundler-updater
-      - RUN yum -y install sudo gcc-c++
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: amazonlinux-2
@@ -43,7 +41,6 @@ platforms:
     image: dokken/amazonlinux-2
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install sudo gcc-c++
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: debian-8
@@ -52,7 +49,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: debian-9
   driver:
@@ -60,14 +56,12 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: centos-6
   driver:
     image: dokken/centos-6
     pid_one_command: /sbin/init
     intermediate_instructions:
-      - RUN yum -y install sudo gcc-c++
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: centos-7
@@ -75,7 +69,6 @@ platforms:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install sudo gcc-c++
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: fedora-latest
@@ -83,7 +76,6 @@ platforms:
     image: dokken/fedora-latest
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install sudo gcc-c++
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: ubuntu-14.04
@@ -92,7 +84,6 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: ubuntu-16.04
   driver:
@@ -100,7 +91,6 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: ubuntu-18.04
   driver:
@@ -108,14 +98,11 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get -y install sudo
 
 - name: opensuse-leap
   driver:
     image: dokken/opensuse-leap
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/zypper install -y sudo gcc-c++
 
 suites:
   - name: base


### PR DESCRIPTION
Sudo was added to dokken images. gcc-c++ was added to appbundle-updater. Also use the kitchen-appbundle-updater from rubygems since it's up to date. No need to pull from the repo for this.

Signed-off-by: Tim Smith <tsmith@chef.io>