### PR TITLE
Officially deprecate cookbook shadowing and audit mode

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -376,6 +376,10 @@ class Chef::Application::Client < Chef::Application
     end
 
     if mode = config[:audit_mode] || Chef::Config[:audit_mode]
+      if [:enabled, :audit_only].include?(mode)
+        Chef.deprecated(:audit_mode, "Chef's Audit mode has been deprecated and will be removed in Chef 15 (April 2019). Consider migrating to InSpec as a replacement for this functionality.")
+      end
+
       expected_modes = [:enabled, :disabled, :audit_only]
       unless expected_modes.include?(mode)
         Chef::Application.fatal!(unrecognized_audit_mode(mode))

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -68,8 +68,8 @@ class Chef
 
     def warn_about_cookbook_shadowing
       unless merged_cookbooks.empty?
-        Chef::Log.deprecation "The cookbook(s): #{merged_cookbooks.join(', ')} exist in multiple places in your cookbook_path. " +
-          "A composite version has been compiled.  This has been deprecated since 0.10.4, in Chef 13 this behavior will be REMOVED."
+        Chef.deprecated(:cookbook_shadowing, "The cookbook(s): #{merged_cookbooks.join(', ')} exist in multiple places in your cookbook_path. " +
+          "A composite version has been compiled. This has been deprecated since 0.10.4, in Chef 15 this behavior will be REMOVED.")
       end
     end
 

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -207,12 +207,6 @@ class Chef
       target 23
     end
 
-    class MapCollision < Base
-      target 25
-    end
-
-    # id 3694 was deleted
-
     # Returned when using the deprecated option on a property
     class Property < Base
       target 24
@@ -222,9 +216,23 @@ class Chef
       end
     end
 
+    class MapCollision < Base
+      target 25
+    end
+
     class ShellOut < Base
       target 26
     end
+
+    class AuditMode < Base
+      target 27
+    end
+
+    class CookbookShadowing < Base
+      target 28
+    end
+
+    # id 3694 was deleted and should not be reused
 
     class Generic < Base
       def url

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -434,6 +434,7 @@ EOM
         local_mode true
         cookbook_path "#{path_to('cookbooks')}"
         audit_mode :enabled
+        silence_deprecation_warnings %w{chef-27}
 EOM
     end
 

--- a/spec/integration/client/exit_code_spec.rb
+++ b/spec/integration/client/exit_code_spec.rb
@@ -39,6 +39,7 @@ EOM
         local_mode true
         cookbook_path "#{path_to('cookbooks')}"
         audit_mode :audit_only
+        silence_deprecation_warnings %w{chef-27}
 EOM
     end
 


### PR DESCRIPTION
These will throw full stop deprecations now.

Signed-off-by: Tim Smith <tsmith@chef.io>