### PR TITLE
Fix cask resource running each chef-client run

### DIFF
--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -89,7 +89,7 @@ class Chef
 
         def casked?
           unscoped_name = new_resource.cask_name.split("/").last
-          shell_out!('#{new_resource.homebrew_path} cask list 2>/dev/null',
+          shell_out!("#{new_resource.homebrew_path} cask list 2>/dev/null",
             user: new_resource.owner,
             env:  { "HOME" => ::Dir.home(new_resource.owner), "USER" => new_resource.owner },
             cwd: ::Dir.home(new_resource.owner)).stdout.split.include?(unscoped_name)


### PR DESCRIPTION
### Description

This fixes an issue where casks would be installed during each chef-client run because the `casked?` check failed.

### Issues Resolved

Interpolation was not taken into account correctly in the `casked?` check.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

---

@tas50 Should the changes from the [homebrew](https://github.com/chef-cookbooks/homebrew) cookbook all be backported into Chef? (in case this and #8139 don't cover everything yet)