### PR TITLE
Update property descriptions and remove extra nil types

### DIFF
--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -23,10 +23,7 @@ class Chef
     class GemPackage < Chef::Resource::Package
       resource_name :gem_package
 
-      description "Use the gem_package resource to manage gem packages that are only"\
-                  " included in recipes. When a package is installed from a local file,"\
-                  " it must be added to the node using the remote_file or cookbook_file"\
-                  " resources."
+      description "Use the gem_package resource to manage gem packages that are only included in recipes. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."
 
       # the source can either be a path to a package source like:
       #   source /var/tmp/mygem-1.2.3.4.gem
@@ -39,22 +36,23 @@ class Chef
       #
       # FIXME? the array form of installing paths most likely does not work?
       #
-      property :source, [ String, Array ]
-      property :clear_sources, [ TrueClass, FalseClass ], default: lazy { Chef::Config[:clear_gem_sources] }, desired_state: false
-      # Sets a custom gem_binary to run for gem commands.
-      property :gem_binary, String, desired_state: false
+      property :source, [ String, Array ],
+               description: "Optional. The URL, or list of URLs, at which the gem package is located. This list is added to the source configured in Chef::Config[:rubygems_url] (see also include_default_source) to construct the complete list of rubygems sources. Users in an 'airgapped' environment should set Chef::Config[:rubygems_url] to their local RubyGems mirror."
 
-      # set to false to avoid including Chef::Config[:rubygems_url] in the sources
-      property :include_default_source, [ TrueClass, FalseClass ], default: true
+      property :clear_sources, [ TrueClass, FalseClass ],
+               description: "Set to 'true' to download a gem from the path specified by the source property (and not from RubyGems).",
+               default: lazy { Chef::Config[:clear_gem_sources] }, desired_state: false
 
-      ##
-      # Options for the gem install, either a Hash or a String. When a hash is
-      # given, the options are passed to Gem::DependencyInstaller.new, and the
-      # gem will be installed via the gems API. When a String is given, the gem
-      # will be installed by shelling out to the gem command. Using a Hash of
-      # options with an explicit gem_binary will result in undefined behavior.
-      property :options, [ String, Hash, Array, nil ], desired_state: false
+      property :gem_binary, String, desired_state: false,
+               description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the chef-client will be installed."
 
+      property :include_default_source, [ TrueClass, FalseClass ],
+               description: "Set to 'false' to not include 'Chef::Config[:rubygems_url]'' in the sources.",
+               default: true, introduced: "13.0"
+
+      property :options, [ String, Hash, Array, nil ],
+               description: "Options for the gem install, either a Hash or a String. When a hash is given, the options are passed to Gem::DependencyInstaller.new, and the gem will be installed via the gems API. When a String is given, the gem will be installed by shelling out to the gem command. Using a Hash of options with an explicit gem_binary will result in undefined behavior.",
+               desired_state: false
     end
   end
 end

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -45,11 +45,11 @@ class Chef
                description: "The desired Diffie-Hellmann generator.",
                default: 2
 
-      property :owner, [String, nil],
-               description: "The owner of all files created by the resource."
+      property :owner, String,
+               description: "The owner applied to all files created by the resource."
 
-      property :group, [String, nil],
-               description: "The group of all files created by the resource."
+      property :group, String,
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource.",

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -27,7 +27,7 @@ class Chef
       preview_resource true
       resource_name :openssl_ec_private_key
 
-      description "Use the openssl_ec_private_key resource to generate generate elliptic curve (EC) private key files. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, it will be overwritten."
+      description "Use the openssl_ec_private_key resource to generate an elliptic curve (EC) private key files. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, it will be overwritten."
       introduced "14.4"
 
       property :path, String,
@@ -49,10 +49,10 @@ class Chef
                default: "des3"
 
       property :owner, String,
-               description: "The owner of all files created by the resource."
+               description: "The owner applied to all files created by the resource."
 
       property :group, String,
-               description: "The group of all files created by the resource."
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource.",

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -27,7 +27,7 @@ class Chef
       preview_resource true
       resource_name :openssl_ec_private_key
 
-      description "Use the openssl_ec_private_key resource to generate an elliptic curve (EC) private key files. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, it will be overwritten."
+      description "Use the openssl_ec_private_key resource to generate an elliptic curve (EC) private key file. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, then it will be overwritten."
       introduced "14.4"
 
       property :path, String,

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -44,10 +44,10 @@ class Chef
                description: "The passphrase of the provided private key."
 
       property :owner, String,
