### PR TITLE
Remove require mixlib/shellouts where not necessary

### DIFF
--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout"
+require "chef/mixin/shell_out"
 require "chef/provider/user"
 require "openssl"
 require "plist"

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -18,7 +18,6 @@
 #
 
 require "spec_helper"
-require "mixlib/shellout"
 
 describe Chef::Provider::Service::Windows, "load_current_resource", :windows_only do
   include_context "Win32"

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout"
 require "spec_helper"
 
 describe Chef::Provider::User::Aix do

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -18,7 +18,6 @@
 
 require "spec_helper"
 require "ostruct"
-require "mixlib/shellout"
 
 describe Chef::Provider::User::Dscl do
   before do

--- a/spec/unit/provider/user/solaris_spec.rb
+++ b/spec/unit/provider/user/solaris_spec.rb
@@ -20,7 +20,6 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout"
 require "spec_helper"
 
 describe Chef::Provider::User::Solaris do


### PR DESCRIPTION
the dscl user provider uses mixin/shell_out instead and the specs don't seem to use mixlib/shellout or actually need the require.

Signed-off-by: Tim Smith <tsmith@chef.io>