### PR TITLE
Add comment block to sysctl resource

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -330,6 +330,7 @@ which results in `/etc/sysctl.d/99-chef-vw.swappiness.conf` as follows
 # than the high water mark in a zone.
 # The default value is 60.
 vm.swappiness = 10
+```
 
 ## New Resources
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -301,7 +301,7 @@ Chef Solo's `--delete-entire-chef-repo` option has been extended to work in Loca
 
 ### sysctl now accepts a comments parameter
 
-The sysctl resource has been updated to allow additional (optional) comments. Comments can be passed as an array or a string. Any comments provided are prefixed with '#' signs and precede the sysctl setting in generated files.
+The `sysctl` resource has been updated to allow the inclusion of descriptive comments. Comments may be passed as an array or a string. Any comments provided are prefixed with '#' signs and precede the `sysctl` setting in generated files.
 
 An example:
 
@@ -320,7 +320,7 @@ sysctl 'vm.swappiness' do
 end
 ```
 
-which results in `/etc/sysctl.d/99-chef-vw.swappiness.conf` as follows
+which results in `/etc/sysctl.d/99-chef-vm.swappiness.conf` as follows
 ```
 # define how aggressively the kernel will swap memory pages.
 # Higher values will increase aggressiveness

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -299,6 +299,38 @@ Our underlying SSH implementation has been updated to support the new ed25519 SS
 
 Chef Solo's `--delete-entire-chef-repo` option has been extended to work in Local Mode as well. Be warned that this flag does exactly what it states, and when used incorrectly, can result in loss of work.
 
+### sysctl now accepts a comments parameter
+
+The sysctl resource has been updated to allow additional (optional) comments. Comments can be passed as an array or a string. Any comments provided are prefixed with '#' signs and precede the sysctl setting in generated files.
+
+An example:
+
+```
+sysctl 'vm.swappiness' do
+  value 10
+  comment [
+     "define how aggressively the kernel will swap memory pages.",
+     "Higher values will increase aggressiveness",
+     "lower values decrease the amount of swap.",
+     "A value of 0 instructs the kernel not to initiate swap",
+     "until the amount of free and file-backed pages is less",
+     "than the high water mark in a zone.",
+     "The default value is 60."
+    ]
+end
+```
+
+which results in `/etc/sysctl.d/99-chef-vw.swappiness.conf` as follows
+```
+# define how aggressively the kernel will swap memory pages.
+# Higher values will increase aggressiveness
+# lower values decrease the amount of swap.
+# A value of 0 instructs the kernel not to initiate swap
+# until the amount of free and file-backed pages is less
+# than the high water mark in a zone.
+# The default value is 60.
+vm.swappiness = 10
+
 ## New Resources
 
 ### archive_file resource

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -89,7 +89,7 @@ class Chef
 
           sysctl_lines << "#{new_resource.key} = #{new_resource.value}"
 
-          file "#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr('/', '.')}.conf" do
+          file "#{new_resource.conf_dir}/99-chef-#{new_resource.key.tr("/", ".")}.conf" do
             content sysctl_lines.join("\n")
           end
 


### PR DESCRIPTION
### Description

Adds optional comments to the sysctl resource, which are prepended to any settings. Allows for documentation of sysctls on the target system.

### Issues Resolved
This is a new feature, so none.


### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG