### PR TITLE
Chef::Config: Uniform config dir path separator

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -122,7 +122,7 @@ module ChefConfig
       if config_file
         PathHelper.dirname(PathHelper.canonical_path(config_file, false))
       else
-        PathHelper.join(user_home, ".chef", "")
+        PathHelper.join(PathHelper.canonical_path(user_home, false), ".chef", "")
       end
     end
 

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -122,7 +122,7 @@ module ChefConfig
       if config_file
         PathHelper.dirname(PathHelper.canonical_path(config_file, false))
       else
-        PathHelper.join(PathHelper.canonical_path(user_home, false), ".chef", "")
+        PathHelper.join(PathHelper.cleanpath(user_home), ".chef", "")
       end
     end
 

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -644,11 +644,11 @@ RSpec.describe ChefConfig::Config do
 
           context "when the user's home dir is /home/charlie/" do
             before do
-              ChefConfig::Config.user_home = to_platform("/home/charlie")
+              ChefConfig::Config.user_home = "/home/charlie/"
             end
 
             it "config_dir is /home/charlie/.chef/" do
-              expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(to_platform("/home/charlie/.chef"), ""))
+              expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(ChefConfig::PathHelper.cleanpath("/home/charlie/"), ".chef", ""))
             end
 
             context "and chef is running in local mode" do
@@ -657,9 +657,32 @@ RSpec.describe ChefConfig::Config do
               end
 
               it "config_dir is /home/charlie/.chef/" do
-                expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(to_platform("/home/charlie/.chef"), ""))
+                expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(ChefConfig::PathHelper.cleanpath("/home/charlie/"), ".chef", ""))
               end
             end
+          end
+
+          if is_windows
+            context "when the user's home dir is windows specific" do
+              before do
+                ChefConfig::Config.user_home = to_platform("/home/charlie/")
+              end
+
+              it "config_dir is with backslashes" do
+                expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(ChefConfig::PathHelper.cleanpath("/home/charlie/"), ".chef", ""))
+              end
+
+              context "and chef is running in local mode" do
+                before do
+                  ChefConfig::Config.local_mode = true
+                end
+
+                it "config_dir is with backslashes" do
+                  expect(ChefConfig::Config.config_dir).to eq(ChefConfig::PathHelper.join(ChefConfig::PathHelper.cleanpath("/home/charlie/"), ".chef", ""))
+                end
+              end
+            end
+
           end
 
         end


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>

### Description

 - Config dir is extracted from the `config_file` if provided otherwise it is set to the `user_home` path and based on the environments (windows or Linux) we provide canonical path but when we set `user_home` it returns as it is, So In order to make it uniform we are returning environments based uniform path for `user_home` dir as well.

### Issues Resolved

#4909

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
