### PR TITLE
Alternate distro proposal

### DIFF
--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -17,6 +17,8 @@ provisioner:
   github_repo: "chef"
   ohai_refname: "master"
   refname: <%= %x(git rev-parse HEAD) %>
+  github: "bobchaos/chef"
+  branch: "alternate_distro_proposal"
   client_rb:
     diff_disabled: true
 

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -28,14 +28,16 @@ require "mixlib/cli"
 require "tmpdir"
 require "rbconfig"
 require "chef/application/exit_code"
+require "chef/dist"
 
 class Chef
   class Application
     include Mixlib::CLI
-
+    include Chef::Dist::DistHelpers
     def initialize
       super
 
+      logger.warn(Chef::Dist::DISCLAIMER) unless enterprise_distro?
       @chef_client = nil
       @chef_client_json = nil
 

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -9,7 +9,7 @@ class Chef
     DISCLAIMER = "You're running the community's experimental distribution `cinc` and not the official Chef Infra product. Visit https://Chef.io to learn more about Chef Infra by Chef".freeze
 
     # A shorter reminder
-    REMINDER = "You're using `cinc`, the community distribution of chef"
+    REMINDER = "You're using `cinc`, the community distribution of chef".freeze
 
     # The name of this distro
     DIST = "Cinc Infra".freeze
@@ -18,7 +18,7 @@ class Chef
     module DistHelpers
       # Intended to suppress the message where appropriate
       def enterprise_distro?
-        DIST == 'Chef Infra'
+        DIST == "Chef Infra"
       end
     end
   end

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -1,0 +1,25 @@
+class Chef
+  class Dist
+    # Some disclaimers about the ditribution you're using.
+    # Distributions not produced by Chef are expect to change these messages
+    # to indicate their distro is not the official Chef distro in compliance
+    # with Chef's policy on Trademarks
+
+    # The standard disclaimer
+    DISCLAIMER = "You're running the community's experimental distribution `cinc` and not the official Chef Infra product. Visit https://Chef.io to learn more about Chef Infra by Chef".freeze
+
+    # A shorter reminder
+    REMINDER = "You're using `cinc`, the community distribution of chef"
+
+    # The name of this distro
+    DIST = "Cinc Infra".freeze
+
+    # I'm probably not doing this right o.O
+    module DistHelpers
+      # Intended to suppress the message where appropriate
+      def enterprise_distro?
+        DIST == 'Chef Infra'
+      end
+    end
+  end
+end

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -1,13 +1,13 @@
 require "chef/formatters/base"
 require "chef/config"
+require "chef/dist"
 
 class Chef
   module Formatters
-
     # Formatter similar to RSpec's documentation formatter. Uses indentation to
     # show context.
     class Doc < Formatters::Base
-
+      include Chef::Dist::DistHelpers
       attr_reader :start_time, :end_time
 
       cli_name(:doc)
@@ -79,6 +79,7 @@ class Chef
         else
           puts_line "Chef Client finished, #{@updated_resources}/#{total_resources} resources updated in #{pretty_elapsed_time}"
         end
+        puts_line Chef::Dist::DISCLAIMER unless enterprise_distro?
       end
 
       def run_failed(exception)
@@ -88,6 +89,8 @@ class Chef
         else
           puts_line "Chef Client failed. #{@updated_resources} resources updated in #{pretty_elapsed_time}"
         end
+        # intentionally omiting a disclaimer here
+        # to avoiding suggesting the run crashed due to distro
       end
 
       # Called right after ohai runs.


### PR DESCRIPTION
### Description

An alternate proposal for community distributions. This one doesn't line up with the current policy statement but does achieve the stated intention of the policy: to clearly distinguish Chef products from other distros. Mutually exclusive with https://github.com/chef/chef/pull/8341 (presumably)

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
