### PR TITLE
Possible chocolatey package search issue

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -234,7 +234,7 @@ EOS
           package_name_array.each do |pkg|
             available_versions =
               begin
-                cmd = [ "list -r #{pkg}" ]
+                cmd = [ "list -r -a -e #{pkg}" ]
                 cmd.push( "-source #{new_resource.source}" ) if new_resource.source
                 raw = parse_list_output(*cmd)
                 raw.keys.each_with_object({}) do |name, available|

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -60,7 +60,7 @@ describe Chef::Provider::Package::Chocolatey do
     EOF
     remote_list_obj = double(stdout: remote_list_stdout)
     package_names.each do |pkg|
-      allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -r #{pkg}#{args}", { returns: [0], timeout: timeout }).and_return(remote_list_obj)
+      allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -r -a -e #{pkg}#{args}", { returns: [0], timeout: timeout }).and_return(remote_list_obj)
     end
   end
 


### PR DESCRIPTION
When searching available packages by running command `choco.exe list -r <pacakg name>`, it returns bunch of non relating packages,
and if the source is using JFrog Artifactory, the command may not find correct packages at all.
By adding search switches `-a -e` means search for all available versions and get those packages with exact name match, the command `choco.exe list <package name> -r -a -e` will return correct packages.

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
