### PR TITLE
chocolatey_package: use provided options when determing available options to allow using private sources

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -236,6 +236,8 @@ class Chef
               begin
                 cmd = [ "list -r #{pkg}" ]
                 cmd.push( "-source #{new_resource.source}" ) if new_resource.source
+                cmd.push( new_resource.options ) if new_resource.options
+
                 raw = parse_list_output(*cmd)
                 raw.keys.each_with_object({}) do |name, available|
                   available[name] = desired_name_versions[name] || raw[name]

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -282,7 +282,7 @@ describe Chef::Provider::Package::Chocolatey do
     end
 
     it "should pass options into the install command" do
-      allow_remote_list(["git"])
+      allow_remote_list(["git"], " -force")
       new_resource.options("-force")
       provider.load_current_resource
       expect(provider).to receive(:shell_out_compacted!).with("#{choco_exe} install -y -force git", { returns: [0], timeout: timeout }).and_return(double)


### PR DESCRIPTION
### Description

 - Added options parameter while fetching the list of choco packages as is required if the source is private.
 -  Minor fixes required in existing specs.
 - Added specs for the private source.
### Issues Resolved

Completed: https://github.com/chef/chef/pull/6196

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
