### PR TITLE
Add multipackage support to homebrew

### DIFF
--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -101,6 +101,25 @@ class Chef
           end
         end
 
+        #
+        # Return the package information given a package name or package alias
+        #
+        # @param [String] name_or_alias The name of the package or its alias
+        #
+        # @return [Hash] Package information
+        #
+        def package_info(package_name)
+          # return the package name if it's in the brew info hash
+          return brew_info[package_name] if brew_info[package_name]
+
+          # check each item in the hash to see if we were passed an alias
+          brew_info.each_value do |p|
+            return p if p["aliases"].include?(package_name)
+          end
+
+          {}
+        end
+
         # Some packages (formula) are "keg only" and aren't linked,
         # because multiple versions installed can cause conflicts. We
         # handle this by using the last installed version as the
@@ -111,14 +130,16 @@ class Chef
         #
         # @returns [String] package version
         def installed_version(i)
-          if brew_info[i]["keg_only"]
-            if brew_info[i]["installed"].empty?
+          p_data = package_info(i)
+
+          if p_data["keg_only"]
+            if p_data["installed"].empty?
               nil
             else
-              brew_info[i]["installed"].last["version"]
+              p_data["installed"].last["version"]
             end
           else
-            brew_info[i]["linked_keg"]
+            p_data["linked_keg"]
           end
         end
 
@@ -136,7 +157,9 @@ class Chef
         #
         # @returns [String] package version
         def available_version(i)
-          brew_info[i]["versions"]["stable"]
+          p_data = package_info(i)
+
+          p_data["versions"]["stable"]
         end
 
         private

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -54,8 +54,7 @@ class Chef
         end
 
         def install_package(names, versions)
-          packages = names.select { |x| x unless x.nil? }
-          brew("install", options, packages)
+          brew("install", options, names.compact)
         end
 
         def upgrade_package(name, version)
@@ -69,14 +68,12 @@ class Chef
         end
 
         def remove_package(names, versions)
-          packages = names.select { |x| x unless x.nil? }
-          brew("uninstall", options, packages)
+          brew("uninstall", options, names.compact)
         end
 
         # Homebrew doesn't really have a notion of purging, do a "force remove"
         def purge_package(names, versions)
-          packages = names.select { |x| x unless x.nil? }
-          brew("uninstall", "--force", options, packages)
+          brew("uninstall", "--force", options, names.compact)
         end
 
         def brew(*args)

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -95,7 +95,7 @@ class Chef
         # @returns [Hash] a hash of package information where the key is the package name
         def brew_info
           @brew_info ||= begin
-            command_array = ["info", "--json=v1"].concat new_resource.package_name
+            command_array = ["info", "--json=v1"].concat Array(new_resource.package_name)
             # convert the array of hashes into a hash where the key is the package name
             Hash[Chef::JSONCompat.from_json(brew(command_array)).collect { |pkg| [pkg["name"], pkg] }]
           end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -106,7 +106,7 @@ class Chef
         # @return [Hash] Package information
         #
         def package_info(package_name)
-          # return the package name if it's in the brew info hash
+          # return the package hash if it's in the brew info hash
           return brew_info[package_name] if brew_info[package_name]
 
           # check each item in the hash to see if we were passed an alias

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -92,7 +92,7 @@ class Chef
         # @returns [Hash] a hash of package information where the key is the package name
         def brew_info
           @brew_info ||= begin
-            command_array = ["info", "--json=v1"].concat Array(new_resource.package_name)
+            command_array = ["info", "--json=v1"].concat package_name_array
             # convert the array of hashes into a hash where the key is the package name
 
             cmd_output = brew_cmd_output(command_array, allow_failure: true)

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -164,7 +164,7 @@ class Chef
 
           logger.trace "Executing 'brew #{command.join(" ")}' as user '#{homebrew_user.name}'"
           # FIXME: this 1800 second default timeout should be deprecated
