### PR TITLE
Use color in chef-solo by default on Windows

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -75,7 +75,7 @@ class Chef::Application::Solo < Chef::Application
   option :color,
     long: "--[no-]color",
     boolean: true,
-    default: !Chef::Platform.windows?,
+    default: true,
     description: "Use colored output, defaults to enabled"
 
   option :log_level,


### PR DESCRIPTION
This matches our behavior in all our other commands since Chef 12.5.

Signed-off-by: Tim Smith <tsmith@chef.io>