### PR TITLE
add tests for yum version with package_source bug

### DIFF
--- a/spec/functional/resource/yum_package_spec.rb
+++ b/spec/functional/resource/yum_package_spec.rb
@@ -485,6 +485,24 @@ describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
         expect(yum_package.updated_by_last_action?).to be false
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
+
+      it "is idempotent when the package is already installed and there is a version string" do
+        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        yum_packger.version "1.2-1"
+        yum_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        yum_package.run_action(:install)
+        expect(yum_package.updated_by_last_action?).to be false
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+      end
+
+      it "is idempotent when the package is already installed and there is a version string with arch" do
+        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        yum_packger.version "1.2-1.#{pkg_arch}"
+        yum_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        yum_package.run_action(:install)
+        expect(yum_package.updated_by_last_action?).to be false
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+      end
     end
 
     context "with no available version" do

--- a/spec/functional/resource/yum_package_spec.rb
+++ b/spec/functional/resource/yum_package_spec.rb
@@ -488,7 +488,7 @@ describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
 
       it "is idempotent when the package is already installed and there is a version string" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        yum_packger.version "1.2-1"
+        yum_package.version "1.2-1"
         yum_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
         yum_package.run_action(:install)
         expect(yum_package.updated_by_last_action?).to be false
@@ -497,7 +497,7 @@ describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
 
       it "is idempotent when the package is already installed and there is a version string with arch" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        yum_packger.version "1.2-1.#{pkg_arch}"
+        yum_package.version "1.2-1.#{pkg_arch}"
         yum_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
         yum_package.run_action(:install)
         expect(yum_package.updated_by_last_action?).to be false


### PR DESCRIPTION
Turns out there's no bug here.  We're doing the right thing now, but prior versions of chef were ignoring epochs in versions.  That bug got fixed, so now epochs are compared correctly and leaving the epoch off has an implicit value of '0' so it fails the check if the package has an epoch.

Merging this because it is additional test coverage over useful cases.

See #7552 for background.