### PR TITLE
ignore failures doing apt-get update

### DIFF
--- a/spec/functional/resource/apt_package_spec.rb
+++ b/spec/functional/resource/apt_package_spec.rb
@@ -103,7 +103,7 @@ describe Chef::Resource::AptPackage, metadata do
       # Disable mixlib-shellout live streams
       Chef::Log.level = :warn
       start_apt_server
-      enable_testing_apt_source
+      enable_testing_apt_source rescue nil # important: ignore errors so the before all does not get re-run on failures
     end
 
     after(:all) do


### PR DESCRIPTION
when the apt-get update fails in the before(:all) block it has the effect of
failing the block.  when the block fails the rspec will retry it again
on the next test, even though it is marked :all.

what we're seeing is that we're getting rate limited by the upstream apt
source.  when that happens, the before(:all) becomes a before(:each)
which causes it to hammer on apt-get update, which cannot help with the
rate limiting.
