### PR TITLE
resource inspector: don't convert nil to "nil" in default values

### DIFF
--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -31,7 +31,7 @@ module ResourceInspector
       # code for the resource ourselves and just no
       "lazy default"
     else
-      default.inspect # inspect properly returns symbols
+      default.inspect unless default.nil? # inspect properly returns symbols
     end
   end
 


### PR DESCRIPTION
Only inspec the value if it isn't nil.

Signed-off-by: Tim Smith <tsmith@chef.io>