### PR TITLE
Fix chef-apply crash for reboot

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -191,10 +191,12 @@ class Chef::Application::Apply < Chef::Application
     recipe, run_context = get_recipe_and_run_context
     recipe.instance_eval(@recipe_text, @recipe_filename, 1)
     runner = Chef::Runner.new(run_context)
-    begin
-      runner.converge
-    ensure
-      @recipe_fh.close
+    catch(:end_client_run_early) do
+      begin
+        runner.converge
+      ensure
+        @recipe_fh.close
+      end
     end
     Chef::Platform::Rebooter.reboot_if_needed!(runner)
   end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

Per issue when we use the reboot resource with chef-apply then it crashes and returns `UncaughtThrowError`. So updated code handles the `UncaughtThrowError` and also reboot the machine.


### Issues Resolved
Fixes https://github.com/chef/chef/issues/4088

### Output after code update
```
PS C:\Users\azure\chef> bundle exec chef-apply C:\reboot.rb

Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * reboot[foo] action reboot_now[2018-10-04T12:03:38+00:00] WARN: Rebooting system immediately, requested by 'foo'
[2018-10-04T12:03:38+00:00] WARN: Rebooting system immediately, requested by 'foo'
[2018-10-04T12:03:38+00:00] WARN: Rebooting server at a recipe's request. Details: {:delay_mins=>2, :reason=>"Reboot by
Chef", :timestamp=>2018-10-04 12:03:38 +0000, :requested_by=>"foo"}
[2018-10-04T12:03:38+00:00] WARN: Rebooting server at a recipe's request. Details: {:delay_mins=>2, :reason=>"Reboot by
Chef", :timestamp=>2018-10-04 12:03:38 +0000, :requested_by=>"foo"}
[2018-10-04T12:03:38+00:00] FATAL: Stacktrace dumped to C:/chef/cache/chef-stacktrace.out
[2018-10-04T12:03:38+00:00] FATAL: Stacktrace dumped to C:/chef/cache/chef-stacktrace.out
[2018-10-04T12:03:38+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2018-10-04T12:03:38+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2018-10-04T12:03:38+00:00] FATAL: Chef::Exceptions::Reboot: Rebooting server at a recipe's request. Details: {:delay_mi
ns=>2, :reason=>"Reboot by Chef", :timestamp=>2018-10-04 12:03:38 +0000, :requested_by=>"foo"}
[2018-10-04T12:03:38+00:00] FATAL: Chef::Exceptions::Reboot: Rebooting server at a recipe's request. Details: {:delay_mi
ns=>2, :reason=>"Reboot by Chef", :timestamp=>2018-10-04 12:03:38 +0000, :requested_by=>"foo"}
PS C:\Users\azure\chef>
```