### PR TITLE
mount: Add proper new lines when on AIX to prevent failures

### DIFF
--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -164,7 +164,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/filesystems", "a") do |fstab|
-            fstab.puts("\n#{@new_resource.mount_point}:")
+            fstab.puts("\n\n#{@new_resource.mount_point}:")
             if network_device?
               device_details = device_fstab.split(":")
               fstab.puts("\tdev\t\t= #{device_details[1]}")

--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -164,7 +164,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/filesystems", "a") do |fstab|
-            fstab.puts("#{@new_resource.mount_point}:")
+            fstab.puts("\n#{@new_resource.mount_point}:")
             if network_device?
               device_details = device_fstab.split(":")
               fstab.puts("\tdev\t\t= #{device_details[1]}")


### PR DESCRIPTION
This PR supersedes #8101. Adds a new blank line `\n\n` when appending a new mount point for AIX, adds a spec and is rebased on master.

### Description
Without a newline separating entries, AIX will not allow the entry preceding the one managed by Chef to be mounted anymore - this appears not to be an issue for already-mounted filesystems.

### Issues Resolved
See Zendesk ticket 20952 for more details.

Closes #8101 

### Check List
* [ ]  New functionality includes tests
* [ ]  All tests pass
* [ ]  RELEASE_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
* [ ]  All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco

