### PR TITLE
Bump dependencies to fix failing functional test for windows_task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     highline (1.7.10)
     htmlentities (4.3.4)
     iniparse (1.4.4)
-    inspec-core (2.2.35)
+    inspec-core (2.2.41)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -182,8 +182,8 @@ GEM
     mixlib-config (2.2.13)
       tomlrb
     mixlib-log (2.0.4)
-    mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
+    mixlib-shellout (2.4.0)
+    mixlib-shellout (2.4.0-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)
@@ -339,13 +339,13 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.9)
+    win32-taskscheduler (1.0.10)
       ffi
       structured_warnings
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
     wmi-lite (1.0.0)
-    yard (0.9.14)
+    yard (0.9.15)
 
 PLATFORMS
   ruby

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 836bd650d49e6350dfa40b43a1398c5847a6fd42
+  revision: d48afdf29dd9c9d0562656675d1036cd035c2a46
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.90)
-      aws-sdk-resources (= 2.11.90)
-    aws-sdk-core (2.11.90)
+    aws-sdk (2.11.93)
+      aws-sdk-resources (= 2.11.93)
+    aws-sdk-core (2.11.93)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.90)
-      aws-sdk-core (= 2.11.90)
+    aws-sdk-resources (2.11.93)
+      aws-sdk-core (= 2.11.93)
     aws-sigv4 (1.0.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -135,8 +135,8 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (1.7.1)
-    mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
+    mixlib-shellout (2.4.0)
+    mixlib-shellout (2.4.0-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.2)


### PR DESCRIPTION
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
Bumped win32-taskscheduler version to 1.0.10 to get latest fix and which resolves breaking functional test in windows_task resource as mentioned in #7502 .