### PR TITLE
Expeditor: Remove labels that don't exist / chef 12 config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,4 @@
-# Documentation available at http://expeditor-docs.es.chef.io/
+# Documentation available at https://expeditor-docs.es.chef.io/
 
 # The name of the product keys for this product (from mixlib-install)
 product_key:
@@ -42,32 +42,26 @@ github:
         version_constraint: 14.*
     - chef-13:
         version_constraint: 13.*
-    - chef-12:
-        version_constraint: 12.*
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:
       ignore_labels:
-        - "Version: Skip Bump"
         - "Expeditor: Skip Version Bump"
         - "Expeditor: Skip All"
   - bash:.expeditor/update_version.sh:
       only_if: built_in:bump_version
   - built_in:update_changelog:
       ignore_labels:
-        - "Meta: Exclude From Changelog"
         - "Expeditor: Exclude From Changelog"
         - "Expeditor: Skip All"
   - built_in:trigger_habitat_package_build:
       ignore_labels:
-        - "Omnibus: Skip Build"
         - "Expeditor: Skip Build"
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
   - built_in:trigger_omnibus_release_build:
       ignore_labels:
-        - "Omnibus: Skip Build"
         - "Expeditor: Skip Build"
         - "Expeditor: Skip All"
       only_if: built_in:bump_version

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,4 @@
-# Documentation available at https://expeditor-docs.es.chef.io/
+# Documentation available at https://expeditor.chef.io
 
 # The name of the product keys for this product (from mixlib-install)
 product_key:


### PR DESCRIPTION
Remove labels that we don't use in chef/chef. Also remove Chef 12 branch setup.

Signed-off-by: Tim Smith <tsmith@chef.io>