### PR TITLE
[SHACK-304] Deprecation checking turns up false positive

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -65,8 +65,13 @@ class Chef
         return true if Chef::Config[:silence_deprecation_warnings] == true
         # Check if this warning has been silenced by the config.
         return true if Chef::Config[:silence_deprecation_warnings].any? do |silence_spec|
-          # Just in case someone uses a symbol in the config by mistake.
-          silence_spec = silence_spec.to_s
+          if silence_spec.is_a? Integer
+            # Integers can end up matching the line number in the `location` string
+            silence_spec = "CHEF-#{silence_spec}"
+          else
+            # Just in case someone uses a symbol in the config by mistake.
+            silence_spec = silence_spec.to_s
+          end
            # Check for a silence by deprecation name, or by location.
           self.class.deprecation_key == silence_spec || self.class.deprecation_id.to_s == silence_spec || "chef-#{self.class.deprecation_id}" == silence_spec.downcase || location.include?(silence_spec)
         end

--- a/spec/unit/chef_class_spec.rb
+++ b/spec/unit/chef_class_spec.rb
@@ -143,6 +143,16 @@ describe "Chef class" do
         Chef.deprecated(:generic, "This is my handle.")
       end
 
+      it "allows silencing specific IDs without matching the line number" do
+        Chef::Config[:silence_deprecation_warnings] = [__LINE__ + 4]
+        expect(Chef::Log).to receive(:warn).with(/I'm a little teapot/).once
+        expect(Chef::Log).to receive(:warn).with(/Short and stout/).once
+        expect(Chef::Log).to receive(:warn).with(/This is my handle/).once
+        Chef.deprecated(:generic, "I'm a little teapot.")
+        Chef.deprecated(:internal_api, "Short and stout.")
+        Chef.deprecated(:generic, "This is my handle.")
+      end
+
       it "allows silencing specific IDs using the CHEF- syntax" do
         Chef::Config[:silence_deprecation_warnings] = ["CHEF-0"]
         expect(Chef::Log).to receive(:warn).with(/I'm a little teapot/).once


### PR DESCRIPTION
### Description

When the location string during a deprecation check looks like
`/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.3.37/spec/unit/chef_class_spec.rb:141:in
'block (4 levels) in <top (required)>'` then trying to silence
deprecation warnings using only an index number (EG,
`Chef::Config[:silence_deprecation_warnings] = [0]`) can end up matching
part of that location string incorrectly. In this case it matched the 0
in the ruby version.

### Issues Resolved

SHACK-304

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>
