### PR TITLE
replace some instances of to_hash with to_h

### DIFF
--- a/lib/chef/api_client.rb
+++ b/lib/chef/api_client.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Nuo Yan (<nuo@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ class Chef
     # Private key is included if available.
     #
     # @return [Hash]
-    def to_hash
+    def to_h
       result = {
         "name" => @name,
         "public_key" => @public_key,
@@ -123,11 +123,13 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     # The JSON representation of the object.
     #
     # @return [String] the JSON string.
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def self.from_hash(o)

--- a/lib/chef/api_client_v1.rb
+++ b/lib/chef/api_client_v1.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Nuo Yan (<nuo@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -146,7 +146,7 @@ class Chef
     # Private key is included if available.
     #
     # @return [Hash]
-    def to_hash
+    def to_h
       result = {
         "name" => @name,
         "validator" => @validator,
@@ -159,11 +159,13 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     # The JSON representation of the object.
     #
     # @return [String] the JSON string.
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def self.from_hash(o)
@@ -312,7 +314,7 @@ class Chef
 
         new_client = chef_rest_v0.post("clients", payload)
       end
-      Chef::ApiClientV1.from_hash(to_hash.merge(new_client))
+      Chef::ApiClientV1.from_hash(to_h.merge(new_client))
     end
 
     # As a string

--- a/lib/chef/audit/audit_reporter.rb
+++ b/lib/chef/audit/audit_reporter.rb
@@ -118,7 +118,7 @@ class Chef
 
         audit_history_url = "controls"
         Chef::Log.trace("Sending audit report (run-id: #{audit_data.run_id})")
-        run_data = audit_data.to_hash
+        run_data = audit_data.to_h
 
         if @audit_phase_error
           error_info = "#{@audit_phase_error.class}: #{@audit_phase_error.message}"

--- a/lib/chef/audit/control_group_data.rb
+++ b/lib/chef/audit/control_group_data.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
 #
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,15 +35,17 @@ class Chef
         control_groups << control_group
       end
 
-      def to_hash
+      def to_h
         {
             node_name: node_name,
             run_id: run_id,
             start_time: start_time,
             end_time: end_time,
-            control_groups: control_groups.collect { |c| c.to_hash },
+            control_groups: control_groups.collect { |c| c.to_h },
         }
       end
+
+      alias_method :to_hash, :to_h
     end
 
     class ControlGroupData
@@ -76,7 +78,7 @@ class Chef
         control
       end
 
-      def to_hash
+      def to_h
         # We sort it so the examples appear in the output in the same order
         # they appeared in the recipe
         controls.sort! { |x, y| x.line_number <=> y.line_number }
@@ -85,11 +87,13 @@ class Chef
               status: status,
               number_succeeded: number_succeeded,
               number_failed: number_failed,
-              controls: controls.collect { |c| c.to_hash },
+              controls: controls.collect { |c| c.to_h },
         }
         # If there is a duplicate key, metadata will overwrite it
         add_display_only_data(h).merge(metadata)
       end
+
+      alias_method :to_hash, :to_h
 
       private
 
@@ -122,7 +126,7 @@ class Chef
         end
       end
 
-      def to_hash
+      def to_h
         h = {
             name: name,
             status: status,
@@ -133,6 +137,8 @@ class Chef
         h[:context] = context || []
         h
       end
+
+      alias_method :to_hash, :to_h
     end
 
   end

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -311,7 +311,7 @@ class Chef
             cookbook_type = path[0]
             result = nil
             begin
-              result = Chef::CookbookManifest.new(entry.chef_object, policy_mode: cookbook_type == "cookbook_artifacts").to_hash
+              result = Chef::CookbookManifest.new(entry.chef_object, policy_mode: cookbook_type == "cookbook_artifacts").to_h
             rescue Chef::ChefFS::FileSystem::NotFoundError => e
               raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
             end
@@ -334,7 +334,7 @@ class Chef
             end
 
             if cookbook_type == "cookbook_artifacts"
-              result["metadata"] = result["metadata"].to_hash
+              result["metadata"] = result["metadata"].to_h
               result["metadata"].delete_if do |key, value|
                 value == [] ||
                   (value == {} && !%w{dependencies attributes recipes}.include?(key)) ||

--- a/lib/chef/chef_fs/data_handler/data_handler_base.rb
+++ b/lib/chef/chef_fs/data_handler/data_handler_base.rb
@@ -114,7 +114,7 @@ class Chef
         def from_ruby(path)
           r = chef_class.new
           r.from_file(path)
-          r.to_hash
+          r.to_h
         end
 
         #

--- a/lib/chef/cookbook/manifest_v2.rb
+++ b/lib/chef/cookbook/manifest_v2.rb
@@ -1,4 +1,4 @@
-# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# Copyright:: Copyright 2015-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,17 +23,21 @@ class Chef
 
       minimum_api_version 2
 
-      def self.from_hash(hash)
-        Chef::Log.trace "processing manifest: #{hash}"
-        Mash.new hash
-      end
+      class << self
+        def from_hash(hash)
+          Chef::Log.trace "processing manifest: #{hash}"
+          Mash.new hash
+        end
 
-      def self.to_hash(manifest)
-        result = manifest.manifest.dup
-        result["all_files"].map! { |file| file.delete("full_path"); file }
-        result["frozen?"] = manifest.frozen_version?
-        result["chef_type"] = "cookbook_version"
-        result.to_hash
+        def to_h(manifest)
+          result = manifest.manifest.dup
+          result["all_files"].map! { |file| file.delete("full_path"); file }
+          result["frozen?"] = manifest.frozen_version?
+          result["chef_type"] = "cookbook_version"
+          result.to_hash
+        end
+
+        alias_method :to_hash, :to_h
       end
 
     end

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -465,7 +465,7 @@ class Chef
         end
       end
 
-      def to_hash
+      def to_h
         {
           NAME                   => name,
           DESCRIPTION            => description,
@@ -488,8 +488,10 @@ class Chef
         }
       end
 
+      alias_method :to_hash, :to_h
+
       def to_json(*a)
-        Chef::JSONCompat.to_json(to_hash, *a)
+        Chef::JSONCompat.to_json(to_h, *a)
       end
 
       def self.from_hash(o)

--- a/lib/chef/cookbook_manifest.rb
+++ b/lib/chef/cookbook_manifest.rb
@@ -1,5 +1,5 @@
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# Copyright:: Copyright 2015-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ class Chef
     def_delegator :@cookbook_version, :frozen_version?
 
     # Create a new CookbookManifest object for the given `cookbook_version`.
-    # You can subsequently call #to_hash to get a Hash representation of the
+    # You can subsequently call #to_h to get a Hash representation of the
     # cookbook_version in the "manifest" format, or #to_json to get a JSON
     # representation of the cookbook_version.
     #
@@ -119,12 +119,14 @@ class Chef
       @policy_mode
     end
 
-    def to_hash
-      CookbookManifestVersions.to_hash(self)
+    def to_h
+      CookbookManifestVersions.to_h(self)
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      result = to_hash
+      result = to_h
       result["json_class"] = "Chef::CookbookVersion"
       Chef::JSONCompat.to_json(result, *a)
     end
@@ -321,5 +323,6 @@ class Chef
 
     def_versioned_delegator :from_hash
     def_versioned_delegator :to_hash
+    def_versioned_delegator :to_h
   end
 end

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -407,7 +407,7 @@ class Chef
       output["cookbook_name"] = name
       output["name"] = full_name
       output["frozen?"] = frozen_version?
-      output["metadata"] = metadata.to_hash
+      output["metadata"] = metadata.to_h
       output["version"] = version
       output.merge(cookbook_manifest.by_parent_directory)
     end

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -58,7 +58,7 @@ class Chef
       )
     end
 
-    def to_hash
+    def to_h
       result = {
         "name"       => @name,
         "json_class" => self.class.name,
@@ -67,9 +67,11 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     # Serialize this object as a hash
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def chef_server_rest

--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -101,12 +101,14 @@ class Chef
       "data_bag_item_#{data_bag_name}_#{id}"
     end
 
-    def to_hash
+    def to_h
       result = raw_data.dup
       result["chef_type"] = "data_bag_item"
       result["data_bag"] = data_bag.to_s
       result
     end
+
+    alias_method :to_hash, :to_h
 
     # Serialize this object as a hash
     def to_json(*a)
@@ -180,9 +182,9 @@ class Chef
     end
 
     def ==(other)
-      other.respond_to?(:to_hash) &&
+      other.respond_to?(:to_h) &&
         other.respond_to?(:data_bag) &&
-        (other.to_hash == to_hash) &&
+        (other.to_h == to_h) &&
         (other.data_bag.to_s == data_bag.to_s)
     end
 

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Leff (<adamleff@chef.io>)
 # Author:: Ryan Cragun (<ryan@chef.io>)
 #
-# Copyright:: Copyright 2012-2017, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -428,7 +428,7 @@ class Chef
         @all_resource_reports << OpenStruct.new(
           resource: resource_report.new_resource,
           action: resource_report.action,
-          report_data: resource_report.to_hash
+          report_data: resource_report.to_h
         )
       end
 

--- a/lib/chef/data_collector/resource_report.rb
+++ b/lib/chef/data_collector/resource_report.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Leff (<adamleff@chef.io>)
 # Author:: Ryan Cragun (<ryan@chef.io>)
 #
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,7 +65,7 @@ class Chef
         %w{updated failed}.include?(status)
       end
 
-      def to_hash
+      def to_h
         hash = {
           "type"           => new_resource.resource_name.to_sym,
           "name"           => new_resource.name.to_s,
@@ -90,8 +90,8 @@ class Chef
 
         hash
       end
-      alias :to_h :to_hash
-      alias :for_json :to_hash
+      alias_method :to_hash, :to_h
+      alias_method :for_json, :to_h
 
       # We should be able to call the identity of a resource safely, but there
       # is an edge case where resources that have a lazy property that is both

--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,9 +84,11 @@ class Chef::EncryptedDataBagItem
     raise ArgumentError, "assignment not supported for #{self.class}"
   end
 
-  def to_hash
+  def to_h
     @enc_hash.keys.inject({}) { |hash, key| hash[key] = self[key]; hash }
   end
+
+  alias_method :to_hash, :to_h
 
   def self.encrypt_data_bag_item(plain_hash, secret)
     plain_hash.inject({}) do |h, (key, val)|

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -117,7 +117,7 @@ class Chef
       @cookbook_versions[cookbook] = version
     end
 
-    def to_hash
+    def to_h
       result = {
         "name" => @name,
         "description" => @description,
@@ -130,8 +130,10 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def update_from!(o)

--- a/lib/chef/handler.rb
+++ b/lib/chef/handler.rb
@@ -1,6 +1,6 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -259,7 +259,7 @@ class Chef
 
     # Return the Hash representation of the run_status
     def data
-      @run_status.to_hash
+      @run_status.to_h
     end
 
   end

--- a/lib/chef/json_compat.rb
+++ b/lib/chef/json_compat.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/key.rb
+++ b/lib/chef/key.rb
@@ -115,7 +115,7 @@ class Chef
                     regex: /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|infinity)$/)
     end
 
-    def to_hash
+    def to_h
       result = {
         @actor_field_name => @actor,
       }
@@ -127,8 +127,10 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def create
@@ -155,7 +157,7 @@ class Chef
       result = chef_rest.post("#{api_base}/#{@actor}/keys", payload)
       # append the private key to the current key if the server returned one,
       # since the POST endpoint just returns uri and private_key if needed.
-      new_key = to_hash
+      new_key = to_h
       new_key["private_key"] = result["private_key"] if result["private_key"]
       Chef::Key.from_hash(new_key)
     end
@@ -175,12 +177,12 @@ class Chef
       # to @name.
       put_name = @name if put_name.nil?
 
-      new_key = chef_rest.put("#{api_base}/#{@actor}/keys/#{put_name}", to_hash)
+      new_key = chef_rest.put("#{api_base}/#{@actor}/keys/#{put_name}", to_h)
       # if the server returned a public_key, remove the create_key field, as we now have a key
       if new_key["public_key"]
         delete_create_key
       end
-      Chef::Key.from_hash(to_hash.merge(new_key))
+      Chef::Key.from_hash(to_h.merge(new_key))
     end
 
     def save

--- a/lib/chef/knife/client_edit.rb
+++ b/lib/chef/knife/client_edit.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ class Chef
           exit 1
         end
 
-        original_data = Chef::ApiClientV1.load(@client_name).to_hash
+        original_data = Chef::ApiClientV1.load(@client_name).to_h
         edited_client = edit_hash(original_data)
         if original_data != edited_client
           client = Chef::ApiClientV1.from_hash(edited_client)

--- a/lib/chef/knife/data_bag_show.rb
+++ b/lib/chef/knife/data_bag_show.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Falcon (<seth@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software, Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ class Chef
                       raw = Chef::EncryptedDataBagItem.load(@name_args[0],
                                                             @name_args[1],
                                                             secret)
-                      format_for_display(raw.to_hash)
+                      format_for_display(raw.to_h)
                     elsif encrypted && !secret
                       ui.warn("Encrypted data bag detected, but no secret provided for decoding. Displaying encrypted data.")
                       format_for_display(raw_data)

--- a/lib/chef/knife/osc_user_edit.rb
+++ b/lib/chef/knife/osc_user_edit.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ class Chef
           exit 1
         end
 
-        original_user = Chef::User.load(@user_name).to_hash
+        original_user = Chef::User.load(@user_name).to_h
         edited_user = edit_hash(original_user)
         if original_user != edited_user
           user = Chef::User.from_hash(edited_user)

--- a/lib/chef/knife/user_edit.rb
+++ b/lib/chef/knife/user_edit.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ EOF
           exit 1
         end
 
-        original_user = Chef::UserV1.load(@user_name).to_hash
+        original_user = Chef::UserV1.load(@user_name).to_h
         # DEPRECATION NOTE
         # Remove this if statement and corrosponding code post OSC 11 support.
         #

--- a/lib/chef/org.rb
+++ b/lib/chef/org.rb
@@ -58,7 +58,7 @@ class Chef
                     arg, kind_of: String)
     end
 
-    def to_hash
+    def to_h
       result = {
         "name" => @name,
         "full_name" => @full_name,
@@ -68,20 +68,22 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def create
       payload = { name: name, full_name: full_name }
       new_org = chef_rest.post("organizations", payload)
-      Chef::Org.from_hash(to_hash.merge(new_org))
+      Chef::Org.from_hash(to_h.merge(new_org))
     end
 
     def update
       payload = { name: name, full_name: full_name }
       new_org = chef_rest.put("organizations/#{name}", payload)
-      Chef::Org.from_hash(to_hash.merge(new_org))
+      Chef::Org.from_hash(to_h.merge(new_org))
     end
 
     def destroy

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -3,7 +3,7 @@
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2016 Chef Software, Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,7 @@ class Chef
         # interface we need to properly send this through to
         # events.run_list_expanded as it is expecting a RunListExpansion
         # object.
-        def to_hash
+        def to_h
           # It looks like version only gets populated in the expanded_run_list when
           # using a little used feature of roles to version lock cookbooks, so
           # version is not reliable in here anyway (places like Automate UI are
@@ -73,8 +73,10 @@ class Chef
           data_collector_hash
         end
 
+        alias_method :to_hash, :to_h
+
         def to_json(*opts)
-          to_hash.to_json(*opts)
+          to_h.to_json(*opts)
         end
       end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -682,7 +682,7 @@ class Chef
       Chef::JSONCompat.to_json(results, *a)
     end
 
-    def to_hash
+    def to_h
       # Grab all current state, then any other ivars (backcompat)
       result = {}
       self.class.state_properties.each do |p|
@@ -696,6 +696,8 @@ class Chef
       end
       result
     end
+
+    alias_method :to_hash, :to_h
 
     def self.from_hash(o)
       resource = new(o["instance_vars"]["@name"])

--- a/lib/chef/resource_collection/resource_collection_serialization.rb
+++ b/lib/chef/resource_collection/resource_collection_serialization.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tyler Ball (<tball@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ class Chef
   class ResourceCollection
     module ResourceCollectionSerialization
       # Serialize this object as a hash
-      def to_hash
+      def to_h
         instance_vars = Hash.new
         instance_variables.each do |iv|
           instance_vars[iv] = instance_variable_get(iv)
@@ -32,6 +32,8 @@ class Chef
             "instance_vars" => instance_vars,
         }
       end
+
+      alias_method :to_hash, :to_h
 
       def to_json(*a)
         Chef::JSONCompat.to_json(to_hash, *a)

--- a/lib/chef/role.rb
+++ b/lib/chef/role.rb
@@ -130,7 +130,7 @@ class Chef
       )
     end
 
-    def to_hash
+    def to_h
       env_run_lists_without_default = @env_run_lists.dup
       env_run_lists_without_default.delete("_default")
       result = {
@@ -152,9 +152,11 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     # Serialize this object as a hash
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def update_from!(o)

--- a/lib/chef/run_list/run_list_expansion.rb
+++ b/lib/chef/run_list/run_list_expansion.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -144,13 +144,15 @@ class Chef
       end
 
       def to_json(*a)
-        Chef::JSONCompat.to_json(to_hash, *a)
+        Chef::JSONCompat.to_json(to_h, *a)
       end
 
-      def to_hash
+      def to_h
         seen_items = { recipe: {}, role: {} }
         { id: @environment, run_list: convert_run_list_trace("top level", seen_items) }
       end
+
+      alias_method :to_hash, :to_h
 
       private
 

--- a/lib/chef/run_status.rb
+++ b/lib/chef/run_status.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,7 +102,7 @@ class Chef::RunStatus
   # * :updated_resources
   # * :exception
   # * :backtrace
-  def to_hash
+  def to_h
     # use a flat hash here so we can't errors from intermediate values being nil
     { node: node,
       success: success?,
@@ -115,6 +115,8 @@ class Chef::RunStatus
       backtrace: backtrace,
       run_id: run_id }
   end
+
+  alias_method :to_hash, :to_h
 
   # Returns a string of the format "ExceptionClass: message" or +nil+ if no
   # +exception+ is set.

--- a/lib/chef/user.rb
+++ b/lib/chef/user.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (steve@chef.io)
-# Copyright:: Copyright 2012-2016, Chef Software, Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,7 +77,7 @@ class Chef
                     arg, kind_of: String)
     end
 
-    def to_hash
+    def to_h
       result = {
         "name" => @name,
         "public_key" => @public_key,
@@ -88,8 +88,10 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def destroy
@@ -100,7 +102,7 @@ class Chef
       payload = { name: name, admin: admin, password: password }
       payload[:public_key] = public_key if public_key
       new_user = chef_rest_v0.post("users", payload)
-      Chef::User.from_hash(to_hash.merge(new_user))
+      Chef::User.from_hash(to_h.merge(new_user))
     end
 
     def update(new_key = false)
@@ -108,7 +110,7 @@ class Chef
       payload[:private_key] = new_key if new_key
       payload[:password] = password if password
       updated_user = chef_rest_v0.put("users/#{name}", payload)
-      Chef::User.from_hash(to_hash.merge(updated_user))
+      Chef::User.from_hash(to_h.merge(updated_user))
     end
 
     def save(new_key = false)

--- a/lib/chef/user_v1.rb
+++ b/lib/chef/user_v1.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (steve@chef.io)
-# Copyright:: Copyright 2012-2016, Chef Software, Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,7 +112,7 @@ class Chef
                     arg, kind_of: String)
     end
 
-    def to_hash
+    def to_h
       result = {
         "username" => @username,
       }
@@ -128,8 +128,10 @@ class Chef
       result
     end
 
+    alias_method :to_hash, :to_h
+
     def to_json(*a)
-      Chef::JSONCompat.to_json(to_hash, *a)
+      Chef::JSONCompat.to_json(to_h, *a)
     end
 
     def destroy
@@ -180,7 +182,7 @@ class Chef
         new_user = chef_root_rest_v0.post("users", payload)
       end
 
-      Chef::UserV1.from_hash(to_hash.merge(new_user))
+      Chef::UserV1.from_hash(to_h.merge(new_user))
     end
 
     def update(new_key = false)
@@ -213,7 +215,7 @@ class Chef
         end
         updated_user = chef_root_rest_v0.put("users/#{username}", payload)
       end
-      Chef::UserV1.from_hash(to_hash.merge(updated_user))
+      Chef::UserV1.from_hash(to_h.merge(updated_user))
     end
 
     def save(new_key = false)
@@ -229,7 +231,7 @@ class Chef
     # Note: remove after API v0 no longer supported by client (and knife command).
     def reregister
       begin
-        payload = to_hash.merge({ "private_key" => true })
+        payload = to_h.merge({ "private_key" => true })
         reregistered_self = chef_root_rest_v0.put("users/#{username}", payload)
         private_key(reregistered_self["private_key"])
       # only V0 supported for reregister

--- a/spec/unit/audit/audit_reporter_spec.rb
+++ b/spec/unit/audit/audit_reporter_spec.rb
@@ -53,7 +53,7 @@ describe Chef::Audit::AuditReporter do
   describe "#run_completed" do
 
     let(:audit_data) { Chef::Audit::AuditData.new(node.name, run_id) }
-    let(:run_data) { audit_data.to_hash }
+    let(:run_data) { audit_data.to_h }
 
     before do
       allow(reporter).to receive(:auditing_enabled?).and_return(true)
@@ -61,7 +61,7 @@ describe Chef::Audit::AuditReporter do
       allow(rest).to receive(:post).and_return(true)
       allow(reporter).to receive(:audit_data).and_return(audit_data)
       allow(reporter).to receive(:run_status).and_return(run_status)
-      allow(audit_data).to receive(:to_hash).and_return(run_data)
+      allow(audit_data).to receive(:to_h).and_return(run_data)
     end
 
     describe "a successful run with auditing enabled" do
@@ -233,7 +233,7 @@ EOM
   describe "#run_failed" do
 
     let(:audit_data) { Chef::Audit::AuditData.new(node.name, run_id) }
-    let(:run_data) { audit_data.to_hash }
+    let(:run_data) { audit_data.to_h }
 
     let(:audit_error) do
       double("AuditError", class: "Chef::Exceptions::AuditError",
@@ -249,7 +249,7 @@ EOM
       allow(reporter).to receive(:auditing_enabled?).and_return(true)
       allow(reporter).to receive(:run_status).and_return(run_status)
       allow(reporter).to receive(:audit_data).and_return(audit_data)
-      allow(audit_data).to receive(:to_hash).and_return(run_data)
+      allow(audit_data).to receive(:to_h).and_return(run_data)
     end
 
     context "when no prior exception is stored" do

--- a/spec/unit/audit/control_group_data_spec.rb
+++ b/spec/unit/audit/control_group_data_spec.rb
@@ -2,7 +2,7 @@
 # Author:: Tyler Ball (<tball@chef.io>)
 # Author:: Claire McQuin (<claire@chef.io>)
 #
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,9 +57,9 @@ describe Chef::Audit::AuditData do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
 
-    let(:audit_data_hash) { audit_data.to_hash }
+    let(:audit_data_hash) { audit_data.to_h }
 
     it "returns a hash" do
       expect(audit_data_hash).to be_a(Hash)
@@ -90,7 +90,7 @@ describe Chef::Audit::AuditData do
         end
 
         it "is a one-element list containing the control group hash" do
-          expect(control_group_1).to receive(:to_hash).once.and_return(control_hash_1)
+          expect(control_group_1).to receive(:to_h).once.and_return(control_hash_1)
           expect(control_groups.size).to eq 1
           expect(control_groups).to include(control_hash_1)
         end
@@ -103,8 +103,8 @@ describe Chef::Audit::AuditData do
         end
 
         it "is a list of control group hashes" do
-          expect(control_group_1).to receive(:to_hash).and_return(control_hash_1)
-          expect(control_group_2).to receive(:to_hash).and_return(control_hash_2)
+          expect(control_group_1).to receive(:to_h).and_return(control_hash_1)
+          expect(control_group_2).to receive(:to_h).and_return(control_hash_2)
           expect(control_groups.size).to eq 2
           expect(control_groups).to include(control_hash_1)
           expect(control_groups).to include(control_hash_2)
@@ -127,9 +127,9 @@ describe Chef::Audit::ControlData do
                         resource_type: resource_type, resource_name: resource_name,
                         context: context, line_number: line_number) end
 
-  describe "#to_hash" do
+  describe "#to_h" do
 
-    let(:control_data_hash) { control_data.to_hash }
+    let(:control_data_hash) { control_data.to_h }
 
     it "returns a hash" do
       expect(control_data_hash).to be_a(Hash)
@@ -385,9 +385,9 @@ describe Chef::Audit::ControlGroupData do
     end
   end
 
-  describe "#to_hash" do
+  describe "#to_h" do
 
-    let(:control_group_data_hash) { control_group_data.to_hash }
+    let(:control_group_data_hash) { control_group_data.to_h }
 
     it "returns a hash" do
       expect(control_group_data_hash).to be_a(Hash)
@@ -413,11 +413,11 @@ describe Chef::Audit::ControlGroupData do
         include_context "control"
 
         let(:control_list) { [control_data] }
-        let(:control_hash) { control.to_hash }
+        let(:control_hash) { control.to_h }
 
         before do
           expect(control_group_data).to receive(:controls).twice.and_return(control_list)
-          expect(control_data).to receive(:to_hash).and_return(control_hash)
+          expect(control_data).to receive(:to_h).and_return(control_hash)
         end
 
         it "is a one-element list containing the control hash" do
@@ -426,7 +426,7 @@ describe Chef::Audit::ControlGroupData do
         end
 
         it "adds a sequence number to the control" do
-          control_group_data.to_hash
+          control_group_data.to_h
           expect(control_hash).to have_key(:sequence_number)
         end
 
@@ -441,15 +441,15 @@ describe Chef::Audit::ControlGroupData do
         let(:control_1) do
           double("control 1",
           line_number: control_hash_1[:line_number],
-          to_hash: control_hash_1) end
+          to_h: control_hash_1) end
         let(:control_2) do
           double("control 2",
           line_number: control_hash_2[:line_number],
-          to_hash: control_hash_2) end
+          to_h: control_hash_2) end
         let(:control_3) do
           double("control 3",
           line_number: control_hash_3[:line_number],
-          to_hash: control_hash_3) end
+          to_h: control_hash_3) end
 
         let(:control_list) { [control_1, control_2, control_3] }
         let(:ordered_control_hashes) { [control_hash_2, control_hash_1, control_hash_3] }
@@ -470,7 +470,7 @@ describe Chef::Audit::ControlGroupData do
         end
 
         it "assigns sequence numbers in order" do
-          control_group_data.to_hash
+          control_group_data.to_h
           ordered_control_hashes.each_with_index do |control_hash, idx|
             expect(control_hash[:sequence_number]).to eq idx + 1
           end

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
to_hash on a lot of these objects should go away, but even eliminating
all our calls to to_hash on these objects internally is difficult.

(e.g. converting the knife ui code to call #to_h means we wind up
calling nil#to_h which "helpfully" becomes '{}' which is hilarious and
i don't know why someone thought that was a good idea).

rationale:  https://zverok.github.io/blog/2016-01-18-implicit-vs-expicit.html