### PR TITLE
Allow digging of attributes

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -89,6 +89,7 @@ class Chef
        :count,
        :cycle,
        :detect,
+       :dig,
        :drop,
        :drop_while,
        :each,

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -617,6 +617,46 @@ describe Chef::Node::Attribute do
     end
   end
 
+  describe "dig" do
+    before do
+      @attributes = Chef::Node::Attribute.new(
+        {
+          "one" =>  { "two" => "three" },
+          "hut" =>  { "two" => "three" },
+          "place" => {},
+        },
+        {
+          "one" => { "four" => "five" },
+          "hut" =>  { "two" => "masked" },
+          "snakes" => "on a plane",
+        },
+        {
+          "one" => { "six" => "seven" },
+          "snack" => "cookies",
+        },
+        {}
+      )
+    end
+
+    it "should return attribute if exists" do
+      expect(@attributes.dig("one", "two")).to eq("three")
+      expect(@attributes.dig("one", "four")).to eq("five")
+      expect(@attributes.dig("one", "six")).to eq("seven")
+      expect(@attributes.dig("hut", "two")).to eq("three")
+      expect(@attributes.dig("snakes")).to eq("on a plane")
+    end
+
+    it "should return nil if any key in chain is missing" do
+      expect(@attributes.dig("one", "ten")).to eq(nil)
+      expect(@attributes.dig("snacks", "are", "delicious")).to eq(nil)
+      expect(@attributes.dig("missing")).to eq(nil)
+    end
+
+    it "should raise a typeerror if chain contains incompatible type" do
+      expect { @attributes.dig("one", "two", "three") }.to raise_error(TypeError)
+    end
+  end
+
   describe "each" do
     before(:each) do
       @attributes = Chef::Node::Attribute.new(


### PR DESCRIPTION
Facilitates using [`dig`](https://ruby-doc.org/core-2.4.0/Hash.html#method-i-dig) (available since ruby 2.3) on `node` attribute objects.

This is helpful in at least two cases:
1. When dealing with attributes out of the cookbook authors control
2. When dealing with attributes that may be redefined by the end user as a `Hash`

```rb
node.default['foo']['bar']['qux'] = 'value'
[...]
node.dig('foo', 'bar', 'qux') #=> 'value'
node.dig('foo', 'baz', 'qux') #=> nil
```

Hoping this is simple and unobjectionable 🤞 