### PR TITLE
Fix registry key bug when sensitive is true

### DIFF
--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -126,16 +126,22 @@ class Chef
               value[:data] = value[:data].to_i
             end
             unless current_value[:type] == value[:type] && current_value[:data] == value[:data]
-              converge_by_value = value
-              converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+              converge_by_value = if new_resource.sensitive
+                                    value.merge(data: "*sensitive value suppressed*")
+                                  else
+                                    value
+                                  end
 
               converge_by("set value #{converge_by_value}") do
                 registry.set_value(new_resource.key, value)
               end
             end
           else
-            converge_by_value = value
-            converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+            converge_by_value = if new_resource.sensitive
+                                  value.merge(data: "*sensitive value suppressed*")
+                                else
+                                  value
+                                end
 
             converge_by("set value #{converge_by_value}") do
               registry.set_value(new_resource.key, value)
@@ -152,8 +158,11 @@ class Chef
         end
         new_resource.unscrubbed_values.each do |value|
           unless @name_hash.key?(value[:name].downcase)
-            converge_by_value = value
-            converge_by_value[:data] = "*sensitive value suppressed*" if new_resource.sensitive
+            converge_by_value = if new_resource.sensitive
+                                  value.merge(data: "*sensitive value suppressed*")
+                                else
+                                  value
+                                end
 
             converge_by("create value #{converge_by_value}") do
               registry.set_value(new_resource.key, value)


### PR DESCRIPTION
### Description

Fixes bug with `registry_key` resource when sensitive is true

Tested against Chef 14.5.33 on Windows 2012r2 & 2016

The following example results in `*sensitive value suppressed*` being written to the registry value, instead of `some value`

```ruby
registry_key "HKEY_LOCAL_MACHINE\\path-to-key\\Policies\\System\Demo" do
  values [{
    name: 'example',
    type: :string,
    data: 'some value'
  }]
  sensitive true
  action :create
end
```

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
