### PR TITLE
Move all knife cookbook site plugin logic into knife supermarket

### DIFF
--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -17,106 +17,18 @@
 #
 
 require "chef/knife"
+require "chef/knife/supermarket_download"
 
 class Chef
   class Knife
-    class CookbookSiteDownload < Knife
+    class CookbookSiteDownload < Knife::SupermarketDownload
 
-      deps do
-        require "fileutils"
-      end
+      # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site download COOKBOOK [VERSION] (options)"
       category "cookbook site"
-
-      option :file,
-        short: "-f FILE",
-        long: "--file FILE",
-        description: "The filename to write to"
-
-      option :force,
-        long: "--force",
-        description: "Force download deprecated version"
-
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        if current_cookbook_deprecated?
-          message = "DEPRECATION: This cookbook has been deprecated. "
-          replacement = replacement_cookbook
-          if !replacement.to_s.strip.empty?
-            message << "It has been replaced by #{replacement}."
-          else
-            message << "No replacement has been defined."
-          end
-          ui.warn message
-
-          unless config[:force]
-            ui.warn "Use --force to force download deprecated cookbook."
-            return
-          end
-        end
-
-        download_cookbook
-      end
-
-      def version
-        @version = desired_cookbook_data["version"]
-      end
-
-      private
-
-      def cookbooks_api_url
-        "#{config[:supermarket_site]}/api/v1/cookbooks"
-      end
-
-      def current_cookbook_data
-        @current_cookbook_data ||= begin
-                                     noauth_rest.get "#{cookbooks_api_url}/#{@name_args[0]}"
-                                   end
-      end
-
-      def current_cookbook_deprecated?
-        current_cookbook_data["deprecated"] == true
-      end
-
-      def desired_cookbook_data
-        @desired_cookbook_data ||= begin
-                                     uri = if @name_args.length == 1
-                                             current_cookbook_data["latest_version"]
-                                           else
-                                             specific_cookbook_version_url
-                                           end
-
-                                     noauth_rest.get uri
-                                   end
-      end
-
-      def download_cookbook
-        ui.info "Downloading #{@name_args[0]} from Supermarket at version #{version} to #{download_location}"
-        tf = noauth_rest.streaming_request(desired_cookbook_data["file"])
-
-        ::FileUtils.cp tf.path, download_location
-        ui.info "Cookbook saved: #{download_location}"
-      end
-
-      def download_location
-        config[:file] ||= File.join Dir.pwd, "#{@name_args[0]}-#{version}.tar.gz"
-        config[:file]
-      end
-
-      def replacement_cookbook
-        File.basename(current_cookbook_data["replacement"] || "")
-      end
-
-      def specific_cookbook_version_url
-        "#{cookbooks_api_url}/#{@name_args[0]}/versions/#{@name_args[1].tr('.', '_')}"
-      end
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -17,180 +17,19 @@
 #
 
 require "chef/knife"
-require "chef/exceptions"
-require "shellwords"
-require "mixlib/archive"
+require "chef/knife/supermarket_install"
 
 class Chef
   class Knife
-    class CookbookSiteInstall < Knife
+    class CookbookSiteInstall < Knife::SupermarketInstall
 
-      deps do
-        require "chef/mixin/shell_out"
-        require "chef/knife/core/cookbook_scm_repo"
-        require "chef/cookbook/metadata"
-      end
+      # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site install COOKBOOK [VERSION] (options)"
       category "cookbook site"
 
