### PR TITLE
Fix duplicated query parameters to resolve Chef::HTTP::Simple regression

### DIFF
--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -152,7 +152,7 @@ class Chef
       end
 
       def configure_http_request(request_body = nil)
-        req_path = (path).to_s
+        req_path = path.to_s.dup
         req_path << "?#{query}" if query
 
         @http_request = case method.to_s.downcase

--- a/spec/unit/http/http_request_spec.rb
+++ b/spec/unit/http/http_request_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Klaas Jan Wierenga (<k.j.wierenga@gmail.com>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,12 @@ describe Chef::HTTP::HTTPRequest do
       expect(request.headers["Host"]).to eql("yourhost.com:8888")
     end
 
+    it "should not mutate the URI when it contains parameters" do
+      # buggy constructor code mutated strings owned by the URI parameter
+      uri = URI("http://dummy.com/foo?bar=baz")
+      request = Chef::HTTP::HTTPRequest.new(:GET, uri, "")
+      expect(uri).to eql(URI("http://dummy.com/foo?bar=baz"))
+    end
   end
 
   context "with HTTPS url scheme" do


### PR DESCRIPTION
rubocop rule led to us mutating the argument to the constructor here
and continuously appending query params.

closes #7461