### PR TITLE
Refactor Cookbook loader logic now that we don't support merging

### DIFF
--- a/spec/unit/cookbook_loader_spec.rb
+++ b/spec/unit/cookbook_loader_spec.rb
@@ -59,7 +59,6 @@ describe Chef::CookbookLoader do
       ]
     end
     it "should not support multiple merged cookbooks in the cookbook path" do
-      start_merged_cookbooks = cookbook_loader.merged_cookbooks
       expect { cookbook_loader.load_cookbooks }.to raise_error(Chef::Exceptions::CookbookMergingError)
     end
   end


### PR DESCRIPTION
this can be cleaned up by the removal of the multiple loaders per
cookbook (since shadowing / merging is gone) and just because the
logic was getting really weird.
