### PR TITLE
Update rubygems to 2.7.7 and bundler to 1.17.3

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,8 +4,8 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "2.7.6"
-override :bundler, version: "1.16.1"
+override :rubygems, version: "2.7.7"
+override :bundler, version: "1.17.3"
 override "nokogiri", version: "1.8.5"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
These are the last versions of these stable releases. We may want to go
bundler 2.0 / rubygems 3.0, but this is a solid first step.

Signed-off-by: Tim Smith <tsmith@chef.io>