### PR TITLE
Backport windows service fix

### DIFF
--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -505,6 +505,31 @@ describe Chef::Provider::Service::Windows, "load_current_resource", :windows_onl
         double("StatusStruct", current_state: "running"))
     end
 
+    context "run_as_user user is specified" do
+      let(:run_as_user) { provider.new_resource.class.properties[:run_as_user].default }
+
+      before do
+        provider.new_resource.run_as_user run_as_user
+      end
+
+      it "configures service run_as_user and run_as_password" do
+        expect(provider).to receive(:configure_service_run_as_properties).and_call_original
+        expect(Win32::Service).to receive(:configure)
+        provider.start_service
+      end
+    end
+
+    context "run_as_user user is not specified" do
+      before do
+        expect(provider.new_resource.property_is_set?(:run_as_user)).to be false
+      end
+
+      it "does not configure service run_as_user and run_as_password" do
+        expect(Win32::Service).not_to receive(:configure)
+        provider.start_service
+      end
+    end
+
     it "calls the start command if one is specified" do
       new_resource.start_command "sc start #{chef_service_name}"
       expect(provider).to receive(:shell_out!).with((new_resource.start_command).to_s).and_return("Starting custom service")


### PR DESCRIPTION
### Description

Backport fix for #8080 to Chef 14.

### Issues Resolved

- #8080

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
