### PR TITLE
[chef/chef]Fix duplicate logs

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,7 +205,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      !(Chef::Config.is_default?(Chef::Config[:log_location]) || STDOUT.closed? || Chef::Config[:daemonize])
+      ( Chef::Config[:log_location].class != IO ) && STDOUT.tty? && !Chef::Config[:daemonize]
     end
 
     def configure_stdout_logger

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -205,7 +205,7 @@ class Chef
     # Based on config and whether or not STDOUT is a tty, should we setup a
     # secondary logger for stdout?
     def want_additional_logger?
-      Chef::Config.is_default?(:log_location) && Chef::Config[:log_location].tty? && !Chef::Config[:daemonize]
+      !(Chef::Config.is_default?(Chef::Config[:log_location]) || STDOUT.closed? || Chef::Config[:daemonize])
     end
 
     def configure_stdout_logger

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -80,8 +80,5 @@ class Chef
       end
     end
 
-    def self.is_default?(key)
-      key.is_a?(IO)
-    end
   end
 end

--- a/lib/chef/config.rb
+++ b/lib/chef/config.rb
@@ -80,5 +80,8 @@ class Chef
       end
     end
 
+    def self.is_default?(key)
+      key.is_a?(IO)
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

This fixes the duplicate logs for `log_location` 

### Issues Resolved

fixes https://github.com/chef/chef/issues/7184

Manual testing completed : 

1. With chef-client
  a) when :log_location is set STDOUT
```
[azure@dh-rhel chef]$ bundle exec chef-client -z -o starter -c ../chef-repo/client.rb
[2018-09-27T05:31:18-04:00] INFO: Started chef-zero at chefzero://localhost:1 with repository at /home/azure/chef-repo
  One version per cookbook

Starting Chef Client, version 14.5.24
[2018-09-27T05:31:18-04:00] INFO: *** Chef 14.5.24 ***
[2018-09-27T05:31:18-04:00] INFO: Platform: x86_64-linux
[2018-09-27T05:31:18-04:00] INFO: Chef-client pid: 120873
[2018-09-27T05:31:18-04:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-09-27T05:31:22-04:00] WARN: Run List override has been provided.
[2018-09-27T05:31:22-04:00] WARN: Original Run List: [recipe[starter]]
[2018-09-27T05:31:22-04:00] WARN: Overridden Run List: [recipe[starter]]
[2018-09-27T05:31:22-04:00] INFO: Run List is [recipe[starter]]
[2018-09-27T05:31:22-04:00] INFO: Run List expands to [starter]
[2018-09-27T05:31:22-04:00] INFO: Starting Chef Run for dh-rhel.vqnxmzhfoz1exeiqi3rsinisrd.dx.internal.cloudapp.net
[2018-09-27T05:31:22-04:00] INFO: Running start handlers
[2018-09-27T05:31:22-04:00] INFO: Start handlers complete.
resolving cookbooks for run list: ["starter"]
[2018-09-27T05:31:22-04:00] INFO: Loading cookbooks [starter@0.1.0]
[2018-09-27T05:31:22-04:00] INFO: Skipping removal of obsoleted cookbooks from the cache
Synchronizing Cookbooks:
  - starter (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: starter::default
  * log[Welcome to Chef, #{node["starter_name"]}!] action write[2018-09-27T05:31:23-04:00] INFO: Processing log[Welcome to Chef, #{node["starter_name"]}!] action write (starter::default line 9)
[2018-09-27T05:31:23-04:00] INFO: Welcome to Chef, #{node["starter_name"]}!


[2018-09-27T05:31:23-04:00] WARN: Skipping final node save because override_runlist was given
[2018-09-27T05:31:23-04:00] INFO: Chef Run complete in 0.102184799 seconds
[2018-09-27T05:31:23-04:00] INFO: Skipping removal of unused files from the cache

Running handlers:
[2018-09-27T05:31:23-04:00] INFO: Running report handlers
Running handlers complete
[2018-09-27T05:31:23-04:00] INFO: Report handlers complete
Chef Client finished, 1/1 resources updated in 04 seconds
[azure@dh-rhel chef]$
```
  b) when :log_location is set to a file "/path/to/logfile"
