### PR TITLE
short circuit before the version_compare call

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -496,7 +496,7 @@ class Chef
                 elsif current_version.nil?
                   logger.trace("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
                   target_version_array.push(candidate_version)
-                elsif version_compare(current_version, candidate_version) == 1 && !allow_downgrade
+                elsif !allow_downgrade && version_compare(current_version, candidate_version) == 1
                   logger.trace("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{candidate_version}. Skipping...)")
                   target_version_array.push(nil)
                 else


### PR DESCRIPTION
combined with the other PRs this will make most of the
subclasses never even call version_compare now.

the subclasses that need allow_downgrade as a feature
should implement both the property and implement
version_compare now.
