### PR TITLE
cab_package: Chef should fail when specified package is not applicable to the image

### DIFF
--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -74,9 +74,13 @@ class Chef
         end
 
         def dism_command(command)
-          shellout = Mixlib::ShellOut.new("dism.exe /Online /English #{command} /NoRestart", timeout: new_resource.timeout)
           with_os_architecture(nil) do
-            shellout.run_command
+            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout })
+            if result.exitstatus == -2146498530
+              raise Chef::Exceptions::Package, "The specified package is not applicable to this image." if result.stdout.include?("0x800f081e")
+              result.error!
+            end
+            result
           end
         end
 

--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -76,6 +76,20 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
     end
   end
 
+  context "when an msu package is not applicable to the image." do
+    def package_name
+      "Package_for_KB4019990"
+    end
+
+    def package_source
+      "http://download.windowsupdate.com/c/msdownload/update/software/updt/2017/05/windows8-rt-kb4019990-x64_a77f4e3e1f2d47205824763e7121bb11979c2716.msu"
+    end
+
+    it "raises error while installing" do
+      expect { subject.run_action(:install) }.to raise_error(Chef::Exceptions::Package, /The specified package is not applicable to this image./)
+    end
+  end
+
   def remove_package
     pkg_to_remove = Chef::Resource::MsuPackage.new(package_name, run_context)
     pkg_to_remove.source = package_source


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description

- We have use `shell_out()` instead of directly hitting Mixlib::Shellout `shellout = Mixlib::ShellOut.new("dism.exe /Online /English #{command} /NoRestart", { :timeout => @new_resource.timeout })`
- Then we are using exitstatus rather than raising an error directly
- After that We are maching `Error: 0x800f081e` and raise an error like `The specified package is not applicable to this image.`

### Issues Resolved

Fixes MSYS-918: ZD 20361 - tecRacer GmbH & Co. KG - msu_package / cab_package should check return code of call to dism.exe

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
