### PR TITLE
Hide knife cookbook site & null by setting them to deprecated category

### DIFF
--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -28,7 +28,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site download COOKBOOK [VERSION] (options)"
-      category "cookbook site"
+      category "deprecated"
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -28,7 +28,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site install COOKBOOK [VERSION] (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -28,7 +28,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site list (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/cookbook_site_search.rb
+++ b/lib/chef/knife/cookbook_site_search.rb
@@ -28,7 +28,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site search QUERY (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -29,7 +29,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site share COOKBOOK [CATEGORY] (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -28,7 +28,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site show COOKBOOK [VERSION] (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/cookbook_site_unshare.rb
+++ b/lib/chef/knife/cookbook_site_unshare.rb
@@ -29,7 +29,7 @@ class Chef
       options.merge!(superclass.options)
 
       banner "knife cookbook site unshare COOKBOOK (options)"
-      category "cookbook site"
+      category "deprecated"
 
     end
   end

--- a/lib/chef/knife/null.rb
+++ b/lib/chef/knife/null.rb
@@ -3,6 +3,9 @@ class Chef
     class Null < Chef::Knife
       banner "knife null"
 
+      # setting the category to deprecated keeps it out of help
+      category "deprecated"
+
       def run
       end
     end


### PR DESCRIPTION
This keeps these commands out of the help text.

Signed-off-by: Tim Smith <tsmith@chef.io>