### PR TITLE
windows_certificate: Fix failures in delete action fails if certificate doesn't exist

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -58,7 +58,6 @@ class Chef
 
       action :create do
         description "Creates or updates a certificate."
-
         add_cert(OpenSSL::X509::Certificate.new(raw_source))
       end
 
@@ -90,8 +89,12 @@ class Chef
 
       action :delete do
         description "Deletes a certificate."
-
-        delete_cert
+        cert_obj = fetch_cert
+        if cert_obj
+          converge_by("Deleting certificate #{new_resource.source} from Store #{new_resource.store_name}") do
+            delete_cert
+          end
+        end
       end
 
       action :fetch do


### PR DESCRIPTION
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description

Currently  certificate delete action fails if certificate doesn't exist as mentioned here https://github.com/chef-cookbooks/windows/issues/578. This fix handles this. I will be adding same fix on the windows cookbook side too.

We need to merge https://github.com/chef/win32-certstore/pull/45 before merging this.

### Issues Resolved

https://github.com/chef-cookbooks/windows/issues/578


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
