### PR TITLE
Don't require rubygems in our binaries

### DIFF
--- a/bin/chef-apply
+++ b/bin/chef-apply
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems"
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef/application/apply"
 

--- a/bin/chef-client
+++ b/bin/chef-client
@@ -3,7 +3,7 @@
 # ./chef-client - Run the chef client
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems"
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef"
 require "chef/application/client"

--- a/bin/chef-service-manager
+++ b/bin/chef-service-manager
@@ -3,7 +3,7 @@
 # ./chef-service-manager - Control chef-service on Windows platforms.
 #
 # Author:: Serdar Sutay (serdar@chef.io)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems"
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef"
 require "chef/application/windows_service_manager"

--- a/bin/chef-shell
+++ b/bin/chef-shell
@@ -3,7 +3,7 @@
 # ./chef-shell - Run the Chef REPL (Shell)
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
-# Copyright:: Copyright (c) 2009
+# Copyright:: Copyright 2009-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-begin
-  require "rubygems"
-rescue LoadError
-end
 
 Encoding.default_external = Encoding::UTF_8
 

--- a/bin/chef-solo
+++ b/bin/chef-solo
@@ -3,7 +3,7 @@
 # ./chef-solo - Run the chef client, in stand-alone mode
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems"
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef/application/solo"
 

--- a/bin/chef-windows-service
+++ b/bin/chef-windows-service
@@ -2,7 +2,7 @@
 #
 # Author:: Jay Mundrawala (<jdm@chef.io>)
 #
-# Copyright:: 2014, Chef Software, Inc.
+# Copyright:: 2014-2018, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 # generate will call that file, and will be registered as
 # a windows service.
 
-require "rubygems"
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef"
 require "chef/application/windows_service"

--- a/bin/knife
+++ b/bin/knife
@@ -3,7 +3,7 @@
 # ./knife - Chef CLI interface
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rubygems"
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
 require "chef/application/knife"
 


### PR DESCRIPTION
Rubygems is built in Ruby now.

Signed-off-by: Tim Smith <tsmith@chef.io>