### PR TITLE
Enable Amazon Linux 2.0 tests again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
   only:
   - master
   - chef-13
-  - chef-12
 
 env:
   global:
@@ -115,26 +114,23 @@ matrix:
   #   script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
   #   rvm: 2.5.1
   ### START TEST KITCHEN ONLY ###
-  #
-  # Amazon Linux 2 disabled pending fixes in omnitruck/mixlib-install
-  #
-  # - rvm: 2.4.4
-  #   services: docker
-  #   sudo: required
-  #   gemfile: kitchen-tests/Gemfile
-  #   before_install:
-  #     - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-  #     - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
-  #   before_script:
-  #     - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-  #     - cd kitchen-tests
-  #   script:
-  #     - bundle exec kitchen test end-to-end-amazonlinux-2
-  #   after_failure:
-  #     - cat .kitchen/logs/kitchen.log
-  #   env:
-  #     - AMAZON=2
-  #     - KITCHEN_YAML=kitchen.travis.yml
+  - rvm: 2.4.4
+    services: docker
+    sudo: required
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
+      - bundle exec kitchen test end-to-end-amazonlinux-2
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+      - AMAZON=2
+      - KITCHEN_YAML=kitchen.travis.yml
   - rvm: 2.4.4
     services: docker
     sudo: required


### PR DESCRIPTION
We've deployed a new omnitruck release which should correct the version
identification bug we had before.

Signed-off-by: Tim Smith <tsmith@chef.io>