### PR TITLE
windows_certificate: Import PFX certificates with their private keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ PATH
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
-      win32-certstore (>= 0.1.8)
+      win32-certstore (~> 0.2.4)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
@@ -366,7 +366,7 @@ GEM
       hashdiff
     websocket (1.2.8)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.2.3)
+    win32-certstore (0.2.4)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -16,7 +16,7 @@ gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", "~> 0.12.1"
-gemspec.add_dependency "win32-certstore", ">= 0.1.8"
+gemspec.add_dependency "win32-certstore", "~> 0.2.4"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 


### PR DESCRIPTION
- Using `add_pfx` of Win32::Certstore to import a PFX certificate with its private key
- Using required version of the `win32-certstore` gem 
- Added Test cases
- Minor cleanup and optimization

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

### Description

We created a method `add_pfx` in `win32-certstore` which uses purely Crypt APIs and without any conversion to other formats or data loss, imports a PFX certificate into the certstore.
Using the same here to import a PFX certificate with its private key.

### Issues Resolved

#8180 
[windows#580](https://github.com/chef-cookbooks/windows/issues/580)
[windows#575](https://github.com/chef-cookbooks/windows/issues/575 )

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>