### PR TITLE
Require mixin::shellout where we use it

### DIFF
--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -20,6 +20,7 @@ require "chef/dsl/reboot_pending"
 require "chef/log"
 require "chef/platform"
 require "chef/application/exit_code"
+require "chef/mixin/shell_out"
 
 class Chef
   class Platform


### PR DESCRIPTION
We're extending this in a few places where we didn't actually require
it. We should probably just require it here.

Signed-off-by: Tim Smith <tsmith@chef.io>