### PR TITLE
Add @tas50 as the opensuse lieutenant and maintainer for macos / windows

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -113,6 +113,7 @@ To mention the team, use @chef/client-windows
 * [Stuart Preston](https://github.com/stuartpreston)
 * [Salim Alam](https://github.com/chefsalim)
 * [Matt Wrock](https://github.com/mwrock)
+* [Tim Smith](https://github.com/tas50)
 
 ## Solaris
 
@@ -146,6 +147,7 @@ To mention the team, use @chef/client-os-x
 
 * [Tyler Ball](https://github.com/tyler-ball)
 * [mikedodge04](https://github.com/mikedodge04)
+* [Tim Smith](https://github.com/tas50)
 
 ## Debian
 
@@ -172,10 +174,13 @@ To mention the team, use @chef/client-fedora
 
 To mention the team, use @chef/client-opensuse
 
+### Lieutenant
+
+* [Tim Smith](https://github.com/tas50)
+
 ### Maintainers
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
-* [Tim Smith](https://github.com/tas50)
 
 ## SUSE Enterprise Linux Server
 

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -112,7 +112,8 @@ The specific components of Chef related to a given platform - including (but not
           "smurawski",
           "stuartpreston",
           "chefsalim",
-          "mwrock"
+          "mwrock",
+          "tas50"
         ]
 
       [Org.Components.Subsystems.Solaris]
@@ -139,7 +140,8 @@ The specific components of Chef related to a given platform - including (but not
 
         maintainers = [
           "tyler-ball",
-          "mikedodge04"
+          "mikedodge04",
+          "tas50"
         ]
 
       [Org.Components.Subsystems.Debian]
@@ -165,9 +167,10 @@ The specific components of Chef related to a given platform - including (but not
         title = "openSUSE"
         team = "client-opensuse"
 
+        lieutenant = "tas50"
+
         maintainers = [
-          "lamont-granquist",
-          "tas50"
+          "lamont-granquist"
         ]
 
       [Org.Components.Subsystems."SUSE Enterprise Linux"]


### PR DESCRIPTION
opensuse should have a lieutenant and I've been working on the overall support in Chef client. I've also been working on the windows/macos side of things.

Signed-off-by: Tim Smith <tsmith@chef.io>