### PR TITLE
Chef 14: windows_share: Properly split the users to be revoked using quotes

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -298,7 +298,7 @@ class Chef
         end
 
         def revoke_user_permissions(users)
-          revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join(',')}\" -Force"
+          revoke_command = "Revoke-SmbShareAccess -Name '#{new_resource.share_name}' -AccountName \"#{users.join('","')}\" -Force"
           Chef::Log.debug("Running '#{revoke_command}' to revoke share permissions")
           powershell_out!(revoke_command)
         end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>