### PR TITLE
Enable license acceptance during bootstrap 

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -171,7 +171,7 @@ class Chef
         def start_chef
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
           client_path = @chef_config[:chef_client_path] || "#{Chef::Dist::CLIENT}"
-          s = "#{client_path} -j /etc/chef/first-boot.json"
+          s = "CHEF_LICENSE=accept #{client_path} -j /etc/chef/first-boot.json"
           if @config[:verbosity] && @config[:verbosity] >= 3
             s << " -l trace"
           elsif @config[:verbosity] && @config[:verbosity] >= 2

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -154,6 +154,7 @@ class Chef
         def start_chef
           bootstrap_environment_option = bootstrap_environment.nil? ? "" : " -E #{bootstrap_environment}"
           start_chef = "SET \"PATH=%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
+          start_chef << "SET \"CHEF_LICENSE=accept\"\n"
           start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}\n"
         end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -46,21 +46,21 @@ describe Chef::Knife::Core::BootstrapContext do
     expect { described_class.new(config, run_list, chef_config) }.not_to raise_error
   end
 
-  it "runs chef with the first-boot.json with no environment specified" do
-    expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json"
+  it "runs chef with the first-boot.json with no environment other than chef-license acceptance specified" do
+    expect(bootstrap_context.start_chef).to eq "CHEF_LICENSE=accept chef-client -j /etc/chef/first-boot.json"
   end
 
   describe "when in verbosity mode" do
     let(:config) { { verbosity: 2, color: true } }
     it "adds '-l debug' when verbosity is >= 2" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json -l debug"
+      expect(bootstrap_context.start_chef).to eq "CHEF_LICENSE=accept chef-client -j /etc/chef/first-boot.json -l debug"
     end
   end
 
   describe "when no color value has been set in config" do
     let(:config) { { color: false } }
     it "adds '--no-color' when color is false" do
-      expect(bootstrap_context.start_chef).to eq "chef-client -j /etc/chef/first-boot.json --no-color"
+      expect(bootstrap_context.start_chef).to eq "CHEF_LICENSE=accept chef-client -j /etc/chef/first-boot.json --no-color"
     end
   end
 
@@ -82,7 +82,7 @@ describe Chef::Knife::Core::BootstrapContext do
   describe "alternate chef-client path" do
     let(:chef_config) { { chef_client_path: "/usr/local/bin/chef-client" } }
     it "runs chef-client from another path when specified" do
-      expect(bootstrap_context.start_chef).to eq "/usr/local/bin/chef-client -j /etc/chef/first-boot.json"
+      expect(bootstrap_context.start_chef).to eq "CHEF_LICENSE=accept /usr/local/bin/chef-client -j /etc/chef/first-boot.json"
     end
   end
 
@@ -105,7 +105,7 @@ describe Chef::Knife::Core::BootstrapContext do
   describe "when bootstrapping into a specific environment" do
     let(:config) { { environment: "prodtastic", color: true } }
     it "starts chef in the configured environment" do
-      expect(bootstrap_context.start_chef).to eq("chef-client -j /etc/chef/first-boot.json -E prodtastic")
+      expect(bootstrap_context.start_chef).to eq("CHEF_LICENSE=accept chef-client -j /etc/chef/first-boot.json -E prodtastic")
     end
   end
 

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -264,4 +264,12 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
       end
     end
   end
+
+  describe "#start_chef" do
+    it "the command includes the license acceptance environment variable" do
+      expect(bootstrap_context.start_chef).to match(/SET "CHEF_LICENSE=accept"\n/m)
+    end
+
+  end
+
 end


### PR DESCRIPTION
 
### Description

When performing the initial `chef-client` converge
on a bootstrapped host, ensure that we set the license
environment variable that indicates the license was accepted.

This will allow the run to continue under Chef 15, which requires
license acceptance.

I used the environment variable instead of the CLI flag
because older versions of Chef do not support the CLI flag.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG