### PR TITLE
Break out appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,12 @@ platform:
   - x64
 
 cache:
-- vendor/bundle
+  - vendor/bundle
+
+configuration:
+  - integration
+  - functional
+  - unit
 
 environment:
   matrix:
@@ -41,6 +46,7 @@ install:
   - SET BUNDLE_WITHOUT=server:docgen:maintenance:pry:travis:integration:ci
   - bundle config --local path vendor/bundle # use the cache we define above
   - bundle install || bundle install || bundle install
+  - SET SPEC_OPTS=--format progress
 
 build: off
 
@@ -50,6 +56,23 @@ before_test:
   - bundler --version
   - bundle env
 
-test_script:
-  - SET SPEC_OPTS=--format progress
-  - bundle exec rake spec
+for:
+  -
+    matrix:
+      only:
+        - configuration: integration
+    build_script:
+      - bundle exec rake spec:integration
+  -
+    matrix:
+      only:
+        - configuration: functional
+    build_script:
+      - bundle exec rake spec:functional
+  -
+    matrix:
+      only:
+        - configuration: unit
+    build_script:
+      - bundle exec rake spec:unit
+      - bundle exec rake component_specs


### PR DESCRIPTION
Currently our rspec run in Appveyor takes 35 minutes. Even with the non-cached first run this dropped it down to 19 minutes, which is about how long our longest Travis run takes.

Signed-off-by: Tim Smith <tsmith@chef.io>
