### PR TITLE
Enable x86_64-linux-kernel2 habitat builds for chef-client

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -19,7 +19,8 @@ docker_images:
   - chef
 
 habitat_packages:
-  - chef-client
+  - chef-client:
+      also_build_for_linux_kernel2: true
 
 github:
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file


### PR DESCRIPTION
This PR enables Habitat package builds of chef-client for the x86_64-linux-kernel2 PackageTarget

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>
