### PR TITLE
Fix testing / installing on SLES 15

### DIFF
--- a/omnibus/package-scripts/angrychef/postrm
+++ b/omnibus/package-scripts/angrychef/postrm
@@ -17,8 +17,8 @@ is_darwin() {
 
 is_suse() {
   if [ -f /etc/os-release ]; then
-    source /etc/os-release
-    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+    . /etc/os-release
+    [ "$ID_LIKE" = "sles" ] || [ "$ID_LIKE" = "suse" ]
   else
     [ -f /etc/SuSE-release ]
   fi

--- a/omnibus/package-scripts/angrychef/postrm
+++ b/omnibus/package-scripts/angrychef/postrm
@@ -11,9 +11,17 @@ is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
-is_darwin()
-{
+is_darwin() {
   uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+is_suse() {
+  if [ -f /etc/os-release ]; then
+    source /etc/os-release
+    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+  else
+    [ -f /etc/SuSE-release ]
+  fi
 }
 
 if is_smartos; then
@@ -33,7 +41,7 @@ cleanup_symlinks() {
 
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022
-if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! is_suse ]; then
   # not a redhat-ish RPM-based system
   cleanup_symlinks
 elif [ "x$1" = "x0" ]; then

--- a/omnibus/package-scripts/chef-fips/postrm
+++ b/omnibus/package-scripts/chef-fips/postrm
@@ -17,8 +17,8 @@ is_darwin() {
 
 is_suse() {
   if [ -f /etc/os-release ]; then
-    source /etc/os-release
-    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+    . /etc/os-release
+    [ "$ID_LIKE" = "sles" ] || [ "$ID_LIKE" = "suse" ]
   else
     [ -f /etc/SuSE-release ]
   fi

--- a/omnibus/package-scripts/chef-fips/postrm
+++ b/omnibus/package-scripts/chef-fips/postrm
@@ -11,9 +11,17 @@ is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
-is_darwin()
-{
+is_darwin() {
   uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+is_suse() {
+  if [ -f /etc/os-release ]; then
+    source /etc/os-release
+    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+  else
+    [ -f /etc/SuSE-release ]
+  fi
 }
 
 if is_smartos; then
@@ -33,7 +41,7 @@ cleanup_symlinks() {
 
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022
-if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! is_suse ]; then
   # not a redhat-ish RPM-based system
   cleanup_symlinks
 elif [ "x$1" = "x0" ]; then

--- a/omnibus/package-scripts/chef/postrm
+++ b/omnibus/package-scripts/chef/postrm
@@ -17,8 +17,8 @@ is_darwin() {
 
 is_suse() {
   if [ -f /etc/os-release ]; then
-    source /etc/os-release
-    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+    . /etc/os-release
+    [ "$ID_LIKE" = "sles" ] || [ "$ID_LIKE" = "suse" ]
   else
     [ -f /etc/SuSE-release ]
   fi

--- a/omnibus/package-scripts/chef/postrm
+++ b/omnibus/package-scripts/chef/postrm
@@ -11,9 +11,17 @@ is_smartos() {
   uname -v | grep "^joyent" 2>&1 >/dev/null
 }
 
-is_darwin()
-{
+is_darwin() {
   uname -v | grep "^Darwin" 2>&1 >/dev/null
+}
+
+is_suse() {
+  if [ -f /etc/os-release ]; then
+    source /etc/os-release
+    [ $ID_LIKE == "sles" ] || [ $ID_LIKE == "suse" ]
+  else
+    [ -f /etc/SuSE-release ]
+  fi
 }
 
 if is_smartos; then
@@ -33,7 +41,7 @@ cleanup_symlinks() {
 
 # Clean up binary symlinks if they exist
 # see: http://tickets.opscode.com/browse/CHEF-3022
-if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! is_suse ]; then
   # not a redhat-ish RPM-based system
   cleanup_symlinks
 elif [ "x$1" = "x0" ]; then

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -220,7 +220,8 @@ def selinux_enabled?
 end
 
 def suse?
-  File.exists?("/etc/SuSE-release")
+  ::File.exists?("/etc/SuSE-release") ||
+    ( ::File.exists?("/etc/os-release") && /sles|suse/.match?(File.read("/etc/os-release")) )
 end
 
 def root?


### PR DESCRIPTION
Make sure we identify SLES 15 as suse for our zypper tests
Make sure we don't remove the symlinks on SLES when doing an upgrade or the new release will be broken

Signed-off-by: Tim Smith <tsmith@chef.io>