### PR TITLE
Fix failed RHEL6 32-bit functional tests

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -237,9 +237,9 @@ class Chef
         def installed_version(index)
           @installed_version ||= []
           @installed_version[index] ||= if new_resource.source
-                                          python_helper.package_query(:whatinstalled, available_version(index).name, version: safe_version_array[index], arch: safe_arch_array[index])
+                                          python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index])
                                         else
-                                          python_helper.package_query(:whatinstalled, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index])
+                                          python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index])
                                         end
           @installed_version[index]
         end


### PR DESCRIPTION
We've been relying on the yum libraries to throw away the version
information that we supply here and return the version that is
installed that matches the name + arch.

On el6 32-bit we've hit a bug in the yum libraries where it appears
to not do this.  The simple solution here is to just throw away the
version information ourselves.

I think at one point early in the development of the new yum provider
that there was more of a point to supplying the version here, but as
it evolved that went away, but this argument was still kept around
vestigially.
