### PR TITLE
Backport: Avoid rhel 6 DB corruption in jenkins RHEL 6 boxes

### DIFF
--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -2,6 +2,18 @@
 
 set -evx
 
+# Our tests hammer YUM pretty hard and the EL6 testers get corrupted
+# after some period of time. Rebuilding the RPM database clears
+# up the underlying corruption. We'll do this each test run just to
+# be safe.
+if [ -f /etc/redhat-release ]; then
+  major_version=`sed 's/^.\+ release \([0-9]\+\).*/\1/' /etc/redhat-release`
+  if [ "$major_version" -lt "7" ]; then
+    sudo rm -rf /var/lib/rpm/__db.00*
+    sudo rpm --rebuilddb
+  fi
+fi
+
 # Set up a custom tmpdir, and clean it up before and after the tests
 TMPDIR="${TMPDIR:-/tmp}/cheftest"
 export TMPDIR

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -9,8 +9,10 @@ set -evx
 if [ -f /etc/redhat-release ]; then
   major_version=`sed 's/^.\+ release \([0-9]\+\).*/\1/' /etc/redhat-release`
   if [ "$major_version" -lt "7" ]; then
-    sudo rm -rf /var/lib/rpm/__db.00*
+    sudo rm -rf /var/lib/rpm/__db*
+    sudo db_verify /var/lib/rpm/Packages
     sudo rpm --rebuilddb
+    sudo yum clean all
   fi
 fi
 


### PR DESCRIPTION
Bring some stability to our build system