### PR TITLE
Switch to inspec/train from gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,7 @@ gem "cheffish", "~> 14"
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
-  gem "inspec-core", git: "https://github.com/inspec/inspec.git", branch: "master"
-  gem "train-core", git: "https://github.com/inspec/train.git", branch: "master"
-  gem "train", git: "https://github.com/inspec/train.git", branch: "master"
+  gem "inspec-core", ">= 4.0.0.a", "< 5"
   gem "chef-vault"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 3cbf90d12abb2fe11bc486b87449a98ea02988d2
+  revision: 5c70e89388ebc8ddf7d2d7bfd489024b11c0aece
   branch: master
   specs:
-    ohai (15.0.32)
+    ohai (15.0.34)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -23,68 +23,6 @@ GIT
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-
-GIT
-  remote: https://github.com/inspec/inspec.git
-  revision: 50a8fd7370032c11d1b4640813444e9b1c604716
-  branch: master
-  specs:
-    inspec-core (4.1.3)
-      addressable (~> 2.4)
-      faraday (>= 0.9.0)
-      faraday_middleware (~> 0.12.2)
-      hashie (~> 3.4)
-      htmlentities
-      json (>= 1.8, < 3.0)
-      license-acceptance (~> 0.2)
-      method_source (~> 0.8)
-      mixlib-log
-      multipart-post
-      parallel (~> 1.9)
-      parslet (~> 1.5)
-      pry (~> 0)
-      rspec (~> 3)
-      rspec-its (~> 1.2)
-      rubyzip (~> 1.1)
-      semverse
-      sslshake (~> 1.2)
-      term-ansicolor
-      thor (~> 0.20)
-      tomlrb (~> 1.2)
-      train-core (~> 2.0)
-      tty-prompt (~> 0.17)
-      tty-table (~> 0.10)
-
-GIT
-  remote: https://github.com/inspec/train.git
-  revision: e68511376de81172d69bcd3c773438b8754b9ee4
-  branch: master
-  specs:
-    train (2.0.8)
-      azure_graph_rbac (~> 0.16)
-      azure_mgmt_key_vault (~> 0.17)
-      azure_mgmt_resources (~> 0.15)
-      bcrypt_pbkdf (~> 1.0)
-      docker-api (~> 1.26)
-      ed25519 (~> 1.2)
-      google-api-client (~> 0.23.9)
-      googleauth (~> 0.6.6)
-      inifile
-      json (>= 1.8, < 3.0)
-      mixlib-shellout (>= 2.0, < 4.0)
-      net-scp (>= 1.2, < 3.0)
-      net-ssh (>= 2.9, < 6.0)
-      winrm (~> 2.0)
-      winrm-fs (~> 1.0)
-    train-core (2.0.8)
-      bcrypt_pbkdf (~> 1.0)
-      ed25519 (~> 1.2)
-      json (>= 1.8, < 3.0)
-      mixlib-shellout (>= 2.0, < 4.0)
-      net-scp (>= 1.2, < 3.0)
-      net-ssh (>= 2.9, < 6.0)
-      winrm (~> 2.0)
-      winrm-fs (~> 1.0)
 
 PATH
   remote: .
@@ -177,12 +115,6 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
-    azure_graph_rbac (0.17.1)
-      ms_rest_azure (~> 0.11.0)
-    azure_mgmt_key_vault (0.17.3)
-      ms_rest_azure (~> 0.11.0)
-    azure_mgmt_resources (0.17.3)
-      ms_rest_azure (~> 0.11.0)
     bcrypt_pbkdf (1.0.1)
     bcrypt_pbkdf (1.0.1-x64-mingw32)
     bcrypt_pbkdf (1.0.1-x86-mingw32)
@@ -201,28 +133,16 @@ GEM
       chef-zero (~> 14.0)
       net-ssh
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    docker-api (1.34.2)
-      excon (>= 0.47.0)
-      multi_json
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.2.4)
     equatable (0.5.0)
     erubis (2.7.0)