-      option :no_deps,
-       short: "-D",
-       long: "--skip-dependencies",
-       boolean: true,
-       default: false,
-       description: "Skips automatic dependency installation."
-
-      option :cookbook_path,
-        short: "-o PATH:PATH",
-        long: "--cookbook-path PATH:PATH",
-        description: "A colon-separated path to look for cookbooks in",
-        proc: lambda { |o| o.split(":") }
-
-      option :default_branch,
-        short: "-B BRANCH",
-        long: "--branch BRANCH",
-        description: "Default branch to work with",
-        default: "master"
-
-      option :use_current_branch,
-        short: "-b",
-        long: "--use-current-branch",
-        description: "Use the current branch",
-        boolean: true,
-        default: false
-
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      attr_reader :cookbook_name
-      attr_reader :vendor_path
-
-      def run
-        extend Chef::Mixin::ShellOut
-
-        if config[:cookbook_path]
-          Chef::Config[:cookbook_path] = config[:cookbook_path]
-        else
-          config[:cookbook_path] = Chef::Config[:cookbook_path]
-        end
-
-        @cookbook_name = parse_name_args!
-        # Check to ensure we have a valid source of cookbooks before continuing
-        #
-        @install_path = File.expand_path(Array(config[:cookbook_path]).first)
-        ui.info "Installing #{@cookbook_name} to #{@install_path}"
-
-        @repo = CookbookSCMRepo.new(@install_path, ui, config)
-        # cookbook_path = File.join(vendor_path, name_args[0])
-        upstream_file = File.join(@install_path, "#{@cookbook_name}.tar.gz")
-
-        @repo.sanity_check
-        unless config[:use_current_branch]
-          @repo.reset_to_default_state
-          @repo.prepare_to_import(@cookbook_name)
-        end
-
-        downloader = download_cookbook_to(upstream_file)
-        clear_existing_files(File.join(@install_path, @cookbook_name))
-        extract_cookbook(upstream_file, downloader.version)
-
-        # TODO: it'd be better to store these outside the cookbook repo and
-        # keep them around, e.g., in ~/Library/Caches on OS X.
-        ui.info("Removing downloaded tarball")
-        File.unlink(upstream_file)
-
-        if @repo.finalize_updates_to(@cookbook_name, downloader.version)
-          unless config[:use_current_branch]
-            @repo.reset_to_default_state
-          end
-          @repo.merge_updates_from(@cookbook_name, downloader.version)
-        else
-          unless config[:use_current_branch]
-            @repo.reset_to_default_state
-          end
-        end
-
-        unless config[:no_deps]
-          preferred_metadata.dependencies.each_key do |cookbook|
-            # Doesn't do versions.. yet
-            nv = self.class.new
-            nv.config = config
-            nv.name_args = [ cookbook ]
-            nv.run
-          end
-        end
-      end
-
-      def parse_name_args!
-        if name_args.empty?
-          ui.error("Please specify a cookbook to download and install.")
-          exit 1
-        elsif name_args.size >= 2
-          unless name_args.last.match(/^(\d+)(\.\d+){1,2}$/) && name_args.size == 2
-            ui.error("Installing multiple cookbooks at once is not supported.")
-            exit 1
-          end
-        end
-        name_args.first
-      end
-
-      def download_cookbook_to(download_path)
-        downloader = Chef::Knife::CookbookSiteDownload.new
-        downloader.config[:file] = download_path
-        downloader.config[:supermarket_site] = config[:supermarket_site]
-        downloader.name_args = name_args
-        downloader.run
-        downloader
-      end
-
-      def extract_cookbook(upstream_file, version)
-        ui.info("Uncompressing #{@cookbook_name} version #{version}.")
-        Mixlib::Archive.new(convert_path(upstream_file)).extract(@install_path, perms: false)
-      end
-
-      def clear_existing_files(cookbook_path)
-        ui.info("Removing pre-existing version.")
-        FileUtils.rmtree(cookbook_path) if File.directory?(cookbook_path)
-      end
-
-      def convert_path(upstream_file)
-        # converts a Windows path (C:\foo) to a mingw path (/c/foo)
-        if ENV["MSYSTEM"] == "MINGW32"
-          upstream_file.sub(/^([[:alpha:]]):/, '/\1')
-        else
-          Shellwords.escape upstream_file
-        end
-      end
-
-      # Get the preferred metadata path on disk. Chef prefers the metadata.rb
-      # over the metadata.json.
-      #
-      # @raise if there is no metadata in the cookbook
-      #
-      # @return [Chef::Cookbook::Metadata]
-      def preferred_metadata
-        md = Chef::Cookbook::Metadata.new
-
-        rb = File.join(@install_path, @cookbook_name, "metadata.rb")
-        if File.exist?(rb)
-          md.from_file(rb)
-          return md
-        end
-
-        json = File.join(@install_path, @cookbook_name, "metadata.json")
-        if File.exist?(json)
-          json = IO.read(json)
-          md.from_json(json)
-          return md
-        end
-
-        raise Chef::Exceptions::MetadataNotFound.new(@install_path, @cookbook_name)
-      end
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -17,49 +17,19 @@
 #
 
 require "chef/knife"
+require "chef/knife/supermarket_list"
 
 class Chef
   class Knife
-    class CookbookSiteList < Knife
+    class CookbookSiteList < Knife::SupermarketList
+
+      # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site list (options)"
       category "cookbook site"
 
-      option :with_uri,
-        short: "-w",
-        long: "--with-uri",
-        description: "Show corresponding URIs"
-
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        if config[:with_uri]
-          cookbooks = Hash.new
-          get_cookbook_list.each { |k, v| cookbooks[k] = v["cookbook"] }
-          ui.output(format_for_display(cookbooks))
-        else
-          ui.msg(ui.list(get_cookbook_list.keys.sort, :columns_down))
-        end
-      end
-
-      def get_cookbook_list(items = 10, start = 0, cookbook_collection = {})
-        cookbooks_url = "#{config[:supermarket_site]}/api/v1/cookbooks?items=#{items}&start=#{start}"
-        cr = noauth_rest.get(cookbooks_url)
-        cr["items"].each do |cookbook|
-          cookbook_collection[cookbook["cookbook_name"]] = cookbook
-        end
-        new_start = start + cr["items"].length
-        if new_start < cr["total"]
-          get_cookbook_list(items, new_start, cookbook_collection)
-        else
-          cookbook_collection
-        end
-      end
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_search.rb
+++ b/lib/chef/knife/cookbook_site_search.rb
@@ -17,38 +17,19 @@
 #
 
 require "chef/knife"
+require "chef/knife/supermarket_search"
 
 class Chef
   class Knife
