### PR TITLE
Multiple fixes to dmg_package

### DIFF
--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -71,9 +71,9 @@ class Chef
                description: "Specify whether to accept the EULA. Certain dmgs require acceptance of EULA before mounting.",
                default: false, desired_state: false
 
-      property :headers, [Hash, nil],
+      property :headers, Hash,
                description: "Allows custom HTTP headers (like cookies) to be set on the remote_file resource.",
-               default: nil, desired_state: false
+               desired_state: false
 
       property :allow_untrusted, [TrueClass, FalseClass],
                description: "Allow installation of packages that do not have trusted certificates.",

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -107,7 +107,7 @@ class Chef
               accept_eula_cmd = new_resource.accept_eula ? "echo Y | echo Y | PAGER=true " : ""
               shell_out!("#{accept_eula_cmd} /usr/bin/hdiutil attach #{passphrase_cmd} '#{dmg_file}' -nobrowse -mountpoint '/Volumes/#{new_resource.volumes_dir}' -quiet", env: { "PAGER" => "true" })
             end
-            not_if "/usr/bin/hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
+            not_if { dmg_attached? }
           end
 
           case new_resource.type
@@ -155,6 +155,12 @@ class Chef
         def software_license_agreement?
           # example hdiutil imageinfo output: http://rubular.com/r/0xvOaA6d8B
           /Software License Agreement: true/.match?(shell_out!("/usr/bin/hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}'").stdout)
+        end
+
+        # @return [Boolean] is the dmg file currently attached?
+        def dmg_attached?
+          # example hdiutil imageinfo output: http://rubular.com/r/CDcqenkixg
+          /image-path.*#{dmg_file}/.match?(shell_out!("/usr/bin/hdiutil info #{passphrase_cmd}").stdout)
         end
       end
     end

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -148,7 +148,7 @@ class Chef
 
         # @return [String] the hdiutil flag for handling DMGs with a password
         def passphrase_cmd
-          new_resource.dmg_passphrase ? "-passphrase #{new_resource.dmg_passphrase}" : ""
+          @passphrase_cmd ||= new_resource.dmg_passphrase ? "-passphrase #{new_resource.dmg_passphrase}" : ""
         end
 
         # @return [Boolean] does the DMG require a software license agreement

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -106,12 +106,12 @@ class Chef
           ruby_block "attach #{dmg_file}" do
             block do
               # example hdiutil imageinfo output: http://rubular.com/r/0xvOaA6d8B
-              software_license_agreement = /Software License Agreement: true/.match?(shell_out!("hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}'").stdout)
+              software_license_agreement = /Software License Agreement: true/.match?(shell_out!("/usr/bin/hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}'").stdout)
               raise "Requires EULA Acceptance; add 'accept_eula true' to dmg_package resource" if software_license_agreement && !new_resource.accept_eula
               accept_eula_cmd = new_resource.accept_eula ? "echo Y | PAGER=true" : ""
-              shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -mountpoint '/Volumes/#{volumes_dir}' -quiet")
+              shell_out!("#{accept_eula_cmd} /usr/bin/hdiutil attach #{passphrase_cmd} '#{dmg_file}' -nobrowse -mountpoint '/Volumes/#{volumes_dir}' -quiet")
             end
-            not_if "hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
+            not_if "/usr/bin/hdiutil info #{passphrase_cmd} | grep -q 'image-path.*#{dmg_file}'"
           end
 
           case new_resource.type
@@ -134,7 +134,7 @@ class Chef
             end
           end
 
-          execute "hdiutil detach '/Volumes/#{volumes_dir}' || hdiutil detach '/Volumes/#{volumes_dir}' -force"
+          execute "/usr/bin/hdiutil detach '/Volumes/#{volumes_dir}' || /usr/bin/hdiutil detach '/Volumes/#{volumes_dir}' -force"
         end
       end
 

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -81,9 +81,9 @@ class Chef
 
       load_current_value do |new_resource|
         if ::File.directory?("#{new_resource.destination}/#{new_resource.app}.app")
-          Chef::Log.info "Already installed; to upgrade, remove \"#{new_resource.destination}/#{new_resource.app}.app\""
-        elsif shell_out("pkgutil --pkgs='#{new_resource.package_id}'").exitstatus == 0
-          Chef::Log.info "Already installed; to upgrade, try \"sudo pkgutil --forget '#{new_resource.package_id}'\""
+          Chef::Log.info "#{new_resource.app} is already installed. To upgrade, remove \"#{new_resource.destination}/#{new_resource.app}.app\""
+        elsif shell_out("pkgutil --pkg-info '#{new_resource.package_id}'").exitstatus == 0
+          Chef::Log.info "#{new_resource.app} is already installed. To upgrade, try \"sudo pkgutil --forget '#{new_resource.package_id}'\""
         else
           current_value_does_not_exist! # allows us to check for current_resource.nil? below
         end

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -94,8 +94,7 @@ class Chef
           dmg_name = new_resource.dmg_name ? new_resource.dmg_name : new_resource.app
 
           if new_resource.source
-            declare_resource(:remote_file, "#{dmg_file} - #{new_resource.name}") do
-              path dmg_file
+            remote_file dmg_file do
               source new_resource.source
               headers new_resource.headers if new_resource.headers
               checksum new_resource.checksum if new_resource.checksum

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -55,25 +55,26 @@ class Chef
       property :type, String,
                description: "The type of package.",
                equal_to: %w{app pkg mpkg},
