### PR TITLE
Update knife bootstrap template to use up to date omnitruck URL

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -171,7 +171,7 @@ do_download() {
 <% if knife_config[:bootstrap_install_command] %>
   <%= knife_config[:bootstrap_install_command] %>
 <% else %>
-  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://omnitruck-direct.chef.io/chef/install.sh" %>"
+  install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://omnitruck.chef.io/chef/install.sh" %>"
   if test -f /usr/bin/chef-client; then
     echo "-----> Existing Chef installation detected"
   else


### PR DESCRIPTION
omnitruck-direct.chef.io is a legacy URL that now points to the same
place as omnitruck.chef.io, and was originally in place to support
clients with older SSL libraries. However, the backward compatible
behavior of omnitruck-direct hasn't been the case for a while now. This
change just corrects the URL in the bootstrap template also.

https://github.com/chef/chef/pull/4312 was where the omnitruck-direct URL was originally set up.