### PR TITLE
Functional tests: Ensure we logon with the local security_user account

### DIFF
--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -34,10 +34,7 @@ describe "Chef::Win32::Security", :windows_only do
     let(:password) { "Security@123" }
 
     let(:domain) do
-      whoami = Mixlib::ShellOut.new("whoami")
-      whoami.run_command
-      whoami.error!
-      whoami.stdout.split("\\")[0]
+      ENV['COMPUTERNAME']
     end
 
     before do

--- a/spec/functional/win32/security_spec.rb
+++ b/spec/functional/win32/security_spec.rb
@@ -34,7 +34,7 @@ describe "Chef::Win32::Security", :windows_only do
     let(:password) { "Security@123" }
 
     let(:domain) do
-      ENV['COMPUTERNAME']
+      ENV["COMPUTERNAME"]
     end
 
     before do


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This resolves the functional test failures so they work on an Azure AD-connected Windows 10 or Windows 2016 machine.  Our tests always create a "local" user however the domain name on an AAD connected machine is the NetBIOS name of the domain (e.g. OPSCODECORP).

### Issues Resolved

Fixes #7440 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
