### PR TITLE
Replace kitchen-appbundle-updater in Travis tests with Test Kitchen lifecycle hooks

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -4,8 +4,7 @@ gem "rake" # required to build some native extensions
 gem "chef", path: ".."
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master" # avoids failures when we bump chef major
 gem "berkshelf", git: "https://github.com/berkshelf/berkshelf.git", branch: "master"
-gem "kitchen-appbundle-updater"
-gem "kitchen-dokken", "=1.1.1" # 2.x fails atm: https://travis-ci.org/chef/chef/jobs/199125787
+gem "kitchen-dokken", "~> 2.0"
 gem "kitchen-docker", git: "https://github.com/test-kitchen/kitchen-docker.git", branch: "master"
 gem "kitchen-inspec", git: "https://github.com/chef/kitchen-inspec.git", branch: "master"
 gem "inspec", git: "https://github.com/inspec/inspec.git", branch: "master" # this goes away when we ship inspec 4

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -9,17 +9,20 @@ transport:
   name: dokken
 
 provisioner:
-  name: chef_github
-  root_path: /opt/kitchen
-  require_chef_omnibus: latest
-  chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
-  chef_omnibus_install_options: "-c current"
-  github_owner: "chef"
-  github_repo: "chef"
-  refname: <%= ENV['TRAVIS_COMMIT'] %>
-  ohai_refname: "<%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %>"
-  github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
-  data_path: test/fixtures
+  name: dokken
+  # require_chef_omnibus: latest
+  # chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
+  # chef_omnibus_install_options: "-c current"
+
+
+lifecycle:
+  pre_converge:
+    - remote: /opt/chef/embedded/bin/gem install appbundle-updater
+    - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT'] %>
+    - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %>
+
+#  github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
+
 # disable file provider diffs so we don't overflow travis' line limit
   client_rb:
     diff_disabled: true

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -10,22 +10,14 @@ transport:
 
 provisioner:
   name: dokken
-  # require_chef_omnibus: latest
-  # chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
-  # chef_omnibus_install_options: "-c current"
-
+  client_rb:
+    diff_disabled: true
 
 lifecycle:
   pre_converge:
     - remote: /opt/chef/embedded/bin/gem install appbundle-updater
-    - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT'] %> --tarball --github chef/chef
     - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
-
-#  github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
-
-# disable file provider diffs so we don't overflow travis' line limit
-  client_rb:
-    diff_disabled: true
+    - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT'] %> --tarball --github chef/chef
 
 verifier:
   name: inspec

--- a/kitchen-tests/kitchen.travis.yml
+++ b/kitchen-tests/kitchen.travis.yml
@@ -18,8 +18,8 @@ provisioner:
 lifecycle:
   pre_converge:
     - remote: /opt/chef/embedded/bin/gem install appbundle-updater
-    - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT'] %>
-    - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %>
+    - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT'] %> --tarball --github chef/chef
+    - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
 
 #  github_access_token: <%= ENV['KITCHEN_GITHUB_TOKEN'] %>
 


### PR DESCRIPTION
update of kitchen end-to-end testing for the modern world