-               default: "app"
+               default: "app", desired_state: false
 
       property :package_id, String,
                description: "The package id registered with pkgutil when a pkg or mpkg is installed."
 
       property :dmg_passphrase, String,
-               description: "Specify a passphrase to use to unencrypt the dmg while mounting."
+               description: "Specify a passphrase to use to unencrypt the dmg while mounting.",
+               desired_state: false
 
       property :accept_eula, [TrueClass, FalseClass],
                description: "Specify whether to accept the EULA. Certain dmgs require acceptance of EULA before mounting.",
-               default: false
+               default: false, desired_state: false
 
       property :headers, [Hash, nil],
                description: "Allows custom HTTP headers (like cookies) to be set on the remote_file resource.",
-               default: nil
+               default: nil, desired_state: false
 
       property :allow_untrusted, [TrueClass, FalseClass],
                description: "Allow installation of packages that do not have trusted certificates.",
-               default: false
+               default: false, desired_state: false
 
       load_current_value do |new_resource|
         if ::File.directory?("#{new_resource.destination}/#{new_resource.app}.app")

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -50,7 +50,9 @@ class Chef
                description: "The Directory under /Volumes where the dmg is mounted as not all dmgs are mounted into a /Volumes location matching the name of the dmg."
 
       property :dmg_name, String,
-               description: "The name of the dmg if it is not the same as app, or if the name has spaces."
+               description: "The name of the dmg if it is not the same as app, or if the name has spaces.",
+               desired_state: false,
+               default: lazy { |r| r.app }
 
       property :type, String,
                description: "The type of package.",
@@ -91,7 +93,6 @@ class Chef
 
         if current_resource.nil?
           volumes_dir = new_resource.volumes_dir ? new_resource.volumes_dir : new_resource.app
-          dmg_name = new_resource.dmg_name ? new_resource.dmg_name : new_resource.app
 
           if new_resource.source
             remote_file dmg_file do

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -104,8 +104,11 @@ class Chef
           ruby_block "attach #{dmg_file}" do
             block do
               raise "This DMG package requires EULA acceptance. Add 'accept_eula true' to dmg_package resource to accept the EULA during installation." if software_license_agreement? && !new_resource.accept_eula
-              accept_eula_cmd = new_resource.accept_eula ? "echo Y | echo Y | PAGER=true " : ""
-              shell_out!("#{accept_eula_cmd} /usr/bin/hdiutil attach #{passphrase_cmd} '#{dmg_file}' -nobrowse -mountpoint '/Volumes/#{new_resource.volumes_dir}' -quiet", env: { "PAGER" => "true" })
+
+              attach_cmd = new_resource.accept_eula ? "yes | " : ""
+              attach_cmd << "/usr/bin/hdiutil attach #{passphrase_cmd} '#{dmg_file}' -nobrowse -mountpoint '/Volumes/#{new_resource.volumes_dir}'"
+
+              shell_out!(attach_cmd, env: { "PAGER" => "true" })
             end
             not_if { dmg_attached? }
           end

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -105,9 +105,9 @@ class Chef
           passphrase_cmd = new_resource.dmg_passphrase ? "-passphrase #{new_resource.dmg_passphrase}" : ""
           ruby_block "attach #{dmg_file}" do
             block do
-              cmd = shell_out("hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}' | grep -q 'Software License Agreement: true'")
-              software_license_agreement = cmd.exitstatus == 0
-              raise "Requires EULA Acceptance; add 'accept_eula true' to package resource" if software_license_agreement && !new_resource.accept_eula
+              # example hdiutil imageinfo output: http://rubular.com/r/0xvOaA6d8B
+              software_license_agreement = /Software License Agreement: true/.match?(shell_out!("hdiutil imageinfo #{passphrase_cmd} '#{dmg_file}'").stdout)
+              raise "Requires EULA Acceptance; add 'accept_eula true' to dmg_package resource" if software_license_agreement && !new_resource.accept_eula
               accept_eula_cmd = new_resource.accept_eula ? "echo Y | PAGER=true" : ""
               shell_out!("#{accept_eula_cmd} hdiutil attach #{passphrase_cmd} '#{dmg_file}' -mountpoint '/Volumes/#{volumes_dir}' -quiet")
             end

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -44,7 +44,7 @@ class Chef
                default: "/Applications"
 
       property :checksum, String,
-               description: "The sha256 checksum of the dmg to download"
+               description: "The sha256 checksum of the dmg to download."
 
       property :volumes_dir, String,
                description: "The Directory under /Volumes where the dmg is mounted as not all dmgs are mounted into a /Volumes location matching the name of the dmg."
@@ -58,7 +58,7 @@ class Chef
                default: "app"
 
       property :package_id, String,
-               description: "The package id registered with pkgutil when a pkg or mpkg is installed"
+               description: "The package id registered with pkgutil when a pkg or mpkg is installed."
 
       property :dmg_passphrase, String,
                description: "Specify a passphrase to use to unencrypt the dmg while mounting."


### PR DESCRIPTION
1) Remove the "installed" property that was being used to track state and instead properly load the current_value
2) Set desired_state false on several properties that aren't part of the desired state
3) Add missing periods to a few descriptions
4) Remove declare_resource where it's not necessary
5) Fix dmg_name to properly take on app as the default value
6) Move some of the logic into helper methods that can be tested at some point
7) Move some values into default values instead of variables we set later that contained the same logic
8) Improved the error message you get if your package requires setting the EULA
9) Don't use grep to find the string that indicates the EULA is required
10) Use the full path to hdiutil so we're not depending on the PATH variable being correct
11) Accepting the EULA now works