### PR TITLE
Switch back to chefstyle from git and use the updated chef omnibus def

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group(:development, :test) do
   gem "webmock"
 
   # for testing new chefstyle rules
-  gem "chefstyle"
+  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
 end
 
 group(:travis) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/chef/chefstyle.git
+  revision: 5e596babac0e107170ce7c5cc706646bf609ab25
+  branch: master
+  specs:
+    chefstyle (0.11.0)
+      rubocop (= 0.55.0)
+
 PATH
   remote: .
   specs:
@@ -108,8 +116,6 @@ GEM
     cheffish (14.0.1)
       chef-zero (~> 14.0)
       net-ssh
-    chefstyle (0.11.0)
-      rubocop (= 0.55.0)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -355,7 +361,7 @@ DEPENDENCIES
   chef-config!
   chef-vault
   cheffish (~> 14)
-  chefstyle
+  chefstyle!
   inspec-core (~> 2)
   netrc
   octokit

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: ec8df13fa165b7d3866ee61fc05f060283adc642
+  revision: 7f8d59bf247140abf02a2bcd3eee0265496f7dcd
   branch: master
   specs:
     omnibus-software (4.0.0)


### PR DESCRIPTION
Turns out if we switch to non-git chefstyle we just end up with 2 copies and that's not smaller. Keep it as git since everything else pulls it from git. This does pull in the updated definition that should slim our install by about 400k.

Signed-off-by: Tim Smith <tsmith@chef.io>