### PR TITLE
Update Cheffish to 14.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       mixlib-log (~> 2.0)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    cheffish (14.0.1)
+    cheffish (14.0.4)
       chef-zero (~> 14.0)
       net-ssh
     coderay (1.1.2)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.111.0)
+    aws-partitions (1.112.0)
     aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)


### PR DESCRIPTION
The cheffish bump fixes a bug in the private_key resource which was failing tests in appveyor due to a openssl / ruby bump that occurred there.

Signed-off-by: Tim Smith <tsmith@chef.io>