### PR TITLE
ifconfig: Allow specifying VLAN on RHEL/Centos

### DIFF
--- a/lib/chef/provider/ifconfig/redhat.rb
+++ b/lib/chef/provider/ifconfig/redhat.rb
@@ -42,6 +42,7 @@ class Chef
 <% if new_resource.bonding_opts %>BONDING_OPTS="<%= new_resource.bonding_opts %>"<% end %>
 <% if new_resource.master %>MASTER=<%= new_resource.master %><% end %>
 <% if new_resource.slave %>SLAVE=<%= new_resource.slave %><% end %>
+<% if new_resource.vlan %>VLAN=<%= new_resource.vlan %><% end %>
           }
           @config_path = "/etc/sysconfig/network-scripts/ifcfg-#{new_resource.device}"
         end

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -92,6 +92,14 @@ class Chef
       property :slave, String,
                introduced: "13.4",
                description: "When set to yes, this device is controlled by the channel bonding interface that is specified via the master property."
+
+      property :vlan, String,
+               introduced: "14.4",
+               description: "The VLAN to assign the interface to."
+
+      property :gateways, String,
+               introduced: "14.4",
+               description: "The gateway to assign the interface to."
     end
   end
 end

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -96,10 +96,6 @@ class Chef
       property :vlan, String,
                introduced: "14.4",
                description: "The VLAN to assign the interface to."
-
-      property :gateways, String,
-               introduced: "14.4",
-               description: "The gateway to assign the interface to."
     end
   end
 end

--- a/spec/unit/provider/ifconfig/redhat_spec.rb
+++ b/spec/unit/provider/ifconfig/redhat_spec.rb
@@ -35,6 +35,7 @@ describe Chef::Provider::Ifconfig::Redhat do
     @new_resource.bonding_opts "mode=active-backup miimon=100"
     @new_resource.master "bond0"
     @new_resource.slave "yes"
+    @new_resource.vlan "yes"
     @provider = Chef::Provider::Ifconfig::Redhat.new(@new_resource, @run_context)
     @current_resource = Chef::Resource::Ifconfig.new("10.0.0.1", @run_context)
 
@@ -60,6 +61,7 @@ describe Chef::Provider::Ifconfig::Redhat do
         expect(arg).to match(/^\s*BONDING_OPTS="mode=active-backup miimon=100"\s*$/)
         expect(arg).to match(/^\s*MASTER=bond0\s*$/)
         expect(arg).to match(/^\s*SLAVE=yes\s*$/)
+        expect(arg).to match(/^\s*VLAN=yes\s*$/)
       end
       expect(@config).to receive(:run_action).with(:create)
       expect(@config).to receive(:updated?).and_return(true)

--- a/spec/unit/provider/route_spec.rb
+++ b/spec/unit/provider/route_spec.rb
@@ -167,7 +167,7 @@ describe Chef::Provider::Route do
       expect(@provider.generate_command(:add).join(" ")).not_to match(/\svia\s#{Regexp.escape(@new_resource.gateway.to_s)}/)
     end
 
-    it "should use the gatway when target is default" do
+    it "should use the gateway when target is default" do
       @default_resource.gateway("10.0.0.10")
       expect(@default_provider.generate_command(:add).join(" ")).to match(/10.0.0.10/)
     end


### PR DESCRIPTION
This is the rebase of #6400 