### PR TITLE
Rename windows_ad_join's newname to be new_hostname

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -52,8 +52,9 @@ class Chef
                description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.",
                default: :immediate
 
-      property :new_name, String,
-               description: "Specifies a new name for the computer in the new domain."
+      property :new_hostname, String,
+               description: "Specifies a new hostname for the computer in the new domain.",
+               introduced: "14.5"
 
       # define this again so we can default it to true. Otherwise failures print the password
       property :sensitive, [TrueClass, FalseClass],


### PR DESCRIPTION
newname matches powershell, but isn't entirely apparent to
non-PowerShell users. We should give it a name that requires no
knowledge outside of Chef. This also adds the introduced field, which we
use to generate docs.

Signed-off-by: Tim Smith <tsmith@chef.io>