### PR TITLE
Loosen the win32-cerstore and win32-service dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,14 +63,14 @@ PATH
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.2.4)
+      win32-certstore (~> 0.3)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
-      win32-service (~> 1.0)
+      win32-service (>= 1.0, < 3.0)
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
@@ -356,7 +356,7 @@ GEM
       hashdiff
     websocket (1.2.8)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.2.4)
+    win32-certstore (0.3.0)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -5,18 +5,18 @@ gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 gemspec.add_dependency "win32-api", "~> 1.5.3"
 gemspec.add_dependency "win32-dir", "~> 0.5.0"
 gemspec.add_dependency "win32-event", "~> 0.6.1"
-# TODO: Relax this pin and make the necessary updaets. The issue originally
+# TODO: Relax this pin and make the necessary updates. The issue originally
 # leading to this pin has been fixed in 0.6.5.
 gemspec.add_dependency "win32-eventlog", "0.6.3"
 gemspec.add_dependency "win32-mmap", "~> 0.4.1"
 gemspec.add_dependency "win32-mutex", "~> 0.4.2"
 gemspec.add_dependency "win32-process", "~> 0.8.2"
-gemspec.add_dependency "win32-service", "~> 1.0"
+gemspec.add_dependency "win32-service", ">= 1.0", "< 3.0"
 gemspec.add_dependency "windows-api", "~> 0.4.4"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
 gemspec.add_dependency "iso8601", "~> 0.12.1"
-gemspec.add_dependency "win32-certstore", "~> 0.2.4"
+gemspec.add_dependency "win32-certstore", "~> 0.3"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 


### PR DESCRIPTION
Bring in the updated win32-certstore gem and allow bringing in the updated service gem later on.

Signed-off-by: Tim Smith <tsmith@chef.io>