### PR TITLE
Remove legacy require_recipe DSL method

### DIFF
--- a/lib/chef/dsl/include_recipe.rb
+++ b/lib/chef/dsl/include_recipe.rb
@@ -29,12 +29,6 @@ class Chef
       def load_recipe(recipe_name)
         run_context.load_recipe(recipe_name, current_cookbook: cookbook_name)
       end
-
-      def require_recipe(*args)
-        Chef::Log.warn("require_recipe is deprecated and will be removed in a future release, please use include_recipe")
-        include_recipe(*args)
-      end
-
     end
   end
 end


### PR DESCRIPTION
We've been warning on this one for YEARS and we have a Foodcritic rule
for it as well, which has been around since before I was at Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>