### PR TITLE
update the Chef::REST deprecation warning

### DIFF
--- a/lib/chef/rest.rb
+++ b/lib/chef/rest.rb
@@ -4,7 +4,7 @@
 # Author:: Nuo Yan (<nuo@chef.io>)
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,7 +59,7 @@ class Chef
     # http://localhost:4000, a call to +get_rest+ with 'nodes' will make an
     # HTTP GET request to http://localhost:4000/nodes
     def initialize(url, client_name = Chef::Config[:node_name], signing_key_filename = Chef::Config[:client_key], options = {})
-      Chef.deprecated(:chef_rest, "Chef::REST is deprecated. Please use Chef::ServerAPI, or investigate Ridley or ChefAPI.")
+      Chef.deprecated(:chef_rest, "Chef::REST is deprecated. Please use Chef::ServerAPI (and see Chef::HTTP and the related derived classes).")
 
       signing_key_filename = nil if chef_zero_uri?(url)
 

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -2,8 +2,8 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,7 +96,7 @@ describe Chef::REST do
   it "emits a deprecation warning" do
     Chef::Config[:treat_deprecation_warnings_as_errors] = true
     expect { Chef::REST.new(base_url) }.to raise_error Chef::Exceptions::DeprecatedFeatureError,
-      /Chef::REST is deprecated. Please use Chef::ServerAPI, or investigate Ridley or ChefAPI./
+      /Chef::REST is deprecated/
   end
 
   context "when created with a chef zero URL" do


### PR DESCRIPTION
ridley is also deprecated, and chef-api is largely abandonware at
this point, so more firmly point people at Chef::ServerAPI since
there seems to be confusion around it.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
