### PR TITLE
powershell_script: Prefer user provided flags over the defaults

### DIFF
--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -60,8 +60,8 @@ class Chef
       def flags
         interpreter_flags = [*default_interpreter_flags].join(" ")
 
-        if ! (new_resource.flags.nil?)
-          interpreter_flags = [new_resource.flags, interpreter_flags].join(" ")
+        unless new_resource.flags.nil?
+          interpreter_flags = [interpreter_flags, new_resource.flags].join(" ")
         end
 
         interpreter_flags

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -231,20 +231,26 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       expect(is_64_bit).to eq(detected_64_bit)
     end
 
+    it "returns 0 if a valid flag is passed to the interpreter" do
+      resource.code(cmdlet_exit_code_success_content)
+      resource.flags(valid_powershell_interpreter_flag)
+      resource.returns(0)
+      resource.run_action(:run)
+    end
+
+    it "returns 0 if no flag is passed to the interpreter" do
+      resource.code(cmdlet_exit_code_success_content)
+      resource.returns(0)
+      resource.run_action(:run)
+    end
+
     it "returns 1 if an invalid flag is passed to the interpreter" do
       pending "powershell.exe always exits with 0 on nano" if Chef::Platform.windows_nano_server?
 
       resource.code(cmdlet_exit_code_success_content)
       resource.flags(invalid_powershell_interpreter_flag)
       resource.returns(1)
-      resource.run_action(:run)
-    end
-
-    it "returns 0 if a valid flag is passed to the interpreter" do
-      resource.code(cmdlet_exit_code_success_content)
-      resource.flags(valid_powershell_interpreter_flag)
-      resource.returns(0)
-      resource.run_action(:run)
+      expect { resource.run_action(:run) }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
     end
 
     it "raises an error when given a block and a guard_interpreter" do

--- a/spec/support/shared/unit/script_resource.rb
+++ b/spec/support/shared/unit/script_resource.rb
@@ -41,7 +41,7 @@ shared_examples_for "a script resource" do
 
   it "should accept a string for the flags" do
     script_resource.flags "-f"
-    expect(script_resource.flags).to eql("-f")
+    expect(script_resource.flags.strip).to eql("-f")
   end
 
   it "should raise an exception if users set command on the resource", chef: ">= 13" do

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -130,7 +130,29 @@ describe Chef::Resource::PowershellScript do
     let(:resource_instance_name ) { @resource.command }
     let(:resource_name) { :powershell_script }
     let(:interpreter_file_name) { "powershell.exe" }
-
+    before do
+      allow(@resource).to receive(:default_flags).and_return(nil)
+    end
     it_behaves_like "a Windows script resource"
+  end
+
+  context "Attribute: flags" do
+    let(:resource) { @resource }
+    let(:default) { "FLAGS" }
+    before(:each) do
+      allow(@resource).to receive(:default_flags).and_return(default)
+    end
+    context "When User input given" do
+      it "Appands user input after the default flags" do
+        flags = "USER FLAGS"
+        resource.flags flags
+        expect(resource.flags).to eql(default + " " + flags)
+      end
+    end
+    context "When User input is not given" do
+      it "Uses default flags" do
+        expect(resource.flags).to eql(default)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Handling `flags` property at resource level instead of provider
- Fixed the order of concatenating user defined and default flags
- Added test cases
- Chef-style maintained

### Description

The order of concatenating user input flag and the default flag was incorrect.
`Powershell` would favor the flag value which is happening at last mentioned. Thus, to give priority to user input flag, we should append them at latter place.


### Issues Resolved

#3057 

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
