### PR TITLE
Fix for windows service action start resets credentials on service

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -84,9 +84,10 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
   def start_service
     if Win32::Service.exists?(@new_resource.service_name)
       # reconfiguration is idempotent, so just do it.
+      config_info = Win32::Service.config_info(@new_resource.service_name)
       new_config = {
         service_name: @new_resource.service_name,
-        service_start_name: @new_resource.run_as_user,
+        service_start_name: config_info.service_start_name,
         password: @new_resource.run_as_password,
       }.reject { |k, v| v.nil? || v.length == 0 }
 


### PR DESCRIPTION
Signed-off-by: vijaymmali1990 <vijay.mali@msystechnologies.com>

### Description
windows_service resource action start was reseting the credentials for services other than service of localsystem. Added fix for the same.

### Issues Resolved
Fixed #8080 

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
