### PR TITLE
added multipackage support for pacman resource

### DIFF
--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -28,6 +28,7 @@ class Chef
         provides :pacman_package
 
         use_multipackage_api
+        allow_nils
 
         def load_current_resource
           @current_resource = Chef::Resource::Package.new(new_resource.name)

--- a/lib/chef/provider/package/pacman.rb
+++ b/lib/chef/provider/package/pacman.rb
@@ -42,7 +42,7 @@ class Chef
             repos = pacman.scan(/\[(.+)\]/).flatten
           end
 
-          repos = repos.map { |r| Regexp.escape(r) }.join("|")
+          repos = Regexp.union(repos)
           status = shell_out("pacman", "-Sl")
 
           unless status.exitstatus == 0 || status.exitstatus == 1

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -15,179 +15,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require "spec_helper"
+
+def create_provider_for(name)
+  @new_resource = Chef::Resource::Package.new(name)
+  provider = Chef::Provider::Package::Pacman.new(@new_resource, @run_context)
+  allow(provider).to receive(:shell_out_compacted).and_return(@status)
+  provider
+end
+
+RSpec.shared_examples "current_resource" do |pkg, version, candidate|
+  let(:current_resource) { @provider.load_current_resource }
+  before(:each) do
+    @provider = create_provider_for(pkg)
+  end
+
+  it "sets current_resource name" do
+    expect(current_resource.package_name).to eql(pkg)
+  end
+
+  it "sets current_resource version" do
+    expect(current_resource.version).to eql(version)
+  end
+
+  it "sets candidate version" do
+    current_resource
+    expect(@provider.candidate_version).to eql(candidate)
+  end
+end
 
 describe Chef::Provider::Package::Pacman do
   before(:each) do
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new
     @run_context = Chef::RunContext.new(@node, {}, @events)
-    @new_resource = Chef::Resource::Package.new("nano")
-    @current_resource = Chef::Resource::Package.new("nano")
+    @pacman_conf = <<~PACMAN_CONF
+      [options]
+      HoldPkg      = pacman glibc
+      Architecture = auto
 
