### PR TITLE
Simplify the sub-systems in the Chef maintainers file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -49,23 +49,6 @@ To mention the team, use @chef/client-core
 * [Tyler Ball](https://github.com/tyler-ball)
 * [Josh Hudson](https://github.com/itmustbejj)
 
-## Chef Provisioning
-
-Chef Provisioning and Drivers.  Supported Drivers are listed in the [README](https://github.com/chef/chef-provisioning/blob/master/README.md#chef-provisioning).
-
-To mention the team, use @chef/provisioning
-
-### Lieutenant
-
-* [Tyler Ball](https://github.com/tyler-ball)
-
-### Maintainers
-
-* [John Keiser](https://github.com/jkeiser)
-* [JJ Asghar](https://github.com/jjasghar)
-* [Stuart Preston](https://github.com/stuartpreston)
-* [Harley Alaniz](https://github.com/thehar)
-
 ## Platform Specific Components
 
 The specific components of Chef related to a given platform - including (but not limited to) resources, providers, and the core DSL.
@@ -135,9 +118,9 @@ To mention the team, use @chef/client-aix
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
 
-## Mac OS X
+## macOS
 
-To mention the team, use @chef/client-os-x
+To mention the team, use @chef/client-macos
 
 ### Lieutenant
 
@@ -170,21 +153,13 @@ To mention the team, use @chef/client-fedora
 
 * [Lamont Granquist](https://github.com/lamont-granquist)
 
-## openSUSE
+## openSUSE and SUSE Linux Enterprise Server
 
-To mention the team, use @chef/client-opensuse
+To mention the team, use @chef/client-suse
 
 ### Lieutenant
 
 * [Tim Smith](https://github.com/tas50)
-
-### Maintainers
-
-* [Lamont Granquist](https://github.com/lamont-granquist)
-
-## SUSE Enterprise Linux Server
-
-To mention the team, use @chef/client-suse
 
 ### Maintainers
 
@@ -198,39 +173,3 @@ To mention the team, use @chef/client-freebsd
 
 * [Amy Aronsohn](https://github.com/OnlyHaveCans)
 
-### Maintainers
-
-* [Cory Stephenson](https://github.com/Aevin1387)
-
-## OpenBSD
-
-To mention the team, use @chef/client-openbsd
-
-### Lieutenant
-
-* [Joe Miller](https://github.com/joemiller)
-
-## Gentoo
-
-To mention the team, use @chef/client-gentoo
-
-### Maintainers
-
-* [Lamont Granquist](https://github.com/lamont-granquist)
-
-## OmniOS
-
-To mention the team, use @chef/client-omnios
-
-### Maintainers
-
-* [Thom May](https://github.com/thommay)
-
-## ArchLinux
-
-To mention the team, use @chef/client-archlinux
-
-### Maintainers
-
-* [Lamont Granquist](https://github.com/lamont-granquist)
-* [Ryan Cragun](https://github.com/ryancragun)

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -56,23 +56,6 @@ Maintainers for the Chef client, Ohai, mixlibs, ChefDK, ChefSpec, Foodcritic, ch
         "itmustbejj"
       ]
 
-    [Org.Components.Provisioning]
-      title = "Chef Provisioning"
-      team = "provisioning"
-      text = """
-Chef Provisioning and Drivers.  Supported Drivers are listed in the [README](https://github.com/chef/chef-provisioning/blob/master/README.md#chef-provisioning).
-"""
-
-      lieutenant = "tyler-ball"
-
-      maintainers = [
-        "jkeiser",
-        "jjasghar",
-        "stuartpreston",
-        "thehar",
-        "jjlimepoint"
-      ]
-
     [Org.Components.Subsystems]
       title = "Platform Specific Components"
       text = """
@@ -133,9 +116,9 @@ The specific components of Chef related to a given platform - including (but not
 
         lieutenant = "lamont-granquist"
 
-      [Org.Components.Subsystems."Mac OS X"]
-        title = "Mac OS X"
-        team = "client-os-x"
+      [Org.Components.Subsystems."macOS"]
+        title = "macOS"
+        team = "client-macos"
 
         lieutenant = "jtimberman"
 
@@ -164,19 +147,11 @@ The specific components of Chef related to a given platform - including (but not
           "lamont-granquist"
         ]
 
-      [Org.Components.Subsystems.openSUSE]
-        title = "openSUSE"
-        team = "client-opensuse"
+      [Org.Components.Subsystems.SUSE]
+        title = "openSUSE and SUSE Linux Enterprise Server"
+        team = "client-suse"
 
         lieutenant = "tas50"
-
-        maintainers = [
-          "lamont-granquist"
-        ]
-
-      [Org.Components.Subsystems."SUSE Enterprise Linux"]
-        title = "SUSE Enterprise Linux Server"
-        team = "client-suse"
 
         maintainers = [
           "lamont-granquist"
@@ -186,43 +161,7 @@ The specific components of Chef related to a given platform - including (but not
         title = "FreeBSD"
         team = "client-freebsd"
 
-        lieutenant = "martinisoft"
-
-        maintainers = [
-          "Aevin1387",
-          "OnlyHaveCans"
-        ]
-
-      [Org.Components.Subsystems.OpenBSD]
-        title = "OpenBSD"
-        team = "client-openbsd"
-
-        lieutenant = "joemiller"
-
-    [Org.Components.Subsystems.Gentoo]
-        title = "Gentoo"
-        team = "client-gentoo"
-
-        maintainers = [
-          "lamont-granquist"
-        ]
-
-    [Org.Components.Subsystems.OmniOS]
-        title = "OmniOS"
-        team = "client-omnios"
-
-        maintainers = [
-          "thommay"
-        ]
-
-    [Org.Components.Subsystems.ArchLinux]
-        title = "ArchLinux"
-        team = "client-archlinux"
-
-        maintainers = [
-          "lamont-granquist",
-          "ryancragun"
-        ]
+        lieutenant = "OnlyHaveCans"
 
 [people]
   [people.adamhjk]
@@ -273,10 +212,6 @@ The specific components of Chef related to a given platform - including (but not
     Name = "Lamont Granquist"
     GitHub = "lamont-granquist"
 
-  [people.martinisoft]
-    Name = "Aaron Kalin"
-    GitHub = "martinisoft"
-
   [people.ranjib]
     Name = "Ranjib Dey"
     GitHub = "ranjib"
@@ -290,7 +225,7 @@ The specific components of Chef related to a given platform - including (but not
     GitHub = "stevendanna"
 
   [people.OnlyHaveCans]
-    Name = "David Aronsohn"
+    Name = "Amy Aronsohn"
     GitHub = "OnlyHaveCans"
     IRC = "tBunnyMan"
     Twitter = "OnlyHaveCans"
@@ -309,17 +244,9 @@ The specific components of Chef related to a given platform - including (but not
     Name = "Kartik Cating-Subramanian"
     GitHub = "ksubrama"
 
-  [people.joemiller]
-    Name = "Joe Miller"
-    GitHub = "joemiller"
-
   [people.coderanger]
     Name = "Noah Kantrowitz"
     GitHub = "coderanger"
-
-  [people.ryancragun]
-    Name = "Ryan Cragun"
-    GitHub = "ryancragun"
 
   [people.chefsalim]
     Name = "Salim Alam"


### PR DESCRIPTION
Remove unsupported platforms Arch, Gentoo, Omnios, and openBSD where we've had just about zero action.
Collapse the opensuse and SLES groups into one since the code is now the same
Remove Chef Provisioning
Fixup the TOML for the change in FreeBSD maintainers

Signed-off-by: Tim Smith <tsmith@chef.io>