### PR TITLE
Bump win32-taskscheduler to 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ PATH
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
       win32-service (~> 1.0)
-      win32-taskscheduler (~> 1.0.0)
+      win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
 
@@ -340,7 +340,7 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.12)
+    win32-taskscheduler (2.0.0)
       ffi
       structured_warnings
     windows-api (0.4.4)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -14,7 +14,7 @@ gemspec.add_dependency "win32-process", "~> 0.8.2"
 gemspec.add_dependency "win32-service", "~> 1.0"
 gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
-gemspec.add_dependency "win32-taskscheduler", "~> 1.0.0"
+gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 


### PR DESCRIPTION
We refactored a number of the helper methods to more safely namespace
them. Nothing should be using those methods outside of
win32-taskscheduler, but we bumped the major version because of the
change.