### PR TITLE
Node Attributes: Build ImmutableMash properly in deep_merge!

### DIFF
--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -403,11 +403,11 @@ class Chef
       end
 
       def combined_override(*path)
-        immutablize(merge_overrides(path))
+        merge_overrides(path)
       end
 
       def combined_default(*path)
-        immutablize(merge_defaults(path))
+        merge_defaults(path)
       end
 
       def normal_unless(*args)
@@ -599,9 +599,9 @@ class Chef
         # In all other cases, replace merge_onto with merge_with
         else
           if merge_with.kind_of?(Hash)
-            Chef::Node::VividMash.new(merge_with)
+            Chef::Node::ImmutableMash.new(merge_with)
           elsif merge_with.kind_of?(Array)
-            Chef::Node::AttrArray.new(merge_with)
+            Chef::Node::ImmutableArray.new(merge_with)
           else
             merge_with
           end


### PR DESCRIPTION
closes #7738

The root cause here is that there's a difference between doing

Chef::Node::VividMash.new( <another VividMash> )

And:

Chef::Node::ImmutableMash.new( <a VividMash> )

The former short circuits and does no work in convert_value.  The
latter will not short circuit and does the proper work to dup
and convert the value argument.

Since we build an ImmutableMash now, we do not need to wrap it
with the extra immutablize() call.

This should be perf neutral or very, very slightly better perf.
