### PR TITLE
Fix the knife integration spec timeouts

### DIFF
--- a/spec/integration/knife/raw_spec.rb
+++ b/spec/integration/knife/raw_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -190,12 +190,14 @@ EOM
         app = lambda do |env|
           [200, { "Content-Type" => "application/json" }, ['{ "x": "y", "a": "b" }'] ]
         end
-        @raw_server, @raw_server_thread = start_app_server(app, 9018)
+        @raw_server_thread = start_app_server(app, 9018)
       end
 
       after :each do
-        @raw_server.shutdown if @raw_server
-        @raw_server_thread.kill if @raw_server_thread
+        if @raw_server_thread
+          @raw_server_thread.kill
+          @raw_server_thread.join(30)
+        end
       end
 
       it "knife raw /blah returns the prettified json", skip: (RUBY_VERSION < "1.9") do
@@ -220,12 +222,14 @@ EOM
         app = lambda do |env|
           [200, { "Content-Type" => "text" }, ['{ "x": "y", "a": "b" }'] ]
         end
-        @raw_server, @raw_server_thread = start_app_server(app, 9018)
+        @raw_server_thread = start_app_server(app, 9018)
       end
 
       after :each do
-        @raw_server.shutdown if @raw_server
-        @raw_server_thread.kill if @raw_server_thread
+        if @raw_server_thread
+          @raw_server_thread.kill
+          @raw_server_thread.join(30)
+        end
       end
 
       it "knife raw /blah returns the raw text" do

--- a/spec/integration/knife/redirection_spec.rb
+++ b/spec/integration/knife/redirection_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,12 +36,14 @@ describe "redirection", :workstation do
         app = lambda do |env|
           [302, { "Content-Type" => "text", "Location" => "#{real_chef_server_url}#{env['PATH_INFO']}" }, ["302 found"] ]
         end
-        @redirector_server, @redirector_server_thread = start_app_server(app, 9018)
+        @redirector_server_thread = start_app_server(app, 9018)
       end
 
       after :each do
-        @redirector_server.shutdown if @redirector_server
-        @redirector_thread.kill if @redirector_thread
+        if @redirector_thread
+          @redirector_thread.kill
+          @redirector_thread.join(30)
+        end
       end
 
       it "knife list /roles returns the role" do

--- a/spec/support/shared/integration/app_server_support.rb
+++ b/spec/support/shared/integration/app_server_support.rb
@@ -1,7 +1,7 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright 2012-2016 Chef Software, Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,6 @@ module AppServerSupport
     Timeout.timeout(30) do
       sleep(0.01) until server && server.status == :Running
     end
-    [server, thread]
+    thread
   end
 end


### PR DESCRIPTION
rely on killing the thread to terminate the server, and rely on
thread#join to correctly signal to the main thread that the
server thread is dead, don't leak the server object out of the
helper.
