### PR TITLE
Prevent accidentally configuring windows_service properties

### DIFF
--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -208,11 +208,6 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
       return
     end
 
-    # Until #6300 is solved this is required
-    if new_resource.run_as_user == new_resource.class.properties[:run_as_user].default
-      new_resource.run_as_user = new_resource.class.properties[:run_as_user].default
-    end
-
     converge_if_changed :service_type, :startup_type, :error_control,
                         :binary_path_name, :load_order_group, :dependencies,
                         :run_as_user, :display_name, :description do
@@ -400,16 +395,11 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
   end
 
   def converge_delayed_start
-    config = {}
-    config[:service_name]  = new_resource.service_name
-    config[:delayed_start] = new_resource.delayed_start ? 1 : 0
-
-    # Until #6300 is solved this is required
-    if new_resource.delayed_start == new_resource.class.properties[:delayed_start].default
-      new_resource.delayed_start = new_resource.class.properties[:delayed_start].default
-    end
-
     converge_if_changed :delayed_start do
+      config = {}
+      config[:service_name]  = new_resource.service_name
+      config[:delayed_start] = new_resource.delayed_start ? 1 : 0
+
       Win32::Service.configure(config)
     end
   end

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -354,13 +354,6 @@ describe Chef::Provider::Service::Windows, "load_current_resource", :windows_onl
         allow(Win32::Service).to receive(:configure).with(anything).and_return(true)
       end
 
-      it "works around #6300 if run_as_user is default" do
-        new_resource.run_as_user = new_resource.class.properties[:run_as_user].default
-        expect(provider.new_resource).to receive(:run_as_user=)
-          .with(new_resource.class.properties[:run_as_user].default)
-        provider.action_configure
-      end
-
       # properties that are Strings
       %i{binary_path_name load_order_group dependencies run_as_user
          display_name description}.each do |attr|
@@ -434,13 +427,6 @@ describe Chef::Provider::Service::Windows, "load_current_resource", :windows_onl
   describe Chef::Provider::Service::Windows, "converge_delayed_start" do
     before do
       allow(Win32::Service).to receive(:configure).and_return(true)
-    end
-
-    it "works around #6300 if delayed_start is default" do
-      new_resource.delayed_start = new_resource.class.properties[:delayed_start].default
-      expect(provider.new_resource).to receive(:delayed_start=)
-        .with(new_resource.class.properties[:delayed_start].default)
-      provider.send(:converge_delayed_start)
     end
 
     context "delayed start needs to be updated" do


### PR DESCRIPTION
### Description

As I refactored the `windows_service` resource there are a couple of assumptions that I made originally that turn out to be more harmful than good. i.e. Assuming that when a user removes the `run_as_user` or `delayed_start` properties that they want those property defaults to be enforced. More verbosely stated:

If a user originally has a resource defined as such:

```ruby
windows_service 'MyApp' do
  run_as_user 'MyAppsUser'
  run_as_password 'MyAppsUserPassword'
  startup_type :automatic
  delayed_start true
  action [:configure, :start]
end
```

And then the user updates the resource to:

```ruby
windows_service 'MyApp' do
  startup_type :automatic
  action [:configure, :start]
end
```

I think it's more harmful to assume the user wants to configure the service using `LocalSystem` as the `run_as_user` than it is to assume the user does not want to configure the `run_as_user` or `delayed_start` properties at all.

So this change in combination with clearer documentation should go a long way in providing an overall better user experience.

### Issues Resolved

Doesn't directly solve #8080, but it would be re-introduced if #8318 were to be merged in and users followed the directions of the deprecation.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG