### PR TITLE
Update rubygems to 2.7.8 and bundler to 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -362,6 +362,23 @@ matrix:
     env:
       - RSPEC_CENTOS=7
       - KITCHEN_YAML=kitchen.travis.yml
+  - rvm: 2.5.3
+    services: docker
+    sudo: required
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
+      - bundle exec kitchen test rspec-opensuse-leap
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+     - RSPEC_OPENSUSELEAP=42
+     - KITCHEN_YAML=kitchen.travis.yml
   allow_failures:
     - rvm: 2.5.3
       services: docker
@@ -383,7 +400,7 @@ matrix:
     - env:
         TEST_GEM: poise/halite
       script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-      rvm: 2.5.3 
+      rvm: 2.5.3
 
 notifications:
   on_change: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -380,6 +380,10 @@ matrix:
       env:
        - RSPEC_OPENSUSELEAP=42
        - KITCHEN_YAML=kitchen.travis.yml
+    - env:
+        TEST_GEM: poise/halite
+      script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
+      rvm: 2.5.3 
 
 notifications:
   on_change: true

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -63,10 +63,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
-    chef (14.9.13)
+    chef (14.10.9)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.9.13)
+      chef-config (= 14.10.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -93,10 +93,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.9.13-universal-mingw32)
+    chef (14.10.9-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.9.13)
+      chef-config (= 14.10.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -136,7 +136,7 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.9.13)
+    chef-config (14.10.9)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,8 +4,8 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "2.7.6"
-override :bundler, version: "1.16.1"
+override :rubygems, version: "2.7.8"
+override :bundler, version: "1.17.3"
 override "nokogiri", version: "1.10.1"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -442,6 +442,7 @@ describe Chef::Knife::Bootstrap do
     end
 
     it "doesn't create /etc/chef/trusted_certs if :trusted_certs_dir is empty" do
+      allow(Dir).to receive(:glob).and_call_original
       expect(Dir).to receive(:glob).with(File.join(trusted_certs_dir, "*.{crt,pem}")).and_return([])
       expect(rendered_template).not_to match(%r{mkdir -p /etc/chef/trusted_certs})
     end


### PR DESCRIPTION
Both of these have a long list of bugfixes and are the last versions
before major bumps were made. We should get these new versions pulled in
since we're shipping them in DK.

Signed-off-by: Tim Smith <tsmith@chef.io>