### PR TITLE
lazy the default resource_name until after parsing

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -65,6 +65,8 @@ class Chef
 
           LWRPBase.loaded_lwrps[filename] = true
 
+          # wire up the default resource name after the class is parsed only if we haven't declared one.
+          # (this ordering is important for MapCollision deprecation warnings)
           resource_class.resource_name resource_name.to_sym if resource_class.resource_name.nil?
 
           resource_class

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -49,9 +49,7 @@ class Chef
 
           resource_name = filename_to_qualified_string(cookbook_name, filename)
 
-          # We load the class first to give it a chance to set its own name
           resource_class = Class.new(self)
-          resource_class.resource_name resource_name.to_sym
           resource_class.run_context = run_context
           resource_class.class_from_file(filename)
 
@@ -66,6 +64,8 @@ class Chef
           Chef::Log.trace("Loaded contents of #{filename} into resource #{resource_name} (#{resource_class})")
 
           LWRPBase.loaded_lwrps[filename] = true
+
+          resource_class.resource_name resource_name.to_sym if resource_class.resource_name.nil?
 
           resource_class
         end


### PR DESCRIPTION
only set it if the resource doesn't set one.

this means that we don't call resource_name or provides before parsing
the file so that the chef_version_for_provides API in #7524 can work
(otherwise we throw the deprecation warning before we ever parse the
file).
