### PR TITLE
Fix locale on RHEL 6 / Amazon Linux

### DIFF
--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -61,7 +61,7 @@ class Chef
           end
 
           execute "reload root's lang profile script" do
-            command "source source /etc/sysconfig/i18n; source /etc/profile.d/lang.sh"
+            command "source /etc/sysconfig/i18n; source /etc/profile.d/lang.sh"
             not_if { updated }
           end
         elsif ::File.exist?("/usr/sbin/update-locale")


### PR DESCRIPTION
There was a double source in the command, which would fail.

Signed-off-by: Tim Smith <tsmith@chef.io>