-          output = shell_out!('brew', *command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
+          output = shell_out!("brew", *command, timeout: 1800, user: homebrew_uid, environment: { "HOME" => homebrew_user.dir, "RUBYOPT" => nil, "TMPDIR" => nil })
           output.stdout.chomp
         end
 

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -155,8 +155,6 @@ class Chef
           p_data["versions"]["stable"]
         end
 
-        private
-
         def brew_cmd_output(*command)
           homebrew_uid = find_homebrew_uid(new_resource.respond_to?(:homebrew_user) && new_resource.homebrew_user)
           homebrew_user = Etc.getpwuid(homebrew_uid)

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -63,8 +63,9 @@ class Chef
         # and which packages can be upgrades. We do this by checking if brew_info has an entry
         # via the installed_version helper.
         def upgrade_package(names, versions)
-          upgrade_pkgs = names.filter_map { |x| x if installed_version(x) }
-          install_pkgs = names.filter_map { |x| x unless installed_version(x) }
+          # @todo when we no longer support Ruby 2.6 this can be simplified to be a .filter_map
+          upgrade_pkgs = names.map { |x| x if installed_version(x) }.compact
+          install_pkgs = names.map { |x| x unless installed_version(x) }.compact
 
           brew_cmd_output("upgrade", options, upgrade_pkgs) unless upgrade_pkgs.empty?
           brew_cmd_output("install", options, install_pkgs) unless install_pkgs.empty?

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -64,8 +64,8 @@ class Chef
         # via the installed_version helper.
         def upgrade_package(names, versions)
           # @todo when we no longer support Ruby 2.6 this can be simplified to be a .filter_map
-          upgrade_pkgs = names.map { |x| x if installed_version(x) }.compact
-          install_pkgs = names.map { |x| x unless installed_version(x) }.compact
+          upgrade_pkgs = names.select { |x| x if installed_version(x) }.compact
+          install_pkgs = names.select { |x| x unless installed_version(x) }.compact
 
           brew_cmd_output("upgrade", options, upgrade_pkgs) unless upgrade_pkgs.empty?
           brew_cmd_output("install", options, install_pkgs) unless install_pkgs.empty?

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -36,7 +36,7 @@ class Chef
           @current_resource = Chef::Resource::HomebrewPackage.new(new_resource.name)
           current_resource.package_name(new_resource.package_name)
           current_resource.version(get_current_versions)
-          logger.trace("#{new_resource} current version is #{current_resource.version}") if current_resource.version
+          logger.trace("#{new_resource} current package version(s): #{current_resource.version}") if current_resource.version
 
           current_resource
         end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -96,7 +96,7 @@ class Chef
             # convert the array of hashes into a hash where the key is the package name
 
             cmd_output = brew_cmd_output(command_array, allow_failure: true)
-            return nil if cmd_output.empty? # empty std_out == bad package queried
+            return {} if cmd_output.empty? # empty std_out == bad package queried
 
             Hash[Chef::JSONCompat.from_json(cmd_output).collect { |pkg| [pkg["name"], pkg] }]
           end
@@ -110,8 +110,6 @@ class Chef
         # @return [Hash] Package information
         #
         def package_info(package_name)
-          return nil if brew_info.nil? # continue to raise the nil up the chain
-
           # return the package hash if it's in the brew info hash
           return brew_info[package_name] if brew_info[package_name]
 
@@ -134,9 +132,6 @@ class Chef
         # @returns [String] package version
         def installed_version(i)
           p_data = package_info(i)
-
-          # nil means we couldn't find anything
-          return nil if p_data.nil?
 
           if p_data["keg_only"]
             if p_data["installed"].empty?
@@ -165,8 +160,8 @@ class Chef
         def available_version(i)
           p_data = package_info(i)
 
-          # nil means we couldn't find anything
-          return nil if p_data.nil?
+          # nothing is available
+          return nil if p_data.empty?
 
           p_data["versions"]["stable"]
         end

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -33,7 +33,7 @@ class Chef
       introduced "12.0"
 
       property :homebrew_user, [ String, Integer ],
-        description: "The name of the Homebrew owner to be used by #{Chef::Dist::PRODUCT} when executing a command."
+        description: "The name or uid of the Homebrew owner to be used by #{Chef::Dist::PRODUCT} when executing a command."
 
     end
   end

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::Provider::Package::Homebrew do
   let(:node) { Chef::Node.new }
-  let(:new_resource) { Chef::Resource::HomebrewPackage.new(["emacs", "vim"]) }
+  let(:new_resource) { Chef::Resource::HomebrewPackage.new(%w{emacs vim}) }
   let(:current_resource) { Chef::Resource::HomebrewPackage.new("emacs, vim") }
   let(:provider) do
     node = Chef::Node.new
@@ -31,91 +31,179 @@ describe Chef::Provider::Package::Homebrew do
 
   let(:homebrew_uid) { 1001 }
 
-  let(:uninstalled_brew_info) do
-    {
-      "name" => "emacs",
-      "homepage" => "http://www.gnu.org/software/emacs",
-      "versions" => {
-        "stable" => "24.3",
-        "bottle" => false,
-        "devel" => nil,
-        "head" => nil,
-      },
-      "revision" => 0,
-      "installed" => [],
-      "linked_keg" => nil,
-      "keg_only" => nil,
-      "dependencies" => [],
-      "conflicts_with" => [],
-      "caveats" => nil,
-      "options" => [],
-    }
+  let(:brew_cmd_output_data) { '[{"name":"emacs","full_name":"emacs","oldname":null,"aliases":[],"versioned_formulae":[],"desc":"GNU Emacs text editor","homepage":"https://www.gnu.org/software/emacs/","versions":{"stable":"26.3","devel":null,"head":"HEAD","bottle":true},"urls":{"stable":{"url":"https://ftp.gnu.org/gnu/emacs/emacs-26.3.tar.xz","tag":null,"revision":null}},"revision":0,"version_scheme":0,"bottle":{"stable":{"rebuild":0,"cellar":"/usr/local/Cellar","prefix":"/usr/local","root_url":"https://homebrew.bintray.com/bottles","files":{"catalina":{"url":"https://homebrew.bintray.com/bottles/emacs-26.3.catalina.bottle.tar.gz","sha256":"9ab33f4386ca5f7326a8c28da1324556ec990f682a7ca88641203da0b42dbdae"},"mojave":{"url":"https://homebrew.bintray.com/bottles/emacs-26.3.mojave.bottle.tar.gz","sha256":"8162a26246de7db44c53ea0d0ef0a806140318d19c69e8e5e33aa88ce7e823a8"},"high_sierra":{"url":"https://homebrew.bintray.com/bottles/emacs-26.3.high_sierra.bottle.tar.gz","sha256":"6a2629b6deddf99f81abb1990ecd6c87f0242a0eecbb6b6c2e4c3540e421d4c4"},"sierra":{"url":"https://homebrew.bintray.com/bottles/emacs-26.3.sierra.bottle.tar.gz","sha256":"2a47477e71766d7dd6b16c29ad5ba71817ed80d06212e3261ef3c776e7e9f5a2"}}}},"keg_only":false,"bottle_disabled":false,"options":[],"build_dependencies":["pkg-config"],"dependencies":["gnutls"],"recommended_dependencies":[],"optional_dependencies":[],"uses_from_macos":["libxml2","ncurses"],"requirements":[],"conflicts_with":[],"caveats":null,"installed":[],"linked_keg":null,"pinned":false,"outdated":false},{"name":"vim","full_name":"vim","oldname":null,"aliases":[],"versioned_formulae":[],"desc":"Vi \'workalike\' with many additional features","homepage":"https://www.vim.org/","versions":{"stable":"8.2.0550","devel":null,"head":"HEAD","bottle":true},"urls":{"stable":{"url":"https://github.com/vim/vim/archive/v8.2.0550.tar.gz","tag":null,"revision":null}},"revision":0,"version_scheme":0,"bottle":{"stable":{"rebuild":0,"cellar":"/usr/local/Cellar","prefix":"/usr/local","root_url":"https://homebrew.bintray.com/bottles","files":{"catalina":{"url":"https://homebrew.bintray.com/bottles/vim-8.2.0550.catalina.bottle.tar.gz","sha256":"8f9252500775aa85d8f826af30ca9e1118a56145fc2f961c37abed48bf78cf6b"},"mojave":{"url":"https://homebrew.bintray.com/bottles/vim-8.2.0550.mojave.bottle.tar.gz","sha256":"7566c83b770f3e8c4d4b462a39e5eb26609b37a8f8db6690a2560a3e22ded6b6"},"high_sierra":{"url":"https://homebrew.bintray.com/bottles/vim-8.2.0550.high_sierra.bottle.tar.gz","sha256":"a76e517fc69bf67b6903cb82295bc085c5eb4b46b4659f034c694dd97d2ee2d9"}}}},"keg_only":false,"bottle_disabled":false,"options":[],"build_dependencies":[],"dependencies":["gettext","lua","perl","python","ruby"],"recommended_dependencies":[],"optional_dependencies":[],"uses_from_macos":["ncurses"],"requirements":[],"conflicts_with":["ex-vi","macvim"],"caveats":null,"installed":[{"version":"8.2.0550","used_options":[],"built_as_bottle":true,"poured_from_bottle":true,"runtime_dependencies":[{"full_name":"gettext","version":"0.20.1"},{"full_name":"lua","version":"5.3.5"},{"full_name":"perl","version":"5.30.2"},{"full_name":"gdbm","version":"1.18.1"},{"full_name":"openssl@1.1","version":"1.1.1f"},{"full_name":"readline","version":"8.0.4"},{"full_name":"sqlite","version":"3.31.1"},{"full_name":"xz","version":"5.2.5"},{"full_name":"python","version":"3.7.7"},{"full_name":"libyaml","version":"0.2.2"},{"full_name":"ruby","version":"2.7.1"}],"installed_as_dependency":false,"installed_on_request":true}],"linked_keg":"8.2.0550","pinned":false,"outdated":false}]' }
+
+  let(:brew_info_data) do
+    { "openssl@1.1" =>
+      { "name" => "openssl@1.1",
+       "full_name" => "openssl@1.1",
+       "oldname" => nil,
+       "aliases" => ["openssl"],
+       "versioned_formulae" => [],
+       "desc" => "Cryptography and SSL/TLS Toolkit",
+       "homepage" => "https://openssl.org/",
+       "versions" => { "stable" => "1.1.1f", "devel" => nil, "head" => nil, "bottle" => true },
+       "urls" => { "stable" => { "url" => "https://www.openssl.org/source/openssl-1.1.1f.tar.gz", "tag" => nil, "revision" => nil } },
+       "revision" => 0,
+       "version_scheme" => 1,
+       "bottle" =>
+        { "stable" =>
+          { "rebuild" => 0,
+           "cellar" => "/usr/local/Cellar",
+           "prefix" => "/usr/local",
+           "root_url" => "https://homebrew.bintray.com/bottles",
+           "files" =>
+            { "catalina" => { "url" => "https://homebrew.bintray.com/bottles/openssl@1.1-1.1.1f.catalina.bottle.tar.gz", "sha256" => "724cd97c269952cdc28e24798e350fcf520a32c5985aeb26053ce006a09d8179" },
+             "mojave" => { "url" => "https://homebrew.bintray.com/bottles/openssl@1.1-1.1.1f.mojave.bottle.tar.gz", "sha256" => "25ab844d2f14fc85c7f52958b4b89bdd2965bbd9c557445829eff6473f238744" },
+             "high_sierra" => { "url" => "https://homebrew.bintray.com/bottles/openssl@1.1-1.1.1f.high_sierra.bottle.tar.gz", "sha256" => "27f26e2442222ac0565193fe0b86d8719559d776bcdd070d6113c16bb13accf6" } } } },
+       "keg_only" => true,
+       "bottle_disabled" => false,
+       "options" => [],
+       "build_dependencies" => [],
+       "dependencies" => [],
+       "recommended_dependencies" => [],
+       "optional_dependencies" => [],
+       "uses_from_macos" => [],
+       "requirements" => [],
+       "conflicts_with" => [],
+       "caveats" =>
+        "A CA file has been bootstrapped using certificates from the system\nkeychain. To add additional certificates, place .pem files in\n  $(brew --prefix)/etc/openssl@1.1/certs\n\nand run\n  $(brew --prefix)/opt/openssl@1.1/bin/c_rehash\n",
+       "installed" => [{ "version" => "1.1.1f", "used_options" => [], "built_as_bottle" => true, "poured_from_bottle" => true, "runtime_dependencies" => [], "installed_as_dependency" => true, "installed_on_request" => false }],
+       "linked_keg" => nil,
+       "pinned" => false,
+       "outdated" => false },
+     "kubernetes-cli" =>
+      { "name" => "kubernetes-cli",
+       "full_name" => "kubernetes-cli",
+       "oldname" => nil,
+       "aliases" => ["kubectl"],
+       "versioned_formulae" => [],
+       "desc" => "Kubernetes command-line interface",
+       "homepage" => "https://kubernetes.io/",
+       "versions" => { "stable" => "1.18.1", "devel" => nil, "head" => "HEAD", "bottle" => true },
+      "urls" => { "stable" => { "url" => "https://github.com/kubernetes/kubernetes.git", "tag" => "v1.18.1", "revision" => "7879fc12a63337efff607952a323df90cdc7a335" } },
+       "revision" => 0,
+       "version_scheme" => 0,
+       "bottle" =>
+        { "stable" =>
+          { "rebuild" => 0,
+           "cellar" => ":any_skip_relocation",
+           "prefix" => "/usr/local",
+           "root_url" => "https://homebrew.bintray.com/bottles",
+           "files" =>
+            { "catalina" => { "url" => "https://homebrew.bintray.com/bottles/kubernetes-cli-1.18.1.catalina.bottle.tar.gz", "sha256" => "0b3d688ee458b70b914a37a4ba867e202c6e71190d0c40a27f84628aec744749" },
+             "mojave" => { "url" => "https://homebrew.bintray.com/bottles/kubernetes-cli-1.18.1.mojave.bottle.tar.gz", "sha256" => "21fddfc86ec6d3e4f7ea787310b0fafd845d368de37524569bbe45938b18ba09" },
+             "high_sierra" => { "url" => "https://homebrew.bintray.com/bottles/kubernetes-cli-1.18.1.high_sierra.bottle.tar.gz", "sha256" => "1e20dcd177fd16b862b2432950984807b048cca5879c27bec59e85590f40eece" } } } },
+       "keg_only" => false,
+       "bottle_disabled" => false,
+       "options" => [],
+       "build_dependencies" => ["go"],
+       "dependencies" => [],
+       "recommended_dependencies" => [],
+       "optional_dependencies" => [],
+       "uses_from_macos" => [],
+       "requirements" => [],
+       "conflicts_with" => [],
+       "caveats" => nil,
+       "installed" => [],
+       "linked_keg" => nil,
+       "pinned" => false,
+       "outdated" => false },
+     "vim" =>
+      { "name" => "vim",
+       "full_name" => "vim",
+       "oldname" => nil,
+       "aliases" => [],
+       "versioned_formulae" => [],
+       "desc" => "Vi 'workalike' with many additional features",
+       "homepage" => "https://www.vim.org/",
+       "versions" => { "stable" => "8.2.0550", "devel" => nil, "head" => "HEAD", "bottle" => true },
+       "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/v8.2.0550.tar.gz", "tag" => nil, "revision" => nil } },
+       "revision" => 0,
+       "version_scheme" => 0,
+       "bottle" =>
+        { "stable" =>
+          { "rebuild" => 0,
+           "cellar" => "/usr/local/Cellar",
+           "prefix" => "/usr/local",
+           "root_url" => "https://homebrew.bintray.com/bottles",
+           "files" =>
+            { "catalina" => { "url" => "https://homebrew.bintray.com/bottles/vim-8.2.0550.catalina.bottle.tar.gz", "sha256" => "8f9252500775aa85d8f826af30ca9e1118a56145fc2f961c37abed48bf78cf6b" },
+                    "mojave" => { "url" => "https://homebrew.bintray.com/bottles/vim-8.2.0550.mojave.bottle.tar.gz", "sha256" => "7566c83b770f3e8c4d4b462a39e5eb26609b37a8f8db6690a2560a3e22ded6b6" },
+             "high_sierra" => { "url" => "https://homebrew.bintray.com/bottles/vim-8.2.0550.high_sierra.bottle.tar.gz", "sha256" => "a76e517fc69bf67b6903cb82295bc085c5eb4b46b4659f034c694dd97d2ee2d9" } } } },
+       "keg_only" => false,
+       "bottle_disabled" => false,
+       "options" => [],
+       "build_dependencies" => [],
+       "dependencies" => %w{gettext lua perl python ruby},
+       "recommended_dependencies" => [],
+       "optional_dependencies" => [],
+       "uses_from_macos" => ["ncurses"],
+       "requirements" => [],
+       "conflicts_with" => %w{ex-vi macvim},
+       "caveats" => nil,
+       "installed" =>
+        [{ "version" => "8.2.0550",
+          "used_options" => [],
+          "built_as_bottle" => true,
+          "poured_from_bottle" => true,
+          "runtime_dependencies" =>
+           [{ "full_name" => "gettext", "version" => "0.20.1" },
+            { "full_name" => "lua", "version" => "5.3.5" },
+            { "full_name" => "perl", "version" => "5.30.2" },
+            { "full_name" => "gdbm", "version" => "1.18.1" },
+            { "full_name" => "openssl@1.1", "version" => "1.1.1f" },
+            { "full_name" => "readline", "version" => "8.0.4" },
+            { "full_name" => "sqlite", "version" => "3.31.1" },
+            { "full_name" => "xz", "version" => "5.2.5" },
+            { "full_name" => "python", "version" => "3.7.7" },
+            { "full_name" => "libyaml", "version" => "0.2.2" },
+            { "full_name" => "ruby", "version" => "2.7.1" }],
+          "installed_as_dependency" => false,
+          "installed_on_request" => true }],
+       "linked_keg" => "8.2.0550",
+       "pinned" => false,
+       "outdated" => false },
+     "curl" =>
+      { "name" => "curl",
+       "full_name" => "curl",
+       "oldname" => nil,
+       "aliases" => [],
+       "versioned_formulae" => [],
+       "desc" => "Get a file from an HTTP, HTTPS or FTP server",
+       "homepage" => "https://curl.haxx.se/",
+       "versions" => { "stable" => "7.69.1", "devel" => nil, "head" => "HEAD", "bottle" => true },
+       "urls" => { "stable" => { "url" => "https://curl.haxx.se/download/curl-7.69.1.tar.bz2", "tag" => nil, "revision" => nil } },
+       "revision" => 0,
+       "version_scheme" => 0,
+       "bottle" =>
+         { "stable" =>
+          { "rebuild" => 0,
+           "cellar" => ":any",
+           "prefix" => "/usr/local",
+           "root_url" => "https://homebrew.bintray.com/bottles",
+           "files" =>
+            { "catalina" => { "url" => "https://homebrew.bintray.com/bottles/curl-7.69.1.catalina.bottle.tar.gz", "sha256" => "400500fede02f9335bd38c16786b2bbf5e601e358dfac8c21e363d2a8fdd8fac" },
+             "mojave" => { "url" => "https://homebrew.bintray.com/bottles/curl-7.69.1.mojave.bottle.tar.gz", "sha256" => "f082c275f9af1e8e93be12b63a1aff659ba6efa48c8528a97e26c9858a6f95b6" },
+             "high_sierra" => { "url" => "https://homebrew.bintray.com/bottles/curl-7.69.1.high_sierra.bottle.tar.gz", "sha256" => "ad023093c252799a4c60646a149bfe14ffa6984817cf463a6f0e98f6551057fe" } } } },
+       "keg_only" => true,
+       "bottle_disabled" => false,
+       "options" => [],
+       "build_dependencies" => ["pkg-config"],
+       "dependencies" => [],
+       "recommended_dependencies" => [],
+       "optional_dependencies" => [],
+       "uses_from_macos" => ["openssl@1.1", "zlib"],
+       "requirements" => [],
+       "conflicts_with" => [],
+       "caveats" => nil,
+       "installed" => [],
+       "linked_keg" => nil,
+       "pinned" => false,
+       "outdated" => false } }
   end
 
-  let(:installed_brew_info) do
-    {
-      "name" => "emacs",
-      "homepage" => "http://www.gnu.org/software/emacs/",
-      "versions" => {
-        "stable" => "24.3",
-        "bottle" => false,
-        "devel" => nil,
-        "head" => "HEAD",
-      },
-      "revision" => 0,
-      "installed" => [{ "version" => "24.3" }],
-      "linked_keg" => "24.3",
-      "keg_only" => nil,
-      "dependencies" => [],
-      "conflicts_with" => [],
-      "caveats" => "",
-      "options" => [],
-    }
-  end
-
-  let(:keg_only_brew_info) do
-    {
-      "name" => "emacs-kegger",
-      "homepage" => "http://www.gnu.org/software/emacs/",
-      "versions" => {
-        "stable" => "24.3-keggy",
-        "bottle" => false,
-        "devel" => nil,
-        "head" => "HEAD",
-      },
-      "revision" => 0,
-      "installed" => [{ "version" => "24.3-keggy" }],
-      "linked_keg" => nil,
-      "keg_only" => true,
-      "dependencies" => [],
-      "conflicts_with" => [],
-      "caveats" => "",
-      "options" => [],
-    }
-  end
-
-  let(:keg_only_uninstalled_brew_info) do
-    {
-      "name" => "emacs-kegger",
-      "homepage" => "http://www.gnu.org/software/emacs/",
-      "versions" => {
-        "stable" => "24.3-keggy",
-        "bottle" => false,
-        "devel" => nil,
-        "head" => "HEAD",
-      },
-      "revision" => 0,
-      "installed" => [],
-      "linked_keg" => nil,
-      "keg_only" => true,
-      "dependencies" => [],
-      "conflicts_with" => [],
-      "caveats" => "",
-      "options" => [],
-    }
-  end
-
-  describe "load_current_resource" do
+  describe "#load_current_resource" do
     before(:each) do
       allow(provider).to receive(:installed_version).and_return(nil)
       allow(provider).to receive(:available_version).and_return("1.0")
