### PR TITLE
Add a deprecation warning to knife cookbook site

### DIFF
--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software, Inc.
+# Copyright:: Copyright 2009-2019, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,12 @@ class Chef
 
       banner "knife cookbook site download COOKBOOK [VERSION] (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site download has been deprecated in favor of knife supermarket download. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
+
     end
   end
 end

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2010-2018, Chef Software Inc.
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,11 @@ class Chef
 
       banner "knife cookbook site install COOKBOOK [VERSION] (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site install has been deprecated in favor of knife supermarket install. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end

--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,11 @@ class Chef
 
       banner "knife cookbook site list (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site list has been deprecated in favor of knife supermarket list. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end

--- a/lib/chef/knife/cookbook_site_search.rb
+++ b/lib/chef/knife/cookbook_site_search.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,11 @@ class Chef
 
       banner "knife cookbook site search QUERY (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site search has been deprecated in favor of knife supermarket search. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Nuo Yan (<nuo@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,11 @@ class Chef
 
       banner "knife cookbook site share COOKBOOK [CATEGORY] (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site share has been deprecated in favor of knife supermarket share. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,11 @@ class Chef
 
       banner "knife cookbook site show COOKBOOK [VERSION] (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site show has been deprecated in favor of knife supermarket show. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end

--- a/lib/chef/knife/cookbook_site_unshare.rb
+++ b/lib/chef/knife/cookbook_site_unshare.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Stephen Delano (<stephen@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2010-2016, Chef Software Inc.
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,11 @@ class Chef
 
       banner "knife cookbook site unshare COOKBOOK (options)"
       category "cookbook site"
+
+      def run
+        Chef::Log.warn("knife cookbook site unshare has been deprecated in favor of knife supermarket unshare. In Chef 16 (April 2020) this will result in an error!")
+        super
+      end
 
     end
   end


### PR DESCRIPTION
Our docs already list this is deprecated. We should make sure users running the command know now.

Signed-off-by: Tim Smith <tsmith@chef.io>