### PR TITLE
Mildly speed up knife by moving deps into dep blocks

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -18,7 +18,6 @@
 
 require "chef/knife"
 require "chef/knife/data_bag_secret_options"
-require "erubis"
 require "chef/knife/bootstrap/chef_vault_handler"
 require "chef/knife/bootstrap/client_builder"
 require "chef/util/path_helper"
@@ -32,6 +31,7 @@ class Chef
       attr_accessor :chef_vault_handler
 
       deps do
+        require "erubis"
         require "chef/knife/core/bootstrap_context"
         require "chef/json_compat"
         require "tempfile"

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -17,7 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/util/path_helper"
 
 class Chef
   class Knife
@@ -26,6 +25,7 @@ class Chef
       attr_reader :chef_repo, :new_client_key, :validation_client_name, :validation_key
 
       deps do
+        require "chef/util/path_helper"
         require "ohai"
         Chef::Knife::ClientCreate.load_deps
         Chef::Knife::UserCreate.load_deps

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -17,9 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/exceptions"
-require "shellwords"
-require "mixlib/archive"
 
 class Chef
   class Knife
@@ -29,6 +26,9 @@ class Chef
         require "chef/mixin/shell_out"
         require "chef/knife/core/cookbook_scm_repo"
         require "chef/cookbook/metadata"
+        require "chef/exceptions"
+        require "shellwords"
+        require "mixlib/archive"
       end
 
       banner "knife cookbook site install COOKBOOK [VERSION] (options)"

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -18,22 +18,19 @@
 #
 
 require "chef/knife"
-require "chef/mixin/shell_out"
 
 class Chef
   class Knife
     class CookbookSiteShare < Knife
 
-      include Chef::Mixin::ShellOut
-
       deps do
         require "chef/cookbook_loader"
         require "chef/cookbook_uploader"
         require "chef/cookbook_site_streaming_uploader"
-        require "mixlib/shellout"
-      end
+        require "chef/mixin/shell_out"
 
-      include Chef::Mixin::ShellOut
+        include Chef::Mixin::ShellOut
+      end
 
       banner "knife cookbook site share COOKBOOK [CATEGORY] (options)"
       category "cookbook site"

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -19,7 +19,6 @@
 #
 
 require "chef/knife"
-require "chef/cookbook_uploader"
 
 class Chef
   class Knife

--- a/lib/chef/knife/data_bag_from_file.rb
+++ b/lib/chef/knife/data_bag_from_file.rb
@@ -18,7 +18,6 @@
 #
 
 require "chef/knife"
-require "chef/util/path_helper"
 require "chef/knife/data_bag_secret_options"
 
 class Chef
@@ -27,6 +26,7 @@ class Chef
       include DataBagSecretOptions
 
       deps do
+        require "chef/util/path_helper"
         require "chef/data_bag"
         require "chef/data_bag_item"
         require "chef/knife/core/object_loader"

--- a/lib/chef/knife/exec.rb
+++ b/lib/chef/knife/exec.rb
@@ -17,11 +17,14 @@
 #
 
 require "chef/knife"
-require "chef/util/path_helper"
 
 class Chef::Knife::Exec < Chef::Knife
 
   banner "knife exec [SCRIPT] (options)"
+
+  deps do
+    require "chef/util/path_helper"
+  end
 
   option :exec,
     short: "-E CODE",

--- a/lib/chef/knife/node_show.rb
+++ b/lib/chef/knife/node_show.rb
@@ -17,7 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/knife/core/node_presenter"
 
 class Chef
   class Knife
@@ -27,6 +26,7 @@ class Chef
       include Knife::Core::MultiAttributeReturnOption
 
       deps do
+        require "chef/knife/core/node_presenter"
         require "chef/node"
         require "chef/json_compat"
       end

--- a/lib/chef/knife/raw.rb
+++ b/lib/chef/knife/raw.rb
@@ -15,7 +15,6 @@
 #
 
 require "chef/knife"
-require "chef/http"
 
 class Chef
   class Knife

--- a/lib/chef/knife/recipe_list.rb
+++ b/lib/chef/knife/recipe_list.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/knife"
+
 class Chef::Knife::RecipeList < Chef::Knife
 
   banner "knife recipe list [PATTERN]"

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -15,13 +15,16 @@
 #
 
 require "chef/knife"
-require "chef/local_mode"
 
 class Chef
   class Knife
     class Serve < Knife
 
       banner "knife serve (options)"
+
+      deps do
+        require "chef/local_mode"
+      end
 
       option :repo_mode,
         long: "--repo-mode MODE",

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require "chef/mixin/shell_out"
 require "chef/knife"
 
 class Chef
@@ -30,7 +29,7 @@ class Chef
         require "chef/exceptions"
         require "chef/search/query"
         require "chef/util/path_helper"
-        require "mixlib/shellout"
+        require "chef/mixin/shell_out"
       end
 
       include Chef::Mixin::ShellOut

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -17,16 +17,17 @@
 #
 
 require "chef/knife"
-require "chef/knife/core/status_presenter"
-require "chef/knife/core/node_presenter"
 
 class Chef
   class Knife
     class Status < Knife
-      include Knife::Core::NodeFormattingOptions
 
       deps do
+        require "chef/knife/core/status_presenter"
+        require "chef/knife/core/node_presenter"
         require "chef/search/query"
+
+        include Knife::Core::NodeFormattingOptions
       end
 
       banner "knife status QUERY (options)"

--- a/spec/unit/cookbook_uploader_spec.rb
+++ b/spec/unit/cookbook_uploader_spec.rb
@@ -17,6 +17,7 @@
 #
 
 require "spec_helper"
+require "chef/cookbook_uploader"
 
 describe Chef::CookbookUploader do
 


### PR DESCRIPTION
We can lazily load the requirements for knife plugins, but we don't do that for all our plugins. We should. Is this a game changer? Nope. It does make it 4% faster though, which makes it worth doing.

Side note: We have some dupe requires in here and we also requires mixlib-shellout and mixin-shellout when we only used mixin-shellout.

Signed-off-by: Tim Smith <tsmith@chef.io>