### PR TITLE
Allow unforked interval runs on Windows in solo

### DIFF
--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -503,7 +503,7 @@ class Chef::Application::Client < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked chef-client interval runs are disabled in Chef 12." +
+    "Unforked chef-client interval runs are only supported on Windows." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -265,7 +265,9 @@ class Chef::Application::Solo < Chef::Application
       Chef::Config[:client_fork] = !!Chef::Config[:interval]
     end
 
-    Chef::Application.fatal!(unforked_interval_error_message) if !Chef::Config[:client_fork] && Chef::Config[:interval]
+    if !Chef::Config[:client_fork] && Chef::Config[:interval] && !Chef::Platform.windows?
+      Chef::Application.fatal!(unforked_interval_error_message)
+    end
 
     if Chef::Config[:recipe_url]
       cookbooks_path = Array(Chef::Config[:cookbook_path]).detect { |e| Pathname.new(e).cleanpath.to_s =~ /\/cookbooks\/*$/ }
@@ -365,7 +367,7 @@ class Chef::Application::Solo < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked chef-client interval runs are disabled in Chef 12." +
+    "Unforked chef-client interval runs are only supported on Windows" +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -326,7 +326,7 @@ describe Chef::Application::Client, "reconfigure" do
       Chef::Config[:interval] = 600
       allow(ChefConfig).to receive(:windows?).and_return(false)
       expect(Chef::Application).to receive(:fatal!).with(
-        "Unforked chef-client interval runs are disabled in Chef 12.
+        "Unforked chef-client interval runs are only supported on Windows..
 Configuration settings:
   interval  = 600 seconds
 Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -57,18 +57,26 @@ describe Chef::Application::Solo do
           Chef::Config[:splay] = nil
         end
 
-        context "when interval is given" do
-          before do
-            Chef::Config[:interval] = 600
-          end
-
-          it "should terminate with message" do
-            expect(Chef::Application).to receive(:fatal!).with(
-              "Unforked chef-client interval runs are disabled in Chef 12.
+        it "should terminal with message when interval is given" do
+          Chef::Config[:interval] = 600
+          allow(ChefConfig).to receive(:windows?).and_return(false)
+          expect(Chef::Application).to receive(:fatal!).with(
+            "Unforked chef-client interval runs are only supported on Windows.
 Configuration settings:
   interval  = 600 seconds
 Enable chef-client interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."
-            )
+          )
+          app.reconfigure
+        end
+
+        context "when interval is given on windows" do
+          before do
+            Chef::Config[:interval] = 600
+            allow(ChefConfig).to receive(:windows?).and_return(true)
+          end
+
+          it "should not terminate" do
+            expect(Chef::Application).not_to receive(:fatal!)
             app.reconfigure
           end
         end


### PR DESCRIPTION
This matches the behavior of chef-client. I also updated the messaging since no one cares that we allowed it in Chef 11.

Signed-off-by: Tim Smith <tsmith@chef.io>