### PR TITLE
Pin win32-taskscheduler to 1.0.2 and bump inspec-core/mixlib-shellout to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ PATH
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
       win32-service (~> 1.0)
-      win32-taskscheduler (~> 1.0.0)
+      win32-taskscheduler (= 1.0.2)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
 
@@ -149,7 +149,7 @@ GEM
     highline (1.7.10)
     htmlentities (4.3.4)
     iniparse (1.4.4)
-    inspec-core (2.2.35)
+    inspec-core (2.2.41)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -182,8 +182,8 @@ GEM
     mixlib-config (2.2.13)
       tomlrb
     mixlib-log (2.0.4)
-    mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
+    mixlib-shellout (2.4.0)
+    mixlib-shellout (2.4.0-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)
@@ -339,13 +339,13 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.9)
+    win32-taskscheduler (1.0.2)
       ffi
       structured_warnings
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
     wmi-lite (1.0.0)
-    yard (0.9.14)
+    yard (0.9.15)
 
 PLATFORMS
   ruby

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -14,7 +14,7 @@ gemspec.add_dependency "win32-process", "~> 0.8.2"
 gemspec.add_dependency "win32-service", "~> 1.0"
 gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
-gemspec.add_dependency "win32-taskscheduler", "~> 1.0.0"
+gemspec.add_dependency "win32-taskscheduler", "=1.0.2" # this is in place until windows scheduled tasks jobs pass with 1.0.9
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += %w{ext/win32-eventlog/Rakefile ext/win32-eventlog/chef-log.man}
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 836bd650d49e6350dfa40b43a1398c5847a6fd42
+  revision: d48afdf29dd9c9d0562656675d1036cd035c2a46
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.90)
-      aws-sdk-resources (= 2.11.90)
-    aws-sdk-core (2.11.90)
+    aws-sdk (2.11.93)
+      aws-sdk-resources (= 2.11.93)
+    aws-sdk-core (2.11.93)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.90)
-      aws-sdk-core (= 2.11.90)
+    aws-sdk-resources (2.11.93)
+      aws-sdk-core (= 2.11.93)
     aws-sigv4 (1.0.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -135,8 +135,8 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (1.7.1)
-    mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
+    mixlib-shellout (2.4.0)
+    mixlib-shellout (2.4.0-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.2)


### PR DESCRIPTION
Pull in the latest deps, but pin win32-taskscheduler  to 1.0.2 as 1.0.9 broke tests and the scheduled task resource.

Signed-off-by: Tim Smith <tsmith@chef.io>