### PR TITLE
openssl resources: Improve descriptions and fix provides for Chef 14.X

### DIFF
--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -26,10 +26,7 @@ class Chef
       resource_name :openssl_dhparam
       provides(:openssl_dhparam) { true }
 
-      description "Use the openssl_dhparam resource to generate dhparam.pem files. If a"\
-                  " valid dhparam.pem file is found at the specified location, no new file"\
-                  " will be created. If a file is found at the specified location but it is"\
-                  " not a valid dhparam file, it will be overwritten."
+      description "Use the openssl_dhparam resource to generate dhparam.pem files. If a valid dhparam.pem file is found at the specified location, no new file will be created. If a file is found at the specified location but it is not a valid dhparam file, it will be overwritten."
       introduced "14.0"
 
       property :path, String,

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: Copyright 2018, Chef Software Inc.
+# Author:: Julien Huon
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +27,7 @@ class Chef
       preview_resource true
       resource_name :openssl_ec_private_key
 
-      description "Use the openssl_ec_private_key resource to generate generate ec private key files. If a valid ec key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, it will be overwritten."
+      description "Use the openssl_ec_private_key resource to generate generate elliptic curve (EC) private key files. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, it will be overwritten."
       introduced "14.4"
 
       property :path, String,

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: Copyright 2018, Chef Software Inc.
+# Author:: Julien Huon
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +27,7 @@ class Chef
       preview_resource true
       resource_name :openssl_ec_public_key
 
-      description "Use the openssl_ec_public_key resource to generate ec public key files given a private key."
+      description "Use the openssl_ec_public_key resource to generate elliptic curve (EC) public key files given a private key."
       introduced "14.4"
 
       property :path, String,

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -24,7 +24,7 @@ class Chef
 
       preview_resource true
       resource_name :openssl_x509_certificate
-      provides(:openssl_x509) { true } # legacy cookbook name. Cookbook will win. @todo Make this true in Chef 15
+      provides(:openssl_x509) { false } # legacy cookbook name. Cookbook will win. @todo Make this true in Chef 15
 
       description "Use the openssl_x509_certificate resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. Note: This resource was renamed from openssl_x509 to openssl_x509_certificate. The legacy name will continue to function, but cookbook code should be updated for the new resource name."
       introduced "14.4"

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -1,5 +1,7 @@
 #
 # License:: Apache License, Version 2.0
+# Author:: Julien Huon
+# Copyright:: Copyright 2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -25,7 +25,7 @@ class Chef
       preview_resource true
       resource_name :openssl_x509_crl
 
-      description "Use the openssl_x509_crl resource to generate PEM-formatted x509 CRL files."
+      description "Use the openssl_x509_crl resource to generate PEM-formatted x509 certificate revocation list (CRL) files."
       introduced "14.4"
 
       property :path, String,

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -1,5 +1,7 @@
 #
 # License:: Apache License, Version 2.0
+# Author:: Julien Huon
+# Copyright:: Copyright 2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -1,5 +1,7 @@
 #
 # License:: Apache License, Version 2.0
+# Author:: Julien Huon
+# Copyright:: Copyright 2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update the descriptions, add copyrights, add authors, make sure the cookbook wins until Chef 15 for the legacy openssl_x509 name.