### PR TITLE
Update knife status --long to use cloud attributes not ec2 specific attributes

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nicolas DUPEUX (<nicolas.dupeux@arkea.com>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,8 +67,8 @@ class Chef
 
             result["name"] = node["name"] || node.name
             result["chef_environment"] = node["chef_environment"]
-            ip = (node["ec2"] && node["ec2"]["public_ipv4"]) || node["ipaddress"]
-            fqdn = (node["ec2"] && node["ec2"]["public_hostname"]) || node["fqdn"]
+            ip = (node["cloud"] && node["cloud"]["public_ipv4_addrs"].first) || node["ipaddress"]
+            fqdn = (node["cloud"] && node["cloud"]["public_hostname"]) || node["fqdn"]
             result["ip"] = ip if ip
             result["fqdn"] = fqdn if fqdn
             result["run_list"] = node.run_list if config["run_list"]

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Ian Meyer (<ianmmeyer@gmail.com>)
-# Copyright:: Copyright 2010-2016, Ian Meyer
+# Copyright:: Copyright 2010-2020, Ian Meyer
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,7 +59,7 @@ class Chef
         else
           opts = { filter_result:
                  { name: ["name"], ipaddress: ["ipaddress"], ohai_time: ["ohai_time"],
-                   ec2: ["ec2"], run_list: ["run_list"], platform: ["platform"],
+                   cloud: ["cloud"], run_list: ["run_list"], platform: ["platform"],
                    platform_version: ["platform_version"], chef_environment: ["chef_environment"] } }
         end
 

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Sahil Muthoo (<sahil.muthoo@gmail.com>)
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ describe Chef::Knife::Status do
     let(:opts) do
       { filter_result:
                  { name: ["name"], ipaddress: ["ipaddress"], ohai_time: ["ohai_time"],
-                   ec2: ["ec2"], run_list: ["run_list"], platform: ["platform"],
+                   cloud: ["cloud"], run_list: ["run_list"], platform: ["platform"],
                    platform_version: ["platform_version"], chef_environment: ["chef_environment"] } }
     end
 


### PR DESCRIPTION
This way we get the public IP / hostname on Azure, GCE, DigitalOcean, Softlayer, etc.

Signed-off-by: Tim Smith <tsmith@chef.io>