### PR TITLE
Allow the use of tagged?(tags) method in both only_if and not_if blocks

### DIFF
--- a/lib/chef/dsl/universal.rb
+++ b/lib/chef/dsl/universal.rb
@@ -47,6 +47,13 @@ class Chef
       include Chef::Mixin::PowershellExec
       include Chef::Mixin::PowershellOut
       include Chef::Mixin::ShellOut
+
+      def tagged?(*tags)
+        tags.each do |tag|
+          return false unless run_context.node.tags.include?(tag)
+        end
+        true
+      end
     end
   end
 end

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -71,21 +71,6 @@ class Chef
       run_context.node.tag(*tags)
     end
 
-    # Returns true if the node is tagged with *all* of the supplied +tags+.
-    #
-    # === Parameters
-    # tags<Array>:: A list of tags
-    #
-    # === Returns
-    # true<TrueClass>:: If all the parameters are present
-    # false<FalseClass>:: If any of the parameters are missing
-    def tagged?(*tags)
-      tags.each do |tag|
-        return false unless run_context.node.tags.include?(tag)
-      end
-      true
-    end
-
     # Removes the list of tags from the node.
     #
     # === Parameters

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1204,4 +1204,27 @@ describe Chef::Resource do
       klass.provides(:test_resource, allow_cookbook_override: false)
     end
   end
+
+  describe "tagged" do
+    let(:recipe) do
+      Chef::Recipe.new("hjk", "test", run_context)
+    end
+
+    describe "with the default node object" do
+      let(:node) { Chef::Node.new }
+
+      it "should return false for any tags" do
+        expect(resource.tagged?("foo")).to be(false)
+      end
+    end
+
+    it "should return true from tagged? if node is tagged" do
+      recipe.tag "foo"
+      expect(resource.tagged?("foo")).to be(true)
+    end
+
+    it "should return false from tagged? if node is not tagged" do
+      expect(resource.tagged?("foo")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description

- I have added a new module `CommonHelpers` for using common methods on both `recipe.rb` and `resource.rb`
- In this module has added `tagged?(tags)` method and included this module on both `recipe.rb` and `resource.rb`
- Added test cases
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes ZD 20517 
Fixed #7449 
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
