### PR TITLE
[SHACK-290] Unpacking tarball paths suffer from URI error

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -529,14 +529,14 @@ class Chef::Application::Client < Chef::Application
 
   def fetch_recipe_tarball(url, path)
     Chef::Log.debug("Download recipes tarball from #{url} to #{path}")
-    if url =~ URI.regexp
+    if File.exist?(url)
+      FileUtils.cp(url, path)
+    elsif url =~ URI.regexp
       File.open(path, "wb") do |f|
         open(url) do |r|
           f.write(r.read)
         end
       end
-    elsif File.exist?(url)
-      FileUtils.cp(url, path)
     else
       Chef::Application.fatal! "You specified --recipe-url but the value is neither a valid URL nor a path to a file that exists on disk." +
         "Please confirm the location of the tarball and try again."


### PR DESCRIPTION
### Description

Original error: https://github.com/chef/chef-apply/pull/9
I thought I fixed this in https://github.com/chef/chef/pull/7223 but it
turns out relative or absolute paths continue to match the URI regular
expression. This means that Windows continues to fail to unpack
policyfile tarballs.

Reversing the order of these checks ensures that real paths do not fall
prey to the URI error.

### Issues Resolved

SHACK-290

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>