-    @status = double(stdout: "", exitstatus: 0)
-    @provider = Chef::Provider::Package::Pacman.new(@new_resource, @run_context)
-    allow(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
+      [customrepo]
+      Server = https://my.custom.repo
 
-    allow(@provider).to receive(:shell_out_compacted).and_return(@status)
-    @stdin = StringIO.new
-    @stdout = StringIO.new(<<~ERR)
-      error: package "nano" not found
-ERR
-    @stderr = StringIO.new
-    @pid = 2342
+      [core]
+      Include = /etc/pacman.d/mirrorlist
+
+      [extra]
+      Include = /etc/pacman.d/mirrorlist
+
+      [community]
+      Include = /etc/pacman.d/mirrorlist
+    PACMAN_CONF
+
+    allow(::File).to receive(:exist?).with("/etc/pacman.conf").and_return(true)
+    allow(::File).to receive(:read).with("/etc/pacman.conf").and_return(@pacman_conf)
+
+    pacman_out = <<~PACMAN_OUT
+      extra nano 3.450-1
+      extra emacs 0.12.0-1 [installed]
+      core sed 3.234-2 [installed: 3.234-1]
+    PACMAN_OUT
+    @status = double(stdout: pacman_out, exitstatus: 0)
+
   end
 
-  describe "when determining the current package state" do
-    it "should create a current resource with the name of the new_resource" do
-      expect(Chef::Resource::Package).to receive(:new).and_return(@current_resource)
-      @provider.load_current_resource
+  describe "loading the current resource" do
+
+    describe "for an existing and installed but upgradable package" do
+      include_examples "current_resource", ["sed"], ["3.234-1"], ["3.234-2"]
     end
 
-    it "should set the current resources package name to the new resources package name" do
-      expect(@current_resource).to receive(:package_name).with(@new_resource.package_name)
-      @provider.load_current_resource
+    describe "for an existing and installed package" do
+      include_examples "current_resource", ["emacs"], ["0.12.0-1"], ["0.12.0-1"]
     end
 
-    it "should run pacman query with the package name" do
-      expect(@provider).to receive(:shell_out_compacted).with("pacman", "-Qi", @new_resource.package_name, { timeout: 900 }).and_return(@status)
-      @provider.load_current_resource
+    describe "for an existing non installed package" do
+      include_examples "current_resource", ["nano"], [nil], ["3.450-1"]
     end
 
-    it "should read stdout on pacman" do
-      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
-      @provider.load_current_resource
+    describe "for a non existing and an upgradable package" do
+      include_examples "current_resource", %w{nano sed}, [nil, "3.234-1"], ["3.450-1", "3.234-2"]
     end
 
-    it "should set the installed version to nil on the current resource if pacman installed version not exists" do
-      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
-      @provider.load_current_resource
-    end
+    describe "for a non existing package" do
+      let(:current_resource) { @provider.load_current_resource }
+      before(:each) do
+        @provider = create_provider_for("vim")
+      end
 
-    it "should set the installed version if pacman has one" do
-      stdout = <<~PACMAN
-        Name           : nano
-        Version        : 2.2.2-1
-        URL            : http://www.nano-editor.org
-        Licenses       : GPL
-        Groups         : base
-        Provides       : None
-        Depends On     : glibc  ncurses
-        Optional Deps  : None
-        Required By    : None
-        Conflicts With : None
-        Replaces       : None
-        Installed Size : 1496.00 K
-        Packager       : Andreas Radke <andyrtr@archlinux.org>
-        Architecture   : i686
-        Build Date     : Mon 18 Jan 2010 06:16:16 PM CET
-        Install Date   : Mon 01 Feb 2010 10:06:30 PM CET
-        Install Reason : Explicitly installed
-        Install Script : Yes
-        Description    : Pico editor clone with enhancements
-PACMAN
-
-      status = double(stdout: stdout, exitstatus: 0)
-      allow(@provider).to receive(:shell_out_compacted).and_return(status)
-      @provider.load_current_resource
-      expect(@current_resource.version).to eq("2.2.2-1")
-    end
-
-    it "should set the candidate version if pacman has one" do
-      status = double(stdout: "core nano 2.2.3-1", exitstatus: 0)
-      allow(@provider).to receive(:shell_out_compacted).and_return(status)
-      @provider.load_current_resource
-      expect(@provider.candidate_version).to eql("2.2.3-1")
-    end
-
-    it "should use pacman.conf to determine valid repo names for package versions" do
-      @pacman_conf = <<~PACMAN_CONF
-        [options]
-        HoldPkg      = pacman glibc
-        Architecture = auto
-
-        [customrepo]
-        Server = https://my.custom.repo
-
-        [core]
-        Include = /etc/pacman.d/mirrorlist
-
-        [extra]
-        Include = /etc/pacman.d/mirrorlist
-
-        [community]
-        Include = /etc/pacman.d/mirrorlist
-PACMAN_CONF
-
-      status = double(stdout: "customrepo nano 1.2.3-4", exitstatus: 0)
-      allow(::File).to receive(:exist?).with("/etc/pacman.conf").and_return(true)
-      allow(::File).to receive(:read).with("/etc/pacman.conf").and_return(@pacman_conf)
-      allow(@provider).to receive(:shell_out_compacted).and_return(status)
-
-      @provider.load_current_resource
-      expect(@provider.candidate_version).to eql("1.2.3-4")
-    end
-
-    it "should raise an exception if pacman fails" do
-      expect(@status).to receive(:exitstatus).and_return(2)
-      expect { @provider.load_current_resource }.to raise_error(Chef::Exceptions::Package)
-    end
-
-    it "should not raise an exception if pacman succeeds" do
-      expect(@status).to receive(:exitstatus).and_return(0)
-      expect { @provider.load_current_resource }.not_to raise_error
-    end
-
-    it "should raise an exception if pacman does not return a candidate version" do
-      allow(@provider).to receive(:shell_out_compacted).and_return(@status)
-      expect { @provider.candidate_version }.to raise_error(Chef::Exceptions::Package)
-    end
-
-    it "should return the current resouce" do
-      expect(@provider.load_current_resource).to eql(@current_resource)
-    end
-  end
-
-  describe Chef::Provider::Package::Pacman, "install_package" do
-    it "should run pacman install with the package name and version" do
-      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
-      @provider.install_package("nano", "1.0")
-    end
-
-    it "should run pacman install with the package name and version and options if specified" do
-      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--sync", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
-      @new_resource.options("--debug")
-
-      @provider.install_package("nano", "1.0")
-    end
-  end
-
-  describe Chef::Provider::Package::Pacman, "upgrade_package" do
-    it "should run install_package with the name and version" do
-      expect(@provider).to receive(:install_package).with("nano", "1.0")
-      @provider.upgrade_package("nano", "1.0")
-    end
-  end
-
-  describe Chef::Provider::Package::Pacman, "remove_package" do
-    it "should run pacman remove with the package name" do
-      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "nano", { timeout: 900 })
-      @provider.remove_package("nano", "1.0")
-    end
-
-    it "should run pacman remove with the package name and options if specified" do
-      expect(@provider).to receive(:shell_out_compacted!).with("pacman", "--remove", "--noconfirm", "--noprogressbar", "--debug", "nano", { timeout: 900 })
-      @new_resource.options("--debug")
-
-      @provider.remove_package("nano", "1.0")
-    end
-  end
-
-  describe Chef::Provider::Package::Pacman, "purge_package" do
-    it "should run remove_package with the name and version" do
-      expect(@provider).to receive(:remove_package).with("nano", "1.0")
-      @provider.purge_package("nano", "1.0")
+      it "raises an error" do
+        expect { current_resource }.to raise_error(Chef::Exceptions::Package)
+      end
     end
 
   end


### PR DESCRIPTION
Signed-off-by: Ingo Becker <ingo@orgizm.net>

### Description
This PR adds multipackage support to the pacman resource. The chef documentation doesn't mention the fact that the pacman resource doesn't support an array for `package_name` containing multiple package names. The result of supplying an array is an exception which doesn't make sense to the user. It took me quite some time to recognize, that the error originates from the documentation/implementation (depending on your point of view). I went down the path of implementing multi package support. There are still some issues like the resource is ignoring given version numbers and installs the latest version available to pacman all the time.

I'm not entirely sure about the way i wrote the tests. The original test 'injected' a resource object into the provider in order to assert specific message calls on it. Any comments on that are highly appreciated.

### Issues Resolved

Closes #5780

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
