### PR TITLE
Fix for locale resource not setting LC_ALL

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
@@ -20,15 +20,15 @@ file "/tmp/chef-test-\xFDmlaut" do
   content "testing illegal UTF-8 char in the filename"
 end
 
+locale "set locale" do
+  lang "en_GB.utf8"
+  lc_all "en_GB.utf8"
+end
+
 node["network"]["interfaces"].each do |interface_data|
   interface = interface_data[0]
   sysctl_param "net/ipv4/conf/#{interface}/rp_filter" do
     value 0
     ignore_failure true
   end
-end
-
-locale "set locale" do
-  lang "en_US.utf8"
-  lc_all "en_US.utf8"
 end

--- a/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
@@ -27,3 +27,8 @@ node["network"]["interfaces"].each do |interface_data|
     ignore_failure true
   end
 end
+
+locale "set locale" do
+  lang "en_US.utf8"
+  lc_all "en_US.utf8"
+end

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -36,13 +36,15 @@ class Chef
       action :update do
         description "Update the system's locale."
 
-        if node["init_package"] == "systemd"
-          # on systemd settings LC_ALL is (correctly) reserved only for testing and cannot be set globally
-          execute "localectl set-locale LANG=#{new_resource.lang}" do
-            # RHEL uses /etc/locale.conf
-            not_if { up_to_date?("/etc/locale.conf", new_resource.lang) } if ::File.exist?("/etc/locale.conf")
-            # Ubuntu 16.04 still uses /etc/default/locale
-            not_if { up_to_date?("/etc/default/locale", new_resource.lang) } if ::File.exist?("/etc/default/locale")
+        if ::File.exist?("/usr/sbin/update-locale")
+          execute "Generate locales" do
+            command "locale-gen #{new_resource.lang}"
+            not_if { up_to_date?("/etc/default/locale", new_resource.lang, new_resource.lc_all) }
+          end
+
+          execute "Update locale" do
+            command "update-locale LANG=#{new_resource.lang} LC_ALL=#{new_resource.lc_all}"
+            not_if { up_to_date?("/etc/default/locale", new_resource.lang, new_resource.lc_all) }
           end
         elsif ::File.exist?("/etc/sysconfig/i18n")
           locale_file_path = "/etc/sysconfig/i18n"
@@ -64,15 +66,13 @@ class Chef
             command "source /etc/sysconfig/i18n; source /etc/profile.d/lang.sh"
             not_if { updated }
           end
-        elsif ::File.exist?("/usr/sbin/update-locale")
-          execute "Generate locales" do
-            command "locale-gen"
-            not_if { up_to_date?("/etc/default/locale", new_resource.lang, new_resource.lc_all) }
-          end
-
-          execute "Update locale" do
-            command "update-locale LANG=#{new_resource.lang} LC_ALL=#{new_resource.lc_all}"
-            not_if { up_to_date?("/etc/default/locale", new_resource.lang, new_resource.lc_all) }
+        elsif node["init_package"] == "systemd"
+          # on systemd settings LC_ALL is (correctly) reserved only for testing and cannot be set globally
+          execute "localectl set-locale LANG=#{new_resource.lang}" do
+            # RHEL uses /etc/locale.conf
+            not_if { up_to_date?("/etc/locale.conf", new_resource.lang) } if ::File.exist?("/etc/locale.conf")
+            # Ubuntu 16.04 still uses /etc/default/locale
+            not_if { up_to_date?("/etc/default/locale", new_resource.lang) } if ::File.exist?("/etc/default/locale")
           end
         else
           raise "#{node["platform"]} platform not supported by the chef locale resource."

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -53,6 +53,11 @@ class Chef
 
         unless up_to_date?(contents, new_resource.lang, new_resource.lc_all)
           converge_by("Applying locale settings") do
+            execute "Generate locales" do
+              command "locale-gen #{new_resource.lang}"
+              only_if { check_locale?(new_resource.lang, locale_file) }
+            end
+
             file locale_file do
               content add_or_replace(contents, new_resource.lang, new_resource.lc_all)
             end
@@ -60,42 +65,58 @@ class Chef
         end
       end
 
+      # @param contents [String] locale file contents
+      # @param lang [String] lang value
+      # @param lc_all [String] lc_all value
+      #
+      # @return [Boolean]
+      #
       def up_to_date?(contents, lang, lc_all)
         h = parse_and_get_hash(contents)
