### PR TITLE
Add Chef::Dist to abstract branding details to a single location

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -26,6 +26,7 @@ require "fileutils"
 require "tempfile"
 require "chef/providers"
 require "chef/resources"
+require "chef/dist"
 
 class Chef::Application::Apply < Chef::Application
 
@@ -85,9 +86,9 @@ class Chef::Application::Apply < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show chef version",
+    description: "Show #{Chef::Dist::PRODUCT} version",
     boolean: true,
-    proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+    proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
 
   option :why_run,
@@ -98,7 +99,7 @@ class Chef::Application::Apply < Chef::Application
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire Chef run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
     boolean: true,
     default: false
 
@@ -110,7 +111,7 @@ class Chef::Application::Apply < Chef::Application
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins chef needs to function",
+    description: "Only run the bare minimum ohai plugins #{Chef::Dist::CLIENT} needs to function",
     boolean: true
 
   attr_reader :json_attribs

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -29,6 +29,7 @@ require "chef/mixin/shell_out"
 require "chef-config/mixin/dot_d"
 require "mixlib/archive"
 require "uri"
+require "chef/dist"
 
 class Chef::Application::Client < Chef::Application
   include Chef::Mixin::ShellOut
@@ -70,7 +71,7 @@ class Chef::Application::Client < Chef::Application
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire Chef run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
     boolean: true,
     default: false
 
@@ -125,7 +126,7 @@ class Chef::Application::Client < Chef::Application
   option :pid_file,
     short: "-P PID_FILE",
     long: "--pid PIDFILE",
-    description: "Set the PID file location, for the chef-client daemon process. Defaults to /tmp/chef-client.pid",
+    description: "Set the PID file location, for the #{Chef::Dist::CLIENT} daemon process. Defaults to /tmp/chef-client.pid",
     proc: nil
 
   option :lockfile,
@@ -136,12 +137,12 @@ class Chef::Application::Client < Chef::Application
   option :interval,
     short: "-i SECONDS",
     long: "--interval SECONDS",
-    description: "Run chef-client periodically, in seconds",
+    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds",
     proc: lambda { |s| s.to_i }
 
   option :once,
     long: "--once",
-    description: "Cancel any interval or splay options, run chef once and exit",
+    description: "Cancel any interval or splay options, run #{Chef::Dist::CLIENT} once and exit",
     boolean: true
 
   option :json_attribs,
@@ -165,7 +166,7 @@ class Chef::Application::Client < Chef::Application
   option :chef_server_url,
     short: "-S CHEFSERVERURL",
     long: "--server CHEFSERVERURL",
-    description: "The chef server URL",
+    description: "The #{Chef::Dist::PRODUCT} server URL",
     proc: nil
 
   option :validation_key,
@@ -188,14 +189,14 @@ class Chef::Application::Client < Chef::Application
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the Chef Environment on the node"
+    description: "Set the #{Chef::Dist::PRODUCT} Environment on the node"
 
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show chef version",
+    description: "Show #{Chef::Dist::PRODUCT} version",
     boolean: true,
-    proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+    proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
 
   option :override_runlist,
@@ -237,13 +238,13 @@ class Chef::Application::Client < Chef::Application
   option :enable_reporting,
     short: "-R",
     long: "--enable-reporting",
-    description: "Enable reporting data collection for chef runs",
+    description: "Enable reporting data collection for #{Chef::Dist::PRODUCT} runs",
     boolean: true
 
   option :local_mode,
     short: "-z",
     long: "--local-mode",
-    description: "Point chef-client at local repository",
+    description: "Point #{Chef::Dist::CLIENT} at local repository",
     boolean: true
 
   option :chef_zero_host,
@@ -268,13 +269,13 @@ class Chef::Application::Client < Chef::Application
     option :fatal_windows_admin_check,
       short: "-A",
       long: "--fatal-windows-admin-check",
-      description: "Fail the run when chef-client doesn't have administrator privileges on Windows",
+      description: "Fail the run when #{Chef::Dist::CLIENT} doesn't have administrator privileges on Windows",
       boolean: true
   end
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins chef needs to function",
+    description: "Only run the bare minimum ohai plugins #{Chef::Dist::CLIENT} needs to function",
     boolean: true
 
   option :listen,
@@ -328,7 +329,7 @@ class Chef::Application::Client < Chef::Application
 
     if Chef::Config[:recipe_url]
       if !Chef::Config.local_mode
-        Chef::Application.fatal!("chef-client recipe-url can be used only in local-mode")
+        Chef::Application.fatal!("recipe-url can be used only in local-mode")
       else
         if Chef::Config[:delete_entire_chef_repo]
           Chef::Log.trace "Cleanup path #{Chef::Config.chef_repo_path} before extract recipes into it"
@@ -419,7 +420,7 @@ class Chef::Application::Client < Chef::Application
   # Run the chef client, optionally daemonizing or looping at intervals.
   def run_application
     if Chef::Config[:version]
-      puts "Chef version: #{::Chef::VERSION}"
+      puts "#{Chef::Dist::PRODUCT} version: #{::Chef::VERSION}"
     end
 
     if !Chef::Config[:client_fork] || Chef::Config[:once]
@@ -440,7 +441,7 @@ class Chef::Application::Client < Chef::Application
 
   def interval_run_chef_client
     if Chef::Config[:daemonize]