-               description: "The owner of all files created by the resource."
+               description: "The owner applied to all files created by the resource."
 
       property :group, String,
-               description: "The group of all files created by the resource."
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource.",

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -49,11 +49,11 @@ class Chef
                description: "The designed cipher to use when generating your key. Run `openssl list-cipher-algorithms` to see available options.",
                default: "des3"
 
-      property :owner, [String, nil],
-               description: "The owner of all files created by the resource."
+      property :owner, String,
+               description: "The owner applied to all files created by the resource."
 
-      property :group, [String, nil],
-               description: "The group of all files created by the resource."
+      property :group, String,
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource.",

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -42,11 +42,11 @@ class Chef
       property :private_key_pass, String,
                description: "The passphrase of the provided private key."
 
-      property :owner, [String, nil],
-               description: "The owner of all files created by the resource."
+      property :owner, String,
+               description: "The owner applied to all files created by the resource."
 
-      property :group, [String, nil],
-               description: "The group of all files created by the resource."
+      property :group, String,
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource.",

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -36,10 +36,10 @@ class Chef
                name_property: true
 
       property :owner, String,
-               description: "The owner of all files created by the resource."
+               description: "The owner applied to all files created by the resource."
 
       property :group, String,
-               description: "The group of all files created by the resource."
+               description: "The group ownership applied to all files created by the resource."
 
       property :expire, Integer,
                description: "Value representing the number of days from now through which the issued certificate cert will remain valid. The certificate will expire after this period.",

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -38,7 +38,7 @@ class Chef
                description: "Serial of the X509 Certificate to revoke."
 
       property :revocation_reason, Integer,
-               description: "Reason for the revokation.",
+               description: "Reason for the revocation.",
                default: 0
 
       property :expire, Integer,

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -34,10 +34,10 @@ class Chef
                description: "The optional path to write the file to if you'd like to specify it here instead of in the resource name."
 
       property :owner, String,
-               description: "The owner of all files created by the resource."
+               description: "The owner applied to all files created by the resource."
 
       property :group, String,
-               description: "The group of all files created by the resource."
+               description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],
                description: "The permission mode applied to all files created by the resource."

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -56,15 +56,15 @@ class Chef
                default: ["ALL"]
 
       property :host, String,
-               description: "The host to set in the sudo config.",
+               description: "The host to set in the sudo configuration.",
                default: "ALL"
 
       property :runas, String,
-               description: "User the command(s) can be run as.",
+               description: "User that the command(s) can be run as.",
                default: "ALL"
 
       property :nopasswd, [TrueClass, FalseClass],
-               description: "Allow running sudo without specifying a password sudo.",
+               description: "Allow sudo to be run without specifying a password.",
                default: false
 
       property :noexec, [TrueClass, FalseClass],
@@ -83,11 +83,11 @@ class Chef
                default: lazy { [] }
 
       property :command_aliases, Array,
-               description: "Command aliases that can be used as allowed commands later in the config.",
+               description: "Command aliases that can be used as allowed commands later in the configuration.",
                default: lazy { [] }
 
       property :setenv, [TrueClass, FalseClass],
-               description: "Whether to permit the preserving of environment with sudo -E.",
+               description: "Determines whether or not to permit preservation of the environment with 'sudo -E'.",
                default: false
 
       property :env_keep_add, Array,
@@ -102,11 +102,11 @@ class Chef
                description: "Deprecated property. Do not use."
 
       property :visudo_binary, String,
-               description: "The path to visudo for config verification.",
+               description: "The path to visudo for configuration verification.",
                default: "/usr/sbin/visudo"
 
       property :config_prefix, String,
-               description: "The directory containing the sudoers config file.",
+               description: "The directory that contains the sudoers configuration file",
                default: lazy { platform_config_prefix }
 
       # handle legacy cookbook property

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -31,14 +31,14 @@ class Chef
                name_property: true
 
       property :size, Integer,
-               description: "The size (in MBs) for the swap file."
+               description: "The size (in MBs) of the swap file."
 
       property :persist, [TrueClass, FalseClass],
                description: "Persist the swapon.",
                default: false
 
       property :timeout, Integer,
