### PR TITLE
Add docs team as owners on readme / release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*               @chef/client-maintainers
-.expeditor/**   @chef/jex-team
+*                 @chef/client-maintainers
+.expeditor/**     @chef/jex-team
+README.md         @chef/docs-team
+RELEASE_NOTES.md  @chef/docs-team


### PR DESCRIPTION
Since the release notes end up on the docs site we should involve the
docs team as early in the process as possible.

Signed-off-by: Tim Smith <tsmith@chef.io>