### PR TITLE
Switch from opensuse 42 -> 15 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -296,11 +296,11 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test end-to-end-opensuse-leap
+      - bundle exec kitchen test end-to-end-opensuse-leap-15
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
-     - OPENSUSELEAP=42
+     - OPENSUSELEAP=15
      - KITCHEN_YAML=kitchen.travis.yml
   - rvm: 2.5.1
     sudo: required

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -100,9 +100,9 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: opensuse-leap
+- name: opensuse-leap-15
   driver:
-    image: dokken/opensuse-leap
+    image: dokken/opensuse-leap-15
     pid_one_command: /bin/systemd
 
 suites:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -29,6 +29,7 @@ platforms:
   - name: debian-8
   - name: debian-9
   - name: opensuse-leap-42
+  - name: opensuse-leap-15
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04


### PR DESCRIPTION
15 is the new release and 42 goes EOL in the not so distant future. Let's test on the latest.

Signed-off-by: Tim Smith <tsmith@chef.io>