-        h["LANG"] == lang && h["LC_ALL"] == lc_all
+        if lang && lc_all
+          h["LANG"] == lang && h["LC_ALL"] == lc_all
+        elsif lang
+          h["LANG"] == lang
+        elsif lc_all
+          h["LC_ALL"] == lc_all
+        else
+          true
+        end
       end
 
+      # @param contents [String] locale file contents
+      # @param lang [String] lang value
+      # @param lc_all [String] lc_all value
+      #
+      # @return [String] new_contents for locale file
+      #
       def add_or_replace(contents, lang, lc_all)
         lang_flag = true if lang
         lc_all_flag = true if lc_all
         new_contents = []
         contents.each_line do |line|
-          new_contents <<  if PARSER.match? line
-                             kv = parse_and_get_hash(line)
-                             if kv["LANG"] && lang
-                               lang_flag = false
-                               if kv["LANG"] != lang
-                                 set("LANG", lang)
-                               else
-                                 line
-                               end
-                             elsif kv["LC_ALL"] && lc_all
-                               lc_all_flag = false
-                               if kv["LC_ALL"] != lc_all
-                                 set("LC_ALL", lc_all)
-                               else
-                                 line
-                               end
-                             else
-                               line
-                             end
-                           else
-                             line
-                           end
+          new_contents << if PARSER.match? line
+                            kv = parse_and_get_hash(line)
+                            if kv["LANG"] && lang
+                              lang_flag = false
+                              set_parameter("LANG", kv["LANG"], lang, line)
+                            elsif kv["LC_ALL"] && lc_all
+                              lc_all_flag = false
+                              set_parameter("LC_ALL", kv["LC_ALL"], lc_all, line)
+                            else
+                              line
+                            end
+                          else
+                            line
+                          end
         end
         new_contents << set("LANG", lang) if lang_flag
         new_contents << set("LC_ALL", lc_all) if lc_all_flag
         new_contents.join
+      end
+
+      def check_locale?(lang, locale_file)
+        `locale -a`.include?("#{lang}") && locale_file == "/etc/default/locale"
       end
 
       private
@@ -105,7 +126,7 @@ class Chef
       # Key can be any word character (letter, number, underscore)
       # Separated by "="
       # Value can also contain dots and quotations
