### PR TITLE
Fix DelayedEvaluator's with negative arity

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -666,7 +666,7 @@ class Chef
 
     def exec_in_resource(resource, proc, *args)
       if resource
-        if proc.arity > args.size
+        if proc.arity > args.size || ~proc.arity > args.size
           value = proc.call(resource, *args)
         else
           value = resource.instance_exec(*args, &proc)


### PR DESCRIPTION
### Description

`DelayedEvaluator` procs utilising a `*rest` param get a negative arity value, this causes them to be evaluated in the wrong context, checking against negative arity fixes this.

This functionality is useful when extending the DSL in cookbooks to support other kinds of `DelayedEvaluator`s. I've included the real world example that lead to discovering this case under the fold in case there's an error in approach that invalidates this use case.

<details>
<summary>Custom <code>DelayedEvaluator</code> example</summary>

```rb
class MemoizedDelayedEvaluator < Chef::DelayedEvaluator
  Empty = BasicObject.new

  def self.new(&proc)
    memo = Empty
    super() do |resource, *args|
      if memo == Empty
        memo = if proc.arity > args.size || ~proc.arity > args.size
          proc.call(resource, *args)
        else
          resource.instance_exec(*args, &proc)
        end
      end
      memo
    end
  end
end
```
</details>

### Reproduction

```rb
log 'this works now' do
  message lazy { |a, b| a.level.to_s }
  level :warn
end
# [2018-07-07T19:12:37+01:00] WARN: warn

log 'this is fixed by this pr' do
  message lazy { |a, *b| a.level.to_s }
  level :warn
end
# [2018-07-07T19:12:47+01:00] FATAL: NoMethodError: undefined method `level' for nil:NilClass
```