### PR TITLE
Fix for error when using reboot resource on Linux when delay_mins is used

### DIFF
--- a/lib/chef/platform/rebooter.rb
+++ b/lib/chef/platform/rebooter.rb
@@ -55,8 +55,6 @@ class Chef
           rescue Mixlib::ShellOut::ShellCommandFailed => e
             raise Chef::Exceptions::RebootFailed.new(e.message)
           end
-
-          raise Chef::Exceptions::Reboot.new(msg)
         end
 
         # this is a wrapper function so Chef::Client only needs a single line of code.

--- a/spec/functional/rebooter_spec.rb
+++ b/spec/functional/rebooter_spec.rb
@@ -75,7 +75,6 @@ describe Chef::Platform::Rebooter do
           allow(ChefConfig).to receive(:windows?).and_return(is_windows)
           node.automatic["os"] = node.automatic["platform"] = node.automatic["platform_family"] = "solaris2" if is_solaris
           expect(rebooter).to receive(:shell_out!).once.with(expected_reboot_str)
-          expect(rebooter).to receive(:raise).with(Chef::Exceptions::Reboot)
           expect(rebooter).to receive(method_sym).once.and_call_original
           rebooter.send(method_sym, run_context.node)
         end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- At the end of the `reboot!(node)` method, we were raising an exception and there is no need to raise an exception after successful execution of `reboot!(node)` method. so we have removed `raise Chef::Exceptions::Reboot.new(msg)` line from `reboot!` method of `Chef::Platform::Rebooter`
- Ensured chef-style

### Issues Resolved
Fixes #7734

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
