### PR TITLE
Bump all deps to the latest versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     appbundler (0.11.6)
       mixlib-cli (~> 1.4)
       mixlib-shellout (~> 2.0)
@@ -118,11 +119,11 @@ GEM
     docile (1.3.1)
     equatable (0.5.0)
     erubis (2.7.0)
-    ethon (0.11.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
+    faraday_middleware (0.13.0)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
     ffi (1.10.0-x64-mingw32)
@@ -239,6 +240,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (3.0.3)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
@@ -298,7 +300,7 @@ GEM
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
       sfl
-    sslshake (1.2.0)
+    sslshake (1.3.0)
     strings (0.1.4)
       strings-ansi (~> 0.1.0)
       unicode-display_width (~> 1.4.0)
@@ -308,7 +310,7 @@ GEM
     syslog-logger (1.6.8)
     systemu (2.6.5)
     thor (0.20.3)
-    timers (4.2.0)
+    timers (4.3.0)
     tomlrb (1.2.8)
     train-core (1.6.3)
       json (>= 1.8, < 3.0)
@@ -379,7 +381,7 @@ GEM
       win32-api (>= 1.4.5)
     wisper (2.0.0)
     wmi-lite (1.0.2)
-    yard (0.9.16)
+    yard (0.9.18)
 
 PLATFORMS
   ruby

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 51cc8d6143c6737dc5d51fe89f7a45fe52f34731
+  revision: c1f49993ce7daeac6fbb4352e8787468d81a1121
   branch: master
   specs:
-    omnibus (6.0.11)
+    omnibus (6.0.12)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: f876bb6a1d60e0b9e2b52a4ce16318d05327bdfd
+  revision: 222f2955a04b6e57c841faf58d1879ab7280e734
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.125.0)
-    aws-sdk-core (3.44.1)
+    aws-partitions (1.133.0)
+    aws-sdk-core (3.46.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.30.0)
+    aws-sdk-s3 (1.30.1)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -63,10 +63,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
-    chef (14.8.12)
+    chef (14.9.13)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.8.12)
+      chef-config (= 14.9.13)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -74,7 +74,7 @@ GEM
       ffi-yajl (~> 2.2)
       highline (~> 1.6, >= 1.6.9)
       iniparse (~> 1.4)
-      mixlib-archive (~> 0.4)
+      mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
       mixlib-cli (~> 1.7)
       mixlib-log (~> 2.0, >= 2.0.3)
@@ -93,10 +93,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.8.12-universal-mingw32)
+    chef (14.9.13-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.8.12)
+      chef-config (= 14.9.13)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -105,7 +105,7 @@ GEM
       highline (~> 1.6, >= 1.6.9)
       iniparse (~> 1.4)
       iso8601 (~> 0.12.1)
-      mixlib-archive (~> 0.4)
+      mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
       mixlib-cli (~> 1.7)
       mixlib-log (~> 2.0, >= 2.0.3)
@@ -136,13 +136,13 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.8.12)
+    chef-config (14.9.13)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (4.2.1)
+    chef-sugar (5.0.0)
     chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -158,9 +158,9 @@ GEM
     erubis (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
-    ffi (1.9.25-x64-mingw32)
-    ffi (1.9.25-x86-mingw32)
+    ffi (1.10.0)
+    ffi (1.10.0-x64-mingw32)
+    ffi (1.10.0-x86-mingw32)
     ffi-win32-extensions (1.0.3)
       ffi
     ffi-yajl (2.3.1)
@@ -190,7 +190,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.9.2)
-    minitar (0.7)
+    minitar (0.8)
     mixlib-archive (0.4.19)
       mixlib-log
     mixlib-archive (0.4.19-universal-mingw32)
@@ -244,7 +244,7 @@ GEM
       multipart-post (~> 2.0.0)
       progressbar
       zhexdump (>= 0.0.2)
-    plist (3.4.0)
+    plist (3.5.0)
     progressbar (1.10.0)
     proxifier (1.0.3)
     pry (0.12.2)
@@ -294,7 +294,7 @@ GEM
     solve (4.0.2)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
-    specinfra (2.76.5)
+    specinfra (2.76.9)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -302,7 +302,7 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.23.5)
+    test-kitchen (1.24.0)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -315,10 +315,10 @@ GEM
     thor (0.20.3)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
-    tomlrb (1.2.7)
+    tomlrb (1.2.8)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.1.11)
+    win32-certstore (0.2.2)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)
@@ -338,12 +338,12 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (2.0.1)
+    win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
-    winrm (2.3.0)
+    winrm (2.3.1)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -352,15 +352,15 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-elevated (1.1.0)
+    winrm-elevated (1.1.1)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.1)
+    winrm-fs (1.3.2)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    wmi-lite (1.0.1)
+    wmi-lite (1.0.2)
     zhexdump (0.0.2)
 
 PLATFORMS
@@ -382,4 +382,4 @@ DEPENDENCIES
   winrm-fs (~> 1.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This brings in multiple misc deps that we don't have expeditor setup to subscribe to.

Signed-off-by: Tim Smith <tsmith@chef.io>