### PR TITLE
Throw better error on invalid resources actions

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -175,8 +175,8 @@ class Chef
             return true if value == tb
           end
           # Ruby will print :something as something, which confuses users so make sure to print them as symbols
-          corrected_type_array = to_be.collect { |x| x.kind_of?(Symbol) ? ":#{x}" : x }
-          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{corrected_type_array.join(", ")}!  You passed #{value.inspect}.")
+          # by inspecting the value instead of just printing it
+          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{to_be.map { |v| v.inspect }.join(", ")}!  You passed #{value.inspect}.")
         end
       end
 

--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -174,7 +174,9 @@ class Chef
           to_be.each do |tb|
             return true if value == tb
           end
-          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{to_be.join(", ")}!  You passed #{value.inspect}.")
+          # Ruby will print :something as something, which confuses users so make sure to print them as symbols
+          corrected_type_array = to_be.collect { |x| x.kind_of?(Symbol) ? ":#{x}" : x }
+          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{corrected_type_array.join(", ")}!  You passed #{value.inspect}.")
         end
       end
 


### PR DESCRIPTION
Right now if a user enters an incorrect action they get a message like
this that doesn't print the actions as being symbols. That's super
confusing to new users and results in random cookbook bugs from time to
time.

[2018-10-07T13:26:39-07:00] FATAL: Chef::Exceptions::ValidationFailed: Option action must be equal to one of: nothing, create, remove, modify, manage, lock, unlock!  You passed :whatever.

With this change we properly print out symbols as symbols so it's clear
what the available values are.

[2018-10-07T13:24:09-07:00] FATAL: Chef::Exceptions::ValidationFailed: Option action must be equal to one of: :nothing, :create, :remove, :modify, :manage, :lock, :unlock!  You passed :whatever.

It's a small thing, but I think this will have a pretty big impact on
first time users. This one tripped me up when I first started.

Signed-off-by: Tim Smith <tsmith@chef.io>