### PR TITLE
Remove unnecessary declare_resource usage in build_essential

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -38,22 +38,22 @@ class Chef
 
         case node["platform_family"]
         when "debian"
-          declare_resource(:package,  %w{ autoconf binutils-doc bison build-essential flex gettext ncurses-dev })
+          package %w{ autoconf binutils-doc bison build-essential flex gettext ncurses-dev }
         when "amazon", "fedora", "rhel"
-          declare_resource(:package,  %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch })
+          package %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch }
 
           # Ensure GCC 4 is available on older pre-6 EL
-          declare_resource(:package,  %w{ gcc44 gcc44-c++ }) if platform_family?("rhel") && node["platform_version"].to_i < 6
+          package %w{ gcc44 gcc44-c++ } if platform_family?("rhel") && node["platform_version"].to_i < 6
         when "freebsd"
-          declare_resource(:package,  "devel/gmake")
-          declare_resource(:package,  "devel/autoconf")
-          declare_resource(:package,  "devel/m4")
-          declare_resource(:package,  "devel/gettext")
+          package "devel/gmake"
+          package "devel/autoconf"
+          package "devel/m4"
+          package "devel/gettext"
         when "mac_os_x"
           unless xcode_cli_installed?
             # This script was graciously borrowed and modified from Tim Sutton's
             # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
-            declare_resource(:execute, "install XCode Command Line tools") do
+            execute "install XCode Command Line tools" do
               command <<-EOH.gsub(/^ {14}/, "")
                 # create the placeholder file that's checked by CLI updates' .dist code
                 # in Apple's SUS catalog
@@ -68,46 +68,46 @@ class Chef
             end
           end
         when "omnios"
-          declare_resource(:package,  "developer/gcc48")
-          declare_resource(:package,  "developer/object-file")
-          declare_resource(:package,  "developer/linker")
-          declare_resource(:package,  "developer/library/lint")
-          declare_resource(:package,  "developer/build/gnu-make")
-          declare_resource(:package,  "system/header")
-          declare_resource(:package,  "system/library/math/header-math")
+          package "developer/gcc48"
+          package "developer/object-file"
+          package "developer/linker"
+          package "developer/library/lint"
+          package "developer/build/gnu-make"
+          package "system/header"
+          package "system/library/math/header-math"
 
           # Per OmniOS documentation, the gcc bin dir isn't in the default
           # $PATH, so add it to the running process environment
           # http://omnios.omniti.com/wiki.php/DevEnv
           ENV["PATH"] = "#{ENV['PATH']}:/opt/gcc-4.7.2/bin"
         when "solaris2"
-          declare_resource(:package,  "autoconf")
-          declare_resource(:package,  "automake")
-          declare_resource(:package,  "bison")
-          declare_resource(:package,  "gnu-coreutils")
-          declare_resource(:package,  "flex")
-          declare_resource(:package,  "gcc") do
+          package "autoconf"
+          package "automake"
+          package "bison"
+          package "gnu-coreutils"
+          package "flex"
+          package "gcc" do
             # lock because we don't use 5 yet
             version "4.8.2"
           end
-          declare_resource(:package,  "gcc-3")
-          declare_resource(:package,  "gnu-grep")
-          declare_resource(:package,  "gnu-make")
-          declare_resource(:package,  "gnu-patch")
-          declare_resource(:package,  "gnu-tar")
-          declare_resource(:package,  "make")
-          declare_resource(:package,  "pkg-config")
-          declare_resource(:package,  "ucb")
+          package "gcc-3"
+          package "gnu-grep"
+          package "gnu-make"
+          package "gnu-patch"
+          package "gnu-tar"
+          package "make"
+          package "pkg-config"
+          package "ucb"
         when "smartos"
-          declare_resource(:package,  "autoconf")
-          declare_resource(:package,  "binutils")
-          declare_resource(:package,  "build-essential")
-          declare_resource(:package,  "gcc47")
-          declare_resource(:package,  "gmake")
-          declare_resource(:package,  "pkg-config")
+          package "autoconf"
+          package "binutils"
+          package "build-essential"
+          package "gcc47"
+          package "gmake"
+          package "pkg-config"
         when "suse"
-          declare_resource(:package,  %w{ autoconf bison flex gcc gcc-c++ kernel-default-devel make m4 })
-          declare_resource(:package,  %w{ gcc48 gcc48-c++ }) if node["platform_version"].to_i < 12
+          package %w{ autoconf bison flex gcc gcc-c++ kernel-default-devel make m4 }
+          package %w{ gcc48 gcc48-c++ } if node["platform_version"].to_i < 12
         else
           Chef::Log.warn <<-EOH
         The build_essential resource does not currently support the '#{node['platform_family']}'


### PR DESCRIPTION
This is a custom resource so we don't need this.

Signed-off-by: Tim Smith <tsmith@chef.io>