### PR TITLE
Resolve new_resource error with cron_d resource

### DIFF
--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -160,7 +160,7 @@ class Chef
 
       # warn if someone passes the deprecated cookbook property
       def after_created
-        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that this resource ships in Chef itself." if new_resource.cookbook
+        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that this resource ships in Chef itself." if cookbook
       end
 
       action :create do


### PR DESCRIPTION
new_resource.cookbook needed to be cookbook inside after_created

Signed-off-by: Tim Smith <tsmith@chef.io>