### PR TITLE
File provider:  fix sticky bits management / preservation

### DIFF
--- a/lib/chef/file_content_management/deploy/mv_unix.rb
+++ b/lib/chef/file_content_management/deploy/mv_unix.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,9 +44,6 @@ class Chef
 
           Chef::Log.trace("Applying mode = #{mode.to_s(8)}, uid = #{uid}, gid = #{gid} to #{src}")
 
-          # i own the inode, so should be able to at least chmod it
-          ::File.chmod(mode, src)
-
           # we may be running as non-root in which case because we are doing an mv we cannot preserve
           # the file modes.  after the mv we have a different inode and if we don't have rights to
           # chown/chgrp on the inode then we can't fix the ownership.
@@ -66,6 +63,10 @@ class Chef
           rescue Errno::EPERM
             Chef::Log.warn("Could not set gid = #{gid} on #{src}, file modes not preserved")
           end
+
+          # i own the inode, so should be able to at least chmod it
+          # NOTE: this must come last due to POSIX stripping sticky mode bits on chown/chgrp
+          ::File.chmod(mode, src)
 
           Chef::Log.trace("Moving temporary file #{src} into place at #{dst}")
           FileUtils.mv(src, dst)

--- a/spec/unit/file_content_management/deploy/mv_unix_spec.rb
+++ b/spec/unit/file_content_management/deploy/mv_unix_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,5 +97,17 @@ describe Chef::FileContentManagement::Deploy::MvUnix do
       end
     end
 
+  end
+
+  describe "when testing against real files", unix_only: true do
+    it "preserves sticky bits" do
+      staging_file = Tempfile.new("staging_file")
+      target_file = Tempfile.new("target_file")
+      File.chmod(04755, target_file.path)
+      content_deployer.deploy(staging_file.path, target_file.path)
+      expect(::File.stat(target_file.path).mode & 07777).to eql(04755)
+      staging_file.unlink
+      target_file.unlink
+    end
   end
 end


### PR DESCRIPTION
Looks to be an at least 5 year old bug here dealing with how POSIX
strips sticky bits off of files on a chown/chgrp.

closes #7711