-      PARSER = /^(\s*\w+\s*)=([ \t]*[\w+."']+)/i
+      PARSER = (/^(\s*\w+\s*)=([ \t]*[\w+."']+)/i).freeze
 
       def parse_and_get_hash(contents)
         # For quick matching purpose, keys are converted in upper case
@@ -115,7 +136,11 @@ class Chef
       end
 
       def set(key, val)
-        "\n#{key}=#{val}\n"
+        "\n#{key}=#{val} #created by chef\n"
+      end
+
+      def set_parameter(parameter_type, parameter_value, locale, line)
+        parameter_value != locale ? set(parameter_type, locale) : line
       end
     end
   end

--- a/spec/functional/resource/locale_spec.rb
+++ b/spec/functional/resource/locale_spec.rb
@@ -1,0 +1,76 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright: Copyright 2008-2018, Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "functional/resource/base"
+
+describe Chef::Resource::Locale, :unix_only do
+  let(:locale_obj) { Chef::Resource::Locale.new("foo_resource", run_context) }
+  describe "when user pass lang and lc_all" do
+    let(:resource) do
+      resource = locale_obj
+      resource.lang("en_GB.utf8")
+      resource.lc_all("en_GB.utf8")
+      resource
+    end
+
+    it "when the lang and lc_all is not the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).to be_updated_by_last_action
+    end
+
+    it "when the lang and lc_all is the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).not_to be_updated_by_last_action
+    end
+  end
+
+  describe "when user pass only lang" do
+    let(:resource) do
+      resource = locale_obj
+      resource.lang("en_US.utf8")
+      resource
+    end
+    it "when the lang is not the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).to be_updated_by_last_action
+    end
+
+    it "when the lang is the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).not_to be_updated_by_last_action
+    end
+  end
+
+  describe "when user pass only lc_all" do
+    let(:resource) do
+      resource = locale_obj
+      resource.lc_all("en_US.utf8")
+      resource
+    end
+    it "when the lc_all is not the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).to be_updated_by_last_action
+    end
+
+    it "when the lc_all is the same as current locale values" do
+      resource.run_action(:update)
+      expect(resource).not_to be_updated_by_last_action
+    end
+  end
+end

--- a/spec/unit/resource/locale_spec.rb
+++ b/spec/unit/resource/locale_spec.rb
@@ -19,42 +19,390 @@
 require "spec_helper"
 
 describe Chef::Resource::Locale do
-
   let(:resource) { Chef::Resource::Locale.new("fakey_fakerton") }
 
   it "has a name of locale" do
     expect(resource.resource_name).to eq(:locale)
   end
 
-  it "the lang property is equal to en_US.utf8" do
-    expect(resource.lang).to eql("en_US.utf8")
-  end
-
-  it "the lc_all property is equal to en_US.utf8" do
-    expect(resource.lc_all).to eql("en_US.utf8")
-  end
-
-  it "sets the default action as :update" do
-    expect(resource.action).to eql([:update])
-  end
-
   it "supports :update action" do
     expect { resource.action :update }.not_to raise_error
   end
 
-  describe "when the language is not the default one" do
-    let(:resource) { Chef::Resource::Locale.new("fakey_fakerton") }
+  context "Default" do
+    it "lang: nil" do
+      expect(resource.lang).to be_nil
+    end
+    it "lc_all: nil" do
+      expect(resource.lc_all).to be_nil
+    end
+    it "action: :update" do
+      expect(resource.action).to eql([:update])
+    end
+  end
+
+  context "When lang is set" do
+    before do
+      resource.lang("fr_FR.utf8")
+    end
+    it "the lang property is set" do
+      expect(resource.lang).to eql("fr_FR.utf8")
+    end
+    it "the lc_all property remains nil" do
+      expect(resource.lc_all).to be_nil
+    end
+  end
+
+  context "When lc_all is set" do
+    before do
+      resource.lc_all("fr_FR.utf8")
+    end
+    it "the lang property remains nil" do
+      expect(resource.lang).to be_nil
+    end
+    it "the lc_all property is set" do
+      expect(resource.lc_all).to eql("fr_FR.utf8")
+    end
+  end
+
+  context "When property is set" do
     before do
       resource.lang("fr_FR.utf8")
       resource.lc_all("fr_FR.utf8")
     end
-
-    it "the lang property is equal to fr_FR.utf8" do
+    it "the lang property is set" do
       expect(resource.lang).to eql("fr_FR.utf8")
     end
-
-    it "the lc_all property is equal to fr_FR.utf8" do
+    it "the lc_all property is set" do
       expect(resource.lc_all).to eql("fr_FR.utf8")
+    end
+  end
+
+  should_not_change = <<-ENVFILE
+  An example file
+    with some tabs,
+  LC_ALL
+
+  next lines,
+  # Comments
+  and most important, LANG = as some value. Hey,
+  did you noticed those whitespaces.?
+          and lets put
+  some another LC_ALL = as some random value.
+  LANG =
+  FILE ENDS HERE
+
+  ENVFILE
+
+  [
+    {
+      "Setting LANG" => {
+        lang: "X",
+        lc_all: nil,
+        cases: [
+          {
+            context: "In empty file",
+            actual: "",
+            up_to_date: false,
+            expected: '
+LANG=X
+',
+          },
+          {
+            context: "In a file having same LANG",
+            actual: should_not_change + '
+            LANG=X',
+            up_to_date: true,
+            expected: should_not_change + '
+            LANG=X',
+          },
+          {
+            context: "In a file having different LANG",
+            actual: should_not_change + '
+            LANG=Z
+            ',
+            up_to_date: false,
+            expected: should_not_change + '
+
+LANG=X
+            ',
+          },
+          {
+            context: "In a file having LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Y',
+            up_to_date: false,
+            expected: should_not_change + '
+            LC_ALL=Y
+LANG=X
+',
+          },
+          {
+            context: "In a file having different LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Z',
+            up_to_date: false,
+            expected: should_not_change + '
+            LC_ALL=Z
+LANG=X
+',
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL",
+            actual: '
+            LANG=bar
+            LC_ALL=foo
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+
+LANG=X
+            LC_ALL=foo
+            ' + should_not_change,
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL & whitespaces",
+            actual: '
+            LC_ALL = foo
+            LANG = bar
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+            LC_ALL = foo
+
+LANG=X
+            ' + should_not_change,
+          }
+        ],
+      },
+    },
+    {
+      "Setting LC_ALL" => {
+        lang: nil,
+        lc_all: "Y",
+        cases: [
+          {
+            context: "In empty file",
+            actual: "",
+            up_to_date: false,
+            expected: '
+LC_ALL=Y
+',
+          },
+          {
+            context: "In a file having same LANG",
+            actual: should_not_change + '
+            LANG=X',
+            up_to_date: false,
+            expected: should_not_change + '
+            LANG=X
+LC_ALL=Y
+',
+          },
+          {
+            context: "In a file having different LANG",
+            actual: should_not_change + '
+            LANG=Z',
+            up_to_date: false,
+            expected: should_not_change + '
+            LANG=Z
+LC_ALL=Y
+',
+          },
+          {
+            context: "In a file having same LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Y
+            ',
+            up_to_date: true,
+            expected: should_not_change + '
+            LC_ALL=Y
+            ',
+          },
+          {
+            context: "In a file having different LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Z
+            ',
+            up_to_date: false,
+            expected: should_not_change + '
+
+LC_ALL=Y
+            ',
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL",
+            actual: '
+            LANG=bar
+            LC_ALL=foo
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+            LANG=bar
+
+LC_ALL=Y
+            ' + should_not_change,
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL & whitespaces",
+            actual: '
+            LC_ALL = foo
+            LANG = bar
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+
+LC_ALL=Y
+            LANG = bar
+            ' + should_not_change,
+          }
+        ],
+      },
+    },
+    {
+      "Setting LANG and LC_ALL" => {
+        lang: "X",
+        lc_all: "Y",
+        cases: [
+          {
+            context: "In empty file",
+            actual: "",
+            up_to_date: false,
+            expected: '
+LANG=X
+
+LC_ALL=Y
+',
+          },
+            {
+              context: "In a file having same LANG",
+              actual: should_not_change + '
+              LANG=X',
+              up_to_date: false,
+              expected: should_not_change + '
+              LANG=X
+LC_ALL=Y
+',
+            },
+          {
+            context: "In a file having different LANG",
+            actual: should_not_change + '
+            LANG=Z',
+            up_to_date: false,
+            expected: should_not_change + '
+
+LANG=X
+
+LC_ALL=Y
+',
+          },
+          {
+            context: "In a file having same LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Y',
+            up_to_date: false,
+            expected: should_not_change + '
+            LC_ALL=Y
+LANG=X
+',
+          },
+          {
+            context: "In a file having different LC_ALL",
+            actual: should_not_change + '
+            LC_ALL=Z',
+            up_to_date: false,
+            expected: should_not_change + '
+
+LC_ALL=Y
+
+LANG=X
+',
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL",
+            actual: '
+            LC_ALL=foo
+            LANG=bar
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+
+LC_ALL=Y
+
+LANG=X
+            ' + should_not_change,
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL & whitespaces",
+            actual: '
+            LC_ALL = foo
+            LANG = bar
+            ' + should_not_change,
+            up_to_date: false,
+            expected: '
+
+LC_ALL=Y
+
+LANG=X
+            ' + should_not_change,
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL, whitespaces & Inline comments",
+            actual: should_not_change + '
+            # this is a comment
+            LC_ALL="value" # comment
+            LANG=value # comment
+            ' + should_not_change,
+            up_to_date: false,
+            expected: should_not_change + '
+            # this is a comment
+
+LC_ALL=Y
+
+LANG=X
+            ' + should_not_change,
+          },
+          {
+            context: "In a file having different LANG and different LC_ALL, Whitespaces, Comments, underscores and dots",
+            actual: should_not_change + '
+            # this is a comment
+            LC_ALL = "Some.Value_X" # comment
+              LANG=value1_VAL2.XX # comment
+            ' + should_not_change,
+            up_to_date: false,
+            expected: should_not_change + '
+            # this is a comment
+
+LC_ALL=Y
+
+LANG=X
+            ' + should_not_change,
+          }
+        ],
+      },
+    }
+  ].each do |t|
+    t.each do |desc, test_case|
+      describe desc do
+        let(:lang) { test_case[:lang] }
+        let(:lc_all) { test_case[:lc_all] }
+        test_case[:cases].each do |t_case|
+          context t_case[:context] do
+            let(:contents) { t_case[:actual] }
+            describe "#up_to_date?" do
+              subject { resource.up_to_date?(contents, lang, lc_all) }
+              it { is_expected.to be(t_case[:up_to_date]) }
+            end
+            describe "#add_or_replace" do
+              subject { resource.add_or_replace(contents, lang, lc_all) }
+              it "returns expected string" do
+                expect(subject).to eq(t_case[:expected])
+                # expect(subject).to be_nil
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/resource/locale_spec.rb
+++ b/spec/unit/resource/locale_spec.rb
@@ -105,7 +105,7 @@ describe Chef::Resource::Locale do
             actual: "",
             up_to_date: false,
             expected: '
-LANG=X
+LANG=X #created by chef
 ',
           },
           {
@@ -124,7 +124,7 @@ LANG=X
             up_to_date: false,
             expected: should_not_change + '
 
-LANG=X
+LANG=X #created by chef
             ',
           },
           {
@@ -134,7 +134,7 @@ LANG=X
             up_to_date: false,
             expected: should_not_change + '
             LC_ALL=Y
-LANG=X
+LANG=X #created by chef
 ',
           },
           {
@@ -144,7 +144,7 @@ LANG=X
             up_to_date: false,
             expected: should_not_change + '
             LC_ALL=Z
-LANG=X
+LANG=X #created by chef
 ',
           },
           {
@@ -156,7 +156,7 @@ LANG=X
             up_to_date: false,
             expected: '
 
-LANG=X
+LANG=X #created by chef
             LC_ALL=foo
             ' + should_not_change,
           },
@@ -170,7 +170,7 @@ LANG=X
             expected: '
             LC_ALL = foo
 
-LANG=X
+LANG=X #created by chef
             ' + should_not_change,
           }
         ],
@@ -186,7 +186,7 @@ LANG=X
             actual: "",
             up_to_date: false,
             expected: '
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
           },
           {
@@ -196,7 +196,7 @@ LC_ALL=Y
             up_to_date: false,
             expected: should_not_change + '
             LANG=X
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
           },
           {
@@ -206,7 +206,7 @@ LC_ALL=Y
             up_to_date: false,
             expected: should_not_change + '
             LANG=Z
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
           },
           {
@@ -227,7 +227,7 @@ LC_ALL=Y
             up_to_date: false,
             expected: should_not_change + '
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
             ',
           },
           {
@@ -240,7 +240,7 @@ LC_ALL=Y
             expected: '
             LANG=bar
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
             ' + should_not_change,
           },
           {
@@ -252,7 +252,7 @@ LC_ALL=Y
             up_to_date: false,
             expected: '
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
             LANG = bar
             ' + should_not_change,
           }
@@ -269,9 +269,9 @@ LC_ALL=Y
             actual: "",
             up_to_date: false,
             expected: '
-LANG=X
+LANG=X #created by chef
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
           },
             {
@@ -281,7 +281,7 @@ LC_ALL=Y
               up_to_date: false,
               expected: should_not_change + '
               LANG=X
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
             },
           {
@@ -291,9 +291,9 @@ LC_ALL=Y
             up_to_date: false,
             expected: should_not_change + '
 
-LANG=X
+LANG=X #created by chef
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 ',
           },
           {
@@ -303,7 +303,7 @@ LC_ALL=Y
             up_to_date: false,
             expected: should_not_change + '
             LC_ALL=Y
-LANG=X
+LANG=X #created by chef
 ',
           },
           {
@@ -313,9 +313,9 @@ LANG=X
             up_to_date: false,
             expected: should_not_change + '
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 
-LANG=X
+LANG=X #created by chef
 ',
           },
           {
@@ -327,9 +327,9 @@ LANG=X
             up_to_date: false,
             expected: '
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 
-LANG=X
+LANG=X #created by chef
             ' + should_not_change,
           },
           {
@@ -341,9 +341,9 @@ LANG=X
             up_to_date: false,
             expected: '
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 
-LANG=X
+LANG=X #created by chef
             ' + should_not_change,
           },
           {
@@ -357,9 +357,9 @@ LANG=X
             expected: should_not_change + '
             # this is a comment
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 
-LANG=X
+LANG=X #created by chef
             ' + should_not_change,
           },
           {
@@ -373,9 +373,9 @@ LANG=X
             expected: should_not_change + '
             # this is a comment
 
-LC_ALL=Y
+LC_ALL=Y #created by chef
 
-LANG=X
+LANG=X #created by chef
             ' + should_not_change,
           }
         ],


### PR DESCRIPTION
### Description
- Before we were using utilities like `localectl set-locale` `locale-gen` and `update-locale`, but now we are directly writing the contents in required files which affects system locale. This would be a generic change and will support almost all the OS and that too without relying on the presence of an external script to achieve the same functionality.
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes #7904 MSYS-946: locale resource does not set LC_ALL

Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>
### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
