### PR TITLE
Minor optimization in yum_helper.py

### DIFF
--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -125,8 +125,9 @@ def query(command):
     #   - in order to fix this, something would have to happen where getProvides was called first and
     #     then the result was searchNevra'd.  please be extremely careful if attempting to fix that
     #     since searchNevra does not support prco tuples.
-    if any(elem in command['provides'] for elem in r"<=>"):
-        # handles flags (<, >, =, etc) and versions, but no wildcareds 
+    if bool(re.search('\\s+', command['provides'])):
+        # handles flags (<, >, =, etc) and versions, but no wildcareds
+        # raises error for any invalid input like: 'FOO BAR BAZ' 
         pkgs = obj.getProvides(*string_to_prco_tuple(command['provides']))
     elif do_nevra:
         # now if we're given version or arch properties explicitly, then we do a SearchNevra.


### PR DESCRIPTION
- Catching invalid package names at first place instead of allowing them to go to another method
- Tested manually (logs below)

Signed-off-by: Nimesh <nimesh.patni@msystechnologies.com>

### Description
- Concentrating on invalid strings: "foo bar baz"
- ```string_to_prco_tuple``` checks such invalid strings and raise error
- Instead of calling ```searchProvides``` and then raising error from ```string_to_prco_tuple```
- Catch the names having any white spaces within the first condition itself
- Valid: "foo <=> version"
- Strings like: "foo bar" are already handled in  ruby side

### Issues Resolved

MSYS-866:
On CENTOS/RHEL 6, if the package resource is given a name that contains a space it will cause rpmdb corruption errors

- Root cause of such issue is caching and could mostly be prevented by using [yum clean all](https://unix.stackexchange.com/questions/198703/yum-errorrpmdb-open-failed/198704#198704)
- Similar issue is discussed in [fedora forums](https://forums.fedoraforum.org/showthread.php?271415-yum-update-Errors) and [linux posts](https://www.linuxquestions.org/questions/fedora-35/typeerror-rpmdb-open-failed-498627/)

### Logs of manual testing performed

```ruby
# *********************************************************
# CASE 1: "FOO = BAR"

  ================================================================================
   Error executing action `install` on resource 'yum_package[FOO = BAR]'
  ================================================================================

   Chef::Exceptions::Package
   -------------------------
   No candidate version available for FOO = BAR


# *********************************************************
# CASE 2: "FOO BAR*"

  =========================================================================
    Error executing action `install` on resource 'yum_package[FOO BAR*]'
  =========================================================================

    Chef::Exceptions::Package
    -------------------------
    No candidate version available for FOO BAR*


# *********************************************************
# CASE 3: "FOO = 123"

  ===========================================================================
  Error executing action `install` on resource 'yum_package[FOO = 123]'
  ===========================================================================

  Chef::Exceptions::Package
  -------------------------
  No candidate version available for FOO = 123


# *********************************************************
# CASE 4: "FOO BAR BAZ" (Containing Spaces)

  =========================================================================
    Error executing action `install` on resource 'yum_package[FOO BAR BAZ]'
  =========================================================================

    RuntimeError
    ------------
    yum-helper.py had stderr/stdout output:

    Traceback (most recent call last):
      File "/lib/chef/provider/package/yum/yum_helper.py", line 203, in <module>
        query(command)
      File "/lib/chef/provider/package/yum/yum_helper.py", line 131, in query
        pkgs = obj.getProvides(*string_to_prco_tuple(command['provides']))
      File "/usr/lib/python2.6/site-packages/yum/misc.py", line 704, in
        string_to_prco_tuple
        raise Errors.MiscError, 'Invalid version flag: %s' % f
    yum.Errors.MiscError: Invalid version flag: BAR
    Loaded plugins: product-id

# *********************************************************
# CASE 5: "FOO  BAR     BAZ" (Containing Tabs)

  ================================================================================
    Error executing action `install` on resource 'yum_package[FOO  BAR     BAZ]'
  ================================================================================

    RuntimeError
    ------------
    yum-helper.py had stderr/stdout output:

    Traceback (most recent call last):
      File "/lib/chef/provider/package/yum/yum_helper.py", line 203, in <module>
        query(command)
      File "/lib/chef/provider/package/yum/yum_helper.py", line 131, in query
        pkgs = obj.getProvides(*string_to_prco_tuple(command['provides']))
      File "/usr/lib/python2.6/site-packages/yum/misc.py", line 704, in string_to_prco_tuple
        raise Errors.MiscError, 'Invalid version flag: %s' % f
    yum.Errors.MiscError: Invalid version flag: BAR
    Loaded plugins: product-id
```

### Check List

- [] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
