### PR TITLE
Update rubyzip to 1.2.2 and mixlib-archive to 0.4.16

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,4 +1,4 @@
-# Documentation available at https://expeditor-docs.es.chef.io/
+# Documentation available at https://expeditor.chef.io/docs/getting-started/
 
 # The name of the product keys for this product (from mixlib-install)
 product_key:
@@ -31,16 +31,17 @@ github:
   enable_expire_cache: true
   # The tag format to use (e.g. v1.0.0)
   version_tag_format: "v{{version}}"
-  # The Github Team primarily responsible for handling incoming Pull Requests.
-  maintainer_group: chef/client-core
+  # allow bumping the minor release via label
+  minor_bump_labels:
+    - "Expeditor: Bump Minor Version"
   # Which Github branches to build Omnibus releases from, and what versions
   # (as determined by the value in the VERSION file) those branches are responsible
   # for building.
   release_branch:
     - master:
-        version_constraint: 14.*
+        version_constraint: 14*
     - chef-13:
-        version_constraint: 13.*
+        version_constraint: 13*
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
@@ -60,16 +61,18 @@ merge_actions:
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
 
-# These actions are taken, in the order specified, when an Omnibus artifact is promoted
-# within Chef's internal artifact storage system.
-artifact_actions:
-  promoted_to_unstable:
-    - built_in:build_docker_image
-  promoted_to_current:
-    - built_in:tag_docker_image
-  promoted_to_stable:
-    - built_in:rollover_changelog
-    - bash:.expeditor/update_dockerfile.sh
-    - built_in:tag_docker_image
-    - built_in:publish_rubygems
-    - built_in:notify_chefio_slack_channels
+subscriptions:
+  - workload: artifact_published:unstable:chef:{{version_constraint}}
+    actions:
+      - built_in:build_docker_image
+  - workload: artifact_published:current:chef:{{version_constraint}}
+    actions:
+      - built_in:tag_docker_image
+  - workload: artifact_published:stable:chef:{{version_constraint}}
+    actions:
+      - built_in:rollover_changelog
+      - bash:.expeditor/update_dockerfile.sh
+      - built_in:tag_docker_image
+      - built_in:publish_rubygems
+      - built_in:notify_chefio_slack_channels
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       mixlib-cli (~> 1.4)
       mixlib-shellout (~> 2.0)
     ast (2.4.0)
-    backports (3.11.3)
+    backports (3.11.4)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -129,7 +129,7 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     excon (0.62.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
@@ -188,7 +188,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.9.0)
-    mixlib-archive (0.4.13)
+    mixlib-archive (0.4.16)
       mixlib-log
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
@@ -213,10 +213,10 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    net-telnet (0.2.0)
+    net-telnet (0.1.1)
     netrc (0.11.0)
     nori (2.6.0)
-    octokit (4.10.0)
+    octokit (4.12.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (13.10.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
@@ -287,7 +287,7 @@ GEM
     ruby-progressbar (1.10.0)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
@@ -305,10 +305,10 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (3.6.0)
-    specinfra (2.75.1)
+    specinfra (2.76.2)
       net-scp
       net-ssh (>= 2.7)
-      net-telnet
+      net-telnet (= 0.1.1)
       sfl
     sslshake (1.2.0)
     syslog-logger (1.6.8)
@@ -323,7 +323,7 @@ GEM
       net-ssh (>= 2.9, < 5.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    travis (1.8.8)
+    travis (1.8.9)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
@@ -370,7 +370,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-fs (1.2.1)
+    winrm-fs (1.3.0)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -410,4 +410,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 8369ed7b074102971c9e25e732001d8a3566423b
+  revision: 8773058b6cafc053159bbe24851bc7eeb407d492
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -29,13 +29,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.107)
-      aws-sdk-resources (= 2.11.107)
-    aws-sdk-core (2.11.107)
+    aws-sdk (2.11.136)
+      aws-sdk-resources (= 2.11.136)
+    aws-sdk-core (2.11.136)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.107)
-      aws-sdk-core (= 2.11.107)
+    aws-sdk-resources (2.11.136)
+      aws-sdk-core (= 2.11.136)
     aws-sigv4 (1.0.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
@@ -76,13 +76,13 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (14.3.37)
+    chef-config (14.5.33)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (4.0.1)
+    chef-sugar (4.1.0)
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.2)
@@ -122,7 +122,7 @@ GEM
       multi_json (~> 1.10)
     method_source (0.9.0)
     minitar (0.6.1)
-    mixlib-archive (0.4.13)
+    mixlib-archive (0.4.16)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -148,9 +148,9 @@ GEM
       net-ssh (>= 2.6.5)
     nio4r (2.3.1)
     nori (2.6.0)
-    octokit (4.10.0)
+    octokit (4.12.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.4.0)
+    ohai (14.5.4)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -179,7 +179,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable
@@ -201,7 +201,7 @@ GEM
       varia_model (~> 0.4.0)
     ruby-progressbar (1.10.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -223,7 +223,7 @@ GEM
     thor (0.20.0)
     timers (4.0.4)
       hitimes
-    toml-rb (1.1.1)
+    toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.7)
     varia_model (0.4.1)
@@ -243,7 +243,7 @@ GEM
     winrm-elevated (1.1.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.2.1)
+    winrm-fs (1.3.0)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -269,4 +269,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.16.3
+   1.16.5


### PR DESCRIPTION
Fix the rubyzip CVE and also bring in the mixlib-archive fixes on windows.

Signed-off-by: Tim Smith <tsmith@chef.io>