### PR TITLE
osx_profile: Use the full path to /usr/bin/profiles

### DIFF
--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -188,14 +188,14 @@ class Chef
       end
 
       def install_profile(profile_path)
-        cmd = "profiles -I -F '#{profile_path}'"
+        cmd = "/usr/bin/profiles -I -F '#{profile_path}'"
         Chef::Log.debug("cmd: #{cmd}")
         shellout_results = shell_out(cmd)
         shellout_results.exitstatus
       end
 
       def remove_profile
-        cmd = "profiles -R -p '#{@new_profile_identifier}'"
+        cmd = "/usr/bin/profiles -R -p '#{@new_profile_identifier}'"
         Chef::Log.debug("cmd: #{cmd}")
         shellout_results = shell_out(cmd)
         shellout_results.exitstatus
@@ -225,7 +225,7 @@ class Chef
       end
 
       def write_installed_profiles(tempfile)
-        cmd = "profiles -P -o '#{tempfile}'"
+        cmd = "/usr/bin/profiles -P -o '#{tempfile}'"
         shell_out!(cmd)
       end
 

--- a/spec/unit/provider/osx_profile_spec.rb
+++ b/spec/unit/provider/osx_profile_spec.rb
@@ -116,7 +116,7 @@ describe Chef::Provider::OsxProfile do
       allow(provider).to receive(:generate_tempfile).and_return(tempfile)
       allow(provider).to receive(:get_installed_profiles).and_call_original
       allow(provider).to receive(:read_plist).and_return(all_profiles)
-      expect(provider).to receive(:shell_out!).with("profiles -P -o '/tmp/allprofiles.plist'")
+      expect(provider).to receive(:shell_out!).with("/usr/bin/profiles -P -o '/tmp/allprofiles.plist'")
       provider.load_current_resource
     end
 
@@ -164,7 +164,7 @@ describe Chef::Provider::OsxProfile do
       all_profiles["_computerlevel"][1]["ProfileUUID"] = "1781fbec-3325-565f-9022-9bb39245d4dd"
       provider.load_current_resource
       allow(provider).to receive(:write_profile_to_disk).and_return(profile_path)
-      expect(provider).to receive(:shell_out).with("profiles -I -F '#{profile_path}'").and_return(shell_out_success)
+      expect(provider).to receive(:shell_out).with("/usr/bin/profiles -I -F '#{profile_path}'").and_return(shell_out_success)
       provider.action_install()
     end
 
@@ -248,7 +248,7 @@ describe Chef::Provider::OsxProfile do
       new_resource.identifier "com.testprofile.screensaver"
       new_resource.action(:remove)
       provider.load_current_resource
-      expect(provider).to receive(:shell_out).with("profiles -R -p '#{new_resource.identifier}'").and_return(shell_out_success)
+      expect(provider).to receive(:shell_out).with("/usr/bin/profiles -R -p '#{new_resource.identifier}'").and_return(shell_out_success)
       provider.action_remove()
     end
   end


### PR DESCRIPTION
This prevents an app named profiles being later in the path, which was reported by a user.

Signed-off-by: Tim Smith <tsmith@chef.io>