### PR TITLE
Pin expeditor to ruby 2.5.3 and bump train to 1.7.6

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -11,6 +11,9 @@
 
 set -evx
 
+# this attempts to work around the bundle update making unsolvable dep tree
+asdf local ruby 2.5.3
+
 function new_gem_included() {
   git diff | grep -E '^\+' | grep "${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})"
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.4.0)
     appbundler (0.12.0)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -239,7 +238,6 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.0.3)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
@@ -304,7 +302,7 @@ GEM
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
-    train-core (1.7.5)
+    train-core (1.7.6)
       json (>= 1.8, < 3.0)
       mixlib-shellout (~> 2.0)
     travis (1.8.9)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (5.0.0)
+    chef-sugar (5.0.1)
     chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)


### PR DESCRIPTION
Expeditor keeps incorrectly bumping addressable to 2.5.2, which seems like some sort of ruby/bundler bug, which is breaking builds. We're attempting to switch back to ruby 2.5.3. in expeditor to see if that resolves the bumping issues.

Signed-off-by: Tim Smith <tsmith@chef.io>