### PR TITLE
Use the latest omnibus-software and nokogiri

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: c1f49993ce7daeac6fbb4352e8787468d81a1121
+  revision: 0ee44af9fd6892d2ccf52aaa4b7dfda65730840d
   branch: master
   specs:
-    omnibus (6.0.12)
+    omnibus (6.0.14)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 222f2955a04b6e57c841faf58d1879ab7280e734
+  revision: ce1e03de4c9970da53b4c63176b17af518426968
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.133.0)
+    aws-partitions (1.134.0)
     aws-sdk-core (3.46.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,7 +6,7 @@
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "2.7.7"
 override :bundler, version: "1.17.3"
-override "nokogiri", version: "1.8.5"
+override "nokogiri", version: "1.10.1"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.4"


### PR DESCRIPTION
The new omnibus-software includes a patch I added to fix compilation
failures on non C99 compatible compilers with 2.6.0.

The omnibus release that gets pulled in is also necessary for Ruby 2.6 on macOS

The new nokogiri supports windows on Ruby 2.6, which the previous
version did not.

Signed-off-by: Tim Smith <tsmith@chef.io>