### PR TITLE
Update python_helpers for rhel-8

### DIFF
--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -37,7 +37,7 @@ class Chef
           DNF_HELPER = ::File.expand_path(::File.join(::File.dirname(__FILE__), "dnf_helper.py")).freeze
 
           def dnf_command
-            @dnf_command ||= which("python", "python3", "python2", "python2.7") do |f|
+            @dnf_command ||= which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
               shell_out("#{f} -c 'import dnf'").exitstatus == 0
             end + " #{DNF_HELPER}"
           end

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -40,7 +40,7 @@ class Chef
           YUM_HELPER = ::File.expand_path(::File.join(::File.dirname(__FILE__), "yum_helper.py")).freeze
 
           def yum_command
-            @yum_command ||= which("python", "python2", "python2.7") do |f|
+            @yum_command ||= which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
               shell_out("#{f} -c 'import yum'").exitstatus == 0
             end + " #{YUM_HELPER}"
           end


### PR DESCRIPTION
### Description

RHEL 8 uses '/usr/libexec/platform-python' for system tooling, this version should be used for dnf/yum

Obvious fix.

### Issues Resolved

This makes the dnf_package and yum_package providers work on rhel-8

For more details see:
https://developers.redhat.com/blog/2018/11/14/python-in-rhel-8/

> Careful readers might have noticed a discrepancy here: Python is not installed by default, but yum is, and yum is written in Python. What magic makes that possible?
>
> It turns out there is an internal Python interpreter called “Platform-Python”. This is what system tools use. It only includes the parts of Python needed for the system to function, and there are no guarantees that any particular feature won’t be removed from it in the future.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/html-single/configuring_basic_system_settings/#the_internal_platform_python_package


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
