### PR TITLE
Don't system exit on ohai CriticalPluginFailure

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -607,9 +607,6 @@ class Chef
       filter = Chef::Config[:minimal_ohai] ? %w{fqdn machinename hostname platform platform_version ohai_time os os_version init_package} : nil
       ohai.all_plugins(filter)
       events.ohai_completed(node)
-    rescue Ohai::Exceptions::CriticalPluginFailure => e
-      logger.error("Critical Ohai plugins failed: #{e.message}")
-      exit(false)
     end
 
     #

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -51,7 +51,7 @@ describe Chef::Client do
         class CriticalPluginFailure < Error; end
       end
       expect(ohai_system).to receive(:all_plugins) { raise Ohai::Exceptions::CriticalPluginFailure }
-      expect { client.run_ohai }.to raise_error(SystemExit)
+      expect { client.run_ohai }.to raise_error(Ohai::Exceptions::CriticalPluginFailure)
     end
   end
 


### PR DESCRIPTION
### Description

When critical ohai plugins fail, they currently cause the chef run to `exit(false)`, which makes the chef run_exception "SystemExit: exit", which isn't very clear as to what actually went wrong.

### Issues Resolved

By removing the rescue block the run fails with Ohai::Exceptions::CriticalPluginFailure, with a run_exception akin to ""Ohai::Exceptions::CriticalPluginFailure: The following Ohai plugins marked as critical failed: [:BlockDevice]. Failing Chef run."

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
