### PR TITLE
Remove preview resource from windows_certificate & windows_share

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -24,7 +24,6 @@ require "openssl"
 class Chef
   class Resource
     class WindowsCertificate < Chef::Resource
-      preview_resource true
       resource_name :windows_certificate
 
       description "Use the windows_certificate resource to install a certificate into the Windows certificate store from a file. The resource grants read-only access to the private key for designated accounts. Due to current limitations in WinRM, installing certificates remotely may not work if the operation requires a user profile. Operations on the local machine store should still work."

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -25,7 +25,6 @@ require "chef/json_compat"
 class Chef
   class Resource
     class WindowsShare < Chef::Resource
-      preview_resource true
       resource_name :windows_share
 
       description "Use the windows_share resource to create, modify and remove Windows shares."


### PR DESCRIPTION
The initial PR was for the backport, but we don't want these to be
previews in Chef 15

Signed-off-by: Tim Smith <tsmith@chef.io>