### PR TITLE
Early allocation of the Chef::RunContext

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -263,7 +263,7 @@ class Chef
         Chef.resource_handler_map.lock!
         Chef.provider_handler_map.lock!
 
-        setup_run_context(run_context)
+        setup_run_context
 
         load_required_recipe(@rest, run_context) unless Chef::Config[:solo_legacy_mode]
 
@@ -465,9 +465,11 @@ class Chef
     # @return The newly set up run context
     #
     # @api private
-    def setup_run_context(run_context)
+    def setup_run_context
       policy_builder.setup_run_context(specific_recipes, run_context)
       assert_cookbook_path_not_empty(run_context)
+      run_status.run_context = run_context # backcompat for chefspec
+      run_context
     end
 
     #

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -473,7 +473,7 @@ class Chef
     #
     # @api private
     def setup_run_context
-      run_context = policy_builder.setup_run_context(specific_recipes, run_context)
+      @run_context = policy_builder.setup_run_context(specific_recipes, run_context)
       assert_cookbook_path_not_empty(run_context)
       run_status.run_context = run_context # backcompat for chefspec
       run_context

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -473,7 +473,7 @@ class Chef
     #
     # @api private
     def setup_run_context
-      policy_builder.setup_run_context(specific_recipes, run_context)
+      run_context = policy_builder.setup_run_context(specific_recipes, run_context)
       assert_cookbook_path_not_empty(run_context)
       run_status.run_context = run_context # backcompat for chefspec
       run_context

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -92,13 +92,6 @@ class Chef
     attr_reader :ohai
 
     #
-    # The rest object used to communicate with the Chef server.
-    #
-    # @return [Chef::ServerAPI]
-    #
-    attr_reader :rest
-
-    #
     # The runner used to converge.
     #
     # @return [Chef::Runner]
@@ -234,7 +227,10 @@ class Chef
 
         run_status.run_id = request_id = Chef::RequestID.instance.request_id
 
-        run_context = nil
+        run_context = Chef::RunContext.new
+        run_context.events = events
+        run_status.run_context = run_context
+
         events.run_start(Chef::VERSION, run_status)
 
         logger.info("*** Chef #{Chef::VERSION} ***")
@@ -244,7 +240,15 @@ class Chef
         enforce_path_sanity
         run_ohai
 
-        register unless Chef::Config[:solo_legacy_mode]
+        unless Chef::Config[:solo_legacy_mode]
+          register
+
+          # create and save the rest objects in the run_context
+          run_context.rest = rest
+          run_context.rest_clean = rest_clean
+
+          events.register(Chef::ResourceReporter.new(rest_clean))
+        end
 
         load_node
 
@@ -259,7 +263,7 @@ class Chef
         Chef.resource_handler_map.lock!
         Chef.provider_handler_map.lock!
 
-        run_context = setup_run_context
+        setup_run_context(run_context)
 
         load_required_recipe(@rest, run_context) unless Chef::Config[:solo_legacy_mode]
 
@@ -349,16 +353,27 @@ class Chef
       end
     end
 
+    # Standard rest object for talking to the Chef Server
+    #
+    # FIXME: Can we drop this and only use the rest_clean object?  Did I add rest_clean
+    # only out of some cant-break-a-minor-version paranoia?
+    #
+    # @api private
+    def rest
+      @rest ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], client_name: node_name,
+                                    signing_key_filename: Chef::Config[:client_key])
+    end
+
     # A rest object with validate_utf8 set to false.  This will not throw exceptions
     # on non-UTF8 strings in JSON but will sanitize them so that e.g. POSTs will
     # never fail.  Cannot be configured on a request-by-request basis, so we carry
     # around another rest object for it.
     #
     # @api private
-    def rest_clean(client_name = node_name, config = Chef::Config)
+    def rest_clean
       @rest_clean ||=
-        Chef::ServerAPI.new(config[:chef_server_url], client_name: client_name,
-                                                      signing_key_filename: config[:client_key], validate_utf8: false)
+        Chef::ServerAPI.new(Chef::Config[:chef_server_url], client_name: node_name,
+                            signing_key_filename: Chef::Config[:client_key], validate_utf8: false)
     end
 
     #
@@ -450,11 +465,9 @@ class Chef
     # @return The newly set up run context
     #
     # @api private
