### PR TITLE
paludis_package: Make sure timeout property is an Integer

### DIFF
--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -30,7 +30,9 @@ class Chef
 
       allowed_actions :install, :remove, :upgrade
 
-      property :timeout, default: 3600
+      property :timeout, Integer,
+               description: "The amount of time (in seconds) to wait before timing out.",
+               default: 3600
     end
   end
 end


### PR DESCRIPTION
This is meant to be an integer, but we didn't specify.

Signed-off-by: Tim Smith <tsmith@chef.io>