### PR TITLE
WIP Fixes for duplicate logs spec is remaining

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,7 +205,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      Chef::Config.is_default?(:log_location) && Chef::Config[:log_location].tty? && !Chef::Config[:daemonize]
+      Chef::Config.is_default?(:log_location) && STDOUT.closed? && Chef::Config[:daemonize]
     end
 
     def configure_stdout_logger


### PR DESCRIPTION
Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>

### Description

Fixes for duplicate log 
```
chef$ bundle exec bin/chef-client -c ../.chef/knife.rb 
Starting Chef Client, version 14.4.57
[2018-08-29T13:52:16+05:30] INFO: *** Chef 14.4.57 ***
[2018-08-29T13:52:16+05:30] INFO: Platform: x86_64-linux
[2018-08-29T13:52:16+05:30] INFO: Chef-client pid: 28477
[2018-08-29T13:52:16+05:30] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-08-29T13:52:20+05:30] INFO: Run List is []
[2018-08-29T13:52:20+05:30] INFO: Run List expands to []
[2018-08-29T13:52:20+05:30] INFO: Starting Chef Run for msys
[2018-08-29T13:52:20+05:30] INFO: Running start handlers
[2018-08-29T13:52:20+05:30] INFO: Start handlers complete.

chef$ bundle exec bin/chef-apply ~/chef-repo/cookbooks/elasticsearch/recipes/default.rb
[2018-08-29T13:53:36+05:30] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2018-08-29T13:53:36+05:30] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2018-08-29T13:53:36+05:30] FATAL: LoadError: cannot load such file -- chef/provisioning/aws_driver
```

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