-    def setup_run_context
-      run_context = policy_builder.setup_run_context(specific_recipes)
+    def setup_run_context(run_context)
+      policy_builder.setup_run_context(specific_recipes, run_context)
       assert_cookbook_path_not_empty(run_context)
-      run_status.run_context = run_context
-      run_context
     end
 
     #
@@ -607,14 +620,6 @@ class Chef
         Chef::ApiClient::Registration.new(node_name, config[:client_key]).run
         events.registration_completed
       end
-      # We now have the client key, and should use it from now on.
-      @rest = Chef::ServerAPI.new(config[:chef_server_url], client_name: client_name,
-                                                            signing_key_filename: config[:client_key])
-      # force initialization of the rest_clean API object
-      rest_clean(client_name, config)
-      # FIXME: we could initialize rest_clean much earlier and hang it off of the run_status and then
-      # have the ResourceReporter pull it off of the run_status and eliminate this tight coupling.
-      events.register(Chef::ResourceReporter.new(rest_clean))
     rescue Exception => e
       # TODO this should probably only ever fire if we *started* registration.
       # Move it to the block above.

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -72,6 +72,13 @@ class Chef
     attr_reader :run_status
 
     #
+    # The run context of the Chef run.
+    #
+    # @return [Chef::RunContext]
+    #
+    attr_reader :run_context
+
+    #
     # The node represented by this client.
     #
     # @return [Chef::Node]
@@ -227,7 +234,7 @@ class Chef
 
         run_status.run_id = request_id = Chef::RequestID.instance.request_id
 
-        run_context = Chef::RunContext.new
+        @run_context = Chef::RunContext.new
         run_context.events = events
         run_status.run_context = run_context
 

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Nuo Yan (<nuo@chef.io>)
 # Author:: Christopher Brown (<cb@chef.io>)
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,8 +32,8 @@ class Chef
     include Chef::Mixin::FromFile
     include Chef::Mixin::ParamsValidate
 
-    VALID_NAME = /^[\.\-[:alnum:]_]+$/
-    RESERVED_NAMES = /^(node|role|environment|client)$/
+    VALID_NAME = /^[\.\-[:alnum:]_]+$/.freeze
+    RESERVED_NAMES = /^(node|role|environment|client)$/.freeze
 
     def self.validate_name!(name)
       unless name =~ VALID_NAME

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -32,8 +32,8 @@ class Chef
     include Chef::Mixin::FromFile
     include Chef::Mixin::ParamsValidate
 
-    VALID_NAME = /^[\.\-[:alnum:]_]+$/.freeze
-    RESERVED_NAMES = /^(node|role|environment|client)$/.freeze
+    VALID_NAME = /^[\.\-[:alnum:]_]+$/
+    RESERVED_NAMES = /^(node|role|environment|client)$/
 
     def self.validate_name!(name)
       unless name =~ VALID_NAME

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -3,7 +3,7 @@
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -175,14 +175,17 @@ class Chef
       # run.
       #
       # @return [Chef::RunContext]
-      def setup_run_context(specific_recipes = nil)
+      def setup_run_context(specific_recipes = nil, run_context = nil)
         Chef::Cookbook::FileVendor.fetch_from_remote(api_service)
         sync_cookbooks
         cookbook_collection = Chef::CookbookCollection.new(cookbooks_to_sync)
         cookbook_collection.validate!
         cookbook_collection.install_gems(events)
 
-        run_context = Chef::RunContext.new(node, cookbook_collection, events)
+        run_context ||= Chef::RunContext.new
+        run_context.node = node
+        run_context.cookbook_collection = cookbook_collection
+        run_context.events = events
 
         setup_chef_class(run_context)
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -102,7 +102,6 @@ shared_context "a client run" do
   let(:api_client_exists?) { false }
   let(:enable_fork)        { false }
 
-  let(:http_data_collector)   { double("Chef::ServerAPI (data collector)") }
   let(:http_cookbook_sync)    { double("Chef::ServerAPI (cookbook sync)") }
   let(:http_node_load)        { double("Chef::ServerAPI (node)") }
   let(:http_node_save)        { double("Chef::ServerAPI (node save)") }

--- a/spec/unit/run_context_spec.rb
+++ b/spec/unit/run_context_spec.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Allow for allocation of the Chef::RunContext without its arguments and
use that to allocate it early.  The APIs are kept backcompatible since
otherwise this has a decent chance of blowing up something like
chefspec.
