### PR TITLE
Don't require all of chef in chef-solo

### DIFF
--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "chef"
 require "chef/application"
 require "chef/application/client"
 require "chef/client"


### PR DESCRIPTION
This greatly speeds up basic operations like -v which goes from 1.6 to
.3 seconds on my system.

Signed-off-by: Tim Smith <tsmith@chef.io>