### PR TITLE
Run more Travis tests on Ruby 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ matrix:
   #   script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
   #   rvm: 2.5.1
   ### START TEST KITCHEN ONLY ###
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -132,7 +132,7 @@ matrix:
     env:
       - AMAZON=2
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -149,7 +149,7 @@ matrix:
     env:
       - AMAZON=201X
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -166,7 +166,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -183,7 +183,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -200,7 +200,7 @@ matrix:
     env:
       - UBUNTU=18.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -217,7 +217,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -234,7 +234,7 @@ matrix:
     env:
       - DEBIAN=9
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -251,7 +251,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -268,7 +268,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -285,7 +285,7 @@ matrix:
     env:
       - FEDORA=latest
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -323,7 +323,7 @@ matrix:
       - sudo cat /var/log/squid3/access.log
   # Use test-kitchen to launch a centos docker container to run the full rspec tests against.  This catches
   # errors in travis, before PRs are merged, hopefully before they become errors in jenkins.
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -340,7 +340,7 @@ matrix:
     env:
       - RSPEC_CENTOS=7
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.4.4
+  - rvm: 2.5.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile


### PR DESCRIPTION
There's no reason to keep executing our TK tests against ruby 2.4.

Signed-off-by: Tim Smith <tsmith@chef.io>