### PR TITLE
group: convert to properties with descriptions and improve comma separated parsing

### DIFF
--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,11 +35,11 @@ class Chef
                description: "The identifier for the group."
 
       property :members, [String, Array], default: lazy { [] },
-               coerce: proc { |x| x.kind_of?(String) ? x.split(",") : x },
+               coerce: proc { |arg| arg.is_a?(String) ? arg.split(/\s*,\s*/) : arg },
                description: "Which users should be set or appended to a group. This can be either an array or a comma separated list."
 
       property :excluded_members, [String, Array], default: lazy { [] },
-               coerce: proc { |x| x.kind_of?(String) ? x.split(",") : x },
+               coerce: proc { |arg| arg.is_a?(String) ? arg.split(/\s*,\s*/) : arg },
                description: "Remove users from a group. May only be used when append is set to true."
 
       property :append, [ TrueClass, FalseClass ], default: false,

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -27,38 +27,31 @@ class Chef
       allowed_actions :create, :remove, :modify, :manage
       default_action :create
 
-      def initialize(name, run_context = nil)
-        super
-        @members = []
-        @excluded_members = []
-      end
+      property :group_name, String,
+               name_property: true, identity: true,
+               description: "The name of the group."
 
-      property :group_name, String, name_property: true, identity: true
-      property :gid, [ String, Integer ]
+      property :gid, [ String, Integer ],
+               description: "The identifier for the group."
 
-      def members(arg = nil)
-        converted_members = arg.is_a?(String) ? arg.split(",") : arg
-        set_or_return(
-          :members,
-          converted_members,
-          kind_of: [ Array ]
-        )
-      end
+      property :members, [String, Array], default: lazy { [] },
+               coerce: proc { |x| x.kind_of?(String) ? x.split(",") : x },
+               description: "Which users should be set or appended to a group. This can be either an array or a comma separated list."
+
+      property :excluded_members, [String, Array], default: lazy { [] },
+               coerce: proc { |x| x.kind_of?(String) ? x.split(",") : x },
+               description: "Remove users from a group. May only be used when append is set to true."
+
+      property :append, [ TrueClass, FalseClass ], default: false,
+               description: "How members should be appended and/or removed from a group. When true, members are appended and excluded_members are removed. When false, group members are reset to the value of the members property."
+
+      property :system, [ TrueClass, FalseClass ], default: false,
+               description: "Sets the group to belong to the system group."
+
+      property :non_unique, [ TrueClass, FalseClass ], default: false,
+               description: "Allow gid duplication. May only be used with the Groupadd provider."
 
       alias_method :users, :members
-
-      def excluded_members(arg = nil)
-        converted_members = arg.is_a?(String) ? arg.split(",") : arg
-        set_or_return(
-          :excluded_members,
-          converted_members,
-          kind_of: [ Array ]
-        )
-      end
-
-      property :append, [ TrueClass, FalseClass ], default: false
-      property :system, [ TrueClass, FalseClass ], default: false
-      property :non_unique, [ TrueClass, FalseClass ], default: false
     end
   end
 end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Chirag Jog (<chirag@clogeny.com>)
 # Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   include Chef::Mixin::ShellOut
 
   def group_should_exist(group)
-    case ohai[:platform_family]
-    when "debian", "fedora", "rhel", "suse", "gentoo", "slackware", "arch"
+    case ohai[:os]
+    when "linux"
       expect { Etc.getgrnam(group) }.not_to raise_error
       expect(group).to eq(Etc.getgrnam(group).name)
     when "windows"
@@ -50,8 +50,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   end
 
   def group_should_not_exist(group)
-    case ohai[:platform_family]
-    when "debian", "fedora", "rhel", "suse", "gentoo", "slackware", "arch"
+    case ohai[:os]
+    when "linux"
       expect { Etc.getgrnam(group) }.to raise_error(ArgumentError, "can't find group for #{group}")
     when "windows"
       expect { Chef::Util::Windows::NetGroup.new(group).local_get_members }.to raise_error(ArgumentError, /The group name could not be found./)

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -21,11 +21,7 @@ require "spec_helper"
 require "functional/resource/base"
 require "chef/mixin/shell_out"
 
