### PR TITLE
Chef 14: apt_repository: prevent gpg key import on newer Debian releases

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -225,7 +225,7 @@ class Chef
       #
       # @return [String] the full apt-key command to run
       def keyserver_install_cmd(key, keyserver)
-        cmd = "apt-key adv --recv"
+        cmd = "apt-key adv --no-tty --recv"
         cmd << " --keyserver-options http-proxy=#{new_resource.key_proxy}" if new_resource.key_proxy
         cmd << " --keyserver "
         cmd << if keyserver.start_with?("hkp://")

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -160,18 +160,19 @@ C5986B4F1257FFA86632CBA746181433FBB75451
     end
   end
 
-  describe "#keyserver_install_cmd" do
+  describe "#
+" do
     it "returns keyserver install command" do
-      expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --recv --keyserver hkp://gpg.mit.edu:80 ABC")
+      expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --no-tty --recv --keyserver hkp://gpg.mit.edu:80 ABC")
     end
 
     it "uses proxy if key_proxy property is set" do
       new_resource.key_proxy("proxy.mycorp.dmz:3128")
-      expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --recv --keyserver-options http-proxy=proxy.mycorp.dmz:3128 --keyserver hkp://gpg.mit.edu:80 ABC")
+      expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --no-tty --recv --keyserver-options http-proxy=proxy.mycorp.dmz:3128 --keyserver hkp://gpg.mit.edu:80 ABC")
     end
 
     it "properly handles keyservers passed with hkp:// URIs" do
-      expect(provider.keyserver_install_cmd("ABC", "hkp://gpg.mit.edu")).to eq("apt-key adv --recv --keyserver hkp://gpg.mit.edu ABC")
+      expect(provider.keyserver_install_cmd("ABC", "hkp://gpg.mit.edu")).to eq("apt-key adv --no-tty --recv --keyserver hkp://gpg.mit.edu ABC")
     end
   end
 

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -160,8 +160,7 @@ C5986B4F1257FFA86632CBA746181433FBB75451
     end
   end
 
-  describe "#
-" do
+ describe "#keyserver_install_cmd" do
     it "returns keyserver install command" do
       expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --no-tty --recv --keyserver hkp://gpg.mit.edu:80 ABC")
     end

--- a/spec/unit/provider/apt_repository_spec.rb
+++ b/spec/unit/provider/apt_repository_spec.rb
@@ -160,7 +160,7 @@ C5986B4F1257FFA86632CBA746181433FBB75451
     end
   end
 
- describe "#keyserver_install_cmd" do
+  describe "#keyserver_install_cmd" do
     it "returns keyserver install command" do
       expect(provider.keyserver_install_cmd("ABC", "gpg.mit.edu")).to eq("apt-key adv --no-tty --recv --keyserver hkp://gpg.mit.edu:80 ABC")
     end


### PR DESCRIPTION
use --no-tty during apt-keys for gpg 