### PR TITLE
Fix for Property deprecations are broken in Chef 13

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -285,6 +285,10 @@ class Chef
       def inspect
         "#{message}\n#{location}"
       end
+
+      def target
+        "property.html"
+      end
     end
 
     class Generic < Base


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- In chef-13 whenever we were using the `deprecated:` option in a property on a custom resource, we were facing `subclasses of Chef::Deprecated::Base should define #target` exception at the time of `chef-client` run, so we have added `target` method in `Property` class, now it's working fine.
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes #7762

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
