### PR TITLE
Remove the deprecated knife bootstrap --identity-file flag

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -767,7 +767,6 @@ module ChefConfig
       default :bootstrap_template, nil
       default :secret, nil
       default :secret_file, nil
-      default :identity_file, nil
       default :host_key_verify, nil
       default :forward_agent, nil
       default :sort_status_reverse, nil

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -78,10 +78,6 @@ class Chef
         description: "Enable SSH agent forwarding",
         boolean: true
 
-      option :identity_file,
-        long: "--identity-file IDENTITY_FILE",
-        description: "The SSH identity file used for authentication. [DEPRECATED] Use --ssh-identity-file instead."
-
       option :ssh_identity_file,
         short: "-i IDENTITY_FILE",
         long: "--ssh-identity-file IDENTITY_FILE",
@@ -434,7 +430,7 @@ class Chef
         ssh.config[:ssh_gateway] = config[:ssh_gateway]
         ssh.config[:ssh_gateway_identity] = config[:ssh_gateway_identity]
         ssh.config[:forward_agent] = config[:forward_agent]
-        ssh.config[:ssh_identity_file] = config[:ssh_identity_file] || config[:identity_file]
+        ssh.config[:ssh_identity_file] = config[:ssh_identity_file]
         ssh.config[:manual] = true
         ssh.config[:host_key_verify] = config[:host_key_verify]
         ssh.config[:on_error] = true


### PR DESCRIPTION
I missed a few of these in Chef 14. This removes the remainder.

Signed-off-by: Tim Smith <tsmith@chef.io>
 