-               description: "Timeout for dd/fallocate.",
+               description: "Timeout for 'dd' / 'fallocate' commands.",
                default: 600
 
       property :swappiness, Integer,

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -30,21 +30,21 @@ class Chef
       introduced "14.0"
 
       property :domain_name, String,
-               description: "The FQDN of the AD domain to join.",
+               description: "The FQDN of the Active Directory domain to join.",
                validation_message: "The 'domain_name' property must be a FQDN.",
                regex: /.\../, # anything.anything
                name_property: true
 
       property :domain_user, String,
-               description: "The domain user to use to join the host to the domain.",
+               description: "The domain user that will be used to join the domain.",
                required: true
 
       property :domain_password, String,
-               description: "The password for the domain user.",
+               description: "The password for the domain user. Note that this resource is set to hide sensitive information by default. ",
                required: true
 
       property :ou_path, String,
-               description: "The path to the OU where you would like to place the host."
+               description: "The path to the Organizational Unit where the host will be placed."
 
       property :reboot, Symbol,
                equal_to: [:immediate, :delayed, :never, :request_reboot, :reboot_now],

--- a/lib/chef/resource/windows_auto_run.rb
+++ b/lib/chef/resource/windows_auto_run.rb
@@ -24,7 +24,7 @@ class Chef
       resource_name :windows_auto_run
       provides(:windows_auto_run) { true }
 
-      description "Use the windows_auto_run resource to set applications to run at logon."
+      description "Use the windows_auto_run resource to set applications to run at login."
       introduced "14.0"
 
       property :program_name, String,
@@ -33,10 +33,10 @@ class Chef
 
       property :path, String,
                coerce: proc { |x| x.tr("/", "\\") }, # make sure we have windows paths for the registry
-               description: "The path to the program to be run at login."
+               description: "The path to the program that will run at login. "
 
       property :args, String,
-               description: "Any arguments for the program."
+               description: "Any arguments to be used with the program."
 
       property :root, Symbol,
                description: "The registry root key to put the entry under.",

--- a/lib/chef/resource/windows_env.rb
+++ b/lib/chef/resource/windows_env.rb
@@ -26,9 +26,7 @@ class Chef
       provides :windows_env
       provides :env # backwards compat with the pre-Chef 14 resource name
 
-      description "Use the env resource to manage environment keys in Microsoft Windows."\
-                  " After an environment key is set, Microsoft Windows must be restarted"\
-                  " before the environment key will be available to the Task Scheduler."
+      description "Use the env resource to manage environment keys in Microsoft Windows. After an environment key is set, Microsoft Windows must be restarted before the environment key will be available to the Task Scheduler."
 
       default_action :create
       allowed_actions :create, :delete, :modify

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -25,20 +25,19 @@ class Chef
       resource_name :windows_feature_dism
       provides(:windows_feature_dism) { true }
 
-      description "Using the windows_feature_dism resource to add, remove or"\
-                  " delete Windows features and roles using DISM"
+      description "Use the windows_feature_dism resource to add, remove or delete Windows features and roles using DISM"
       introduced "14.0"
 
       property :feature_name, [Array, String],
-               description: "The name of the feature/role(s) to install if it differs from the resource name.",
+               description: "The name of the feature(s) or role(s) to install, if it differs from the resource name.",
                coerce: proc { |x| to_formatted_array(x) },
                name_property: true
 
       property :source, String,
-               description: "Use a local repository for the feature install."
+               description: "Specify a local repository for the feature install."
 
       property :all, [TrueClass, FalseClass],
-               description: "Install all sub features. This is the equivalent of specifying the /All switch to dism.exe",
+               description: "Install all sub-features. When set to 'true', this is the equivalent of specifying the /All switch to dism.exe",
                default: false
 
       property :timeout, Integer,

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -25,9 +25,7 @@ class Chef
       resource_name :windows_font
       provides(:windows_font) { true }
 
-      description "Use the windows_font resource to install font files on Windows."\
-                  " By default, the font is sourced from the cookbook using the resource, but a URI"\
-                  " source can be specified as well."
+      description "Use the windows_font resource to install font files on Windows. By default, the font is sourced from the cookbook using the resource, but a URI source can be specified as well."
       introduced "14.0"
 
       property :font_name, String,
@@ -35,7 +33,7 @@ class Chef
                name_property: true
 
       property :source, String,
