### PR TITLE
Require mixlib-shellout 2.4 or later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       mixlib-authentication (~> 2.1)
       mixlib-cli (~> 1.7)
       mixlib-log (~> 2.0, >= 2.0.3)
-      mixlib-shellout (~> 2.0)
+      mixlib-shellout (~> 2.4)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (~> 4.2)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -56,7 +56,7 @@ PATH
       mixlib-authentication (~> 2.1)
       mixlib-cli (~> 1.7)
       mixlib-log (~> 2.0, >= 2.0.3)
-      mixlib-shellout (~> 2.0)
+      mixlib-shellout (~> 2.4)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (~> 4.2)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -345,7 +345,7 @@ GEM
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
     wmi-lite (1.0.0)
-    yard (0.9.15)
+    yard (0.9.16)
 
 PLATFORMS
   ruby

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", "~> 1.7"
   s.add_dependency "mixlib-log", "~> 2.0", ">= 2.0.3"
   s.add_dependency "mixlib-authentication", "~> 2.1"
-  s.add_dependency "mixlib-shellout", "~> 2.0"
+  s.add_dependency "mixlib-shellout", "~> 2.4"
   s.add_dependency "mixlib-archive", "~> 0.4"
   s.add_dependency "ohai", "~> 14.0"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 6c242471a79698e5fc7b8d8364dedea3c246ef4a
+  revision: 386cd17f6a6365bd4585761a2738b4561fbaea97
   branch: master
   specs:
-    omnibus (5.6.15)
+    omnibus (6.0.1)
       aws-sdk (~> 2)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.105)
-      aws-sdk-resources (= 2.11.105)
-    aws-sdk-core (2.11.105)
+    aws-sdk (2.11.106)
+      aws-sdk-resources (= 2.11.106)
+    aws-sdk-core (2.11.106)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.105)
-      aws-sdk-core (= 2.11.105)
+    aws-sdk-resources (2.11.106)
+      aws-sdk-core (= 2.11.106)
     aws-sigv4 (1.0.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -114,7 +114,7 @@ GEM
     kitchen-vagrant (1.3.2)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.13)
+    license_scout (1.0.15)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)


### PR DESCRIPTION
We need this to merge in https://github.com/chef/chef/pull/7353

Signed-off-by: Tim Smith <tsmith@chef.io>