### PR TITLE
chef 14: windows_certificate: Fix invalid byte sequence errors with pfx certicates

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -250,7 +250,7 @@ class Chef
                 when ".cer"
                   powershell_out("openssl x509 -text -inform DER -in #{source} -outform PEM").stdout
                 when ".pfx"
-                  powershell_out("openssl pkcs12 -in #{source} -nodes -passin pass:#{new_resource.pfx_password}").stdout
+                  powershell_out("openssl pkcs12 -in #{source} -nodes -passin pass:'#{new_resource.pfx_password}'").stdout
                 when ".p7b"
                   powershell_out("openssl pkcs7 -print_certs -in #{source} -outform PEM").stdout
                 end

--- a/spec/unit/resource/windows_certificate.rb
+++ b/spec/unit/resource/windows_certificate.rb
@@ -73,4 +73,11 @@ describe Chef::Resource::WindowsCertificate do
     resource.pfx_password "foo"
     expect(resource.sensitive).to be_truthy
   end
+
+  it "doesn't raise error if pfx_password contains special characters" do
+    resource.pfx_password "chef$123"
+    resource.source "C:\\certs\\test-cert.pfx"
+    resource.store_name "MY"
+    expect { resource.action :create }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description
This change will fix  the error `ArgumentError: invalid byte sequence in UTF-8`.

### Issues Resolved
Fixes [chef-cookbooks/windows#582](https://github.com/chef-cookbooks/windows/issues/582)
### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
