### PR TITLE
windows_service: Remove potentially sensitive info from the log

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -91,7 +91,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
       }.reject { |k, v| v.nil? || v.length == 0 }
 
       Win32::Service.configure(new_config)
-      logger.info "#{@new_resource} configured with #{new_config.inspect}"
+      logger.info "#{@new_resource} configured."
 
       # LocalSystem is the default runas user, which is a special service account that should ultimately have the rights of BUILTIN\Administrators, but we wouldn't see that from get_account_right
       if new_config.key?(:service_start_name) && new_config[:service_start_name].casecmp("localsystem") != 0


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Removes the logging of potentially sensitive information in the log when a Windows service is configured or reconfigured.

### Issues Resolved

#7634 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
