### PR TITLE
Utilize repo discovery in Chef::ChefFS::Knife

### DIFF
--- a/lib/chef/chef_fs/knife.rb
+++ b/lib/chef/chef_fs/knife.rb
@@ -67,6 +67,15 @@ class Chef
           Chef::ChefFS::Config::INFLECTIONS.each_value do |variable_name|
             Chef::Config.delete("#{variable_name}_path".to_sym)
           end
+        elsif Chef::Config[:chef_repo_path] == Chef::Config.cache_path
+          Chef::Config[:chef_repo_path] = discover_repo_dir(Dir.pwd)
+          Chef::ChefFS::Config::INFLECTIONS.each_value do |variable_name|
+            # Only override paths based off of the cache_path
+            path = Chef::Config.public_send("#{variable_name}_path".to_sym)
+            if path.include?("#{Chef::Config.cache_path}/")
+              Chef::Config.delete("#{variable_name}_path".to_sym)
+            end
+          end
         end
 
         @chef_fs_config = Chef::ChefFS::Config.new(Chef::Config, Dir.pwd, config, ui)


### PR DESCRIPTION
### Description

When using a newly generated chef-repo + `knife configure` the Knife
commands that are based off of `Chef::ChefFS::Knife` currently fail
because the `Chef::Config[:chef_repo_path]` and associated sub-paths
default to be based off of the `Chef::Config.cache_path` which will be
`~/.chef`. This commit checks for this case and instead utilizes `discover_chef_repo`
to get a more accurate default chef_repo_path based on where the
knife command is being run from.

### Issues Resolved

* #7568 

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
