### PR TITLE
Remove the platform check from RPM compression in Omnibus

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -70,11 +70,8 @@ end
 
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
-
-  unless rhel? && platform_version.satisfies?("< 6")
-    compression_level 1
-    compression_type :xz
-  end
+  compression_level 1
+  compression_type :xz
 end
 
 package :deb do


### PR DESCRIPTION
We don't build on RHEL 5 anymore so there's no need to gate this.

Signed-off-by: Tim Smith <tsmith@chef.io>