@@ -144,25 +232,37 @@ describe Chef::Provider::Package::Homebrew do
     end
   end
 
-  describe "current_installed_version" do
+  describe "#brew_info" do
+    it "returns a hash of data per package" do
+      allow(provider).to receive(:brew_cmd_output).and_return(brew_cmd_output_data)
+      expect(provider.brew_info).to have_key("vim")
+    end
+  end
+
+  describe "#installed_version" do
     it "returns the latest version from brew info if the package is keg only" do
-      allow(provider).to receive(:brew_info).and_return(keg_only_brew_info)
-      expect(provider.current_installed_version).to eql("24.3-keggy")
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.installed_version("openssl@1.1")).to eql("1.1.1f")
     end
 
     it "returns the linked keg version if the package is not keg only" do
-      allow(provider).to receive(:brew_info).and_return(installed_brew_info)
-      expect(provider.current_installed_version).to eql("24.3")
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.installed_version("vim")).to eql("8.2.0550")
     end
 
     it "returns nil if the package is not installed" do
-      allow(provider).to receive(:brew_info).and_return(uninstalled_brew_info)
-      expect(provider.current_installed_version).to be_nil
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.installed_version("kubernetes-cli")).to be_nil
     end
 
     it "returns nil if the package is keg only and not installed" do
-      allow(provider).to receive(:brew_info).and_return(keg_only_uninstalled_brew_info)
-      expect(provider.current_installed_version).to be_nil
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.installed_version("curl")).to be_nil
+    end
+
+    it "returns the version if a package alias is given" do
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.installed_version("openssl")).to eql("1.1.1f")
     end
   end
 

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -284,7 +284,7 @@ describe Chef::Provider::Package::Homebrew do
       expect(Etc).to receive(:getpwuid).with(homebrew_uid).and_return(OpenStruct.new(name: "name", dir: "/"))
     end
 
-    it "passes a single to the brew command and return stdout" do
+    it "passes a single pkg to the brew command and return stdout" do
       allow(provider).to receive(:shell_out!).and_return(OpenStruct.new(stdout: "zombo"))
       expect(provider.brew_cmd_output).to eql("zombo")
     end
@@ -301,43 +301,6 @@ describe Chef::Provider::Package::Homebrew do
         allow(provider).to receive(:shell_out!).and_return(OpenStruct.new(stdout: "zombo"))
         expect(provider.brew_cmd_output).to eql("zombo")
       end
-    end
-  end
-
-  describe "#install_package" do
-    it "calls #brew_cmd_output to install the packages" do
-      expect(provider).to receive(:brew_cmd_output).with("install", nil, %w{vim git})
-      provider.install_package(%w{vim git}, ["8.2.0550", "2.26.1"])
-    end
-
-    it "passes options if set on the resource" do
-    end
-  end
-
-  describe "#upgrade_package" do
-    it "calls #brew_cmd_output to upgrade the packages" do
-    end
-
-    it "calls #brew_cmd_output to install packages that aren't yet installed" do
-    end
-
-    it "passes options if set on the resource" do
-    end
-  end
-
-  describe "#remove_package" do
-    it "calls #brew_cmd_output to remove the packages" do
-    end
-
-    it "passes options if set on the resource" do
-    end
-  end
-
-  describe "#purge_package" do
-    it "calls #brew_cmd_output to remove the packages with the --force option" do
-    end
-
-    it "passes options if set on the resource" do
     end
   end
 

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -238,9 +238,9 @@ describe Chef::Provider::Package::Homebrew do
       expect(provider.brew_info).to have_key("vim")
     end
 
