### PR TITLE
Attempt a convervative bundle update when bumping chef versions

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -11,9 +11,6 @@
 
 set -evx
 
-# this attempts to work around the bundle update making unsolvable dep tree
-asdf local ruby 2.5.3
-
 function new_gem_included() {
   git diff | grep -E '^\+' | grep "${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})"
 }

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -15,7 +15,7 @@ sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" chef-config
 sed -i -r "s/VersionString\.new\(\".+\"\)/VersionString.new(\"$(cat VERSION)\")/" lib/chef/version.rb
 
 # Update the version inside Gemfile.lock
-bundle update chef chef-config --jobs=7
+bundle update chef chef-config --jobs=7 --conservative
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
This should keep out other deps.

Signed-off-by: Tim Smith <tsmith@chef.io>