### PR TITLE
Pull ohai from the 14-stable branch in kitchen tests

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rake" # required to build some native extensions
 gem "chef", path: ".."
-gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master" # avoids failures when we bump chef major
+gem "ohai", git: "https://github.com/chef/ohai.git", branch: "14-stable" # avoids failures when we bump chef major
 gem "berkshelf", git: "https://github.com/berkshelf/berkshelf.git", branch: "master"
 gem "kitchen-appbundle-updater"
 gem "kitchen-dokken", "< 2.0" # 2.x fails atm: https://travis-ci.org/chef/chef/jobs/199125787


### PR DESCRIPTION
This fixes our kitchen tests

Signed-off-by: Tim Smith <tsmith@chef.io>