### PR TITLE
Add placeholder license acceptance flags

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -113,6 +113,11 @@ class Chef::Application::Apply < Chef::Application
     description: "Only run the bare minimum ohai plugins chef needs to function",
     boolean: true
 
+  option :chef_license,
+    long: "--chef-license ACCEPTANCE",
+    description: "Placeholder option for Chef license acceptance to provide compatibility with Chef Infra 15+ command line options.",
+    required: false
+
   attr_reader :json_attribs
 
   def initialize

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -302,6 +302,11 @@ class Chef::Application::Client < Chef::Application
     description: "Use cached cookbooks without overwriting local differences from the server",
     boolean: false
 
+  option :chef_license,
+    long: "--chef-license ACCEPTANCE",
+    description: "Placeholder option for Chef license acceptance to provide compatibility with Chef Infra 15+ command line options.",
+    required: false
+
   IMMEDIATE_RUN_SIGNAL = "1".freeze
   RECONFIGURE_SIGNAL = "H".freeze
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -213,6 +213,11 @@ class Chef::Application::Solo < Chef::Application
     description: "Run chef-solo in legacy mode",
     boolean: true
 
+  option :chef_license,
+    long: "--chef-license ACCEPTANCE",
+    description: "Placeholder option for Chef license acceptance to provide compatibility with Chef Infra 15+ command line options.",
+    required: false
+
   attr_reader :chef_client_json
 
   # Get this party started

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -250,6 +250,11 @@ class Chef
           Chef::Config[:knife][:bootstrap_vault_item]
         }
 
+      option :chef_license,
+        long: "--chef-license ACCEPTANCE",
+        description: "Placeholder option for Chef license acceptance to provide compatibility with Chef Infra 15+ command line options.",
+        required: false
+
       def initialize(argv = [])
         super
         @client_builder = Chef::Knife::Bootstrap::ClientBuilder.new(


### PR DESCRIPTION
This provides forwards compatibility with the flags we're shipping in
Chef 15 so that someone can upgrade to a new Chef 14 release, add the
flags, then upgrade to Chef 15.

Signed-off-by: Tim Smith <tsmith@chef.io>