### PR TITLE
windows_share: Improve path comparison to prevent convering on each run

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -21,6 +21,7 @@
 
 require "chef/resource"
 require "chef/json_compat"
+require "chef/util/path_helper"
 
 class Chef
   class Resource

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -183,10 +183,12 @@ class Chef
 
         converge_if_changed do
           # you can't actually change the path so you have to delete the old share first
-          delete_share if different_path?
-
-          # powershell cmdlet for create is different than updates
-          if current_resource.nil?
+          if different_path?
+            Chef::Log.debug('The path has changed so we will delete and recreate share')
+            delete_share
+            create_share
+          elsif current_resource.nil?
+            # powershell cmdlet for create is different than updates
             Chef::Log.debug("The current resource is nil so we will create a new share")
             create_share
           else
@@ -214,7 +216,7 @@ class Chef
       action_class do
         def different_path?
           return false if current_resource.nil? # going from nil to something isn't different for our concerns
-          return false if current_resource.path == new_resource.path
+          return false if current_resource.path == Chef::Util::PathHelper.cleanpath(new_resource.path)
           true
         end
 
@@ -235,7 +237,7 @@ class Chef
         def create_share
           raise "#{new_resource.path} is missing or not a directory. Shares cannot be created if the path doesn't first exist." unless ::File.directory? new_resource.path
 
-          share_cmd = "New-SmbShare -Name '#{new_resource.share_name}' -Path '#{new_resource.path}' -Description '#{new_resource.description}' -ConcurrentUserLimit #{new_resource.concurrent_user_limit} -CATimeout #{new_resource.ca_timeout} -EncryptData:#{bool_string(new_resource.encrypt_data)} -ContinuouslyAvailable:#{bool_string(new_resource.continuously_available)}"
+          share_cmd = "New-SmbShare -Name '#{new_resource.share_name}' -Path '#{Chef::Util::PathHelper.cleanpath(new_resource.path)}' -Description '#{new_resource.description}' -ConcurrentUserLimit #{new_resource.concurrent_user_limit} -CATimeout #{new_resource.ca_timeout} -EncryptData:#{bool_string(new_resource.encrypt_data)} -ContinuouslyAvailable:#{bool_string(new_resource.continuously_available)}"
           share_cmd << " -ScopeName #{new_resource.scope_name}" unless new_resource.scope_name == "*" # passing * causes the command to fail
           share_cmd << " -Temporary:#{bool_string(new_resource.temporary)}" if new_resource.temporary # only set true
 

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -184,7 +184,7 @@ class Chef
         converge_if_changed do
           # you can't actually change the path so you have to delete the old share first
           if different_path?
-            Chef::Log.debug('The path has changed so we will delete and recreate share')
+            Chef::Log.debug("The path has changed so we will delete and recreate share")
             delete_share
             create_share
           elsif current_resource.nil?


### PR DESCRIPTION
### Description

Fixes issue where updating a share will cause the share to be deleted
but not re-created until chef is next run, and for chef to fail the run

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Issues Resolved

Share cannot update a path without delete and recreate, however logic will only delete and not recreate currently

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
