### PR TITLE
Chef 14: A windows support to the timezone resource

### DIFF
--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -25,7 +25,7 @@ class Chef
       preview_resource true
       resource_name :timezone
 
-      description "Use the timezone resource to change the system timezone on Linux and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones."
+      description "Use the timezone resource to change the system timezone on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for Linux and macOS here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for Windows here: https://ss64.com/nt/timezones.html."
       introduced "14.6"
 
       property :timezone, String,

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -96,12 +96,18 @@ class Chef
                 shell_out!("sudo systemsetup -settimezone #{new_resource.timezone}")
               end
             end
+          when "windows"
+            unless current_windows_tz.casecmp?(new_resource.timezone)
+              converge_by("set timezone to \"#{new_resource.timezone}\"") do
+                shell_out!("tzutil /s \"#{new_resource.timezone}\"")
+              end
+            end
           end
         end
       end
 
       action_class do
-        # detect the current TZ on darwin hosts
+        # detect the current TZ on darwin hosts & windows hosts
         #
         # @since 14.7
         # @return [String] TZ database value
@@ -111,6 +117,14 @@ class Chef
             raise "The timezone resource requires adminstrative priveleges to run on macOS hosts!"
           else
             /Time Zone: (.*)/.match(tz_shellout.stdout)[1]
+          end
+        end
+        def current_windows_tz
+          tz_shellout = shell_out!("tzutil /g")
+          if /is not recognized as an internal/.match?(tz_shellout.stderr)
+            raise "The timezone resource requires tzutil to run on windows hosts!"
+          else
+            tz_shellout.stdout.strip
           end
         end
       end

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -98,7 +98,7 @@ class Chef
             end
           when "windows"
             unless current_windows_tz.casecmp?(new_resource.timezone)
-              converge_by("set timezone to \"#{new_resource.timezone}\"") do
+              converge_by("setting timezone to \"#{new_resource.timezone}\"") do
                 shell_out!("tzutil /s \"#{new_resource.timezone}\"")
               end
             end
@@ -107,7 +107,7 @@ class Chef
       end
 
       action_class do
-        # detect the current TZ on darwin hosts & windows hosts
+        # detect the current TZ on darwin hosts
         #
         # @since 14.7
         # @return [String] TZ database value
@@ -119,13 +119,15 @@ class Chef
             /Time Zone: (.*)/.match(tz_shellout.stdout)[1]
           end
         end
+
+        # detect the current timezone on windows hosts
+        #
+        # @since 14.9
+        # @return [String] timezone id
         def current_windows_tz
-          tz_shellout = shell_out!("tzutil /g")
-          if /is not recognized as an internal/.match?(tz_shellout.stderr)
-            raise "The timezone resource requires tzutil to run on windows hosts!"
-          else
-            tz_shellout.stdout.strip
-          end
+          tz_shellout = shell_out("tzutil /g")
+          raise "There was an error running the tzutil command" if tz_shellout.exitstatus == 1
+          tz_shellout.stdout.strip
         end
       end
     end

--- a/spec/functional/resource/timezone_spec.rb
+++ b/spec/functional/resource/timezone_spec.rb
@@ -1,0 +1,39 @@
+#
+# Author:: Gary Bright (<digitalgaz@hotmail.com>)
+# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require "spec_helper"
+
+describe Chef::Resource::Timezone, :windows_only do
+  let(:timezone) { "GMT Standard Time" }
+
+  def timezone_resource
+    Chef::Resource::Timezone.new(timezone, run_context)
+  end
+
+  describe "when a timezone is provided on windows" do
+    it "should set a timezone" do
+      timezone_resource.run_action(:set)
+    end
+  end
+
+  describe "when a timezone is not provided on windows" do
+    let(:timezone) { nil }
+    it "raises an exception" do
+      expect { timezone_resource.run_action(:set) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    end
+  end
+end


### PR DESCRIPTION
This backports the work that @username-is-already-taken2 and @Stromweld did here. We missed bringing this into Chef 14.