### PR TITLE
Add windows_service deprecation of configuring run_as properties

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -233,6 +233,10 @@ class Chef
       target 28
     end
 
+    class WindowsServiceConfigureStartup < Base
+      target 29
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client/"

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -264,6 +264,13 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
   def configure_service_run_as_properties
     return unless new_resource.property_is_set?(:run_as_user)
 
+    unless new_resource.action.include?(:configure)
+      new_actions = new_resource.action.dup
+      insert_position = new_actions.find_index(:start) || 0
+      new_actions.insert(insert_position, :configure)
+      Chef.deprecated(:windows_service_configure_startup, "The :start action no longer configures run_as_user or run_as_password. Please prepend :configure action, i.e. action #{new_actions.inspect}")
+    end
+
     new_config = {
       service_name: new_resource.service_name,
       service_start_name: new_resource.run_as_user,


### PR DESCRIPTION
### Description

Steps towards cleaning up the `windows_service` resource.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
