### PR TITLE
chef-13: Temporarily disable testing on Amazon Linux 2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,23 +125,25 @@ matrix:
     rvm: 2.4.3
   ### START TEST KITCHEN ONLY ###
   #
-  - rvm: 2.4.3
-    services: docker
-    sudo: required
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-      - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
-    before_script:
-      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      - cd kitchen-tests
-    script:
-      - bundle exec kitchen test base-amazonlinux
-    after_failure:
-      - cat .kitchen/logs/kitchen.log
-    env:
-      - AMAZON=LATEST
-      - KITCHEN_YAML=.kitchen.travis.yml
+  # Temporarily Disable Amazon Linux 2
+  #
+  # - rvm: 2.4.3
+  #   services: docker
+  #   sudo: required
+  #   gemfile: kitchen-tests/Gemfile
+  #   before_install:
+  #     - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+  #     - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
+  #   before_script:
+  #     - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  #     - cd kitchen-tests
+  #   script:
+  #     - bundle exec kitchen test base-amazonlinux
+  #   after_failure:
+  #     - cat .kitchen/logs/kitchen.log
+  #   env:
+  #     - AMAZON=LATEST
+  #     - KITCHEN_YAML=.kitchen.travis.yml
   - rvm: 2.4.3
     services: docker
     sudo: required


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Keep CI green by temporarily disabling Amazon Linux 2 on chef-13 branch whilst issues with Omnitruck/Mixlib-install are ironed out.

### Issues Resolved

Related: https://github.com/chef/mixlib-install/pull/259 
Related: https://github.com/chef/omnitruck/pull/364

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
