### PR TITLE
Bump license_scout to 1.0.20 for licensing tests

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 23e12509574a66f079b00fc4f99cc8665a4ed50e
+  revision: f54ca7cd82d0e49ac62f8380d9c56d05048db9fd
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.123.0)
-    aws-sdk-core (3.44.0)
+    aws-partitions (1.125.0)
+    aws-sdk-core (3.44.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -63,10 +63,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
-    chef (14.7.17)
+    chef (14.8.12)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.7.17)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -93,10 +93,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.7.17-universal-mingw32)
+    chef (14.8.12-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.7.17)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -136,7 +136,7 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.7.17)
+    chef-config (14.8.12)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
@@ -152,7 +152,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     erubis (2.7.0)
@@ -181,7 +181,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.19)
+    license_scout (1.0.20)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -197,18 +197,18 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
+    mixlib-log (2.0.9)
     mixlib-shellout (2.4.4)
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
-    mixlib-versioning (1.2.2)
+    mixlib-versioning (1.2.7)
     molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)


### PR DESCRIPTION
This will allow the new inspec deps to pass

Signed-off-by: Tim Smith <tsmith@chef.io>