### PR TITLE
Provide a better error when knife plugins are missing from the cache

### DIFF
--- a/lib/chef/knife/core/hashed_command_loader.rb
+++ b/lib/chef/knife/core/hashed_command_loader.rb
@@ -60,7 +60,7 @@ class Chef
           if errors.empty?
             commands
           else
-            Chef::Log.error "There are files specified in the manifest that are missing. Please rehash to update the subcommands cache. If you see this error after rehashing delete the cache at #{Chef::Knife::SubcommandLoader.plugin_manifest_path}"
+            Chef::Log.error "There are plugin files specified in the knife cache that cannot be found. Please run knife rehash to update the subcommands cache. If you see this error after rehashing delete the cache at #{Chef::Knife::SubcommandLoader.plugin_manifest_path}"
             Chef::Log.error "Missing files:\n\t#{errors.values.flatten.join("\n\t")}"
             {}
           end

--- a/spec/unit/knife/core/hashed_command_loader_spec.rb
+++ b/spec/unit/knife/core/hashed_command_loader_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Knife::SubcommandLoader::HashedCommandLoader do
       end
 
       it "lists all commands by category when no argument is given" do
-        expect(Chef::Log).to receive(:error).with(/There are files specified in the manifest that are missing/)
+        expect(Chef::Log).to receive(:error).with(/There are plugin files specified in the knife cache that cannot be found/)
         expect(Chef::Log).to receive(:error).with("Missing files:\n\t/file/for/plugin/b")
         expect(loader.list_commands).to eq({})
       end


### PR DESCRIPTION
No one outside chef developers knows what the manifest is and we don't actually tell them what command to run. Leave the details out. Just tell them how to fix it.

Signed-off-by: Tim Smith <tsmith@chef.io>