### PR TITLE
Cleanup the rake file and make sure dep updates work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,6 @@
 # limitations under the License.
 #
 
-VERSION = IO.read(File.expand_path("../VERSION", __FILE__)).strip
-
-require "rubygems"
-require "chef/version"
 require "chef-config/package_task"
 require_relative "tasks/rspec"
 require_relative "tasks/maintainers"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@ VERSION = IO.read(File.expand_path("../VERSION", __FILE__)).strip
 require "rubygems"
 require "chef/version"
 require "chef-config/package_task"
-require "rdoc/task"
 require_relative "tasks/rspec"
 require_relative "tasks/maintainers"
 require_relative "tasks/cbgb"

--- a/ci/dependency_update.sh
+++ b/ci/dependency_update.sh
@@ -4,6 +4,6 @@
 
 set -evx
 
-bundle install --without omnibus_package test pry integration docgen maintenance travis aix bsd linux mac_os_x solaris windows development
+bundle install --without omnibus_package test pry integration docgen maintenance travis aix bsd linux mac_os_x solaris windows
 
 bundle exec rake dependencies_ci


### PR DESCRIPTION
Cleanup some of the old version logic that I believe was leftover from the github changelog generator
Remove rdoc stuff we don't need
Remove the require on rubygems which modern ruby doesn't require
Make sure we don't bundle install w/o rake (in development group) which was breaking the dependencies update task