### PR TITLE
Add ed25519 deps, bump highline and net-ssh pins and pull inspec from git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "inspec-core", git: "https://github.com/inspec/inspec.git", branch: "master"
-  gem "train-core", git: "https://github.com/inspec/train.git", branch: "ed25519"
+  gem "train-core", git: "https://github.com/inspec/train.git", branch: "master"
   gem "chef-vault"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem "cheffish", "~> 14"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core", git: "https://github.com/chef/inspec.git", branch: "master"
+  gem "inspec-core", git: "https://github.com/inspec/inspec.git", branch: "master"
+  gem "train-core", git: "https://github.com/inspec/train.git", branch: "ed25519"
   gem "chef-vault"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "cheffish", "~> 14"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core", "~> 3"
+  gem "inspec-core", git: "https://github.com/chef/inspec.git", branch: "master"
   gem "chef-vault"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    appbundler (0.12.0)
+    appbundler (0.12.3)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
@@ -188,7 +188,7 @@ GEM
     jaro_winkler (1.5.2)
     json (2.2.0)
     libyajl2 (1.2.0)
-    license-acceptance (0.2.8)
+    license-acceptance (0.2.10)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,10 +26,10 @@ GIT
 
 GIT
   remote: https://github.com/inspec/inspec.git
-  revision: e3999a0814cffdb97257350352fa66272499a687
+  revision: 50a8fd7370032c11d1b4640813444e9b1c604716
   branch: master
   specs:
-    inspec-core (4.1.2)
+    inspec-core (4.1.3)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       faraday_middleware (~> 0.12.2)
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/inspec/train.git
-  revision: 5d9b4f561883ee7946053fe83ef833f2137fa1b3
+  revision: d6c7b34d2b1d3558a6098614a5a09a96603979d8
   branch: ed25519
   specs:
     train-core (2.0.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/inspec/train.git
-  revision: d6c7b34d2b1d3558a6098614a5a09a96603979d8
-  branch: ed25519
+  revision: e68511376de81172d69bcd3c773438b8754b9ee4
+  branch: master
   specs:
-    train-core (2.0.7)
+    train-core (2.0.8)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       json (>= 1.8, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,29 @@ GIT
       rubocop (= 0.62.0)
 
 GIT
-  remote: https://github.com/chef/inspec.git
-  revision: e76978cd679155938242499860645ecaa17fef37
+  remote: https://github.com/chef/ohai.git
+  revision: 3cbf90d12abb2fe11bc486b87449a98ea02988d2
   branch: master
   specs:
-    inspec-core (4.1.0)
+    ohai (15.0.32)
+      chef-config (>= 12.8, < 16)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+
+GIT
+  remote: https://github.com/inspec/inspec.git
+  revision: e3999a0814cffdb97257350352fa66272499a687
+  branch: master
+  specs:
+    inspec-core (4.1.2)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       faraday_middleware (~> 0.12.2)
@@ -38,22 +56,19 @@ GIT
       tty-table (~> 0.10)
 
 GIT
-  remote: https://github.com/chef/ohai.git
-  revision: 3cbf90d12abb2fe11bc486b87449a98ea02988d2
-  branch: master
+  remote: https://github.com/inspec/train.git
+  revision: 5d9b4f561883ee7946053fe83ef833f2137fa1b3
+  branch: ed25519
   specs:
-    ohai (15.0.32)
-      chef-config (>= 12.8, < 16)
-      ffi (~> 1.9)
-      ffi-yajl (~> 2.2)
-      ipaddress
-      mixlib-cli (>= 1.7.0)
-      mixlib-config (>= 2.0, < 4.0)
-      mixlib-log (>= 2.0.1, < 4.0)
+    train-core (2.0.7)
+      bcrypt_pbkdf (~> 1.0)
+      ed25519 (~> 1.2)
+      json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
-      plist (~> 3.1)
-      systemu (~> 2.6.4)
-      wmi-lite (~> 1.0)
+      net-scp (>= 1.2, < 3.0)
+      net-ssh (>= 2.9, < 6.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
 
 PATH
   remote: .
@@ -142,6 +157,9 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
+    bcrypt_pbkdf (1.0.1)
+    bcrypt_pbkdf (1.0.1-x64-mingw32)
+    bcrypt_pbkdf (1.0.1-x86-mingw32)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
@@ -162,6 +180,7 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
+    ed25519 (1.2.4)
     equatable (0.5.0)
     erubis (2.7.0)
     faraday (0.15.4)
@@ -178,10 +197,15 @@ GEM
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashdiff (0.3.8)
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
+    httpclient (2.8.3)
     iniparse (1.4.4)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
@@ -193,6 +217,10 @@ GEM
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     method_source (0.9.2)
     mixlib-archive (1.0.1)
       mixlib-log
@@ -207,8 +235,11 @@ GEM
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     necromancer (0.4.0)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (5.2.0)
@@ -218,6 +249,7 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
+    nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.17.0)
@@ -277,6 +309,7 @@ GEM
     ruby-prof (0.17.0)
     ruby-progressbar (1.10.0)
     ruby-shadow (2.5.0)
+    rubyntlm (0.6.2)
     rubyzip (1.2.2)
     safe_yaml (1.0.5)
     sawyer (0.8.1)
@@ -304,9 +337,6 @@ GEM
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
-    train-core (2.0.5)
-      json (>= 1.8, < 3.0)
-      mixlib-shellout (>= 2.0, < 4.0)
     tty-box (0.3.0)
       pastel (~> 0.7.2)
       strings (~> 0.1.4)
@@ -361,6 +391,20 @@ GEM
     win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
+    winrm (2.3.1)
+      builder (>= 2.1.2)
+      erubis (~> 2.7)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0, >= 0.6.1)
+    winrm-fs (1.3.2)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 2.0)
     wisper (2.0.0)
     wmi-lite (1.0.2)
     yard (0.9.19)
