### PR TITLE
openssl_ec_private_key / openssl_x509_request.rb: properly use the path properties when specified

### DIFF
--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -67,7 +67,7 @@ class Chef
         unless new_resource.force || priv_key_file_valid?(new_resource.path, new_resource.key_pass)
           converge_by("Create an EC private key #{new_resource.path}") do
             log "Generating an #{new_resource.key_curve} "\
-                "EC key file at #{new_resource.name}, this may take some time"
+                "EC key file at #{new_resource.path}, this may take some time"
 
             if new_resource.key_pass
               unencrypted_ec_key = gen_ec_priv_key(new_resource.key_curve)

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -88,7 +88,7 @@ class Chef
 
         unless ::File.exist? new_resource.path
           converge_by("Create CSR #{@new_resource}") do
-            file new_resource.name do
+            file new_resource.path do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode new_resource.mode unless new_resource.mode.nil?


### PR DESCRIPTION
We have a name_property, but we're not using it everywhere here.

Fixes #8105

Signed-off-by: Tim Smith <tsmith@chef.io>