### PR TITLE
fix data collector non-utf8 file output

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -218,7 +218,7 @@ class Chef
       #
       def send_to_file_location(file_name, message)
         File.open(file_name, "a") do |fh|
-          fh.puts Chef::JSONCompat.to_json(message)
+          fh.puts Chef::JSONCompat.to_json(message, validate_utf8: false)
         end
       end
 

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -871,4 +871,12 @@ describe Chef::DataCollector do
 
     end
   end
+
+  describe "#send_to_file_location(file_name, message)" do
+    let(:tempfile) { Tempfile.new("rspec-chef-datacollector-out") }
+    let(:shift_jis) { "I have no idea what this character is:\n #{0x83.chr}#{0x80.chr}.\n" }
+    it "handles invalid UTF-8 properly" do
+      data_collector.send(:send_to_file_location, tempfile, { invalid: shift_jis })
+    end
+  end
 end


### PR DESCRIPTION
forces output to UTF-8 so it doesn't throw.

closes #8326
