### PR TITLE
Fix remote_directory does not obey removal of file specificity

### DIFF
--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -296,9 +296,9 @@ class Chef
         # we're just going to make cookbook_files out of these and make the
         # cookbook find them by filespecificity again. but it's the shortest
         # path to "success" for now.
-        if manifest_record_path =~ /(#{Regexp.escape(segment.to_s)}\/[^\/]+\/#{Regexp.escape(dirname)})\/.+$/
+        if manifest_record_path =~ /(#{Regexp.escape(segment.to_s)}\/[^\/]*\/?#{Regexp.escape(dirname)})\/.+$/
           specificity_dirname = $1
-          non_specific_path = manifest_record_path[/#{Regexp.escape(segment.to_s)}\/[^\/]+\/#{Regexp.escape(dirname)}\/(.+)$/, 1]
+          non_specific_path = manifest_record_path[/#{Regexp.escape(segment.to_s)}\/[^\/]*\/?#{Regexp.escape(dirname)}\/(.+)$/, 1]
           # Record the specificity_dirname only if it's in the list of
           # valid preferences
           if filenames_by_pref[specificity_dirname]

--- a/spec/unit/cookbook_version_file_specificity_spec.rb
+++ b/spec/unit/cookbook_version_file_specificity_spec.rb
@@ -95,6 +95,13 @@ describe Chef::CookbookVersion, "file specificity" do
        # directory adirectory
        {
          name: "files/anotherfile1.rb",
+         path: "files/root_directory/anotherfile1.rb.root",
+         checksum: "csum-root-directory",
+         specificity: "root_directory",
+       },
+
+       {
+         name: "files/anotherfile1.rb",
          path: "files/host-examplehost.example.org/adirectory/anotherfile1.rb.host",
          full_path: "/cookbook-folder/files/host-examplehost.example.org/adirectory/anotherfile1.rb.host",
          checksum: "csum-host-1",
@@ -483,6 +490,19 @@ describe Chef::CookbookVersion, "file specificity" do
   ## Globbing the relative paths out of the manifest records ##
 
   describe "when globbing for relative file paths based on filespecificity" do
+    it "should return a list of relative paths based on priority preference: root directory" do
+      node = Chef::Node.new
+      node.automatic_attrs[:platform] = "ubuntu"
+      node.automatic_attrs[:platform_version] = "9.10"
+      node.automatic_attrs[:fqdn] = "examplehost.example.org"
+
+      filenames = @cookbook.relative_filenames_in_preferred_directory(node, :files, "root_directory")
+      expect(filenames).not_to be_nil
+      expect(filenames.size).to eq(1)
+
+      expect(filenames.sort).to eq(["anotherfile1.rb.root"])
+    end
+
     it "should return a list of relative paths based on priority preference: host" do
       node = Chef::Node.new
       node.automatic_attrs[:platform] = "ubuntu"


### PR DESCRIPTION
I noticed that i was not able to use the `remote_directory` resource when the **source** is within the root of the cookbooks /files directory. I would always get a `FileNotFound` exception. 

e.g. with `example_cookbook/files/tmp/test/test_file.txt`

```
files/host-testvbox/tmp/test 	<= works
files/ubuntu-18.04/tmp/test 	<= works
files/ubuntu-18/tmp/test 	<= works
files/ubuntu/tmp/test 		<= works
files/default/tmp/test 		<= works	
files/tmp/test 			<= fails
```

this issue comes from a regex within `lib/chef/cookbook_version.rb` and `preferences_for_path`. It fails to match the last item so i updated the regex to fix and added a unit test that if run without the fix will illustrate the error.

I tested using:

```
Chef Development Kit Version: 3.1.0
chef-client version: 14.2.0
delivery version: master (6862f27aba89109a9630f0b6c6798efec56b4efe)
berks version: 7.0.4
kitchen version: 1.22.0
inspec version: 2.1.72
```

Thanks

closes #2837