### PR TITLE
switch shell_out to shell_out! in func tests

### DIFF
--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright 2011-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -385,7 +385,7 @@ shared_examples_for "a configured file resource" do
   def selinux_security_context_restored?(path)
     @restorecon_path = which("restorecon") if @restorecon_path.nil?
     restorecon_test_command = "#{@restorecon_path} -n -v #{path}"
-    cmdresult = shell_out(restorecon_test_command)
+    cmdresult = shell_out!(restorecon_test_command)
     # restorecon will print the required changes to stdout if any is
     # needed
     cmdresult.stdout.empty?
@@ -725,7 +725,7 @@ shared_examples_for "a configured file resource" do
     end
 
     before(:each) do
-      result = shell_out("mknod #{path} b 1 2")
+      result = shell_out!("mknod #{path} b 1 2")
       result.stderr.empty?
     end
 
@@ -743,7 +743,7 @@ shared_examples_for "a configured file resource" do
     end
 
     before(:each) do
-      result = shell_out("mknod #{path} c 1 2")
+      result = shell_out!("mknod #{path} c 1 2")
       result.stderr.empty?
     end
 
@@ -761,7 +761,7 @@ shared_examples_for "a configured file resource" do
     end
 
     before(:each) do
-      result = shell_out("mkfifo #{path}")
+      result = shell_out!("mkfifo #{path}")
       result.stderr.empty?
     end
 


### PR DESCRIPTION
not failing here hides issues caused by e.g. mknod not working properly.