@@ -395,6 +439,7 @@ DEPENDENCIES
   ruby-shadow
   simplecov
   tomlrb
+  train-core!
   webmock
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,48 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: 97710fcf8164ce11c64bf0d524e75eadca8c0c75
+  revision: 0f3c0afe4e875c8c17627b8986f23bd4e4dc75cb
   branch: master
   specs:
     chefstyle (0.12.0)
       rubocop (= 0.62.0)
 
 GIT
-  remote: https://github.com/chef/ohai.git
-  revision: 05e507952d8dbff8e31528f1ebcab72664e99aa2
+  remote: https://github.com/chef/inspec.git
+  revision: e76978cd679155938242499860645ecaa17fef37
   branch: master
   specs:
-    ohai (15.0.30)
+    inspec-core (4.1.0)
+      addressable (~> 2.4)
+      faraday (>= 0.9.0)
+      faraday_middleware (~> 0.12.2)
+      hashie (~> 3.4)
+      htmlentities
+      json (>= 1.8, < 3.0)
+      license-acceptance (~> 0.2)
+      method_source (~> 0.8)
+      mixlib-log
+      multipart-post
+      parallel (~> 1.9)
+      parslet (~> 1.5)
+      pry (~> 0)
+      rspec (~> 3)
+      rspec-its (~> 1.2)
+      rubyzip (~> 1.1)
+      semverse
+      sslshake (~> 1.2)
+      term-ansicolor
+      thor (~> 0.20)
+      tomlrb (~> 1.2)
+      train-core (~> 2.0)
+      tty-prompt (~> 0.17)
+      tty-table (~> 0.10)
+
+GIT
+  remote: https://github.com/chef/ohai.git
+  revision: 3cbf90d12abb2fe11bc486b87449a98ea02988d2
+  branch: master
+  specs:
+    ohai (15.0.32)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -37,7 +68,7 @@ PATH
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive
       ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
+      highline (>= 1.6.9, < 2)
       iniparse (~> 1.4)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
@@ -45,7 +76,7 @@ PATH
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (~> 4.2)
+      net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 15.0)
       plist (~> 3.2)
@@ -63,7 +94,7 @@ PATH
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive
       ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
