### PR TITLE
Fix service enable idempotency in sles11

### DIFF
--- a/lib/chef/provider/service/insserv.rb
+++ b/lib/chef/provider/service/insserv.rb
@@ -38,7 +38,7 @@ class Chef
           # Look for a /etc/rc.*/SnnSERVICE link to signify that the service would be started in a runlevel
           service_name = Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)
 
-          if Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
+          if Dir.glob("/etc/rc*/**/S*#{service_name}").empty?
             current_resource.enabled false
           else
             current_resource.enabled true

--- a/lib/chef/provider/service/insserv.rb
+++ b/lib/chef/provider/service/insserv.rb
@@ -36,7 +36,9 @@ class Chef
           super
 
           # Look for a /etc/rc.*/SnnSERVICE link to signify that the service would be started in a runlevel
-          if Dir.glob("/etc/rc.d/rc**/S*#{Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)}").empty?
+          service_name = Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)
+
+          if Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
             current_resource.enabled false
           else
             current_resource.enabled true

--- a/lib/chef/provider/service/insserv.rb
+++ b/lib/chef/provider/service/insserv.rb
@@ -36,7 +36,7 @@ class Chef
           super
 
           # Look for a /etc/rc.*/SnnSERVICE link to signify that the service would be started in a runlevel
-          if Dir.glob("/etc/rc**/S*#{Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)}").empty?
+          if Dir.glob("/etc/rc.d/rc**/S*#{Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)}").empty?
             current_resource.enabled false
           else
             current_resource.enabled true

--- a/spec/functional/assets/inittest
+++ b/spec/functional/assets/inittest
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+TMPDIR="${TMPDIR:-/tmp}"
+
+function create_chef_txt {
+        touch $TMPDIR/inittest.txt
+}
+
+function delete_chef_txt {
+        rm $TMPDIR/inittest.txt
+}
+
+function rename_chef_txt {
+        mv $TMPDIR/inittest.txt $TMPDIR/$1
+}
+
+case "$1" in
+start )
+        create_chef_txt
+        ;;
+stop )
+        delete_chef_txt
+        ;;
+status )
+        [ -f $TMPDIR/inittest.txt ] || [ -f $TMPDIR/inittest_reload.txt ] || [ -f $TMPDIR/inittest_restart.txt ]
+        ;;
+reload )
+        rename_chef_txt "inittest_reload.txt"
+        ;;
+restart )
+        rename_chef_txt "inittest_restart.txt"
+        ;;
+* )
+        echo "Usage: $0 (start | stop | restart | reload)"
+        exit 1
+esac

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -22,7 +22,7 @@ require "functional/resource/base"
 require "chef/mixin/shell_out"
 require "fileutils"
 
