### PR TITLE
Remove checks / patches for old versions of Ruby

### DIFF
--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 require "chef/config"
-if Chef::Platform.windows?
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1")
-    require "chef/monkey_patches/webrick-utils"
-  end
-end
+require "chef/monkey_patches/webrick-utils" if Chef::Platform.windows?
 
 class Chef
   module LocalMode

--- a/lib/chef/monkey_patches/win32/registry.rb
+++ b/lib/chef/monkey_patches/win32/registry.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2015-2016, Chef Software, Inc.
+# Copyright:: Copyright 2015-2019, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,32 +55,6 @@ module Win32
         check RegDeleteKeyExW(hkey, name.to_wstring, 0, 0)
       end
 
-    end
-
-    if RUBY_VERSION =~ /^2\.1/
-      # ::Win32::Registry#write does not correctly handle data in Ruby 2.1
-      # This bug is _reportedly_ resolved in Ruby 2.1.7 and 2.2.3
-      # but fails in appveyor on 2.1.8 unless we keep applying this monkeypatch
-      # https://bugs.ruby-lang.org/issues/11439
-      def write(name, type, data)
-        case type
-        when REG_SZ, REG_EXPAND_SZ
-          data = data.to_s.encode(WCHAR) + WCHAR_NUL
-        when REG_MULTI_SZ
-          data = data.to_a.map { |s| s.encode(WCHAR) }.join(WCHAR_NUL) << WCHAR_NUL << WCHAR_NUL
-        when REG_BINARY
-          data = data.to_s
-        when REG_DWORD
-          data = API.packdw(data.to_i)
-        when REG_DWORD_BIG_ENDIAN
-          data = [data.to_i].pack("N")
-        when REG_QWORD
-          data = API.packqw(data.to_i)
-        else
-          raise TypeError, "Unsupported type #{type}"
-        end
-        API.SetValue(@hkey, name, type, data, data.bytesize)
-      end
     end
   end
 end

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -218,7 +218,7 @@ describe "ChefFSDataStore tests", :workstation do
           knife("list --local /roles").should_succeed "/roles/x.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", skip: (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<~EOM.strip
             {
@@ -281,7 +281,7 @@ describe "ChefFSDataStore tests", :workstation do
           knife("list --local /roles").should_succeed "/roles/z.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty", skip: (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m POST /roles, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m POST /roles").should_succeed( /uri/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<~EOM.strip
             {
@@ -489,7 +489,7 @@ describe "ChefFSDataStore tests", :workstation do
           knife("list --local /users").should_succeed "/users/x.json\n"
         end
 
-        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty", skip: (RUBY_VERSION < "1.9") do
+        it "After knife raw -z -i rolestuff.json -m PUT /roles/x, the output is pretty" do
           knife("raw -z -i #{path_to('rolestuff.json')} -m PUT /roles/x").should_succeed( /"x"/ )
           expect(IO.read(path_to("roles/x.json"))).to eq <<~EOM.strip
             {

--- a/spec/integration/knife/diff_spec.rb
+++ b/spec/integration/knife/diff_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -247,7 +247,7 @@ describe "knife diff", :workstation do
         end
         when_the_chef_server "has an environment with a different value" do
           before { environment "x", { "description" => "hi" } }
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x",
@@ -277,7 +277,7 @@ describe "knife diff", :workstation do
             environment "x", {}
           end
 
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x"
@@ -291,7 +291,7 @@ describe "knife diff", :workstation do
           before do
             environment "x", { "description" => "lo" }
           end
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
    "name": "x",
@@ -533,7 +533,7 @@ describe "knife diff", :workstation do
         end
         when_the_chef_server "has an environment with a different value" do
           before { environment "x", { "description" => "hi" } }
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x",
@@ -560,7 +560,7 @@ describe "knife diff", :workstation do
         end
         when_the_chef_server "has an environment with no value" do
           before { environment "x", {} }
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
 -  "name": "x"
@@ -574,7 +574,7 @@ describe "knife diff", :workstation do
           before do
             environment "x", { "description" => "lo" }
           end
-          it "knife diff reports the difference", skip: (RUBY_VERSION < "1.9") do
+          it "knife diff reports the difference" do
             knife("diff /environments/x.json").should_succeed(/
  {
    "name": "x",

--- a/spec/integration/knife/raw_spec.rb
+++ b/spec/integration/knife/raw_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2018, Chef Software Inc.
+# Copyright:: Copyright 2013-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ describe "knife raw", :workstation do
       user "x", "{}"
     end
 
-    it "knife raw /nodes/x returns the node", skip: (RUBY_VERSION < "1.9") do
+    it "knife raw /nodes/x returns the node" do
       knife("raw /nodes/x").should_succeed <<~EOM
         {
           "name": "x",
@@ -70,7 +70,7 @@ describe "knife raw", :workstation do
       knife("raw /blarghle").should_fail(/ERROR: Server responded with error 404 "Not Found\s*"/)
     end
 
-    it "knife raw -m DELETE /roles/x succeeds", skip: (RUBY_VERSION < "1.9") do
+    it "knife raw -m DELETE /roles/x succeeds" do
       knife("raw -m DELETE /roles/x").should_succeed <<~EOM
         {
           "name": "x",
@@ -94,7 +94,7 @@ describe "knife raw", :workstation do
       knife("show /roles/x.json").should_fail "ERROR: /roles/x.json: No such file or directory\n"
     end
 
-    it "knife raw -m PUT -i blah.txt /roles/x succeeds", skip: (RUBY_VERSION < "1.9") do
+    it "knife raw -m PUT -i blah.txt /roles/x succeeds" do
       Tempfile.open("raw_put_input") do |file|
         file.write <<~EOM
           {
@@ -148,7 +148,7 @@ describe "knife raw", :workstation do
       end
     end
 
-    it "knife raw -m POST -i blah.txt /roles succeeds", skip: (RUBY_VERSION < "1.9") do
+    it "knife raw -m POST -i blah.txt /roles succeeds" do
       Tempfile.open("raw_put_input") do |file|
         file.write <<~EOM
           {
@@ -200,7 +200,7 @@ describe "knife raw", :workstation do
         end
       end
 
-      it "knife raw /blah returns the prettified json", skip: (RUBY_VERSION < "1.9") do
+      it "knife raw /blah returns the prettified json" do
         knife("raw /blah").should_succeed <<~EOM
           {
             "x": "y",

--- a/spec/integration/knife/show_spec.rb
+++ b/spec/integration/knife/show_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +76,7 @@ describe "knife show", :workstation do
           }
         EOM
       end
-      it "knife show /environments/x.json shows the remote version", skip: (RUBY_VERSION < "1.9") do
+      it "knife show /environments/x.json shows the remote version" do
         knife("show /environments/x.json").should_succeed <<~EOM
           /environments/x.json:
           {
@@ -92,7 +92,7 @@ describe "knife show", :workstation do
           }
         EOM
       end
-      it "knife show /roles/x.json shows the remote version", skip: (RUBY_VERSION < "1.9") do
+      it "knife show /roles/x.json shows the remote version" do
         knife("show /roles/x.json").should_succeed <<~EOM
           /roles/x.json:
           {
@@ -135,7 +135,7 @@ describe "knife show", :workstation do
         "name" => "x",
       }
     end
-    it "knife show shows the attributes in a predetermined order", skip: (RUBY_VERSION < "1.9") do
+    it "knife show shows the attributes in a predetermined order" do
       knife("show /environments/x.json").should_succeed <<~EOM
         /environments/x.json:
         {

--- a/spec/unit/chef_fs/parallelizer.rb
+++ b/spec/unit/chef_fs/parallelizer.rb
@@ -215,9 +215,7 @@ describe Chef::ChefFS::Parallelizer do
       end
 
       after :each do
-        if RUBY_VERSION.to_f > 1.8
-          Thread.kill(@thread)
-        end
+        Thread.kill(@thread)
       end
 
       it "parallelize with :main_thread_processing = true does not block" do

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1007,14 +1007,8 @@ describe Chef::Node::Attribute do
       expect(@attributes).to respond_to(:select)
     end
 
-    if RUBY_VERSION >= "1.8.7"
-      it "should not raise a LocalJumpError if no block is given" do
-        expect { @attributes.select }.not_to raise_error
-      end
-    else
-      it "should raise a LocalJumpError if no block is given" do
-        expect { @attributes.select }.to raise_error(LocalJumpError)
-      end
+    it "should not raise a LocalJumpError if no block is given" do
+      expect { @attributes.select }.not_to raise_error
     end
 
     it "should return an empty hash/array (ruby-version-dependent) for a block containing nil" do


### PR DESCRIPTION
Some of this supports older versions of Ruby 2.1/2.2 and others support Ruby 1.8

Signed-off-by: Tim Smith <tsmith@chef.io>