### PR TITLE
Remove the travis apt proxy for the Ruby 2.4 functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ matrix:
       FUNCTIONAL_SPECS_24: 1
     rvm: 2.4.5
     sudo: true
-    script: sudo -E $(which bundle) exec rake spec:functional;
+    # the travis apt proxy screws with our functional testing something fierce
+    script: sudo rm -f /etc/apt/apt.conf.d/99-travis-apt-proxy; sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_25: 1


### PR DESCRIPTION
Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>