### PR TITLE
Fixed introduced version to 14.6 for newly added properties in zypper_package and windows_user resource as it got released in 14.6.

### DIFF
--- a/lib/chef/resource/user/windows_user.rb
+++ b/lib/chef/resource/user/windows_user.rb
@@ -28,7 +28,7 @@ class Chef
 
         property :full_name, String,
                   description: "The full name of the user.",
-                  introduced: "14.5"
+                  introduced: "14.6"
       end
     end
   end

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -38,7 +38,7 @@ class Chef
       property :global_options, [ String, Array ],
                description: "One (or more) additional options that are passed to the package resource other than options to the command.",
                coerce: proc { |x| x.is_a?(String) ? x.shellsplit : x },
-               introduced: "14.5"
+               introduced: "14.6"
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description

Fixed wrong version description in introduced for newly added properties in zypper_pacakge and windows_user resource.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
