### PR TITLE
Backport:  Throw better error on invalid resources actions 

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -179,8 +179,8 @@ class Chef
             return true if value == tb
           end
           # Ruby will print :something as something, which confuses users so make sure to print them as symbols
-          corrected_type_array = to_be.collect { |x| x.kind_of?(Symbol) ? ":#{x}" : x }
-          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{corrected_type_array.join(", ")}!  You passed #{value.inspect}.")
+          # by inspecting the value instead of just printing it
+          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{to_be.map { |v| v.inspect }.join(", ")}!  You passed #{value.inspect}.")
         end
       end
 

--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -178,7 +178,9 @@ class Chef
           to_be.each do |tb|
             return true if value == tb
           end
-          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{to_be.join(", ")}!  You passed #{value.inspect}.")
+          # Ruby will print :something as something, which confuses users so make sure to print them as symbols
+          corrected_type_array = to_be.collect { |x| x.kind_of?(Symbol) ? ":#{x}" : x }
+          raise Exceptions::ValidationFailed, _validation_message(key, "Option #{key} must be equal to one of: #{corrected_type_array.join(", ")}!  You passed #{value.inspect}.")
         end
       end
 


### PR DESCRIPTION
Improve the error message when actions are wrong. This is a super confusing error message to get during cookbook development.