### PR TITLE
Remove unused yum_timeout and yum_lock_timeout configs

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -436,8 +436,6 @@ module ChefConfig
     end
 
     default :rest_timeout, 300
-    default :yum_timeout, 900
-    default :yum_lock_timeout, 30
     default :solo, false
 
     # Are we running in old Chef Solo legacy mode?


### PR DESCRIPTION
These haven't been used since we refactored the yum provider

Signed-off-by: Tim Smith <tsmith@chef.io>