### PR TITLE
Disable s3 omnibus cache

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -29,7 +29,7 @@
 env_omnibus_windows_arch = (ENV["OMNIBUS_WINDOWS_ARCH"] || "").downcase
 env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_arch)
 
-windows_arch   env_omnibus_windows_arch
+windows_arch env_omnibus_windows_arch
 
 # Disable git caching
 # caching is currently disabled as it causes issues when we're running

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -32,8 +32,11 @@ env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_
 windows_arch   env_omnibus_windows_arch
 
 # Disable git caching
+# caching is currently disabled as it causes issues when we're running
+# builds of different product versions on the same host. When forked to prep
+# for the next major release this has caused problems. To enable again:
 # ------------------------------
-# use_git_caching false
+use_git_caching false
 
 # Enable S3 asset caching
 # ------------------------------


### PR DESCRIPTION
This has caused a ton of random issues where builders start pulling in
cache from other branches. Every time we get in this state we just
rebuild without the cache and all is fine again. It seems like we should
just disable it at this point since we run builds on 2 branches at the
same time now.

Signed-off-by: Tim Smith <tsmith@chef.io>