### PR TITLE
Pin rake to 12.0 to prevent shipping 2 copies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group(:development, :test) do
   # we pin rake as a copy of rake is installed from the ruby source
   # if you bump the ruby version you should confirm we don't end up with
   # two rake gems installed again
-  gem "rake", "<= 12.3.0"
+  gem "rake", "<= 12.0.0"
   gem "simplecov"
   gem "webmock"
   gem "chefstyle", "0.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
     rack (2.0.5)
     rainbow (2.2.2)
       rake
-    rake (12.3.0)
+    rake (12.0.0)
     rb-readline (0.5.5)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -392,7 +392,7 @@ DEPENDENCIES
   pry-byebug
   pry-remote
   pry-stack_explorer
-  rake (<= 12.3.0)
+  rake (<= 12.0.0)
   rb-readline
   ruby-prof
   ruby-shadow
@@ -403,4 +403,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.1
+   1.16.6


### PR DESCRIPTION
12.0 comes from our ruby 2.4 install already. This same change was made
for chef 14 where Ruby 2.5 shipped with rake 12.3.

Signed-off-by: Tim Smith <tsmith@chef.io>