### PR TITLE
Alter how we set set group members in solaris / unify group testing

### DIFF
--- a/lib/chef/provider/group/solaris.rb
+++ b/lib/chef/provider/group/solaris.rb
@@ -48,15 +48,9 @@ class Chef
         end
 
         def set_members(members)
+          # Set the group to have exactly the list of members passed to it.
           unless members.empty?
-            members.each do |member|
-              add_member(member)
-            end
-          end
-          unless excluded_members.empty?
-            excluded_members.each do |excluded_member|
-              remove_member(excluded_member)
-            end
+            shell_out!("groupmod", "-U", members.join(","), new_resource.group_name)
           end
         end
 

--- a/lib/chef/provider/group/solaris.rb
+++ b/lib/chef/provider/group/solaris.rb
@@ -35,15 +35,9 @@ class Chef
           super
 
           requirements.assert(:all_actions) do |a|
-            a.assertion { ::File.exist?("/usr/sbin/usermod") }
-            a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/sbin/usermod for #{new_resource}"
+            a.assertion { ::File.exist?("/usr/sbin/usermod") && ::File.exist?("/usr/sbin/groupmod") }
+            a.failure_message Chef::Exceptions::Group, "Could not find binary /usr/sbin/usermod or /usr/sbin/groupmod for #{new_resource}"
             # No whyrun alternative: this component should be available in the base install of any given system that uses it
-          end
-
-          requirements.assert(:modify, :manage) do |a|
-            a.assertion { (new_resource.members.empty? && new_resource.excluded_members.empty?) || new_resource.append }
-            a.failure_message Chef::Exceptions::Group, "setting group members directly is not supported by #{self}, must set append true in group"
-            # No whyrun alternative - this action is simply not supported.
           end
         end
 

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -292,14 +292,16 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
     end
   end
 
-  let(:group_name) { "group#{SecureRandom.random_number(9999)}" }
+  # Groups below 1000 are reserved on a number of OSes, pick higher numbers
+  let(:number) { SecureRandom.random_number(9899) + 100 }
+  let(:group_name) { "grp#{number}" } # groupname 8 characters or less
   let(:included_members) { [] }
   let(:excluded_members) { [] }
   let(:group_resource) do
     group = Chef::Resource::Group.new(group_name, run_context)
     group.members(included_members)
     group.excluded_members(excluded_members)
-    group.gid(30000) unless ohai[:platform_family] == "mac_os_x"
+    group.gid(number) unless ohai[:platform_family] == "mac_os_x"
     group
   end
 
@@ -410,7 +412,7 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" end
     end
   end
 
-  describe "group manage action", :not_supported_on_solaris do
+  describe "group manage action" do
     let(:spec_members) { %w{mnou5sdz htulrvwq x4c3g1lu} }
     let(:included_members) { [spec_members[0], spec_members[1]] }
     let(:excluded_members) { [spec_members[2]] }
@@ -448,37 +450,4 @@ downthestreetalwayshadagoodsmileonhisfacetheoldmanwalkingdownthestreeQQQQQQ" end
     end
   end
 
-  describe "group resource with Usermod provider", :solaris_only do
-    describe "when excluded_members is set" do
-      let(:excluded_members) { ["x4c3g1lu"] }
-
-      it ":manage should raise an error" do
-        expect { group_resource.run_action(:manage) }.to raise_error
-      end
-
-      it ":modify should raise an error" do
-        expect { group_resource.run_action(:modify) }.to raise_error
-      end
-
-      it ":create should raise an error" do
-        expect { group_resource.run_action(:create) }.to raise_error
-      end
-    end
-
-    describe "when append is not set" do
-      let(:included_members) { %w{dfgdf4ds sadfsdfs} }
-
-      before(:each) do
-        group_resource.append(false)
-      end
-
-      it ":manage should raise an error" do
-        expect { group_resource.run_action(:manage) }.to raise_error
-      end
-
-      it ":modify should raise an error" do
-        expect { group_resource.run_action(:modify) }.to raise_error
-      end
-    end
-  end
 end

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -294,7 +294,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
 
   # Groups below 100 are reserved on a number of OSes, pick higher numbers
   let(:number) { SecureRandom.random_number(9899) + 100 }
-  let(:group_name) { "grp#{number}" } # groupname 8 characters or less
+  let(:group_name) { "grp#{number}" } # groupname 8 characters or less for Solaris, and possibly others
+  # https://community.aegirproject.org/developing/architecture/unix-group-limitations/index.html#Group_name_length_limits
   let(:included_members) { [] }
   let(:excluded_members) { [] }
   let(:group_resource) do

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -292,7 +292,7 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
     end
   end
 
-  # Groups below 1000 are reserved on a number of OSes, pick higher numbers
+  # Groups below 100 are reserved on a number of OSes, pick higher numbers
   let(:number) { SecureRandom.random_number(9899) + 100 }
   let(:group_name) { "grp#{number}" } # groupname 8 characters or less
   let(:included_members) { [] }

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -292,9 +292,8 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
     end
   end
 
-  # Groups below 100 are reserved on a number of OSes, pick higher numbers
-  let(:number) { SecureRandom.random_number(9899) + 100 }
-  let(:group_name) { "grp#{number}" } # groupname 8 characters or less for Solaris, and possibly others
+  let(:number) { rand(2000..9999) } # avoid low group numbers
+  let(:group_name) { "grp#{number}" } # group name should be 8 characters or less for Solaris, and possibly others
   # https://community.aegirproject.org/developing/architecture/unix-group-limitations/index.html#Group_name_length_limits
   let(:included_members) { [] }
   let(:excluded_members) { [] }

--- a/spec/unit/provider/group/solaris_spec.rb
+++ b/spec/unit/provider/group/solaris_spec.rb
@@ -54,14 +54,6 @@ describe Chef::Provider::Group::Solaris do
         allow(File).to receive(:exist?).and_return(true)
       end
 
-      it "should raise an error when setting the entire group directly" do
-        @provider.define_resource_requirements
-        @provider.load_current_resource
-        @provider.instance_variable_set("@group_exists", true)
-        @provider.action = :modify
-        expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "setting group members directly is not supported by #{@provider}, must set append true in group")
-      end
-
       it "should groupmod the whole batch when append is false" do
         current_resource = @new_resource.dup
         @provider.current_resource = current_resource

--- a/spec/unit/provider/group/solaris_spec.rb
+++ b/spec/unit/provider/group/solaris_spec.rb
@@ -62,6 +62,15 @@ describe Chef::Provider::Group::Solaris do
         expect { @provider.run_action(@provider.process_resource_requirements) }.to raise_error(Chef::Exceptions::Group, "setting group members directly is not supported by #{@provider}, must set append true in group")
       end
 
+      it "should groupmod the whole batch when append is false" do
+        current_resource = @new_resource.dup
+        @provider.current_resource = current_resource
+        @node.automatic_attrs[:platform] = "solaris2"
+        @new_resource.append(false)
+        expect(@provider).to receive(:shell_out_compacted!).with("groupmod", "-U", "all,your,base", "wheel")
+        @provider.modify_group_members
+      end
+
       platforms.each do |platform, flags|
         it "should usermod +/- each user when the append option is set on #{platform}" do
           current_resource = @new_resource.dup


### PR DESCRIPTION
Now that the functionality matches between solaris and other providers just remove the solaris only / excluded on solaris bits of testing. Then modify the normal tests to not reuse a GID, use high numbered values, and keep the name less than 9 characters.

Based off #8217,  but changes the GID testing floor to work on additional platforms.