### PR TITLE
Fixed empty value for knife status long output

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -100,7 +100,14 @@ class Chef
             fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
-            run_list = (node["run_list"]).to_s if config[:run_list]
+            if config[:run_list]
+              if config[:long_output]
+                run_list = node.run_list.map { |rl| "#{rl.type}[#{rl.name}]" }
+              else
+                run_list = node["run_list"]
+              end
+            end
+
             line_parts = Array.new
 
             if node["ohai_time"]
@@ -128,7 +135,7 @@ class Chef
 
             line_parts << fqdn if fqdn
             line_parts << ip if ip
-            line_parts << run_list if run_list
+            line_parts << run_list.to_s if run_list
 
             if node["platform"]
               platform = node["platform"].dup


### PR DESCRIPTION
Signed-off-by: Vijay Mali <vijay.mali@msystechnologies.com>

### Description

Fixed blank output for knife status with long output option
It displays the output in following format.
```
$ knife status -l --run-list

vm-1, ubuntu, 192.168.102.190, [], ubuntu 16.04.
vm-1, ubuntu, 192.168.102.190, ["recipe[apt]"], ubuntu 16.04.
vm-1, ubuntu, 192.168.102.190, ["recipe[apt]", "recipe[nginx]"], ubuntu 16.04.
```

### Issues Resolved

https://github.com/chef/chef/issues/7764

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG