### PR TITLE
dng_package: Take out the warning when allow_downgrade is used

### DIFF
--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -67,13 +67,6 @@ class Chef
                            { after: true, before: false }
                          end
                        }
-
-      def allow_downgrade(arg = nil)
-        if !arg.nil?
-          Chef.deprecated(:dnf_package_allow_downgrade, "the allow_downgrade property on the dnf_package provider is not used, DNF supports downgrades by default.")
-        end
-        false
-      end
     end
   end
 end


### PR DESCRIPTION
Now that allow_downgrade is set to true by default we need the ability to turn it off. This error message no longer makes sense.

Signed-off-by: Tim Smith <tsmith@chef.io>