### PR TITLE
Remove chef-13 branch from expeditor/travis/appveyor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -51,8 +51,6 @@ github:
         version_constraint: 15*
     - chef-14:
         version_constraint: 14*
-    - chef-13:
-        version_constraint: 13*
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ branches:
   only:
   - master
   - chef-14
-  - chef-13
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,6 @@ branches:
   only:
     - master
     - chef-14
-    - chef-13
 
 install:
   - systeminfo


### PR DESCRIPTION
This is no longer a supported release and we won't be building or
testing it at this point.

This can be merged April 30th, 2019.

Signed-off-by: Tim Smith <tsmith@chef.io>