-    class CookbookSiteSearch < Knife
+    class CookbookSiteSearch < Knife::SupermarketSearch
+
+    # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site search QUERY (options)"
       category "cookbook site"
 
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        output(search_cookbook(name_args[0]))
-      end
-
-      def search_cookbook(query, items = 10, start = 0, cookbook_collection = {})
-        cookbooks_url = "#{config[:supermarket_site]}/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
-        cr = noauth_rest.get(cookbooks_url)
-        cr["items"].each do |cookbook|
-          cookbook_collection[cookbook["cookbook_name"]] = cookbook
-        end
-        new_start = start + cr["items"].length
-        if new_start < cr["total"]
-          search_cookbook(query, items, new_start, cookbook_collection)
-        else
-          cookbook_collection
-        end
-      end
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -18,154 +18,19 @@
 #
 
 require "chef/knife"
-require "chef/mixin/shell_out"
+require "chef/knife/supermarket_share"
 
 class Chef
   class Knife
-    class CookbookSiteShare < Knife
+    class CookbookSiteShare < Knife::SupermarketShare
 
-      include Chef::Mixin::ShellOut
-
-      deps do
-        require "chef/cookbook_loader"
-        require "chef/cookbook_uploader"
-        require "chef/cookbook_site_streaming_uploader"
-        require "mixlib/shellout"
-      end
-
-      include Chef::Mixin::ShellOut
+      # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site share COOKBOOK [CATEGORY] (options)"
       category "cookbook site"
 
-      option :cookbook_path,
-        short: "-o PATH:PATH",
-        long: "--cookbook-path PATH:PATH",
-        description: "A colon-separated path to look for cookbooks in",
-        proc: lambda { |o| Chef::Config.cookbook_path = o.split(":") }
-
-      option :dry_run,
-        long: "--dry-run",
-        short: "-n",
-        boolean: true,
-        default: false,
-        description: "Don't take action, only print what files will be uploaded to Supermarket."
-
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        config[:cookbook_path] ||= Chef::Config[:cookbook_path]
-
-        if @name_args.length < 1
-          show_usage
-          ui.fatal("You must specify the cookbook name.")
-          exit(1)
-        elsif @name_args.length < 2
-          cookbook_name = @name_args[0]
-          category = get_category(cookbook_name)
-        else
-          cookbook_name = @name_args[0]
-          category = @name_args[1]
-        end
-
-        cl = Chef::CookbookLoader.new(config[:cookbook_path])
-        if cl.cookbook_exists?(cookbook_name)
-          cookbook = cl[cookbook_name]
-          Chef::CookbookUploader.new(cookbook).validate_cookbooks
-          tmp_cookbook_dir = Chef::CookbookSiteStreamingUploader.create_build_dir(cookbook)
-          begin
-            Chef::Log.trace("Temp cookbook directory is #{tmp_cookbook_dir.inspect}")
-            ui.info("Making tarball #{cookbook_name}.tgz")
-            shell_out!("#{tar_cmd} -czf #{cookbook_name}.tgz #{cookbook_name}", cwd: tmp_cookbook_dir)
-          rescue => e
-            ui.error("Error making tarball #{cookbook_name}.tgz: #{e.message}. Increase log verbosity (-VV) for more information.")
-            Chef::Log.trace("\n#{e.backtrace.join("\n")}")
-            exit(1)
-          end
-
-          if config[:dry_run]
-            ui.info("Not uploading #{cookbook_name}.tgz due to --dry-run flag.")
-            result = shell_out!("#{tar_cmd} -tzf #{cookbook_name}.tgz", cwd: tmp_cookbook_dir)
-            ui.info(result.stdout)
-            FileUtils.rm_rf tmp_cookbook_dir
-            return
-          end
-
-          begin
-            do_upload("#{tmp_cookbook_dir}/#{cookbook_name}.tgz", category, Chef::Config[:node_name], Chef::Config[:client_key])
-            ui.info("Upload complete")
-            Chef::Log.trace("Removing local staging directory at #{tmp_cookbook_dir}")
-            FileUtils.rm_rf tmp_cookbook_dir
-          rescue => e
-            ui.error("Error uploading cookbook #{cookbook_name} to Supermarket: #{e.message}. Increase log verbosity (-VV) for more information.")
-            Chef::Log.trace("\n#{e.backtrace.join("\n")}")
-            exit(1)
-          end
-
-        else
-          ui.error("Could not find cookbook #{cookbook_name} in your cookbook path.")
-          exit(1)
-        end
-      end
-
-      def get_category(cookbook_name)
-        data = noauth_rest.get("#{config[:supermarket_site]}/api/v1/cookbooks/#{@name_args[0]}")
-        data["category"]
-      rescue => e
-        return "Other" if e.kind_of?(Net::HTTPServerException) && e.response.code == "404"
-        ui.fatal("Unable to reach Supermarket: #{e.message}. Increase log verbosity (-VV) for more information.")
-        Chef::Log.trace("\n#{e.backtrace.join("\n")}")
-        exit(1)
-      end
-
-      def do_upload(cookbook_filename, cookbook_category, user_id, user_secret_filename)
-        uri = "#{config[:supermarket_site]}/api/v1/cookbooks"
-
-        category_string = Chef::JSONCompat.to_json({ "category" => cookbook_category })
-
-        http_resp = Chef::CookbookSiteStreamingUploader.post(uri, user_id, user_secret_filename, {
-          tarball: File.open(cookbook_filename),
-          cookbook: category_string,
-        })
-
-        res = Chef::JSONCompat.from_json(http_resp.body)
-        if http_resp.code.to_i != 201
-          if res["error_messages"]
-            if res["error_messages"][0] =~ /Version already exists/
-              ui.error "The same version of this cookbook already exists on Supermarket."
-              exit(1)
-            else
-              ui.error (res["error_messages"][0]).to_s
-              exit(1)
-            end
-          else
-            ui.error "Unknown error while sharing cookbook"
-            ui.error "Server response: #{http_resp.body}"
-            exit(1)
-          end
-        end
-        res
-      end
-
-      def tar_cmd
-        if !@tar_cmd
-          @tar_cmd = "tar"
-          begin
-            # Unix and Mac only - prefer gnutar
-            if shell_out("which gnutar").exitstatus.equal?(0)
-              @tar_cmd = "gnutar"
-            end
-          rescue Errno::ENOENT
-          end
-        end
-        @tar_cmd
-      end
     end
