### PR TITLE
Allow Integers for all group / owner properties

### DIFF
--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -36,7 +36,7 @@ class Chef
       property :file, String,
                description: "The full path to the .dmg file on the local system."
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The user that should own the package installation."
 
       property :destination, String,

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -48,7 +48,7 @@ class Chef
                description: "The path to the homebrew binary.",
                default: "/usr/local/bin/brew"
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner of the Homebrew installation.",
                default: lazy { find_homebrew_username }
 

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -48,7 +48,7 @@ class Chef
                description: "The path to the Homebrew binary.",
                default: "/usr/local/bin/brew"
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner of the Homebrew installation.",
                default: lazy { find_homebrew_username }
 

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -60,7 +60,7 @@ class Chef
                equal_to: [ :symbolic, :hard ], default: :symbolic
 
       property :group, [String, Integer],
-               description: "A string or ID that identifies the group associated with a symbolic link.",
+               description: "A group name or ID number that identifies the group associated with a symbolic link.",
                regex: [Chef::Config[:group_valid_regex]]
 
       property :owner, [String, Integer],

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -45,10 +45,10 @@ class Chef
                description: "The desired Diffie-Hellmann generator.",
                default: 2
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -47,10 +47,10 @@ class Chef
                description: "The designed cipher to use when generating your key. Run `openssl list-cipher-algorithms` to see available options.",
                default: "des3"
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -42,10 +42,10 @@ class Chef
       property :private_key_pass, String,
                description: "The passphrase of the provided private key."
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -49,10 +49,10 @@ class Chef
                description: "The designed cipher to use when generating your key. Run `openssl list-cipher-algorithms` to see available options.",
                default: "des3"
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -42,10 +42,10 @@ class Chef
       property :private_key_pass, String,
                description: "The passphrase of the provided private key."
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -34,10 +34,10 @@ class Chef
                description: "An optional property for specifying the path to write the file to if it differs from the resource block's name.",
                name_property: true
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :expire, Integer,

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -59,10 +59,10 @@ class Chef
       property :ca_key_pass, String,
                description: "The passphrase for CA private key's passphrase."
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner permission for the CRL file."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group permission for the CRL file."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -32,10 +32,10 @@ class Chef
       property :path, String, name_property: true,
                description: "An optional property for specifying the path to write the file to if it differs from the resource block's name."
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The owner applied to all files created by the resource."
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The group ownership applied to all files created by the resource."
 
       property :mode, [Integer, String],

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -50,11 +50,11 @@ class Chef
                description: "The file mode for the ssh_known_hosts file.",
                default: "0644"
 
-      property :owner, String,
+      property :owner, [String, Integer],
                description: "The file owner for the ssh_known_hosts file.",
                default: "root"
 
-      property :group, String,
+      property :group, [String, Integer],
                description: "The file group for the ssh_known_hosts file.",
                default: lazy { node["root_group"] }
 


### PR DESCRIPTION
We did for many of them, but not all. Many of these should get switched over to securable, but this is a solid first step to give a more consistent user experience.

Signed-off-by: Tim Smith <tsmith@chef.io>