### PR TITLE
 Move ed25519 gems into omnibus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ group(:omnibus_package) do
   gem "rb-readline"
   gem "inspec-core", ">= 4.0.0.a", "< 5"
   gem "chef-vault"
+  gem 'ed25519' # ed25519 ssh key support done here as its a native gem we can't put in train
+  gem 'bcrypt_pbkdf' # ed25519 ssh key support done here as its a native gem we can't put in train
 end
 
 group(:omnibus_package, :pry) do

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ group(:omnibus_package) do
   gem "rb-readline"
   gem "inspec-core", ">= 4.0.0.a", "< 5"
   gem "chef-vault"
-  gem 'ed25519' # ed25519 ssh key support done here as its a native gem we can't put in train
-  gem 'bcrypt_pbkdf' # ed25519 ssh key support done here as its a native gem we can't put in train
+  gem "ed25519" # ed25519 ssh key support done here as it's a native gem we can't put in train
+  gem "bcrypt_pbkdf" # ed25519 ssh key support done here as it's a native gem we can't put in train
 end
 
 group(:omnibus_package, :pry) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashdiff (0.3.8)
+    hashdiff (0.3.9)
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -195,7 +195,7 @@ GEM
     jaro_winkler (1.5.2)
     json (2.2.0)
     libyajl2 (1.2.0)
-    license-acceptance (0.2.10)
+    license-acceptance (0.2.13)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -211,7 +211,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (2.0.3)
-    mixlib-config (2.2.18)
+    mixlib-config (3.0.1)
       tomlrb
     mixlib-log (3.0.1)
     mixlib-shellout (2.4.4)
@@ -320,9 +320,7 @@ GEM
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
-    train-core (2.0.8)
-      bcrypt_pbkdf (~> 1.0)
-      ed25519 (~> 1.2)
+    train-core (2.0.12)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
@@ -408,11 +406,13 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
+  bcrypt_pbkdf
   chef!
   chef-config!
   chef-vault
   cheffish (~> 14)
   chefstyle!
+  ed25519
   inspec-core (>= 4.0.0.a, < 5)
   netrc
   octokit

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (2.0.3)
-    mixlib-config (2.2.18)
+    mixlib-config (3.0.1)
       tomlrb
     mixlib-install (3.11.12)
       mixlib-shellout


### PR DESCRIPTION
We had to move this out of train as they were causing installation failures for inspec. This change makes sure we get them into our omnibus package.

Signed-off-by: Tim Smith <tsmith@chef.io>