### PR TITLE
Chef 15 node attribute array fixes

### DIFF
--- a/lib/chef/node/mixin/immutablize_array.rb
+++ b/lib/chef/node/mixin/immutablize_array.rb
@@ -159,7 +159,6 @@ class Chef
           :sort_by!,
           :uniq!,
           :unshift,
-          :update,
         ].freeze
 
         # Redefine all of the methods that mutate a Hash to raise an error when called.

--- a/lib/chef/node/mixin/mashy_array.rb
+++ b/lib/chef/node/mixin/mashy_array.rb
@@ -1,0 +1,68 @@
+#--
+# Copyright:: Copyright 2016-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Node
+    module Mixin
+      # missing methods for Arrays similar to Chef::Mash methods that call
+      # convert_value correctly.
+      module MashyArray
+        def <<(obj)
+          super(convert_value(obj))
+        end
+
+        def []=(*keys, value)
+          super(*keys, convert_value(value))
+        end
+
+        def push(*objs)
+          objs = objs.map { |obj| convert_value(obj) }
+          super(*objs)
+        end
+
+        def unshift(*objs)
+          objs = objs.map { |obj| convert_value(obj) }
+          super(*objs)
+        end
+
+        def insert(index, *objs)
+          objs = objs.map { |obj| convert_value(obj) }
+          super(index, *objs)
+        end
+
+        def collect!(&block)
+          super
+          map! { |x| convert_value(x) }
+        end
+
+        def map!(&block)
+          super
+          super { |x| convert_value(x) }
+        end
+
+        def fill(*args, &block)
+          super
+          map! { |x| convert_value(x) }
+        end
+
+        def replace(obj)
+          super(convert_value(obj))
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/node/immutable_collections_spec.rb
+++ b/spec/unit/node/immutable_collections_spec.rb
@@ -209,7 +209,6 @@ describe Chef::Node::ImmutableArray do
     :merge!,
     :pop,
     :push,
-    :update,
     :reject!,
     :reverse!,
     :replace,


### PR DESCRIPTION
Doing something like:

```
node.default["foo"] = []
node.default["foo"] << { "bar" => "baz }
```

Would result in a Hash instead of a VividMash inserted into the
AttrArray, so that:

```
node.default["foo"][0]["bar"] # gives the correct result
node.default["foo"][0][:bar]  # does not work due to the sub-Hash not
                              # converting keys
```

This fixes that behavior, but is likely a breaking change to someone
who expects to ingest hashes with symbol keys and get back out symbol
keys, they will now get converted to strings.  This breaking change
is fully 100% intentional.  This makes the node attribute structure
more consistent and predictable.
