### PR TITLE
support repeated options in systemd_unit

### DIFF
--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -61,7 +61,9 @@ class Chef
             content.each_pair do |sect, opts|
               doc.section(sect) do |section|
                 opts.each_pair do |opt, val|
-                  section.option(opt, val)
+                  [val].flatten.each do |v|
+                    section.option(opt, v)
+                  end
                 end
               end
             end

--- a/spec/unit/resource/systemd_unit_spec.rb
+++ b/spec/unit/resource/systemd_unit_spec.rb
@@ -20,11 +20,12 @@ require "spec_helper"
 
 describe Chef::Resource::SystemdUnit do
   let(:resource) { Chef::Resource::SystemdUnit.new("sysstat-collect.timer") }
-  let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
+  let(:unit_content_string) { "[Unit]\nDescription = Run system activity accounting tool every 10 minutes\nDocumentation = foo\nDocumentation = bar\n\n[Timer]\nOnCalendar = *:00/10\n\n[Install]\nWantedBy = sysstat.service\n" }
   let(:unit_content_hash) do
     {
       "Unit" => {
         "Description" => "Run system activity accounting tool every 10 minutes",
+        "Documentation" => %w{foo bar},
       },
       "Timer" => {
         "OnCalendar" => "*:00/10",


### PR DESCRIPTION
### Description

Fixes partial support for systemd unit files by allowing options to be specified multiple times.

### Issues Resolved

Fixes #7559

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
