### PR TITLE
fixed typo in description property of rhsm_errata_level resource

### DIFF
--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -33,7 +33,7 @@ class Chef
                name_property: true
 
       action :install do
-        descripton "Install all packages of the specified errata level."
+        description "Install all packages of the specified errata level."
 
         yum_package "yum-plugin-security" do
           action :install


### PR DESCRIPTION
Signed-off-by: Joshua Colson <joshua.colson@gmail.com>

### Description

There is a misspelling in the 'description' property of the rhsm_errata_level resource. The problem causes chef-client to throw an exception when attempting to call the :install action.

### Issues Resolved

I did not create an issue for this as it is such a simple bug.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
