### PR TITLE
Cleanup some functional helpers

### DIFF
--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -146,7 +146,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
     end
 
     # dscl doesn't perform any error checking and will let you add users that don't exist.
-    describe "when no users exist", :not_supported_on_mac_osx do
+    describe "when no users exist", :not_supported_on_macos do
       describe "when append is not set" do
         # excluded_members can only be used when append is set.  It is ignored otherwise.
         let(:excluded_members) { [] }

--- a/spec/functional/resource/user/dscl_spec.rb
+++ b/spec/functional/resource/user/dscl_spec.rb
@@ -19,7 +19,7 @@ require "spec_helper"
 require "chef/mixin/shell_out"
 
 metadata = {
-  mac_osx_only: true,
+  macos_only: true,
   requires_root: true,
 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -143,14 +143,13 @@ RSpec.configure do |config|
   config.filter_run_excluding skip_travis: true if ENV["TRAVIS"]
 
   config.filter_run_excluding windows_only: true unless windows?
-  config.filter_run_excluding not_supported_on_mac_osx: true if mac_osx?
-  config.filter_run_excluding mac_osx_only: true if !mac_osx?
+  config.filter_run_excluding not_supported_on_macos: true if mac_osx?
+  config.filter_run_excluding macos_only: true if !mac_osx?
   config.filter_run_excluding not_supported_on_aix: true if aix?
   config.filter_run_excluding not_supported_on_solaris: true if solaris?
   config.filter_run_excluding not_supported_on_gce: true if gce?
   config.filter_run_excluding not_supported_on_nano: true if windows_nano_server?
   config.filter_run_excluding win2012r2_only: true unless windows_2012r2?
-  config.filter_run_excluding windows_2008r2_or_later: true unless windows_2008r2_or_later?
   config.filter_run_excluding windows64_only: true unless windows64?
   config.filter_run_excluding windows32_only: true unless windows32?
   config.filter_run_excluding windows_nano_only: true unless windows_nano_server?
@@ -186,7 +185,6 @@ RSpec.configure do |config|
   config.filter_run_excluding not_wpar: true unless wpar?
   config.filter_run_excluding not_supported_under_fips: true if fips?
   config.filter_run_excluding rhel: true unless rhel?
-  config.filter_run_excluding rhel5: true unless rhel5?
   config.filter_run_excluding rhel6: true unless rhel6?
   config.filter_run_excluding rhel7: true unless rhel7?
   config.filter_run_excluding intel_64bit: true unless intel_64bit?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -51,15 +51,6 @@ def windows_domain_joined?
   computer_system["partofdomain"]
 end
 
-def windows_2008r2_or_later?
-  return false unless windows?
-  return false unless host_version
-  components = host_version.split(".").map do |component|
-    component.to_i
-  end
-  components.length >= 2 && components[0] >= 6 && components[1] >= 1
-end
-
 def windows_2012r2?
   return false unless windows?
   (host_version && host_version.start_with?("6.3"))
@@ -165,10 +156,6 @@ end
 
 def rhel?
   !!(ohai[:platform_family] == "rhel")
-end
-
-def rhel5?
-  rhel? && !!(ohai[:platform_version].to_i == 5)
 end
 
 def rhel6?


### PR DESCRIPTION
Rename the macos helpers. Remove unused helpers to check for RHEL 5 and < Windows 2008 R2.

Signed-off-by: Tim Smith <tsmith@chef.io>