### PR TITLE
Convert execute_resource remaining properties to use properties 

### DIFF
--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -18,24 +18,22 @@
 
 require "chef/log"
 require "chef/provider"
-require "forwardable"
 
 class Chef
   class Provider
     class Execute < Chef::Provider
-      extend Forwardable
-
       provides :execute
 
-      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env
+      def initialize(new_resource, run_context)
+        super
+      end
 
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
-        current_resource
       end
 
       def define_resource_requirements
-        if creates && creates_relative? && !cwd
+        if new_resource.creates && creates_relative? && !new_resource.cwd
           # FIXME? move this onto the resource?
           raise Chef::Exceptions::Execute, "Please either specify a full path for the creates property, or specify a cwd property to the #{new_resource} resource"
         end
@@ -48,14 +46,14 @@ class Chef
       end
 
       def action_run
-        if creates && sentinel_file.exist?
+        if new_resource.creates && sentinel_file.exist?
           logger.debug("#{new_resource} sentinel file #{sentinel_file} exists - nothing to do")
           return false
         end
 
         converge_by("execute #{description}") do
           begin
-            shell_out!(command, opts)
+            shell_out!(new_resource.command, opts)
           rescue Mixlib::ShellOut::ShellCommandFailed
             if sensitive?
               ex = Mixlib::ShellOut::ShellCommandFailed.new("Command execution failed. STDOUT/STDERR suppressed for sensitive resource")
@@ -89,15 +87,15 @@ class Chef
       def opts
         opts = {}
         opts[:timeout]     = timeout
-        opts[:returns]     = returns if returns
-        opts[:environment] = environment if environment
-        opts[:user]        = user if user
-        opts[:domain]      = domain if domain
-        opts[:password]    = password if password
-        opts[:group]       = group if group
-        opts[:cwd]         = cwd if cwd
-        opts[:umask]       = umask if umask
-        opts[:default_env] = default_env
+        opts[:returns]     = new_resource.returns if new_resource.returns
+        opts[:environment] = new_resource.environment if new_resource.environment
+        opts[:user]        = new_resource.user if new_resource.user
+        opts[:domain]      = new_resource.domain if new_resource.domain
+        opts[:password]    = new_resource.password if new_resource.password
+        opts[:group]       = new_resource.group if new_resource.group
+        opts[:cwd]         = new_resource.cwd if new_resource.cwd
+        opts[:umask]       = new_resource.umask if new_resource.umask
+        opts[:default_env] = new_resource.default_env
         opts[:log_level]   = :info
         opts[:log_tag]     = new_resource.to_s
         if (logger.info? || live_stream?) && !sensitive?
@@ -107,21 +105,21 @@ class Chef
             opts[:live_stream] = STDOUT
           end
         end
-        opts[:elevated] = elevated if elevated
+        opts[:elevated] = new_resource.elevated if new_resource.elevated
         opts
       end
 
       def description
-        sensitive? ? "sensitive resource" : command
+        sensitive? ? "sensitive resource" : new_resource.command
       end
 
       def creates_relative?
-        Pathname(creates).relative?
+        Pathname(new_resource.creates).relative?
       end
 
       def sentinel_file
         Pathname.new(Chef::Util::PathHelper.cleanpath(
-           ( cwd && creates_relative? ) ? ::File.join(cwd, creates) : creates
+           ( new_resource.cwd && creates_relative? ) ? ::File.join(new_resource.cwd, new_resource.creates) : new_resource.creates
         ))
       end
 

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -23,10 +23,6 @@ class Chef
   class Resource
     class Execute < Chef::Resource
       resource_name :execute
-      provides :execute
-
-      identity_attr :command
-
       description "Use the execute resource to execute a single command. Commands that"\
                   " are executed with this resource are (by their nature) not idempotent,"\
                   " as they are typically unique to the environment in which they are run."\
@@ -48,13 +44,10 @@ class Chef
         @is_guard_interpreter = false
       end
 
-      def command(arg = nil)
-        set_or_return(
-          :command,
-          arg,
-          kind_of: [ String, Array ]
-        )
-      end
+      property :command, [ String, Array ],
+               name_property: true, identity: true,
+               description: "An optional proeprty to set the command to be executed if it differs from the resource block's name."
+
       property :umask, [ String, Integer ],
                description: "The file mode creation mask, or umask."
 
@@ -66,8 +59,6 @@ class Chef
 
       property :environment, Hash,
                description: "A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'})."
-
-      alias :env :environment
 
       property :group, [ String, Integer ],
                description: "The group name or group ID that must be changed before running a command."
@@ -105,6 +96,8 @@ class Chef
       property :elevated, [ TrueClass, FalseClass ], default: false,
                description: "Determines whether the script will run with elevated permissions to circumvent User Access Control (UAC) interactively blocking the process.\nThis will cause the process to be run under a batch login instead of an interactive login. The user running Chef needs the “Replace a process level token” and “Adjust Memory Quotas for a process” permissions. The user that is running the command needs the “Log on as a batch job” permission.\nBecause this requires a login, the user and password properties are required.",
                introduced: "13.3"
+
+      alias :env :environment
 
       def self.set_guard_inherited_attributes(*inherited_attributes)
         @class_inherited_attributes = inherited_attributes

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -22,6 +22,7 @@ require "chef/resource"
 class Chef
   class Resource
     class Execute < Chef::Resource
+      resource_name :execute
       provides :execute
       description "Use the execute resource to execute a single command. Commands that"\
                   " are executed with this resource are (by their nature) not idempotent,"\

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -22,7 +22,7 @@ require "chef/resource"
 class Chef
   class Resource
     class Execute < Chef::Resource
-      resource_name :execute
+      provides :execute
       description "Use the execute resource to execute a single command. Commands that"\
                   " are executed with this resource are (by their nature) not idempotent,"\
                   " as they are typically unique to the environment in which they are run."\

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -46,7 +46,7 @@ class Chef
 
       property :command, [ String, Array ],
                name_property: true, identity: true,
-               description: "An optional proeprty to set the command to be executed if it differs from the resource block's name."
+               description: "An optional property to set the command to be executed if it differs from the resource block's name."
 
       property :umask, [ String, Integer ],
                description: "The file mode creation mask, or umask."

--- a/lib/chef/resource/script.rb
+++ b/lib/chef/resource/script.rb
@@ -39,10 +39,10 @@ class Chef
 
       # FIXME: remove this and use an execute sub-resource instead of inheriting from Execute
       def command(arg = nil)
+        super
         unless arg.nil?
           raise Chef::Exceptions::Script, "Do not use the command property on a #{resource_name} resource, use the 'code' property instead."
         end
-        super
       end
 
       property :code, String, required: true


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
The execute resource has not been fully converted to using property to set properties. We should convert this to setup properties via the property resource DSL.

### Issues Resolved
Fixes #7063
### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
