### PR TITLE
Add support for comment blocks to sysctl resource

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,38 @@ This file holds "in progress" release notes for the current release under develo
 # UNRELEASED (Chef 15)
 
 Chef 15 release notes will be added here as development progresses.
+### sysctl now accepts a comments parameter
+
+The sysctl resource has been updated to allow additional (optional) comments. Comments can be passed as an array or a string. Any comments provided are prefixed with '#' signs and precede the sysctl setting in generated files.
+
+An example:
+
+```
+sysctl 'vm.swappiness' do
+  value 10
+  comment [ 
+     "define how aggressively the kernel will swap memory pages.",
+     "Higher values will increase aggressiveness",
+     "lower values decrease the amount of swap.",
+     "A value of 0 instructs the kernel not to initiate swap",
+     "until the amount of free and file-backed pages is less",
+     "than the high water mark in a zone.",
+     "The default value is 60."
+    ]
+end
+```
+
+which results in `/etc/sysctl.d/99-chef-vw.swappiness.conf` as follows
+```
+# define how aggressively the kernel will swap memory pages.
+# Higher values will increase aggressiveness
+# lower values decrease the amount of swap.
+# A value of 0 instructs the kernel not to initiate swap
+# until the amount of free and file-backed pages is less
+# than the high water mark in a zone.
+# The default value is 60.
+vm.swappiness = 10
+```
 
 ## Breaking Changes
 

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -46,8 +46,7 @@ class Chef
                required: true
 
       property :comment, [Array, String],
-               description: "Optional comments, placed above the resource setting in the generated file."\
-                            " For multi-line comments, use an array of strings, one per line.",
+               description: "Optional comments, placed above the resource setting in the generated file. For multi-line comments, use an array of strings, one per line.",
                default: []
 
       property :conf_dir, String,

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -46,7 +46,8 @@ class Chef
                required: true
 
       property :comment, [Array, String],
-               description: "An optional comment to prepend the resource setting.",
+               description: "Optional comments, placed above the resource setting in the generated file."\
+                            " For multi-line comments, use an array of strings, one per line.",
                default: []
 
       property :conf_dir, String,

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -98,7 +98,6 @@ class Chef
 
           fcontent = comment_lines.join("\n")
 
-
           file "#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf" do
             content fcontent
           end


### PR DESCRIPTION
### Description
Adds support for comments in sysctl files under sysctl.d - permits sysctl settings to be documented/explained for troubleshooting (and informational) purposes.

The comment property is optional and accepts both Strings and Arrays (of strings). 

### Issues Resolved
N/A
### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X ] PR title is a worthy inclusion in the CHANGELOG