### PR TITLE
Fix for registry_key resource doesn't recognise keys when passed as attribute.

### DIFF
--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -74,9 +74,12 @@ class Chef
       def values(arg = nil)
         if not arg.nil?
           if arg.is_a?(Hash)
-            @values = [ arg ]
+            @values = [ Mash.new(arg).symbolize_keys ]
           elsif arg.is_a?(Array)
-            @values = arg
+            @values = []
+            arg.each do |value|
+              @values << Mash.new(value).symbolize_keys
+            end
           else
             raise ArgumentError, "Bad type for RegistryKey resource, use Hash or Array"
           end

--- a/spec/unit/resource/registry_key_spec.rb
+++ b/spec/unit/resource/registry_key_spec.rb
@@ -133,6 +133,10 @@ describe Chef::Resource::RegistryKey, "values" do
       expect { resource.values([ { name: "123", type: :string, data: "carmen" } ]) }.to_not raise_error
     end
   end
+
+  it "does not raise an exception if keys are in string format" do
+    expect { resource.values([ { "name" => "123", "type" => :string, "data" => "carmen" } ]) }.to_not raise_error
+  end
 end
 
 describe Chef::Resource::RegistryKey, "recursive" do


### PR DESCRIPTION

Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description

The registry_key resource doesn't recognise the keys in the option values hash when passed as an attribute.

### Issues Resolved

Fixes #7367

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
