### PR TITLE
Update license_scout to 1.0.22

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 5ac799cdcc5a7865b452daa96f92812144dccb3d
+  revision: 51cc8d6143c6737dc5d51fe89f7a45fe52f34731
   branch: master
   specs:
-    omnibus (6.0.10)
+    omnibus (6.0.11)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 262af48ad7442b5a2edd44ba05106bc024819168
+  revision: f876bb6a1d60e0b9e2b52a4ce16318d05327bdfd
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -181,7 +181,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.21)
+    license_scout (1.0.22)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)


### PR DESCRIPTION
This unbreaks license checks for jaro_winkler gem in Jenkins.

Signed-off-by: Tim Smith <tsmith@chef.io>