### PR TITLE
windows_ad_join: Switch to UPN format usernames for use with AD cmdlets

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -65,7 +65,7 @@ class Chef
 
         unless on_domain?
           cmd = "$pswd = ConvertTo-SecureString \'#{new_resource.domain_password}\' -AsPlainText -Force;"
-          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}\",$pswd);"
+          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}@#{new_resource.domain_name}\",$pswd);"
           cmd << "Add-Computer -DomainName #{new_resource.domain_name} -Credential $credential"
           cmd << " -OUPath \"#{new_resource.ou_path}\"" if new_resource.ou_path
           cmd << " -NewName \"#{new_resource.new_hostname}\"" if new_resource.new_hostname


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Solves an issue where the domain name is required to build the PSCredential object that is required as input to the AD cmdlets behind our windows_ad_join resource. After discussion with the community, it was decided that the UPN format would be valid in more cases, rather than the NetBIOS style (domain\username) approach, plus we require the domain name to be provided in FQDN format anyway.

### Issues Resolved

Fixes #7715 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
