### PR TITLE
Honor chef_server_url for sandbox uploads

### DIFF
--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -77,7 +77,8 @@ class Chef
 
       queue.process(@concurrency)
 
-      sandbox_url = new_sandbox["uri"]
+      sandbox_url = URI.parse(Chef::Config[:chef_server_url])
+      sandbox_url.path = URI.parse(new_sandbox["uri"]).path
       Chef::Log.trace("Committing sandbox")
       # Retry if S3 is claims a checksum doesn't exist (the eventual
       # in eventual consistency)


### PR DESCRIPTION
### Description

Chef uploads cookbooks transactionally by generating a unique sandbox
URL to upload all the associated files to using a "POST
/organizations/<organization>/sandboxes" operation.

This POST operation returns the URL of the sandbox that should then be
used to PUT the cookbook's files to. This URL is pre-resolved, based on
the configuration of the chef server, which can be different from what
is configured in the client.

In special cases of network configuration, this discrepancy forces the
client to use a URL with a non-resolvable or unreachable host for
uploading cookbooks, rather than the scheme/host/port configured with
chef_server_url.

This change parses the sandbox URL returned by the server "POST
/organizations/<organization>/sandboxes" operation, and rewrites
it honor the chef_server_url configuration for subsequent cookbook PUT operations.

### Issues Resolved

- Does not resolve, but is semi-related to https://github.com/chef/chef-server/issues/50

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
