### PR TITLE
pull the ohai version from the bundle not from master

### DIFF
--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -17,7 +17,7 @@ provisioner:
   github_owner: "chef"
   github_repo: "chef"
   refname: <%= ENV['TRAVIS_COMMIT'] %>
-  ohai_refname: "master"
+  ohai_refname: "<%= "v" + `bundle exec ohai --version`.split(/\s+/)[1] %>"
   github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
   data_path: test/fixtures
 # disable file provider diffs so we don't overflow travis' line limit


### PR DESCRIPTION
should fix issues with kitchen tests breaking in travis
after we merge to ohai
