### PR TITLE
Pin Chefstyle to 0.11.2 in chef-14 branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group(:development, :test) do
   gem "webmock"
 
   # for testing new chefstyle rules
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
+  gem "chefstyle", "=0.11.2"
 end
 
 group(:travis) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/chef/chefstyle.git
-  revision: 5190569ae0901e1139f296a92cb448a60d98da56
-  branch: master
-  specs:
-    chefstyle (0.11.1)
-      rubocop (= 0.55.0)
-
 PATH
   remote: .
   specs:
@@ -116,6 +108,8 @@ GEM
     cheffish (14.0.4)
       chef-zero (~> 14.0)
       net-ssh
+    chefstyle (0.11.2)
+      rubocop (= 0.55.0)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -223,8 +217,8 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    parallel (1.13.0)
+    parser (2.6.0.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.2)
@@ -398,7 +392,7 @@ DEPENDENCIES
   chef-config!
   chef-vault
   cheffish (~> 14)
-  chefstyle!
+  chefstyle (= 0.11.2)
   inspec-core (~> 3)
   netrc
   octokit


### PR DESCRIPTION
As Chef 14 goes into stable this avoids the need to keep up with changes in chefstyle. We can chase that on master.

Signed-off-by: Tim Smith <tsmith@chef.io>
