### PR TITLE
Don't set chef_gem_compile_time config in the chef_gem spec

### DIFF
--- a/spec/unit/resource/chef_gem_spec.rb
+++ b/spec/unit/resource/chef_gem_spec.rb
@@ -73,10 +73,7 @@ describe Chef::Resource::ChefGem, "gem_binary" do
       Chef::Recipe.new("hjk", "test", run_context)
     end
 
-    let(:chef_gem_compile_time) { nil }
-
     let(:resource) do
-      Chef::Config[:chef_gem_compile_time] = chef_gem_compile_time
       Chef::Resource::ChefGem.new("foo", run_context)
     end
 


### PR DESCRIPTION
We removed this config in Chef 13. There's no need to set it in the spec
anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>