### PR TITLE
Make SCM resource consistent with other resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -151,6 +151,10 @@ Initial support has been added for Red Hat Enterprise Linux 8. Thank you [@pixdr
 
 gem_package now supports installing gems into Ruby 2.6 or later installations.
 
+### scm / git / subversion
+
+scm now supports the path property in favour of destination. However destination will continue to work at this time.
+
 ### windows_ad_join
 
 windows_ad_join now uses the UPN format for usernames, which prevents some failures to authenticate to the domain.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -153,7 +153,7 @@ gem_package now supports installing gems into Ruby 2.6 or later installations.
 
 ### scm / git / subversion
 
-scm now supports the path property in favour of destination. However destination will continue to work at this time.
+`scm` resource now supports the `path` property rather than the `destination` property. While currently supported, the `destination` property will be deprecated eventually.
 
 ### windows_ad_join
 

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -30,7 +30,7 @@ class Chef
 
       GIT_VERSION_PATTERN = Regexp.compile('git version (\d+\.\d+.\d+)')
 
-      def_delegator :new_resource, :destination, :cwd
+      def_delegator :new_resource, :path, :cwd
 
       def load_current_resource
         @resolved_reference = nil
@@ -80,7 +80,7 @@ class Chef
           enable_submodules
           add_remotes
         else
-          logger.trace "#{new_resource} checkout destination #{cwd} already exists or is a non-empty directory"
+          logger.trace "#{new_resource} checkout path #{cwd} already exists or is a non-empty directory"
         end
       end
 

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -24,8 +24,8 @@ class Chef
       default_action :sync
       allowed_actions :checkout, :export, :sync, :diff, :log
 
-      property :destination, String,
-               description: "The location path to which the source is to be cloned, checked out, or exported. Default value: the name of the resource block.",
+      property :path, String,
+               description: "The location path to which the source is to be cloned, checked out, or exported. Default value: the name of the resource block. This may also be specified by the legacy 'destination' property.",
                name_property: true, identity: true
 
       property :repository, String
@@ -69,6 +69,7 @@ class Chef
                description: "A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'}).",
                default: nil
 
+      alias :destination :path
       alias :env :environment
     end
   end

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -29,7 +29,7 @@ describe Chef::Provider::Git do
 
     @resource = Chef::Resource::Git.new("web2.0 app")
     @resource.repository "git://github.com/opscode/chef.git"
-    @resource.destination "/my/deploy/dir"
+    @resource.path "/my/deploy/dir"
     @resource.revision "d35af14d41ae22b19da05d7d03a0bafc321b244c"
     @node = Chef::Node.new
     @events = Chef::EventDispatch::Dispatcher.new
@@ -71,7 +71,7 @@ describe Chef::Provider::Git do
     end
   end
 
-  it "creates a current_resource with the currently deployed revision when a clone exists in the destination dir" do
+  it "creates a current_resource with the currently deployed revision when a clone exists in the path" do
     allow(@provider).to receive(:find_current_revision).and_return("681c9802d1c62a45b490786c18f0b8216b309440")
     @provider.load_current_resource
     expect(@provider.current_resource.name).to eql(@resource.name)
@@ -358,10 +358,10 @@ describe Chef::Provider::Git do
     end
   end
 
-  it "runs a clone command with escaped destination" do
+  it "runs a clone command with escaped path" do
     @resource.user "deployNinja"
     allow(Etc).to receive(:getpwnam).and_return(double("Struct::Passwd", name: @resource.user, dir: "/home/deployNinja"))
-    @resource.destination "/Application Support/with/space"
+    @resource.path "/Application Support/with/space"
     @resource.ssh_wrapper "do_it_this_way.sh"
     expected_cmd = "git clone \"git://github.com/opscode/chef.git\" \"/Application Support/with/space\""
     expect(@provider).to receive(:shell_out!).with(expected_cmd, user: "deployNinja",
@@ -641,7 +641,7 @@ describe Chef::Provider::Git do
    # @resource.should be_updated
   end
 
-  it "should not checkout if the destination exists or is a non empty directory" do
+  it "should not checkout if the path exists or is a non empty directory" do
     # will be invoked in load_current_resource
     allow(::File).to receive(:exist?).with("/my/deploy/dir/.git").and_return(false)
 
@@ -712,7 +712,7 @@ describe Chef::Provider::Git do
 
   it "does an export by cloning the repo then removing the .git directory" do
     expect(@provider).to receive(:action_checkout)
-    expect(FileUtils).to receive(:rm_rf).with(@resource.destination + "/.git")
+    expect(FileUtils).to receive(:rm_rf).with(@resource.path + "/.git")
     @provider.run_action(:export)
     expect(@resource).to be_updated
   end

--- a/spec/unit/provider/subversion_spec.rb
+++ b/spec/unit/provider/subversion_spec.rb
@@ -23,7 +23,7 @@ describe Chef::Provider::Subversion do
   before do
     @resource = Chef::Resource::Subversion.new("my app")
     @resource.repository "http://svn.example.org/trunk/"
-    @resource.destination "/my/deploy/dir"
+    @resource.path "/my/deploy/dir"
     @resource.revision "12345"
     @resource.svn_arguments(false)
     @resource.svn_info_args(false)
@@ -206,7 +206,7 @@ describe Chef::Provider::Subversion do
     expect { @provider.run_action(:sync) }.to raise_error(Chef::Exceptions::MissingParentDirectory)
   end
 
-  it "should not checkout if the destination exists or is a non empty directory" do
+  it "should not checkout if the path exists or is a non empty directory" do
     allow(::File).to receive(:exist?).with("/my/deploy/dir/.svn").and_return(false)
     allow(::File).to receive(:exist?).with("/my/deploy/dir").and_return(true)
     allow(::File).to receive(:directory?).with("/my/deploy").and_return(true)

--- a/spec/unit/resource/git_spec.rb
+++ b/spec/unit/resource/git_spec.rb
@@ -43,8 +43,8 @@ describe Chef::Resource::Git do
     expect(resource.revision).to eql("v1.0 tag")
   end
 
-  it "the destination property is the name_property" do
-    expect(resource.destination).to eql("fakey_fakerton")
+  it "the path property is the name_property" do
+    expect(resource.path).to eql("fakey_fakerton")
   end
 
   it "sets the default action as :sync" do

--- a/spec/unit/resource/scm_spec.rb
+++ b/spec/unit/resource/scm_spec.rb
@@ -22,8 +22,8 @@ require "spec_helper"
 describe Chef::Resource::Scm do
   let(:resource) { Chef::Resource::Scm.new("fakey_fakerton") }
 
-  it "the destination property is the name_property" do
-    expect(resource.destination).to eql("fakey_fakerton")
+  it "the path property is the name_property" do
+    expect(resource.path).to eql("fakey_fakerton")
   end
 
   it "sets the default action as :sync" do
@@ -38,9 +38,9 @@ describe Chef::Resource::Scm do
     expect { resource.action :sync }.not_to raise_error
   end
 
-  it "takes the destination path as a string" do
-    resource.destination "/path/to/deploy/dir"
-    expect(resource.destination).to eql("/path/to/deploy/dir")
+  it "takes the path as a string" do
+    resource.path "/path/to/deploy/dir"
+    expect(resource.path).to eql("/path/to/deploy/dir")
   end
 
   it "takes a string for the repository URL" do
@@ -146,7 +146,7 @@ describe Chef::Resource::Scm do
 
   describe "when it has repository, revision, user, and group" do
     before do
-      resource.destination("hell")
+      resource.path("hell")
       resource.repository("apt")
       resource.revision("1.2.3")
       resource.user("root")
@@ -158,7 +158,7 @@ describe Chef::Resource::Scm do
       expect(state[:revision]).to eq("1.2.3")
     end
 
-    it "returns the destination as its identity" do
+    it "returns the path as its identity" do
       expect(resource.identity).to eq("hell")
     end
   end

--- a/spec/unit/resource/subversion_spec.rb
+++ b/spec/unit/resource/subversion_spec.rb
@@ -32,8 +32,8 @@ describe Chef::Resource::Subversion do
     expect(resource).to be_a_kind_of(Chef::Resource::Scm)
   end
 
-  it "the destination property is the name_property" do
-    expect(resource.destination).to eql("fakey_fakerton")
+  it "the path property is the name_property" do
+    expect(resource.path).to eql("fakey_fakerton")
   end
 
   it "sets the default action as :sync" do


### PR DESCRIPTION
Introduce the 'path' property and deprecate the 'destination' property.
This provides a more consistent experience for users across file based
resources.

Fixes https://github.com/chef/chef/issues/7434

Updated tests and release notes as per issue template.