### PR TITLE
Use the existing helper method for package resource classes that don't support allow_downgrade

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -480,7 +480,7 @@ class Chef
                 elsif current_version.nil?
                   Chef::Log.debug("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
                   target_version_array.push(candidate_version)
-                elsif version_compare(current_version, candidate_version) == 1 && !new_resource.allow_downgrade
+                elsif version_compare(current_version, candidate_version) == 1 && !allow_downgrade
                   Chef::Log.debug("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{candidate_version}. Skipping...)")
                   target_version_array.push(nil)
                 else


### PR DESCRIPTION
Backporting Noah's fix to Chef 14 back to Chef 13.