### PR TITLE
Remove the deprecated ohai_name property from the ohai resource

### DIFF
--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -27,10 +27,6 @@ class Chef
 
       description "Use the ohai resource to reload the Ohai configuration on a node. This allows recipes that change system attributes (like a recipe that adds a user) to refer to those attributes later on during the chef-client run."
 
-      property :ohai_name,
-               deprecated: true,
-               name_property: true, introduced: "12.17"
-
       property :plugin, String,
                description: "The name of an Ohai plugin to be reloaded. If this property is not specified, the chef-client will reload all plugins."
 

--- a/spec/unit/resource/ohai_spec.rb
+++ b/spec/unit/resource/ohai_spec.rb
@@ -26,10 +26,6 @@ describe Chef::Resource::Ohai do
     expect(resource.resource_name).to eql(:ohai)
   end
 
-  it "the ohai_name property is the name_property" do
-    expect(resource.ohai_name).to eql("fakey_fakerton")
-  end
-
   it "sets the default action as :reload" do
     expect(resource.action).to eql([:reload])
   end


### PR DESCRIPTION
This did nothing and we deprecated it already.

Signed-off-by: Tim Smith <tsmith@chef.io>