### PR TITLE
Fix for openssl_dhparam resource properties update

### DIFF
--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -57,17 +57,27 @@ class Chef
 
       action :create do
         description "Create the dhparam file."
+        unless dhparam_pem_valid?(new_resource.path)
+          converge_by("Create a dhparam file #{new_resource.path}") do
+            dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem
 
-        converge_by("Create a dhparam file #{new_resource.path}") do
-          dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem if !::File.exist?(new_resource.path)
-
+            file new_resource.path do
+              action :create
+              owner new_resource.owner unless new_resource.owner.nil?
+              group new_resource.group unless new_resource.group.nil?
+              mode new_resource.mode
+              sensitive true
+              content dhparam_content
+            end
+          end
+        end
+        if ::File.exist?(new_resource.path)
           file new_resource.path do
             action :create
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
             mode new_resource.mode
             sensitive true
-            content dhparam_content
           end
         end
       end

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -58,9 +58,8 @@ class Chef
       action :create do
         description "Create the dhparam file."
 
-        unless dhparam_pem_valid?(new_resource.path)
           converge_by("Create a dhparam file #{new_resource.path}") do
-            dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem
+            dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem if !::File.exist?(new_resource.path)
 
             file new_resource.path do
               action :create
@@ -71,7 +70,6 @@ class Chef
               content dhparam_content
             end
           end
-        end
       end
     end
   end

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -58,18 +58,18 @@ class Chef
       action :create do
         description "Create the dhparam file."
 
-          converge_by("Create a dhparam file #{new_resource.path}") do
-            dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem if !::File.exist?(new_resource.path)
+        converge_by("Create a dhparam file #{new_resource.path}") do
+          dhparam_content = gen_dhparam(new_resource.key_length, new_resource.generator).to_pem if !::File.exist?(new_resource.path)
 
-            file new_resource.path do
-              action :create
-              owner new_resource.owner unless new_resource.owner.nil?
-              group new_resource.group unless new_resource.group.nil?
-              mode new_resource.mode
-              sensitive true
-              content dhparam_content
-            end
+          file new_resource.path do
+            action :create
+            owner new_resource.owner unless new_resource.owner.nil?
+            group new_resource.group unless new_resource.group.nil?
+            mode new_resource.mode
+            sensitive true
+            content dhparam_content
           end
+        end
       end
     end
   end

--- a/spec/unit/resource/openssl_dhparam.rb
+++ b/spec/unit/resource/openssl_dhparam.rb
@@ -53,4 +53,9 @@ describe Chef::Resource::OpensslDhparam do
     expect { resource.key_length 1234 }.to raise_error(ArgumentError)
   end
 
+  it "sets the mode which user provides for existing file" do
+    resource.mode '0600'
+    expect(resource.mode).to eql("0600")
+  end
+
 end

--- a/spec/unit/resource/openssl_dhparam.rb
+++ b/spec/unit/resource/openssl_dhparam.rb
@@ -54,7 +54,7 @@ describe Chef::Resource::OpensslDhparam do
   end
 
   it "sets the mode which user provides for existing file" do
-    resource.mode '0600'
+    resource.mode "0600"
     expect(resource.mode).to eql("0600")
   end
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

The `openssl_dhparam` resource does not honor the specified mode if the file already exists.
Chef-client will not change the mode of the file on a subsequent run. If the mode is specified, it should be set according to specification.
To achieve this, the file resource should be executed in every case, not just if there is no valid dhparam.pem file

### Description

Properties `mode,owner & group` can be updated now with this fix.

### Issues Resolved

Fixes https://github.com/chef/chef/issues/8099

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
