### PR TITLE
Prevent failures using windows_feature due to the platform helper

### DIFF
--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -259,6 +259,11 @@ class Chef
            node[:virtualization][:systems][:docker] && node[:virtualization][:systems][:docker] == "guest")
       end
 
+      # a simple helper to determine if we're on a windows release pre-2012 / 8
+      # @return [Boolean] Is the system older than Windows 8 / 2012
+      def older_than_win_2012_or_8?(node = run_context.nil? ? nil : run_context.node)
+        node["platform_version"].to_f < 6.2
+      end
     end
   end
 end

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -22,7 +22,7 @@ class Chef
     class << self
       # a simple helper to determine if we're on a windows release pre-2012 / 8
       # @return [Boolean] Is the system older than Windows 8 / 2012
-      def older_than_win_2012_or_8?
+      def older_than_win_2012_or_8?(node = run_context.nil? ? nil : run_context.node)
         node["platform_version"].to_f < 6.2
       end
 

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -20,12 +20,6 @@ class Chef
   class Platform
 
     class << self
-      # a simple helper to determine if we're on a windows release pre-2012 / 8
-      # @return [Boolean] Is the system older than Windows 8 / 2012
-      def older_than_win_2012_or_8?(node = run_context.nil? ? nil : run_context.node)
-        node["platform_version"].to_f < 6.2
-      end
-
       def windows?
         ChefConfig.windows?
       end

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -50,7 +50,7 @@ class Chef
         x = x.split(/\s*,\s*/) if x.is_a?(String) # split multiple forms of a comma separated list
 
         # feature installs on windows < 2012 are case sensitive so only downcase when on 2012+
-        Chef::Platform.older_than_win_2012_or_8? ? x : x.map(&:downcase)
+        older_than_win_2012_or_8? ? x : x.map(&:downcase)
       end
 
       action :install do
@@ -201,7 +201,7 @@ class Chef
           # dism on windows 2012+ isn't case sensitive so it's best to compare
           # lowercase lists so the user input doesn't need to be case sensitive
           # @todo when we're ready to remove windows 2008R2 the gating here can go away
-          feature_details.downcase! unless Chef::Platform.older_than_win_2012_or_8?
+          feature_details.downcase! unless older_than_win_2012_or_8?
           node.override["dism_features_cache"][feature_type] << feature_details
         end
 
@@ -219,7 +219,7 @@ class Chef
         # Fail unless we're on windows 8+ / 2012+ where deleting a feature is supported
         # @return [void]
         def raise_if_delete_unsupported
-          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not supported on Windows releases before Windows 8/2012. Cannot continue!" if Chef::Platform.older_than_win_2012_or_8?
+          raise Chef::Exceptions::UnsupportedAction, "#{self} :delete action not supported on Windows releases before Windows 8/2012. Cannot continue!" if older_than_win_2012_or_8?
         end
       end
     end


### PR DESCRIPTION
Move older_than_win_2012_or_8? to platform_introspection and pass in node automatically.

Signed-off-by: Tim Smith <tsmith@chef.io>