### PR TITLE
better kithen ohai pinning

### DIFF
--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -17,7 +17,7 @@ provisioner:
   github_owner: "chef"
   github_repo: "chef"
   refname: <%= ENV['TRAVIS_COMMIT'] %>
-  ohai_refname: "<%= "v" + `bundle exec ohai --version`.split(/\s+/)[1] %>"
+  ohai_refname: "<%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %>"
   github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
   data_path: test/fixtures
 # disable file provider diffs so we don't overflow travis' line limit


### PR DESCRIPTION
since it turns out kitchen-tests/Gemfile.lock isn't actually checked in
the prior change was still just effectively floating on master, this
now makes us parse the ohai version out of the root Gemfile.lock and
use that to install ohai from git in our virt.
