### PR TITLE
Adding cheeseplus as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,6 +31,7 @@ To mention the team, use @chef/client-core
 * [Adam Leff](https://github.com/adamleff)
 * [Bryan McLellan](https://github.com/btm)
 * [Noah Kantrowitz](https://github.com/coderanger)
+* [Seth Thomas](https://github.com/cheeseplus)
 * [Daniel DeLeo](https://github.com/danielsdeleo)
 * [AJ Christensen](https://github.com/fujin)
 * [Phil Dibowitz](https://github.com/jaymzh)

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -37,6 +37,7 @@ Maintainers for the Chef client, Ohai, mixlibs, ChefDK, ChefSpec, Foodcritic, ch
         "adamleff",
         "btm",
         "coderanger",
+        "cheeseplus",
         "danielsdeleo",
         "fujin",
         "jaymzh",
@@ -364,3 +365,7 @@ The specific components of Chef related to a given platform - including (but not
     GitHub = "itmustbejj"
     Twitter = "itmustbejj"
     IRC = "itmustbejj"
+
+  [people.cheeseplus]
+    Name = "Seth Thomas"
+    GitHub = "cheeseplus"


### PR DESCRIPTION
### Description

Adding cheeseplus as maintainer

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
