### PR TITLE
Only include the Windows distro files on Windows

### DIFF
--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -16,7 +16,7 @@ gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 1.0.0"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
-gemspec.files += %w{ext/win32-eventlog/Rakefile ext/win32-eventlog/chef-log.man}
+gemspec.files += Dir.glob("{distro,ext}/**/*")
 
 gemspec.executables += %w{ chef-service-manager chef-windows-service }
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -59,5 +59,5 @@ Gem::Specification.new do |s|
   s.executables  = %w{ chef-client chef-solo knife chef-shell chef-apply chef-resource-inspector }
 
   s.require_paths = %w{ lib }
-  s.files = %w{Gemfile Rakefile LICENSE README.md CONTRIBUTING.md VERSION} + Dir.glob("{distro,lib,lib-backcompat,tasks,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
+  s.files = %w{Gemfile Rakefile LICENSE README.md VERSION} + Dir.glob("{lib,lib-backcompat,tasks,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
 end


### PR DESCRIPTION
We don't actually need these powershell scripts and DLLs on non-Windows platforms. This shaves 300k from our gem size on non-Windows platforms.

I skipped the contributing.md file as well which is useless in a Ruby install.

Signed-off-by: Tim Smith <tsmith@chef.io>