### PR TITLE
Add knife config get/use-profile commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes.
 
+## New `knife config get-profile` and `knife config use-profile` commands
+
+Two new commands under `knife config` have been added, in addition to the previous
+`knife config get`. `get-profile` will display the active credentials profile
+name. `use-profile` will, conversely, set the default profile name. The default
+profile set via `use-profile` can still be overridden by the `--profile` command
+line option or the `$CHEF_PROFILE` environment variable.
+
 # Chef Client Release Notes 14.3:
 
 ## New Preview Resources Concept

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,30 @@
 This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes.
 
-## New `knife config get-profile` and `knife config use-profile` commands
+## Knife configuration profile management commands
 
-Two new commands under `knife config` have been added, in addition to the previous
-`knife config get`. `get-profile` will display the active credentials profile
-name. `use-profile` will, conversely, set the default profile name. The default
-profile set via `use-profile` can still be overridden by the `--profile` command
-line option or the `$CHEF_PROFILE` environment variable.
+Several new commands have been added under `knife config` to help manage multiple
+profiles in your `credentials` file.
+
+`knife config get-profile` will display the active profile.
+
+`knife config use-profile PROFILE` will set the workstation-level default
+profile. That default can still be overridden by the `--profile` command line
+option or the `$CHEF_PROFILE` environment variable.
+
+`knife config list-profiles` will display all your available profiles along with
+summary information on each.
+
+```bash
+$ knife config get-profile
+staging
+$ knife config use-profile prod
+Set default profile to prod
+$ knife config list-profiles
+ Profile  Client  Key               Server
+-----------------------------------------------------------------------------
+ staging  myuser  ~/.chef/user.pem  https://example.com/organizations/staging
+*prod     myuser  ~/.chef/user.pem  https://example.com/organizations/prod
+```
 
 # Chef Client Release Notes 14.3:
 

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -41,7 +41,7 @@ module ChefConfig
           profile
         elsif ENV.include?("CHEF_PROFILE")
           ENV["CHEF_PROFILE"]
-        elsif File.exist?(context_file)
+        elsif File.file?(context_file)
           File.read(context_file).strip
         else
           "default"
@@ -56,7 +56,7 @@ module ChefConfig
       # @return [void]
       def load_credentials(profile = nil)
         credentials_file = PathHelper.home(".chef", "credentials").freeze
-        return unless File.exist?(credentials_file)
+        return unless File.file?(credentials_file)
         profile = credentials_profile(profile)
         config = Tomlrb.load_file(credentials_file)
         if config[profile].nil?

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -304,8 +304,12 @@ class Chef
 
       # knife node run_list add requires that we have extra logic to handle
       # the case that command name words could be joined by an underscore :/
-      command_name_words = command_name_words.join("_")
-      @name_args.reject! { |name_arg| command_name_words == name_arg }
+      command_name_joined = command_name_words.join("_")
+      @name_args.reject! { |name_arg| command_name_joined == name_arg }
+
+      # Similar handling for hyphens.
+      command_name_joined = command_name_words.join("-")
+      @name_args.reject! { |name_arg| command_name_joined == name_arg }
 
       if config[:help]
         msg opt_parser

--- a/lib/chef/knife/config_get_profile.rb
+++ b/lib/chef/knife/config_get_profile.rb
@@ -1,0 +1,37 @@
+#
+# Copyright:: Copyright (c) 2018, Noah Kantrowitz
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/knife"
+
+class Chef
+  class Knife
+    class ConfigGetProfile < Knife
+      banner "knife config get-profile"
+
+      # Disable normal config loading since this shouldn't fail if the profile
+      # doesn't exist of the config is otherwise corrupted.
+      def configure_chef
+        apply_computed_config
+      end
+
+      def run
+        ui.msg(self.class.config_loader.credentials_profile(config[:profile]))
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/config_list_profiles.rb
+++ b/lib/chef/knife/config_list_profiles.rb
@@ -87,14 +87,14 @@ class Chef
       def render_table(profiles, padding: 2)
         # Replace the home dir in the client key path with ~.
         profiles.each do |profile|
