### PR TITLE
Add some retry/delay in HTTP functional tests

### DIFF
--- a/spec/functional/http/simple_spec.rb
+++ b/spec/functional/http/simple_spec.rb
@@ -32,8 +32,8 @@ describe Chef::HTTP::Simple do
 
   before(:each) do
     Chef::Config[:rest_timeout] = 2
-    Chef::Config[:http_retry_delay] = 0
-    Chef::Config[:http_retry_count] = 0
+    Chef::Config[:http_retry_delay] = 1
+    Chef::Config[:http_retry_count] = 2
   end
 
   after(:all) do

--- a/spec/functional/resource/remote_file_spec.rb
+++ b/spec/functional/resource/remote_file_spec.rb
@@ -29,8 +29,8 @@ describe Chef::Resource::RemoteFile do
     @old_file_cache = Chef::Config[:file_cache_path]
     Chef::Config[:file_cache_path] = file_cache_path
     Chef::Config[:rest_timeout] = 2
-    Chef::Config[:http_retry_delay] = 0
-    Chef::Config[:http_retry_count] = 0
+    Chef::Config[:http_retry_delay] = 1
+    Chef::Config[:http_retry_count] = 2
   end
 
   after(:each) do


### PR DESCRIPTION
We are seeing some failures when running the functional tests on our new
Anka-based macOS testers. This small tweaks to the `Chef::Config` used
in the specs fix the issues.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
