### PR TITLE
chef-solo: Fixes for extra cookbook_path with parent dir that doesn't exist causes crash

### DIFF
--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -110,7 +110,8 @@ class Chef
             else
               child_paths[name].each do |path|
                 begin
-                  Dir.mkdir(path, 0700)
+                  ::FileUtils.mkdir_p(path)
+                  ::FileUtils.chmod(0700, path)
                   if Chef::Platform.windows?
                     all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
                     administrators = Chef::ReservedNames::Win32::Security::SID.Administrators


### PR DESCRIPTION


Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>

### Description

- Created specified path recursively instead to assume that parent dir should exist.

### Issues Resolved
#7638 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