-
   end
 end

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -17,51 +17,19 @@
 #
 
 require "chef/knife"
+require "chef/knife/supermarket_show"
 
 class Chef
   class Knife
-    class CookbookSiteShow < Knife
+    class CookbookSiteShow < Knife::SupermarketShow
+
+    # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
       banner "knife cookbook site show COOKBOOK [VERSION] (options)"
       category "cookbook site"
 
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        output(format_for_display(get_cookbook_data))
-      end
-
-      def supermarket_uri
-        "#{config[:supermarket_site]}/api/v1"
-      end
-
-      def get_cookbook_data
-        case @name_args.length
-        when 1
-          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}")
-        when 2
-          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}/versions/#{name_args[1].tr('.', '_')}")
-        end
-      end
-
-      def get_cookbook_list(items = 10, start = 0, cookbook_collection = {})
-        cookbooks_url = "#{supermarket_uri}/cookbooks?items=#{items}&start=#{start}"
-        cr = noauth_rest.get(cookbooks_url)
-        cr["items"].each do |cookbook|
-          cookbook_collection[cookbook["cookbook_name"]] = cookbook
-        end
-        new_start = start + cr["items"].length
-        if new_start < cr["total"]
-          get_cookbook_list(items, new_start, cookbook_collection)
-        else
-          cookbook_collection
-        end
-      end
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_unshare.rb
+++ b/lib/chef/knife/cookbook_site_unshare.rb
@@ -18,45 +18,18 @@
 #
 
 require "chef/knife"
+require "chef/knife/supermarket_unshare"
 
 class Chef
   class Knife
-    class CookbookSiteUnshare < Knife
+    class CookbookSiteUnshare < Knife::SupermarketUnshare
 
-      deps do
-        require "chef/json_compat"
-      end
+    # Handle the subclassing (knife doesn't do this :()
+      dependency_loaders.concat(superclass.dependency_loaders)
+      options.merge!(superclass.options)
 
-      banner "knife cookbook site unshare COOKBOOK"
+      banner "knife cookbook site unshare COOKBOOK (options)"
       category "cookbook site"
-
-      option :supermarket_site,
-        short: "-m SUPERMARKET_SITE",
-        long: "--supermarket-site SUPERMARKET_SITE",
-        description: "Supermarket Site",
-        default: "https://supermarket.chef.io",
-        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
-      def run
-        @cookbook_name = @name_args[0]
-        if @cookbook_name.nil?
-          show_usage
-          ui.fatal "You must provide the name of the cookbook to unshare"
-          exit 1
-        end
-
-        confirm "Do you really want to unshare all versions of the cookbook #{@cookbook_name}"
-
-        begin
-          rest.delete "#{config[:supermarket_site]}/api/v1/cookbooks/#{@name_args[0]}"
-        rescue Net::HTTPServerException => e
-          raise e unless e.message =~ /Forbidden/
-          ui.error "Forbidden: You must be the maintainer of #{@cookbook_name} to unshare it."
-          exit 1
-        end
-
-        ui.info "Unshared all versions of the cookbook #{@cookbook_name}"
-      end
 
     end
   end

--- a/lib/chef/knife/supermarket_download.rb
+++ b/lib/chef/knife/supermarket_download.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,106 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_download"
 
 class Chef
   class Knife
-    class SupermarketDownload < Knife::CookbookSiteDownload
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
+    class SupermarketDownload < Knife
 
       banner "knife supermarket download COOKBOOK [VERSION] (options)"
       category "supermarket"
+
+      deps do
+        require "fileutils"
+      end
+
+      option :file,
+        short: "-f FILE",
+        long: "--file FILE",
+        description: "The filename to write to"
+
+      option :force,
+        long: "--force",
+        description: "Force download deprecated version"
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      def run
+        if current_cookbook_deprecated?
+          message = "DEPRECATION: This cookbook has been deprecated. "
+          replacement = replacement_cookbook
+          if !replacement.to_s.strip.empty?
+            message << "It has been replaced by #{replacement}."
+          else
+            message << "No replacement has been defined."
+          end
+          ui.warn message
+
+          unless config[:force]
+            ui.warn "Use --force to force download deprecated cookbook."
+            return
+          end
+        end
+
+        download_cookbook
+      end
+
+      def version
+        @version = desired_cookbook_data["version"]
+      end
+
+      private
+
+      def cookbooks_api_url
+        "#{config[:supermarket_site]}/api/v1/cookbooks"
+      end
+
+      def current_cookbook_data
+        @current_cookbook_data ||= begin
+                                     noauth_rest.get "#{cookbooks_api_url}/#{@name_args[0]}"
+                                   end
+      end
+
+      def current_cookbook_deprecated?
+        current_cookbook_data["deprecated"] == true
+      end
+
+      def desired_cookbook_data
+        @desired_cookbook_data ||= begin
+                                     uri = if @name_args.length == 1
+                                             current_cookbook_data["latest_version"]
+                                           else
+                                             specific_cookbook_version_url
+                                           end
+
+                                     noauth_rest.get uri
+                                   end
+      end
+
+      def download_cookbook
+        ui.info "Downloading #{@name_args[0]} from Supermarket at version #{version} to #{download_location}"
+        tf = noauth_rest.streaming_request(desired_cookbook_data["file"])
+
+        ::FileUtils.cp tf.path, download_location
+        ui.info "Cookbook saved: #{download_location}"
+      end
+
+      def download_location
+        config[:file] ||= File.join Dir.pwd, "#{@name_args[0]}-#{version}.tar.gz"
+        config[:file]
+      end
+
+      def replacement_cookbook
+        File.basename(current_cookbook_data["replacement"] || "")
+      end
+
+      def specific_cookbook_version_url
+        "#{cookbooks_api_url}/#{@name_args[0]}/versions/#{@name_args[1].tr('.', '_')}"
+      end
     end
   end
 end

--- a/lib/chef/knife/supermarket_install.rb
+++ b/lib/chef/knife/supermarket_install.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,180 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_install"
+require "chef/exceptions"
+require "shellwords"
+require "mixlib/archive"
 
 class Chef
   class Knife
-    class SupermarketInstall < Knife::CookbookSiteInstall
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
+    class SupermarketInstall < Knife
+
+      deps do
+        require "chef/mixin/shell_out"
+        require "chef/knife/core/cookbook_scm_repo"
+        require "chef/cookbook/metadata"
+      end
 
       banner "knife supermarket install COOKBOOK [VERSION] (options)"
       category "supermarket"
+
+      option :no_deps,
+       short: "-D",
+       long: "--skip-dependencies",
+       boolean: true,
+       default: false,
+       description: "Skips automatic dependency installation."
+
+      option :cookbook_path,
+        short: "-o PATH:PATH",
+        long: "--cookbook-path PATH:PATH",
+        description: "A colon-separated path to look for cookbooks in",
+        proc: lambda { |o| o.split(":") }
+
+      option :default_branch,
+        short: "-B BRANCH",
+        long: "--branch BRANCH",
+        description: "Default branch to work with",
+        default: "master"
+
+      option :use_current_branch,
+        short: "-b",
+        long: "--use-current-branch",
+        description: "Use the current branch",
+        boolean: true,
+        default: false
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      attr_reader :cookbook_name
+      attr_reader :vendor_path
+
+      def run
+        extend Chef::Mixin::ShellOut
+
+        if config[:cookbook_path]
+          Chef::Config[:cookbook_path] = config[:cookbook_path]
+        else
+          config[:cookbook_path] = Chef::Config[:cookbook_path]
+        end
+
+        @cookbook_name = parse_name_args!
+        # Check to ensure we have a valid source of cookbooks before continuing
+        #
+        @install_path = File.expand_path(Array(config[:cookbook_path]).first)
+        ui.info "Installing #{@cookbook_name} to #{@install_path}"
+
+        @repo = CookbookSCMRepo.new(@install_path, ui, config)
+        # cookbook_path = File.join(vendor_path, name_args[0])
+        upstream_file = File.join(@install_path, "#{@cookbook_name}.tar.gz")
+
+        @repo.sanity_check
+        unless config[:use_current_branch]
+          @repo.reset_to_default_state
+          @repo.prepare_to_import(@cookbook_name)
+        end
+
+        downloader = download_cookbook_to(upstream_file)
+        clear_existing_files(File.join(@install_path, @cookbook_name))
+        extract_cookbook(upstream_file, downloader.version)
+
+        # TODO: it'd be better to store these outside the cookbook repo and
+        # keep them around, e.g., in ~/Library/Caches on OS X.
+        ui.info("Removing downloaded tarball")
+        File.unlink(upstream_file)
+
+        if @repo.finalize_updates_to(@cookbook_name, downloader.version)
+          unless config[:use_current_branch]
+            @repo.reset_to_default_state
+          end
+          @repo.merge_updates_from(@cookbook_name, downloader.version)
+        else
+          unless config[:use_current_branch]
+            @repo.reset_to_default_state
+          end
+        end
+
+        unless config[:no_deps]
+          preferred_metadata.dependencies.each_key do |cookbook|
+            # Doesn't do versions.. yet
+            nv = self.class.new
+            nv.config = config
+            nv.name_args = [ cookbook ]
+            nv.run
+          end
+        end
+      end
+
+      def parse_name_args!
+        if name_args.empty?
+          ui.error("Please specify a cookbook to download and install.")
+          exit 1
+        elsif name_args.size >= 2
+          unless name_args.last.match(/^(\d+)(\.\d+){1,2}$/) && name_args.size == 2
+            ui.error("Installing multiple cookbooks at once is not supported.")
+            exit 1
+          end
+        end
+        name_args.first
+      end
+
+      def download_cookbook_to(download_path)
+        downloader = Chef::Knife::CookbookSiteDownload.new
+        downloader.config[:file] = download_path
+        downloader.config[:supermarket_site] = config[:supermarket_site]
+        downloader.name_args = name_args
+        downloader.run
+        downloader
+      end
+
+      def extract_cookbook(upstream_file, version)
+        ui.info("Uncompressing #{@cookbook_name} version #{version}.")
+        Mixlib::Archive.new(convert_path(upstream_file)).extract(@install_path, perms: false)
+      end
+
+      def clear_existing_files(cookbook_path)
+        ui.info("Removing pre-existing version.")
+        FileUtils.rmtree(cookbook_path) if File.directory?(cookbook_path)
+      end
+
+      def convert_path(upstream_file)
+        # converts a Windows path (C:\foo) to a mingw path (/c/foo)
+        if ENV["MSYSTEM"] == "MINGW32"
+          upstream_file.sub(/^([[:alpha:]]):/, '/\1')
+        else
+          Shellwords.escape upstream_file
+        end
+      end
+
+      # Get the preferred metadata path on disk. Chef prefers the metadata.rb
+      # over the metadata.json.
+      #
+      # @raise if there is no metadata in the cookbook
+      #
+      # @return [Chef::Cookbook::Metadata]
+      def preferred_metadata
+        md = Chef::Cookbook::Metadata.new
+
+        rb = File.join(@install_path, @cookbook_name, "metadata.rb")
+        if File.exist?(rb)
+          md.from_file(rb)
+          return md
+        end
+
+        json = File.join(@install_path, @cookbook_name, "metadata.json")
+        if File.exist?(json)
+          json = IO.read(json)
+          md.from_json(json)
+          return md
+        end
+
+        raise Chef::Exceptions::MetadataNotFound.new(@install_path, @cookbook_name)
+      end
     end
   end
 end

