### PR TITLE
Backport various name_property fixes in resources from Chef 15

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -58,8 +58,8 @@ class Chef
         homebrew_tap "caskroom/cask" if new_resource.install_cask
 
         unless casked?
-          converge_by("install cask #{new_resource.name} #{new_resource.options}") do
-            shell_out!("#{new_resource.homebrew_path} cask install #{new_resource.name} #{new_resource.options}",
+          converge_by("install cask #{new_resource.cask_name} #{new_resource.options}") do
+            shell_out!("#{new_resource.homebrew_path} cask install #{new_resource.cask_name} #{new_resource.options}",
                 user: new_resource.owner,
                 env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },
                 cwd: ::Dir.home(new_resource.owner))
@@ -73,8 +73,8 @@ class Chef
         homebrew_tap "caskroom/cask" if new_resource.install_cask
 
         if casked?
-          converge_by("uninstall cask #{new_resource.name}") do
-            shell_out!("#{new_resource.homebrew_path} cask uninstall #{new_resource.name}",
+          converge_by("uninstall cask #{new_resource.cask_name}") do
+            shell_out!("#{new_resource.homebrew_path} cask uninstall #{new_resource.cask_name}",
                 user: new_resource.owner,
                 env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },
                 cwd: ::Dir.home(new_resource.owner))
@@ -88,7 +88,7 @@ class Chef
         alias_method :action_uninstall, :action_remove
 
         def casked?
-          unscoped_name = new_resource.name.split("/").last
+          unscoped_name = new_resource.cask_name.split("/").last
           shell_out!('#{new_resource.homebrew_path} cask list 2>/dev/null',
             user: new_resource.owner,
             env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -55,9 +55,9 @@ class Chef
       action :tap do
         description "Add a Homebrew tap."
 
-        unless tapped?(new_resource.name)
-          converge_by("tap #{new_resource.name}") do
-            shell_out!("#{new_resource.homebrew_path} tap #{new_resource.full ? '--full' : ''} #{new_resource.name} #{new_resource.url || ''}",
+        unless tapped?(new_resource.tap_name)
+          converge_by("tap #{new_resource.tap_name}") do
+            shell_out!("#{new_resource.homebrew_path} tap #{new_resource.full ? '--full' : ''} #{new_resource.tap_name} #{new_resource.url || ''}",
                 user: new_resource.owner,
                 env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },
                 cwd: ::Dir.home(new_resource.owner))
@@ -68,9 +68,9 @@ class Chef
       action :untap do
         description "Remove a Homebrew tap."
 
-        if tapped?(new_resource.name)
-          converge_by("untap #{new_resource.name}") do
-            shell_out!("#{new_resource.homebrew_path} untap #{new_resource.name}",
+        if tapped?(new_resource.tap_name)
+          converge_by("untap #{new_resource.tap_name}") do
+            shell_out!("#{new_resource.homebrew_path} untap #{new_resource.tap_name}",
                 user: new_resource.owner,
                 env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },
                 cwd: ::Dir.home(new_resource.owner))

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -68,7 +68,7 @@ class Chef
         unless new_resource.force || priv_key_file_valid?(new_resource.path, new_resource.key_pass)
           converge_by("Create an EC private key #{new_resource.path}") do
             log "Generating an #{new_resource.key_curve} "\
-                "EC key file at #{new_resource.name}, this may take some time"
+                "EC key file at #{new_resource.path}, this may take some time"
 
             if new_resource.key_pass
               unencrypted_ec_key = gen_ec_priv_key(new_resource.key_curve)

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -89,7 +89,7 @@ class Chef
 
         unless ::File.exist? new_resource.path
           converge_by("Create CSR #{@new_resource}") do
-            file new_resource.name do
+            file new_resource.path do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode new_resource.mode unless new_resource.mode.nil?

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -104,7 +104,7 @@ class Chef
         keys = r.variables[:entries].reject(&:empty?)
 
         if key_exists?(keys, key, comment)
-          Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
+          Chef::Log.debug "Known hosts key for #{new_resource.host} already exists - skipping"
         else
           r.variables[:entries].push(key)
         end

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -114,7 +114,7 @@ class Chef
 
           port_name = "IP_#{new_resource.ipv4_address}"
 
-          declare_resource(:powershell_script, "Creating printer: #{new_resource.name}") do
+          declare_resource(:powershell_script, "Creating printer: #{new_resource.device_id}") do
             code <<-EOH
 
               Set-WmiInstance -class Win32_Printer `
@@ -133,9 +133,9 @@ class Chef
         end
 
         def delete_printer
-          declare_resource(:powershell_script, "Deleting printer: #{new_resource.name}") do
+          declare_resource(:powershell_script, "Deleting printer: #{new_resource.device_id}") do
             code <<-EOH
-              $printer = Get-WMIObject -class Win32_Printer -EnableAllPrivileges -Filter "name = '#{new_resource.name}'"
+              $printer = Get-WMIObject -class Win32_Printer -EnableAllPrivileges -Filter "name = '#{new_resource.device_id}'"
               $printer.Delete()
             EOH
           end


### PR DESCRIPTION
This backports:

https://github.com/chef/chef/pull/8125
https://github.com/chef/chef/pull/8124
https://github.com/chef/chef/pull/8123
https://github.com/chef/chef/pull/8122

It fixes homebrew_cask, homebrew_tap, windows_printer, openssl_ec_private_key, openssl_x509_request, and ssh_known_host_entry resources to correctly honor name properties that are passed by the user.
