### PR TITLE
Remove require json_compat where not used

### DIFF
--- a/lib/chef/knife/client_bulk_delete.rb
+++ b/lib/chef/knife/client_bulk_delete.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       option :delete_validators,

--- a/lib/chef/knife/client_create.rb
+++ b/lib/chef/knife/client_create.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       option :file,

--- a/lib/chef/knife/client_delete.rb
+++ b/lib/chef/knife/client_delete.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       option :delete_validators,

--- a/lib/chef/knife/client_edit.rb
+++ b/lib/chef/knife/client_edit.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       banner "knife client edit CLIENT (options)"

--- a/lib/chef/knife/client_list.rb
+++ b/lib/chef/knife/client_list.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       banner "knife client list (options)"

--- a/lib/chef/knife/client_reregister.rb
+++ b/lib/chef/knife/client_reregister.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       banner "knife client reregister CLIENT (options)"

--- a/lib/chef/knife/client_show.rb
+++ b/lib/chef/knife/client_show.rb
@@ -26,7 +26,6 @@ class Chef
 
       deps do
         require "chef/api_client_v1"
-        require "chef/json_compat"
       end
 
       banner "knife client show CLIENT (options)"

--- a/lib/chef/knife/data_bag_from_file.rb
+++ b/lib/chef/knife/data_bag_from_file.rb
@@ -30,7 +30,6 @@ class Chef
         require "chef/data_bag"
         require "chef/data_bag_item"
         require "chef/knife/core/object_loader"
-        require "chef/json_compat"
         require "chef/encrypted_data_bag_item"
       end
 

--- a/lib/chef/knife/environment_create.rb
+++ b/lib/chef/knife/environment_create.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/environment"
-        require "chef/json_compat"
       end
 
       banner "knife environment create ENVIRONMENT (options)"

--- a/lib/chef/knife/environment_delete.rb
+++ b/lib/chef/knife/environment_delete.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/environment"
-        require "chef/json_compat"
       end
 
       banner "knife environment delete ENVIRONMENT (options)"

--- a/lib/chef/knife/environment_edit.rb
+++ b/lib/chef/knife/environment_edit.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/environment"
-        require "chef/json_compat"
       end
 
       banner "knife environment edit ENVIRONMENT (options)"

--- a/lib/chef/knife/environment_list.rb
+++ b/lib/chef/knife/environment_list.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/environment"
-        require "chef/json_compat"
       end
 
       banner "knife environment list (options)"

--- a/lib/chef/knife/environment_show.rb
+++ b/lib/chef/knife/environment_show.rb
@@ -26,7 +26,6 @@ class Chef
 
       deps do
         require "chef/environment"
-        require "chef/json_compat"
       end
 
       banner "knife environment show ENVIRONMENT (options)"

--- a/lib/chef/knife/role_run_list_remove.rb
+++ b/lib/chef/knife/role_run_list_remove.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/role"
-        require "chef/json_compat"
       end
 
       banner "knife role run_list remove [ROLE] [ENTRY]"

--- a/lib/chef/knife/role_run_list_set.rb
+++ b/lib/chef/knife/role_run_list_set.rb
@@ -25,7 +25,6 @@ class Chef
 
       deps do
         require "chef/role"
-        require "chef/json_compat"
       end
 
       banner "knife role run_list set [ROLE] [ENTRIES]"

--- a/lib/chef/knife/role_show.rb
+++ b/lib/chef/knife/role_show.rb
@@ -25,7 +25,7 @@ class Chef
       include Knife::Core::MultiAttributeReturnOption
 
       deps do
-        require "chef/node"
+        require "chef/role"
       end
 
       banner "knife role show ROLE (options)"

--- a/lib/chef/knife/role_show.rb
+++ b/lib/chef/knife/role_show.rb
@@ -26,7 +26,6 @@ class Chef
 
       deps do
         require "chef/node"
-        require "chef/json_compat"
       end
 
       banner "knife role show ROLE (options)"

--- a/lib/chef/knife/user_create.rb
+++ b/lib/chef/knife/user_create.rb
@@ -28,7 +28,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       option :file,

--- a/lib/chef/knife/user_delete.rb
+++ b/lib/chef/knife/user_delete.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       banner "knife user delete USER (options)"

--- a/lib/chef/knife/user_edit.rb
+++ b/lib/chef/knife/user_edit.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       banner "knife user edit USER (options)"

--- a/lib/chef/knife/user_list.rb
+++ b/lib/chef/knife/user_list.rb
@@ -26,7 +26,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       banner "knife user list (options)"

--- a/lib/chef/knife/user_reregister.rb
+++ b/lib/chef/knife/user_reregister.rb
@@ -24,7 +24,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       banner "knife user reregister USER (options)"

--- a/lib/chef/knife/user_show.rb
+++ b/lib/chef/knife/user_show.rb
@@ -26,7 +26,6 @@ class Chef
 
       deps do
         require "chef/user_v1"
-        require "chef/json_compat"
       end
 
       banner "knife user show USER (options)"


### PR DESCRIPTION
We're not directly manipulating json in these knife plugins. We're using mostly using the  API class or environment/role classes directly.

Signed-off-by: Tim Smith <tsmith@chef.io>