-      Chef::Daemon.daemonize("chef-client")
+      Chef::Daemon.daemonize(Chef::DIST::CLIENT)
 
       # Start first daemonized run after configured number of seconds
       if Chef::Config[:daemonize].is_a?(Integer)
@@ -503,10 +504,10 @@ class Chef::Application::Client < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked chef-client interval runs are disabled in Chef 12." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in Chef 12." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
-      "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+      "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
   end
 
   def fetch_recipe_tarball(url, path)

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -441,7 +441,7 @@ class Chef::Application::Client < Chef::Application
 
   def interval_run_chef_client
     if Chef::Config[:daemonize]
-      Chef::Daemon.daemonize(Chef::DIST::CLIENT)
+      Chef::Daemon.daemonize(Chef::Dist::CLIENT)
 
       # Start first daemonized run after configured number of seconds
       if Chef::Config[:daemonize].is_a?(Integer)
@@ -504,7 +504,7 @@ class Chef::Application::Client < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in Chef 12." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -24,9 +24,9 @@ require "chef/dist"
 
 class Chef::Application::Knife < Chef::Application
 
-  NO_COMMAND_GIVEN = "You need to pass a sub-command (e.g., #{Chef::Dist::KNIFE} SUB-COMMAND)\n".freeze
+  NO_COMMAND_GIVEN = "You need to pass a sub-command (e.g., knife SUB-COMMAND)\n".freeze
 
-  banner "Usage: #{Chef::Dist::KNIFE} sub-command (options)"
+  banner "Usage: knife sub-command (options)"
 
   option :config_file,
     short: "-c CONFIG",
@@ -119,7 +119,7 @@ class Chef::Application::Knife < Chef::Application
   option :local_mode,
     short: "-z",
     long: "--local-mode",
-    description: "Point #{Chef::Dist::KNIFE} commands at local repository instead of server",
+    description: "Point knife commands at local repository instead of server",
     boolean: true
 
   option :chef_zero_host,

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -20,12 +20,13 @@ require "chef/application"
 require "mixlib/log"
 require "ohai/config"
 require "chef/monkey_patches/net_http.rb"
+require "chef/dist"
 
 class Chef::Application::Knife < Chef::Application
 
-  NO_COMMAND_GIVEN = "You need to pass a sub-command (e.g., knife SUB-COMMAND)\n".freeze
+  NO_COMMAND_GIVEN = "You need to pass a sub-command (e.g., #{Chef::Dist::KNIFE} SUB-COMMAND)\n".freeze
 
-  banner "Usage: knife sub-command (options)"
+  banner "Usage: #{Chef::Dist::KNIFE} sub-command (options)"
 
   option :config_file,
     short: "-c CONFIG",
@@ -58,7 +59,7 @@ class Chef::Application::Knife < Chef::Application
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the Chef environment (except for in searches, where this will be flagrantly ignored)"
+    description: "Set the #{Chef::Dist::PRODUCT} environment (except for in searches, where this will be flagrantly ignored)"
 
   option :editor,
     short: "-e EDITOR",
@@ -94,7 +95,7 @@ class Chef::Application::Knife < Chef::Application
   option :chef_server_url,
     short: "-s URL",
     long: "--server-url URL",
-    description: "Chef Server URL"
+    description: "#{Chef::Dist::PRODUCT} Server URL"
 
   option :yes,
     short: "-y",
@@ -118,7 +119,7 @@ class Chef::Application::Knife < Chef::Application
   option :local_mode,
     short: "-z",
     long: "--local-mode",
-    description: "Point knife commands at local repository instead of server",
+    description: "Point #{Chef::Dist::KNIFE} commands at local repository instead of server",
     boolean: true
 
   option :chef_zero_host,
@@ -137,9 +138,9 @@ class Chef::Application::Knife < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show chef version",
+    description: "Show #{Chef::Dist::PRODUCT} version",
     boolean: true,
-    proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+    proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
 
   option :fips,

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -29,6 +29,7 @@ require "chef/mixin/shell_out"
 require "pathname"
 require "chef-config/mixin/dot_d"
 require "mixlib/archive"
+require "chef/dist"
 
 class Chef::Application::Solo < Chef::Application
   include Chef::Mixin::ShellOut
@@ -68,7 +69,7 @@ class Chef::Application::Solo < Chef::Application
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire Chef run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
     boolean: true,
     default: false
 
@@ -127,7 +128,7 @@ class Chef::Application::Solo < Chef::Application
   option :interval,
     short: "-i SECONDS",
     long: "--interval SECONDS",
-    description: "Run chef-client periodically, in seconds",
+    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds",
     proc: lambda { |s| s.to_i }
 
   option :json_attribs,
@@ -156,9 +157,9 @@ class Chef::Application::Solo < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show chef version",
+    description: "Show #{Chef::Dist::EXEC} version",
     boolean: true,
-    proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+    proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
 
   option :override_runlist,
@@ -191,7 +192,7 @@ class Chef::Application::Solo < Chef::Application
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the Chef Environment on the node"
+    description: "Set the #{Chef::Dist::PRODUCT} Environment on the node"
 
   option :run_lock_timeout,
     long: "--run-lock-timeout SECONDS",
@@ -200,7 +201,7 @@ class Chef::Application::Solo < Chef::Application
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins chef needs to function",
+    description: "Only run the bare minimum ohai plugins #{Chef::Dist::PRODUCT} needs to function",
     boolean: true
 
   option :delete_entire_chef_repo,
