### PR TITLE
package: move response_file and response_file_variables out of base package resource

### DIFF
--- a/lib/chef/provider/package/deb.rb
+++ b/lib/chef/provider/package/deb.rb
@@ -1,0 +1,131 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/provider/package"
+
+class Chef
+  class Provider
+    class Package
+      module Deb
+        def self.included(base)
+          base.class_eval do
+            use_multipackage_api
+
+            action :reconfig do
+              if current_resource.version.nil?
+                logger.trace("#{new_resource} is NOT installed - nothing to do")
+                return
+              end
+
+              unless new_resource.response_file
+                logger.trace("#{new_resource} no response_file provided - nothing to do")
+                return
+              end
+
+              if preseed_file = get_preseed_file(new_resource.package_name, current_resource.version)
+                converge_by("reconfigure package #{new_resource.package_name}") do
+                  preseed_package(preseed_file)
+                  multipackage_api_adapter(new_resource.package_name, current_resource.version) do |name, _version|
+                    reconfig_package(name)
+                  end
+                  logger.info("#{new_resource} reconfigured")
+                end
+              else
+                logger.trace("#{new_resource} preseeding has not changed - nothing to do")
+              end
+            end
+
+            # This method is used for getting preseed file
+            # it will return preseed file path or false if response_file is present
+            def prepare_for_installation
+              if new_resource.response_file && preseed_file = get_preseed_file(package_names_for_targets, versions_for_targets)
+                converge_by("preseed package #{package_names_for_targets}") do
+                  preseed_package(preseed_file)
+                end
+              end
+            end
+
+            def get_preseed_file(name, version)
+              resource = preseed_resource(name, version)
+              resource.run_action(:create)
+              logger.trace("#{new_resource} fetched preseed file to #{resource.path}")
+
+              if resource.updated_by_last_action?
+                resource.path
+              else
+                false
+              end
+            end
+
+            def preseed_resource(name, version)
+              # A directory in our cache to store this cookbook's preseed files in
+              file_cache_dir = Chef::FileCache.create_cache_path("preseed/#{new_resource.cookbook_name}")
+              # The full path where the preseed file will be stored
+              cache_seed_to = "#{file_cache_dir}/#{name}-#{version}.seed"
+
+              logger.trace("#{new_resource} fetching preseed file to #{cache_seed_to}")
+
+              if template_available?(new_resource.response_file)
+                logger.trace("#{new_resource} fetching preseed file via Template")
+                remote_file = Chef::Resource::Template.new(cache_seed_to, run_context)
+                remote_file.variables(new_resource.response_file_variables)
+              elsif cookbook_file_available?(new_resource.response_file)
+                logger.trace("#{new_resource} fetching preseed file via cookbook_file")
+                remote_file = Chef::Resource::CookbookFile.new(cache_seed_to, run_context)
+              else
+                message = "No template or cookbook file found for response file #{new_resource.response_file}"
+                raise Chef::Exceptions::FileNotFound, message
+              end
+
+              remote_file.cookbook_name = new_resource.cookbook_name
+              remote_file.source(new_resource.response_file)
+              remote_file.backup(false)
+              remote_file
+            end
+
+            def preseed_package(preseed_file)
+              logger.info("#{new_resource} pre-seeding package installation instructions")
+              run_noninteractive("debconf-set-selections", preseed_file)
+            end
+
+            def reconfig_package(name)
+              logger.info("#{new_resource} reconfiguring")
+              run_noninteractive("dpkg-reconfigure", *name)
+            end
+
+            # Runs command via shell_out with magic environment to disable
+            # interactive prompts.
+            def run_noninteractive(*command)
+              shell_out!(*command, env: { "DEBIAN_FRONTEND" => "noninteractive" })
+            end
+
+            private
+
+            def template_available?(path)
+              run_context.has_template_in_cookbook?(new_resource.cookbook_name, path)
+            end
+
+            def cookbook_file_available?(path)
+              run_context.has_cookbook_file_in_cookbook?(new_resource.cookbook_name, path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -35,6 +35,14 @@ class Chef
                description: "Overwrite existing configuration files with those supplied by the package, if prompted by APT.",
                default: false
 
+      property :response_file, String,
+               description: "The direct path to the file used to pre-seed a package.",
+               desired_state: false
+
+      property :response_file_variables, Hash,
+               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
+               default: lazy { Hash.new }, desired_state: false
+
     end
   end
 end

--- a/lib/chef/resource/dpkg_package.rb
+++ b/lib/chef/resource/dpkg_package.rb
@@ -28,6 +28,14 @@ class Chef
 
       property :source, [ String, Array, nil ],
                description: "The path to a package in the local file system."
+
+      property :response_file, String,
+               description: "The direct path to the file used to pre-seed a package.",
+               desired_state: false
+
+      property :response_file_variables, Hash,
+               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
+               default: lazy { Hash.new }, desired_state: false
     end
   end
 end

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -52,14 +52,6 @@ class Chef
                description: "One (or more) additional command options that are passed to the command.",
                coerce: proc { |x| x.is_a?(String) ? x.shellsplit : x }
 
-      property :response_file, String,
-               description: "The direct path to the file used to pre-seed a package.",
-               desired_state: false
-
-      property :response_file_variables, Hash,
-               description: "A Hash of response file variables in the form of {'VARIABLE' => 'VALUE'}.",
-               default: lazy { Hash.new }, desired_state: false
-
       property :source, String,
                description: "The optional path to a package on the local file system.",
                desired_state: false

--- a/spec/data/cookbooks/irssi/files/default/irssi.response
+++ b/spec/data/cookbooks/irssi/files/default/irssi.response
@@ -1,0 +1,2 @@
+# Hi, I'm pretending to be the preseed file for installing the irssi on debian
+# or Ubuntu

--- a/spec/data/cookbooks/wget/files/default/wget.response
+++ b/spec/data/cookbooks/wget/files/default/wget.response
@@ -1,0 +1,2 @@
+# Hi, I'm pretending to be the preseed file for installing the wget on debian
+# or Ubuntu

--- a/spec/support/shared/unit/provider/package/package_shared.rb
+++ b/spec/support/shared/unit/provider/package/package_shared.rb
@@ -1,0 +1,95 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+shared_examples_for "given a response file" do
+  let(:cookbook_repo) { File.expand_path(File.join(CHEF_SPEC_DATA, "cookbooks")) }
+  let(:cookbook_loader) do
+    Chef::Cookbook::FileVendor.fetch_from_disk(cookbook_repo)
+    Chef::CookbookLoader.new(cookbook_repo)
+  end
+  let(:cookbook_collection) do
+    cookbook_loader.load_cookbooks
+    Chef::CookbookCollection.new(cookbook_loader)
+  end
+  let(:run_context) { Chef::RunContext.new(node, cookbook_collection, events) }
+
+  describe "creating the cookbook file resource to fetch the response file" do
+    before do
+      expect(Chef::FileCache).to receive(:create_cache_path).with(path).and_return(tmp_path)
+    end
+
+    it "sets the preseed resource's runcontext to its own run context" do
+      cookbook_collection
+      allow(Chef::FileCache).to receive(:create_cache_path).and_return(tmp_path)
+      expect(@provider.preseed_resource(package_name, package_version).run_context).not_to be_nil
+      expect(@provider.preseed_resource(package_name, package_version).run_context).to equal(@provider.run_context)
+    end
+
+    it "should set the cookbook name of the remote file to the new resources cookbook name" do
+      expect(@provider.preseed_resource(package_name, package_version).cookbook_name).to eq(package_name)
+    end
+
+    it "should set remote files source to the new resources response file" do
+      expect(@provider.preseed_resource(package_name, package_version).source).to eq(response)
+    end
+
+    it "should never back up the cached response file" do
+      expect(@provider.preseed_resource(package_name, package_version).backup).to be_falsey
+    end
+
+    it "sets the install path of the resource to $file_cache/$cookbook/$pkg_name-$pkg_version.seed" do
+      expect(@provider.preseed_resource(package_name, package_version).path).to eq(tmp_preseed_path)
+    end
+  end
+
+  describe "when installing the preseed file to the cache location" do
+    let(:response_file_destination) { Dir.tmpdir + preseed_path }
+    let(:response_file_resource) do
+      response_file_resource = Chef::Resource::CookbookFile.new(response_file_destination, run_context)
+      response_file_resource.cookbook_name = package_name
+      response_file_resource.backup(false)
+      response_file_resource.source(response)
+      response_file_resource
+    end
+
+    before do
+      expect(@provider).to receive(:preseed_resource).with(package_name, package_version).and_return(response_file_resource)
+    end
+
+    after do
+      FileUtils.rm(response_file_destination) if ::File.exist?(response_file_destination)
+    end
+
+    it "creates the preseed file in the cache" do
+      expect(response_file_resource).to receive(:run_action).with(:create)
+      @provider.get_preseed_file(package_name, package_version)
+    end
+
+    it "returns the path to the response file if the response file was updated" do
+      expect(@provider.get_preseed_file(package_name, package_version)).to eq(response_file_destination)
+    end
+
+    it "should return false if the response file has not been updated" do
+      response_file_resource.updated_by_last_action(false)
+      expect(response_file_resource).not_to be_updated_by_last_action
+      # don't let the response_file_resource set updated to true
+      expect(response_file_resource).to receive(:run_action).with(:create)
+      expect(@provider.get_preseed_file(package_name, package_version)).to be(false)
+    end
+  end
+end

--- a/spec/unit/cookbook_loader_spec.rb
+++ b/spec/unit/cookbook_loader_spec.rb
@@ -101,7 +101,7 @@ describe Chef::CookbookLoader do
         cookbook_loader.each_key do |cookbook_name|
           seen << cookbook_name
         end
-        expect(seen).to eq %w{angrybash apache2 borken ignorken java name-mismatch openldap preseed supports-platform-constraints}
+        expect(seen).to eq %w{angrybash apache2 borken ignorken irssi java name-mismatch openldap preseed supports-platform-constraints wget}
       end
     end
 

--- a/spec/unit/provider/package/deb_spec.rb
+++ b/spec/unit/provider/package/deb_spec.rb
@@ -1,0 +1,135 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright 2010-2019, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Provider::Package::Deb do
+  let(:node) do
+    node = Chef::Node.new
+    node.automatic_attrs[:platform] = :just_testing
+    node.automatic_attrs[:platform_version] = :just_testing
+    node
+  end
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:logger) { double("Mixlib::Log::Child").as_null_object }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:new_resource) { Chef::Resource::AptPackage.new("emacs", run_context) }
+  let(:current_resource) { Chef::Resource::AptPackage.new("emacs", run_context) }
+  let(:candidate_version) { "1.0" }
+  let(:provider) do
+    provider = Chef::Provider::Package::Apt.new(new_resource, run_context) { include Chef::Provider::Package::Deb }
+    provider.current_resource = current_resource
+    provider.candidate_version = candidate_version
+    provider
+  end
+
+  before do
+    allow(run_context).to receive(:logger).and_return(logger)
+  end
+
+  describe "when reconfiguring the package" do
+    before(:each) do
+      allow(provider).to receive(:reconfig_package).and_return(true)
+    end
+
+    context "when reconfigure the package" do
+      it "reconfigure the package and update the resource" do
+        allow(provider).to receive(:get_current_versions).and_return("1.0")
+        allow(new_resource).to receive(:response_file).and_return(true)
+        expect(provider).to receive(:get_preseed_file).and_return("/var/cache/preseed-test")
+        allow(provider).to receive(:preseed_package).and_return(true)
+        allow(provider).to receive(:reconfig_package).and_return(true)
+        expect(logger).to receive(:info).with("apt_package[emacs] reconfigured")
+        expect(provider).to receive(:reconfig_package)
+        provider.run_action(:reconfig)
+        expect(new_resource).to be_updated
+        expect(new_resource).to be_updated_by_last_action
+      end
+    end
+
+    context "when not reconfigure the package" do
+      it "does not reconfigure the package if the package is not installed" do
+        allow(provider).to receive(:get_current_versions).and_return(nil)
+        allow(provider.load_current_resource).to receive(:version).and_return(nil)
+        expect(logger).to receive(:trace).with("apt_package[emacs] is NOT installed - nothing to do")
+        expect(provider).not_to receive(:reconfig_package)
+        provider.run_action(:reconfig)
+        expect(new_resource).not_to be_updated_by_last_action
+      end
+
+      it "does not reconfigure the package if no response_file is given" do
+        allow(provider).to receive(:get_current_versions).and_return("1.0")
+        allow(new_resource).to receive(:response_file).and_return(nil)
+        expect(logger).to receive(:trace).with("apt_package[emacs] no response_file provided - nothing to do")
+        expect(provider).not_to receive(:reconfig_package)
+        provider.run_action(:reconfig)
+        expect(new_resource).not_to be_updated_by_last_action
+      end
+
+      it "does not reconfigure the package if the response_file has not changed" do
+        allow(provider).to receive(:get_current_versions).and_return("1.0")
+        allow(new_resource).to receive(:response_file).and_return(true)
+        expect(provider).to receive(:get_preseed_file).and_return(false)
+        allow(provider).to receive(:preseed_package).and_return(false)
+        expect(logger).to receive(:trace).with("apt_package[emacs] preseeding has not changed - nothing to do")
+        expect(provider).not_to receive(:reconfig_package)
+        provider.run_action(:reconfig)
+        expect(new_resource).not_to be_updated_by_last_action
+      end
+    end
+  end
+
+  describe "Subclass with use_multipackage_api" do
+    class MyDebianPackageResource < Chef::Resource::Package
+    end
+
+    class MyDebianPackageProvider < Chef::Provider::Package
+      include Chef::Provider::Package::Deb
+      use_multipackage_api
+    end
+    let(:node) { Chef::Node.new }
+    let(:events) { Chef::EventDispatch::Dispatcher.new }
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:new_resource) { MyDebianPackageResource.new("installs the packages") }
+    let(:current_resource) { MyDebianPackageResource.new("installs the packages") }
+    let(:provider) do
+      provider = MyDebianPackageProvider.new(new_resource, run_context)
+      provider.current_resource = current_resource
+      provider
+    end
+
+    it "has use_multipackage_api? methods on the class and instance" do
+      expect(MyDebianPackageProvider.use_multipackage_api?).to be true
+      expect(provider.use_multipackage_api?).to be true
+    end
+
+    it "when user passes string to package_name, passes arrays to reconfig_package" do
+      new_resource.package_name "vim"
+      current_resource.package_name "vim"
+      current_resource.version [ "1.0" ]
+      allow(new_resource).to receive(:response_file).and_return(true)
+      allow(new_resource).to receive(:resource_name).and_return(:apt_package)
+      expect(provider).to receive(:get_preseed_file).and_return("/var/cache/preseed-test")
+      allow(provider).to receive(:preseed_package).and_return(true)
+      allow(provider).to receive(:reconfig_package).and_return(true)
+      expect(provider).to receive(:reconfig_package).with([ "vim" ]).and_return(true)
+      provider.run_action(:reconfig)
+      expect(new_resource).to be_updated_by_last_action
+    end
+  end
+end

