### PR TITLE
Fix rake task to build the correct gemspec on Chef

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,9 @@ end
 
 task install: :super_install
 
-Bundler::GemHelper.install_tasks name: "chef"
+# make sure we build the correct gemspec on windows
+gemspec = Gem.win_platform? ? "chef-universal-mingw32" : "chef"
+Bundler::GemHelper.install_tasks name: gemspec
 
 task :pedant, :chef_zero_spec
 

--- a/chef-config/chef-config.gemspec
+++ b/chef-config/chef-config.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable"
   spec.add_dependency "tomlrb", "~> 1.2"
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
 
   %w{rspec-core rspec-expectations rspec-mocks}.each do |rspec|
     spec.add_development_dependency(rspec, "~> 3.2")


### PR DESCRIPTION
Make sure we build our Windows gemspec when on Windows. Previously we handled this via the omnibus-software def, but it made it so the Rake task never worked on Windows.