### PR TITLE
Update cheffish to 14.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       mixlib-log (~> 2.0)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    cheffish (14.0.1)
+    cheffish (14.0.4)
       chef-zero (~> 14.0)
       net-ssh
     coderay (1.1.2)


### PR DESCRIPTION
The cheffish bump fixes a bug in the private_key resource which was failing tests in appveyor due to a openssl / ruby bump that occurred there.

Signed-off-by: Tim Smith tsmith@chef.io