### PR TITLE
Improve the error message when no config can be loaded 

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -132,10 +132,10 @@ class Chef
       config[:config_file] = config_fetcher.expanded_path
 
       if config[:config_file].nil?
-        logger.warn("No config file found or specified on command line, using command line options instead.")
+        logger.warn("No config file found or specified on command line. Using command line options instead.")
       elsif config_fetcher.config_missing?
         logger.warn("*****************************************")
-        logger.warn("Did not find config file: #{config[:config_file]}, using command line options instead.")
+        logger.warn("Did not find config file: #{config[:config_file]}. Using command line options instead.")
         logger.warn("*****************************************")
       else
         config_content = config_fetcher.read_config

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -132,10 +132,10 @@ class Chef
       config[:config_file] = config_fetcher.expanded_path
 
       if config[:config_file].nil?
-        logger.warn("No config file found or specified on command line, using command line options.")
+        logger.warn("No config file found or specified on command line, using command line options instead.")
       elsif config_fetcher.config_missing?
         logger.warn("*****************************************")
-        logger.warn("Did not find config file: #{config[:config_file]}, using command line options.")
+        logger.warn("Did not find config file: #{config[:config_file]}, using command line options instead.")
         logger.warn("*****************************************")
       else
         config_content = config_fetcher.read_config

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -313,7 +313,7 @@ class Chef
           end
         rescue Errno::ENOENT
           Chef::Log.warn("*****************************************")
-          Chef::Log.warn("Did not find config file: #{config[:config_file]}, using command line options.")
+          Chef::Log.warn("Did not find config file: #{config[:config_file]}, using command line options instead.")
           Chef::Log.warn("*****************************************")
 
           Chef::Config.merge!(config)

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -313,7 +313,7 @@ class Chef
           end
         rescue Errno::ENOENT
           Chef::Log.warn("*****************************************")
-          Chef::Log.warn("Did not find config file: #{config[:config_file]}, using command line options instead.")
+          Chef::Log.warn("Did not find config file: #{config[:config_file]}. Using command line options instead.")
           Chef::Log.warn("*****************************************")
 
           Chef::Config.merge!(config)

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -162,7 +162,7 @@ describe Chef::Application do
 
         it "should emit a warning" do
           expect(Chef::Config).not_to receive(:from_file).with("/etc/chef/default.rb")
-          expect(Chef::Log).to receive(:warn).with("No config file found or specified on command line, using command line options.")
+          expect(Chef::Log).to receive(:warn).with("No config file found or specified on command line, using command line options instead.")
           @app.configure_chef
         end
       end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -162,7 +162,7 @@ describe Chef::Application do
 
         it "should emit a warning" do
           expect(Chef::Config).not_to receive(:from_file).with("/etc/chef/default.rb")
-          expect(Chef::Log).to receive(:warn).with("No config file found or specified on command line, using command line options instead.")
+          expect(Chef::Log).to receive(:warn).with("No config file found or specified on command line. Using command line options instead.")
           @app.configure_chef
         end
       end

--- a/spec/unit/log/syslog_spec.rb
+++ b/spec/unit/log/syslog_spec.rb
@@ -40,8 +40,8 @@ describe "Chef::Log::Syslog", unix_only: true do
   end
 
   it "should send message with severity warning to syslog." do
-    expect(syslog).to receive(:add).with(2, "No config file found or specified on command line, using command line options.", nil)
-    Chef::Log.warn("No config file found or specified on command line, using command line options.")
+    expect(syslog).to receive(:add).with(2, "No config file found or specified on command line, using command line options instead.", nil)
+    Chef::Log.warn("No config file found or specified on command line, using command line options instead.")
   end
 
   it "should fallback into send message with severity info to syslog when wrong format." do

--- a/spec/unit/log/syslog_spec.rb
+++ b/spec/unit/log/syslog_spec.rb
@@ -40,8 +40,8 @@ describe "Chef::Log::Syslog", unix_only: true do
   end
 
   it "should send message with severity warning to syslog." do
-    expect(syslog).to receive(:add).with(2, "No config file found or specified on command line, using command line options instead.", nil)
-    Chef::Log.warn("No config file found or specified on command line, using command line options instead.")
+    expect(syslog).to receive(:add).with(2, "No config file found or specified on command line. Using command line options instead.", nil)
+    Chef::Log.warn("No config file found or specified on command line. Using command line options instead.")
   end
 
   it "should fallback into send message with severity info to syslog when wrong format." do

--- a/spec/unit/log/winevt_spec.rb
+++ b/spec/unit/log/winevt_spec.rb
@@ -43,8 +43,8 @@ describe Chef::Log::WinEvt do
   end
 
   it "should send message with severity warning to Windows Event Log." do
-    expect(winevt).to receive(:add).with(2, "No config file found or specified on command line, using command line options.", nil)
-    Chef::Log.warn("No config file found or specified on command line, using command line options.")
+    expect(winevt).to receive(:add).with(2, "No config file found or specified on command line, using command line options instead.", nil)
+    Chef::Log.warn("No config file found or specified on command line, using command line options instead.")
   end
 
   it "should fallback into send message with severity info to Windows Event Log when wrong format." do

--- a/spec/unit/log/winevt_spec.rb
+++ b/spec/unit/log/winevt_spec.rb
@@ -43,8 +43,8 @@ describe Chef::Log::WinEvt do
   end
 
   it "should send message with severity warning to Windows Event Log." do
-    expect(winevt).to receive(:add).with(2, "No config file found or specified on command line, using command line options instead.", nil)
-    Chef::Log.warn("No config file found or specified on command line, using command line options instead.")
+    expect(winevt).to receive(:add).with(2, "No config file found or specified on command line. Using command line options instead.", nil)
+    Chef::Log.warn("No config file found or specified on command line. Using command line options instead.")
   end
 
   it "should fallback into send message with severity info to Windows Event Log when wrong format." do


### PR DESCRIPTION
You could interpret this error message in 2 different ways. This makes it super clear we're skipping the config file since we couldn't find it.