### PR TITLE
Fixes rpmdb corruption errors for multiple yum package

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -64,6 +64,9 @@ class Chef
       def load_current_resource; end
 
       def define_resource_requirements
+        # Before install and upgrade we are validating package name
+        validate_package(new_resource.package_name)
+
         # XXX: upgrade with a specific version doesn't make a whole lot of sense, but why don't we throw this anyway if it happens?
         # if not, shouldn't we raise to tell the user to use install instead of upgrade if they want to pin a version?
         requirements.assert(:install) do |a|
@@ -170,7 +173,6 @@ class Chef
       end
 
       def removing_package?
-        validate_package(new_resource.package_name)
         if !current_version_array.any?
           # ! any? means it's all nil's, which means nothing is installed
           false
@@ -306,11 +308,6 @@ class Chef
       end
 
       def validate_package(name)
-        raise( Chef::Exceptions::Package, "package name not allowed spaces, tabs, newlines, etc." ) if invalid_name?(name)
-      end
-
-      def invalid_name?(x)
-        ( x.is_a?(Array) && x.any? { |name| name.strip.index(/\s/) } ) || ( x.is_a?(String) && x.strip.index(/\s/) )
       end
 
       # used by subclasses.  deprecated.  use #a_to_s instead.

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -170,6 +170,7 @@ class Chef
       end
 
       def removing_package?
+        validate_package(new_resource.package_name)
         if !current_version_array.any?
           # ! any? means it's all nil's, which means nothing is installed
           false
@@ -302,6 +303,14 @@ class Chef
 
       def unlock_package(name, version)
         raise( Chef::Exceptions::UnsupportedAction, "#{self} does not support :unlock" )
+      end
+
+      def validate_package(name)
+        raise( Chef::Exceptions::Package, "package name not allowed spaces, tabs, newlines, etc." ) if invalid_name?(name)
+      end
+
+      def invalid_name?(x)
+        ( x.is_a?(Array) && x.any? { |name| name.strip.index(/\s/) } ) || ( x.is_a?(String) && x.strip.index(/\s/) )
       end
 
       # used by subclasses.  deprecated.  use #a_to_s instead.

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -86,6 +86,14 @@ class Chef
           end
         end
 
+        def validate_package(name)
+          raise( Chef::Exceptions::Package, "Package names containing whitespace characters such as spaces, tabs, or newlines are not allowed." ) if valid_package_names?(name)
+        end
+
+        def valid_package_names?(package_name)
+          Array(package_name).any? { |name| name.index(/\s|\\t|\\n/) }
+        end
+
         def install_package(names, versions)
           method = nil
           methods = []


### PR DESCRIPTION
Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>

### Description
1: Fixes rpmdb corruption errors if package resource is given a name that contains a space.
2: Validate package_name if contains a space.
3: Fix Yum arguments so that user can add and remove multiple packages following way:
```
package 'box bag foo' do
  action :remove
end
```
```
package 'remove multiple packages' do
   package_name "box bag foo"
   action :remove
end
```
```
package 'remove multiple packages' do
   package_name '["box", "bag", "foo"]'
   action :remove
end
```
Similarly with `install`

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
