### PR TITLE
windows_share: Accounts to be revoked should be provided as an individually quoted string array

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -303,7 +303,7 @@ class Chef
         # revoke user permissions from a share
         # @param [Array] users
         def revoke_user_permissions(users)
-          revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join(',')}\" -Force"
+          revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join('","')}\" -Force"
           Chef::Log.debug("Running '#{revoke_command}' to revoke share permissions")
           powershell_out!(revoke_command)
         end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Solves an issue where if multiple accounts need to be revoked from the share access list, the input is not in a format that can be parsed as a PowerShell string array.

### Issues Resolved

Ref #7956 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
