### PR TITLE
Fix issue of setting comment for windows user

### DIFF
--- a/lib/chef/provider/user/windows.rb
+++ b/lib/chef/provider/user/windows.rb
@@ -45,7 +45,7 @@ class Chef
             user_info = @net_user.get_info
 
             current_resource.uid(user_info[:user_id])
-            current_resource.comment(user_info[:full_name])
+            current_resource.comment(user_info[:comment])
             current_resource.home(user_info[:home_dir])
             current_resource.shell(user_info[:script_path])
           rescue Chef::Exceptions::UserIDNotFound => e
@@ -100,7 +100,7 @@ class Chef
           opts = { name: new_resource.username }
 
           field_list = {
-            "comment" => "full_name",
+            "comment" => "comment",
             "home" => "home_dir",
             "uid" => "user_id",
             "shell" => "script_path",

--- a/spec/unit/provider/user/windows_spec.rb
+++ b/spec/unit/provider/user/windows_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Provider::User::Windows do
 
     describe "and the properties match" do
       it "doesn't set the comment field to be updated" do
-        expect(@provider.set_options).not_to have_key(:full_name)
+        expect(@provider.set_options).not_to have_key(:comment)
       end
 
       it "doesn't set the home directory to be updated" do
@@ -102,8 +102,8 @@ describe Chef::Provider::User::Windows do
         @provider.current_resource = @current_resource
       end
 
-      it "marks the full_name field to be updated" do
-        expect(@provider.set_options[:full_name]).to eq("Adam Jacob")
+      it "marks the comment field to be updated" do
+        expect(@provider.set_options[:comment]).to eq("Adam Jacob")
       end
 
       it "marks the home_dir property to be updated" do


### PR DESCRIPTION
Currently, User resource on windows applies `comment` as `full_name`, does not allow for setting `description`. Now able to set `comment` as `description` and not as `fullname`. Done testing with below output:
```
PS C:\Users\ashuser> $dom = $env:userdomain
PS C:\Users\ashuser> $usr = $env:username
PS C:\Users\ashuser> ([adsi]"WinNT://$dom/$usr,user").fullname

PS C:\Users\ashuser> ([adsi]"WinNT://$dom/$usr,user").description
the comment
```

Issue fixed : https://github.com/chef/chef/issues/7356

Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>