### PR TITLE
Lower the lock timeout

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,1 @@
-daysUntilLock: 60
+daysUntilLock: 14


### PR DESCRIPTION
Old PRs and Issues fall off our radar much faster than 2 months, and in
the case where someone does make a comment and it is missed, then
waiting 2 months to autolock it just makes it worse by having it sit in
limbo.

Any activity on the closed PR/Issue does reset the timer to zero.