--- a/lib/chef/knife/supermarket_list.rb
+++ b/lib/chef/knife/supermarket_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,49 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_list"
 
 class Chef
   class Knife
-    class SupermarketList < Knife::CookbookSiteList
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
+    class SupermarketList < Knife
 
       banner "knife supermarket list (options)"
       category "supermarket"
+
+      option :with_uri,
+        short: "-w",
+        long: "--with-uri",
+        description: "Show corresponding URIs"
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      def run
+        if config[:with_uri]
+          cookbooks = Hash.new
+          get_cookbook_list.each { |k, v| cookbooks[k] = v["cookbook"] }
+          ui.output(format_for_display(cookbooks))
+        else
+          ui.msg(ui.list(get_cookbook_list.keys.sort, :columns_down))
+        end
+      end
+
+      def get_cookbook_list(items = 10, start = 0, cookbook_collection = {})
+        cookbooks_url = "#{config[:supermarket_site]}/api/v1/cookbooks?items=#{items}&start=#{start}"
+        cr = noauth_rest.get(cookbooks_url)
+        cr["items"].each do |cookbook|
+          cookbook_collection[cookbook["cookbook_name"]] = cookbook
+        end
+        new_start = start + cr["items"].length
+        if new_start < cr["total"]
+          get_cookbook_list(items, new_start, cookbook_collection)
+        else
+          cookbook_collection
+        end
+      end
     end
   end
 end

--- a/lib/chef/knife/supermarket_search.rb
+++ b/lib/chef/knife/supermarket_search.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,37 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_search"
 
 class Chef
   class Knife
-    class SupermarketSearch < Knife::CookbookSiteSearch
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
-
+    class SupermarketSearch < Knife
       banner "knife supermarket search QUERY (options)"
       category "supermarket"
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      def run
+        output(search_cookbook(name_args[0]))
+      end
+
+      def search_cookbook(query, items = 10, start = 0, cookbook_collection = {})
+        cookbooks_url = "#{config[:supermarket_site]}/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
+        cr = noauth_rest.get(cookbooks_url)
+        cr["items"].each do |cookbook|
+          cookbook_collection[cookbook["cookbook_name"]] = cookbook
+        end
+        new_start = start + cr["items"].length
+        if new_start < cr["total"]
+          search_cookbook(query, items, new_start, cookbook_collection)
+        else
+          cookbook_collection
+        end
+      end
     end
   end
 end

--- a/lib/chef/knife/supermarket_share.rb
+++ b/lib/chef/knife/supermarket_share.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,153 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_share"
+require "chef/mixin/shell_out"
 
 class Chef
   class Knife
-    class SupermarketShare < Knife::CookbookSiteShare
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
+    class SupermarketShare < Knife
+
+      include Chef::Mixin::ShellOut
+
+      deps do
+        require "chef/cookbook_loader"
+        require "chef/cookbook_uploader"
+        require "chef/cookbook_site_streaming_uploader"
+        require "mixlib/shellout"
+      end
+
+      include Chef::Mixin::ShellOut
 
       banner "knife supermarket share COOKBOOK [CATEGORY] (options)"
       category "supermarket"
