### PR TITLE
Deprecate ohai resource's ohai_name property

### DIFF
--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -27,8 +27,12 @@ class Chef
 
       description "Use the ohai resource to reload the Ohai configuration on a node. This allows recipes that change system attributes (like a recipe that adds a user) to refer to those attributes later on during the chef-client run."
 
-      property :ohai_name, name_property: true, introduced: "12.17"
-      property :plugin, String
+      property :ohai_name,
+               deprecated: true,
+               name_property: true, introduced: "12.17"
+
+      property :plugin, String,
+               description: "The name of an Ohai plugin to be reloaded. If this property is not specified, the chef-client will reload all plugins."
 
       default_action :reload
       allowed_actions :reload


### PR DESCRIPTION
This isn't actually used anywhere in the resource and there's no point. It reload's plugins based on the plugin property. We should kill this thing off and reduce the complexity a tiny bit.

Signed-off-by: Tim Smith <tsmith@chef.io>