### PR TITLE
Update inspec-core and win32-taskscheduler to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     highline (1.7.10)
     htmlentities (4.3.4)
     iniparse (1.4.4)
-    inspec-core (2.2.35)
+    inspec-core (2.2.41)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -339,13 +339,13 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.2)
+    win32-taskscheduler (1.0.9)
       ffi
       structured_warnings
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
     wmi-lite (1.0.0)
-    yard (0.9.14)
+    yard (0.9.15)
 
 PLATFORMS
   ruby

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 836bd650d49e6350dfa40b43a1398c5847a6fd42
+  revision: d48afdf29dd9c9d0562656675d1036cd035c2a46
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.90)
-      aws-sdk-resources (= 2.11.90)
-    aws-sdk-core (2.11.90)
+    aws-sdk (2.11.93)
+      aws-sdk-resources (= 2.11.93)
+    aws-sdk-core (2.11.93)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.90)
-      aws-sdk-core (= 2.11.90)
+    aws-sdk-resources (2.11.93)
+      aws-sdk-core (= 2.11.93)
     aws-sigv4 (1.0.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)


### PR DESCRIPTION
InSpec ships with some nice bugfixes
win32-taskscheduler supports priorities and running on battery

Signed-off-by: Tim Smith <tsmith@chef.io>