### PR TITLE
Remove the travis gem from our gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,10 +65,6 @@ group(:development, :test) do
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
 end
 
-group(:travis) do
-  gem "travis"
-end
-
 instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
 
 # If you want to load debugging tools into the bundle exec sandbox,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,6 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
-    backports (3.12.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -131,12 +130,8 @@ GEM
     docile (1.3.1)
     equatable (0.5.0)
     erubis (2.7.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
     ffi (1.10.0-x64-mingw32)
     ffi (1.10.0-x86-mingw32)
@@ -145,13 +140,6 @@ GEM
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
-    gh (0.15.1)
-      addressable (~> 2.4.0)
-      backports
-      faraday (~> 0.8)
-      multi_json (~> 1.0)
-      net-http-persistent (~> 2.9)
-      net-http-pipeline
     hashdiff (0.3.8)
     hashie (3.6.0)
     highline (1.7.10)
@@ -184,8 +172,6 @@ GEM
     iso8601 (0.12.1)
     jaro_winkler (1.5.2)
     json (2.2.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     libyajl2 (1.2.0)
     method_source (0.9.2)
     mixlib-archive (1.0.1)
@@ -201,11 +187,8 @@ GEM
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
-    multi_json (1.13.1)
     multipart-post (2.0.0)
     necromancer (0.4.0)
-    net-http-persistent (2.9.4)
-    net-http-pipeline (1.0.1)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
@@ -240,9 +223,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.3)
-    pusher-client (0.6.2)
-      json
-      websocket (~> 1.0)
     rack (2.0.6)
     rainbow (3.0.0)
     rake (12.3.0)
@@ -307,15 +287,6 @@ GEM
     train-core (1.7.6)
       json (>= 1.8, < 3.0)
       mixlib-shellout (~> 2.0)
-    travis (1.8.9)
-      backports
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9, >= 0.9.1)
-      gh (~> 0.13)
-      highline (~> 1.6)
-      launchy (~> 2.1)
-      pusher-client (~> 0.4)
-      typhoeus (~> 0.6, >= 0.6.8)
     tty-color (0.4.3)
     tty-cursor (0.6.1)
     tty-prompt (0.18.1)
@@ -335,8 +306,6 @@ GEM
       pastel (~> 0.7.2)
       strings (~> 0.1.0)
       tty-screen (~> 0.6.4)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
@@ -344,7 +313,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.8)
     win32-api (1.5.3-universal-mingw32)
     win32-certstore (0.3.0)
       ffi
@@ -405,7 +373,6 @@ DEPENDENCIES
   ruby-shadow
   simplecov
   tomlrb
-  travis
   webmock
   yard
 


### PR DESCRIPTION
It doesn't look like we're using this anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>