### PR TITLE
Enable running windows_service provider tests on all platforms

### DIFF
--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -19,7 +19,7 @@
 
 require "spec_helper"
 
-describe Chef::Provider::Service::Windows, "load_current_resource", :windows_only do
+describe Chef::Provider::Service::Windows, "load_current_resource" do
   include_context "Win32"
 
   let(:logger) { double("Mixlib::Log::Child").as_null_object }
@@ -88,7 +88,15 @@ describe Chef::Provider::Service::Windows, "load_current_resource", :windows_onl
   let(:service_right) { Chef::Provider::Service::Windows::SERVICE_RIGHT }
 
   before(:all) do
+    Holder::Win32::Service = Win32::Service
+    Holder::Chef::ReservedNames::Win32::Security = Chef::ReservedNames::Win32::Security
     Win32::Service = Class.new
+    Chef::ReservedNames::Win32::Security = Class.new
+  end
+
+  after(:all) do
+    Win32::Service = Holder::Win32::Service
+    Chef::ReservedNames::Win32::Security = Holder::Chef::ReservedNames::Win32::Security
   end
 
   before(:each) do


### PR DESCRIPTION
### Description

This will enable the `windows_service` provider unit tests to run on all platforms.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
