### PR TITLE
Switch tests to Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       INTEGRATION_SPECS_26: 1
-    rvm: 2.6
+    rvm: 2.6.1
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -55,7 +55,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_26: 1
-    rvm: 2.6
+    rvm: 2.6.1
     sudo: true
     script: sudo rm -f /etc/apt/apt.conf.d/99-travis-apt-proxy; sudo -E $(which bundle) exec rake spec:functional;
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -69,7 +69,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       UNIT_SPECS_26: 1
-    rvm: 2.6
+    rvm: 2.6.1
     sudo: true
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
@@ -77,7 +77,7 @@ matrix:
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
   - env:
       CHEFSTYLE: 1
-    rvm: 2.5.3
+    rvm: 2.6.1
     script: bundle exec rake style
     # also remove integration / external tests
     bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
@@ -87,36 +87,36 @@ matrix:
   - env:
       TEST_GEM: sethvargo/chef-sugar
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.3
+    rvm: 2.6.1
   - env:
       - PEDANT_OPTS=--skip-oc_id
       - TEST_GEM=chef/chef-zero
       - CHEF_FS=true
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake pedant
-    rvm: 2.5.3
+    rvm: 2.6.1
   - env:
       TEST_GEM: chef/cheffish
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.3
+    rvm: 2.6.1
   - env:
       TEST_GEM: chefspec/chefspec
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake
-    rvm: 2.5.3
+    rvm: 2.6.1
   - env:
       TEST_GEM: poise/halite
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-    rvm: 2.5.3
+    rvm: 2.6.1
   - env:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
-    rvm: 2.5.3
+    rvm: 2.6.1
   # disable this pending a Chef 14 compat version of poise
   # - env:
   #     TEST_GEM: poise/poise
   #   script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-  #   rvm: 2.5.3
+  #   rvm: 2.6.1
   ### START TEST KITCHEN ONLY ###
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -132,7 +132,7 @@ matrix:
     env:
       - AMAZON=2
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -148,7 +148,7 @@ matrix:
     env:
       - AMAZON=201X
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -164,7 +164,7 @@ matrix:
     env:
       - UBUNTU=14.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -180,7 +180,7 @@ matrix:
     env:
       - UBUNTU=16.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -196,7 +196,7 @@ matrix:
     env:
       - UBUNTU=18.04
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -212,7 +212,7 @@ matrix:
     env:
       - DEBIAN=8
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -228,7 +228,7 @@ matrix:
     env:
       - DEBIAN=9
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -244,7 +244,7 @@ matrix:
     env:
       - CENTOS=6
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -260,7 +260,7 @@ matrix:
     env:
       - CENTOS=7
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -276,7 +276,7 @@ matrix:
     env:
       - FEDORA=latest
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     gemfile: kitchen-tests/Gemfile
     before_install:
@@ -292,7 +292,7 @@ matrix:
     env:
      - OPENSUSELEAP=42
      - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     before_install:
       - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
       - rvm @global do gem uninstall bundler -a -x || true
@@ -312,7 +312,7 @@ matrix:
       - sudo cat /var/log/squid3/access.log
   # Use test-kitchen to launch a centos docker container to run the full rspec tests against.  This catches
   # errors in travis, before PRs are merged, hopefully before they become errors in jenkins.
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -329,7 +329,7 @@ matrix:
     env:
       - RSPEC_CENTOS=7
       - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.3
+  - rvm: 2.6.1
     services: docker
     sudo: required
     gemfile: kitchen-tests/Gemfile
@@ -347,7 +347,7 @@ matrix:
      - RSPEC_OPENSUSELEAP=42
      - KITCHEN_YAML=kitchen.travis.yml
   allow_failures:
-    - rvm: 2.5.3
+    - rvm: 2.6.1
       services: docker
       sudo: required
       gemfile: kitchen-tests/Gemfile
@@ -367,7 +367,7 @@ matrix:
     - env:
         TEST_GEM: poise/halite
       script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-      rvm: 2.5.3
+      rvm: 2.6.1
 
 notifications:
   on_change: true


### PR DESCRIPTION
Move all the generic tests to Ruby 2.6.1 not 2.5.3
Switch from 2.6 to 2.6.1 due to travis breakage

Signed-off-by: Tim Smith <tsmith@chef.io>