### PR TITLE
Simplify the rake task to updating gem dependencies

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -20,7 +20,8 @@ bundle install
 # the gem is actually available via bundler on rubygems.org.
 sleep 120
 
-bundle exec rake dependencies:update
+gem install rake
+rake dependencies:update_gemfile_lock
 
 git add .
 

--- a/ci/dependency_update.sh
+++ b/ci/dependency_update.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# FIXME: this seems uselessly trivial, replace with a rake task and have ci call the rake task?
-
-set -evx
-
-bundle install --without omnibus_package test pry integration docgen maintenance travis aix bsd linux mac_os_x solaris windows
-
-bundle exec rake dependencies_ci

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -20,24 +20,9 @@ require "bundler"
 desc "Tasks to update and check dependencies"
 namespace :dependencies do
 
-  # Running update_ci on your local system wont' work. The best way to update
-  # dependencies locally is by running the dependency update script.
-  desc "Update all dependencies. dependencies:update to update as little as possible."
-  task :update do |t, rake_args|
-    # FIXME: probably broken, and needs less indirection
-    system((File.join(Dir.pwd, "ci", "dependency_update.sh")).to_s)
-  end
-
-  desc "Force update (when adding new gems to Gemfiles)"
-  task :force_update do |t, rake_args|
-    # FIXME: probably broken, and needs less indirection
-    FileUtils.rm_f(File.join(Dir.pwd, ".bundle", "config"))
-    system((File.join(Dir.pwd, "ci", "dependency_update.sh")).to_s)
-  end
-
   # Update all dependencies to the latest constraint-matching version
-  desc "Update all dependencies. dependencies:update to update as little as possible (CI-only)."
-  task update_ci: %w{
+  desc "Update all dependencies."
+  task update: %w{
                     dependencies:update_gemfile_lock
                     dependencies:update_omnibus_gemfile_lock
                   }
@@ -71,8 +56,3 @@ namespace :dependencies do
   bundle_update_locked_multiplatform_task :update_omnibus_gemfile_lock, "omnibus"
 
 end
-
-desc "Update all dependencies and check for outdated gems."
-task dependencies_ci: [ "dependencies:update_ci" ]
-task dependencies: [ "dependencies:update" ]
-task update: [ "dependencies:update" ]


### PR DESCRIPTION
we're calling scripts to call rake tasks to call scripts to call rake
tasks to mostly execute shellcodes.  this gets rid of at least 2 levels
of indirection.
