### PR TITLE
Support for battery power options in windows_task resource

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -327,14 +327,12 @@ class Chef
         def task_needs_update?(task)
           flag = false
           if new_resource.frequency == :none
-            # require "byebug"
-            # byebug
             flag = (task.account_information != new_resource.user ||
             task.application_name != new_resource.command ||
             task.parameters != new_resource.command_arguments.to_s ||
             task.principals[:run_level] != run_level ||
-            task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_on_battery ||
-            task.settings[:stop_if_going_on_batteries] != new_resource.stop_on_battery)
+            task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_if_on_batteries ||
+            task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries)
           else
             current_task_trigger = task.trigger(0)
             new_task_trigger = trigger
@@ -358,8 +356,8 @@ class Chef
                   task.principals[:logon_type] != logon_type ||
                   task.principals[:run_level] != run_level ||
                   PRIORITY[task.priority] != new_resource.priority ||
-                  task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_on_battery ||
-                  task.settings[:stop_if_going_on_batteries] != new_resource.stop_on_battery
+                  task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_if_on_batteries ||
+                  task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries
               if trigger_type == TaskScheduler::MONTHLYDATE
                 flag = true if current_task_trigger[:run_on_last_day_of_month] != new_task_trigger[:run_on_last_day_of_month]
               end
@@ -557,8 +555,8 @@ class Chef
           settings[:idle_duration] = new_resource.idle_time if new_resource.idle_time
           settings[:run_only_if_idle] = true if new_resource.idle_time
           settings[:priority] = new_resource.priority
-          settings[:disallow_start_if_on_batteries] = new_resource.disallow_start_on_battery
-          settings[:stop_if_going_on_batteries] = new_resource.stop_on_battery
+          settings[:disallow_start_if_on_batteries] = new_resource.disallow_start_if_on_batteries
+          settings[:stop_if_going_on_batteries] = new_resource.stop_if_going_on_batteries
           settings
         end
 

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -327,10 +327,14 @@ class Chef
         def task_needs_update?(task)
           flag = false
           if new_resource.frequency == :none
+            # require "byebug"
+            # byebug
             flag = (task.account_information != new_resource.user ||
             task.application_name != new_resource.command ||
             task.parameters != new_resource.command_arguments.to_s ||
-            task.principals[:run_level] != run_level)
+            task.principals[:run_level] != run_level ||
+            task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_on_battery ||
+            task.settings[:stop_if_going_on_batteries] != new_resource.stop_on_battery)
           else
             current_task_trigger = task.trigger(0)
             new_task_trigger = trigger
@@ -353,8 +357,9 @@ class Chef
                   task.working_directory != new_resource.cwd.to_s ||
                   task.principals[:logon_type] != logon_type ||
                   task.principals[:run_level] != run_level ||
-                  PRIORITY[task.priority] != new_resource.priority
-
+                  PRIORITY[task.priority] != new_resource.priority ||
+                  task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_on_battery ||
+                  task.settings[:stop_if_going_on_batteries] != new_resource.stop_on_battery
               if trigger_type == TaskScheduler::MONTHLYDATE
                 flag = true if current_task_trigger[:run_on_last_day_of_month] != new_task_trigger[:run_on_last_day_of_month]
               end

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -552,6 +552,8 @@ class Chef
           settings[:idle_duration] = new_resource.idle_time if new_resource.idle_time
           settings[:run_only_if_idle] = true if new_resource.idle_time
           settings[:priority] = new_resource.priority
+          settings[:disallow_start_if_on_batteries] = new_resource.disallow_start_on_battery
+          settings[:stop_if_going_on_batteries] = new_resource.stop_on_battery
           settings
         end
 

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -61,6 +61,8 @@ class Chef
       property :minutes_interval, [String, Integer]
       property :priority, Integer, description: "Use to set Priority Levels range from 0 to 10.", default: 7,
                callbacks: { "should be in range of 0 to 10" => proc { |v| v >= 0 && v <= 10 } }
+      property :disallow_start_on_battery, [TrueClass, FalseClass], default: false
+      property :stop_on_battery, [TrueClass, FalseClass], default: false
 
       attr_accessor :exists, :task, :command_arguments
 

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -61,10 +61,10 @@ class Chef
       property :minutes_interval, [String, Integer]
       property :priority, Integer, description: "Use to set Priority Levels range from 0 to 10.", default: 7,
                callbacks: { "should be in range of 0 to 10" => proc { |v| v >= 0 && v <= 10 } }
-      property :disallow_start_on_battery, [TrueClass, FalseClass], default: false,
+      property :disallow_start_if_on_batteries, [TrueClass, FalseClass], default: false,
                introduced: "14.4",
-               description: "Scheduled task option when system is on AC power."
-      property :stop_on_battery, [TrueClass, FalseClass], default: false,
+               description: "Disallow start of the task if the system is running on battery power."
+      property :stop_if_going_on_batteries, [TrueClass, FalseClass], default: false,
                introduced: "14.4",
                description: "Scheduled task option when system is switching on battery."
 

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -61,8 +61,12 @@ class Chef
       property :minutes_interval, [String, Integer]
       property :priority, Integer, description: "Use to set Priority Levels range from 0 to 10.", default: 7,
                callbacks: { "should be in range of 0 to 10" => proc { |v| v >= 0 && v <= 10 } }
-      property :disallow_start_on_battery, [TrueClass, FalseClass], default: false
-      property :stop_on_battery, [TrueClass, FalseClass], default: false
+      property :disallow_start_on_battery, [TrueClass, FalseClass], default: false,
+               introduced: "14.4",
+               description: "Scheduled task option when system is on AC power."
+      property :stop_on_battery, [TrueClass, FalseClass], default: false,
+               introduced: "14.4",
+               description: "Scheduled task option when system is switching on battery."
 
       attr_accessor :exists, :task, :command_arguments
 

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -53,12 +53,12 @@ describe Chef::Resource::WindowsTask, :windows_only do
     expect(resource.frequency_modifier).to eql(1)
   end
 
-  it "sets the default value for disallow_start_on_battery as false" do
-    expect(resource.disallow_start_on_battery).to eql(false)
+  it "sets the default value for disallow_start_if_on_batteries as false" do
+    expect(resource.disallow_start_if_on_batteries).to eql(false)
   end
 
-  it "sets the default value for stop_on_battery as false" do
-    expect(resource.stop_on_battery).to eql(false)
+  it "sets the default value for stop_if_going_on_batteries as false" do
+    expect(resource.stop_if_going_on_batteries).to eql(false)
   end
 
   context "when frequency is not provided" do

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -53,6 +53,14 @@ describe Chef::Resource::WindowsTask, :windows_only do
     expect(resource.frequency_modifier).to eql(1)
   end
 
+  it "sets the default value for disallow_start_on_battery as false" do
+    expect(resource.disallow_start_on_battery).to eql(false)
+  end
+
+  it "sets the default value for stop_on_battery as false" do
+    expect(resource.stop_on_battery).to eql(false)
+  end
+
   context "when frequency is not provided" do
     it "raises ArgumentError to provide frequency" do
       expect { resource.after_created }.to raise_error(ArgumentError, "Frequency needs to be provided. Valid frequencies are :minute, :hourly, :daily, :weekly, :monthly, :once, :on_logon, :onstart, :on_idle, :none." )


### PR DESCRIPTION
### Description

Support for running tasks when on battery. Properties `disallow_start_on_battery` and `stop_on_battery` is being added.

### Issues Resolved
Fixes https://github.com/chef/chef/issues/6403