### PR TITLE
Update cacerts to 2019-01-22 file

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 00c81e99278b7d715f39968e72eb96c3c948f015
+  revision: 44f52c320c3fe866e4d4186319fb6b5537f0656f
   branch: master
   specs:
     omnibus-software (4.0.0)


### PR DESCRIPTION
Adds these new roots:

    GTS Root R1
    GTS Root R2
    GTS Root R3
    GTS Root R4
    UCA Global G2 Root
    UCA Extended Validation Root
    Certigna Root CA

Signed-off-by: Tim Smith <tsmith@chef.io>