### PR TITLE
"chef-client" => #{Chef::Dist::CLIENT}

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -28,6 +28,7 @@ require "mixlib/cli"
 require "tmpdir"
 require "rbconfig"
 require "chef/application/exit_code"
+require "chef/dist"
 
 class Chef
   class Application
@@ -313,7 +314,7 @@ class Chef
             " finishing converge to exit normally (send SIGINT to terminate immediately)")
         end
 
-        client_solo = chef_config[:solo] ? "chef-solo" : "chef-client"
+        client_solo = chef_config[:solo] ? "chef-solo" : "#{Chef::Dist::CLIENT}"
         $0 = "#{client_solo} worker: ppid=#{Process.ppid};start=#{Time.new.strftime("%R:%S")};"
         begin
           logger.trace "Forked instance now converging"

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -324,7 +324,7 @@ class Chef::Application::Solo < Chef::Application
 
   def interval_run_chef_client
     if Chef::Config[:daemonize]
-      Chef::Daemon.daemonize("chef-client")
+      Chef::Daemon.daemonize("#{Chef::Dist::CLIENT}")
     end
 
     loop do

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -57,7 +57,7 @@ class Chef
       option :interval,
         short: "-i SECONDS",
         long: "--interval SECONDS",
-        description: "Set the number of seconds to wait between chef-client runs",
+        description: "Set the number of seconds to wait between #{Chef::Dist::CLIENT} runs",
         proc: lambda { |s| s.to_i }
 
       DEFAULT_LOG_LOCATION ||= "#{ENV['SYSTEMDRIVE']}/chef/client.log".freeze

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -17,6 +17,7 @@ require "chef/client"
 require "chef/util/threaded_job_queue"
 require "chef/server_api"
 require "singleton"
+require "chef/dist"
 
 class Chef
 
@@ -63,7 +64,7 @@ class Chef
         # manifest.
         cache.find(File.join(%w{cookbooks ** {*,.*}})).each do |cache_filename|
           unless @valid_cache_entries[cache_filename]
-            Chef::Log.info("Removing #{cache_filename} from the cache; it is no longer needed by chef-client.")
+            Chef::Log.info("Removing #{cache_filename} from the cache; it is no longer needed by #{Chef::Dist::CLIENT}.")
             cache.delete(cache_filename)
           end
         end

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 require "chef-config/exceptions"
+require "chef/dist"
 
 class Chef
   # == Chef::Exceptions
@@ -401,7 +402,7 @@ class Chef
       def initialize(response_length, content_length)
         super <<~EOF
           Response body length #{response_length} does not match HTTP Content-Length header #{content_length}.
-          This error is most often caused by network issues (proxies, etc) outside of chef-client.
+          This error is most often caused by network issues (proxies, etc) outside of #{Chef::Dist::CLIENT}.
         EOF
       end
     end

--- a/lib/chef/formatters/error_inspectors/api_error_formatting.rb
+++ b/lib/chef/formatters/error_inspectors/api_error_formatting.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/http/authenticator"
+require "chef/dist"
 
 class Chef
   module Formatters
@@ -39,7 +40,7 @@ class Chef
       def describe_eof_error(error_description)
         error_description.section("Authentication Error:", <<~E)
           Received an EOF on transport socket.  This almost always indicates a network
-          error external to chef-client.  Some causes include:
+          error external to #{Chef::Dist::CLIENT}.  Some causes include:
 
             - Blocking ICMP Dest Unreachable (breaking Path MTU Discovery)
             - IPsec or VPN tunnelling / TCP Encapsulation MTU issues

--- a/lib/chef/formatters/error_inspectors/node_load_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/node_load_error_inspector.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/formatters/error_inspectors/api_error_formatting"
+require "chef/dist"
 
 class Chef
   module Formatters
@@ -45,7 +46,7 @@ class Chef
           when Chef::Exceptions::PrivateKeyMissing
             error_description.section("Private Key Not Found:", <<~E)
               Your private key could not be loaded. If the key file exists, ensure that it is
-              readable by chef-client.
+              readable by #{Chef::Dist::CLIENT}.
             E
             error_description.section("Relevant Config Settings:", <<~E)
               client_key        "#{api_key}"

--- a/lib/chef/formatters/error_inspectors/registration_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/registration_error_inspector.rb
@@ -1,7 +1,8 @@
+require "chef/dist"
+
 class Chef
   module Formatters
     module ErrorInspectors
-
       # == RegistrationErrorInspector
       # Wraps exceptions that occur during the client registration process and
       # suggests possible causes.
@@ -38,7 +39,7 @@ class Chef
           when Chef::Exceptions::PrivateKeyMissing
             error_description.section("Private Key Not Found:", <<~E)
               Your private key could not be loaded. If the key file exists, ensure that it is
-              readable by chef-client.
+              readable by #{Chef::Dist::CLIENT}.
             E
             error_description.section("Relevant Config Settings:", <<~E)
               validation_key "#{api_key}"

--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require "chef/dist"
 
 class Chef
   module Formatters
@@ -55,7 +56,7 @@ class Chef
             require "chef/win32/security"
 
             if !Chef::ReservedNames::Win32::Security.has_admin_privileges?
-              error_description.section("Missing Windows Admin Privileges", "chef-client doesn't have administrator privileges. This can be a possible reason for the resource failure.")
+              error_description.section("Missing Windows Admin Privileges", "#{Chef::Dist::CLIENT} doesn't have administrator privileges. This can be a possible reason for the resource failure.")
             end
           end
         end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -22,6 +22,7 @@ require "erubis"
 require "chef/knife/bootstrap/chef_vault_handler"
 require "chef/knife/bootstrap/client_builder"
 require "chef/util/path_helper"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -251,14 +252,14 @@ class Chef
       option :first_boot_attributes,
         short: "-j JSON_ATTRIBS",
         long: "--json-attributes",
-        description: "A JSON string to be added to the first run of chef-client",
+        description: "A JSON string to be added to the first run of #{Chef::Dist::CLIENT}",
         proc: lambda { |o| Chef::JSONCompat.parse(o) },
         default: nil
 
       # bootstrap template
       option :first_boot_attributes_from_file,
         long: "--json-attribute-file FILE",
-        description: "A JSON file to be used to the first run of chef-client",
+        description: "A JSON file to be used to the first run of #{Chef::Dist::CLIENT}",
         proc: lambda { |o| Chef::JSONCompat.parse(File.read(o)) },
         default: nil
 
@@ -296,25 +297,25 @@ class Chef
       # bootstrap override: Do this instead of our own setup.sh from omnitruck. Causes bootstrap_url to be ignored.
       option :bootstrap_install_command,
         long: "--bootstrap-install-command COMMANDS",
-        description: "Custom command to install chef-client",
+        description: "Custom command to install #{Chef::Dist::CLIENT}",
         proc: Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
       # bootstrap template: Run this command first in the bootstrap script
       option :bootstrap_preinstall_command,
         long: "--bootstrap-preinstall-command COMMANDS",
-        description: "Custom commands to run before installing chef-client",
+        description: "Custom commands to run before installing #{Chef::Dist::CLIENT}",
         proc: Proc.new { |preic| Chef::Config[:knife][:bootstrap_preinstall_command] = preic }
 
       # bootstrap template
       option :bootstrap_wget_options,
         long: "--bootstrap-wget-options OPTIONS",
-        description: "Add options to wget when installing chef-client",
+        description: "Add options to wget when installing #{Chef::Dist::CLIENT}",
         proc: Proc.new { |wo| Chef::Config[:knife][:bootstrap_wget_options] = wo }
 
       # bootstrap template
       option :bootstrap_curl_options,
         long: "--bootstrap-curl-options OPTIONS",
-        description: "Add options to curl when install chef-client",
+        description: "Add options to curl when install #{Chef::Dist::CLIENT}",
         proc: Proc.new { |co| Chef::Config[:knife][:bootstrap_curl_options] = co }
 
       # chef_vault_handler
@@ -417,7 +418,7 @@ class Chef
       # @return [String] Default bootstrap template
       def default_bootstrap_template
         if target_host.base_os == :windows