--- a/spec/unit/resource/apt_package_spec.rb
+++ b/spec/unit/resource/apt_package_spec.rb
@@ -53,4 +53,14 @@ describe Chef::Resource::AptPackage, "initialize" do
   it "should preserve configuration files by default" do
     expect(resource.overwrite_config_files).to eql(false)
   end
+
+  it "accepts a string for the response file" do
+    resource.response_file "something"
+    expect(resource.response_file).to eql("something")
+  end
+
+  it "accepts a hash for response file template variables" do
+    resource.response_file_variables({ variables: true })
+    expect(resource.response_file_variables).to eql({ variables: true })
+  end
 end

--- a/spec/unit/resource/dpkg_package_spec.rb
+++ b/spec/unit/resource/dpkg_package_spec.rb
@@ -36,6 +36,16 @@ describe Chef::Resource::DpkgPackage, "initialize" do
       expect(resource.action).to eql([:install])
     end
 
+    it "accepts a string for the response file" do
+      resource.response_file "something"
+      expect(resource.response_file).to eql("something")
+    end
+
+    it "accepts a hash for response file template variables" do
+      resource.response_file_variables({ variables: true })
+      expect(resource.response_file_variables).to eql({ variables: true })
+    end
+
     it "supports :install, :lock, :purge, :reconfig, :remove, :unlock, :upgrade actions" do
       expect { resource.action :install }.not_to raise_error
       expect { resource.action :lock }.not_to raise_error

--- a/spec/unit/resource/package_spec.rb
+++ b/spec/unit/resource/package_spec.rb
@@ -50,16 +50,6 @@ describe Chef::Resource::Package do
     expect(resource.version).to eql("something")
   end
 
-  it "accepts a string for the response file" do
-    resource.response_file "something"
-    expect(resource.response_file).to eql("something")
-  end
-
-  it "accepts a hash for response file template variables" do
-    resource.response_file_variables({ variables: true })
-    expect(resource.response_file_variables).to eql({ variables: true })
-  end
-
   it "accepts a string for the source" do
     resource.source "something"
     expect(resource.source).to eql("something")


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description

- Moved `response_file` and `response_file_variables` properties from `package` resource to `apt_package` and `dpkg_package` resources
- Created a `Chef::Provider::Package::Deb` module for `apt` and `dpkg` providers and included it into Apt and Dpkg classes which are the sub-classes of the Package class, and also moved common methods of `apt` and `dpkg` providers in `Chef::Provider::Package::Deb`
- Added test cases
- Ensured chef-style on the code changes made
### Issues Resolved
Fixes #7599 MSYS-986

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
