### PR TITLE
wipe the installer direction before installation

### DIFF
--- a/omnibus/package-scripts/angrychef/preinst
+++ b/omnibus/package-scripts/angrychef/preinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
+INSTALLER_DIR=/opt/angrychef
+echo "removing $INSTALLER_DIR..."
+rm -f $INSTALLER_DIR

--- a/omnibus/package-scripts/chef-fips/preinst
+++ b/omnibus/package-scripts/chef-fips/preinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
+INSTALLER_DIR=/opt/chef-fips
+echo "removing $INSTALLER_DIR..."
+rm -f $INSTALLER_DIR

--- a/omnibus/package-scripts/chef/preinst
+++ b/omnibus/package-scripts/chef/preinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
+INSTALLER_DIR=/opt/chef
+echo "removing $INSTALLER_DIR..."
+rm -f $INSTALLER_DIR


### PR DESCRIPTION
this leaves the diretory after an uninstall, but it should get the
crazy redhat use case correct where installs run before uninstalls,
so we wipe first, install, then run the uninstall stuff on upgrade.