-describe Chef::Resource::Service, :requires_root, :sles11, :rhel6 do
+describe Chef::Resource::Service, :requires_root, :sles11 do
 
   include Chef::Mixin::ShellOut
 

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -1,0 +1,145 @@
+# encoding: UTF-8
+#
+# Author:: Dheeraj Dubey (<dheeraj.dubey@msystechnologies.com>)
+# Copyright:: Copyright 2009-2019, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "functional/resource/base"
+require "chef/mixin/shell_out"
+require "fileutils"
+
+describe Chef::Resource::Service, :requires_root, :sles11 do
+
+  include Chef::Mixin::ShellOut
+
+  def service_should_be_enabled
+    expect(shell_out!("/sbin/insserv -r -f #{new_resource.service_name}").exitstatus).to eq(0)
+    expect(shell_out!("/sbin/insserv -d -f #{new_resource.service_name}").exitstatus).to eq(0)
+    !Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
+  end
+
+  def service_should_be_disabled
+    expect(shell_out!("/sbin/insserv -r -f #{new_resource.service_name}").exitstatus).to eq(0)
+    Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
+  end
+
+  # Platform specific validation routines.
+  def service_should_be_started(file_name)
+    # The existence of this file indicates that the service was started.
+    expect(File.exists?("#{Dir.tmpdir}/#{file_name}")).to be_truthy
+  end
+
+  def service_should_be_stopped(file_name)
+    expect(File.exists?("#{Dir.tmpdir}/#{file_name}")).to be_falsey
+  end
+
+  def delete_test_files
+    files = Dir.glob("#{Dir.tmpdir}/init[a-z_]*.txt")
+    File.delete(*files)
+  end
+
+  # Actual tests
+  let(:new_resource) do
+    new_resource = Chef::Resource::Service.new("inittest", run_context)
+    new_resource.provider Chef::Provider::Service::Insserv
+    new_resource.supports({ status: true, restart: true, reload: true })
+    new_resource
+  end
+
+  let(:provider) do
+    provider = new_resource.provider_for_action(new_resource.action)
+    provider
+  end
+
+  let (:service_name) { "Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)" }
+
+  let(:current_resource) do
+    provider.load_current_resource
+    provider.current_resource
+  end
+
+  before(:all) do
+    File.delete("/etc/init.d/inittest") if File.exists?("/etc/init.d/inittest")
+    FileUtils.cp((File.join(File.dirname(__FILE__), "/../assets/inittest")).to_s, "/etc/init.d/inittest")
+  end
+
+  after(:all) do
+    File.delete("/etc/init.d/inittest") if File.exists?("/etc/init.d/inittest")
+  end
+
+  before(:each) do
+    delete_test_files
+  end
+
+  after(:each) do
+    delete_test_files
+  end
+
+  describe "start service" do
+    it "should start the service" do
+      new_resource.run_action(:start)
+      service_should_be_started("inittest.txt")
+    end
+  end
+
+  describe "stop service" do
+    before do
+      new_resource.run_action(:start)
+    end
+
+    it "should stop the service" do
+      new_resource.run_action(:stop)
+      service_should_be_stopped("inittest.txt")
+    end
+  end
+
+  describe "restart service" do
+    before do
+      new_resource.run_action(:start)
+    end
+
+    it "should restart the service" do
+      new_resource.run_action(:restart)
+      service_should_be_started("inittest_restart.txt")
+    end
+  end
+
+  describe "reload service" do
+    before do
+      new_resource.run_action(:start)
+    end
+
+    it "should reload the service" do
+      new_resource.run_action(:reload)
+      service_should_be_started("inittest_reload.txt")
+    end
+  end
+
+  describe "enable service" do
+    it "should enable the service" do
+      new_resource.run_action(:enable)
+      service_should_be_enabled
+    end
+  end
+
+  describe "disable_service" do
+    it "should disable the service" do
+      new_resource.run_action(:disable)
+      service_should_be_disabled
+    end
+  end
+end

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -181,7 +181,6 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should be idempotent" do
       new_resource.run_action(:enable)
       service_should_be_enabled
-      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:enable)
       service_should_be_enabled
       expect(new_resource).not_to be_updated_by_last_action
@@ -198,7 +197,6 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should be idempotent" do
       new_resource.run_action(:disable)
       service_should_be_disabled
-      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:disable)
       service_should_be_disabled
       expect(new_resource).not_to be_updated_by_last_action

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -29,12 +29,12 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
   def service_should_be_enabled
     expect(shell_out!("/sbin/insserv -r -f #{new_resource.service_name}").exitstatus).to eq(0)
     expect(shell_out!("/sbin/insserv -d -f #{new_resource.service_name}").exitstatus).to eq(0)
-    !Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
+    !Dir.glob("/etc/rc*/**/S*#{service_name}").empty?
   end
 
   def service_should_be_disabled
     expect(shell_out!("/sbin/insserv -r -f #{new_resource.service_name}").exitstatus).to eq(0)
-    Dir.glob("/etc/rc**/**/S*#{service_name}").empty?
+    Dir.glob("/etc/rc*/**/S*#{service_name}").empty?
   end
 
   # Platform specific validation routines.

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -22,7 +22,7 @@ require "functional/resource/base"
 require "chef/mixin/shell_out"
 require "fileutils"
 
-describe Chef::Resource::Service, :requires_root, :sles11 do
+describe Chef::Resource::Service, :requires_root, :sles11, :rhel6 do
 
   include Chef::Mixin::ShellOut
 
@@ -132,14 +132,6 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
       new_resource.run_action(:restart)
       service_should_be_started("inittest_restart.txt")
     end
-
-    it "should be idempotent" do
-      new_resource.run_action(:restart)
-      service_should_be_started("inittest_restart.txt")
-      new_resource.run_action(:restart)
-      service_should_be_started("inittest_restart.txt")
-      expect(new_resource).not_to be_updated_by_last_action
-    end
   end
 
   describe "reload service" do
