### PR TITLE
Cleanup requires / includes in knife supermarket

### DIFF
--- a/lib/chef/knife/supermarket_install.rb
+++ b/lib/chef/knife/supermarket_install.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +18,14 @@
 
 require "chef/knife"
 require "chef/exceptions"
-require "shellwords"
-require "mixlib/archive"
 
 class Chef
   class Knife
     class SupermarketInstall < Knife
 
       deps do
-        require "chef/mixin/shell_out"
+        require "shellwords"
+        require "mixlib/archive"
         require "chef/knife/core/cookbook_scm_repo"
         require "chef/cookbook/metadata"
       end
@@ -71,8 +70,6 @@ class Chef
       attr_reader :vendor_path
 
       def run
-        extend Chef::Mixin::ShellOut
-
         if config[:cookbook_path]
           Chef::Config[:cookbook_path] = config[:cookbook_path]
         else

--- a/lib/chef/knife/supermarket_share.rb
+++ b/lib/chef/knife/supermarket_share.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Webber (<cwebber@chef.io>)
-# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
 #
 
 require "chef/knife"
-require "chef/mixin/shell_out"
 
 class Chef
   class Knife
@@ -29,10 +28,8 @@ class Chef
         require "chef/cookbook_loader"
         require "chef/cookbook_uploader"
         require "chef/cookbook_site_streaming_uploader"
-        require "mixlib/shellout"
+        require "chef/mixin/shell_out"
       end
-
-      include Chef::Mixin::ShellOut
 
       banner "knife supermarket share COOKBOOK [CATEGORY] (options)"
       category "supermarket"


### PR DESCRIPTION
1) Move everything into the deps blocks
2) don't require shell_out in install since we're not using it. We use mixlib_archive now

Signed-off-by: Tim Smith <tsmith@chef.io>