### PR TITLE
Backport: windows_feature: Move provider logic into the default of the install_method property

### DIFF
--- a/lib/chef/resource/windows_feature.rb
+++ b/lib/chef/resource/windows_feature.rb
@@ -44,7 +44,8 @@ class Chef
 
       property :install_method, Symbol,
                description: "The underlying installation method to use for feature installation. Specify ':windows_feature_dism' for DISM or ':windows_feature_powershell' for PowerShell.",
-               equal_to: [:windows_feature_dism, :windows_feature_powershell, :windows_feature_servermanagercmd]
+               equal_to: [:windows_feature_dism, :windows_feature_powershell, :windows_feature_servermanagercmd],
+               default: :windows_feature_dism
 
       property :timeout, Integer,
                description: "Specifies a timeout (in seconds) for the feature installation.",
@@ -72,16 +73,15 @@ class Chef
         # call the appropriate windows_feature resource based on the specified subresource
         # @return [void]
         def run_default_subresource(desired_action)
-          raise "Support for Windows feature installation via servermanagercmd.exe has been removed as this support is no longer needed in Windows 2008 R2 and above. You will need to update your cookbook to install either via dism or powershell (preferred)." if new_resource.install_method == :windows_feature_servermanagercmd
+          raise "Support for Windows feature installation via servermanagercmd.exe has been removed as this support is no longer needed in Windows 2008 R2 and above. You will need to update your recipe to install either via dism or powershell (preferred)." if new_resource.install_method == :windows_feature_servermanagercmd
 
-          subresource = new_resource.install_method || :windows_feature_dism
-          declare_resource(subresource, new_resource.name) do
+          declare_resource(new_resource.install_method, new_resource.name) do
             action desired_action
             feature_name new_resource.feature_name
             source new_resource.source if new_resource.source
             all new_resource.all
             timeout new_resource.timeout
-            management_tools new_resource.management_tools if subresource == :windows_feature_powershell
+            management_tools new_resource.management_tools if new_resource.install_method == :windows_feature_powershell
           end
         end
       end

--- a/spec/unit/resource/windows_feature.rb
+++ b/spec/unit/resource/windows_feature.rb
@@ -50,6 +50,10 @@ describe Chef::Resource::WindowsFeature do
     expect(resource.timeout).to eql(600)
   end
 
+  it "install_method property defaults to :windows_feature_dism" do
+    expect(resource.install_method).to eql(:windows_feature_dism)
+  end
+
   it "install_method accepts :windows_feature_dism, :windows_feature_powershell, and :windows_feature_servermanagercmd" do
     expect { resource.install_method :windows_feature_dism }.not_to raise_error
     expect { resource.install_method :windows_feature_powershell }.not_to raise_error


### PR DESCRIPTION
This eliminates the need for setting the subresource variable and also allows us to auto-generate docs that are aware of the default.

Signed-off-by: Tim Smith <tsmith@chef.io>