### PR TITLE
Add Ruby 2.6 testing Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ configuration:
 environment:
   matrix:
     - ruby_version: "25-x64"
+    - ruby_version: "26-x64"
 
 clone_folder: c:\projects\chef
 clone_depth: 1


### PR DESCRIPTION
They have a ruby26 environment now. We should test with it.

Signed-off-by: Tim Smith <tsmith@chef.io>