### PR TITLE
Chef-15: switch default of allow_downgrade to true

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,29 @@ Chef 15 release notes will be added here as development progresses.
 
 ## Breaking Changes
 
+### Package provider allow_downgrade is now true by default
+
+The behavior of the package provider without any allow_downgrade flag is now to allow downgrades.  This will mostly
+affect users of the rpm and zypper package providers.
+
+```
+package "foo" do
+  version "1.2.3"
+end
+```
+
+That code should now be read as asserting that the package `foo` must be version `1.2.3` after that resource is run.
+
+```
+package "foo" do
+  allow_downgrade false
+  version "1.2.3"
+end
+```
+
+That code is now what is necessary to specify that `foo` must be version `1.2.3` or higher.  Note that the yum provider
+supports syntax like `package "foo > 1.2.3"` which is preferred to using allow_downgrade and should be used instead.
+
 ### Node Attributes deep merge nil values
 
 Writing a nil to a precedence level in the node object now acts like any other value and can be used to override values back to nil.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,8 +8,7 @@ Chef 15 release notes will be added here as development progresses.
 
 ### Package provider allow_downgrade is now true by default
 
-The behavior of the package provider without any allow_downgrade flag is now to allow downgrades.  This will mostly
-affect users of the rpm and zypper package providers.
+A package provider without any `allow_downgrade` flag now will allow downgrades, which is opposite from previous versions. This behavior change will mostly affect users of the rpm and zypper package providers.
 
 ```
 package "foo" do
@@ -26,8 +25,7 @@ package "foo" do
 end
 ```
 
-That code is now what is necessary to specify that `foo` must be version `1.2.3` or higher.  Note that the yum provider
-supports syntax like `package "foo > 1.2.3"` which is preferred to using allow_downgrade and should be used instead.
+That code is now what is necessary to specify that `foo` must be version `1.2.3` or higher.  Note that the yum provider supports syntax like `package "foo > 1.2.3"` which should be used and is preferred over using allow_downgrade.
 
 ### Node Attributes deep merge nil values
 

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -96,7 +96,7 @@ class Chef
 
             name = av.name # resolve the name via the available/candidate version
 
-            iv = python_helper.package_query(:whatinstalled, name)
+            iv = python_helper.package_query(:whatinstalled, av.name_with_arch)
 
             method = "install"
 

--- a/lib/chef/provider/package/yum/version.rb
+++ b/lib/chef/provider/package/yum/version.rb
@@ -40,6 +40,10 @@ class Chef
             "#{version}.#{arch}" unless version.nil?
           end
 
+          def name_with_arch
+            "#{name}.#{arch}" unless name.nil?
+          end
+
           def matches_name_and_arch?(other)
             other.version == version && other.arch == arch
           end

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/resource/rpm_package.rb
+++ b/lib/chef/resource/rpm_package.rb
@@ -26,7 +26,7 @@ class Chef
 
       description "Use the rpm_package resource to manage packages for the RPM Package Manager platform."
 
-      property :allow_downgrade, [ true, false ], default: false, desired_state: false
+      property :allow_downgrade, [ true, false ], default: true, desired_state: false
 
     end
   end

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -69,7 +69,8 @@ class Chef
 
       property :allow_downgrade, [ true, false ],
                description: "Downgrade a package to satisfy requested version requirements.",
-               default: false
+               default: true,
+               desired_state: false
 
       property :yum_binary, String
     end

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -33,7 +33,9 @@ class Chef
 
       property :allow_downgrade, [ TrueClass, FalseClass ],
                description: "Allow downgrading a package to satisfy requested version requirements.",
-               default: false, introduced: "13.6"
+               default: true,
+               desired_state: false,
+               introduced: "13.6"
 
       property :global_options, [ String, Array ],
                description: "One (or more) additional command options that are passed to the command. For example, common zypper directives, such as '--no-recommends'. See the zypper man page at https://en.opensuse.org/SDB:Zypper_manual_(plain) for the full list.",

--- a/spec/functional/resource/yum_package_spec.rb
+++ b/spec/functional/resource/yum_package_spec.rb
@@ -443,8 +443,9 @@ describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
 
