### PR TITLE
Backport: Fix inspector to properly handle defaults that are symbols

### DIFF
--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -31,7 +31,7 @@ module ResourceInspector
       # code for the resource ourselves and just no
       "lazy default"
     else
-      default
+      default.inspect # inspect properly returns symbols
     end
   end
 


### PR DESCRIPTION
We need to .inspect these so the default value is a symbol not the
string version of the symbol.

Signed-off-by: Tim Smith <tsmith@chef.io>