### PR TITLE
Backport for 13: scrub tempfile names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       INTEGRATION_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -51,7 +51,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -65,7 +65,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_24: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -73,13 +73,13 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       CHEFSTYLE: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       AUDIT_CHECK: 1
-    rvm: 2.4.3
+    rvm: 2.4.4
     script: bundle exec bundle-audit check --update
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -89,45 +89,45 @@ matrix:
   - env:
       TEST_GEM: sethvargo/chef-sugar
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       PEDANT_OPTS: --skip-oc_id
       TEST_GEM: chef/chef-zero
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec cheffs
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: chef/cheffish
     script: bundle exec tasks/bin/run_external_test $TEST_GEM cheffish-13 rake spec
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: chefspec/chefspec
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: foodcritic/foodcritic
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake test
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: poise/halite
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: poise/poise
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.4.3
+    rvm: 2.4.4
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.4.3
+    rvm: 2.4.4
   ### START TEST KITCHEN ONLY ###
   #
   # Temporarily Disable Amazon Linux 2
   #
-  # - rvm: 2.4.3
+  # - rvm: 2.4.4
   #   services: docker
   #   sudo: required
   #   gemfile: kitchen-tests/Gemfile
@@ -144,7 +144,7 @@ matrix:
   #   env:
   #     - AMAZON=LATEST
   #     - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -161,7 +161,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -178,7 +178,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -195,7 +195,7 @@ matrix:
     env:
       - DEBIAN=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -212,7 +212,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -229,7 +229,7 @@ matrix:
     env:
       - DEBIAN=9
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -246,7 +246,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -263,7 +263,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -280,7 +280,7 @@ matrix:
     env:
      - FEDORA=latest
      - KITCHEN_YAML=.kitchen.travis.yml
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -297,7 +297,7 @@ matrix:
     env:
      - OPENSUSELEAP=42
      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -314,7 +314,7 @@ matrix:
 #    env:
 #      - AWESOME_CUSTOMERS_UBUNTU=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
-#  - rvm: 2.4.3
+#  - rvm: 2.4.4
 #    services: docker
 #    sudo: required
 #    gemfile: kitchen-tests/Gemfile
@@ -332,7 +332,7 @@ matrix:
 #      - AWESOME_CUSTOMERS_RHEL=1
 #      - KITCHEN_YAML=.kitchen.travis.yml
 #    ### END TEST KITCHEN ONLY ###
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     sudo: required
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ dist: trusty
 before_install:
   - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
   - gem --version
-  - rvm @global do gem uninstall bundler -a -x
+    # travis may preinstall a bundler gem which is later than the one which we pin, which may totally hose us, so we preemtively
+    # uninstall anything they may have installed here.  if they haven't installed anything then we have to ignore the failure
+    # to uninstall the default bundler that ships embedded in ruby itself.
+  - rvm @global do gem uninstall bundler -a -x || true
   - gem install bundler -v $(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
   - bundle --version
   - rm -f .bundle/config

--- a/kitchen-tests/cookbooks/base/recipes/packages.rb
+++ b/kitchen-tests/cookbooks/base/recipes/packages.rb
@@ -15,7 +15,7 @@ pkgs.each do |pkg|
   multipackage pkgs
 end
 
-gems = %w{fpm aws-sdk}
+gems = %w{fpm community_cookbook_releaser}
 
 gems.each do |gem|
   chef_gem gem do

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,7 @@ class Chef
         # the leading "[.]chef-" here should be considered a public API and should not be changed
         basename.insert 0, "chef-"
         basename.insert 0, "." unless Chef::Platform.windows? # dotfile if we're not on windows
-        basename
+        basename.scrub
       end
 
       # this is similar to File.extname() but greedy about the extension (from the first dot, not the last dot)
@@ -76,7 +76,7 @@ class Chef
         # complexity here is due to supporting mangling non-UTF8 strings (e.g. latin-1 filenames with characters that are illegal in UTF-8)
         b = File.basename(@new_resource.path)
         i = b.index(".")
-        i.nil? ? "" : b[i..-1]
+        i.nil? ? "" : b[i..-1].scrub
       end
 
       # Returns the possible directories for the tempfile to be created in.


### PR DESCRIPTION
### Description

To fix travis

Also removing the `aws-sdk` gem from the set of integration tests which install gems to ensure `chef-client` can do what it advertises. This gem takes over 10 minutes to install on centos 6 for some reason, and we no longer install it in Chef master. We shouldn't use this gem to validate that chef can do what it says (with `chef_gem`) because its so massive.

Backporting https://github.com/chef/chef/pull/7104 to Chef 13

### Issues Resolved

SHACK-290

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md, has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>