### PR TITLE
Allow the use of `--delete-entire-chef-repo`

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -332,7 +332,7 @@ class Chef::Application::Client < Chef::Application
       else
         if Chef::Config[:delete_entire_chef_repo]
           Chef::Log.trace "Cleanup path #{Chef::Config.chef_repo_path} before extract recipes into it"
-          FileUtils.rm_rf(recipes_path, secure: true)
+          FileUtils.rm_rf(Chef::Config.chef_repo_path, secure: true)
         end
         Chef::Log.trace "Creating path #{Chef::Config.chef_repo_path} to extract recipes into"
         FileUtils.mkdir_p(Chef::Config.chef_repo_path)


### PR DESCRIPTION
Signed-off-by: Adam Bewsher <adam.bewsher@neos.co.uk>

### Description

Allows the use of `--delete-entire-chef-repo` in chef-client when also using `--local-mode` with `--recipe-url`

### Issues Resolved

Previously when using these options, chef-client exited with `undefined local variable or method  'recipes_path'`.  This was due to a copy/paste error in https://github.com/chef/chef/pull/4545 and no tests.
