### PR TITLE
chocolatey_package: Require exact match on package name and support artifactory

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -234,7 +234,7 @@ EOS
           package_name_array.each do |pkg|
             available_versions =
               begin
-                cmd = [ "list -r #{pkg}" ]
+                cmd = [ "list -r -a -e #{pkg}" ]
                 cmd.push( "-source #{new_resource.source}" ) if new_resource.source
                 raw = parse_list_output(*cmd)
                 raw.keys.each_with_object({}) do |name, available|

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -60,7 +60,7 @@ describe Chef::Provider::Package::Chocolatey do
     EOF
     remote_list_obj = double(stdout: remote_list_stdout)
     package_names.each do |pkg|
-      allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -r #{pkg}#{args}", { returns: [0], timeout: timeout }).and_return(remote_list_obj)
+      allow(provider).to receive(:shell_out_compacted!).with("#{choco_exe} list -r -a -e #{pkg}#{args}", { returns: [0], timeout: timeout }).and_return(remote_list_obj)
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Kelvin Huang <kelvinxjh@gmail.com>

### Description

The command `choco list -r <package name>` may returns bunch of packages which are not relating to the package at all.
And in my case where `-source=https://myartifactory/`, it doesn't even return valid package result.

By adding `-a -e` will return exactly available packages, and it works perfectly with my Jfrog Artifactory.

