### PR TITLE
Defer running initramfs_command until end of run

### DIFF
--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -40,12 +40,14 @@ class Chef
 
         file "#{new_resource.load_dir}/#{new_resource.modname}.conf" do
           content "#{new_resource.modname}\n"
-          notifies :run, "execute[update initramfs]"
+          notifies :run, "execute[update initramfs]", :delayed
         end
 
-        execute "update initramfs" do
-          command initramfs_command
-          action :nothing
+        with_run_context :root do
+          find_resource(:execute, "update initramfs") do
+            command initramfs_command
+            action :nothing
+          end
         end
       end
 
@@ -54,17 +56,19 @@ class Chef
 
         file "#{new_resource.load_dir}/#{new_resource.modname}.conf" do
           action :delete
-          notifies :run, "execute[update initramfs]"
+          notifies :run, "execute[update initramfs]", :delayed
         end
 
         file "#{new_resource.unload_dir}/blacklist_#{new_resource.modname}.conf" do
           action :delete
-          notifies :run, "execute[update initramfs]"
+          notifies :run, "execute[update initramfs]", :delayed
         end
 
-        execute "update initramfs" do
-          command initramfs_command
-          action :nothing
+        with_run_context :root do
+          find_resource(:execute, "update initramfs") do
+            command initramfs_command
+            action :nothing
+          end
         end
 
         new_resource.run_action(:unload)
@@ -75,12 +79,14 @@ class Chef
 
         file "#{new_resource.unload_dir}/blacklist_#{new_resource.modname}.conf" do
           content "blacklist #{new_resource.modname}"
-          notifies :run, "execute[update initramfs]"
+          notifies :run, "execute[update initramfs]", :delayed
         end
 
-        execute "update initramfs" do
-          command initramfs_command
-          action :nothing
+        with_run_context :root do
+          find_resource(:execute, "update initramfs") do
+            command initramfs_command
+            action :nothing
+          end
         end
 
         new_resource.run_action(:unload)


### PR DESCRIPTION
Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

### Description

Defer running initramfs_command until end of run. Updating initramfs is expensive and only needs to be performed once

### Issues Resolved

https://github.com/chef/chef/issues/7471

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
