### PR TITLE
[MSYS-843] - Add remove_account_right function to win32/security

### DIFF
--- a/lib/chef/win32/api/security.rb
+++ b/lib/chef/win32/api/security.rb
@@ -446,6 +446,7 @@ class Chef
         safe_attach_function :LookupPrivilegeDisplayNameW, [ :LPCWSTR, :LPCWSTR, :LPWSTR, :LPDWORD, :LPDWORD ], :BOOL
         safe_attach_function :LookupPrivilegeValueW, [ :LPCWSTR, :LPCWSTR, :PLUID ], :BOOL
         safe_attach_function :LsaAddAccountRights, [ :pointer, :pointer, :pointer, :ULONG ], :NTSTATUS
+        safe_attach_function :LsaRemoveAccountRights, [ :pointer, :pointer, :BOOL, :pointer, :ULONG ], :NTSTATUS
         safe_attach_function :LsaClose, [ :LSA_HANDLE ], :NTSTATUS
         safe_attach_function :LsaEnumerateAccountRights, [ :LSA_HANDLE, :PSID, :PLSA_UNICODE_STRING, :PULONG ], :NTSTATUS
         safe_attach_function :LsaFreeMemory, [ :PVOID ], :NTSTATUS

--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -117,6 +117,19 @@ class Chef
         end
       end
 
+      def self.remove_account_right(name, privilege)
+        privilege_pointer = FFI::MemoryPointer.new LSA_UNICODE_STRING, 1
+        privilege_lsa_string = LSA_UNICODE_STRING.new(privilege_pointer)
+        privilege_lsa_string[:Buffer] = FFI::MemoryPointer.from_string(privilege.to_wstring)
+        privilege_lsa_string[:Length] = privilege.length * 2
+        privilege_lsa_string[:MaximumLength] = (privilege.length + 1) * 2
+
+        with_lsa_policy(name) do |policy_handle, sid|
+          result = LsaRemoveAccountRights(policy_handle.read_pointer, sid, false, privilege_pointer, 1)
+          test_and_raise_lsa_nt_status(result)
+        end
+      end
+
       def self.adjust_token_privileges(token, privileges)
         token = token.handle if token.respond_to?(:handle)
         old_privileges_size = FFI::Buffer.new(:long).write_long(privileges.size_with_privileges)

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -176,6 +176,27 @@ describe "Chef::Win32::Security", :windows_only do
     end
   end
 
+  describe ".remove_account_right" do
+    let(:username) { ENV["USERNAME"] }
+
+    context "when given a valid username" do
+      it "removes the account right constants" do
+        Chef::ReservedNames::Win32::Security.add_account_right(username, "SeBatchLogonRight")
+        expect(Chef::ReservedNames::Win32::Security.get_account_right(username)).to include("SeBatchLogonRight")
+        Chef::ReservedNames::Win32::Security.remove_account_right(username, "SeBatchLogonRight")
+        expect(Chef::ReservedNames::Win32::Security.get_account_right(username)).not_to include("SeBatchLogonRight")
+      end
+    end
+
+    context "when given an invalid username" do
+      let(:username) { "noooooooooope" }
+
+      it "raises an exception" do
+        expect { Chef::ReservedNames::Win32::Security.remove_account_right(username, "SeBatchLogonRight") }.to raise_error(Chef::Exceptions::Win32APIError)
+      end
+    end
+  end
+
   describe ".test_and_raise_lsa_nt_status" do
     # NTSTATUS code: 0xC0000001 / STATUS_UNSUCCESSFUL
     # Windows Error: ERROR_GEN_FAILURE / 31 / 0x1F / A device attached to the system is not functioning.


### PR DESCRIPTION
- Added functionality 'remove_account_right' to remove the type of logon that a user account can perform.
- Added functional test case

Signed-off-by: [Nimesh](nimesh.patni@msystechnologies.com)

### Description

PR includes addition of a method `remove_account_right` by which we can remove a privilege of a user

### Issues Resolved

#[6716](https://github.com/chef/chef/issues/6716)

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