@@ -150,14 +142,6 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should reload the service" do
       new_resource.run_action(:reload)
       service_should_be_started("inittest_reload.txt")
-    end
-
-    it "should be idempotent" do
-      new_resource.run_action(:reload)
-      service_should_be_started("inittest_reload.txt")
-      new_resource.run_action(:reload)
-      service_should_be_started("inittest_reload.txt")
-      expect(new_resource).not_to be_updated_by_last_action
     end
   end
 

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -93,11 +93,13 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should start the service" do
       new_resource.run_action(:start)
       service_should_be_started("inittest.txt")
+      expect(new_resource).to be_updated_by_last_action
     end
 
     it "should be idempotent" do
       new_resource.run_action(:start)
       service_should_be_started("inittest.txt")
+      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:start)
       service_should_be_started("inittest.txt")
       expect(new_resource).not_to be_updated_by_last_action
@@ -112,11 +114,13 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should stop the service" do
       new_resource.run_action(:stop)
       service_should_be_stopped("inittest.txt")
+      expect(new_resource).to be_updated_by_last_action
     end
 
     it "should be idempotent" do
       new_resource.run_action(:stop)
       service_should_be_stopped("inittest.txt")
+      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:stop)
       service_should_be_stopped("inittest.txt")
       expect(new_resource).not_to be_updated_by_last_action
@@ -131,6 +135,17 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should restart the service" do
       new_resource.run_action(:restart)
       service_should_be_started("inittest_restart.txt")
+      expect(new_resource).to be_updated_by_last_action
+    end
+
+    it "should be idempotent" do
+      skip "FIXME: restart is not idempotent"
+      new_resource.run_action(:restart)
+      service_should_be_disabled
+      expect(new_resource).to be_updated_by_last_action
+      new_resource.run_action(:restart)
+      service_should_be_disabled
+      expect(new_resource).not_to be_updated_by_last_action
     end
   end
 
@@ -142,6 +157,17 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should reload the service" do
       new_resource.run_action(:reload)
       service_should_be_started("inittest_reload.txt")
+      expect(new_resource).to be_updated_by_last_action
+    end
+
+    it "should be idempotent" do
+      skip "FIXME: reload is not idempotent"
+      new_resource.run_action(:reload)
+      service_should_be_disabled
+      expect(new_resource).to be_updated_by_last_action
+      new_resource.run_action(:reload)
+      service_should_be_disabled
+      expect(new_resource).not_to be_updated_by_last_action
     end
   end
 
@@ -149,11 +175,13 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should enable the service" do
       new_resource.run_action(:enable)
       service_should_be_enabled
+      expect(new_resource).to be_updated_by_last_action
     end
 
     it "should be idempotent" do
       new_resource.run_action(:enable)
       service_should_be_enabled
+      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:enable)
       service_should_be_enabled
       expect(new_resource).not_to be_updated_by_last_action
@@ -164,11 +192,13 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should disable the service" do
       new_resource.run_action(:disable)
       service_should_be_disabled
+      expect(new_resource).to be_updated_by_last_action
     end
 
     it "should be idempotent" do
       new_resource.run_action(:disable)
       service_should_be_disabled
+      expect(new_resource).to be_updated_by_last_action
       new_resource.run_action(:disable)
       service_should_be_disabled
       expect(new_resource).not_to be_updated_by_last_action

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -94,6 +94,14 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
       new_resource.run_action(:start)
       service_should_be_started("inittest.txt")
     end
+
+    it "should be idempotent" do
+      new_resource.run_action(:start)
+      service_should_be_started("inittest.txt")
+      new_resource.run_action(:start)
+      service_should_be_started("inittest.txt")
+      expect(new_resource).not_to be_updated_by_last_action
+    end
   end
 
   describe "stop service" do
@@ -104,6 +112,14 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
     it "should stop the service" do
       new_resource.run_action(:stop)
       service_should_be_stopped("inittest.txt")
+    end
+
+    it "should be idempotent" do
+      new_resource.run_action(:stop)
+      service_should_be_stopped("inittest.txt")
+      new_resource.run_action(:stop)
+      service_should_be_stopped("inittest.txt")
+      expect(new_resource).not_to be_updated_by_last_action
     end
   end
 
@@ -116,6 +132,14 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
       new_resource.run_action(:restart)
       service_should_be_started("inittest_restart.txt")
     end
