### PR TITLE
chocolatey_source: add support for enable/disable and user/pw

### DIFF
--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -36,10 +36,12 @@ class Chef
                description: "The priority level of the source."
 
       property :user, String,
-               description: "The username to authenticate to the source"
+               introduced: "14.6",
+               description: "The username to authenticate to the source."
 
       property :password, String,
-               description: "The password to authenticate to the source"
+               introduced: "14.6",
+               description: "The password to authenticate to the source."
 
       load_current_value do
         element = fetch_source_element(source_name)
@@ -87,6 +89,7 @@ class Chef
       end
 
       action :enable do
+        introduced "14.6",
         description "Enables a Chocolatey source."
 
         if current_resource
@@ -97,6 +100,7 @@ class Chef
       end
 
       action :disable do
+        introduced "14.6",
         description "Disables a Chocolatey source."
 
         if current_resource

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -36,11 +36,11 @@ class Chef
                description: "The priority level of the source."
 
       property :user, String,
-               introduced: "14.6"
+               introduced: "14.6",
                description: "The username to authenticate to the source."
 
       property :password, String,
-               introduced: "14.6"
+               introduced: "14.6",
                description: "The password to authenticate to the source.",
                sensitive: true
 

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -36,12 +36,13 @@ class Chef
                description: "The priority level of the source."
 
       property :user, String,
-               introduced: "14.6",
+               introduced: "14.6"
                description: "The username to authenticate to the source."
 
       property :password, String,
-               introduced: "14.6",
-               description: "The password to authenticate to the source."
+               introduced: "14.6"
+               description: "The password to authenticate to the source.",
+               sensitive: true
 
       load_current_value do
         element = fetch_source_element(source_name)
@@ -89,22 +90,22 @@ class Chef
       end
 
       action :enable do
-        introduced "14.6",
+        introduced "14.6"
         description "Enables a Chocolatey source."
 
         if current_resource
-          converge_by("enable Chocolatey source '#{new_resource.source_name}'") do
+          converge_if_changed("enable Chocolatey source '#{new_resource.source_name}'") do
             shell_out!(choco_cmd("enable"))
           end
         end
       end
 
       action :disable do
-        introduced "14.6",
+        introduced "14.6"
         description "Disables a Chocolatey source."
 
         if current_resource
-          converge_by("disable Chocolatey source '#{new_resource.source_name}'") do
+          converge_if_changed("disable Chocolatey source '#{new_resource.source_name}'") do
             shell_out!(choco_cmd("disable"))
           end
         end

--- a/spec/unit/resource/chocolatey_source_spec.rb
+++ b/spec/unit/resource/chocolatey_source_spec.rb
@@ -66,9 +66,11 @@ CONFIG
     expect(resource.action).to eql([:add])
   end
 
-  it "supports :add and :remove actions" do
+  it "supports :add, :remove, :enable, :disable actions" do
     expect { resource.action :add }.not_to raise_error
     expect { resource.action :remove }.not_to raise_error
+    expect { resource.action :enable }.not_to raise_error
+    expect { resource.action :disable }.not_to raise_error
   end
 
   it "bypass_proxy property defaults to false" do


### PR DESCRIPTION
### Description

Adds support to enable & disable chocolatey sources along with adding sources with a username and password, if desired.

### Issues Resolved

No outstanding issues- only discussed in the community Slack.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
