### PR TITLE
Update script resource deprecation waring

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -267,7 +267,7 @@ module ChefConfig
     # Determine if the given path is protected by OS X System Integrity Protection.
     def self.is_sip_path?(path, node)
       if node["platform"] == "mac_os_x" && Gem::Version.new(node["platform_version"]) >= Gem::Version.new("10.11")
-          # todo: parse rootless.conf for this?
+          # @todo: parse rootless.conf for this?
         sip_paths = [
           "/System", "/bin", "/sbin", "/usr"
         ]

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -157,7 +157,7 @@ class Chef
       event_handlers += Array(Chef::Config[:event_handlers])
 
       @events = EventDispatch::Dispatcher.new(*event_handlers)
-      # TODO it seems like a bad idea to be deletin' other peoples' hashes.
+      # @todo it seems like a bad idea to be deletin' other peoples' hashes.
       @override_runlist = args.delete(:override_runlist)
       @specific_recipes = args.delete(:specific_recipes)
       @run_status = Chef::RunStatus.new(nil, events)

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -49,9 +49,9 @@ class Chef
 
       def load_current_resource
         super
-        # @todo Chef-13: change this to an exception
+        # @todo Chef-15: change this to an exception
         if code.nil?
-          logger.warn "#{new_resource}: No code attribute was given, resource does nothing, this behavior is deprecated and will be removed in Chef-13"
+          logger.warn "#{new_resource}: No code attribute was given, resource does nothing, this behavior is deprecated and will be removed in Chef 15 (April 2019)"
         end
       end
 


### PR DESCRIPTION
We'll actually deprecate this in Chef 15. Also update todos to be YARD.

Signed-off-by: Tim Smith <tsmith@chef.io>