+      highline (>= 1.6.9, < 2)
       iniparse (~> 1.4)
       iso8601 (~> 0.12.1)
       mixlib-archive (>= 0.4, < 2.0)
@@ -72,7 +103,7 @@ PATH
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (~> 4.2)
+      net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 15.0)
       plist (~> 3.2)
@@ -152,35 +183,16 @@ GEM
     highline (1.7.10)
     htmlentities (4.3.4)
     iniparse (1.4.4)
-    inspec-core (3.9.0)
-      addressable (~> 2.4)
-      faraday (>= 0.9.0)
-      faraday_middleware (~> 0.12.2)
-      hashie (~> 3.4)
-      htmlentities
-      json (>= 1.8, < 3.0)
-      method_source (~> 0.8)
-      mixlib-log
-      multipart-post
-      parallel (~> 1.9)
-      parslet (~> 1.5)
-      pry (~> 0)
-      rspec (~> 3)
-      rspec-its (~> 1.2)
-      rubyzip (~> 1.1)
-      semverse
-      sslshake (~> 1.2)
-      term-ansicolor
-      thor (~> 0.20)
-      tomlrb (~> 1.2)
-      train-core (~> 1.5, >= 1.7.2)
-      tty-prompt (~> 0.17)
-      tty-table (~> 0.10)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jaro_winkler (1.5.2)
     json (2.2.0)
     libyajl2 (1.2.0)
+    license-acceptance (0.2.8)
+      pastel (~> 0.7)
+      tomlrb (~> 1.2)
+      tty-box (~> 0.3)
+      tty-prompt (~> 0.18)
     method_source (0.9.2)
     mixlib-archive (1.0.1)
       mixlib-log
@@ -199,7 +211,7 @@ GEM
     necromancer (0.4.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
+    net-ssh (5.2.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     net-ssh-multi (1.2.1)
@@ -209,7 +221,7 @@ GEM
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.17.0)
-    parser (2.6.2.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.2)
@@ -244,7 +256,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)
@@ -292,9 +304,13 @@ GEM
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
-    train-core (1.7.6)
+    train-core (2.0.5)
       json (>= 1.8, < 3.0)
-      mixlib-shellout (~> 2.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+    tty-box (0.3.0)
+      pastel (~> 0.7.2)
+      strings (~> 0.1.4)
+      tty-cursor (~> 0.6.0)
     tty-color (0.4.3)
     tty-cursor (0.6.1)
     tty-prompt (0.18.1)
@@ -361,7 +377,7 @@ DEPENDENCIES
   chef-vault
   cheffish (~> 14)
   chefstyle!
-  inspec-core (~> 3)
+  inspec-core!
   netrc
   octokit
   ohai!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,12 @@ PATH
   specs:
     chef (15.0.224)
       addressable
+      bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
       chef-config (= 15.0.224)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
+      ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive
@@ -101,10 +103,12 @@ PATH
       uuidtools (~> 2.1.5)
     chef (15.0.224-universal-mingw32)
       addressable
+      bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
       chef-config (= 15.0.224)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
+      ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ffi", "~> 1.9", ">= 1.9.25"
   s.add_dependency "ffi-yajl", "~> 2.2"
-  s.add_dependency "net-ssh", "~> 4.2"
+  s.add_dependency "net-ssh", ">= 4.2", "< 6"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
   s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
-  s.add_dependency "highline", "~> 1.6", ">= 1.6.9"
+  s.add_dependency "highline", ">= 1.6.9", "< 2"
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh", ">= 4.2", "< 6"
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
   s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
+  s.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
+  s.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
   s.add_dependency "highline", ">= 1.6.9", "< 2"
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "erubis", "~> 2.7"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.2)
+    win32-service (2.1.4)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: af75fc2b244de04e76961c02b30db504d5b1a8f4
+  revision: b6e267d0554feca5fd0a09d306cccfac7f7e43b9
   branch: master
   specs:
