### PR TITLE
Added property `description` on windows_task resource

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -147,6 +147,7 @@ class Chef
               task.configure_principals(principal_settings)
               task.set_account_information(new_resource.user, new_resource.password)
               task.creator = new_resource.user
+              task.description = new_resource.description unless new_resource.description.nil?
               task.activate(new_resource.task_name)
             end
           end
@@ -252,6 +253,7 @@ class Chef
             task.trigger = trigger unless new_resource.frequency == :none
             task.configure_settings(config_settings)
             task.creator = new_resource.user
+            task.description = new_resource.description unless new_resource.description.nil?
             task.configure_principals(principal_settings)
           end
         end
@@ -329,6 +331,7 @@ class Chef
           if new_resource.frequency == :none
             flag = (task.account_information != new_resource.user ||
             task.application_name != new_resource.command ||
+            description_needs_update?(task) ||
             task.parameters != new_resource.command_arguments.to_s ||
             task.principals[:run_level] != run_level ||
             task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_if_on_batteries ||
@@ -351,6 +354,7 @@ class Chef
                   current_task_trigger[:minutes_interval].to_i != new_task_trigger[:minutes_interval].to_i ||
                   task.account_information != new_resource.user ||
                   task.application_name != new_resource.command ||
+                  description_needs_update?(task) ||
                   task.parameters != new_resource.command_arguments.to_s ||
                   task.working_directory != new_resource.cwd.to_s ||
                   task.principals[:logon_type] != logon_type ||
@@ -565,6 +569,10 @@ class Chef
           settings [:run_level] = run_level
           settings[:logon_type] = logon_type
           settings
+        end
+
+        def description_needs_update?(task)
+          task.description != new_resource.description unless new_resource.description.nil?
         end
 
         def logon_type

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -116,6 +116,10 @@ class Chef
                  introduced: "14.4", default: false,
                  description: "Scheduled task option when system is switching on battery."
 
+        property :description, String,
+                 introduced: "14.7",
+                 description: "The task description."
+
         attr_accessor :exists, :task, :command_arguments
 
         VALID_WEEK_DAYS = %w{ mon tue wed thu fri sat sun * }.freeze


### PR DESCRIPTION
- Added a property `description` to allow user to add a description of a task on windows task scheduler
- Added test cases
- Ensured chef-style on the code changes made

Signed-off-by: kapil chouhan <kapil.chouhan@msystechnologies.com>

### Description

- Added a property `description` (String) in windows_task resource
- Consuming the method `comment` of win32-taskscheduler in provider to achieve the functionality
- Ensured the idempotency 

### Issues Resolved

Fixes MSYS-913: windows_task resource should support a 'description' property

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

### TODO

Will send another PR on [chef-web-docs](https://github.com/chef/chef-web-docs/blob/master/chef_master/source/resource_windows_task.rst) to update the property once this PR will be merged. 