+
+    it "should be idempotent" do
+      new_resource.run_action(:restart)
+      service_should_be_started("inittest_restart.txt")
+      new_resource.run_action(:restart)
+      service_should_be_started("inittest_restart.txt")
+      expect(new_resource).not_to be_updated_by_last_action
+    end
   end
 
   describe "reload service" do
@@ -127,6 +151,14 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
       new_resource.run_action(:reload)
       service_should_be_started("inittest_reload.txt")
     end
+
+    it "should be idempotent" do
+      new_resource.run_action(:reload)
+      service_should_be_started("inittest_reload.txt")
+      new_resource.run_action(:reload)
+      service_should_be_started("inittest_reload.txt")
+      expect(new_resource).not_to be_updated_by_last_action
+    end
   end
 
   describe "enable service" do
@@ -134,12 +166,28 @@ describe Chef::Resource::Service, :requires_root, :sles11 do
       new_resource.run_action(:enable)
       service_should_be_enabled
     end
+
+    it "should be idempotent" do
+      new_resource.run_action(:enable)
+      service_should_be_enabled
+      new_resource.run_action(:enable)
+      service_should_be_enabled
+      expect(new_resource).not_to be_updated_by_last_action
+    end
   end
 
   describe "disable_service" do
     it "should disable the service" do
       new_resource.run_action(:disable)
       service_should_be_disabled
+    end
+
+    it "should be idempotent" do
+      new_resource.run_action(:disable)
+      service_should_be_disabled
+      new_resource.run_action(:disable)
+      service_should_be_disabled
+      expect(new_resource).not_to be_updated_by_last_action
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -172,6 +172,7 @@ RSpec.configure do |config|
   config.filter_run_excluding linux_only: true unless linux?
   config.filter_run_excluding aix_only: true unless aix?
   config.filter_run_excluding suse_only: true unless suse?
+  config.filter_run_excluding sles11: true unless sles11?
   config.filter_run_excluding debian_family_only: true unless debian_family?
   config.filter_run_excluding supports_cloexec: true unless supports_cloexec?
   config.filter_run_excluding selinux_only: true unless selinux_enabled?

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -162,6 +162,10 @@ def rhel6?
   rhel? && !!(ohai[:platform_version].to_i == 6)
 end
 
+def sles11?
+  suse? && !!(ohai[:platform_version].to_i == 11)
+end
+
 def rhel7?
   rhel? && !!(ohai[:platform_version].to_i == 7)
 end

--- a/spec/unit/provider/service/insserv_service_spec.rb
+++ b/spec/unit/provider/service/insserv_service_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::Service::Insserv do
   describe "load_current_resource" do
     describe "when startup links exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc**/S*initgrediant").and_return(["/etc/rc5.d/S18initgrediant", "/etc/rc2.d/S18initgrediant", "/etc/rc4.d/S18initgrediant", "/etc/rc3.d/S18initgrediant"])
+        allow(Dir).to receive(:glob).with("/etc/rc.d/rc**/S*initgrediant").and_return(["/etc/rc5.d/S18initgrediant", "/etc/rc2.d/S18initgrediant", "/etc/rc4.d/S18initgrediant", "/etc/rc3.d/S18initgrediant"])
       end
 
       it "sets the current enabled status to true" do
@@ -47,7 +47,7 @@ describe Chef::Provider::Service::Insserv do
 
     describe "when startup links do not exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc**/S*initgrediant").and_return([])
+        allow(Dir).to receive(:glob).with("/etc/rc.d/rc**/S*initgrediant").and_return([])
       end
 
       it "sets the current enabled status to false" do

--- a/spec/unit/provider/service/insserv_service_spec.rb
+++ b/spec/unit/provider/service/insserv_service_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::Service::Insserv do
   describe "load_current_resource" do
     describe "when startup links exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc**/**/S*initgrediant").and_return(["/etc/rc5.d/S18initgrediant", "/etc/rc2.d/S18initgrediant", "/etc/rc4.d/S18initgrediant", "/etc/rc3.d/S18initgrediant", "/etc/rc.d/rc3.d/S18initgrediant"])
+        allow(Dir).to receive(:glob).with("/etc/rc*/**/S*initgrediant").and_return(["/etc/rc.d/rc5.d/S18initgrediant", "/etc/rc.d/rc2.d/S18initgrediant", "/etc/rc.d/rc4.d/S18initgrediant", "/etc/rc.d/rc3.d/S18initgrediant"])
       end
 
       it "sets the current enabled status to true" do