@@ -365,9 +366,9 @@ class Chef::Application::Solo < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked chef-client interval runs are disabled in Chef 12." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
-      "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+      "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
   end
 end

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -121,7 +121,7 @@ class Chef
 
       def service_stop
         run_warning_displayed = false
-        Chef::Log.info("STOP requeschefm.")
+        Chef::Log.info("STOP request from operating system.")
         loop do
           # See if a run is in flight
           if @service_action_mutex.try_lock

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -131,7 +131,7 @@ class Chef
             break
           else
             unless run_warning_displayed
-              Chef::Log.info("Currently a #{Chef::Dist::GENERIC} run is happening on this system.")
+              Chef::Log.info("Currently a #{Chef::Dist::PRODUCT} run is happening on this system.")
               Chef::Log.info("Service will stop when run is completed.")
               run_warning_displayed = true
             end

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -29,6 +29,7 @@ require "socket"
 require "uri"
 require "win32/daemon"
 require "chef/mixin/shell_out"
+require "chef/dist"
 
 class Chef
   class Application
@@ -66,7 +67,7 @@ class Chef
         @service_signal = ConditionVariable.new
 
         reconfigure
-        Chef::Log.info("Chef Client Service initialized")
+        Chef::Log.info("#{Chef::Dist::CLIENT} Service initialized")
       end
 
       def service_main(*startup_parameters)
@@ -78,7 +79,7 @@ class Chef
           # Grab the service_action_mutex to make a chef-client run
           @service_action_mutex.synchronize do
             begin
-              Chef::Log.info("Next chef-client run will happen in #{timeout} seconds")
+              Chef::Log.info("Next #{Chef::Dist::CLIENT} run will happen in #{timeout} seconds")
               @service_signal.wait(@service_action_mutex, timeout)
 
               # Continue only if service is RUNNING
@@ -95,7 +96,7 @@ class Chef
               # run chef-client only if service is in RUNNING state
               next if state != RUNNING
 
-              Chef::Log.info("Chef-Client service is starting a chef-client run...")
+              Chef::Log.info("#{Chef::Dist::CLIENT} service is starting a #{Chef::Dist::CLIENT} run...")
               run_chef_client
             rescue SystemExit => e
               # Do not raise any of the errors here in order to
@@ -120,7 +121,7 @@ class Chef
 
       def service_stop
         run_warning_displayed = false
-        Chef::Log.info("STOP request from operating system.")
+        Chef::Log.info("STOP requeschefm.")
         loop do
           # See if a run is in flight
           if @service_action_mutex.try_lock
@@ -130,12 +131,12 @@ class Chef
             break
           else
             unless run_warning_displayed
-              Chef::Log.info("Currently a chef run is happening on this system.")
-              Chef::Log.info("Service  will stop when run is completed.")
+              Chef::Log.info("Currently a #{Chef::Dist::GENERIC} run is happening on this system.")
+              Chef::Log.info("Service will stop when run is completed.")
               run_warning_displayed = true
             end
 
-            Chef::Log.trace("Waiting for chef-client run...")
+            Chef::Log.trace("Waiting for #{Chef::Dist::CLIENT} run...")
             sleep 1
           end
         end
@@ -149,7 +150,7 @@ class Chef
         # since this is a PAUSE signal.
 
         if @service_action_mutex.locked?
-          Chef::Log.info("Currently a chef-client run is happening.")
+          Chef::Log.info("Currently a #{Chef::Dist::CLIENT} run is happening.")
           Chef::Log.info("Service will pause once it's completed.")
         else
           Chef::Log.info("Service is pausing....")
@@ -184,7 +185,7 @@ class Chef
         # The log_location and config_file of the parent process is passed to the new chef-client process.
         # We need to add the --no-fork, as by default it is set to fork=true.
 
-        Chef::Log.info "Starting chef-client in a new process"
+        Chef::Log.info "Starting #{Chef::Dist::CLIENT} in a new process"
         # Pass config params to the new process
         config_params = " --no-fork"
         config_params += " -c #{Chef::Config[:config_file]}" unless Chef::Config[:config_file].nil?
@@ -196,20 +197,20 @@ class Chef
         # Starts a new process and waits till the process exits
 
         result = shell_out(
-          "chef-client.bat #{config_params}",
+          "#{Chef::Dist::CLIENT}.bat #{config_params}",
           timeout: Chef::Config[:windows_service][:watchdog_timeout],
           logger: Chef::Log
         )
         Chef::Log.trace (result.stdout).to_s
         Chef::Log.trace (result.stderr).to_s
       rescue Mixlib::ShellOut::CommandTimeout => e
-        Chef::Log.error "chef-client timed out\n(#{e})"
+        Chef::Log.error "#{Chef::Dist::CLIENT} timed out\n(#{e})"
         Chef::Log.error(<<-EOF)
-            Your chef-client run timed out. You can increase the time chef-client is given
+            Your #{Chef::Dist::CLIENT} run timed out. You can increase the time #{Chef::Dist::CLIENT} is given
             to complete by configuring windows_service.watchdog_timeout in your client.rb.
         EOF
       rescue Mixlib::ShellOut::ShellCommandFailed => e
-        Chef::Log.warn "Not able to start chef-client in new process (#{e})"
+        Chef::Log.warn "Not able to start #{Chef::Dist::CLIENT} in new process (#{e})"
       rescue => e
         Chef::Log.error e
       ensure

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -54,6 +54,7 @@ require "chef/platform/rebooter"
 require "chef/mixin/deprecation"
 require "ohai"
 require "rbconfig"
+require "chef/dist"
 
 class Chef
   # == Chef::Client
@@ -240,10 +241,10 @@ class Chef
 
         events.run_start(Chef::VERSION, run_status)
 
-        logger.info("*** Chef #{Chef::VERSION} ***")
+        logger.info("*** #{Chef::Dist::PRODUCT} #{Chef::VERSION} ***")
         logger.info("Platform: #{RUBY_PLATFORM}")
-        logger.info "Chef-client pid: #{Process.pid}"
-        logger.debug("Chef-client request_id: #{request_id}")
+        logger.info "#{Chef::Dist::CLIENT.capitalize} pid: #{Process.pid}"
+        logger.debug("#{Chef::Dist::CLIENT.capitalize} request_id: #{request_id}")
         enforce_path_sanity
         run_ohai
 
@@ -262,7 +263,7 @@ class Chef
         build_node
 
         run_status.start_clock
-        logger.info("Starting Chef Run for #{node.name}")
+        logger.info("Starting #{Chef::Dist::PRODUCT} Run for #{node.name}")
         run_started
 
         do_windows_admin_check
@@ -277,7 +278,7 @@ class Chef
         converge_and_save(run_context)
 
         run_status.stop_clock
-        logger.info("Chef Run complete in #{run_status.elapsed_time} seconds")
+        logger.info("#{Chef::Dist::PRODUCT} Run complete in #{run_status.elapsed_time} seconds")
         run_completed_successfully
         events.run_completed(node, run_status)
 
@@ -715,7 +716,7 @@ class Chef
         logger.trace("Checking for administrator privileges....")
 
         if !has_admin_privileges?
-          message = "chef-client doesn't have administrator privileges on node #{node_name}."
+          message = "#{Chef::Dist::CLIENT} doesn't have administrator privileges on node #{node_name}."
           if Chef::Config[:fatal_windows_admin_check]
             logger.fatal(message)
             logger.fatal("fatal_windows_admin_check is set to TRUE.")
@@ -724,7 +725,7 @@ class Chef
             logger.warn("#{message} This might cause unexpected resource failures.")
           end
         else
-          logger.trace("chef-client has administrator privileges on node #{node_name}.")
+          logger.trace("#{Chef::Dist::CLIENT} has administrator privileges on node #{node_name}.")
         end
       end
     end

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -6,9 +6,6 @@ class Chef
     # The client's alias (chef-client)
     CLIENT = "chef-client".freeze
 
-    # the server tool's name (knife)
-    KNIFE = "knife".freeze
-
     # Name used for certain directories. Merge with chef_executable?
     GENERIC = "chef".freeze
 

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -1,13 +1,11 @@
 class Chef
   class Dist
+    # This class is not fully implemented, depending on it is not recommended!
     # When referencing a product directly, like Chef (Now Chef Infra)
     PRODUCT = "Chef Infra".freeze
 
     # The client's alias (chef-client)
     CLIENT = "chef-client".freeze
-
-    # Name used for certain directories. Merge with chef_executable?
-    GENERIC = "chef".freeze
 
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
     EXEC = "chef".freeze

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -1,0 +1,21 @@
+class Chef
+  class Dist
+    # When referencing a product directly, like Chef (Now Chef Infra)
+    PRODUCT = "Chef Infra".freeze
+
+    # The client's alias (chef-client)
+    CLIENT = "chef-client".freeze
+
+    # the server tool's name (knife)
+    KNIFE = "knife".freeze
+
+    # Name used for certain directories. Merge with chef_executable?
+    GENERIC = "chef".freeze
+
+    # The chef executable, as in `chef gem install` or `chef generate cookbook`
+    EXEC = "chef".freeze
+
+    # product website address
+    WEBSITE = "https://chef.io".freeze
+  end
+end

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -22,6 +22,7 @@
 #
 require "uri"
 require "net/http"
+require "chef/dist"
 
 # To load faster, we only want ohai's version string.
 # However, in ohai before 0.6.0, the version is defined
@@ -40,8 +41,8 @@ class Chef
 
       engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : "ruby"
 
-      UA_COMMON = "/#{::Chef::VERSION} (#{engine}-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}; ohai-#{Ohai::VERSION}; #{RUBY_PLATFORM}; +https://chef.io)".freeze
-      DEFAULT_UA = "Chef Client" << UA_COMMON
+      UA_COMMON = "/#{::Chef::VERSION} (#{engine}-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}; ohai-#{Ohai::VERSION}; #{RUBY_PLATFORM}; +#{Chef::Dist::WEBSITE})".freeze
+      DEFAULT_UA = "#{Chef::Dist::PRODUCT} Client" << UA_COMMON
 
       USER_AGENT = "User-Agent".freeze
 

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -42,7 +42,7 @@ class Chef
       engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : "ruby"
 
       UA_COMMON = "/#{::Chef::VERSION} (#{engine}-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}; ohai-#{Ohai::VERSION}; #{RUBY_PLATFORM}; +#{Chef::Dist::WEBSITE})".freeze
-      DEFAULT_UA = "#{Chef::Dist::PRODUCT} Client" << UA_COMMON
+      DEFAULT_UA = "Chef Client" << UA_COMMON
 
       USER_AGENT = "User-Agent".freeze
 

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -36,7 +36,7 @@ require "chef/dist"
 class Chef
   class Knife
 
-    Chef::HTTP::HTTPRequest.user_agent = "#{Chef::Dist::PRODUCT} #{Chef::Dist::KNIFE} #{Chef::HTTP::HTTPRequest::UA_COMMON}"
+    Chef::HTTP::HTTPRequest.user_agent = "#{Chef::Dist::PRODUCT} Knife#{Chef::HTTP::HTTPRequest::UA_COMMON}"
 
     include Mixlib::CLI
     include Chef::Mixin::PathSanity
@@ -183,7 +183,7 @@ class Chef
       config_loader.profile = profile
       config_loader.load
 
-      ui.warn("No config.rb (formerly #{Chef::Dist::KNIFE}.rb) configuration file found. See https://docs.chef.io/config_rb_knife.html for details.") if config_loader.no_config_found?
+      ui.warn("No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.") if config_loader.no_config_found?
 
       config_loader
     rescue Exceptions::ConfigurationError => e
@@ -240,7 +240,7 @@ class Chef
     class << self
       def list_commands(preferred_category = nil)
         category_desc = preferred_category ? preferred_category + " " : ""
-        msg "Available #{category_desc}subcommands: (for details, #{Chef::Dist::KNIFE} SUB-COMMAND --help)\n\n"
+        msg "Available #{category_desc}subcommands: (for details, knife SUB-COMMAND --help)\n\n"
         subcommand_loader.list_commands(preferred_category).sort.each do |category, commands|
           next if category =~ /deprecated/i
           msg "** #{category.upcase} COMMANDS **"
@@ -267,7 +267,7 @@ class Chef
 
         # Mention rehash when the subcommands cache(plugin_manifest.json) is used
         if subcommand_loader.is_a?(Chef::Knife::SubcommandLoader::HashedCommandLoader)
-          ui.info("If this is a recently installed plugin, please run '#{Chef::Dist::KNIFE} rehash' to update the subcommands cache.")
+          ui.info("If this is a recently installed plugin, please run 'knife rehash' to update the subcommands cache.")
         end
 
         if category_commands = guess_category(args)
@@ -439,7 +439,7 @@ class Chef
 
     def run_with_pretty_exceptions(raise_exception = false)
       unless respond_to?(:run)
-        ui.error "You need to add a #run method to your #{Chef::Dist::KNIFE} command before you can use it"
+        ui.error "You need to add a #run method to your knife command before you can use it"
       end
       enforce_path_sanity
       maybe_setup_fips
@@ -460,17 +460,17 @@ class Chef
         humanize_http_exception(e)
       when OpenSSL::SSL::SSLError
         ui.error "Could not establish a secure connection to the server."
-        ui.info "Use `#{Chef::Dist::KNIFE} ssl check` to troubleshoot your SSL configuration."
+        ui.info "Use `knife ssl check` to troubleshoot your SSL configuration."
         ui.info "If your #{Chef::Dist::PRODUCT} Server uses a self-signed certificate, you can use"
-        ui.info "`#{Chef::Dist::KNIFE} ssl fetch` to make #{Chef::Dist::KNIFE} trust the server's certificates."
+        ui.info "`knife ssl fetch` to make knife trust the server's certificates."
         ui.info ""
         ui.info  "Original Exception: #{e.class.name}: #{e.message}"
       when Errno::ECONNREFUSED, Timeout::Error, Errno::ETIMEDOUT, SocketError
         ui.error "Network Error: #{e.message}"
-        ui.info "Check your #{Chef::Dist::KNIFE} configuration and network settings"
+        ui.info "Check your knife configuration and network settings"
       when NameError, NoMethodError
-        ui.error "#{Chef::Dist::KNIFE} encountered an unexpected error"
-        ui.info  "This may be a bug in the '#{self.class.common_name}' #{Chef::Dist::KNIFE} command or plugin"
+        ui.error "knife encountered an unexpected error"
+        ui.info  "This may be a bug in the '#{self.class.common_name}' knife command or plugin"
         ui.info  "Please collect the output of this command with the `-VVV` option before filing a bug report."
         ui.info  "Exception: #{e.class.name}: #{e.message}"
       when Chef::Exceptions::PrivateKeyMissing
@@ -478,7 +478,7 @@ class Chef
         ui.info  "Check your configuration file and ensure that your private key is readable"
       when Chef::Exceptions::InvalidRedirect
         ui.error "Invalid Redirect: #{e.message}"
-        ui.info  "Change your server location in config.rb (formerly #{Chef::Dist::KNIFE}.rb) to the server's FQDN to avoid unwanted redirections."
+        ui.info  "Change your server location in knife.rb to the server's FQDN to avoid unwanted redirections."
       else
         ui.error "#{e.class.name}: #{e.message}"
       end
@@ -517,8 +517,8 @@ class Chef
         client_api_version = version_header["request_version"]
         min_server_version = version_header["min_version"]
         max_server_version = version_header["max_version"]
-        ui.error "The version of #{Chef::Dist::PRODUCT} that #{Chef::Dist::KNIFE} is using is not supported by the #{Chef::Dist::PRODUCT} server you sent this request to"
-        ui.info "The request that #{Chef::Dist::KNIFE} sent was using API version #{client_api_version}"
+        ui.error "The version of #{Chef::Dist::PRODUCT} that Knife is using is not supported by the #{Chef::Dist::PRODUCT} server you sent this request to"
+        ui.info "The request that Knife sent was using API version #{client_api_version}"
         ui.info "The #{Chef::Dist::PRODUCT} server you sent the request to supports a min API verson of #{min_server_version} and a max API version of #{max_server_version}"
         ui.info "Please either update your #{Chef::Dist::PRODUCT} client or server to be a compatible set"
       else

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -173,7 +173,7 @@ do_download() {
 <% else %>
   install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://omnitruck.chef.io/chef/install.sh" %>"
   if test -f /usr/bin/chef-client; then
-    echo "-----> Existing Chef installation detected"
+    echo "-----> Existing <%= Chef::Dist::PRODUCT %> installation detected"
   else
     echo "-----> Installing Chef Omnibus (<%= latest_current_chef_version_string %>)"
     do_download ${install_sh} $tmp_dir/install.sh
@@ -237,6 +237,6 @@ mkdir -p /etc/chef/client.d
 <%= client_d %>
 <% end -%>
 
-echo "Starting the first Chef Client run..."
+echo "Starting the first <%= Chef::Dist::PRODUCT %> Client run..."
 
 <%= start_chef %>'

--- a/lib/chef/run_lock.rb
+++ b/lib/chef/run_lock.rb
@@ -23,6 +23,7 @@ end
 require "chef/config"
 require "chef/exceptions"
 require "timeout"
+require "chef/dist"
 
 class Chef
 
@@ -95,7 +96,7 @@ class Chef
     # Waits until acquiring the system-wide lock.
     #
     def wait
-      Chef::Log.warn("Chef client #{runpid} is running, will wait for it to finish and then run.")
+      Chef::Log.warn("#{Chef::Dist::PRODUCT} client #{runpid} is running, will wait for it to finish and then run.")
       if Chef::Platform.windows?
         mutex.wait
       else

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -25,6 +25,7 @@ require "chef/version"
 require "chef/client"
 require "chef/config"
 require "chef/config_fetcher"
+require "chef/dist"
 
 require "chef/shell/shell_session"
 require "chef/workstation_config_loader"
@@ -253,7 +254,7 @@ module Shell
     option :client,
       short: "-z",
       long: "--client",
-      description: "chef-client session",
+      description: "#{Chef::Dist::CLIENT} session",
       boolean: true
 
     option :solo_legacy_shell,
@@ -271,15 +272,15 @@ module Shell
     option :chef_server_url,
       short: "-S CHEFSERVERURL",
       long: "--server CHEFSERVERURL",
-      description: "The chef server URL",
+      description: "The #{Chef::Dist::PRODUCT} server URL",
       proc: nil
 
     option :version,
       short: "-v",
       long: "--version",
-      description: "Show chef version",
+      description: "Show #{Chef::Dist::PRODUCT} version",
       boolean: true,
-      proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+      proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
       exit: 0
 
     option :override_runlist,

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -28,7 +28,7 @@ describe "Chef Versions" do
 
   binaries.each do |binary|
     it "#{binary} version should be sane" do
-      expect(shell_out!("ruby #{File.join("bin", binary)} -v", cwd: chef_dir).stdout.chomp).to include("Chef: #{Chef::VERSION}")
+      expect(shell_out!("ruby #{File.join("bin", binary)} -v", cwd: chef_dir).stdout.chomp).to include("#{Chef::Dist::PRODUCT}: #{Chef::VERSION}")
     end
   end
 

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -28,7 +28,7 @@ describe "Chef Versions" do
 
   binaries.each do |binary|
     it "#{binary} version should be sane" do
-      expect(shell_out!("ruby #{File.join("bin", binary)} -v", cwd: chef_dir).stdout.chomp).to include("#{Chef::Dist::PRODUCT}: #{Chef::VERSION}")
+      expect(shell_out!("ruby #{File.join("bin", binary)} -v", cwd: chef_dir).stdout.chomp).to match(/.*: #{Chef::VERSION}/)
     end
   end
 

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -163,7 +163,7 @@ describe "chef-solo" do
         ruby_block "sleeping" do
           block do
             retries = 200
-            while IO.read(Chef::Config[:log_location]) !~ /Chef client .* is running, will wait for it to finish and then run./
+            while IO.read(Chef::Config[:log_location]) !~ /#{Chef::Dist::PRODUCT} client .* is running, will wait for it to finish and then run./
               sleep 0.1
               raise "we ran out of retries" if ( retries -= 1 ) <= 0
             end
@@ -207,10 +207,10 @@ describe "chef-solo" do
       run_log = File.read(path_to("logs/runs.log"))
 
       # second run should have a message which indicates it's waiting for the first run
-      expect(run_log).to match(/Chef client .* is running, will wait for it to finish and then run./)
+      expect(run_log).to match(/#{Chef::Dist::PRODUCT} client .* is running, will wait for it to finish and then run./)
 
       # both of the runs should succeed
-      expect(run_log.lines.reject { |l| !l.include? "INFO: Chef Run complete in" }.length).to eq(2)
+      expect(run_log.lines.reject { |l| !l.include? "INFO: #{Chef::Dist::PRODUCT} Run complete in" }.length).to eq(2)
     end
 
   end

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -163,7 +163,7 @@ describe "chef-solo" do
         ruby_block "sleeping" do
           block do
             retries = 200
-            while IO.read(Chef::Config[:log_location]) !~ /#{Chef::Dist::PRODUCT} client .* is running, will wait for it to finish and then run./
+            while IO.read(Chef::Config[:log_location]) !~ /.* client .* is running, will wait for it to finish and then run./
               sleep 0.1
               raise "we ran out of retries" if ( retries -= 1 ) <= 0
             end
@@ -207,10 +207,10 @@ describe "chef-solo" do
       run_log = File.read(path_to("logs/runs.log"))
 
       # second run should have a message which indicates it's waiting for the first run
-      expect(run_log).to match(/#{Chef::Dist::PRODUCT} client .* is running, will wait for it to finish and then run./)
+      expect(run_log).to match(/.* client .* is running, will wait for it to finish and then run./)
 
       # both of the runs should succeed
-      expect(run_log.lines.reject { |l| !l.include? "INFO: #{Chef::Dist::PRODUCT} Run complete in" }.length).to eq(2)
+      expect(run_log.lines.reject { |l| !l.include? "Run complete in" }.length).to eq(2)
     end
 
   end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -226,7 +226,7 @@ describe Chef::Application::Client, "reconfigure" do
 
       context "local mode not set" do
         it "fails with a message stating local mode required" do
-          expect(Chef::Application).to receive(:fatal!).with("chef-client recipe-url can be used only in local-mode").and_raise("error occured")
+          expect(Chef::Application).to receive(:fatal!).with("recipe-url can be used only in local-mode").and_raise("error occured")
           ARGV.replace(["--recipe-url=test_url"])
           expect { app.reconfigure }.to raise_error "error occured"
         end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -1,4 +1,4 @@
-#
+
 # Author:: AJ Christensen (<aj@junglist.gen.nz>)
 # Copyright:: Copyright 2008-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -326,10 +326,10 @@ describe Chef::Application::Client, "reconfigure" do
       Chef::Config[:interval] = 600
       allow(ChefConfig).to receive(:windows?).and_return(false)
       expect(Chef::Application).to receive(:fatal!).with(
-        "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12.
+        /Unforked .* interval runs are disabled in .* 12\.
 Configuration settings:
   interval  = 600 seconds
-Enable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable .* interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options\./
       )
       app.reconfigure
     end

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -326,10 +326,10 @@ describe Chef::Application::Client, "reconfigure" do
       Chef::Config[:interval] = 600
       allow(ChefConfig).to receive(:windows?).and_return(false)
       expect(Chef::Application).to receive(:fatal!).with(
-        "Unforked chef-client interval runs are disabled in Chef 12.
+        "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
       )
       app.reconfigure
     end

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -64,10 +64,10 @@ describe Chef::Application::Solo do
 
           it "should terminate with message" do
             expect(Chef::Application).to receive(:fatal!).with(
-              "Unforked chef-client interval runs are disabled in Chef 12.
+              "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12.
 Configuration settings:
   interval  = 600 seconds
-Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
             )
             app.reconfigure
           end

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -64,10 +64,10 @@ describe Chef::Application::Solo do
 
           it "should terminate with message" do
             expect(Chef::Application).to receive(:fatal!).with(
-              "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12.
+              /Unforked .* interval runs are disabled in .* 12\.
 Configuration settings:
   interval  = 600 seconds
-Enable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
+Enable .* interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options\./
             )
             app.reconfigure
           end

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -458,7 +458,7 @@ describe Chef::Knife do
         allow(knife).to receive(:username).and_return("sadpanda")
         knife.run_with_pretty_exceptions
         expect(stderr.string).to match(%r{ERROR: You authenticated successfully to http.+ as sadpanda but you are not authorized for this action})
-        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your #{Chef::Dist::PRODUCT} server may need to be added to NO_PROXY.})
+        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your .* server may need to be added to NO_PROXY.})
         expect(stderr.string).to match(%r{Response:  y u no administrator})
       end
     end
@@ -494,9 +494,9 @@ describe Chef::Knife do
       allow(knife).to receive(:run).and_raise(Net::HTTPClientException.new("406 Not Acceptable", response))
 
       knife.run_with_pretty_exceptions
-      expect(stderr.string).to include("The request that #{Chef::Dist::KNIFE} sent was using API version 10000000")
-      expect(stderr.string).to include("The #{Chef::Dist::PRODUCT} server you sent the request to supports a min API verson of 0 and a max API version of 1")
-      expect(stderr.string).to include("Please either update your #{Chef::Dist::PRODUCT} client or server to be a compatible set")
+      expect(stderr.string).to match(/The request that .* sent was using API version 10000000/)
+      expect(stderr.string).to match(/The .* server you sent the request to supports a min API verson of 0 and a max API version of 1/)
+      expect(stderr.string).to match(/Please either update your .* client or server to be a compatible set/)
     end
 
     it "formats 500s nicely" do
@@ -542,8 +542,8 @@ describe Chef::Knife do
     it "formats NameError and NoMethodError nicely" do
       allow(knife).to receive(:run).and_raise(NameError.new("Undefined constant FUUU"))
       knife.run_with_pretty_exceptions
-      expect(stderr.string).to match(%r{ERROR: #{Chef::Dist::KNIFE} encountered an unexpected error})
-      expect(stderr.string).to match(%r{This may be a bug in the 'knife' #{Chef::Dist::KNIFE} command or plugin})
+      expect(stderr.string).to match(%r{ERROR: .* encountered an unexpected error})
+      expect(stderr.string).to match(%r{This may be a bug in the 'knife' .* command or plugin})
       expect(stderr.string).to match(%r{Exception: NameError: Undefined constant FUUU})
     end
 
@@ -562,7 +562,7 @@ describe Chef::Knife do
       # *nix = Errno::ECONNREFUSED: Connection refused
       # win32: Errno::ECONNREFUSED: No connection could be made because the target machine actively refused it.
       expect(stderr.string).to match(%r{ERROR: Network Error: .* - y u no shut up})
-      expect(stderr.string).to match(%r{Check your #{Chef::Dist::KNIFE} configuration and network settings})
+      expect(stderr.string).to match(%r{Check your .* configuration and network settings})
     end
 
     it "formats SSL errors nicely and suggests to use `knife ssl check` and `knife ssl fetch`" do
@@ -573,11 +573,11 @@ describe Chef::Knife do
 
       expected_message = <<~MSG
         ERROR: Could not establish a secure connection to the server.
-        Use `#{Chef::Dist::KNIFE} ssl check` to troubleshoot your SSL configuration.
-        If your #{Chef::Dist::PRODUCT} Server uses a self-signed certificate, you can use
-        `#{Chef::Dist::KNIFE} ssl fetch` to make #{Chef::Dist::KNIFE} trust the server's certificates.
+        Use `.* ssl check` to troubleshoot your SSL configuration.
+        If your .* Server uses a self-signed certificate, you can use
+        `.* ssl fetch` to make .* trust the server's certificates.
       MSG
-      expect(stderr.string).to include(expected_message)
+      expect(stderr.string).to match(expected_message)
     end
 
   end

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -458,7 +458,7 @@ describe Chef::Knife do
         allow(knife).to receive(:username).and_return("sadpanda")
         knife.run_with_pretty_exceptions
         expect(stderr.string).to match(%r{ERROR: You authenticated successfully to http.+ as sadpanda but you are not authorized for this action})
-        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your Chef server may need to be added to NO_PROXY.})
+        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your #{Chef::Dist::PRODUCT} server may need to be added to NO_PROXY.})
         expect(stderr.string).to match(%r{Response:  y u no administrator})
       end
     end
@@ -494,9 +494,9 @@ describe Chef::Knife do
       allow(knife).to receive(:run).and_raise(Net::HTTPClientException.new("406 Not Acceptable", response))
 
       knife.run_with_pretty_exceptions
-      expect(stderr.string).to include("The request that Knife sent was using API version 10000000")
-      expect(stderr.string).to include("The Chef server you sent the request to supports a min API verson of 0 and a max API version of 1")
-      expect(stderr.string).to include("Please either update your Chef client or server to be a compatible set")
+      expect(stderr.string).to include("The request that #{Chef::Dist::KNIFE} sent was using API version 10000000")
+      expect(stderr.string).to include("The #{Chef::Dist::PRODUCT} server you sent the request to supports a min API verson of 0 and a max API version of 1")
+      expect(stderr.string).to include("Please either update your #{Chef::Dist::PRODUCT} client or server to be a compatible set")
     end
 
     it "formats 500s nicely" do
@@ -542,8 +542,8 @@ describe Chef::Knife do
     it "formats NameError and NoMethodError nicely" do
       allow(knife).to receive(:run).and_raise(NameError.new("Undefined constant FUUU"))
       knife.run_with_pretty_exceptions
-      expect(stderr.string).to match(%r{ERROR: knife encountered an unexpected error})
-      expect(stderr.string).to match(%r{This may be a bug in the 'knife' knife command or plugin})
+      expect(stderr.string).to match(%r{ERROR: #{Chef::Dist::KNIFE} encountered an unexpected error})
+      expect(stderr.string).to match(%r{This may be a bug in the 'knife' #{Chef::Dist::KNIFE} command or plugin})
       expect(stderr.string).to match(%r{Exception: NameError: Undefined constant FUUU})
     end
 
@@ -562,7 +562,7 @@ describe Chef::Knife do
       # *nix = Errno::ECONNREFUSED: Connection refused
       # win32: Errno::ECONNREFUSED: No connection could be made because the target machine actively refused it.
       expect(stderr.string).to match(%r{ERROR: Network Error: .* - y u no shut up})
-      expect(stderr.string).to match(%r{Check your knife configuration and network settings})
+      expect(stderr.string).to match(%r{Check your #{Chef::Dist::KNIFE} configuration and network settings})
     end
 
     it "formats SSL errors nicely and suggests to use `knife ssl check` and `knife ssl fetch`" do
@@ -573,9 +573,9 @@ describe Chef::Knife do
 
       expected_message = <<~MSG
         ERROR: Could not establish a secure connection to the server.
-        Use `knife ssl check` to troubleshoot your SSL configuration.
-        If your Chef Server uses a self-signed certificate, you can use
-        `knife ssl fetch` to make knife trust the server's certificates.
+        Use `#{Chef::Dist::KNIFE} ssl check` to troubleshoot your SSL configuration.
+        If your #{Chef::Dist::PRODUCT} Server uses a self-signed certificate, you can use
+        `#{Chef::Dist::KNIFE} ssl fetch` to make #{Chef::Dist::KNIFE} trust the server's certificates.
       MSG
       expect(stderr.string).to include(expected_message)
     end


### PR DESCRIPTION
### Description
This PR replaces https://github.com/chef/chef/pull/8341 , same stuff, updated with latest information regarding Chef's trademark policy, and moved to a new github org to make collaboration easier.

first steps towards allowing multiple distros of Chef in compliance with the Trademark policy

### Issues Resolved

first steps towards https://github.com/chef/chef/issues/8376

Presented as a user story, it could be defined as "As a Chef community member, I would like to create an OSS `chef-client` distribution in compliance with Chef (the company)'s Trademark policy in a simple, automatable and manageable way. The distribution should be a drop-in replacement for `chef-client`"

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG