### PR TITLE
Update win32-certstore to include a license

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     plist (3.4.0)
@@ -331,7 +331,7 @@ GEM
       hashdiff
     websocket (1.2.8)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.1.8)
+    win32-certstore (0.1.10)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.106.0)
-    aws-sdk-core (3.35.0)
+    aws-partitions (1.107.0)
+    aws-sdk-core (3.36.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.11.0)
       aws-sdk-core (~> 3, >= 3.26.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.23.0)
+    aws-sdk-s3 (1.23.1)
       aws-sdk-core (~> 3, >= 3.26.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -177,7 +177,7 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jmespath (1.4.0)
-    kitchen-vagrant (1.3.5)
+    kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     license_scout (1.0.16)
@@ -189,7 +189,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.9.0)
-    minitar (0.6.1)
+    minitar (0.7)
     mixlib-archive (0.4.18)
       mixlib-log
     mixlib-archive (0.4.18-universal-mingw32)
@@ -378,4 +378,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
The previous release did not ship a license file and was failing license validation in Jenkins.

Signed-off-by: Tim Smith <tsmith@chef.io>