### PR TITLE
Chef-15:  require instead of load libraries

### DIFF
--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -226,7 +226,7 @@ class Chef
           begin
             # FIXME(log): should be trace
             logger.debug("Loading cookbook #{cookbook_name}'s library file: #{filename}")
-            Kernel.load(filename)
+            Kernel.require(filename)
             @events.library_file_loaded(filename)
           rescue Exception => e
             @events.library_file_load_failed(filename, e)

--- a/spec/unit/run_context/cookbook_compiler_spec.rb
+++ b/spec/unit/run_context/cookbook_compiler_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2012-2016, Chef Software Inc.
+# Copyright:: Copyright 2012-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,6 +106,10 @@ describe Chef::RunContext::CookbookCompiler do
     it "loads libraries in run list order" do
       node.run_list("test-with-deps::default", "test-with-circular-deps::default")
 
+      compiler.compile_libraries
+      expect(LibraryLoadOrder.load_order).to eq(["dependency1", "dependency2", "test-with-deps", "circular-dep2", "circular-dep1", "test-with-circular-deps"])
+
+      # additionally test that we only load them once
       compiler.compile_libraries
       expect(LibraryLoadOrder.load_order).to eq(["dependency1", "dependency2", "test-with-deps", "circular-dep2", "circular-dep1", "test-with-circular-deps"])
     end


### PR DESCRIPTION
This reverts a change which was working around problems caused by
unforked interval runs.  Fixes issues with chefspec, should make
it faster and reduce warning spam.

closes #6450