### PR TITLE
Add a project alias in expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,9 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 
+# the name we use for this project when interacting with expeditor chatbot
+project:
+  alias: chef-15
+
 # The name of the product keys for this product (from mixlib-install)
 product_key:
   - chef


### PR DESCRIPTION
This means we can run:

/expeditor promote chef-15 15.0.31337

instead of:

/expeditor promote chef/chef:master 15.0.31337

Signed-off-by: Tim Smith <tsmith@chef.io>