### PR TITLE
Pull in the gem update retry logic from DK

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -11,17 +11,26 @@
 
 set -evx
 
+function new_gem_included() {
+  git diff | grep -E '^\+' | grep "${GEM_NAME} (${VERSION})"
+}
+
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
 bundle install
 
-# it appears that the gem that triggers this script fires off this script before
-# the gem is actually available via bundler on rubygems.org.
-sleep 240
-
-gem install rake
-rake dependencies:update_gemfile_lock
+tries=12
+for (( i=1; i<=$tries; i+=1 )); do
+  bundle exec rake dependencies:update_gemfile_lock
+  new_gem_included && break || sleep 20
+  if [ $i -eq $tries ]; then
+    echo "Searching for '${GEM_NAME} (${VERSION})' ${i} times and did not find it"
+    exit 1
+  else
+    echo "Searched ${i} times for '${GEM_NAME} (${VERSION})'"
+  fi
+done
 
 git add .
 


### PR DESCRIPTION
Pulls in the logic that tyler wrote in DK that performs retries and
validates that the gem was actually updated. This preventts empty PRs
from being opened and shortens the time the job takes to run.

Signed-off-by: Tim Smith <tsmith@chef.io>