### PR TITLE
windows_ad_join: validate ad user format

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -38,7 +38,7 @@ class Chef
       property :domain_user, String,
                description: "The domain user that will be used to join the domain.",
                validation_message: "The 'domain_user' property must be in the 'DOMAIN\\username' format.",
-               regex: /.+\\.+/, #anything\anything
+               regex: /.+\\.+/, # anything\anything
                required: true
 
       property :domain_password, String,

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -37,6 +37,8 @@ class Chef
 
       property :domain_user, String,
                description: "The domain user that will be used to join the domain.",
+               validation_message: "The 'domain_user' property must be in the 'DOMAIN\\username' format.",
+               regex: /.+\\.+/, #anything\anything
                required: true
 
       property :domain_password, String,

--- a/spec/unit/resource/windows_ad_join_spec.rb
+++ b/spec/unit/resource/windows_ad_join_spec.rb
@@ -40,6 +40,10 @@ describe Chef::Resource::WindowsAdJoin do
     expect { resource.domain_name "example" }.to raise_error(ArgumentError)
   end
 
+  it "only accepts DOMAIN\\username as the domain_user property" do
+    expect { resource.domain_user "username" }.to raise_error(ArgumentError)
+  end
+
   it "accepts :immediate, :reboot_now, :request_reboot, :delayed, or :never values for 'reboot' property" do
     expect { resource.reboot :immediate }.not_to raise_error
     expect { resource.reboot :delayed }.not_to raise_error


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

Validates `domain_user` to be in the `DOMAIN\username` format.

### Issues Resolved

https://github.com/chef/chef/issues/7715

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
