### PR TITLE
Restart Python yum helper before each repo enable/disable

### DIFF
--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -112,10 +112,11 @@ class Chef
             parameters = { "provides" => provides, "version" => version, "arch" => arch }
             repo_opts = options_params(options || {})
             parameters.merge!(repo_opts)
+            # XXX: for now we restart before and after every query with an enablerepo/disablerepo to clean the helpers internal state
+            restart unless repo_opts.empty?
             query_output = query(action, parameters)
             version = parse_response(query_output.lines.last)
             Chef::Log.trace "parsed #{version} from python helper"
-            # XXX: for now we restart after every query with an enablerepo/disablerepo to clean the helpers internal state
             restart unless repo_opts.empty?
             version
           end


### PR DESCRIPTION
### Description

This restarts the yum Python helper before each repo enable/disable in order to work around a bug in the yum API that occurs on CentOS 6.

### Issues Resolved

#7540

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
