### PR TITLE
windows_service: Remove potentially sensitive info from the log

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -43,7 +43,7 @@ github:
     - chef-13:
         version_constraint: 13*
 
-# These actions are taken, in order they are specified, anytime a Pull Request is merged.
+# These actions are taken, in order they are specified, anytime a PR is merged.
 merge_actions:
   - built_in:bump_version:
       ignore_labels:
@@ -75,4 +75,3 @@ subscriptions:
       - built_in:tag_docker_image
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
-

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -74,7 +74,7 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
       }.reject { |k, v| v.nil? || v.length == 0 }
 
       Win32::Service.configure(new_config)
-      Chef::Log.info "#{@new_resource} configured with #{new_config.inspect}"
+      Chef::Log.info "#{@new_resource} configured."
 
       if new_config.has_key?(:service_start_name)
         unless Chef::ReservedNames::Win32::Security.get_account_right(canonicalize_username(new_config[:service_start_name])).include?(SERVICE_RIGHT)


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Removes the logging of potentially sensitive information in the log when a Windows service is configured or reconfigured.

### Issues Resolved

#7634 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
