### PR TITLE
package resource: Add RHEL 8 support to DNF package installer

### DIFF
--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -37,7 +37,8 @@ class Chef
           DNF_HELPER = ::File.expand_path(::File.join(::File.dirname(__FILE__), "dnf_helper.py")).freeze
 
           def dnf_command
-            @dnf_command ||= which("python", "python3", "python2", "python2.7") do |f|
+            # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
+            @dnf_command ||= which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
               shell_out("#{f} -c 'import dnf'").exitstatus == 0
             end + " #{DNF_HELPER}"
           end


### PR DESCRIPTION


Signed-off-by: pixdrift <support@pixeldrift.net>

### Description
Bug fix for package resource under RHEL 8 using DNF when no python binary is installed.

RHEL 8 by default does not ship a selected python version, with the preference of python2/python3 left to the user. If a Cookbook was executed on a default system without python installed the install would fail. RHEL 8 does ship a `platform-python` python binary that is used by system tools (including DNF) and is installed on the system. This commit updates the DNF python binary search to look for the `platform-python` binary in its default location `/usr/libexec`. `platform-python` is prioritised in the search as it should be the preferred binary for system tools such as DNF.

### Issues Resolved

#7988

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
