### PR TITLE
Added Integration Rspecs

### DIFF
--- a/spec/integration/knife/data_bag_create_spec.rb
+++ b/spec/integration/knife/data_bag_create_spec.rb
@@ -27,29 +27,98 @@ describe "knife data bag create", :workstation do
   let(:err) { "Created data_bag[foo]\n" }
   let(:out) { "Created data_bag_item[bar]\n" }
   let(:exists) { "Data bag foo already exists\n" }
+  let(:secret) { "abc" }
 
   when_the_chef_server "is empty" do
-    it "creates a new data bag" do
-      knife("data bag create foo").should_succeed stderr: err
+    context "with encryption key" do
+      it "creates a new data bag and item" do
+        pretty_json = Chef::JSONCompat.to_json_pretty({ :id => "bar", :test => "pass" })
+        allow(Chef::JSONCompat).to receive(:to_json_pretty).and_return(pretty_json)
+        knife("data bag create foo bar --secret #{secret}").should_succeed stdout: out, stderr: err
+        expect(knife("data bag show foo bar --secret #{secret}").stderr).to eq("Encrypted data bag detected, decrypting with provided secret.\n")
+        expect(knife("data bag show foo bar --secret #{secret}").stdout).to eq("id:   bar\ntest: pass\n")
+      end
+
+      it "creates a new data bag and an empty item" do
+        knife("data bag create foo bar --secret #{secret}").should_succeed stdout: out, stderr: err
+        expect(knife("data bag show foo bar --secret #{secret}").stderr).to eq("WARNING: Unencrypted data bag detected, ignoring any provided secret options.\n")
+        expect(knife("data bag show foo bar --secret #{secret}").stdout).to eq("id: bar\n")
+      end
     end
 
-    it "creates a new data bag and item" do
-      knife("data bag create foo bar").should_succeed stdout: out, stderr: err
+    context "without encryption key" do
+      it "creates a new data bag" do
+        knife("data bag create foo").should_succeed stderr: err
+        expect(knife("data bag show foo").stderr).to eq("")
+      end
+
+      it "creates a new data bag and item" do
+        knife("data bag create foo bar").should_succeed stdout: out, stderr: err
+        expect(knife("data bag show foo").stdout).to eq("bar\n")
+      end
+    end
+  end
+
+  when_the_chef_server "has some data bags" do
+    before do
+      data_bag "foo", {}
+      data_bag "bag", { "box" => {} }
     end
 
-    it "adds a new item to an existing bag" do
-      knife("data bag create foo").should_succeed stderr: err
-      knife("data bag create foo bar").should_succeed stdout: out, stderr: exists
+    context "with encryption key" do
+      it "creates a new data bag and item" do
+        pretty_json = Chef::JSONCompat.to_json_pretty({ :id => "bar", :test => "pass" })
+        allow(Chef::JSONCompat).to receive(:to_json_pretty).and_return(pretty_json)
+        knife("data bag create rocket bar --secret #{secret}").should_succeed stdout: out, stderr: <<~EOM
+          Created data_bag[rocket]
+        EOM
+        expect(knife("data bag show rocket bar --secret #{secret}").stderr).to eq("Encrypted data bag detected, decrypting with provided secret.\n")
+        expect(knife("data bag show rocket bar --secret #{secret}").stdout).to eq("id:   bar\ntest: pass\n")
+      end
+
+      it "creates a new data bag and an empty item" do
+        knife("data bag create rocket bar --secret #{secret}").should_succeed stdout: out, stderr: <<~EOM
+          Created data_bag[rocket]
+        EOM
+        expect(knife("data bag show rocket bar --secret #{secret}").stderr).to eq("WARNING: Unencrypted data bag detected, ignoring any provided secret options.\n")
+        expect(knife("data bag show rocket bar --secret #{secret}").stdout).to eq("id: bar\n")
+      end
+
+      it "adds a new item to an existing bag" do
+        knife("data bag create foo bar --secret #{secret}").should_succeed stdout: out, stderr: exists
+        expect(knife("data bag show foo bar --secret #{secret}").stderr).to eq("WARNING: Unencrypted data bag detected, ignoring any provided secret options.\n")
+        expect(knife("data bag show foo bar --secret #{secret}").stdout).to eq("id: bar\n")
+      end
+
+      it "fails to add an existing item" do
+        expect { knife("data bag create bag box --secret #{secret}") }.to raise_error(Net::HTTPClientException)
+      end
     end
 
-    it "refuses to add an existing data bag" do
-      knife("data bag create foo").should_succeed stderr: err
-      knife("data bag create foo").should_succeed stderr: exists
-    end
+    context "without encryption key" do
+      it "creates a new data bag" do
+        knife("data bag create rocket").should_succeed stderr: <<~EOM
+          Created data_bag[rocket]
+        EOM
+      end
 