-    excon (0.64.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday-cookie_jar (0.0.6)
-      faraday (>= 0.7.4)
-      http-cookie (~> 1.0.0)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.10.0)
@@ -235,21 +155,6 @@ GEM
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
-    google-api-client (0.23.9)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.5, < 0.7.0)
-      httpclient (>= 2.8.1, < 3.0)
-      mime-types (~> 3.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
-      signet (~> 0.9)
-    googleauth (0.6.7)
-      faraday (~> 0.12)
-      jwt (>= 1.4, < 3.0)
-      memoist (~> 0.16)
-      multi_json (~> 1.11)
-      os (>= 0.9, < 2.0)
-      signet (~> 0.7)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
@@ -258,16 +163,37 @@ GEM
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     httpclient (2.8.3)
-    inifile (3.0.0)
     iniparse (1.4.4)
+    inspec-core (4.1.4.preview)
+      addressable (~> 2.4)
+      faraday (>= 0.9.0)
+      faraday_middleware (~> 0.12.2)
+      hashie (~> 3.4)
+      htmlentities
+      json (>= 1.8, < 3.0)
+      license-acceptance (~> 0.2)
+      method_source (~> 0.8)
+      mixlib-log
+      multipart-post
+      parallel (~> 1.9)
+      parslet (~> 1.5)
+      pry (~> 0)
+      rspec (~> 3)
+      rspec-its (~> 1.2)
+      rubyzip (~> 1.1)
+      semverse
+      sslshake (~> 1.2)
+      term-ansicolor
+      thor (~> 0.20)
+      tomlrb (~> 1.2)
+      train-core (~> 2.0)
+      tty-prompt (~> 0.17)
+      tty-table (~> 0.10)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jaro_winkler (1.5.2)
     json (2.2.0)
-    jwt (2.1.0)
     libyajl2 (1.2.0)
     license-acceptance (0.2.10)
       pastel (~> 0.7)
@@ -278,11 +204,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    memoist (0.16.0)
     method_source (0.9.2)
-    mime-types (3.2.2)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
     mixlib-archive (1.0.1)
       mixlib-log
     mixlib-archive (1.0.1-universal-mingw32)
@@ -296,15 +218,6 @@ GEM
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
-    ms_rest (0.7.3)
-      concurrent-ruby (~> 1.0)
-      faraday (~> 0.9)
-      timeliness (~> 0.3)
-    ms_rest_azure (0.11.0)
-      concurrent-ruby (~> 1.0)
-      faraday (~> 0.9)
-      faraday-cookie_jar (~> 0.0.6)
-      ms_rest (~> 0.7.2)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     necromancer (0.4.0)
@@ -322,7 +235,6 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    os (1.0.0)
     parallel (1.17.0)
     parser (2.6.2.1)
       ast (~> 2.4.0)
@@ -350,18 +262,13 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     rb-readline (0.5.5)
-    representable (3.0.4)
-      declarative (< 0.1.0)
-      declarative-option (< 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.1.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-its (1.3.0)
@@ -392,11 +299,6 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (3.0.0)
-    signet (0.11.0)
-      addressable (~> 2.3)
-      faraday (~> 0.9)
-      jwt (>= 1.5, < 3.0)
-      multi_json (~> 1.10)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -415,10 +317,18 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (0.20.3)
-    timeliness (0.4.0)
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
+    train-core (2.0.8)
+      bcrypt_pbkdf (~> 1.0)
+      ed25519 (~> 1.2)
+      json (>= 1.8, < 3.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      net-scp (>= 1.2, < 3.0)
+      net-ssh (>= 2.9, < 6.0)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
     tty-box (0.3.0)
       pastel (~> 0.7.2)
       strings (~> 0.1.4)
@@ -442,10 +352,6 @@ GEM
       pastel (~> 0.7.2)
       strings (~> 0.1.0)
       tty-screen (~> 0.6.4)
-    uber (0.1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
@@ -507,7 +413,7 @@ DEPENDENCIES
   chef-vault
   cheffish (~> 14)
   chefstyle!
-  inspec-core!
+  inspec-core (>= 4.0.0.a, < 5)
   netrc
   octokit
   ohai!
@@ -525,8 +431,6 @@ DEPENDENCIES
   ruby-shadow
   simplecov
   tomlrb
-  train!
-  train-core!
   webmock
   yard
 

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem "berkshelf", ">= 7.0"
 
   # We pin here to the last release Ohai so prevent more current chef coming in
-  gem "ohai", "~> 14.0"
+  gem "ohai"
 
   # Use Test Kitchen with Vagrant for converging the build environment
   gem "test-kitchen", ">= 1.23"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 34aaf2346d3467aac2d40b051ffb68852a3af896
+  revision: 3d4327c0032b8cc7d25eb33290a7aec2fce20a2a
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -38,10 +38,10 @@ GEM
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.16.0)
+    aws-sdk-kms (1.17.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.36.0)
+    aws-sdk-s3 (1.36.1)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -64,10 +64,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.12.3)
+    chef (14.12.9)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -94,10 +94,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.12.3-universal-mingw32)
+    chef (14.12.9-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -136,7 +136,7 @@ GEM
       win32-service (>= 1.0, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
-    chef-config (14.12.3)
+    chef-config (14.12.9)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -254,7 +254,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-its (1.3.0)
@@ -360,7 +360,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf (>= 7.0)
   kitchen-vagrant (>= 1.3.1)
-  ohai (~> 14.0)
+  ohai
   omnibus!
   omnibus-software!
   pedump


### PR DESCRIPTION
We now have a preview of inspec 4 out so we can switch back to gems and kill off the full train gem and all its deps.

Signed-off-by: Tim Smith <tsmith@chef.io>