### PR TITLE
Remove a functional test for the reboot_pending DSL

### DIFF
--- a/spec/functional/dsl/reboot_pending_spec.rb
+++ b/spec/functional/dsl/reboot_pending_spec.rb
@@ -59,25 +59,6 @@ describe Chef::DSL::RebootPending, :windows_only do
       end
     end
 
-    describe 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired' do
-      let(:reg_key) { 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootRequired' }
-      let(:original_set) { registry.key_exists?(reg_key) }
-
-      it "returns true if the registry key exists" do
-        skip "found existing registry key" if original_set
-        pending "Permissions are limited to 'TrustedInstaller' by default"
-        registry.create_key(reg_key, false)
-
-        expect(recipe.reboot_pending?).to be_truthy
-      end
-
-      after do
-        unless original_set
-          registry.delete_key(reg_key, false)
-        end
-      end
-    end
-
     describe 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' do
       let(:reg_key) { 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' }
       let(:original_set) { registry.key_exists?(reg_key) }


### PR DESCRIPTION
The 'Component Based Servicing' registry key is limited by permissions
to Trusted Installer, so we can't easily create/delete it. We do cover
this key in the unit tests, and the other functional tests cover the
code paths already, so we can remove this rather than leaving it
'pending' forever.

Closes #3085