### PR TITLE
Simplify / fix our yard doc Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,21 +57,17 @@ begin
     task.options += ["--display-cop-names", "--no-color"]
   end
 rescue LoadError
-  puts "chefstyle/rubocop is not available.  gem install chefstyle to do style checking."
+  puts "chefstyle/rubocop is not available. bundle install first to make sure all dependencies are installed."
 end
 
 begin
   require "yard"
-  DOC_FILES = [ "README.rdoc", "LICENSE", "spec/tiny_server.rb", "lib/**/*.rb" ].freeze
-  namespace :yard do
-    desc "Create YARD documentation"
+  DOC_FILES = [ "spec/tiny_server.rb", "lib/**/*.rb" ].freeze
 
-    YARD::Rake::YardocTask.new(:html) do |t|
-      t.files = DOC_FILES
-      t.options = ["--format", "html"]
-    end
+  YARD::Rake::YardocTask.new(:docs) do |t|
+    t.files = DOC_FILES
+    t.options = ["--format", "html"]
   end
-
 rescue LoadError
-  puts "yard is not available. (sudo) gem install yard to generate yard documentation."
+  puts "yard is not available. bundle install first to make sure all dependencies are installed."
 end

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -215,7 +215,7 @@ class Chef
     # you to unlink the tempfile when you're done with it.
     #
     # @yield [tempfile] block to process the tempfile
-    # @yieldparams [tempfile<Tempfile>] tempfile
+    # @yieldparam [tempfile<Tempfile>] tempfile
     def streaming_request(path, headers = {}, tempfile = nil)
       http_attempts ||= 0
       url = create_url(path)

--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require "rubygems"
 require "webrick"
 require "webrick/https"
 require "rack"


### PR DESCRIPTION
We were trying to parse out a readme file that doesn't exist and the license file which produced errors
We namespaced the task in a way we don't do anywhere else. This matches our other gems now
Tell people to use bundler in the errors instead of gem installing things
We required rubygems which is not necessary

Signed-off-by: Tim Smith <tsmith@chef.io>