### PR TITLE
Add a few missing license headers

### DIFF
--- a/lib/chef/cookbook/chefignore.rb
+++ b/lib/chef/cookbook/chefignore.rb
@@ -1,4 +1,3 @@
-#--
 # Author:: Daniel DeLeo (<dan@chef.io>)
 # Copyright:: Copyright 2011-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/cookbook/cookbook_collection.rb
+++ b/lib/chef/cookbook/cookbook_collection.rb
@@ -1,4 +1,3 @@
-#--
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Copyright:: Copyright 2010-2018, Chef Software Inc.

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -1,3 +1,17 @@
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require "chef/cookbook_version"
 require "chef/cookbook/chefignore"

--- a/lib/chef/cookbook/file_system_file_vendor.rb
+++ b/lib/chef/cookbook/file_system_file_vendor.rb
@@ -1,4 +1,3 @@
-#--
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Copyright:: Copyright 2010-2016, Chef Software Inc.

--- a/lib/chef/cookbook/file_vendor.rb
+++ b/lib/chef/cookbook/file_vendor.rb
@@ -1,4 +1,3 @@
-#
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Copyright:: Copyright 2010-2016, Chef Software Inc.

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright:: Copyright (c) 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -1,4 +1,3 @@
-#
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Seth Falcon (<seth@chef.io>)

--- a/lib/chef/cookbook/remote_file_vendor.rb
+++ b/lib/chef/cookbook/remote_file_vendor.rb
@@ -1,4 +1,3 @@
-#
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Copyright:: Copyright 2010-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -1,3 +1,18 @@
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef/client"
 require "chef/util/threaded_job_queue"
 require "chef/server_api"

--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -1,4 +1,3 @@
-#
 # Author:: Daniel DeLeo (<dan@chef.io>)
 # Copyright:: Copyright 2010-2016, Chef Software Inc.
 # License:: Apache License, Version 2.0


### PR DESCRIPTION
We should probably have these everywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>