### PR TITLE
Added property `comment` on Windows group.

### DIFF
--- a/lib/chef/provider/group/windows.rb
+++ b/lib/chef/provider/group/windows.rb
@@ -77,6 +77,7 @@ class Chef
           else
             @net_group.local_set_members(new_resource.members)
           end
+          @net_group.local_group_set_info(new_resource.comment) if new_resource.comment
         end
 
         def has_current_group_member?(member)

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -51,6 +51,10 @@ class Chef
       property :non_unique, [ TrueClass, FalseClass ], default: false,
                description: "Allow gid duplication. May only be used with the Groupadd provider."
 
+      property :comment, String,
+               introduced: "14.9",
+               description: "Specifies a comment to associate with the local group."
+
       alias_method :users, :members
     end
   end

--- a/lib/chef/util/windows/net_group.rb
+++ b/lib/chef/util/windows/net_group.rb
@@ -58,6 +58,12 @@ class Chef::Util::Windows::NetGroup
     raise ArgumentError, e
   end
 
+  def local_group_set_info(comment)
+    Chef::ReservedNames::Win32::NetUser.net_local_group_set_info(nil, groupname, comment)
+  rescue Chef::Exceptions::Win32APIError => e
+    raise ArgumentError, e
+  end
+
   def local_delete_members(members)
     Chef::ReservedNames::Win32::NetUser.net_local_group_del_members(nil, groupname, members)
   rescue Chef::Exceptions::Win32APIError => e

--- a/lib/chef/win32/api/net.rb
+++ b/lib/chef/win32/api/net.rb
@@ -144,6 +144,11 @@ class Chef
           layout :lgrpi0_name, :LPWSTR
         end
 
+        class LOCALGROUP_INFO_1 < FFI::Struct
+          layout :lgrpi1_name, :LPWSTR,
+                 :lgrpi1_comment, :LPWSTR
+        end
+
         class USE_INFO_2 < FFI::Struct
           include StructHelpers
 
@@ -166,6 +171,17 @@ class Chef
         # );
         safe_attach_function :NetLocalGroupAdd, [
           :LPCWSTR, :DWORD, :LPBYTE, :LPDWORD
+        ], :DWORD
+
+        # NET_API_STATUS NetLocalGroupSetInfo(
+        #   _In_ LPCWSTR servername,
+        #   _In_ LPCWSTR groupname,
+        #   _In_ DWORD   level,
+        #   _In_ LPBYTE  buf,
+        #   _Out_ LPDWORD parm_err
+        # );
+        safe_attach_function :NetLocalGroupSetInfo, [
+          :LPCWSTR, :LPCWSTR, :DWORD, :LPBYTE, :LPDWORD
         ], :DWORD
 
         # NET_API_STATUS NetLocalGroupDel(

--- a/lib/chef/win32/net.rb
+++ b/lib/chef/win32/net.rb
@@ -180,6 +180,21 @@ class Chef
         end
       end
 
+      def self.net_local_group_set_info(server_name, group_name, comment)
+        server_name = wstring(server_name)
+        group_name = wstring(group_name)
+        comment = wstring(comment)
+
+        buf = LOCALGROUP_INFO_1.new
+        buf[:lgrpi1_name] = FFI::MemoryPointer.from_string(group_name)
+        buf[:lgrpi1_comment] = FFI::MemoryPointer.from_string(comment)
+
+        rc = NetLocalGroupSetInfo(server_name, group_name, 1, buf, nil)
+        if rc != NERR_Success
+          Chef::ReservedNames::Win32::Error.raise!(nil, rc)
+        end
+      end
+
       def self.net_user_del(server_name, user_name)
         server_name = wstring(server_name)
         user_name = wstring(user_name)

--- a/spec/unit/provider/group/windows_spec.rb
+++ b/spec/unit/provider/group/windows_spec.rb
@@ -49,6 +49,7 @@ describe Chef::Provider::Group::Windows do
   describe "manage_group" do
     before do
       @new_resource.members([ "us" ])
+      @new_resource.comment = "this is group comment"
       @current_resource = Chef::Resource::Group.new("staff")
       @current_resource.members %w{all your base}
       @new_resource.excluded_members %w{all}
@@ -57,6 +58,7 @@ describe Chef::Provider::Group::Windows do
       allow(@net_group).to receive(:local_add_members)
       allow(@net_group).to receive(:local_set_members)
       allow(@provider).to receive(:lookup_account_name)
+      allow(@net_group).to receive(:local_group_set_info)
       allow(@provider).to receive(:validate_member!).and_return(true)
       @provider.current_resource = @current_resource
     end
@@ -70,6 +72,19 @@ describe Chef::Provider::Group::Windows do
     it "should call @net_group.local_add_members" do
       @new_resource.append(true)
       expect(@net_group).to receive(:local_add_members).with(@new_resource.members)
+      @provider.manage_group
+    end
+
+    it "when comment is present, should call @net_group.local_group_set_info" do
+      @new_resource.append(true)
+      expect(@net_group).to receive(:local_group_set_info).with(@new_resource.comment)
+      @provider.manage_group
+    end
+
+    it "when comment is not present, should not call @net_group.local_group_set_info" do
+      @new_resource.comment = nil
+      @new_resource.append(true)
+      expect(@net_group).not_to receive(:local_group_set_info).with(@new_resource.comment)
       @provider.manage_group
     end
 

--- a/spec/unit/resource/group_spec.rb
+++ b/spec/unit/resource/group_spec.rb
@@ -49,6 +49,10 @@ describe Chef::Resource::Group, "initialize" do
     expect(resource.members).to eql([])
   end
 
+  it "defaults comment to be nil" do
+    expect(resource.comment).to eql(nil)
+  end
+
   it "aliases users to members, also an empty array" do
     expect(resource.users).to eql([])
   end
@@ -144,5 +148,18 @@ describe Chef::Resource::Group, "append" do
     it "returns the group name as its identity" do
       expect(resource.identity).to eq("pokemon")
     end
+  end
+end
+
+describe Chef::Resource::Group, "comment" do
+  let(:resource) { Chef::Resource::Group.new("fakey_fakerton") }
+
+  it "allows an string" do
+    resource.comment "this is a group comment"
+    expect(resource.comment).to eql("this is a group comment")
+  end
+
+  it "does not allow a hash" do
+    expect { resource.send(:comment, { some_other_user: "is freakin awesome" }) }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description

- Added a property `comment` to allow user to add a comment of a windows group
- Added a method `net_local_group_set_info` for set a comment of windows group by using `NetLocalGroupSetInfo`
- Added test cases
- Ensured chef-style on the code changes made

### Issues Resolved

Fixes MSYS-897: Allow setting the comment/description on a Windows group

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
