### PR TITLE
Pin the ohai definition to use the ohai version from Gemfile.lock

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -23,3 +23,8 @@ override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 override "openssl", version: "1.0.2q"
+
+# this pins the ohai omnibus definition ohai version to the same version that's
+# in the gemfile.lock, which is what the chef defition will end up using. If we
+# don't pin in this file we get master, which isn't the released version (usually)
+override "ohai", version: ::File.readlines("Gemfile.lock", File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; $1


### PR DESCRIPTION
Without this we end up with chef-client's definition using the version
of ohai in the gemfile.lock and the ohai defintion using whatever is in
master. This is bad for two reasons:

1. we're shipping an unreleased master version even when we ship chef 13
or chef 14
2. we ship the ohai gem twice which takes up space on disk

Signed-off-by: Tim Smith <tsmith@chef.io>