### PR TITLE
Wire up openssl_x509

### DIFF
--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -26,7 +26,7 @@ class Chef
 
       preview_resource true
       resource_name :openssl_x509_certificate
-      # provides(:openssl_x509) { true } # legacy cookbook name. Cookbook will win for now. @todo Uncomment this for Chef 15
+      provides(:openssl_x509) { true } # legacy cookbook name.
 
       description "Use the openssl_x509_certificate resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. Note: This resource was renamed from openssl_x509 to openssl_x509_certificate. The legacy name will continue to function, but cookbook code should be updated for the new resource name."
       introduced "14.4"


### PR DESCRIPTION
I originally left this uncommented, but this actually broke backwards
compatibility more than the potential for Chef winning over the
cookbook. I think we have to just bite the bullet here and let Chef win
in the name of backwards compatibility with the name.

Signed-off-by: Tim Smith <tsmith@chef.io>