### PR TITLE
Remove Ubuntu 14.04 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,22 +158,6 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test end-to-end-ubuntu-1404
-    after_failure:
-      - cat .kitchen/logs/kitchen.log
-    env:
-      - UBUNTU=14.04
-      - KITCHEN_YAML=kitchen.travis.yml
-  - rvm: 2.5.5
-    services: docker
-    gemfile: kitchen-tests/Gemfile
-    before_install:
-      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
-    before_script:
-      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      - cd kitchen-tests
-    script:
       - bundle exec kitchen test end-to-end-ubuntu-1604
     after_failure:
       - cat .kitchen/logs/kitchen.log

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -79,13 +79,6 @@ platforms:
     intermediate_instructions:
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-
 - name: ubuntu-16.04
   driver:
     image: dokken/ubuntu-16.04

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -24,12 +24,12 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
+  - name: amazonlinux-2
   - name: centos-6
   - name: centos-7
   - name: debian-8
   - name: debian-9
   - name: opensuse-leap-42
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
 

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -39,8 +39,6 @@ platforms:
     run_list: apt::default
   - name: freebsd-11
     run_list: freebsd::portsnap
-  - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
     run_list: apt::default
   - name: ubuntu-18.04


### PR DESCRIPTION
This goes EOL at the end of April and we won't be supporting it in Chef 15 officially although support in code will continue.

Signed-off-by: Tim Smith <tsmith@chef.io>