### PR TITLE
Fix for windows_package when version number is passed with build number

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -509,7 +509,7 @@ class Chef
                   if version_requirement_satisfied?(current_version, new_version)
                     logger.trace("#{new_resource} #{package_name} #{current_version} satisifies #{new_version} requirement")
                     target_version_array.push(nil)
-                  elsif current_version && !allow_downgrade && version_compare(current_version, new_version) == 1
+                  elsif current_version && version_compare(current_version, new_version) == 1 && !allow_downgrade
                     logger.warn("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{new_version}. Skipping...)")
                     target_version_array.push(nil)
                   else

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -218,6 +218,10 @@ class Chef
             return 0
           end
 
+          # Till now we are getting v1 as an array. But we need only the latest version of the package in form of string.
+          # So we pass only the first element of the array.
+          # If we pass array in `Gem::Version.new(Array)` it will throw `Malformed version number string []` error.
+          v1 = v1.first if v1.is_a?(Array)
           gem_v1 = Gem::Version.new(v1)
           gem_v2 = Gem::Version.new(v2)
 


### PR DESCRIPTION
Signed-off-by: vijaymmali1990 <vijay.mali@msystechnologies.com>

### Description

windows_package explodes when we pass version number in SemVer format (major.minor.patch)
Added fix for this
The reason for the issue is as we are passing array to get the version instead of string due to which it throws the Malformed version number string error. Resolved this by consider first element of Array.

```
irb(main):008:0> v1 = ["10.1.15.3917699"]
=> ["10.1.15.3917699"]
irb(main):009:0> gem_v1 = Gem::Version.new(v1)
Traceback (most recent call last):
        5: from /opt/chefdk/embedded/bin/irb:11:in `<main>'
        4: from (irb):9
        3: from /opt/chefdk/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
        2: from /opt/chefdk/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
        1: from /opt/chefdk/embedded/lib/ruby/2.5.0/rubygems/version.rb:208:in `initialize'
ArgumentError (Malformed version number string ["10.1.15.3917699"])
```

### Issues Resolved
It resolves following error while running the windows_package resource 
recipe:
```
windows_package 'VMware Tools' do
source 'C:\vmtools\setup.exe'
version '10.1.15'
installer_type :custom
options '/S /qn REBOOT=R ADDLOCAL=ALL'
end
```
Log trace:

```
Generated at 2018-11-21 13:53:52 +0000
ArgumentError: windows_package[VMware Tools] (@recipe_files::C:/vmtools/vmtools.rb line 1) had an error: ArgumentError: Malformed version number string ["10.0.9.3917699"]
C:/opscode/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:208:in `initialize'
C:/opscode/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
C:/opscode/chef/embedded/lib/ruby/2.5.0/rubygems/version.rb:199:in `new'
C:/opscode/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.5.33-universal-mingw32/lib/chef/provider/package/windows.rb:199:in `version_compare'
C:/opscode/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.5.33-universal-mingw32/lib/chef/provider/package.rb:507:in `block in target_version_array'
C:/opscode/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.5.33-universal-mingw32/lib/chef/provider/package.rb:590:in `block in each_package'
```
Fixes MSYS-942

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