+
+      option :cookbook_path,
+        short: "-o PATH:PATH",
+        long: "--cookbook-path PATH:PATH",
+        description: "A colon-separated path to look for cookbooks in",
+        proc: lambda { |o| Chef::Config.cookbook_path = o.split(":") }
+
+      option :dry_run,
+        long: "--dry-run",
+        short: "-n",
+        boolean: true,
+        default: false,
+        description: "Don't take action, only print what files will be uploaded to Supermarket."
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      def run
+        config[:cookbook_path] ||= Chef::Config[:cookbook_path]
+
+        if @name_args.length < 1
+          show_usage
+          ui.fatal("You must specify the cookbook name.")
+          exit(1)
+        elsif @name_args.length < 2
+          cookbook_name = @name_args[0]
+          category = get_category(cookbook_name)
+        else
+          cookbook_name = @name_args[0]
+          category = @name_args[1]
+        end
+
+        cl = Chef::CookbookLoader.new(config[:cookbook_path])
+        if cl.cookbook_exists?(cookbook_name)
+          cookbook = cl[cookbook_name]
+          Chef::CookbookUploader.new(cookbook).validate_cookbooks
+          tmp_cookbook_dir = Chef::CookbookSiteStreamingUploader.create_build_dir(cookbook)
+          begin
+            Chef::Log.trace("Temp cookbook directory is #{tmp_cookbook_dir.inspect}")
+            ui.info("Making tarball #{cookbook_name}.tgz")
+            shell_out!("#{tar_cmd} -czf #{cookbook_name}.tgz #{cookbook_name}", cwd: tmp_cookbook_dir)
+          rescue => e
+            ui.error("Error making tarball #{cookbook_name}.tgz: #{e.message}. Increase log verbosity (-VV) for more information.")
+            Chef::Log.trace("\n#{e.backtrace.join("\n")}")
+            exit(1)
+          end
+
+          if config[:dry_run]
+            ui.info("Not uploading #{cookbook_name}.tgz due to --dry-run flag.")
+            result = shell_out!("#{tar_cmd} -tzf #{cookbook_name}.tgz", cwd: tmp_cookbook_dir)
+            ui.info(result.stdout)
+            FileUtils.rm_rf tmp_cookbook_dir
+            return
+          end
+
+          begin
+            do_upload("#{tmp_cookbook_dir}/#{cookbook_name}.tgz", category, Chef::Config[:node_name], Chef::Config[:client_key])
+            ui.info("Upload complete")
+            Chef::Log.trace("Removing local staging directory at #{tmp_cookbook_dir}")
+            FileUtils.rm_rf tmp_cookbook_dir
+          rescue => e
+            ui.error("Error uploading cookbook #{cookbook_name} to Supermarket: #{e.message}. Increase log verbosity (-VV) for more information.")
+            Chef::Log.trace("\n#{e.backtrace.join("\n")}")
+            exit(1)
+          end
+
+        else
+          ui.error("Could not find cookbook #{cookbook_name} in your cookbook path.")
+          exit(1)
+        end
+      end
+
+      def get_category(cookbook_name)
+        data = noauth_rest.get("#{config[:supermarket_site]}/api/v1/cookbooks/#{@name_args[0]}")
+        data["category"]
+      rescue => e
+        return "Other" if e.kind_of?(Net::HTTPServerException) && e.response.code == "404"
+        ui.fatal("Unable to reach Supermarket: #{e.message}. Increase log verbosity (-VV) for more information.")
+        Chef::Log.trace("\n#{e.backtrace.join("\n")}")
+        exit(1)
+      end
+
+      def do_upload(cookbook_filename, cookbook_category, user_id, user_secret_filename)
+        uri = "#{config[:supermarket_site]}/api/v1/cookbooks"
+
+        category_string = Chef::JSONCompat.to_json({ "category" => cookbook_category })
+
+        http_resp = Chef::CookbookSiteStreamingUploader.post(uri, user_id, user_secret_filename, {
+          tarball: File.open(cookbook_filename),
+          cookbook: category_string,
+        })
+
+        res = Chef::JSONCompat.from_json(http_resp.body)
+        if http_resp.code.to_i != 201
+          if res["error_messages"]
+            if res["error_messages"][0] =~ /Version already exists/
+              ui.error "The same version of this cookbook already exists on Supermarket."
+              exit(1)
+            else
+              ui.error (res["error_messages"][0]).to_s
+              exit(1)
+            end
+          else
+            ui.error "Unknown error while sharing cookbook"
+            ui.error "Server response: #{http_resp.body}"
+            exit(1)
+          end
+        end
+        res
+      end
+
+      def tar_cmd
+        if !@tar_cmd
+          @tar_cmd = "tar"
+          begin
+            # Unix and Mac only - prefer gnutar
+            if shell_out("which gnutar").exitstatus.equal?(0)
+              @tar_cmd = "gnutar"
+            end
+          rescue Errno::ENOENT
+          end
+        end
+        @tar_cmd
+      end
     end
   end
 end

--- a/lib/chef/knife/supermarket_show.rb
+++ b/lib/chef/knife/supermarket_show.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,51 @@
 #
 
 require "chef/knife"
-require "chef/knife/cookbook_site_show"
 
 class Chef
   class Knife
