### PR TITLE
Sysctl: Allow slashes in key or block name

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/tests.rb
@@ -19,3 +19,11 @@ end
 file "/tmp/chef-test-\xFDmlaut" do
   content "testing illegal UTF-8 char in the filename"
 end
+
+node["network"]["interfaces"].each do |interface_data|
+  interface = interface_data[0]
+  sysctl_param "net/ipv4/conf/#{interface}/rp_filter" do
+    value 0
+    ignore_failure true
+  end
+end

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -37,3 +37,4 @@ suites:
   - name: end-to-end
     run_list:
       - recipe[end_to_end::default]
+      - recipe[end_to_end::tests]

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -80,7 +80,7 @@ class Chef
 
           directory new_resource.conf_dir
 
-          file "#{new_resource.conf_dir}/99-chef-#{new_resource.key}.conf" do
+          file "#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf" do
             content "#{new_resource.key} = #{new_resource.value}"
           end
 
@@ -96,9 +96,9 @@ class Chef
         description "Remove a sysctl value."
 
         # only converge the resource if the file actually exists to delete
-        if ::File.exist?("#{new_resource.conf_dir}/99-chef-#{new_resource.key}.conf")
-          converge_by "removing sysctl config at #{new_resource.conf_dir}/99-chef-#{new_resource.key}.conf" do
-            file "#{new_resource.conf_dir}/99-chef-#{new_resource.key}.conf" do
+        if ::File.exist?("#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf")
+          converge_by "removing sysctl config at #{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf" do
+            file "#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf" do
               action :delete
             end
 
@@ -140,8 +140,8 @@ class Chef
       # return the value. Raise in case this conf file needs to be created
       # or updated
       def get_sysctld_value(key)
-        raise unless ::File.exist?("/etc/sysctl.d/99-chef-#{key}.conf")
-        k, v = ::File.read("/etc/sysctl.d/99-chef-#{key}.conf").match(/(.*) = (.*)/).captures
+        raise unless ::File.exist?("/etc/sysctl.d/99-chef-#{key.tr('/', '.')}.conf")
+        k, v = ::File.read("/etc/sysctl.d/99-chef-#{key.tr('/', '.')}.conf").match(/(.*) = (.*)/).captures
         raise "Unknown sysctl key!" if k.nil?
         raise "Unknown sysctl value!" if v.nil?
         v


### PR DESCRIPTION
This change will allow user to pass slash separated key/name in `sysctl` resource.

## Description

### Issue

As per the functionality, sysctl resource creates a file in `sysctl.d` directory with the file name as the key/name passed in resource. (`"99-chef-<key>"`). Due to this reason, even if we want to pass slashes in key, then while creating a file it was being considered as a directory and raised an error.
But as per sysctl's syntax, in case an interface name contains dot in it, then other properties must be separated by slash.
```
eg: Interface: ens256.401
valid sysctl key: net/ipv4/conf/ens256.401/rp_filter
```
We should be able to take care of this necessity.

### Resolution

With these changes: 
- Name of the File which is created by chef will always be dot separated
  - This would avoid any of it's consideration to a directory. Hence any exception wouldn't arise.
- File content will be as same as the key/name passed by the user
  - Hence, user can also pass slashes as a valid separator for sysctl.

### Note

Similar to systctl, now we also support both the separators as a valid sysctl key when an interface doesn't contains dot in it. We might send another PR for document updation
```
   net/ipv4/conf/default/rp_filter
   net.ipv4.conf.default.rp_filter
```

Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Issues Resolved

MSYS-931: Sysctl doesn't work when key has a . in the name

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