-# Chef::Resource::Group are turned off on Mac OS X 10.6 due to caching
-# issues around Etc.getgrnam() not picking up the group membership
-# changes that are done on the system. Etc.endgrent is not functioning
-# correctly on certain 10.6 boxes.
-describe Chef::Resource::Group, :requires_root_or_running_windows, :not_supported_on_mac_osx_106 do
+describe Chef::Resource::Group, :requires_root_or_running_windows do
   include Chef::Mixin::ShellOut
 
   def group_should_exist(group)

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -293,8 +293,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   end
 
   let(:group_name) { "group#{SecureRandom.random_number(9999)}" }
-  let(:included_members) { nil }
-  let(:excluded_members) { nil }
+  let(:included_members) { [] }
+  let(:excluded_members) { [] }
   let(:group_resource) do
     group = Chef::Resource::Group.new(group_name, run_context)
     group.members(included_members)

--- a/spec/unit/resource/group_spec.rb
+++ b/spec/unit/resource/group_spec.rb
@@ -1,7 +1,7 @@
 #
-# Author:: AJ Christensen (<aj@chef.io>)
+# Author:: AJ Christensen (<aj@junglistheavy.industries>)
 # Author:: Tyler Cloke (<tyler@chef.io>);
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ describe Chef::Resource::Group, "group_name" do
   end
 
   it "does not allow a hash" do
-    expect { resource.send(:group_name, { aj: "is freakin awesome" }) }.to raise_error(ArgumentError)
+    expect { resource.send(:group_name, { some_other_user: "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 end
 
@@ -85,7 +85,7 @@ describe Chef::Resource::Group, "gid" do
   end
 
   it "does not allow a hash" do
-    expect { resource.send(:gid, { aj: "is freakin awesome" }) }.to raise_error(ArgumentError)
+    expect { resource.send(:gid, { some_other_user: "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 end
 
@@ -93,23 +93,23 @@ describe Chef::Resource::Group, "members" do
   let(:resource) { Chef::Resource::Group.new("fakey_fakerton") }
 
   [ :users, :members].each do |method|
-    it "(#{method}) allows and convert a string" do
-      resource.send(method, "aj")
-      expect(resource.send(method)).to eql(["aj"])
+    it "(#{method}) allows a String and coerces it to an Array" do
+      resource.send(method, "some_user")
+      expect(resource.send(method)).to eql(["some_user"])
     end
 
-    it "(#{method}) should split a string on commas" do
-      resource.send(method, "aj,adam")
-      expect(resource.send(method)).to eql( %w{aj adam} )
+    it "(#{method}) coerces a comma separated list of users to an Array" do
+      resource.send(method, "some_user, other_user ,another_user,just_one_more_user")
+      expect(resource.send(method)).to eql( %w{some_user other_user another_user just_one_more_user} )
     end
 
-    it "(#{method}) allows an array" do
-      resource.send(method, %w{aj adam})
-      expect(resource.send(method)).to eql( %w{aj adam} )
+    it "(#{method}) allows an Array" do
+      resource.send(method, %w{some_user other_user})
+      expect(resource.send(method)).to eql( %w{some_user other_user} )
     end
 
-    it "(#{method}) does not allow a hash" do
-      expect { resource.send(method, { aj: "is freakin awesome" }) }.to raise_error(ArgumentError)
+    it "(#{method}) does not allow a Hash" do
+      expect { resource.send(method, { some_user: "is freakin awesome" }) }.to raise_error(ArgumentError)
     end
   end
 end
@@ -127,7 +127,7 @@ describe Chef::Resource::Group, "append" do
   end
 
   it "does not allow a hash" do
-    expect { resource.send(:gid, { aj: "is freakin awesome" }) }.to raise_error(ArgumentError)
+    expect { resource.send(:gid, { some_other_user: "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 
   describe "when it has members" do


### PR DESCRIPTION
This converts another resource to use properties and gives each property
a description from the docs site.

It also  makes the string parsing a bit more user spacing proof.

accepted before:
  - 1,2,3

accepted now:
  - 1,2,3
  - 1, 2, 3
  - 1 ,2 ,3
  - any combo of the above 3

Signed-off-by: Tim Smith <tsmith@chef.io>