### PR TITLE
Require Ruby 2.5 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,36 +35,16 @@ env:
 matrix:
   include:
   - env:
-      INTEGRATION_SPECS_24: 1
-    rvm: 2.4.5
-    sudo: true
-    script: sudo -E $(which bundle) exec rake spec:integration;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
-  - env:
       INTEGRATION_SPECS_25: 1
     rvm: 2.5.3
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
-      FUNCTIONAL_SPECS_24: 1
-    rvm: 2.4.5
-    sudo: true
-    script: sudo -E $(which bundle) exec rake spec:functional;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
-  - env:
       FUNCTIONAL_SPECS_25: 1
     rvm: 2.5.3
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:functional;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
-  - env:
-      UNIT_SPECS_24: 1
-    rvm: 2.4.5
-    sudo: true
-    script:
-      - sudo -E $(which bundle) exec rake spec:unit;
-      - sudo -E $(which bundle) exec rake component_specs
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_25: 1

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
 


### PR DESCRIPTION
We haven't fully added 2.6 support, but Chef 15 will continue or RFC defined Ruby support process of supporting N and N-1. Now that the latest Ohai 15 is in the Gemfile.lock the unit tests on Ruby 2.4 fail. This bumps the required version to 2.5 and removes the 2.4 tests.

Signed-off-by: Tim Smith <tsmith@chef.io>