-          profile[:client_key] = profile[:client_key].to_s.gsub(/^#{Regexp.escape(Dir.home)}/, '~') if profile[:client_key]
+          profile[:client_key] = profile[:client_key].to_s.gsub(/^#{Regexp.escape(Dir.home)}/, "~") if profile[:client_key]
         end
         # Render the data to a 2D array that will be used for the table.
-        table_data = [['', 'Profile', 'Client', 'Key', 'Server']] + profiles.map do |profile|
-          [profile[:active] ? '*' : ''] + profile.values_at(:profile, :client_name, :client_key, :server_url).map(&:to_s)
+        table_data = [["", "Profile", "Client", "Key", "Server"]] + profiles.map do |profile|
+          [profile[:active] ? "*" : ""] + profile.values_at(:profile, :client_name, :client_key, :server_url).map(&:to_s)
         end
         # Compute column widths.
-        column_widths = table_data.first.length.times.map do |i|
+        column_widths = Array.new(table_data.first.length) do |i|
           table_data.map { |row| row[i].length + padding }.max
         end
         # Special case, the first col gets no padding (because indicator) and last
@@ -102,7 +102,7 @@ class Chef
         column_widths[0] -= padding
         column_widths[-1] -= padding
         # Build the format string for each row.
-        format_string = column_widths.map { |w| "%-#{w}.#{w}s" }.join('')
+        format_string = column_widths.map { |w| "%-#{w}.#{w}s" }.join("")
         format_string << "\n"
         # Print the header row and a separator.
         table = ui.color(format_string % table_data.first, :green)

--- a/lib/chef/knife/config_list_profiles.rb
+++ b/lib/chef/knife/config_list_profiles.rb
@@ -1,0 +1,121 @@
+#
+# Copyright:: Copyright (c) 2018, Noah Kantrowitz
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/knife"
+require "chef/workstation_config_loader"
+
+class Chef
+  class Knife
+    class ConfigListProfiles < Knife
+      banner "knife config list-profiles"
+
+      option :ignore_knife_rb,
+             short: "-i",
+             long: "--ignore-knife-rb",
+             description: "Ignore the current knife.rb configuration",
+             default: false
+
+      def run
+        credentials_data = self.class.config_loader.parse_credentials_file
+        if credentials_data.nil? || credentials_data.empty?
+          # Should this just show the ambient knife.rb config as "default" instead?
+          ui.fatal("No profiles found, #{self.class.config_loader.credentials_file_path} does not exist or is empty")
+          exit 1
+        end
+
+        current_profile = self.class.config_loader.credentials_profile(config[:profile])
+        profiles = credentials_data.keys.map do |profile|
+          if config[:ignore_knife_rb]
+            # Don't do any fancy loading nonsense, just the raw data.
+            profile_data = credentials_data[profile]
+            {
+              profile: profile,
+              active: profile == current_profile,
+              client_name: profile_data["client_name"] || profile_data["node_name"],
+              client_key: profile_data["client_key"],
+              server_url: profile_data["chef_server_url"],
+            }
+          else
+            # Fancy loading nonsense so we get what the actual config would be.
+            # Note that this modifies the global config, after this, all bets are
+            # off as to whats in the config.
+            Chef::Config.reset
+            wcl = Chef::WorkstationConfigLoader.new(nil, Chef::Log, profile: profile)
+            wcl.load
+            {
+              profile: profile,
+              active: profile == current_profile,
+              client_name: Chef::Config[:node_name],
+              client_key: Chef::Config[:client_key],
+              server_url: Chef::Config[:chef_server_url],
+            }
+          end
+        end
+
+        # Try to reset the config.
+        unless config[:ignore_knife_rb]
+          Chef::Config.reset
+          Chef::WorkstationConfigLoader.new(config[:config_file], Chef::Log, profile: config[:profile]).load
+          apply_computed_config
+        end
+
+        if ui.interchange?
+          # Machine-readable output.
+          ui.output(profiles)
+        else
+          # Table output.
+          ui.output(render_table(profiles))
+        end
+      end
+
+      private
+
+      def render_table(profiles, padding: 2)
+        # Replace the home dir in the client key path with ~.
+        profiles.each do |profile|
+          profile[:client_key] = profile[:client_key].to_s.gsub(/^#{Regexp.escape(Dir.home)}/, '~') if profile[:client_key]
+        end
+        # Render the data to a 2D array that will be used for the table.
+        table_data = [['', 'Profile', 'Client', 'Key', 'Server']] + profiles.map do |profile|
+          [profile[:active] ? '*' : ''] + profile.values_at(:profile, :client_name, :client_key, :server_url).map(&:to_s)
+        end
+        # Compute column widths.
+        column_widths = table_data.first.length.times.map do |i|
+          table_data.map { |row| row[i].length + padding }.max
+        end
+        # Special case, the first col gets no padding (because indicator) and last
+        # get no padding because last.
+        column_widths[0] -= padding
+        column_widths[-1] -= padding
+        # Build the format string for each row.
+        format_string = column_widths.map { |w| "%-#{w}.#{w}s" }.join('')
+        format_string << "\n"
+        # Print the header row and a separator.
+        table = ui.color(format_string % table_data.first, :green)
+        table << "-" * column_widths.sum
+        table << "\n"
+        # Print the rest of the table.
+        table_data.drop(1).each do |row|
+          table << format_string % row
+        end
+        # Trim the last newline because ui.output adds one.
+        table.chomp!
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/config_use_profile.rb
+++ b/lib/chef/knife/config_use_profile.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: Copyright (c) 2018, Noah Kantrowitz
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "fileutils"
+
+require "chef/knife"
+
+class Chef
+  class Knife
+    class ConfigUseProfile < Knife
+      banner "knife config use-profile PROFILE"
+
+      # Disable normal config loading since this shouldn't fail if the profile
+      # doesn't exist of the config is otherwise corrupted.
+      def configure_chef
+        apply_computed_config
+      end
+
+      def run
+        context_file = ChefConfig::PathHelper.home(".chef", "context").freeze
+        profile = @name_args[0]&.strip
+        if profile && !profile.empty?
+          # Ensure the .chef/ folder exists.
+          FileUtils.mkdir_p(File.dirname(context_file))
+          IO.write(context_file, "#{profile}\n")
+          ui.msg("Set default profile to #{profile}")
+        else
+          show_usage
+          ui.fatal("You must specify a profile")
+          exit 1
+        end
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -142,7 +142,7 @@ class Chef
         words = words.dup
         match = nil
         until match || words.empty?
-          candidate = words.join(sep)
+          candidate = words.join(sep).tr("-", "_")
           if hash.key?(candidate)
             match = candidate
           else

--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -139,6 +139,7 @@ class Chef
       # hash composed of the given words joined by the separator.
       #
       def find_longest_key(hash, words, sep = "_")
+        words = words.dup
         match = nil
         until match || words.empty?
           candidate = words.join(sep)

--- a/spec/integration/knife/config_get_profile_spec.rb
+++ b/spec/integration/knife/config_get_profile_spec.rb
@@ -1,0 +1,112 @@
+#
+# Copyright 2018, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "support/shared/integration/integration_helper"
+require "support/shared/context/config"
+
+describe "knife config get-profile", :workstation do
+  include IntegrationSupport
+  include KnifeSupport
+
+  include_context "default config options"
+  include_context "with a chef repo"
+
+  let(:cmd_args) { [] }
+
+  subject do
+    cmd = knife("config", "get-profile", *cmd_args, instance_filter: lambda { |instance|
+      # Fake the failsafe check because this command doesn't actually process knife.rb.
+      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+    })
+    cmd.stdout
+  end
+
+  around do |ex|
+    # Store and reset the value of some env vars.
+    old_chef_home = ENV["CHEF_HOME"]
+    old_knife_home = ENV["KNIFE_HOME"]
+    old_home = ENV["HOME"]
+    old_wd = Dir.pwd
+    ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
+    # Clear these out because they are cached permanently.
+    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+    Chef::Knife::ConfigGet.reset_config_loader!
+    begin
+      ex.run
+    ensure
+      ENV["CHEF_HOME"] = old_chef_home
+      ENV["KNIFE_HOME"] = old_knife_home
+      ENV["HOME"] = old_home
+      Dir.chdir(old_wd)
+      ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+      ChefConfig::PathHelper.per_tool_home_environment = nil
+    end
+  end
+
+  before do
+    # Always run from the temp folder. This can't be in the `around` block above
+    # because it has to run after the before set in the "with a chef repo" shared context.
+    directory("repo")
+    Dir.chdir(path_to("repo"))
+    ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+    ENV["HOME"] = path_to(".")
+  end
+
+  context "with no configuration" do
+    it { is_expected.to eq "default\n" }
+  end
+
+  context "with --profile" do
+    let(:cmd_args) { %w{--profile production} }
+    it { is_expected.to eq "production\n" }
+  end
+
+  context "with an environment variable" do
+    around do |ex|
+      old_chef_profile = ENV["CHEF_PROFILE"]
+      begin
+        ENV["CHEF_PROFILE"] = "staging"
+        ex.run
+      ensure
+        ENV["CHEF_PROFILE"] = old_chef_profile
+      end
+    end
+
+    it { is_expected.to eq "staging\n" }
+  end
+
+  context "with a context file" do
+    before { file(".chef/context", "development\n") }
+    it { is_expected.to eq "development\n" }
+  end
+
+  context "with a context file under $CHEF_HOME" do
+    before do
+      file("chefhome/.chef/context", "other\n")
+      ENV["CHEF_HOME"] = path_to("chefhome")
+    end
+
+    it { is_expected.to eq "other\n" }
+  end
+
+  context "with a context file under $KNIFE_HOME" do
+    before do
+      file("knifehome/.chef/context", "other\n")
+      ENV["KNIFE_HOME"] = path_to("knifehome")
+    end
+
+    it { is_expected.to eq "other\n" }
+  end
+end

--- a/spec/integration/knife/config_get_profile_spec.rb
+++ b/spec/integration/knife/config_get_profile_spec.rb
@@ -42,7 +42,7 @@ describe "knife config get-profile", :workstation do
     ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
     # Clear these out because they are cached permanently.
     ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigGet.reset_config_loader!
+    Chef::Knife::ConfigGetProfile.reset_config_loader!
     begin
       ex.run
     ensure

--- a/spec/integration/knife/config_list_profiles_spec.rb
+++ b/spec/integration/knife/config_list_profiles_spec.rb
@@ -62,33 +62,33 @@ describe "knife config list-profiles", :workstation do
   # 2) Because of how the format strings are built, there is substantial trailing
   # whitespace in most cases which many editors "helpfully" remove.
 
-  context 'with no credentials file' do
+  context "with no credentials file" do
     subject { knife_list_profiles.stderr }
     it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
   end
 
-  context 'with an empty credentials file' do
-    before { file('.chef/credentials', '') }
+  context "with an empty credentials file" do
+    before { file(".chef/credentials", "") }
     subject { knife_list_profiles.stderr }
     it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
   end
 
-  context 'with a simple default profile' do
-    before { file('.chef/credentials', <<~EOH) }
+  context "with a simple default profile" do
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       client_name = "testuser"
       client_key = "testkey.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+    it { is_expected.to eq <<-EOH.delete("#") }
  Profile  Client    Key                  Server                                   #
 ----------------------------------------------------------------------------------#
 *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
 EOH
   end
 
-  context 'with multiple profiles' do
-    before { file('.chef/credentials', <<~EOH) }
+  context "with multiple profiles" do
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       client_name = "testuser"
       client_key = "testkey.pem"
@@ -104,7 +104,7 @@ EOH
       client_key = "~/src/qauser.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+    it { is_expected.to eq <<-EOH.delete("#") }
  Profile  Client    Key                  Server                                   #
 ----------------------------------------------------------------------------------#
 *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
@@ -113,9 +113,9 @@ EOH
 EOH
   end
 
-  context 'with a non-default active profile' do
+  context "with a non-default active profile" do
     let(:cmd_args) { %w{--profile prod} }
-    before { file('.chef/credentials', <<~EOH) }
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       client_name = "testuser"
       client_key = "testkey.pem"
@@ -131,7 +131,7 @@ EOH
       client_key = "~/src/qauser.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+    it { is_expected.to eq <<-EOH.delete("#") }
  Profile  Client    Key                  Server                                   #
 ----------------------------------------------------------------------------------#
  default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
@@ -140,21 +140,21 @@ EOH
 EOH
   end
 
-  context 'with a minimal profile' do
-    before { file('.chef/credentials', <<~EOH) }
+  context "with a minimal profile" do
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
     it { is_expected.to match %r{^*default .*? https://example.com/organizations/testorg$} }
   end
 
-  context 'with -i' do
+  context "with -i" do
     let(:cmd_args) { %w{-i} }
-    before { file('.chef/credentials', <<~EOH) }
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+    it { is_expected.to eq <<-EOH.delete("#") }
  Profile  Client  Key  Server                                   #
 ----------------------------------------------------------------#
 *default               https://example.com/organizations/testorg#
@@ -163,7 +163,7 @@ EOH
 
   context "with --format=json" do
     let(:cmd_args) { %w{--format=json node_name} }
-    before { file('.chef/credentials', <<~EOH) }
+    before { file(".chef/credentials", <<~EOH) }
       [default]
       client_name = "testuser"
       client_key = "testkey.pem"
@@ -179,10 +179,11 @@ EOH
       client_key = "~/src/qauser.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { expect(JSON.parse(subject)).to eq [
-      {"profile" => "default", "active" => true, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/testorg"},
-      {"profile" => "prod", "active" => false, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/prod"},
-      {"profile" => "qa", "active" => false, "client_name" => "qauser", "client_key" => path_to("src/qauser.pem"), "server_url" => "https://example.com/organizations/testorg"},
+    it {
+      expect(JSON.parse(subject)).to eq [
+      { "profile" => "default", "active" => true, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/testorg" },
+      { "profile" => "prod", "active" => false, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/prod" },
+      { "profile" => "qa", "active" => false, "client_name" => "qauser", "client_key" => path_to("src/qauser.pem"), "server_url" => "https://example.com/organizations/testorg" },
     ] }
   end
 end

--- a/spec/integration/knife/config_list_profiles_spec.rb
+++ b/spec/integration/knife/config_list_profiles_spec.rb
@@ -57,10 +57,9 @@ describe "knife config list-profiles", :workstation do
     ENV["HOME"] = path_to(".")
   end
 
-  # NOTE: The funky formatting of some of the output examples are because
-  # 1) ~ mode heredocs get sad about the unequal leading whitespace.
-  # 2) Because of how the format strings are built, there is substantial trailing
-  # whitespace in most cases which many editors "helpfully" remove.
+  # NOTE: The funky formatting with # at the end of the line of some of the
+  # output examples are because of how the format strings are built, there is
+  # substantial trailing whitespace in most cases which many editors "helpfully" remove.
 
   context "with no credentials file" do
     subject { knife_list_profiles.stderr }
@@ -80,11 +79,11 @@ describe "knife config list-profiles", :workstation do
       client_key = "testkey.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.delete("#") }
- Profile  Client    Key                  Server                                   #
-----------------------------------------------------------------------------------#
-*default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-EOH
+    it { is_expected.to eq <<~EOH.delete("#") }
+       Profile  Client    Key                  Server                                   #
+      ----------------------------------------------------------------------------------#
+      *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+    EOH
   end
 
   context "with multiple profiles" do
@@ -104,13 +103,13 @@ EOH
       client_key = "~/src/qauser.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.delete("#") }
- Profile  Client    Key                  Server                                   #
-----------------------------------------------------------------------------------#
-*default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
- prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
- qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
-EOH
+    it { is_expected.to eq <<~EOH.delete("#") }
+       Profile  Client    Key                  Server                                   #
+      ----------------------------------------------------------------------------------#
+      *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+       prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+       qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+    EOH
   end
 
   context "with a non-default active profile" do
@@ -131,13 +130,13 @@ EOH
       client_key = "~/src/qauser.pem"
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.delete("#") }
- Profile  Client    Key                  Server                                   #
-----------------------------------------------------------------------------------#
- default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-*prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
- qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
-EOH
+    it { is_expected.to eq <<~EOH.delete("#") }
+       Profile  Client    Key                  Server                                   #
+      ----------------------------------------------------------------------------------#
+       default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+      *prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+       qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+    EOH
   end
 
   context "with a minimal profile" do
@@ -154,11 +153,11 @@ EOH
       [default]
       chef_server_url = "https://example.com/organizations/testorg"
     EOH
-    it { is_expected.to eq <<-EOH.delete("#") }
- Profile  Client  Key  Server                                   #
-----------------------------------------------------------------#
-*default               https://example.com/organizations/testorg#
-EOH
+    it { is_expected.to eq <<~EOH.delete("#") }
+       Profile  Client  Key  Server                                   #
+      ----------------------------------------------------------------#
+      *default               https://example.com/organizations/testorg#
+    EOH
   end
 
   context "with --format=json" do

--- a/spec/integration/knife/config_list_profiles_spec.rb
+++ b/spec/integration/knife/config_list_profiles_spec.rb
@@ -1,0 +1,136 @@
+#
+# Copyright 2018, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "support/shared/integration/integration_helper"
+require "support/shared/context/config"
+
+describe "knife config list-profiles", :workstation do
+  include IntegrationSupport
+  include KnifeSupport
+
+  include_context "default config options"
+  include_context "with a chef repo"
+
+  let(:cmd_args) { [] }
+  let(:knife_list_profiles) do
+    knife("config", "list-profiles", *cmd_args, instance_filter: proc {
+      # Clear the stub set up in KnifeSupport.
+      allow(File).to receive(:file?).and_call_original
+    })
+  end
+  subject { knife_list_profiles.stdout }
+
+  around do |ex|
+    # Store and reset the value of some env vars.
+    old_home = ENV["HOME"]
+    old_wd = Dir.pwd
+    # Clear these out because they are cached permanently.
+    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+    Chef::Knife::ConfigListProfiles.reset_config_loader!
+    begin
+      ex.run
+    ensure
+      ENV["HOME"] = old_home
+      Dir.chdir(old_wd)
+      ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+    end
+  end
+
+  before do
+    # Always run from the temp folder. This can't be in the `around` block above
+    # because it has to run after the before set in the "with a chef repo" shared context.
+    directory("repo")
+    Dir.chdir(path_to("repo"))
+    ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+    ENV["HOME"] = path_to(".")
+  end
+
+  # NOTE: The funky formatting of some of the output examples are because
+  # 1) ~ mode heredocs get sad about the unequal leading whitespace.
+  # 2) Because of how the format strings are built, there is substantial trailing
+  # whitespace in most cases which many editors "helpfully" remove.
+
+  context 'with no credentials file' do
+    subject { knife_list_profiles.stderr }
+    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
+  end
+
+  context 'with an empty credentials file' do
+    before { file('.chef/credentials', '') }
+    subject { knife_list_profiles.stderr }
+    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
+  end
+
+  context 'with a simple default profile' do
+    before { file('.chef/credentials', <<~EOH) }
+      [default]
+      client_name = "testuser"
+      client_key = "testkey.pem"
+      chef_server_url = "https://example.com/organizations/testorg"
+    EOH
+    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+ Profile  Client    Key                  Server                                   #
+----------------------------------------------------------------------------------#
+*default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+EOH
+  end
+
+  context 'with multiple profiles' do
+    before { file('.chef/credentials', <<~EOH) }
+      [default]
+      client_name = "testuser"
+      client_key = "testkey.pem"
+      chef_server_url = "https://example.com/organizations/testorg"
+
+      [prod]
+      client_name = "testuser"
+      client_key = "testkey.pem"
+      chef_server_url = "https://example.com/organizations/prod"
+
+      [qa]
+      client_name = "qauser"
+      client_key = "~/src/qauser.pem"
+      chef_server_url = "https://example.com/organizations/testorg"
+    EOH
+    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+ Profile  Client    Key                  Server                                   #
+----------------------------------------------------------------------------------#
+*default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+ prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+ qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+EOH
+  end
+
+  context 'with a minimal profile' do
+    before { file('.chef/credentials', <<~EOH) }
+      [default]
+      chef_server_url = "https://example.com/organizations/testorg"
+    EOH
+    it { is_expected.to match %r{^*default .*? https://example.com/organizations/testorg$} }
+  end
+
+  context 'with -i' do
+    let(:cmd_args) { %w{-i} }
+    before { file('.chef/credentials', <<~EOH) }
+      [default]
+      chef_server_url = "https://example.com/organizations/testorg"
+    EOH
+    it { is_expected.to eq <<-EOH.gsub(/#/, '') }
+ Profile  Client  Key  Server                                   #
+----------------------------------------------------------------#
+*default               https://example.com/organizations/testorg#
+EOH
+  end
+end

--- a/spec/integration/knife/config_use_profile_spec.rb
+++ b/spec/integration/knife/config_use_profile_spec.rb
@@ -1,0 +1,100 @@
+#
+# Copyright 2018, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "support/shared/integration/integration_helper"
+require "support/shared/context/config"
+
+describe "knife config use-profile", :workstation do
+  include IntegrationSupport
+  include KnifeSupport
+
+  include_context "default config options"
+  include_context "with a chef repo"
+
+  let(:cmd_args) { [] }
+
+  let(:knife_use_profile) do
+    knife("config", "use-profile", *cmd_args, instance_filter: lambda { |instance|
+      # Fake the failsafe check because this command doesn't actually process knife.rb.
+      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+    })
+  end
+
+  subject { knife_use_profile.stdout }
+
+  around do |ex|
+    # Store and reset the value of some env vars.
+    old_chef_home = ENV["CHEF_HOME"]
+    old_knife_home = ENV["KNIFE_HOME"]
+    old_home = ENV["HOME"]
+    old_wd = Dir.pwd
+    ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
+    # Clear these out because they are cached permanently.
+    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+    Chef::Knife::ConfigGet.reset_config_loader!
+    begin
+      ex.run
+    ensure
+      ENV["CHEF_HOME"] = old_chef_home
+      ENV["KNIFE_HOME"] = old_knife_home
+      ENV["HOME"] = old_home
+      Dir.chdir(old_wd)
+      ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+      ChefConfig::PathHelper.per_tool_home_environment = nil
+    end
+  end
+
+  before do
+    # Always run from the temp folder. This can't be in the `around` block above
+    # because it has to run after the before set in the "with a chef repo" shared context.
+    directory("repo")
+    Dir.chdir(path_to("repo"))
+    ENV[ChefConfig.windows? ? "CD" : "PWD"] = Dir.pwd
+    ENV["HOME"] = path_to(".")
+  end
+
+  context "with no argument" do
+    subject { knife_use_profile.stderr }
+    it { is_expected.to eq "FATAL: You must specify a profile\n" }
+  end
+
+  context "with an argument" do
+    let(:cmd_args) { %w{production} }
+    it do
+      is_expected.to eq "Set default profile to production\n"
+      expect(File.read(path_to(".chef/context"))).to eq "production\n"
+    end
+  end
+
+  context "with $CHEF_HOME" do
+    let(:cmd_args) { %w{staging} }
+    before { ENV["CHEF_HOME"] = path_to("chefhome"); file("chefhome/tmp", "") }
+    it do
+      is_expected.to eq "Set default profile to staging\n"
+      expect(File.read(path_to("chefhome/.chef/context"))).to eq "staging\n"
+      expect(File.exist?(path_to(".chef/context"))).to be_falsey
+    end
+  end
+
+  context "with $KNIFE_HOME" do
+    let(:cmd_args) { %w{development} }
+    before { ENV["KNIFE_HOME"] = path_to("knifehome"); file("knifehome/tmp", "") }
+    it do
+      is_expected.to eq "Set default profile to development\n"
+      expect(File.read(path_to("knifehome/.chef/context"))).to eq "development\n"
+      expect(File.exist?(path_to(".chef/context"))).to be_falsey
+    end
+  end
+end

--- a/spec/integration/knife/config_use_profile_spec.rb
+++ b/spec/integration/knife/config_use_profile_spec.rb
@@ -43,7 +43,7 @@ describe "knife config use-profile", :workstation do
     ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
     # Clear these out because they are cached permanently.
     ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigGet.reset_config_loader!
+    Chef::Knife::ConfigUseProfile.reset_config_loader!
     begin
       ex.run
     ensure


### PR DESCRIPTION
Mostly because explaining the `.chef/context` file to people is hard, so hide it behind a command. These should probably grow up to be `chef` CLI commands some day but I'm not doing that until we have a better idea of the plan there.