### PR TITLE
windows_ad_join resource - add newname property

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -52,6 +52,9 @@ class Chef
                description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.",
                default: :immediate
 
+      property :newname, String,
+               description: "Specifies a new name for the computer in the new domain."
+
       # define this again so we can default it to true. Otherwise failures print the password
       property :sensitive, [TrueClass, FalseClass],
                default: true
@@ -64,6 +67,7 @@ class Chef
           cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}\",$pswd);"
           cmd << "Add-Computer -DomainName #{new_resource.domain_name} -Credential $credential"
           cmd << " -OUPath \"#{new_resource.ou_path}\"" if new_resource.ou_path
+          cmd << " -NewName \"#{new_resource.newname}\"" if new_resource.newname
           cmd << " -Force"
 
           converge_by("join Active Directory domain #{new_resource.domain_name}") do

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -52,7 +52,7 @@ class Chef
                description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.",
                default: :immediate
 
-      property :newname, String,
+      property :new_name, String,
                description: "Specifies a new name for the computer in the new domain."
 
       # define this again so we can default it to true. Otherwise failures print the password
@@ -67,7 +67,7 @@ class Chef
           cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}\",$pswd);"
           cmd << "Add-Computer -DomainName #{new_resource.domain_name} -Credential $credential"
           cmd << " -OUPath \"#{new_resource.ou_path}\"" if new_resource.ou_path
-          cmd << " -NewName \"#{new_resource.newname}\"" if new_resource.newname
+          cmd << " -NewName \"#{new_resource.new_name}\"" if new_resource.new_name
           cmd << " -Force"
 
           converge_by("join Active Directory domain #{new_resource.domain_name}") do


### PR DESCRIPTION
Signed-off-by: Derek Groh <derekgroh@github.io>

### Description

Adds the NewName parameter for the Add-Computer command

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/add-computer?view=powershell-5.1#optional-parameters

### Issues Resolved

Stack Overflow request to be able to rename a computer when joining the domain.

### Check List

- [ ] New functionality includes tests (is there a good way to test new properties?)
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
