### PR TITLE
Remove support for unsupported opensuse < 42 from group provider

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/metadata.rb
+++ b/kitchen-tests/cookbooks/end_to_end/metadata.rb
@@ -20,7 +20,7 @@ depends          "git"
 supports         "ubuntu"
 supports         "debian"
 supports         "centos"
-supports         "opensuse"
+supports         "opensuseleap"
 supports         "fedora"
 supports         "amazon"
 

--- a/lib/chef/provider/group/groupadd.rb
+++ b/lib/chef/provider/group/groupadd.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
   class Provider
     class Group
       class Suse < Chef::Provider::Group::Groupadd
-        provides :group, platform: "opensuse", platform_version: "< 12.3"
         provides :group, platform: "suse", platform_version: "< 12.0"
 
         def load_current_resource

--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ class Chef
       class Usermod < Chef::Provider::Group::Groupadd
 
         provides :group, os: %w{openbsd solaris2}
-        provides :group, platform: "opensuse"
 
         def load_current_resource
           super
@@ -79,7 +78,7 @@ class Chef
           case node[:platform]
           when "openbsd", "netbsd", "aix", "solaris2", "smartos", "omnios"
             "-G"
-          when "solaris", "suse", "opensuse"
+          when "solaris"
             [ "-a", "-G" ]
           end
         end

--- a/lib/chef/providers.rb
+++ b/lib/chef/providers.rb
@@ -84,6 +84,7 @@ require "chef/provider/package/bff"
 require "chef/provider/package/cab"
 require "chef/provider/package/powershell"
 require "chef/provider/package/msu"
+require "chef/provider/package/snap"
 
 require "chef/provider/service/arch"
 require "chef/provider/service/freebsd"

--- a/spec/unit/provider/group/usermod_spec.rb
+++ b/spec/unit/provider/group/usermod_spec.rb
@@ -49,8 +49,6 @@ describe Chef::Provider::Group::Usermod do
         "openbsd" => [ "-G" ],
         "netbsd" => [ "-G" ],
         "solaris" => [ "-a", "-G" ],
-        "suse" => [ "-a", "-G" ],
-        "opensuse" => [ "-a", "-G" ],
         "smartos" => [ "-G" ],
         "omnios" => [ "-G" ],
       }

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -674,11 +674,6 @@ describe Chef::ProviderResolver do
     #          service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
               package: [ Chef::Resource::ZypperPackage, Chef::Provider::Package::Zypper ],
               group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ],
-              "12.3" => {
-              },
-              "12.2" => {
-                group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ],
-              },
             },
           },
 

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -671,9 +671,10 @@ describe Chef::ProviderResolver do
               },
             },
             "opensuseleap" => {
-    #          service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
-              package: [ Chef::Resource::ZypperPackage, Chef::Provider::Package::Zypper ],
-              group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ],
+              %w{42.3} => {
+                package: [ Chef::Resource::ZypperPackage, Chef::Provider::Package::Zypper ],
+                group: [ Chef::Resource::Group, Chef::Provider::Group::Gpasswd ],
+              },
             },
           },
 

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -670,7 +670,7 @@ describe Chef::ProviderResolver do
                 group: [ Chef::Resource::Group, Chef::Provider::Group::Suse ],
               },
             },
-            "opensuse" => {
+            "opensuseleap" => {
     #          service: [ Chef::Resource::RedhatService, Chef::Provider::Service::Redhat ],
               package: [ Chef::Resource::ZypperPackage, Chef::Provider::Package::Zypper ],
               group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ],


### PR DESCRIPTION
We had a few places where we checked for legacy opensuse platforms. Chef 15 doesn't support this platform and you won't be able to find binaries via omnitruck. We might as well yank out a bit of provider logic.

Also for some reason usermod has logic in a method for suse, but the provider didn't support that.

Signed-off-by: Tim Smith <tsmith@chef.io>