### PR TITLE
WIP: Move response_file and response_file_variables properties out of the base package resource

### DIFF
--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -35,6 +35,13 @@ class Chef
                description: "Overwrite existing configuration files with those supplied by the package, if prompted by APT.",
                default: false
 
+      property :response_file, String,
+               description: "The direct path to the file used to pre-seed a package.",
+               desired_state: false
+
+      property :response_file_variables, Hash,
+               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
+               default: lazy { Hash.new }, desired_state: false
     end
   end
 end

--- a/lib/chef/resource/dpkg_package.rb
+++ b/lib/chef/resource/dpkg_package.rb
@@ -28,6 +28,14 @@ class Chef
 
       property :source, [ String, Array, nil ],
                description: "The path to a package in the local file system."
+
+      property :response_file, String,
+               description: "The direct path to the file used to pre-seed a package.",
+               desired_state: false
+
+      property :response_file_variables, Hash,
+               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
+               default: lazy { Hash.new }, desired_state: false
     end
   end
 end

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -52,14 +52,6 @@ class Chef
                description: "One (or more) additional command options that are passed to the command.",
                coerce: proc { |x| x.is_a?(String) ? x.shellsplit : x }
 
-      property :response_file, String,
-               description: "The direct path to the file used to pre-seed a package.",
-               desired_state: false
-
-      property :response_file_variables, Hash,
-               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
-               default: lazy { Hash.new }, desired_state: false
-
       property :source, String,
                description: "The optional path to a package on the local file system.",
                desired_state: false

--- a/spec/unit/resource/apt_package_spec.rb
+++ b/spec/unit/resource/apt_package_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,5 +52,15 @@ describe Chef::Resource::AptPackage, "initialize" do
 
   it "should preserve configuration files by default" do
     expect(resource.overwrite_config_files).to eql(false)
+  end
+
+  it "accepts a string for the response file" do
+    resource.response_file "something"
+    expect(resource.response_file).to eql("something")
+  end
+
+  it "accepts a hash for response file template variables" do
+    resource.response_file_variables({ variables: true })
+    expect(resource.response_file_variables).to eql({ variables: true })
   end
 end

--- a/spec/unit/resource/dpkg_package_spec.rb
+++ b/spec/unit/resource/dpkg_package_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,15 @@ describe Chef::Resource::DpkgPackage, "initialize" do
       expect { resource.action :unlock }.not_to raise_error
       expect { resource.action :upgrade }.not_to raise_error
     end
-  end
 
+    it "accepts a string for the response file" do
+      resource.response_file "something"
+      expect(resource.response_file).to eql("something")
+    end
+
+    it "accepts a hash for response file template variables" do
+      resource.response_file_variables({ variables: true })
+      expect(resource.response_file_variables).to eql({ variables: true })
+    end
+  end
 end

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,16 +48,6 @@ describe Chef::Resource::Package do
   it "accepts a string for the version" do
     resource.version "something"
     expect(resource.version).to eql("something")
-  end
-
-  it "accepts a string for the response file" do
-    resource.response_file "something"
-    expect(resource.response_file).to eql("something")
-  end
-
-  it "accepts a hash for response file template variables" do
-    resource.response_file_variables({ variables: true })
-    expect(resource.response_file_variables).to eql({ variables: true })
   end
 
   it "accepts a string for the source" do


### PR DESCRIPTION
This is an apt / dpkg thing and not a generic package thing. Having these properties in the package resource pollutes our resource documentation.

Signed-off-by: Tim Smith <tsmith@chef.io>