-    it "returns nil if brew_cmd_output_data returned empty stdout" do
+    it "returns empty hash if brew_cmd_output_data returned empty stdout" do
       allow(provider).to receive(:brew_cmd_output).and_return("")
-      expect(provider.brew_info).to be_nil
+      expect(provider.brew_info).to eq({})
     end
   end
 
@@ -282,9 +282,9 @@ describe Chef::Provider::Package::Homebrew do
       expect(provider.available_version("openssl")).to eql("1.1.1f")
     end
 
-    it "returns nil if brew_info returns nil" do
-      allow(provider).to receive(:brew_info).and_return(nil)
-      expect(provider.available_version("foo")).to be_nil
+    it "returns nil if the package is not installed" do
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.available_version("bogus")).to be_nil
     end
   end
 

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -304,40 +304,71 @@ describe Chef::Provider::Package::Homebrew do
     end
   end
 
-  context "when testing actions" do
-    before(:each) do
-      provider.current_resource = current_resource
+  describe "#install_package" do
+    it "calls #brew_cmd_output to install the packages" do
+      expect(provider).to receive(:brew_cmd_output).with(["install", nil, %w{vim git}])
+      provider.install_package(%w{vim git}, ["8.2.0550", "2.26.1"])
     end
 
-    describe "install_package" do
-      before(:each) do
-        allow(provider).to receive(:candidate_version).and_return("24.3")
+    it "passes options if set on the resource" do
+    end
+  end
+
+  describe "#upgrade_package" do
+    it "calls #brew_cmd_output to upgrade the packages" do
+    end
+
+    it "calls #brew_cmd_output to install packages that aren't yet installed" do
+    end
+
+    it "passes options if set on the resource" do
+    end
+  end
+
+  describe "#remove_package" do
+    it "calls #brew_cmd_output to remove the packages" do
+    end
+
+    it "passes options if set on the resource" do
+    end
+  end
+
+  describe "#purge_package" do
+    it "calls #brew_cmd_output to remove the packages with the --force option" do
+    end
+
+    it "passes options if set on the resource" do
+    end
+  end
+
+  describe "resource actions" do
+    before(:each) do
+      provider.current_resource = current_resource
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+    end
+
+    describe "install" do
+      it "calls brew_cmd_output to install only the necessary packages" do
+        new_resource.package_name %w{curl openssl}
+        expect(provider).to receive(:brew_cmd_output).with("install", nil, ["curl"])
+        provider.run_action(:install)
       end
 