-          "windows-chef-client-msi"
+          "windows-#{Chef::Dist::CLIENT}-msi"
         else
           "chef-full"
         end

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -172,7 +172,7 @@ do_download() {
   <%= knife_config[:bootstrap_install_command] %>
 <% else %>
   install_sh="<%= knife_config[:bootstrap_url] ? knife_config[:bootstrap_url] : "https://omnitruck.chef.io/chef/install.sh" %>"
-  if test -f /usr/bin/chef-client; then
+  if test -f /usr/bin/<%= Chef::Dist::CLIENT %>}; then
     echo "-----> Existing <%= Chef::Dist::PRODUCT %> installation detected"
   else
     echo "-----> Installing Chef Omnibus (<%= latest_current_chef_version_string %>)"

--- a/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
@@ -110,7 +110,7 @@ goto chef_installed
 
 :chef_installed
 @echo Checking for existing chef installation
-WHERE chef-client >nul 2>nul
+WHERE <%= Chef::Dist::CLIENT %> >nul 2>nul
 If !ERRORLEVEL!==0 (
   @echo Existing Chef installation detected, skipping download
   goto key_create
@@ -120,14 +120,14 @@ If !ERRORLEVEL!==0 (
 )
 
 :install
-@rem If user has provided the custom installation command for chef-client then execute it
+@rem If user has provided the custom installation command for <%= Chef::Dist::CLIENT %> then execute it
 <% if @chef_config[:knife][:bootstrap_install_command] %>
   <%= @chef_config[:knife][:bootstrap_install_command] %>
 <% else %>
-  @rem Install Chef using chef-client MSI installer
+  @rem Install Chef using <%= Chef::Dist::CLIENT %> MSI installer
 
   @set "LOCAL_DESTINATION_MSI_PATH=<%= local_download_path %>"
-  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\chef-client-msi%RANDOM%.log"
+  @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\<%= Chef::Dist::CLIENT %>-msi%RANDOM%.log"
 
   @rem Clear any pre-existing downloads
   @echo Checking for existing downloaded package at "%LOCAL_DESTINATION_MSI_PATH%"
@@ -197,7 +197,7 @@ If !ERRORLEVEL!==0 (
   <%= install_chef %>
 
   @if ERRORLEVEL 1 (
-      echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2"
+      echo <%= Chef::Dist::CLIENT %> package failed to install with status code !ERRORLEVEL!. > "&2"
       echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2"
   ) else (
       @echo Installation completed successfully

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -19,6 +19,7 @@
 require "chef/run_list"
 require "chef/util/path_helper"
 require "pathname"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -169,7 +170,7 @@ class Chef
 
         def start_chef
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
-          client_path = @chef_config[:chef_client_path] || "chef-client"
+          client_path = @chef_config[:chef_client_path] || "#{Chef::Dist::CLIENT}"
           s = "#{client_path} -j /etc/chef/first-boot.json"
           if @config[:verbosity] && @config[:verbosity] >= 3
             s << " -l trace"

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -18,6 +18,7 @@
 
 require "chef/knife/core/bootstrap_context"
 require "chef/util/path_helper"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -268,7 +269,7 @@ class Chef
         end
 
         def local_download_path
-          "%TEMP%\\chef-client-latest.msi"
+          "%TEMP%\\#{Chef::Dist::CLIENT}-latest.msi"
         end
 
         def msi_url(machine_os = nil, machine_arch = nil, download_context = nil)

--- a/lib/chef/log/syslog.rb
+++ b/lib/chef/log/syslog.rb
@@ -19,6 +19,7 @@
 require "logger"
 require "syslog-logger"
 require "chef/mixin/unformatter"
+require "chef/dist"
 
 class Chef
   class Log
@@ -32,7 +33,7 @@ class Chef
 
       attr_accessor :sync, :formatter
 
-      def initialize(program_name = "chef-client", facility = ::Syslog::LOG_DAEMON, logopts = nil)
+      def initialize(program_name = "#{Chef::Dist::CLIENT}", facility = ::Syslog::LOG_DAEMON, logopts = nil)
         super
         return if defined? ::Logger::Syslog::SYSLOG
         ::Logger::Syslog.const_set :SYSLOG, SYSLOG

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -24,6 +24,7 @@ require "chef/run_context"
 require "chef/config"
 require "chef/node"
 require "chef/server_api"
+require "chef/dist"
 
 class Chef
   module PolicyBuilder
@@ -90,7 +91,7 @@ class Chef
         @node = nil
 
         if Chef::Config[:solo_legacy_mode]
-          raise UnsupportedFeature, "Policyfile does not support chef-solo. Use chef-client local mode instead."
+          raise UnsupportedFeature, "Policyfile does not support chef-solo. Use #{Chef::Dist::CLIENT} local mode instead."
         end
 
         if override_runlist

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -31,6 +31,7 @@ require "chef/util/backup"
 require "chef/util/diff"
 require "chef/util/selinux"
 require "chef/file_content_management/deploy"
+require "chef/dist"
 
 # The Tao of File Providers:
 #  - the content provider must always return a tempfile that we can delete/mv
@@ -389,7 +390,7 @@ class Chef
         return if tempfile.nil?
         # but a tempfile that has no path or doesn't exist should not happen
         if tempfile.path.nil? || !::File.exists?(tempfile.path)
-          raise "chef-client is confused, trying to deploy a file that has no path or does not exist..."
+          raise "#{Chef::Dist::CLIENT} is confused, trying to deploy a file that has no path or does not exist..."
         end
 
         # the file? on the next line suppresses the case in why-run when we have a not-file here that would have otherwise been removed

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -24,7 +25,7 @@ class Chef
       provides :breakpoint
       resource_name :breakpoint
 
-      description "Use the breakpoint resource to add breakpoints to recipes. Run the chef-shell in chef-client mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the chef-client during an actual chef-client run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."
+      description "Use the breakpoint resource to add breakpoints to recipes. Run the chef-shell in #{Chef::Dist::CLIENT} mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the #{Chef::Dist::CLIENT} during an actual #{Chef::Dist::CLIENT} run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."
       introduced "12.0"
 
       default_action :break

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -18,6 +18,7 @@
 
 require "chef/resource/package"
 require "chef/resource/gem_package"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -37,12 +38,12 @@ class Chef
       resource_name :chef_gem
 
       property :gem_binary, default: "#{RbConfig::CONFIG['bindir']}/gem", default_description: "Chef's built-in gem binary.",
-                            description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the chef-client will be installed.",
+                            description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the #{Chef::Dist::CLIENT} will be installed.",
                             callbacks: {
                  "The chef_gem resource is restricted to the current gem environment, use gem_package to install to other environments." => proc { |v| v == "#{RbConfig::CONFIG['bindir']}/gem" },
                }
       property :compile_time, [TrueClass, FalseClass],
-               description: "Controls the phase during which a gem is installed on a node. Set to 'true' to install a gem while the resource collection is being built (the 'compile phase'). Set to 'false' to install a gem while the chef-client is configuring the node (the 'converge phase').",
+               description: "Controls the phase during which a gem is installed on a node. Set to 'true' to install a gem while the resource collection is being built (the 'compile phase'). Set to 'false' to install a gem while the #{Chef::Dist::CLIENT} is configuring the node (the 'converge phase').",
                default: false, desired_state: false
 
       # force the resource to compile time if the compile time property has been set

--- a/lib/chef/resource/cookbook_file.rb
+++ b/lib/chef/resource/cookbook_file.rb
@@ -21,6 +21,7 @@
 require "chef/resource/file"
 require "chef/provider/cookbook_file"
 require "chef/mixin/securable"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -29,7 +30,7 @@ class Chef
 
       resource_name :cookbook_file
 
-      description "Use the cookbook_file resource to transfer files from a sub-directory of COOKBOOK_NAME/files/ to a specified path located on a host that is running the chef-client. The file is selected according to file specificity, which allows different source files to be used based on the hostname, host platform (operating system, distro, or as appropriate), or platform version. Files that are located in the COOKBOOK_NAME/files/default sub-directory may be used on any platform.\n\nDuring a chef-client run, the checksum for each local file is calculated and then compared against the checksum for the same file as it currently exists in the cookbook on the Chef server. A file is not transferred when the checksums match. Only files that require an update are transferred from the Chef server to a node."
+      description "Use the cookbook_file resource to transfer files from a sub-directory of COOKBOOK_NAME/files/ to a specified path located on a host that is running the #{Chef::Dist::CLIENT}. The file is selected according to file specificity, which allows different source files to be used based on the hostname, host platform (operating system, distro, or as appropriate), or platform version. Files that are located in the COOKBOOK_NAME/files/default sub-directory may be used on any platform.\n\nDuring a #{Chef::Dist::CLIENT} run, the checksum for each local file is calculated and then compared against the checksum for the same file as it currently exists in the cookbook on the Chef server. A file is not transferred when the checksums match. Only files that require an update are transferred from the Chef server to a node."
 
       property :source, [ String, Array ],
                 description: "The name of the file in COOKBOOK_NAME/files/default or the path to a file located in COOKBOOK_NAME/files. The path must include the file name and its extension. This can be used to distribute specific files depending upon the platform used.",

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -18,6 +18,7 @@
 require "chef/resource/package"
 require "chef/mixin/which"
 require "chef/mixin/shell_out"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -52,7 +53,7 @@ class Chef
 
       # Flush the in-memory available/installed cache, this does not flush the dnf caches on disk
       property :flush_cache, Hash,
-               description: "Flush the in-memory cache before or after a DNF operation that installs, upgrades, or removes a package. DNF automatically synchronizes remote metadata to a local cache. The chef-client creates a copy of the local cache, and then stores it in-memory during the chef-client run. The in-memory cache allows packages to be installed during the chef-client run without the need to continue synchronizing the remote metadata to the local cache while the chef-client run is in-progress.",
+               description: "Flush the in-memory cache before or after a DNF operation that installs, upgrades, or removes a package. DNF automatically synchronizes remote metadata to a local cache. The #{Chef::Dist::CLIENT} creates a copy of the local cache, and then stores it in-memory during the #{Chef::Dist::CLIENT} run. The in-memory cache allows packages to be installed during the #{Chef::Dist::CLIENT} run without the need to continue synchronizing the remote metadata to the local cache while the #{Chef::Dist::CLIENT} run is in-progress.",
                default: { before: false, after: false },
                coerce: proc { |v|
                          if v.is_a?(Hash)

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -18,6 +18,7 @@
 #
 
 require "chef/resource"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -65,7 +66,7 @@ class Chef
                description: "The group name or group ID that must be changed before running a command."
 
       property :live_stream, [ TrueClass, FalseClass ], default: false,
-               description: "Send the output of the command run by this execute resource block to the chef-client event stream."
+               description: "Send the output of the command run by this execute resource block to the #{Chef::Dist::CLIENT} event stream."
 
       # default_env defaults to `false` so that the command execution more exactly matches what the user gets on the command line without magic
       property :default_env, [ TrueClass, FalseClass ], desired_state: false, default: false,
@@ -91,7 +92,7 @@ class Chef
 
       # lazy used to set default value of sensitive to true if password is set
       property :sensitive, [ TrueClass, FalseClass ],
-               description: "Ensure that sensitive resource data is not logged by the chef-client.",
+               description: "Ensure that sensitive resource data is not logged by the #{Chef::Dist::CLIENT}.",
                default: lazy { |r| r.password ? true : false }, default_description: "True if the password property is set. False otherwise."
 
       property :elevated, [ TrueClass, FalseClass ], default: false,

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -22,6 +22,7 @@ require "chef/platform/query_helpers"
 require "chef/mixin/securable"
 require "chef/resource/file/verification"
 require "pathname"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -52,7 +53,7 @@ class Chef
       allowed_actions :create, :delete, :touch, :create_if_missing
 
       property :path, String, name_property: true, identity: true,
-               description: "The full path to the file, including the file name and its extension. For example: /files/file.txt. Default value: the name of the resource block. Microsoft Windows: A path that begins with a forward slash (/) will point to the root of the current working directory of the chef-client process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (/) is not recommended."
+               description: "The full path to the file, including the file name and its extension. For example: /files/file.txt. Default value: the name of the resource block. Microsoft Windows: A path that begins with a forward slash (/) will point to the root of the current working directory of the #{Chef::Dist::CLIENT} process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (/) is not recommended."
 
       property :atomic_update, [ TrueClass, FalseClass ], desired_state: false, default: lazy { |r| r.docker? && r.special_docker_files?(r.path) ? false : Chef::Config[:file_atomic_update] },
                description: "Perform atomic file updates on a per-resource basis. Set to true for atomic file updates. Set to false for non-atomic file updates. This setting overrides file_atomic_update, which is a global setting found in the client.rb file."
@@ -69,7 +70,7 @@ class Chef
       property :diff, [ String, nil ], desired_state: false, skip_docs: true
 
       property :force_unlink, [ TrueClass, FalseClass ], desired_state: false, default: false,
-               description: "How the chef-client handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to true for the chef-client delete the non-file target and replace it with the specified file. Set to false for the chef-client to raise an error."
+               description: "How the #{Chef::Dist::CLIENT} handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to true for the #{Chef::Dist::CLIENT} delete the non-file target and replace it with the specified file. Set to false for the #{Chef::Dist::CLIENT} to raise an error."
 
       property :manage_symlink_source, [ TrueClass, FalseClass ], desired_state: false,
                description: "Change the behavior of the file resource if it is pointed at a symlink. When this value is set to true, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to false, Chef will follow the symlink and will manage the permissions and content of symlink's target file. The default behavior is true but emits a warning that the default value will be changed to false in a future version; setting this explicitly to true or false suppresses this warning."

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource/package"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -44,7 +45,7 @@ class Chef
                default: lazy { Chef::Config[:clear_gem_sources] }, desired_state: false
 
       property :gem_binary, String, desired_state: false,
-               description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the chef-client will be installed."
+               description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the #{Chef::Dist::CLIENT} will be installed."
 
       property :include_default_source, [ TrueClass, FalseClass ],
                description: "Set to 'false' to not include 'Chef::Config[:rubygems_url]'' in the sources.",

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -20,6 +20,7 @@
 
 require "chef/provider/package"
 require "chef/resource/package"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -31,7 +32,7 @@ class Chef
       introduced "12.0"
 
       property :homebrew_user, [ String, Integer ],
-               description: "The name of the Homebrew owner to be used by the chef-client when executing a command."
+               description: "The name of the Homebrew owner to be used by the #{Chef::Dist::CLIENT} when executing a command."
 
     end
   end

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -18,6 +18,7 @@
 #
 
 require "chef/resource"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -25,10 +26,10 @@ class Chef
       resource_name :ohai
       provides :ohai
 
-      description "Use the ohai resource to reload the Ohai configuration on a node. This allows recipes that change system attributes (like a recipe that adds a user) to refer to those attributes later on during the chef-client run."
+      description "Use the ohai resource to reload the Ohai configuration on a node. This allows recipes that change system attributes (like a recipe that adds a user) to refer to those attributes later on during the #{Chef::Dist::CLIENT} run."
 
       property :plugin, String,
-               description: "The name of an Ohai plugin to be reloaded. If this property is not specified, the chef-client will reload all plugins."
+               description: "The name of an Ohai plugin to be reloaded. If this property is not specified, the #{Chef::Dist::CLIENT} will reload all plugins."
 
       default_action :reload
       allowed_actions :reload

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -19,11 +19,12 @@
 
 require "chef/resource"
 require "chef/provider/ruby_block"
+require "chef/dist"
 
 class Chef
   class Resource
     class RubyBlock < Chef::Resource
-      description "Use the ruby_block resource to execute Ruby code during a chef-client run."\
+      description "Use the ruby_block resource to execute Ruby code during a #{Chef::Dist::CLIENT} run."\
                   " Ruby code in the ruby_block resource is evaluated with other resources during"\
                   " convergence, whereas Ruby code outside of a ruby_block resource is evaluated"\
                   " before other resources, as the recipe is compiled."

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -19,6 +19,7 @@
 
 require "chef/resource"
 require "shellwords"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -33,7 +34,7 @@ class Chef
 
       # this is a poor API please do not re-use this pattern
       property :supports, Hash, default: { restart: nil, reload: nil, status: nil },
-               description: "A list of properties that controls how the chef-client is to attempt to manage a service: :restart, :reload, :status. For :restart, the init script or other service provider can use a restart command; if :restart is not specified, the chef-client attempts to stop and then start a service. For :reload, the init script or other service provider can use a reload command. For :status, the init script or other service provider can use a status command to determine if the service is running; if :status is not specified, the chef-client attempts to match the service_name against the process table as a regular expression, unless a pattern is specified as a parameter property. Default value: { restart: false, reload: false, status: false } for all platforms (except for the Red Hat platform family, which defaults to { restart: false, reload: false, status: true }.)",
+               description: "A list of properties that controls how the #{Chef::Dist::CLIENT} is to attempt to manage a service: :restart, :reload, :status. For :restart, the init script or other service provider can use a restart command; if :restart is not specified, the #{Chef::Dist::CLIENT} attempts to stop and then start a service. For :reload, the init script or other service provider can use a reload command. For :status, the init script or other service provider can use a status command to determine if the service is running; if :status is not specified, the #{Chef::Dist::CLIENT} attempts to match the service_name against the process table as a regular expression, unless a pattern is specified as a parameter property. Default value: { restart: false, reload: false, status: false } for all platforms (except for the Red Hat platform family, which defaults to { restart: false, reload: false, status: true }.)",
                coerce: proc { |x| x.is_a?(Array) ? x.each_with_object({}) { |i, m| m[i] = true } : x }
 
       property :service_name, String,
@@ -76,7 +77,7 @@ class Chef
       # specify overrides for the start_command, stop_command and
       # restart_command properties.
       property :init_command, String,
-               description: "The path to the init script that is associated with the service. Use init_command to prevent the need to specify overrides for the start_command, stop_command, and restart_command properties. When this property is not specified, the chef-client will use the default init command for the service provider being used.",
+               description: "The path to the init script that is associated with the service. Use init_command to prevent the need to specify overrides for the start_command, stop_command, and restart_command properties. When this property is not specified, the #{Chef::Dist::CLIENT} will use the default init command for the service provider being used.",
                desired_state: false
 
       # if the service is enabled or not

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -18,6 +18,7 @@
 #
 
 require "chef/resource/scm"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -32,7 +33,7 @@ class Chef
                default: "--no-auth-cache"
 
       property :svn_info_args, [String, nil, FalseClass],
-               description: "Use when the svn info command is used by the chef-client and arguments need to be passed. The svn_arguments command does not work when the svn info command is used.",
+               description: "Use when the svn info command is used by the #{Chef::Dist::CLIENT} and arguments need to be passed. The svn_arguments command does not work when the svn info command is used.",
                coerce: proc { |v| v == false ? nil : v }, # coerce false to nil
                default: "--no-auth-cache"
 

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -20,6 +20,7 @@
 
 require "chef/resource/file"
 require "chef/mixin/securable"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -67,7 +68,7 @@ class Chef
 
       property :local, [ TrueClass, FalseClass ],
                default: false, desired_state: false,
-               description: "Load a template from a local path. By default, the chef-client loads templates from a cookbook’s /templates directory. When this property is set to true, use the source property to specify the path to a template on the local node."
+               description: "Load a template from a local path. By default, the #{Chef::Dist::CLIENT} loads templates from a cookbook’s /templates directory. When this property is set to true, use the source property to specify the path to a template on the local node."
 
       # Declares a helper method to be defined in the template context when
       # rendering.

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -21,6 +21,7 @@ require "chef/util/path_helper"
 require "chef/resource"
 require "win32-certstore" if Chef::Platform.windows?
 require "openssl"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -53,7 +54,7 @@ class Chef
 
       # lazy used to set default value of sensitive to true if password is set
       property :sensitive, [TrueClass, FalseClass],
-               description: "Ensure that sensitive resource data is not logged by the chef-client.",
+               description: "Ensure that sensitive resource data is not logged by the #{Chef::Dist::CLIENT}.",
                default: lazy { |r| r.pfx_password ? true : false }, skip_docs: true
 
       action :create do

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/resource/package"
+require "chef/dist"
 
 class Chef
   class Resource
@@ -51,7 +52,7 @@ class Chef
                coerce: proc { |x| x.is_a?(Array) ? x.to_a : x }
 
       property :flush_cache, Hash,
-               description: "Flush the in-memory cache before or after a Yum operation that installs, upgrades, or removes a package. Accepts a Hash in the form: { :before => true/false, :after => true/false } or an Array in the form [ :before, :after ].\nYum automatically synchronizes remote metadata to a local cache. The chef-client creates a copy of the local cache, and then stores it in-memory during the chef-client run. The in-memory cache allows packages to be installed during the chef-client run without the need to continue synchronizing the remote metadata to the local cache while the chef-client run is in-progress.",
+               description: "Flush the in-memory cache before or after a Yum operation that installs, upgrades, or removes a package. Accepts a Hash in the form: { :before => true/false, :after => true/false } or an Array in the form [ :before, :after ].\nYum automatically synchronizes remote metadata to a local cache. The #{Chef::Dist::CLIENT} creates a copy of the local cache, and then stores it in-memory during the #{Chef::Dist::CLIENT} run. The in-memory cache allows packages to be installed during the #{Chef::Dist::CLIENT} run without the need to continue synchronizing the remote metadata to the local cache while the #{Chef::Dist::CLIENT} run is in-progress.",
                default: { before: false, after: false },
                coerce: proc { |v|
                  if v.is_a?(Hash)

--- a/spec/functional/resource/windows_task_spec.rb
+++ b/spec/functional/resource/windows_task_spec.rb
@@ -18,6 +18,7 @@
 
 require "spec_helper"
 require "chef/provider/windows_task"
+require "chef/dist"
 
 describe Chef::Resource::WindowsTask, :windows_only do
   # resource.task.application_name will default to task_name unless resource.command is set
@@ -45,37 +46,37 @@ describe Chef::Resource::WindowsTask, :windows_only do
 
       context "With Arguments" do
         it "creates scheduled task and sets command arguments" do
-          subject.command "chef-client -W"
+          subject.command "#{Chef::Dist::CLIENT} -W"
           call_for_create_action
           # loading current resource again to check new task is creted and it matches task parameters
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
-          expect(current_resource.task.application_name).to eq("chef-client")
+          expect(current_resource.task.application_name).to eq(Chef::Dist::CLIENT)
           expect(current_resource.task.parameters).to eq("-W")
         end
 
         it "does not converge the resource if it is already converged" do
-          subject.command "chef-client -W"
+          subject.command "#{Chef::Dist::CLIENT} -W"
           subject.run_action(:create)
-          subject.command "chef-client -W"
+          subject.command "#{Chef::Dist::CLIENT} -W"
           subject.run_action(:create)
           expect(subject).not_to be_updated_by_last_action
         end
 
         it "creates scheduled task and sets command arguments when arguments inclusive single quotes" do
-          subject.command "chef-client -W -L 'C:\\chef\\chef-ad-join.log'"
+          subject.command "#{Chef::Dist::CLIENT} -W -L 'C:\\chef\\chef-ad-join.log'"
           call_for_create_action
           # loading current resource again to check new task is creted and it matches task parameters
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
-          expect(current_resource.task.application_name).to eq("chef-client")
+          expect(current_resource.task.application_name).to eq(Chef::Dist::CLIENT)
           expect(current_resource.task.parameters).to eq("-W -L 'C:\\chef\\chef-ad-join.log'")
         end
 
         it "does not converge the resource if it is already converged" do
-          subject.command "chef-client -W -L 'C:\\chef\\chef-ad-join.log'"
+          subject.command "#{Chef::Dist::CLIENT} -W -L 'C:\\chef\\chef-ad-join.log'"
           subject.run_action(:create)
-          subject.command "chef-client -W -L 'C:\\chef\\chef-ad-join.log'"
+          subject.command "#{Chef::Dist::CLIENT} -W -L 'C:\\chef\\chef-ad-join.log'"
           subject.run_action(:create)
           expect(subject).not_to be_updated_by_last_action
         end
@@ -135,19 +136,19 @@ describe Chef::Resource::WindowsTask, :windows_only do
 
       context "Without Arguments" do
         it "creates scheduled task and sets command arguments" do
-          subject.command "chef-client"
+          subject.command Chef::Dist::CLIENT
           call_for_create_action
           # loading current resource again to check new task is creted and it matches task parameters
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
-          expect(current_resource.task.application_name).to eq("chef-client")
+          expect(current_resource.task.application_name).to eq(Chef::Dist::CLIENT)
           expect(current_resource.task.parameters).to be_empty
         end
 
         it "does not converge the resource if it is already converged" do
-          subject.command "chef-client"
+          subject.command Chef::Dist::CLIENT
           subject.run_action(:create)
-          subject.command "chef-client"
+          subject.command Chef::Dist::CLIENT
           subject.run_action(:create)
           expect(subject).not_to be_updated_by_last_action
         end


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <mchamberland@pbsc.com>

### Description
More Changes related to https://github.com/chef/chef/issues/8376, this PR should clean up the word `chef-client` from the code base (perhaps a bit too aggressively).

### Issues Resolved
More work towards https://github.com/chef/chef/issues/8376

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG