### PR TITLE
Don't force DSC functional tests to PS4

### DIFF
--- a/spec/functional/resource/dsc_script_spec.rb
+++ b/spec/functional/resource/dsc_script_spec.rb
@@ -74,11 +74,11 @@ describe Chef::Resource::DscScript, :windows_powershell_dsc_only do
   let(:env_value2) { "value2" }
   let(:dsc_test_run_context) do
     node = Chef::Node.new
+    node.consume_external_attrs(OHAI_SYSTEM.data, {}) # node[:languages][:powershell][:version]
     node.automatic["os"] = "windows"
     node.automatic["platform"] = "windows"
     node.automatic["platform_version"] = "6.1"
     node.automatic["kernel"][:machine] = :x86_64 # Only 64-bit architecture is supported
-    node.automatic[:languages][:powershell][:version] = "4.0"
     empty_events = Chef::EventDispatch::Dispatcher.new
     Chef::RunContext.new(node, {}, empty_events)
   end


### PR DESCRIPTION
New Windows platforms like 2016 have Powershell 5.
