### PR TITLE
Remove mcquin as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -39,7 +39,6 @@ To mention the team, use @chef/client-core
 * [Jon Cowie](https://github.com/jonlives)
 * [Joshua Timberman](https://github.com/jtimberman)
 * [Lamont Granquist](https://github.com/lamont-granquist)
-* [Claire McQuin](https://github.com/mcquin)
 * [Ranjib Dey](https://github.com/ranjib)
 * [Steven Murawski](https://github.com/smurawski)
 * [Steven Danna](https://github.com/stevendanna)

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -45,7 +45,6 @@ Maintainers for the Chef client, Ohai, mixlibs, ChefDK, ChefSpec, Foodcritic, ch
         "jonlives",
         "jtimberman",
         "lamont-granquist",
-        "mcquin",
         "ranjib",
         "smurawski",
         "stevendanna",
@@ -272,17 +271,9 @@ The specific components of Chef related to a given platform - including (but not
     Name = "Aaron Kalin"
     GitHub = "martinisoft"
 
-  [people.mcquin]
-    Name = "Claire McQuin"
-    GitHub = "mcquin"
-
   [people.ranjib]
     Name = "Ranjib Dey"
     GitHub = "ranjib"
-
-  [people.sethvargo]
-    Name = "Seth Vargo"
-    GitHub = "sethvargo"
 
   [people.smurawski]
     Name = "Steven Murawski"


### PR DESCRIPTION
@mcquin recently asked that we remove her from the maintainer list.

I also removed the person field for Seth Vargo since he's not on the list anymore

Signed-off-by: Tim Smith <tsmith@chef.io>