### PR TITLE
add some detail to reporting for user/group mods (NEED HELP)

### DIFF
--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -105,7 +105,7 @@ class Chef
             @change_desc << "remove existing member(s): #{members_to_be_removed.join(', ')}"
           end
         elsif new_resource.members != current_resource.members
-          @change_desc << "replace group members with new list of members"
+          @change_desc << "replace group members (#{current_resource.members}) with new list of members (#{new_resource.members})"
         end
 
         !@change_desc.empty?

--- a/spec/unit/provider/group_spec.rb
+++ b/spec/unit/provider/group_spec.rb
@@ -267,7 +267,7 @@ describe Chef::Provider::User do
       @new_resource.members << "user1"
       allow(@new_resource).to receive(:append).and_return false
       expect(@provider.compare_group).to be_truthy
-      expect(@provider.change_desc).to eq([ "replace group members with new list of members" ])
+      expect(@provider.change_desc).to eq([ "replace group members (#{@current_resource.members}) with new list of members(#{new_resource.members})" ])
     end
 
     it "should report the gid will be changed when it does not match" do


### PR DESCRIPTION
Signed-off-by: Bishop Clark <bishopolis@gmail.com>

### Description

This minor patch provides added detail around user and group changes.  Instead of 
 - would alter group replace group members with new list of members

This change reports 
 - would alter group replace group members ([dave, bob]) with new list of members ([bob, doug])

Similar detail was added to converge_by messages for user mods (uid, homedir, etc)

Just messages changes.

### Issues Resolved


### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