-      it "downgrade on a local file is ignored" do
+      it "downgrade on a local file is ignored when allow_downgrade is false" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        yum_package.allow_downgrade false
         yum_package.version "1.2-1"
         yum_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
         yum_package.run_action(:install)

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -120,14 +120,14 @@ describe Chef::Provider::Package::Zypper do
   describe "install_package" do
     it "should run zypper install with the package name and version" do
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
 
     it "should run zypper install with gpg checks" do
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -135,7 +135,7 @@ describe Chef::Provider::Package::Zypper do
     it "setting the property should disable gpg checks" do
       new_resource.gpg_check false
       shell_out_expectation!(
-        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -143,15 +143,15 @@ describe Chef::Provider::Package::Zypper do
     it "setting the config variable should disable gpg checks" do
       Chef::Config[:zypper_check_gpg] = false
       shell_out_expectation!(
-        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
 
-    it "setting the property should allow downgrade" do
-      new_resource.allow_downgrade true
+    it "setting the property should disallow downgrade" do
+      new_resource.allow_downgrade false
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -159,7 +159,7 @@ describe Chef::Provider::Package::Zypper do
     it "should add user provided options to the command" do
       new_resource.options "--user-provided"
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -167,7 +167,7 @@ describe Chef::Provider::Package::Zypper do
     it "should add user provided global options" do
       new_resource.global_options "--user-provided"
       shell_out_expectation!(
-        "zypper", "--user-provided", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--user-provided", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -175,7 +175,7 @@ describe Chef::Provider::Package::Zypper do
     it "should add multiple user provided global options" do
       new_resource.global_options "--user-provided1 --user-provided2"
       shell_out_expectation!(
-        "zypper", "--user-provided1", "--user-provided2", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--user-provided1", "--user-provided2", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.install_package(["emacs"], ["1.0"])
     end
@@ -184,35 +184,35 @@ describe Chef::Provider::Package::Zypper do
   describe "upgrade_package" do
     it "should run zypper update with the package name and version" do
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper update without gpg checks when setting the property" do
       new_resource.gpg_check false
       shell_out_expectation!(
-        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should run zypper update without gpg checks when setting the config variable" do
       Chef::Config[:zypper_check_gpg] = false
       shell_out_expectation!(
-        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "--no-gpg-checks", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should add user provided options to the command" do
       new_resource.options "--user-provided"
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--non-interactive", "install", "--user-provided", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
     it "should add user provided global options" do
       new_resource.global_options "--user-provided"
       shell_out_expectation!(
-        "zypper", "--user-provided", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0"
+        "zypper", "--user-provided", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0"
       )
       provider.upgrade_package(["emacs"], ["1.0"])
     end
@@ -435,7 +435,7 @@ describe Chef::Provider::Package::Zypper do
     describe "install_package" do
       it "should run zypper install with the package name and version" do
         shell_out_expectation!(
-          "zypper", "install", "--auto-agree-with-licenses", "-y", "emacs"
+          "zypper", "install", "--auto-agree-with-licenses", "--oldpackage", "-y", "emacs"
         )
         provider.install_package(["emacs"], ["1.0"])
       end
@@ -444,7 +444,7 @@ describe Chef::Provider::Package::Zypper do
     describe "upgrade_package" do
       it "should run zypper update with the package name and version" do
         shell_out_expectation!(
-          "zypper", "install", "--auto-agree-with-licenses", "-y", "emacs"
+          "zypper", "install", "--auto-agree-with-licenses", "--oldpackage", "-y", "emacs"
         )
         provider.upgrade_package(["emacs"], ["1.0"])
       end
@@ -463,7 +463,7 @@ describe Chef::Provider::Package::Zypper do
   describe "when installing multiple packages" do # https://github.com/chef/chef/issues/3570
     it "should install an array of package names and versions" do
       shell_out_expectation!(
-        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "emacs=1.0", "vim=2.0"
+        "zypper", "--non-interactive", "install", "--auto-agree-with-licenses", "--oldpackage", "emacs=1.0", "vim=2.0"
       )
       provider.install_package(%w{emacs vim}, ["1.0", "2.0"])
     end


### PR DESCRIPTION
The fact that this:

```
package "foo" do
  version "1.2.3"
end
```

Does not allow downgrades from version "2.3.4" is surprising non-declarative magic.  The meaning of that block should be to pin that package to that version.  Instead we currently make people realize there's an edge condition and then go hunting for `allow_downgrade true` to fix this behavior.  Instead we can reverse that and now the semantics of that block is exactly what it looks like it says and people who want to do "foo > 1.2.3" will need to use `allow_downgrade false` explicitly.

closes #6484