-    omnibus (6.0.25)
+    omnibus (6.0.26)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 0dc67ede1784d56a975cb4a7aea47ad2349bf24a
+  revision: 34aaf2346d3467aac2d40b051ffb68852a3af896
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
-    aws-partitions (1.150.0)
-    aws-sdk-core (3.48.3)
+    aws-partitions (1.151.0)
+    aws-sdk-core (3.48.4)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -47,6 +47,9 @@ GEM
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    bcrypt_pbkdf (1.0.1)
+    bcrypt_pbkdf (1.0.1-x64-mingw32)
+    bcrypt_pbkdf (1.0.1-x86-mingw32)
     berkshelf (7.0.8)
       chef (>= 13.6.52)
       chef-config
@@ -150,6 +153,7 @@ GEM
     cleanroom (1.0.0)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    ed25519 (1.2.4)
     erubis (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -287,7 +291,9 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.0.1)
+    test-kitchen (2.1.0)
+      bcrypt_pbkdf (~> 1.0)
+      ed25519 (~> 1.2)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (>= 1.1, < 3.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 7ad32798cd5893191e4b9bfc5b53e4cc8f32646b
+  revision: af75fc2b244de04e76961c02b30db504d5b1a8f4
   branch: master
   specs:
-    omnibus (6.0.23)
+    omnibus (6.0.25)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 3f3bd5dd6d17212f2b90a2e45c63bf97224b48e6
+  revision: 0dc67ede1784d56a975cb4a7aea47ad2349bf24a
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
-    aws-partitions (1.148.0)
+    aws-partitions (1.150.0)
     aws-sdk-core (3.48.3)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
@@ -61,10 +61,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.11.21)
+    chef (14.12.3)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.11.21)
+      chef-config (= 14.12.3)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -74,9 +74,9 @@ GEM
       iniparse (~> 1.4)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
-      mixlib-cli (~> 1.7)
-      mixlib-log (~> 2.0, >= 2.0.3)
-      mixlib-shellout (~> 2.4)
+      mixlib-cli (>= 1.7, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (~> 4.2)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -91,10 +91,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.11.21-universal-mingw32)
+    chef (14.12.3-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.11.21)
+      chef-config (= 14.12.3)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -105,9 +105,9 @@ GEM
       iso8601 (~> 0.12.1)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
-      mixlib-cli (~> 1.7)
-      mixlib-log (~> 2.0, >= 2.0.3)
-      mixlib-shellout (~> 2.4)
+      mixlib-cli (>= 1.7, < 3.0)
+      mixlib-log (>= 2.0.3, < 4.0)
+      mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (~> 4.2)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -123,22 +123,21 @@ GEM
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
-      win32-certstore (~> 0.2.4)
+      win32-certstore (~> 0.3)
       win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
-      win32-service (~> 1.0)
+      win32-service (>= 1.0, < 3.0)
       win32-taskscheduler (~> 2.0)
-      windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.11.21)
+    chef-config (14.12.3)
       addressable
       fuzzyurl
-      mixlib-config (>= 2.2.12, < 3.0)
-      mixlib-shellout (~> 2.0)
+      mixlib-config (>= 2.2.12, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.0.1)
     chef-zero (14.0.12)
@@ -191,14 +190,14 @@ GEM
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
-    mixlib-cli (1.7.0)
+    mixlib-cli (2.0.3)
     mixlib-config (2.2.18)
       tomlrb
-    mixlib-install (3.11.11)
+    mixlib-install (3.11.12)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.9)
+    mixlib-log (3.0.1)
     mixlib-shellout (2.4.4)
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -254,7 +253,7 @@ GEM
     rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-its (1.2.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)
@@ -304,7 +303,7 @@ GEM
     tomlrb (1.2.8)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.2.4)
+    win32-certstore (0.3.0)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)
@@ -321,14 +320,12 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (1.0.1)
+    win32-service (2.1.2)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
-    windows-api (0.4.4)
-      win32-api (>= 1.4.5)
     winrm (2.3.1)
       builder (>= 2.1.2)
       erubis (~> 2.7)


### PR DESCRIPTION
Highline 1.7 is out and seems reasonable for our minimal highline usage
Pulling inspec from git for now allows us to use the latest train which allows for the new net-ssh
New net-ssh allows for new key formats

Signed-off-by: Tim Smith <tsmith@chef.io>