### PR TITLE
Replace several uses of attribute with property in resources

### DIFF
--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -37,7 +37,7 @@ class Chef
       def define_resource_requirements
         if creates && creates_relative? && !cwd
           # FIXME? move this onto the resource?
-          raise Chef::Exceptions::Execute, "Please either specify a full path for the creates attribute, or specify a cwd property to the #{new_resource} resource"
+          raise Chef::Exceptions::Execute, "Please either specify a full path for the creates property, or specify a cwd property to the #{new_resource} resource"
         end
       end
 

--- a/lib/chef/provider/osx_profile.rb
+++ b/lib/chef/provider/osx_profile.rb
@@ -68,7 +68,7 @@ class Chef
                 !@new_profile_identifier.end_with?(".mobileconfig") &&
                 /^\w+(?:(\.| )\w+)+$/.match(@new_profile_identifier)
             end
-            a.failure_message RuntimeError, "when removing using the identifier attribute, it must match the profile identifier"
+            a.failure_message RuntimeError, "when removing using the identifier property, it must match the profile identifier"
           else
             new_profile_name = new_resource.profile_name
             a.assertion do

--- a/lib/chef/provider/package/apt.rb
+++ b/lib/chef/provider/package/apt.rb
@@ -44,7 +44,7 @@ class Chef
 
           requirements.assert(:all_actions) do |a|
             a.assertion { !new_resource.source }
-            a.failure_message(Chef::Exceptions::Package, "apt package provider cannot handle source attribute. Use dpkg provider instead")
+            a.failure_message(Chef::Exceptions::Package, "apt package provider cannot handle source property. Use dpkg provider instead")
           end
         end
 

--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -54,7 +54,7 @@ EOS
 
           # The check that Chocolatey is installed is in #choco_exe.
 
-          # Chocolatey source attribute points to an alternate feed
+          # Chocolatey source property points to an alternate feed
           # and not a package specific alternate source like other providers
           # so we want to assert candidates exist for the alternate source
           requirements.assert(:upgrade, :install) do |a|

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -53,7 +53,7 @@ class Chef
           # Below are incomplete/missing features for this package provider
           requirements.assert(:all_actions) do |a|
             a.assertion { !new_resource.source }
-            a.failure_message(Chef::Exceptions::Package, "The openbsd package provider does not support the source attribute")
+            a.failure_message(Chef::Exceptions::Package, "The openbsd package provider does not support the source property")
           end
           requirements.assert(:all_actions) do |a|
             a.assertion do

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -44,7 +44,7 @@ class Chef
                description: "The path to the directory. Using a fully qualified path is recommended, but is not always required."
 
       property :recursive, [ TrueClass, FalseClass ],
-               description: "Create or delete parent directories recursively. For the owner, group, and mode properties, the value of this attribute applies only to the leaf directory.",
+               description: "Create or delete parent directories recursively. For the owner, group, and mode properties, the value of this property applies only to the leaf directory.",
                default: false
     end
   end

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -87,7 +87,7 @@ class Chef
                description: "The amount of time (in seconds) a command is to wait before timing out."
 
       property :user, [ String, Integer ],
-               description: "The user name of the user identity with which to launch the new process. The user name may optionally be specifed with a domain, i.e. domainuser or user@my.dns.domain.com via Universal Principal Name (UPN)format. It can also be specified without a domain simply as user if the domain is instead specified using the domain attribute. On Windows only, if this property is specified, the password property must be specified."
+               description: "The user name of the user identity with which to launch the new process. The user name may optionally be specifed with a domain, i.e. domainuser or user@my.dns.domain.com via Universal Principal Name (UPN)format. It can also be specified without a domain simply as user if the domain is instead specified using the domain property. On Windows only, if this property is specified, the password property must be specified."
 
       property :domain, String,
                introduced: "12.21",

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -143,7 +143,7 @@ class Chef
                description: "Determines whether to report the instance ID when using Amazon Linux AMIs and repositories."
 
       property :repositoryid, String, regex: [/^[^\/]+$/],
-               description: "Specifies a unique name for each repository, one word. Defaults to name attribute.",
+               description: "Specifies a unique name for each repository, one word. Defaults to name property.",
                validation_message: "repositoryid property cannot contain a forward slash '/'",
                name_property: true
 


### PR DESCRIPTION
We were still calling things attributes when they're actually properties. This fixes some documentation and error messages.

Signed-off-by: Tim Smith <tsmith@chef.io>