### PR TITLE
Add missing require knife

### DIFF
--- a/lib/chef/knife/environment_from_file.rb
+++ b/lib/chef/knife/environment_from_file.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+require "chef/knife"
+
 class Chef
   class Knife
     class EnvironmentFromFile < Knife


### PR DESCRIPTION
This should be in all the plugins and it is except for this one.

Signed-off-by: Tim Smith <tsmith@chef.io>