-      it "installs the named package with brew install" do
-        allow(provider.new_resource).to receive(:version).and_return("24.3")
-        allow(provider.current_resource).to receive(:version).and_return(nil)
-        allow(provider).to receive(:brew_info).and_return(uninstalled_brew_info)
-        expect(provider).to receive(:get_response_from_command).with("brew", "install", nil, "emacs")
-        provider.install_package("emacs", "24.3")
-      end
-
-      it "does not do anything if the package is installed" do
-        allow(provider.current_resource).to receive(:version).and_return("24.3")
-        allow(provider).to receive(:brew_info).and_return(installed_brew_info)
-        expect(provider).not_to receive(:get_response_from_command)
-        provider.install_package("emacs", "24.3")
+      it "does not do anything if all the packages are already installed" do
+        new_resource.package_name %w{vim openssl}
+        expect(provider).not_to receive(:brew_cmd_output)
+        provider.run_action(:install)
       end
 
       it "uses options to the brew command if specified" do
+        new_resource.package_name "curl"
         new_resource.options "--cocoa"
-        allow(provider.current_resource).to receive(:version).and_return("24.3")
-        allow(provider).to receive(:get_response_from_command).with("brew", "install", "--cocoa", "emacs")
-        provider.install_package("emacs", "24.3")
+        expect(provider).to receive(:brew_cmd_output).with("install", ["--cocoa"], ["curl"])
+        provider.run_action(:install)
       end
     end
 
-    describe "upgrade_package" do
+    describe "upgrade" do
       it "uses brew upgrade to upgrade the package if it is installed" do
         allow(provider.current_resource).to receive(:version).and_return("24")
         allow(provider).to receive(:brew_info).and_return(installed_brew_info)
@@ -368,33 +399,31 @@ describe Chef::Provider::Package::Homebrew do
       end
     end
 
-    describe "remove_package" do
-      it "uninstalls the package with brew uninstall" do
-        allow(provider.current_resource).to receive(:version).and_return("24.3")
-        allow(provider).to receive(:brew_info).and_return(installed_brew_info)
-        expect(provider).to receive(:get_response_from_command).with("brew", "uninstall", nil, "emacs")
-        provider.remove_package("emacs", "24.3")
+    describe "remove" do
+      it "calls #brew_cmd_output to uninstall the packages" do
+        new_resource.package_name %w{curl openssl}
+        expect(provider).to receive(:brew_cmd_output).with("uninstall", nil, %w{curl openssl})
+        provider.run_action(:remove)
       end
 
       it "does not do anything if the package is not installed" do
-        allow(provider).to receive(:brew_info).and_return(uninstalled_brew_info)
-        expect(provider).not_to receive(:get_response_from_command)
-        provider.remove_package("emacs", "24.3")
+        new_resource.package_name %w{kubernetes-cli}
+        expect(provider).not_to receive(:brew_cmd_output)
+        provider.run_action(:remove)
       end
     end
 
