### PR TITLE
Remove Bryant Lippert as a FreeBSD maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -202,7 +202,6 @@ To mention the team, use @chef/client-freebsd
 
 * [Cory Stephenson](https://github.com/Aevin1387)
 * [David Aronsohn](https://github.com/OnlyHaveCans)
-* [Bryant Lippert](https://github.com/AgentMeerkat)
 
 ## OpenBSD
 
@@ -236,4 +235,3 @@ To mention the team, use @chef/client-archlinux
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
 * [Ryan Cragun](https://github.com/ryancragun)
-

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -189,8 +189,7 @@ The specific components of Chef related to a given platform - including (but not
 
         maintainers = [
           "Aevin1387",
-          "OnlyHaveCans",
-          "AgentMeerkat"
+          "OnlyHaveCans"
         ]
 
       [Org.Components.Subsystems.OpenBSD]


### PR DESCRIPTION
His github is a 404 and this causes our maintainer scripts to fail since he can't be added to the group.

Signed-off-by: Tim Smith <tsmith@chef.io>