```
[azure@dh-rhel chef]$ bundle exec chef-client -z -o starter -c ../chef-repo/client.rb
[2018-09-27T05:23:25-04:00] INFO: Started chef-zero at chefzero://localhost:1 with repository at /home/azure/chef-repo
  One version per cookbook

Starting Chef Client, version 14.5.24
[2018-09-27T05:23:25-04:00] INFO: *** Chef 14.5.24 ***
[2018-09-27T05:23:25-04:00] INFO: Platform: x86_64-linux
[2018-09-27T05:23:25-04:00] INFO: Chef-client pid: 120415
[2018-09-27T05:23:25-04:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-09-27T05:23:29-04:00] WARN: Run List override has been provided.
[2018-09-27T05:23:29-04:00] WARN: Original Run List: [recipe[starter]]
[2018-09-27T05:23:29-04:00] WARN: Overridden Run List: [recipe[starter]]
[2018-09-27T05:23:29-04:00] INFO: Run List is [recipe[starter]]
[2018-09-27T05:23:29-04:00] INFO: Run List expands to [starter]
[2018-09-27T05:23:29-04:00] INFO: Starting Chef Run for dh-rhel.vqnxmzhfoz1exeiqi3rsinisrd.dx.internal.cloudapp.net
[2018-09-27T05:23:29-04:00] INFO: Running start handlers
[2018-09-27T05:23:29-04:00] INFO: Start handlers complete.
resolving cookbooks for run list: ["starter"]
[2018-09-27T05:23:29-04:00] INFO: Loading cookbooks [starter@0.1.0]
[2018-09-27T05:23:29-04:00] INFO: Skipping removal of obsoleted cookbooks from the cache
Synchronizing Cookbooks:
  - starter (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: starter::default
  * log[Welcome to Chef, #{node["starter_name"]}!] action write[2018-09-27T05:23:29-04:00] INFO: Processing log[Welcome to Chef, #{node["starter_name"]}!] action write (starter::default line 9)
[2018-09-27T05:23:29-04:00] INFO: Welcome to Chef, #{node["starter_name"]}!


[2018-09-27T05:23:29-04:00] WARN: Skipping final node save because override_runlist was given
[2018-09-27T05:23:29-04:00] INFO: Chef Run complete in 0.0932818 seconds
[2018-09-27T05:23:29-04:00] INFO: Skipping removal of unused files from the cache

Running handlers:
[2018-09-27T05:23:29-04:00] INFO: Running report handlers
Running handlers complete
[2018-09-27T05:23:29-04:00] INFO: Report handlers complete
Chef Client finished, 1/1 resources updated in 03 seconds
[azure@dh-rhel chef]$
```
2. With chef-apply
  a) when :log_location is set STDOUT
```
[azure@dh-rhel chef]$ bundle exec chef-apply ../chef-repo/cookbooks/starter/recipes/default.rb -c ../chef-repo/client.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * log[Welcome to Chef, #{node["starter_name"]}!] action write

[azure@dh-rhel chef]$
```
  b) when :log_location is set to a file "/path/to/logfile"
```
[azure@dh-rhel chef]$ bundle exec chef-apply ../chef-repo/cookbooks/starter/recipes/default.rb -c ../chef-repo/client.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * log[Welcome to Chef, #{node["starter_name"]}!] action write

[azure@dh-rhel chef]$
```
3. With chef-solo
a) when :log_location is set STDOUT
```
[azure@dh-rhel chef]$ bundle exec chef-solo -j ../chef-repo/node.json -c ../chef-repo/client.rb
[2018-09-27T05:42:38-04:00] INFO: Started chef-zero at chefzero://localhost:1 with repository at /home/azure/chef-repo
  One version per cookbook

Starting Chef Client, version 14.5.24
[2018-09-27T05:42:39-04:00] INFO: *** Chef 14.5.24 ***
[2018-09-27T05:42:39-04:00] INFO: Platform: x86_64-linux
[2018-09-27T05:42:39-04:00] INFO: Chef-client pid: 121894
[2018-09-27T05:42:39-04:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-09-27T05:42:42-04:00] INFO: Setting the run_list to ["recipe[starter]"] from CLI options
[2018-09-27T05:42:42-04:00] INFO: Run List is [recipe[starter]]
[2018-09-27T05:42:42-04:00] INFO: Run List expands to [starter]
[2018-09-27T05:42:42-04:00] INFO: Starting Chef Run for dh-rhel.vqnxmzhfoz1exeiqi3rsinisrd.dx.internal.cloudapp.net
[2018-09-27T05:42:42-04:00] INFO: Running start handlers
[2018-09-27T05:42:42-04:00] INFO: Start handlers complete.
resolving cookbooks for run list: ["starter"]
[2018-09-27T05:42:42-04:00] INFO: Loading cookbooks [starter@0.1.0]
Synchronizing Cookbooks:
  - starter (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: starter::default
  * log[Welcome to Chef, #{node["starter_name"]}!] action write[2018-09-27T05:42:42-04:00] INFO: Processing log[Welcome to Chef, #{node["starter_name"]}!] action write (starter::default line 9)
[2018-09-27T05:42:42-04:00] INFO: Welcome to Chef, #{node["starter_name"]}!


[2018-09-27T05:42:42-04:00] INFO: Chef Run complete in 0.154306601 seconds

Running handlers:
[2018-09-27T05:42:42-04:00] INFO: Running report handlers
Running handlers complete
[2018-09-27T05:42:42-04:00] INFO: Report handlers complete
Chef Client finished, 1/1 resources updated in 03 seconds
[azure@dh-rhel chef]$
```
b) when :log_location is set to a file "/path/to/logfile"
```
[azure@dh-rhel chef]$ bundle exec chef-solo -j ../chef-repo/node.json -c ../chef-repo/client.rb
[2018-09-27T05:44:23-04:00] INFO: Started chef-zero at chefzero://localhost:1 with repository at /home/azure/chef-repo
  One version per cookbook

Starting Chef Client, version 14.5.24
[2018-09-27T05:44:23-04:00] INFO: *** Chef 14.5.24 ***
[2018-09-27T05:44:23-04:00] INFO: Platform: x86_64-linux
[2018-09-27T05:44:23-04:00] INFO: Chef-client pid: 122184
[2018-09-27T05:44:23-04:00] INFO: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
[2018-09-27T05:44:26-04:00] INFO: Setting the run_list to ["recipe[starter]"] from CLI options
[2018-09-27T05:44:26-04:00] INFO: Run List is [recipe[starter]]
[2018-09-27T05:44:26-04:00] INFO: Run List expands to [starter]
[2018-09-27T05:44:26-04:00] INFO: Starting Chef Run for dh-rhel.vqnxmzhfoz1exeiqi3rsinisrd.dx.internal.cloudapp.net
[2018-09-27T05:44:26-04:00] INFO: Running start handlers
[2018-09-27T05:44:26-04:00] INFO: Start handlers complete.
resolving cookbooks for run list: ["starter"]
[2018-09-27T05:44:27-04:00] INFO: Loading cookbooks [starter@0.1.0]
Synchronizing Cookbooks:
  - starter (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: starter::default
  * log[Welcome to Chef, #{node["starter_name"]}!] action write[2018-09-27T05:44:27-04:00] INFO: Processing log[Welcome to Chef, #{node["starter_name"]}!] action write (starter::default line 9)
[2018-09-27T05:44:27-04:00] INFO: Welcome to Chef, #{node["starter_name"]}!


[2018-09-27T05:44:27-04:00] INFO: Chef Run complete in 0.1637457 seconds

Running handlers:
[2018-09-27T05:44:27-04:00] INFO: Running report handlers
Running handlers complete
[2018-09-27T05:44:27-04:00] INFO: Report handlers complete
Chef Client finished, 1/1 resources updated in 04 seconds
[azure@dh-rhel chef]$
```

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
