### PR TITLE
stop parsing init script at the "### END INIT INFO" marker.

### DIFF
--- a/lib/chef/provider/service/debian.rb
+++ b/lib/chef/provider/service/debian.rb
@@ -78,7 +78,7 @@ class Chef
             if line =~ /^### BEGIN INIT INFO/
               in_info = true
             elsif line =~ /^### END INIT INFO/
-              in_info = false
+              break acc
             elsif in_info
               if line =~ /Default-(Start|Stop):\s+(\d.*)/
                 acc << $2.split(" ")


### PR DESCRIPTION
Signed-off-by: Guido Schoening <guido.schoeing@gmail.com>

### Description
Spring Boot Webapps cat contain an init script as a header of the jar.
By stopping to parse the init script at the marker the binary part of the file is no longer parsed which avoids errors trying to parse binary data as a string. Furthermore to iterate over lines after the marker is unnecessary
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