-    describe "purge_package" do
-      it "uninstalls the package with brew uninstall --force" do
-        allow(provider.current_resource).to receive(:version).and_return("24.3")
-        allow(provider).to receive(:brew_info).and_return(installed_brew_info)
-        expect(provider).to receive(:get_response_from_command).with("brew", "uninstall", "--force", nil, "emacs")
-        provider.purge_package("emacs", "24.3")
+    describe "purge" do
+      it "call #brew_cmd_output to uninstall --force the packages" do
+        new_resource.package_name %w{curl openssl}
+        expect(provider).to receive(:brew_cmd_output).with("uninstall", "--force", nil, %w{curl openssl})
+        provider.run_action(:purge)
       end
 
       it "does not do anything if the package is not installed" do
-        allow(provider).to receive(:brew_info).and_return(uninstalled_brew_info)
-        expect(provider).not_to receive(:get_response_from_command)
-        provider.purge_package("emacs", "24.3")
+        new_resource.package_name %w{kubernetes-cli}
+        expect(provider).not_to receive(:brew_cmd_output)
+        provider.run_action(:purge)
       end
     end
   end

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -278,7 +278,7 @@ describe Chef::Provider::Package::Homebrew do
     end
   end
 
-  describe "brew" do
+  describe "#brew_cmd_output" do
     before do
       expect(provider).to receive(:find_homebrew_uid).and_return(homebrew_uid)
       expect(Etc).to receive(:getpwuid).with(homebrew_uid).and_return(OpenStruct.new(name: "name", dir: "/"))
@@ -286,12 +286,12 @@ describe Chef::Provider::Package::Homebrew do
 
     it "passes a single to the brew command and return stdout" do
       allow(provider).to receive(:shell_out!).and_return(OpenStruct.new(stdout: "zombo"))
-      expect(provider.brew).to eql("zombo")
+      expect(provider.brew_cmd_output).to eql("zombo")
     end
 
     it "takes multiple arguments as an array" do
       allow(provider).to receive(:shell_out!).and_return(OpenStruct.new(stdout: "homestarrunner"))
-      expect(provider.brew("info", "opts", "bananas")).to eql("homestarrunner")
+      expect(provider.brew_cmd_output("info", "opts", "bananas")).to eql("homestarrunner")
     end
 
     context "when new_resource is Package" do
@@ -299,7 +299,7 @@ describe Chef::Provider::Package::Homebrew do
 
       it "does not try to read homebrew_user from Package, which does not have it" do
         allow(provider).to receive(:shell_out!).and_return(OpenStruct.new(stdout: "zombo"))
-        expect(provider.brew).to eql("zombo")
+        expect(provider.brew_cmd_output).to eql("zombo")
       end
     end
   end

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -237,6 +237,11 @@ describe Chef::Provider::Package::Homebrew do
       allow(provider).to receive(:brew_cmd_output).and_return(brew_cmd_output_data)
       expect(provider.brew_info).to have_key("vim")
     end
+
+    it "returns nil if brew_cmd_output_data returned empty stdout" do
+      allow(provider).to receive(:brew_cmd_output).and_return("")
+      expect(provider.brew_info).to be_nil
+    end
   end
 
   describe "#installed_version" do
@@ -275,6 +280,11 @@ describe Chef::Provider::Package::Homebrew do
     it "returns version of package when alias is given" do
       allow(provider).to receive(:brew_info).and_return(brew_info_data)
       expect(provider.available_version("openssl")).to eql("1.1.1f")
+    end
+
+    it "returns nil if brew_info returns nil" do
+      allow(provider).to receive(:brew_info).and_return(nil)
+      expect(provider.available_version("foo")).to be_nil
     end
   end
 

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -266,6 +266,18 @@ describe Chef::Provider::Package::Homebrew do
     end
   end
 
+  describe "#available_version" do
+    it "returns version of package when exact name given" do
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.available_version("openssl@1.1")).to eql("1.1.1f")
+    end
+
+    it "returns version of package when alias is given" do
+      allow(provider).to receive(:brew_info).and_return(brew_info_data)
+      expect(provider.available_version("openssl")).to eql("1.1.1f")
+    end
+  end
+
   describe "brew" do
     before do
       expect(provider).to receive(:find_homebrew_uid).and_return(homebrew_uid)

--- a/spec/unit/provider/package/homebrew_spec.rb
+++ b/spec/unit/provider/package/homebrew_spec.rb
@@ -238,9 +238,10 @@ describe Chef::Provider::Package::Homebrew do
       expect(provider.brew_info).to have_key("vim")
     end
 
-    it "returns empty hash if brew_cmd_output_data returned empty stdout" do
+    it "returns empty hash for packages if they lack data" do
+      new_resource.package_name %w{bogus}
       allow(provider).to receive(:brew_cmd_output).and_return("")
-      expect(provider.brew_info).to eq({})
+      expect(provider.brew_info).to eq("bogus" => {})
     end
   end
 


### PR DESCRIPTION
Issues:
- versions are pretty much ignored, but I think that makes sense with homebrew. It's a roll forward package system so you can't install a specific version. That's just not a concept of the package system.

Signed-off-by: Tim Smith <tsmith@chef.io>