-               description: "A local filesystem path or URI to source the font file from.",
+               description: "A local filesystem path or URI that is used to source the font file.",
                coerce: proc { |x| x =~ /^.:.*/ ? x.tr('\\', "/").gsub("//", "/") : x }
 
       action :install do

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -30,8 +30,7 @@ class Chef
       provides(:windows_package) { true }
       provides :package, os: "windows"
 
-      description "Use the windows_package resource to manage Microsoft Installer Package"\
-                  " (MSI) packages for the Microsoft Windows platform."
+      description "Use the windows_package resource to manage Microsoft Installer Package (MSI) packages for the Microsoft Windows platform."
       introduced "11.12"
 
       allowed_actions :install, :remove

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -27,20 +27,18 @@ class Chef
       resource_name :windows_printer
       provides(:windows_printer) { true }
 
-      description "Use the windows_printer resource to setup Windows printers. Note"\
-                  " that this doesn't currently install a printer driver. You must"\
-                  " already have the driver installed on the system."
+      description "Use the windows_printer resource to setup Windows printers. Note that this doesn't currently install a printer driver. You must already have the driver installed on the system."
       introduced "14.0"
 
       property :device_id, String,
-               description: "Printer queue name, e.g. 'HP LJ 5200 in fifth floor copy room'.",
+               description: "Printer queue name, such as 'HP LJ 5200 in fifth floor copy room'.",
                name_property: true
 
       property :comment, String,
                description: "Optional descriptor for the printer queue."
 
       property :default, [TrueClass, FalseClass],
-               description: "Should this be the system's default printer.",
+               description: "Determines whether or not this should be the system's default printer.",
                default: false
 
       property :driver_name, String,
@@ -48,17 +46,17 @@ class Chef
                required: true
 
       property :location, String,
-               description: "Printer location, e.g. 'Fifth floor copy room'."
+               description: "Printer location, such as 'Fifth floor copy room'."
 
       property :shared, [TrueClass, FalseClass],
-               description: "Should the printer be shared.",
+               description: "Determines whether or not the printer is shared.",
                default: false
 
       property :share_name, String,
-               description: "The name to share the printer as."
+               description: "The name used to identify the shared printer."
 
       property :ipv4_address, String,
-               description: "Printer IPv4 address, e.g. '10.4.64.23'.",
+               description: "The IPv4 address of the printer, such as '10.4.64.23'",
                validation_message: "The ipv4_address property must be in the IPv4 format of WWW.XXX.YYY.ZZZ",
                regex: Resolv::IPv4::Regex
 

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -47,7 +47,7 @@ class Chef
                description: "The description of the port."
 
       property :snmp_enabled, [TrueClass, FalseClass],
-               description: "Should SNMP be enabled on the port.",
+               description: "Determines if SNMP is enabled on the port.",
                default: false
 
       property :port_protocol, Integer,

--- a/lib/chef/resource/windows_service.rb
+++ b/lib/chef/resource/windows_service.rb
@@ -36,18 +36,21 @@ class Chef
       provides(:windows_service) { true }
       provides :service, os: "windows"
 
-      description "Use the windows_service resource to manage a service on the Microsoft Windows platform."
+      description "Use the windows_service resource to create, delete, or manage a service on the Microsoft Windows platform."
       introduced "12.0"
 
       allowed_actions :configure_startup, :create, :delete, :configure
 
       state_attrs :enabled, :running
 
-      property :service_name, name_property: true, identity: true
+      property :service_name, String,
+               description: "The name of the service.",
+               name_property: true, identity: true
 
       # The display name to be used by user interface programs to identify the
       # service. This string has a maximum length of 256 characters.
-      property :display_name, String, regex: /^.{1,256}$/
+      property :display_name, String, regex: /^.{1,256}$/,
+               introduced: "14.0"
 
       # https://github.com/djberg96/win32-service/blob/ffi/lib/win32/windows/constants.rb#L19-L29
       property :desired_access, Integer, default: SERVICE_ALL_ACCESS
@@ -76,27 +79,26 @@ class Chef
       # This only applies if startup_type is :automatic
       # 1 == delayed start is enabled
       # 0 == NO delayed start
-      property :delayed_start, [TrueClass, FalseClass], default: false, coerce: proc { |x|
-        if x.is_a?(Integer)
-          x == 0 ? false : true
-        else
-          x
-        end
-      }
+      property :delayed_start, [TrueClass, FalseClass],
+               introduced: "14.0",
+               default: false, coerce: proc { |x|
+                 if x.is_a?(Integer)
+                   x == 0 ? false : true
+                 else
+                   x
+                 end
+               }
 
       # https://github.com/djberg96/win32-service/blob/ffi/lib/win32/windows/constants.rb#L43-L47
       property :error_control, Integer, default: SERVICE_ERROR_NORMAL
 
