### PR TITLE
Fix for apt_repository creating temporary files as root in running user home directory

### DIFF
--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -206,7 +206,7 @@ class Chef
           mode "0644"
           sensitive new_resource.sensitive
           action :create
-          verify "gpg %{path}"
+          verify "gpg --homedir /tmp/ %{path}"
         end
 
         declare_resource(:execute, "apt-key add #{cached_keyfile}") do


### PR DESCRIPTION
Signed-off-by: vijaymmali1990 <vijay.mali@msystechnologies.com>

### Description
apt_repository was creating temporary files as root in running user home directory as a result when it goes and verifies those files or certificates it was throwing the permission errors. So provided fix for this.

### Issues Resolved

Fixes #8007 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
