### PR TITLE
minimal_ohai: Add init_package plugin as a required plugin

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -604,7 +604,7 @@ class Chef
     # @api private
     #
     def run_ohai
-      filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version ohai_time os os_version} : nil
+      filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version ohai_time os os_version init_package} : nil
       ohai.all_plugins(filter)
       events.ohai_completed(node)
     rescue Ohai::Exceptions::CriticalPluginFailure => e

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -38,7 +38,7 @@ describe Chef::Client do
     end
 
     it "runs ohai with only the minimum required plugins" do
-      expected_filter = %w{fqdn machinename hostname platform platform_version ohai_time os os_version}
+      expected_filter = %w{fqdn machinename hostname platform platform_version ohai_time os os_version init_package}
       expect(ohai_system).to receive(:all_plugins).with(expected_filter)
       client.run_ohai
     end


### PR DESCRIPTION
This is a pretty critical bit of data and we're using it for decisions
in the timezone resource now.

Signed-off-by: Tim Smith <tsmith@chef.io>