### PR TITLE
ssh_known_host_entry: Use the host name_property in debug logging

### DIFF
--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -103,7 +103,7 @@ class Chef
         keys = r.variables[:entries].reject(&:empty?)
 
         if key_exists?(keys, key, comment)
-          Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
+          Chef::Log.debug "Known hosts key for #{new_resource.host} already exists - skipping"
         else
           r.variables[:entries].push(key)
         end


### PR DESCRIPTION
You'd get the resource name not the host property in the logging.

Signed-off-by: Tim Smith <tsmith@chef.io>