### PR TITLE
Replace usage of win_friendly_path helper in windows_certificate

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+require "chef/util/path_helper"
 require "chef/resource"
 require "win32-certstore" if Chef::Platform.windows?
 require "openssl"
@@ -180,7 +181,7 @@ class Chef
 
         def cert_script(persist)
           cert_script = "$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2"
-          file = win_friendly_path(new_resource.source)
+          file = Chef::Util::PathHelper.cleanpath(new_resource.source)
           cert_script << " \"#{file}\""
           if ::File.extname(file.downcase) == ".pfx"
             cert_script << ", \"#{new_resource.pfx_password}\""


### PR DESCRIPTION
This is a helper from the windows cookbook that doesn't exist in core
Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>