### PR TITLE
Move subversion properties out of scm and into subversion

### DIFF
--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -24,22 +24,50 @@ class Chef
       default_action :sync
       allowed_actions :checkout, :export, :sync, :diff, :log
 
-      property :destination, String, name_property: true, identity: true
+      property :destination, String,
+               description: "The location path to which the source is to be cloned, checked out, or exported. Default value: the name of the resource block.",
+               name_property: true, identity: true
+
       property :repository, String
-      property :revision, String, default: "HEAD"
-      property :user, [String, Integer]
-      property :group, [String, Integer]
-      property :svn_username, String
-      property :svn_password, String, sensitive: true, desired_state: false
+
+      property :revision, String,
+               description: "The revision to checkout.",
+               default: "HEAD"
+
+      property :user, [String, Integer],
+               description: "The system user that is responsible for the checked-out code."
+
+      property :group, [String, Integer],
+               description: "The system group that is responsible for the checked-out code."
+
       # Capistrano and git-deploy use ``shallow clone''
-      property :depth, Integer
-      property :enable_submodules, [TrueClass, FalseClass], default: false
-      property :enable_checkout, [TrueClass, FalseClass], default: true
-      property :remote, String, default: "origin"
-      property :ssh_wrapper, String, desired_state: false
-      property :timeout, Integer, desired_state: false
-      property :checkout_branch, String, default: "deploy"
-      property :environment, [Hash, nil], default: nil
+      property :depth, Integer,
+               description: "The number of past revisions to be included in the git shallow clone. Unless specified the default behavior will do a full clone."
+
+      property :enable_submodules, [TrueClass, FalseClass],
+               description: "Perform a sub-module initialization and update.",
+               default: false
+
+      property :enable_checkout, [TrueClass, FalseClass],
+               description: "Check out a repo from master. Set to false when using the checkout_branch attribute to prevent the git resource from attempting to check out master from master.",
+               default: true
+
+      property :remote, String,
+               default: "origin"
+
+      property :ssh_wrapper, String,
+               desired_state: false
+
+      property :timeout, Integer,
+               desired_state: false
+
+      property :checkout_branch, String,
+               description: "Do a one-time checkout **or** use when a branch in the upstream repository is named 'deploy'. To prevent the resource from attempting to check out master from master, set 'enable_checkout' to 'false' when using the 'checkout_branch' property.",
+               default: "deploy"
+
+      property :environment, [Hash, nil],
+               description: "A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'}). (These variables must exist for a command to be run successfully.)",
+               default: nil
 
       alias :env :environment
     end

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -39,6 +39,13 @@ class Chef
       property :svn_binary, String,
                description: "The location of the svn binary."
 
+      property :svn_username, String,
+               description: "The username to use for interacting with subversion."
+
+      property :svn_password, String,
+               description: "The password to use for interacting with subversion.",
+               sensitive: true, desired_state: false
+
       # Override exception to strip password if any, so it won't appear in logs and different Chef notifications
       def custom_exception_message(e)
         "#{self} (#{defined_at}) had an error: #{e.class.name}: #{svn_password ? e.message.gsub(svn_password, "[hidden_password]") : e.message}"

--- a/spec/unit/resource/scm_spec.rb
+++ b/spec/unit/resource/scm_spec.rb
@@ -78,16 +78,6 @@ describe Chef::Resource::Scm do
     expect(resource.group).to eq(23)
   end
 
-  it "has a svn_username String property" do
-    resource.svn_username "moartestsplz"
-    expect(resource.svn_username).to eql("moartestsplz")
-  end
-
-  it "has a svn_password String property" do
-    resource.svn_password "taftplz"
-    expect(resource.svn_password).to eql("taftplz")
-  end
-
   it "takes the depth as an integer for shallow clones" do
     resource.depth 5
     expect(resource.depth).to eq(5)


### PR DESCRIPTION
This way we're not polluting the git resource with the subversion properties. Cleans up our docs generation a bit. I added some property descriptions while I was in there.

Signed-off-by: Tim Smith <tsmith@chef.io>