### PR TITLE
WIP: add poldek package manager support

### DIFF
--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -105,7 +105,7 @@ class Chef
         @@updated = Hash.new
 
         def version_from_nvra(stdout)
-            stdout[/^#{Regexp.escape(@new_resource.package_name)}-(.+)/, 1]
+            stdout[/^#{Regexp.escape(@new_resource.package_name)}-([^-]+)/, 1]
         end
 
         def update_indexes()

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -69,7 +69,8 @@ class Chef
         def install_package(name, version)
             Chef::Log.debug("#{@new_resource} installing package #{name}-#{version}")
             package = "#{name}-#{version}"
-            out = shell_out!("poldek --noask --up #{expand_options(@new_resource.options)} -u #{package}", :env => nil)
+            update_indexes
+            out = shell_out!("poldek --noask #{expand_options(@new_resource.options)} -u #{package}", :env => nil)
         end
 
         def upgrade_package(name, version)
@@ -85,6 +86,17 @@ class Chef
 
         def purge_package(name, version)
             remove_package(name, version)
+        end
+
+        @@updated = false
+        private
+        def update_indexes()
+            if @@updated
+                return
+            end
+            Chef::Log.debug("#{@new_resource} updating package indexes")
+            shell_out!("poldek --up #{expand_options(@new_resource.options)}", :env => nil)
+            @@updated = true
         end
       end
     end

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -1,0 +1,92 @@
+#
+# Author:: Elan Ruusamäe (glen@pld-linux.org)
+# Copyright:: Copyright (c) 2013 Elan Ruusamäe
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/package'
+require 'chef/mixin/shell_out'
+require 'chef/resource/package'
+require 'chef/mixin/get_source_from_package'
+
+class Chef
+  class Provider
+    class Package
+      class Poldek < Chef::Provider::Package
+        include Chef::Mixin::ShellOut
+        attr_accessor :is_virtual_package
+
+        def load_current_resource
+            Chef::Log.debug("#{@new_resource} loading current resource")
+            @current_resource = Chef::Resource::Package.new(@new_resource.name)
+            @current_resource.package_name(@new_resource.package_name)
+            @current_resource.version(nil)
+            check_package_state(@new_resource.package_name)
+            @current_resource # modified by check_package_state
+        end
+
+        def check_package_state(name)
+            Chef::Log.debug("#{@new_resource} checking package #{name}")
+            installed = false
+            @current_resource.version(nil)
+
+            out = shell_out!("rpm -q #{name}", :env => nil, :returns => [0,1])
+            if out.stdout
+                Chef::Log.debug("rpm STDOUT: #{out.stdout}");
+                version = out.stdout[/^#{@new_resource.package_name}-(.+)/, 1]
+                if version
+                    @current_resource.version(version)
+                    installed = true
+                end
+            end
+
+            if !installed
+                out = shell_out!("poldek -q --uniq --skip-installed --cmd 'ls #{name}'", :env => nil, :returns => [0,1])
+                if out.stdout
+                    Chef::Log.debug("poldek STDOUT: #{out.stdout}");
+                    version = out.stdout[/^#{@new_resource.package_name}-(.+)/, 1]
+                    if version
+                        @candidate_version = version
+                    end
+                end
+            end
+
+            return installed
+        end
+
+        def install_package(name, version)
+            Chef::Log.debug("#{@new_resource} installing package #{name}-#{version}")
+            package = "#{name}-#{version}"
+            out = shell_out!("poldek --noask --up -u #{package}", :env => nil)
+        end
+
+        def upgrade_package(name, version)
+            Chef::Log.debug("#{@new_resource} upgrading package #{name}-#{version}")
+            install_package(name, version)
+        end
+
+        def remove_package(name, version)
+            Chef::Log.debug("#{@new_resource} removing package #{name}-#{version}")
+            package = "#{name}-#{version}"
+            out = shell_out!("poldek --noask -e #{package}", :env => nil)
+        end
+
+        def purge_package(name, version)
+            remove_package(name, version)
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Elan Ruusamäe (glen@pld-linux.org)
-# Copyright:: Copyright (c) 2013 Elan Ruusamäe
+# Copyright:: Copyright (c) 2013,2018 Elan Ruusamäe
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,8 @@ class Chef
       class Poldek < Chef::Provider::Package
         include Chef::Mixin::ShellOut
         attr_accessor :is_virtual_package
+
+        provides :package, platform_family: "pld"
 
         def load_current_resource
             Chef::Log.debug("#{@new_resource} loading current resource")

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -67,7 +67,7 @@ class Chef
         def install_package(names, versions)
           logger.trace("#{new_resource} installing package #{names} version #{versions}")
           update_indexes
-          poldek(options, "-u", names)
+          poldek("-u", names)
         end
 
         def upgrade_package(names, versions)
@@ -77,22 +77,22 @@ class Chef
 
         def remove_package(names, versions)
           logger.trace("#{new_resource} removing package #{names} version #{versions}")
-          poldek(options, "-e", names)
+          poldek("-e", names)
         end
 
         private
         @@updated = Hash.new
 
         def update_indexes()
-            checksum = Digest::MD5.hexdigest(opts).to_s
+          checksum = Digest::MD5.hexdigest(opts).to_s
 
-            if @@updated[checksum]
-                return
-            end
+          if @@updated[checksum]
+              return
+          end
 
-            logger.debug("#{@new_resource} updating package indexe")
-            poldek("--up", options, :env => nil)
-            @@updated[checksum] = true
+          logger.debug("#{new_resource} updating package indexes")
+          poldek("--up")
+          @@updated[checksum] = true
         end
 
         def opts
@@ -129,7 +129,7 @@ class Chef
         end
 
         def poldek(*args)
-          shell_out_compact_timeout!(%w{poldek -q --noask}, *args, env: nil, returns: [0, 1, 255])
+          shell_out_compact_timeout!(%w{poldek -q --noask}, options, *args, env: nil, returns: [0, 1, 255])
         end
       end
     end

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -53,7 +53,7 @@ class Chef
             end
 
             if !installed
-                out = shell_out!("poldek -q --uniq --skip-installed #{expand_options(@new_resource.options)} --cmd 'ls #{name}'", :env => nil, :returns => [0,1])
+                out = shell_out!("poldek -q --uniq --skip-installed #{expand_options(@new_resource.options)} --cmd 'ls #{name}'", :env => nil, :returns => [0,1,255])
                 if out.stdout
                     Chef::Log.debug("poldek STDOUT: #{out.stdout}");
                     version = out.stdout[/^#{@new_resource.package_name}-(.+)/, 1]

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -103,7 +103,7 @@ class Chef
         private
         def update_indexes()
             Chef::Log.debug("#{@new_resource} call update indexes #{expand_options(@new_resource.options)}")
-			checksum = Digest::MD5.hexdigest(@new_resource.options || '').to_s
+            checksum = Digest::MD5.hexdigest(@new_resource.options || '').to_s
 
             if @@updated[checksum]
                 return

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -53,7 +53,7 @@ class Chef
             end
 
             if !installed
-                out = shell_out!("poldek -q --uniq --skip-installed --cmd 'ls #{name}'", :env => nil, :returns => [0,1])
+                out = shell_out!("poldek -q --uniq --skip-installed #{expand_options(@new_resource.options)} --cmd 'ls #{name}'", :env => nil, :returns => [0,1])
                 if out.stdout
                     Chef::Log.debug("poldek STDOUT: #{out.stdout}");
                     version = out.stdout[/^#{@new_resource.package_name}-(.+)/, 1]
@@ -69,7 +69,7 @@ class Chef
         def install_package(name, version)
             Chef::Log.debug("#{@new_resource} installing package #{name}-#{version}")
             package = "#{name}-#{version}"
-            out = shell_out!("poldek --noask --up -u #{package}", :env => nil)
+            out = shell_out!("poldek --noask --up #{expand_options(@new_resource.options)} -u #{package}", :env => nil)
         end
 
         def upgrade_package(name, version)
@@ -80,7 +80,7 @@ class Chef
         def remove_package(name, version)
             Chef::Log.debug("#{@new_resource} removing package #{name}-#{version}")
             package = "#{name}-#{version}"
-            out = shell_out!("poldek --noask -e #{package}", :env => nil)
+            out = shell_out!("poldek --noask #{expand_options(@new_resource.options)} -e #{package}", :env => nil)
         end
 
         def purge_package(name, version)

--- a/lib/chef/provider/package/poldek.rb
+++ b/lib/chef/provider/package/poldek.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+require 'digest/md5'
 require 'chef/provider/package'
 require 'chef/mixin/shell_out'
 require 'chef/resource/package'
@@ -98,15 +99,18 @@ class Chef
             remove_package(name, version)
         end
 
-        @@updated = false
+        @@updated = Hash.new
         private
         def update_indexes()
-            if @@updated
+            Chef::Log.debug("#{@new_resource} call update indexes #{expand_options(@new_resource.options)}")
+			checksum = Digest::MD5.hexdigest(@new_resource.options || '').to_s
+
+            if @@updated[checksum]
                 return
             end
-            Chef::Log.debug("#{@new_resource} updating package indexes")
+            Chef::Log.info("#{@new_resource} updating package indexes: #{expand_options(@new_resource.options)}")
             shell_out!("poldek --up #{expand_options(@new_resource.options)}", :env => nil)
-            @@updated = true
+            @@updated[checksum] = true
         end
       end
     end

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -74,6 +74,7 @@ require "chef/provider/package/macports"
 require "chef/provider/package/openbsd"
 require "chef/provider/package/pacman"
 require "chef/provider/package/portage"
+require 'chef/provider/package/poldek'
 require "chef/provider/package/paludis"
 require "chef/provider/package/rpm"
 require "chef/provider/package/rubygems"

--- a/lib/chef/resource/poldek_package.rb
+++ b/lib/chef/resource/poldek_package.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Elan Ruusamäe (glen@pld-linux.org)
+# Copyright:: Copyright (c) 2013 Elan Ruusamäe
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource/package'
+require 'chef/provider/package/poldek'
+
+class Chef
+  class Resource
+    class PoldekPackage < Chef::Resource::Package
+
+      def initialize(name, run_context=nil)
+        super
+        @resource_name = :poldek_package
+        @provider = Chef::Provider::Package::Poldek
+      end
+
+    end
+  end
+end

--- a/lib/chef/resource/poldek_package.rb
+++ b/lib/chef/resource/poldek_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Elan Ruusamäe (glen@pld-linux.org)
-# Copyright:: Copyright (c) 2013 Elan Ruusamäe
+# Copyright:: Copyright (c) 2013,2018 Elan Ruusamäe
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,13 +22,20 @@ require 'chef/provider/package/poldek'
 class Chef
   class Resource
     class PoldekPackage < Chef::Resource::Package
+      extend Chef::Mixin::Which
 
-      def initialize(name, run_context=nil)
-        super
-        @resource_name = :poldek_package
-        @provider = Chef::Provider::Package::Poldek
+      resource_name :poldek_package
+
+      provides :package do
+        which("poldek")
       end
 
+      provides :poldek_package
+
+      description "Use the poldek_package resource to install, upgrade, and remove packages with poldek."
+      introduced "14.3"
+
+      allowed_actions :install, :upgrade, :remove
     end
   end
 end


### PR DESCRIPTION
### Description

poldek is fast frontend to rpm package manager, https://launchpad.net/poldek
mainly used in pld linux distribution as main package manager, https://www.pld-linux.org/

- Replaces https://github.com/opscode/chef/pull/1225

### Issues Resolved

- https://tickets.opscode.com/browse/CHEF-4476

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
