### PR TITLE
Adding @stuartpreston as a Chef maintainer [ci skip]

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -42,6 +42,7 @@ To mention the team, use @chef/client-core
 * [Ranjib Dey](https://github.com/ranjib)
 * [Steven Murawski](https://github.com/smurawski)
 * [Steven Danna](https://github.com/stevendanna)
+* [Stuart Preston](https://github.com/stuartpreston)
 * [Tim Smith](https://github.com/tas50)
 * [Tom Duffield](https://github.com/tduffield)
 * [Tyler Ball](https://github.com/tyler-ball)
@@ -108,6 +109,7 @@ To mention the team, use @chef/client-windows
 * [Jay Mundrawala](https://github.com/jaym)
 * [Kartik Cating-Subramanian](https://github.com/ksubrama)
 * [Steven Murawski](https://github.com/smurawski)
+* [Stuart Preston](https://github.com/stuartpreston)
 * [Salim Alam](https://github.com/chefsalim)
 * [Matt Wrock](https://github.com/mwrock)
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -48,6 +48,7 @@ Maintainers for the Chef client, Ohai, mixlibs, ChefDK, ChefSpec, Foodcritic, ch
         "ranjib",
         "smurawski",
         "stevendanna",
+        "stuartpreston",
         "tas50",
         "tduffield",
         "tyler-ball",
@@ -108,6 +109,7 @@ The specific components of Chef related to a given platform - including (but not
           "jaym",
           "ksubrama",
           "smurawski",
+          "stuartpreston",
           "chefsalim",
           "mwrock"
         ]


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Adding Stuart Preston as a maintainer, in the Core and Windows components. 