### PR TITLE
Fix dupe stdout_logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: fac2105b132fddc5f671411b2b5f1cba7a2307c3
+  revision: c16b9ceab413259bda43a2d683f1f918c1be3db5
   branch: master
   specs:
     chefstyle (0.10.0)
@@ -89,7 +89,7 @@ PATH
     chef-config (14.3.29)
       addressable
       fuzzyurl
-      mixlib-config (>= 2.2.11, < 3.0)
+      mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
 
@@ -149,7 +149,7 @@ GEM
     highline (1.7.10)
     htmlentities (4.3.4)
     iniparse (1.4.4)
-    inspec-core (2.2.27)
+    inspec-core (2.2.34)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -179,7 +179,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.11)
+    mixlib-config (2.2.12)
       tomlrb
     mixlib-log (2.0.4)
     mixlib-shellout (2.3.2)
@@ -300,7 +300,7 @@ GEM
     systemu (2.6.5)
     thor (0.20.0)
     tomlrb (1.2.7)
-    train-core (1.4.19)
+    train-core (1.4.21)
       json (>= 1.8, < 3.0)
       mixlib-shellout (~> 2.0)
     travis (1.8.8)

--- a/chef-config/chef-config.gemspec
+++ b/chef-config/chef-config.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "mixlib-shellout", "~> 2.0"
-  spec.add_dependency "mixlib-config", ">= 2.2.11", "< 3.0"
+  spec.add_dependency "mixlib-config", ">= 2.2.12", "< 3.0"
   spec.add_dependency "fuzzyurl"
   spec.add_dependency "addressable"
   spec.add_dependency "tomlrb", "~> 1.2"

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,7 +205,11 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && !Chef::Config[:daemonize]
+      ( !log_location_default? ) && STDOUT.tty? && !Chef::Config[:daemonize]
+    end
+
+    def log_location_default?
+      Chef::Config.configurables[:log_location].instance_variable_get(:@default_value).inspect == Chef::Config[:log_location].inspect
     end
 
     def configure_stdout_logger

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,7 +205,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      !( chef_config[:log_location].is_a?(IO) && chef_config[:log_location].tty? ) && !chef_config[:daemonize]
+      ( Chef::Config[:log_location] != STDOUT ) && STDOUT.tty? && !Chef::Config[:daemonize]
     end
 
     def configure_stdout_logger

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,11 +205,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      ( !log_location_default? ) && STDOUT.tty? && !Chef::Config[:daemonize]
-    end
-
-    def log_location_default?
-      Chef::Config.configurables[:log_location].instance_variable_get(:@default_value).inspect == Chef::Config[:log_location].inspect
+      Chef::Config.is_default?(:log_location) && Chef::Config[:log_location].tty? && !Chef::Config[:daemonize]
     end
 
     def configure_stdout_logger


### PR DESCRIPTION
I _think_ this resolves issue #7184

Basically reverting back to the previous logic of
`want_additional_logger?`. It was mentioned in the issue comments that
the comparison against `STDOUT` wasn't working, but it seems to work for
me currently on Centos7.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>

### Description

Prevents duplicate stdout_loggers from being created when STDOUT is redirected.
```
# client.rb
#
log_level :info
log_location STDOUT
```
```
 chef-client -z -c /tmp/client.rb | head -100
[2018-06-28T15:50:22+00:00] WARN: No cookbooks directory found at or above current directory.  Assuming /src/chef.
[2018-06-28T15:50:22+00:00] INFO: Started chef-zero at chefzero://localhost:1 with repository at /src/chef
  One version per cookbook

Starting Chef Client, version 14.1.24
[2018-06-28T15:50:22+00:00] INFO: *** Chef 14.1.24 ***
[2018-06-28T15:50:22+00:00] INFO: Platform: x86_64-linux
[2018-06-28T15:50:22+00:00] INFO: Chef-client pid: 18037
[2018-06-28T15:50:22+00:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-06-28T15:50:33+00:00] INFO: Run List is []
[2018-06-28T15:50:33+00:00] INFO: Run List expands to []
[2018-06-28T15:50:33+00:00] INFO: Starting Chef Run for localhost
[2018-06-28T15:50:33+00:00] INFO: Running start handlers
[2018-06-28T15:50:33+00:00] INFO: Start handlers complete.
resolving cookbooks for run list: []
[2018-06-28T15:50:33+00:00] INFO: Loading cookbooks []
Synchronizing Cookbooks:
Installing Cookbook Gems:
Compiling Cookbooks...
[2018-06-28T15:50:33+00:00] WARN: Node localhost has an empty run list.
Converging 0 resources
[2018-06-28T15:50:33+00:00] INFO: Chef Run complete in 0.04621001 seconds

Running handlers:
[2018-06-28T15:50:33+00:00] INFO: Running report handlers
Running handlers complete
[2018-06-28T15:50:33+00:00] INFO: Report handlers complete
Chef Client finished, 0/0 resources updated in 11 seconds
```

### Issues Resolved

#7184 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
