### PR TITLE
ifconfig: Add gateway property on RHEL/Debian based systems

### DIFF
--- a/lib/chef/provider/ifconfig/debian.rb
+++ b/lib/chef/provider/ifconfig/debian.rb
@@ -48,6 +48,7 @@ iface <%= new_resource.device %> <%= new_resource.family %> static
     <% if new_resource.metric %>metric <%= new_resource.metric %><% end %>
     <% if new_resource.hwaddr %>hwaddress <%= new_resource.hwaddr %><% end %>
     <% if new_resource.mtu %>mtu <%= new_resource.mtu %><% end %>
+    <% if new_resource.gateway %>gateway <%= new_resource.gateway %><% end %>
 <% end %>
 <% end %>
           }

--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -43,6 +43,7 @@ class Chef
 <% if new_resource.master %>MASTER=<%= new_resource.master %><% end %>
 <% if new_resource.slave %>SLAVE=<%= new_resource.slave %><% end %>
 <% if new_resource.vlan %>VLAN=<%= new_resource.vlan %><% end %>
+<% if new_resource.gateway %>GATEWAY=<%= new_resource.gateway %><% end %>
           }
           @config_path = "/etc/sysconfig/network-scripts/ifcfg-#{new_resource.device}"
         end

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -45,8 +45,8 @@ class Chef
       property :mask, String,
                description: "The decimal representation of the network mask. For example: 255.255.255.0."
 
-      property :family, String,
-               default: "inet", introduced: "14.0",
+      property :family, String, default: "inet",
+               introduced: "14.0",
                description: "Networking family option for Debian-based systems. For example: inet or inet6."
 
       property :inet_addr, String,
@@ -96,6 +96,10 @@ class Chef
       property :vlan, String,
                introduced: "14.4",
                description: "The VLAN to assign the interface to."
+
+      property :gateway, String,
+               introduced: "14.4",
+               description: "The gateway to use for the interface."
     end
   end
 end


### PR DESCRIPTION
This reimplements #6279 after our conversion of this resource to use properties. It also adds support for RHEL since that's documented here:

https://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-networkscripts-interfaces.html

Signed-off-by: Tim Smith <tsmith@chef.io>