-    class SupermarketShow < Knife::CookbookSiteShow
-      # Handle the subclassing (knife doesn't do this :()
-      dependency_loaders.concat(superclass.dependency_loaders)
-      options.merge!(superclass.options)
+    class SupermarketShow < Knife
 
       banner "knife supermarket show COOKBOOK [VERSION] (options)"
       category "supermarket"
+
+      option :supermarket_site,
+        short: "-m SUPERMARKET_SITE",
+        long: "--supermarket-site SUPERMARKET_SITE",
+        description: "Supermarket Site",
+        default: "https://supermarket.chef.io",
+        proc: Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
+
+      def run
+        output(format_for_display(get_cookbook_data))
+      end
+
+      def supermarket_uri
+        "#{config[:supermarket_site]}/api/v1"
+      end
+
+      def get_cookbook_data
+        case @name_args.length
+        when 1
+          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}")
+        when 2
+          noauth_rest.get("#{supermarket_uri}/cookbooks/#{@name_args[0]}/versions/#{name_args[1].tr('.', '_')}")
+        end
+      end
+
+      def get_cookbook_list(items = 10, start = 0, cookbook_collection = {})
+        cookbooks_url = "#{supermarket_uri}/cookbooks?items=#{items}&start=#{start}"
+        cr = noauth_rest.get(cookbooks_url)
+        cr["items"].each do |cookbook|
+          cookbook_collection[cookbook["cookbook_name"]] = cookbook
+        end
+        new_start = start + cr["items"].length
+        if new_start < cr["total"]
+          get_cookbook_list(items, new_start, cookbook_collection)
+        else
+          cookbook_collection
+        end
+      end
     end
   end
 end

--- a/spec/unit/knife/supermarket_download_spec.rb
+++ b/spec/unit/knife/supermarket_download_spec.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Thomas Bishop (<bishop.thomas@gmail.com>)
 # Copyright:: Copyright 2012-2016, Thomas Bishop
+# Copyright:: Copyright 2018, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +17,14 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require "chef/knife/supermarket_download"
+require "spec_helper"
 
-describe Chef::Knife::CookbookSiteDownload do
+describe Chef::Knife::SupermarketDownload do
 
   describe "run" do
     before do
-      @knife            = Chef::Knife::CookbookSiteDownload.new
+      @knife            = Chef::Knife::SupermarketDownload.new
       @knife.name_args  = ["apache2"]
       @noauth_rest      = double("no auth rest")
       @stderr           = StringIO.new

--- a/spec/unit/knife/supermarket_install_spec.rb
+++ b/spec/unit/knife/supermarket_install_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016, Chef Software, Inc.
+# Copyright:: Copyright 2011-2018, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,11 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
+require "spec_helper"
+require "chef/knife/supermarket_install"
 
-describe Chef::Knife::CookbookSiteInstall do
-  let(:knife) { Chef::Knife::CookbookSiteInstall.new }
+describe Chef::Knife::SupermarketInstall do
+  let(:knife) { Chef::Knife::SupermarketInstall.new }
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
   let(:downloader) { Hash.new }
@@ -52,7 +53,7 @@ describe Chef::Knife::CookbookSiteInstall do
     allow(knife).to receive(:shell_out!).and_return(true)
     allow(Mixlib::Archive).to receive(:new).and_return(archive)
 
-    # CookbookSiteDownload Stup
+    # SupermarketDownload Setup
     allow(knife).to receive(:download_cookbook_to).and_return(downloader)
     allow(downloader).to receive(:version) do
       if knife.name_args.size == 2

--- a/spec/unit/knife/supermarket_share_spec.rb
+++ b/spec/unit/knife/supermarket_share_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Stephen Delano (<stephen@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +17,14 @@
 #
 
 require "spec_helper"
-
+require "chef/knife/supermarket_share"
 require "chef/cookbook_uploader"
 require "chef/cookbook_site_streaming_uploader"
 
-describe Chef::Knife::CookbookSiteShare do
+describe Chef::Knife::SupermarketShare do
 
   before(:each) do
-    @knife = Chef::Knife::CookbookSiteShare.new
+    @knife = Chef::Knife::SupermarketShare.new
     # Merge default settings in.
     @knife.merge_configs
     @knife.name_args = %w{cookbook_name AwesomeSausage}

--- a/spec/unit/knife/supermarket_unshare_spec.rb
+++ b/spec/unit/knife/supermarket_unshare_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Stephen Delano (<stephen@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,11 +18,12 @@
 #
 
 require "spec_helper"
+require "chef/knife/supermarket_unshare"
 
-describe Chef::Knife::CookbookSiteUnshare do
+describe Chef::Knife::SupermarketUnshare do
 
   before(:each) do
-    @knife = Chef::Knife::CookbookSiteUnshare.new
+    @knife = Chef::Knife::SupermarketUnshare.new
     @knife.name_args = ["cookbook_name"]
     allow(@knife).to receive(:confirm).and_return(true)
 


### PR DESCRIPTION
We want to deprecate knife cookbook site. This moves all the logic into
the knife supermarket plugins and has the legacy knife cookbook site
plugins inherit from that.

Signed-off-by: Tim Smith <tsmith@chef.io>