### PR TITLE
Don't ship contributing.md and VERSION file in the gem

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = "chef"
   s.version = Chef::VERSION
   s.platform = Gem::Platform::RUBY
-  s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "LICENSE" ]
+  s.extra_rdoc_files = ["README.md", "LICENSE" ]
   s.summary = "A systems integration framework, built to bring the benefits of configuration management to your entire infrastructure."
   s.description = s.summary
   s.license = "Apache-2.0"
@@ -59,5 +59,5 @@ Gem::Specification.new do |s|
   s.executables  = %w{ chef-client chef-solo knife chef-shell chef-apply chef-resource-inspector }
 
   s.require_paths = %w{ lib }
-  s.files = %w{Gemfile Rakefile LICENSE README.md VERSION} + Dir.glob("{lib,lib-backcompat,tasks,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
+  s.files = %w{Gemfile Rakefile LICENSE README.md} + Dir.glob("{lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
 end


### PR DESCRIPTION
Neither of these are needed in the gem. Gets us back 16k on disk.

Signed-off-by: Tim Smith <tsmith@chef.io>