### PR TITLE
Tune appveyor skip to only version bumps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ clone_depth: 1
 
 skip_commits:
   # version bumps by Expeditor happen as a separate commit after the merge, we can skip
-  author: Chef Expeditor
+  message: /Bump version to [0-9.]+ by Chef Expeditor/
   # if ONLY the files listed below are changed in a commit, skip
   files:
     - MAINTAINERS.md


### PR DESCRIPTION
The Chef repo has Expeditor subscriptions to other repos which
automatically create a PR to bump versions of those dependencies in Chef
when they're released. We were skipping all commits in Appveyor by 'Chef
Expeditor' to avoid testing the automatic version bump commits that
happen on every merge to master.

This change will only skip the version bumps.