### PR TITLE
Updates homebrew_cask tap name

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -55,7 +55,7 @@ class Chef
       action :install do
         description "Install an application packaged as a Homebrew cask."
 
-        homebrew_tap "caskroom/cask" if new_resource.install_cask
+        homebrew_tap "homebrew/cask" if new_resource.install_cask
 
         unless casked?
           converge_by("install cask #{new_resource.cask_name} #{new_resource.options}") do
@@ -70,7 +70,7 @@ class Chef
       action :remove do
         description "Remove an application packaged as a Homebrew cask."
 
-        homebrew_tap "caskroom/cask" if new_resource.install_cask
+        homebrew_tap "homebrew/cask" if new_resource.install_cask
 
         if casked?
           converge_by("uninstall cask #{new_resource.cask_name}") do


### PR DESCRIPTION
### Description

Homebrew cask was merged into homebrew some time ago: https://github.com/Homebrew/homebrew-cask/issues/14384#issuecomment-242328541.

Afterwards the homebrew-cask repositories were also moved to the Homebrew organization.

Also see https://github.com/chef-cookbooks/homebrew/pull/134

### Issues Resolved

Because of that move on Chef 13 and older with this cookbook installing a cask would try to tap `caskroom/cask` every time. If you execute that manually you'll notice that it actually taps `homebrew/cask`.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>