-    it "fails to add an existing item" do
-      knife("data bag create foo bar").should_succeed stdout: out, stderr: err
-      expect { knife("data bag create foo bar") }.to raise_error(Net::HTTPClientException)
+      it "creates a new data bag and item" do
+        knife("data bag create rocket bar").should_succeed stdout: out, stderr: <<~EOM
+          Created data_bag[rocket]
+        EOM
+      end
+
+      it "adds a new item to an existing bag" do
+        knife("data bag create foo bar").should_succeed stdout: out, stderr: exists
+      end
+
+      it "refuses to create an existing data bag" do
+        knife("data bag create foo").should_succeed stderr: exists
+      end
+
+      it "fails to add an existing item" do
+        expect { knife("data bag create bag box") }.to raise_error(Net::HTTPClientException)
+      end
     end
   end
 end

--- a/spec/integration/knife/data_bag_edit_spec.rb
+++ b/spec/integration/knife/data_bag_edit_spec.rb
@@ -1,0 +1,104 @@
+#
+# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "support/shared/integration/integration_helper"
+require "support/shared/context/config"
+require "chef/knife/data_bag_edit"
+
+describe "knife data bag edit", :workstation do
+  include IntegrationSupport
+  include KnifeSupport
+
+  include_context "default config options"
+
+  let(:out) { "Saved data_bag_item[box]\n" }
+  let(:err) { "Saving data bag unencrypted. To encrypt it, provide an appropriate secret.\n" }
+  let(:secret) { "abc" }
+  let(:encrypt) { "Encrypted data bag detected, decrypting with provided secret.\n" }
+
+  when_the_chef_server "is empty" do
+    context "with encryption key" do
+      it "fails to edit an item" do
+        expect { knife("data bag edit bag box --secret #{secret}") }.to raise_error(Net::HTTPClientException)
+      end
+    end
+
+    context "without encryption key" do
+      it "fails to edit an item" do
+        expect { knife("data bag edit bag box") }.to raise_error(Net::HTTPClientException)
+      end
+    end
+  end
+
+  when_the_chef_server "has some data bags" do
+    before do
+      data_bag "foo", {}
+      data_bag "bag", { "box" => {} }
+      data_bag "rocket", { "falcon9" => { heavy: "true" }, "atlas" => {}, "ariane" => {} }
+      data_bag "encrypt", { "box" => { id: "box", foo: { "encrypted_data": "J8N0pJ+LFDQF3XvhzWgkSBOuZZn8Og==\n", "iv": "4S1sb4zLnMt71SXV\n", "auth_tag": "4ChINhxz4WmqOizvZNoPPg==\n", "version": 3, "cipher": "aes-256-gcm" } } }
+    end
+
+    context "with encryption key" do
+      it "fails to edit a non-existing item" do
+        expect { knife("data bag edit foo box --secret #{secret}") }.to raise_error(Net::HTTPClientException)
+      end
+
+      it "edits an encrypted data bag item" do
+        pretty_json = Chef::JSONCompat.to_json_pretty({ :id => "box", :foo => "bar" })
+        allow(Chef::JSONCompat).to receive(:to_json_pretty).and_return(pretty_json)
+        knife("data bag edit encrypt box --secret #{secret}")
+        knife("data bag show encrypt box --secret #{secret}").should_succeed stderr: encrypt, stdout: <<~EOM
+          foo: bar
+          id:  box
+        EOM
+      end
+
+      it "encrypts an unencrypted data bag item" do
+        knife("data bag edit rocket falcon9 --secret #{secret}")
+        knife("data bag show rocket falcon9 --secret #{secret}").should_succeed stderr: encrypt, stdout: <<~EOM
+          heavy: true
+          id:    falcon9
+        EOM
+      end
+    end
+
+    context "without encryption key" do
+      it "fails to edit a non-existing item" do
+        expect { knife("data bag edit foo box") }.to raise_error(Net::HTTPClientException)
+      end
+      it "edits an empty data bag item" do
+        pretty_json = Chef::JSONCompat.to_json_pretty({ :id => "box", :ab => "abc" })
+        allow(Chef::JSONCompat).to receive(:to_json_pretty).and_return(pretty_json)
+        knife("data bag edit bag box").should_succeed stderr: err, stdout: out
+        knife("data bag show bag box").should_succeed <<~EOM
+          ab: abc
+          id: box
+        EOM
+      end
+      it "edits a non-empty data bag item" do
+        pretty_json = Chef::JSONCompat.to_json_pretty({ :id => "falcon9", :heavy => false })
+        allow(Chef::JSONCompat).to receive(:to_json_pretty).and_return(pretty_json)
+        knife("data bag edit rocket falcon9").should_succeed stderr: err, stdout: <<~EOM
+          Saved data_bag_item[falcon9]
+        EOM
+        knife("data bag show rocket falcon9").should_succeed <<~EOM
+          heavy: false
+          id:    falcon9
+        EOM
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added specs for data_bag_create_specs
- Added specs for data_bag_edit_specs
- Added specs for data_bag_show_specs
- Ensured chefstyle

Signed-off-by: vijaymmali1990 <vijay.mali@msystechnologies.com>

### Description
Added a new file `/specs/integration/knife/data_bag_edit_spec.rb` which includes the test for **encypting unencrypted data bag item with edit command**
Added some specs in `/spec/integration/knife/data_bag_create_spec.rb` and `/spec/integration/knife/data_bag_show_spec.rb`

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
