### PR TITLE
Remove hpux support from group's usermod provider

### DIFF
--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -23,7 +23,7 @@ class Chef
     class Group
       class Usermod < Chef::Provider::Group::Groupadd
 
-        provides :group, os: %w{openbsd solaris2 hpux}
+        provides :group, os: %w{openbsd solaris2}
         provides :group, platform: "opensuse"
 
         def load_current_resource

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -790,16 +790,6 @@ describe Chef::ProviderResolver do
           },
         },
 
-        "hpux" => {
-          "hpux" => {
-            "hpux" => {
-              "3.1.4" => {
-                group: [ Chef::Resource::Group, Chef::Provider::Group::Usermod ],
-              },
-            },
-          },
-        },
-
         "netbsd" => {
           "netbsd" => {
             "netbsd" => {


### PR DESCRIPTION
We removed hpux support from other parts of ohai / chef. This appears to be the last of it.

Signed-off-by: Tim Smith <tsmith@chef.io>