@@ -47,7 +47,7 @@ describe Chef::Provider::Service::Insserv do
 
     describe "when startup links do not exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc**/**/S*initgrediant").and_return([])
+        allow(Dir).to receive(:glob).with("/etc/rc*/**/S*initgrediant").and_return([])
       end
 
       it "sets the current enabled status to false" do

--- a/spec/unit/provider/service/insserv_service_spec.rb
+++ b/spec/unit/provider/service/insserv_service_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::Service::Insserv do
   describe "load_current_resource" do
     describe "when startup links exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc.d/rc**/S*initgrediant").and_return(["/etc/rc5.d/S18initgrediant", "/etc/rc2.d/S18initgrediant", "/etc/rc4.d/S18initgrediant", "/etc/rc3.d/S18initgrediant"])
+        allow(Dir).to receive(:glob).with("/etc/rc**/**/S*initgrediant").and_return(["/etc/rc5.d/S18initgrediant", "/etc/rc2.d/S18initgrediant", "/etc/rc4.d/S18initgrediant", "/etc/rc3.d/S18initgrediant", "/etc/rc.d/rc3.d/S18initgrediant"])
       end
 
       it "sets the current enabled status to true" do
@@ -47,7 +47,7 @@ describe Chef::Provider::Service::Insserv do
 
     describe "when startup links do not exist" do
       before do
-        allow(Dir).to receive(:glob).with("/etc/rc.d/rc**/S*initgrediant").and_return([])
+        allow(Dir).to receive(:glob).with("/etc/rc**/**/S*initgrediant").and_return([])
       end
 
       it "sets the current enabled status to false" do


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description
For service resource `action: enable` is not idempotent in case of `SLES v11` because it uses `insserv` for system initialization. Service runlevels in SLES resides inside `rc.d` directory which was missing in conditional.
With this change `action :enable` is idempotent so there is no deviation to enable the service for each chef-client run. 
### Issues Resolved
fixes https://github.com/chef/chef/issues/6870 and https://getchef.zendesk.com/agent/tickets/21373

### Recipe used for test
```
package 'ntp'
service 'ntp' do
  action [:enable, :start]
end
```
In kitchen test I've used : 
```
  multiple_converge: 2
  enforce_idempotency: true
```
to ensure idempotency.

### Output of kitchen test after change
```
PS E:\Backup\Project\Chef_Repo\sap_ntp> kitchen converge
-----> Starting Kitchen (v1.24.0)
WARN: Unresolved specs during Gem::Specification.reset:
      timeliness (~> 0.3)
      term-ansicolor (>= 0)
      specinfra (~> 2.10, ~> 2.72)
      win32-taskscheduler (~> 2.0)
      win32-certstore (>= 0.1.8)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
-----> Converging <default-sles-11>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 7.0.7...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
       chef installation detected
       install_strategy set to 'once'
       Nothing to install
       Transferring files to <default-sles-11>
       Starting Chef Client, version 14.10.9
       resolving cookbooks for run list: ["sap_ntp::default"]
       Synchronizing Cookbooks:
         - sap_ntp (0.1.0)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 2 resources
       Recipe: sap_ntp::default
         * zypper_package[ntp] action install (up to date)
         * service[ntp] action enable (up to date)
         * service[ntp] action start (up to date)

       Running handlers:
       Running handlers complete
       Chef Client finished, 0/3 resources updated in 01 seconds
       Starting Chef Client, version 14.10.9
       resolving cookbooks for run list: ["sap_ntp::default"]
       Synchronizing Cookbooks:
         - sap_ntp (0.1.0)
       Installing Cookbook Gems:
       Compiling Cookbooks...
       Converging 2 resources
       Recipe: sap_ntp::default
         * zypper_package[ntp] action install (up to date)
         * service[ntp] action enable (up to date)
         * service[ntp] action start (up to date)

       Running handlers:
         - #<Class:0x0000000000e79cf8>::UpdatedResources
       Running handlers complete
       Chef Client finished, 0/3 resources updated in 01 seconds
       Downloading files from <default-sles-11>
       Finished converging <default-sles-11> (0m35.56s).
-----> Kitchen is finished. (0m48.20s)
```
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
