### PR TITLE
Replace highline with tty-screen in knife list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ PATH
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
+      tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
     chef (15.0.216-universal-mingw32)
       addressable
@@ -77,6 +78,7 @@ PATH
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
+      tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
       win32-certstore (~> 0.3)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh-multi", "~> 1.2", ">= 1.2.1"
   s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
   s.add_dependency "highline", "~> 1.6", ">= 1.6.9"
+  s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
   s.add_dependency "ffi-libarchive"

--- a/lib/chef/knife/list.rb
+++ b/lib/chef/knife/list.rb
@@ -25,30 +25,35 @@ class Chef
 
       deps do
         require "chef/chef_fs/file_system"
-        require "highline"
+        require "tty-screen"
       end
 
       option :recursive,
         short: "-R",
         boolean: true,
         description: "List directories recursively"
+
       option :bare_directories,
         short: "-d",
         boolean: true,
         description: "When directories match the pattern, do not show the directories' children"
+
       option :local,
         long: "--local",
         boolean: true,
         description: "List local directory instead of remote"
+
       option :flat,
         short: "-f",
         long: "--flat",
         boolean: true,
         description: "Show a list of filenames rather than the prettified ls-like output normally produced"
+
       option :one_column,
         short: "-1",
         boolean: true,
         description: "Show only one column of results"
+
       option :trailing_slashes,
         short: "-p",
         boolean: true,
@@ -143,7 +148,7 @@ class Chef
         if config[:one_column] || !stdout.isatty
           columns = 0
         else
-          columns = HighLine::SystemExtensions.terminal_size[0]
+          columns = TTY::Screen.columns
         end
         current_line = ""
         results.each do |result|


### PR DESCRIPTION
One step closer to killing off highline. We're just getting the terminal width here, which is super overkill for highline. We're still using it in quite a few other places, but this gets us one step closer to moving over to tty entirely.

Signed-off-by: Tim Smith <tsmith@chef.io>