### PR TITLE
Update openssl to 1.0.2r

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -22,7 +22,7 @@ override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
-override "openssl", version: "1.0.2q"
+override "openssl", version: "1.0.2r"
 
 # we build both a chef and ohai omnibus-software defintion which create the
 # chef-client and ohai binstubs. Out of the box the ohai definition uses whatever


### PR DESCRIPTION
This resolves a minor CVE that doesn't impact Chef, but should get fixed anyways.

Signed-off-by: Tim Smith <tsmith@chef.io>