### PR TITLE
Automatically open PRs on dep gem updates

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -32,8 +32,6 @@ github:
   delete_branch_on_merge: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
-  # The Github Team primarily responsible for handling incoming Pull Requests.
-  maintainer_group: chef/client-core
   # allow bumping the minor release via label
   minor_bump_labels:
     - "Expeditor: Bump Minor Version"
@@ -82,3 +80,53 @@ artifact_actions:
     - built_in:tag_docker_image
     - built_in:publish_rubygems
     - built_in:notify_chefio_slack_channels
+
+subscriptions:
+  - workload: ruby_gem_published:mixlib-archive-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:mixlib-authentication-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:mixlib-cli-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:mixlib-log-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:mixlib-shellout-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:chef-vault-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:chef-zero-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:ohai-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:inspec-core-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:train-core-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:win32-process-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:win32-service-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:win32-taskscheduler-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:ffi-yajl-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:libyajl2-*
+    actions:
+      - bash:.expeditor/update_deps.sh
+  - workload: ruby_gem_published:cheffish-*
+    actions:
+      - bash:.expeditor/update_deps.sh

--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -evx
+
+branch="expeditor/${GEM_NAME}_${VERSION}"
+git checkout -b "$branch"
+
+bundle update $GEM_NAME
+
+git add .
+git commit --message "Bump $GEM_NAME to $VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $VERSION was promoted to Rubygems."
+
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"

--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -5,7 +5,7 @@ set -evx
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
-bundle update $GEM_NAME
+bundle update $GEM_NAME -v $VERSION
 
 git add .
 git commit --message "Bump $GEM_NAME to $VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $VERSION was promoted to Rubygems."


### PR DESCRIPTION
This uses expeditor subscriptions to automatically cut a PR to update gems when a dependent Chef managed gem is pushed to rubygems.

Signed-off-by: Tim Smith <tsmith@chef.io>