### PR TITLE
Chef-14: rollback rbnacl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,12 +46,6 @@ group(:ruby_shadow) do
   gem "ruby-shadow", platforms: :ruby
 end
 
-group(:ed25519) do
-  gem "rbnacl-libsodium"
-  gem "rbnacl"
-  gem "bcrypt_pbkdf"
-end
-
 group(:development, :test) do
   # we pin rake as a copy of rake is installed from the ruby source
   # if you bump the ruby version you should confirm we don't end up with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,14 +93,11 @@ GEM
       mixlib-cli (~> 1.4)
       mixlib-shellout (~> 2.0)
     ast (2.4.0)
-    backports (3.11.4)
-    bcrypt_pbkdf (1.0.0)
-    bcrypt_pbkdf (1.0.0-x64-mingw32)
-    bcrypt_pbkdf (1.0.0-x86-mingw32)
+    backports (3.12.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    byebug (10.0.2)
+    byebug (11.0.0)
     chef-vault (3.4.3)
     chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
@@ -171,7 +168,7 @@ GEM
       tty-table (~> 0.10)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
-    json (2.1.0)
+    json (2.2.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     libyajl2 (1.2.0)
@@ -220,7 +217,7 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    parallel (1.13.0)
+    parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
@@ -233,8 +230,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
       pry (~> 0.10)
     pry-remote (0.1.8)
       pry (~> 0.9)
@@ -249,10 +246,6 @@ GEM
     rainbow (3.0.0)
     rake (12.3.0)
     rb-readline (0.5.5)
-    rbnacl (6.0.1)
-      ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -283,7 +276,7 @@ GEM
     ruby-progressbar (1.10.0)
     ruby-shadow (2.5.0)
     rubyzip (1.2.2)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -395,7 +388,6 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
-  bcrypt_pbkdf
   chef!
   chef-config!
   chef-vault
@@ -410,8 +402,6 @@ DEPENDENCIES
   pry-stack_explorer
   rake (<= 12.3.0)
   rb-readline
-  rbnacl
-  rbnacl-libsodium
   ruby-prof
   ruby-shadow
   simplecov


### PR DESCRIPTION
we need to get onto net-ssh 5.x and the ed25519 gem instead, but that
is more involved