-      # The fully qualified path to the service binary file. The path can also
-      # include arguments for an auto-start service.
-      #
-      # This is required for :create and :configure actions -- intentionally
-      # not setting required: true here to support other actions
-      property :binary_path_name, String
+      property :binary_path_name, String,
+               introduced: "14.0",
+               description: "The fully qualified path to the service binary file. The path can also include arguments for an auto-start service. This is required for ':create' and ':configure' actions"
 
-      # The names of the load ordering group of which this service is a member.
-      # Specify nil or an empty string if the service does not belong to a group.
-      property :load_order_group, String
+      property :load_order_group, String,
+               introduced: "14.0",
+               description: "The names of the load ordering group of which this service is a member. Don't set this property if the service does not belong to a group."
 
       # A pointer to a double null-terminated array of null-separated names of
       # services or load ordering groups that the system must start before this
@@ -104,9 +106,12 @@ class Chef
       # dependencies. Dependency on a group means that this service can run if
       # at least one member of the group is running after an attempt to start
       # all members of the group.
-      property :dependencies, [String, Array]
+      property :dependencies, [String, Array],
+               introduced: "14.0"
 
-      property :description, String
+      property :description, String,
+               description: "Description of the service.",
+               introduced: "14.0"
 
       property :run_as_user, String, default: "LocalSystem"
       property :run_as_password, String, default: ""

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -36,7 +36,7 @@ class Chef
                name_property: true
 
       property :command, String,
-               description: ""
+               description: "The command to be executed by the windows scheduled task."
 
       property :cwd, String,
                description: "The directory the task will be run from."
@@ -57,7 +57,8 @@ class Chef
                default: false
 
       property :interactive_enabled, [TrueClass, FalseClass],
-               description: "", default: false
+               description: "Allow task to run interactively or non-interactively. Requires user and password to also be set.",
+               default: false
 
       property :frequency_modifier, [Integer, String],
                default: 1
@@ -90,7 +91,7 @@ class Chef
                description: "For :on_idle frequency, the time (in minutes) without user activity that must pass to trigger the task, from 1 - 999."
 
       property :random_delay, [String, Integer],
-               description: ""
+               description: "Delays the task upto given time (in seconds)."
 
       property :execution_time_limit, [String, Integer],
                description: "The maximum time (in seconds) the task will run.",

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -24,8 +24,7 @@ class Chef
       resource_name :windows_task
       provides(:windows_task) { true }
 
-      description "Use the windows_task resource to create, delete or run a Windows"\
-                  " scheduled task. Requires Windows Server 2008 or later due to API usage."
+      description "Use the windows_task resource to create, delete or run a Windows scheduled task. Requires Windows Server 2008 or later due to API usage."
       introduced "13.0"
 
       allowed_actions :create, :delete, :run, :end, :enable, :disable, :change

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -91,7 +91,7 @@ class Chef
                description: "For :on_idle frequency, the time (in minutes) without user activity that must pass to trigger the task, from 1 - 999."
 
       property :random_delay, [String, Integer],
-               description: "Delays the task upto given time (in seconds)."
+               description: "Delays the task up to a given time (in seconds)."
 
       property :execution_time_limit, [String, Integer],
                description: "The maximum time (in seconds) the task will run.",

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -25,8 +25,7 @@ class Chef
       resource_name :zypper_package
       provides :package, platform_family: "suse"
 
-      description "Use the zypper_package resource to install, upgrade, and remove"\
-                  " packages with Zypper for the SUSE Enterprise and OpenSUSE platforms."
+      description "Use the zypper_package resource to install, upgrade, and remove packages with Zypper for the SUSE Enterprise and OpenSUSE platforms."
 
       property :gpg_check, [ TrueClass, FalseClass ],
                description: "Verify the package's GPG signature",


### PR DESCRIPTION
We allowed String, nil, which is a legacy thing that's not longer necessary. Just make these String.

This syncs all the properties with what I just pushed up to the docs site. It cleans up some wording around owner/group properties and fixes typos.

Signed-off-by: Tim Smith <tsmith@chef.io>d