### PR TITLE
windows_share: Fix idempotency by removing the "everyone" access

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -241,6 +241,10 @@ class Chef
 
           Chef::Log.debug("Running '#{share_cmd}' to create the share")
           powershell_out!(share_cmd)
+
+          # New-SmbShare adds the "Everyone" user with read access no matter what so we need to remove it
+          # before we add our permissions
+          revoke_user_permissions(["Everyone"])
         end
 
         # determine what users in the current state don't exist in the desired state
@@ -296,6 +300,8 @@ class Chef
           false
         end
 
+        # revoke user permissions from a share
+        # @param [Array] users
         def revoke_user_permissions(users)
           revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join(',')}\" -Force"
           Chef::Log.debug("Running '#{revoke_command}' to revoke share permissions")


### PR DESCRIPTION
This resource uses powershell under the hood and calls new-smbshare,
which defaults to adding read only access to the everyone group. With
this change when we create the share we'll remove that permission. Once
that's done we'll go about adding our desired permissions. This only
runs once so the overhead is pretty low and fixes idempotency.

Signed-off-by: Tim Smith <tsmith@chef.io>