### PR TITLE
mount: Add proper new lines when on AIX to prevent failures

### DIFF
--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -164,7 +164,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/filesystems", "a") do |fstab|
-            fstab.puts("\n#{@new_resource.mount_point}:")
+            fstab.puts("\n\n#{@new_resource.mount_point}:")
             if network_device?
               device_details = device_fstab.split(":")
               fstab.puts("\tdev\t\t= #{device_details[1]}")

--- a/lib/chef/provider/mount/aix.rb
+++ b/lib/chef/provider/mount/aix.rb
@@ -164,7 +164,7 @@ class Chef
             disable_fs
           end
           ::File.open("/etc/filesystems", "a") do |fstab|
-            fstab.puts("#{@new_resource.mount_point}:")
+            fstab.puts("\n#{@new_resource.mount_point}:")
             if network_device?
               device_details = device_fstab.split(":")
               fstab.puts("\tdev\t\t= #{device_details[1]}")

--- a/spec/unit/provider/mount/aix_spec.rb
+++ b/spec/unit/provider/mount/aix_spec.rb
@@ -202,12 +202,20 @@ WRONG
     it "should enable mount if it is mounted and not enabled" do
       @new_resource.options("nodev,rw")
       stub_mounted_enabled(@provider, @mounted_output, "")
+      # Add existing mount to test enable action appends additional mount with seperating blank line
       filesystems = StringIO.new
+      filesystems.puts <<~ETCFILESYSTEMS
+        /tmp/abc:
+          dev   = /dev/sdz2
+          vfs   = jfs2
+          mount   = true
+          options   = rw
+      ETCFILESYSTEMS
       allow(::File).to receive(:open).with("/etc/filesystems", "a").and_yield(filesystems)
 
       @provider.run_action(:enable)
 
-      expect(filesystems.string).to match(%r{^/tmp/foo:\n\tdev\t\t= /dev/sdz1\n\tvfs\t\t= jfs2\n\tmount\t\t= false\n\toptions\t\t= nodev,rw\n$})
+      expect(filesystems.string).to match(%r{^\n\n/tmp/foo:\n\tdev\t\t= /dev/sdz1\n\tvfs\t\t= jfs2\n\tmount\t\t= false\n\toptions\t\t= nodev,rw\n$})
     end
 
     it "should not enable mount if it is mounted and already enabled and mount options are unchanged" do


### PR DESCRIPTION
AIX requires double new lines between mounts in fstab. This backports #8271