### PR TITLE
Updating omnibus kitchen builder to work on Windows 10/Hyper-V

### DIFF
--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -70,6 +70,12 @@ Once you have tweaked your `kitchen.yml` (or `kitchen.local.yml`) to your liking
 $ bundle exec kitchen converge chef-ubuntu-1404
 ```
 
+Additional settings are required if using the kitchen-vagrant driver with the Hyper-V provider:
+
+```
+PS> $env:KITCHEN_LOCAL_YAML="kitchen.hyperv.yml"; kitchen converge chef-windows-server-2012r2-standard
+```
+
 Then login to the instance and build the project as described in the Usage section:
 
 ```shell
@@ -89,7 +95,7 @@ $ kitchen login chef-ubuntu-1404
 [vagrant@ubuntu...] $ bundle exec omnibus build chef -l internal
 ```
 
-You can also login to Windows instances but will have to manually call the `load-omnibus-toolchain.bat` script which initializes the build environment. Please note the mounted code directory is also at `C:\home\vagrant\chef\omnibus` as opposed to `C:\Users\vagrant\chef\omnibus`.
+You can also login to Windows instances but will have to manually call the `load-omnibus-toolchain.ps1` script from an administrative PowerShell session which initializes the build environment. You will also need to `git clone https://github.com/chef/chef` into the `c:\vagrant` folder to workaround the lack of a shared folder.
 
 ```shell
 $ bundle exec kitchen login <PROJECT>-windows-81-professional
@@ -97,13 +103,13 @@ Last login: Sat Sep 13 10:19:04 2014 from 172.16.27.1
 Microsoft Windows [Version 6.3.9600]
 (c) 2013 Microsoft Corporation. All rights reserved.
 
-C:\>C:\vagrant\load-omnibus-toolchain.bat
+C:\>C:\vagrant\load-omnibus-toolchain.ps1
 
-C:\>cd C:\vagrant\code\chef\omnibus
+C:\>cd C:\vagrant\chef\omnibus
 
-C:\vagrant\code\chef\omnibus>bundle install --without development
+C:\vagrant\chef\omnibus>bundle install --without development
 
-C:\vagrant\code\chef\omnibus>bundle exec omnibus build chef -l internal
+C:\vagrant\chef\omnibus>bundle exec omnibus build chef -l internal
 ```
 
 For a complete list of all commands and platforms, run `kitchen list` or `kitchen help`.

--- a/omnibus/kitchen.hyperv.yml
+++ b/omnibus/kitchen.hyperv.yml
@@ -1,0 +1,2 @@
+driver:
+  provider: hyperv

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -95,6 +95,7 @@ platforms:
       # mounts at `C:\vagrant\code` and the Chef source folder is available
       # at `C:\vagrant\code\chef`
       - ['../..', '/vagrant/code']
+      communicator: winrm
     provisioner:
       attributes:
         omnibus:
@@ -102,6 +103,9 @@ platforms:
           build_user_group:    Administrators
           build_user_password: vagrant
       chef_omnibus_root: /opscode/angrychef
+    transport:
+      name: winrm
+      elevated: true
 
   # Windows 32-bit
   # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
@@ -111,6 +115,7 @@ platforms:
       box: chef/windows-<%= win_version %> # private
       synced_folders:
       - ['../..', '/vagrant/code']
+      communicator: winrm
     provisioner:
       attributes:
         omnibus:
@@ -118,6 +123,9 @@ platforms:
           build_user_group:    Administrators
           build_user_password: vagrant
       chef_omnibus_root: /opscode/angrychef
+    transport:
+      name: winrm
+      elevated: true
   <% end %>
 
 suites:


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Updates omnibus to build using Hyper-V with the `kitchen-vagrant` driver if required.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
