### PR TITLE
Add Debian 10 testing to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,11 +109,6 @@ matrix:
       TEST_GEM: chef/knife-windows
     script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake unit_spec
     rvm: 2.6.2
-  # disable this pending a Chef 14 compat version of poise
-  # - env:
-  #     TEST_GEM: poise/poise
-  #   script: bundle exec tasks/bin/run_external_test $TEST_GEM master rake spec
-  #   rvm: 2.6.2
   ### START TEST KITCHEN ONLY ###
   - rvm: 2.5.5
     services: docker
@@ -210,6 +205,22 @@ matrix:
       - cat .kitchen/logs/kitchen.log
     env:
       - DEBIAN=9
+      - KITCHEN_YAML=kitchen.travis.yml
+  - rvm: 2.5.5
+    services: docker
+    gemfile: kitchen-tests/Gemfile
+    before_install:
+      - gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
+      - gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
+    before_script:
+      - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+      - cd kitchen-tests
+    script:
+      - bundle exec kitchen test end-to-end-debian-10
+    after_failure:
+      - cat .kitchen/logs/kitchen.log
+    env:
+      - DEBIAN=10
       - KITCHEN_YAML=kitchen.travis.yml
   - rvm: 2.5.5
     services: docker

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -57,6 +57,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
+- name: debian-10
+  driver:
+    image: dokken/debian-10
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
 - name: centos-6
   driver:
     image: dokken/centos-6


### PR DESCRIPTION
We have a dokken box for Debian 10 now. We should integration test PRs against it.

Signed-off-by: Tim Smith <tsmith@chef.io>