### PR TITLE
Swap chef-12 for chef-14 branches in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
 branches:
   only:
   - master
+  - chef-14
   - chef-13
 
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ skip_tags: true
 branches:
   only:
     - master
+    - chef-14
     - chef-13
-    - chef-12
 
 install:
   - systeminfo


### PR DESCRIPTION
chef-14 branch doesn't exist yet, but this way we won't have to update
things when we fork

Signed-off-by: Tim Smith <tsmith@chef.io>