### PR TITLE
Quiet down bundle install/bundle exec messages on Windows [skip ci]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ if RUBY_PLATFORM =~ /mswin|mingw|windows/
   instance_eval do
     ruby_exe_dir = RbConfig::CONFIG["bindir"]
     assemblies = Dir.glob(File.expand_path("distro/ruby_bin_folder", Dir.pwd) + "/*.dll")
-    FileUtils.cp_r assemblies, ruby_exe_dir, verbose: true unless ENV["_BUNDLER_WINDOWS_DLLS_COPIED"]
+    FileUtils.cp_r assemblies, ruby_exe_dir, verbose: false unless ENV["_BUNDLER_WINDOWS_DLLS_COPIED"]
     ENV["_BUNDLER_WINDOWS_DLLS_COPIED"] = "1"
   end
 end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Reduce the amount of verbose logging for bundler on Windows. CI was skipped as this is a dev-only change.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
