### PR TITLE
Implement bootstrap directly with train

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 5c70e89388ebc8ddf7d2d7bfd489024b11c0aece
+  revision: a1ec73298d623d18cbe05c2b53ac57c8cc9beae0
   branch: master
   specs:
     ohai (15.0.34)
@@ -32,7 +32,6 @@ PATH
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
       chef-config (= 15.0.237)
-      chef-core (~> 0.0.3)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -54,6 +53,7 @@ PATH
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
+      train-core (~> 2.0, >= 2.0.12)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
     chef (15.0.237-universal-mingw32)
@@ -61,7 +61,6 @@ PATH
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
       chef-config (= 15.0.237)
-      chef-core (~> 0.0.3)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -84,6 +83,7 @@ PATH
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
+      train-core (~> 2.0, >= 2.0.12)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
@@ -113,7 +113,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    appbundler (0.12.4)
+    appbundler (0.12.5)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
@@ -124,20 +124,6 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (11.0.1)
-    chef-core (0.0.3)
-      chef-telemetry
-      mixlib-log
-      pastel
-      r18n-desktop
-      train-core (~> 2.0, >= 2.0.12)
-      tty-color
-      tty-cursor
-      tty-spinner
-    chef-telemetry (0.1.8)
-      chef-config
-      concurrent-ruby (~> 1.0)
-      ffi-yajl (~> 2.2)
-      http (~> 2.2)
     chef-vault (3.4.3)
     chef-zero (14.0.12)
       ffi-yajl (~> 2.2)
@@ -149,14 +135,11 @@ GEM
       chef-zero (~> 14.0)
       net-ssh
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.2.4)
     equatable (0.5.0)
     erubis (2.7.0)
@@ -182,15 +165,6 @@ GEM
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
-    http (2.2.2)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 1.0.1)
-      http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    http-form_data (1.0.3)
-    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     iniparse (1.4.4)
     inspec-core (4.1.4.preview)
@@ -223,7 +197,7 @@ GEM
     jaro_winkler (1.5.2)
     json (2.2.0)
     libyajl2 (1.2.0)
-    license-acceptance (0.2.13)
+    license-acceptance (0.2.16)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -264,7 +238,7 @@ GEM
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.17.0)
-    parser (2.6.2.1)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.2)
@@ -286,9 +260,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.3)
-    r18n-core (3.2.0)
-    r18n-desktop (3.2.0)
-      r18n-core (= 3.2.0)
     rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
@@ -375,17 +346,12 @@ GEM
       tty-screen (~> 0.6.4)
       wisper (~> 2.0.0)
     tty-screen (0.6.5)
-    tty-spinner (0.9.0)
-      tty-cursor (~> 0.6.0)
     tty-table (0.10.0)
       equatable (~> 0.5.0)
       necromancer (~> 0.4.0)
       pastel (~> 0.7.2)
       strings (~> 0.1.0)
       tty-screen (~> 0.6.4)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.6)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
@@ -417,7 +383,7 @@ GEM
     win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
-    winrm (2.3.1)
+    winrm (2.3.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
-  s.add_dependency "chef-core", "~> 0.0.3"
+  s.add_dependency "train-core", "~> 2.0", ">= 2.0.12"
 
   s.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"

--- a/lib/chef.rb
+++ b/lib/chef.rb
@@ -18,18 +18,6 @@
 
 require "chef/version"
 
-# Ensure that this loads ahead of anything that
-# might cause rubygems to hit Gem.load_yaml, including
-# evaluating gemspecs. When load_yaml is invoked,
-# it stubs out  the YAML::Syck namespace. This causes
-# r18n to break, which expects either YAML::Syck to be there
-# and fully defined (particularly, the Syck::PrivateType class),
-# or for it to not be there at all.
-#
-# When it's not - because it's a stub - r18n explodes on loading.
-# Ensuring chef_core/text and r18n are loaded first prevents this.
-require "chef_core/text"
-
 require "chef/nil_argument"
 require "chef/mash"
 require "chef/exceptions"

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -18,11 +18,6 @@
 
 require "chef/knife"
 require "chef/knife/data_bag_secret_options"
-require "erubis"
-require "chef/knife/bootstrap/chef_vault_handler"
-require "chef/knife/bootstrap/client_builder"
-require "chef/util/path_helper"
-require "chef/dist"
 
 class Chef
   class Knife
@@ -390,7 +385,13 @@ class Chef
       attr_reader   :connection
 
       deps do
+        require "erubis"
+
         require "chef/json_compat"
+        require "chef/util/path_helper"
+        require "chef/knife/bootstrap/chef_vault_handler"
+        require "chef/knife/bootstrap/client_builder"
+        require "chef/knife/bootstrap/train_connector"
       end
 
       banner "knife bootstrap [PROTOCOL://][USER@]FQDN (options)"
@@ -623,8 +624,6 @@ class Chef
       end
 
       def do_connect(conn_options)
-        require "chef/knife/bootstrap/train_connector"
-
         @connection = TrainConnector.new(host_descriptor, connection_protocol, conn_options)
         connection.connect!
       end

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -1,0 +1,293 @@
+# Copyright:: Copyright (c) 2019 Chef Software Inc.
+#
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "train"
+require "tempfile"
+require "uri"
+
+class Chef
+  class Knife
+    class Bootstrap < Knife
+      class TrainConnector
+        SSH_CONFIG_OVERRIDE_KEYS = [:user, :port, :proxy].freeze
+
+        MKTEMP_WIN_COMMAND = <<~EOM.freeze
+          $parent = [System.IO.Path]::GetTempPath();
+          [string] $name = [System.Guid]::NewGuid();
+          $tmp = New-Item -ItemType Directory -Path;
+          (Join-Path $parent $name);
+          $tmp.FullName
+        EOM
+
+        MKTEMP_NIX_COMMAND = "bash -c 'd=$(mktemp -d ${TMPDIR:-/tmp}/chef_XXXXXX); echo $d'".freeze
+
+        def initialize(host_url, default_transport, opts)
+
+          uri_opts = opts_from_uri(host_url)
+          uri_opts[:backend] ||= @default_transport
+          @transport_type = uri_opts[:backend]
+
+          # opts in the URI will override user-provided options
+          @config = transport_config(host_url, opts.merge(uri_opts))
+
+          Train.validate_backend(@config)
+          @train = Train.create(@transport_type, @config)
+        end
+
+        # Because creating a valid train connection for testing is a two-step process in which
+        # we need to connect before mocking config,
+        # we expose test_instance as a way for tests to create actual instances
+        # but ensure that they don't connect to any back end.
+        def self.test_instance(url, protocol: "ssh",
+                               family: "unknown", name: "unknown",
+                               release: "unknown", arch: "x86_64",
+                               opts: {})
+          # Specifying sudo: false ensures that attempted operations
+          # don't fail because the mock platform doesn't support sudo
+          tc = TrainConnector.new(url, protocol, { sudo: false }.merge(opts))
+
+          # Don't pull in the platform-specific mixins automatically during connect
+          # Otherwise, it will raise since it can't resolve the OS without the mock.
+          tc.connect!
+          # We need to provide this mock before invoking mix_in_target_platform,
+          # otherwise it will fail with an unknown OS (since we don't have a real connection).
+          tc.backend.mock_os(
+            family: family,
+            name: name,
+            release: release,
+            arch: arch
+          )
+          tc
+
+        end
+
+        def connect!
+          # Force connection to establish:
+          backend.wait_until_ready
+          true
+        end
+
+        def hostname
+          @config[:host]
+        end
+
+        def password_auth?
+          @config.key? :password
+        end
+
+        # True if we're connected to a linux host
+        def linux?
+          backend.platform.linux?
+        end
+
+        # True if we're connected to a unix host.
+        # NOTE: this is always true
+        # for a linux host because train classifies
+        # linux as a unix
+        def unix?
+          backend.platform.unix?
+        end
+
+        # True if we're connected to a windows host
+        def windows?
+          backend.platform.windows?
+        end
+
+        def winrm?
+          @transport_type == "winrm"
+        end
+
+        def ssh?
+          @transport_type == "ssh"
+        end
+
+        # Creates a temporary directory on the remote host if it
+        # hasn't already. Caches directory location.
+        #
+        # Returns the path.
+        def temp_dir
+          cmd = windows? ? MKTEMP_WIN_COMMAND : MKTEMP_NIX_COMMAND
+          @tmpdir ||= begin
+                        res = run_command!(cmd)
+                        dir = res.stdout.chomp.strip
+                        unless windows?
+                          run_command!("chown #{@config[:user]} '#{dir}'")
+                        end
+                        dir
+                      end
+        end
+
+        def upload_file!(local_path, remote_path)
+          backend.upload(local_path, remote_path)
+        end
+
+        def upload_file_content!(content, remote_path)
+          t = Tempfile.new("chef-content")
+          t << content
+          t.close
+          upload_file!(t.path, remote_path)
+        ensure
+          t.close
+          t.unlink
+        end
+
+        def del_file!(path)
+          if windows?
+            run_command!("If (Test-Path \"#{path}\") { Remove-Item -Force -Path \"#{path}\" }")
+          else
+            run_command!("rm -f \"#{path}\"")
+          end
+        end
+
+        # normalizes path across OS's
+        def normalize_path(path)
+          path.tr("\\", "/")
+        end
+
+        def run_command(command, &data_handler)
+          backend.run_command(command, &data_handler)
+        end
+
+        def run_command!(command, &data_handler)
+          result = run_command(command, &data_handler)
+          if result.exit_status != 0
+            raise RemoteExecutionFailed.new(hostname, command, result)
+          end
+          result
+        end
+
+        # Should be private, but we use them for test validation/mocking
+        def train
+          @train
+        end
+        def backend
+          @train.connection
+        end
+
+        private
+
+        # For a given url and set of options, create a config
+        # hash suitable for passing into train.
+        def transport_config(host_url, opts_in)
+          opts = { target: host_url,
+                   sudo: opts_in[:sudo] === false ? false : true,
+                   # TODO - we should be always encoding password
+                   www_form_encoded_password: true,
+                   key_files: opts_in[:key_files],
+                   non_interactive: true, # Prevent password prompts
+                   transport_retries: 2,
+                   transport_retry_sleep: 1,
+                   logger: opts_in[:logger],
+                   backend: @transport_type }
+
+          # Base opts are those provided by the caller directly
+          opts.merge!(opts_from_caller(opts, opts_in))
+
+          # WinRM has some additional computed options
+          opts.merge!(opts_inferred_from_winrm(opts, opts_in))
+
+          # Now that everything is populated, fill in anything left
+          # from user ssh config that may be present
+          opts.merge!(missing_opts_from_ssh_config(opts, opts_in))
+
+          Train.target_config(opts)
+        end
+
+        # Some winrm options are inferred based on other options.
+        # Return a hash of winrm options based on configuration already built.
+        def opts_inferred_from_winrm(config, opts_in)
+          return {} unless winrm?
+          opts_out = {}
+
+          if opts_in[:ssl]
+            opts_out[:ssl] = true
+            opts_out[:self_signed] = opts_in[:self_signed] || false
+          end
+
+          # See note here: https://github.com/mwrock/WinRM#example
+          if %w{ssl plaintext}.include?(opts_in[:winrm_auth_method])
+            opts_out[:winrm_disable_sspi] = true
+          end
+          opts_out
+        end
+
+        # Returns a hash containing valid options for the current
+        # transport protocol that are not already present in config
+        def opts_from_caller(config, opts_in)
+          # Train.options gives us the supported config options for the
+          # backend provider (ssh, winrm). We'll use that
+          # to filter out options that don't belong
+          # to the transport type we're using.
+          valid_opts = Train.options(config[:backend])
+          opts_in.select do |key, _v|
+            valid_opts.key?(key) &&
+              !config.key?(key) end
+        end
+
+        # Extract any of username/password/host/port/transport
+        # that are in the URI and return them as a config has
+        def opts_from_uri(uri)
+          # Train.unpack_target_from_uri only works for complete URIs in
+          # form of proto://[user[:pass]@]host[:port]/
+          # So we'll add the protocol prefix if it's not supplied.
+          uri_to_check = if URI.regexp.match(uri)
+                           uri
+                         else
+                           "#{@transport_type}://#{uri}"
+                         end
+
+          Train.unpack_target_from_uri(uri_to_check)
+        end
+
+        # This returns a hash that consists of settings
+        # populated from SSH configuration that are not already present
+        # in the configuration passed in.
+        # This is necessary because train will default these values
+        # itself - causing SSH config data to be ignored
+        def missing_opts_from_ssh_config(config, opts_in)
+          return {} unless ssh?
+          host_cfg = ssh_config_for_host(config[:host])
+          opts_out = {}
+          opts_in.each do |key, _value|
+            if SSH_CONFIG_OVERRIDE_KEYS.include?(key) && !config.key?(key)
+              opts_out[key] = host_cfg[key]
+            end
+          end
+          opts_out
+        end
+
+        # Having this as a method makes it easier to mock
+        # SSH Config for testing.
+        def ssh_config_for_host(host)
+          require "net/ssh"
+          Net::SSH::Config.for(host)
+        end
+      end
+
+      class RemoteExecutionFailed < StandardError
+        attr_reader :exit_status, :command, :hostname, :stdout, :stderr
+        def initialize(hostname, command, result)
+          @hostname = hostname
+          @exit_status = result.exit_status
+          @stderr = result.stderr
+          @stdout = result.stdout
+        end
+      end
+
+    end
+  end
+end

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -19,7 +19,6 @@
 
 require "tmpdir"
 require "fileutils"
-require "chef_core/text"
 require "chef/config"
 require "chef/json_compat"
 require "chef/server_api"

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -1,0 +1,24 @@
+#
+# Copyright:: Copyright (c) 2019 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "ostruct"
+require "chef/knife/bootstrap/train_connector"
+
+describe Chef::Knife::Bootstrap::TrainConnector do
+  # Tests in flight, will be pushed up
+end

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -20,5 +20,136 @@ require "ostruct"
 require "chef/knife/bootstrap/train_connector"
 
 describe Chef::Knife::Bootstrap::TrainConnector do
-  # Tests in flight, will be pushed up
+  let(:protocol) { "mock" }
+  let(:family) { "unknown" }
+  let(:release) { "unknown" } # version
+  let(:name) { "unknown" }
+  let(:arch) { "x86_64" }
+  let(:host_url) { "mock://user1@example.com" }
+  let(:opts) { {} }
+  subject do
+    # Create a valid TargetHost with the backend stubbed out.
+    Chef::Knife::Bootstrap::TrainConnector.test_instance(host_url,
+                                                         protocol: protocol,
+                                                         family: family,
+                                                         name: name,
+                                                         release: release,
+                                                         arch: arch,
+                                                         opts: opts)
+  end
+
+  context "connect!" do
+  end
+
+  describe "platform helpers" do
+    context "on linux" do
+      let(:family) { "debian" }
+      let(:name) { "ubuntu" }
+      it "reports that it is linux and unix, because that is how train classifies it" do
+        expect(subject.unix?).to eq true
+        expect(subject.linux?).to eq true
+        expect(subject.windows?).to eq false
+      end
+    end
+    context "on unix" do
+      let(:family) { "os" }
+      let(:name) { "mac_os_x" }
+      it "reports only a unix OS" do
+        expect(subject.unix?).to eq true
+        expect(subject.linux?).to eq false
+        expect(subject.windows?).to eq false
+      end
+    end
+    context "on windows" do
+      let(:family) { "windows" }
+      let(:name) { "windows" }
+      it "reports only a windows OS" do
+        expect(subject.unix?).to eq false
+        expect(subject.linux?).to eq false
+        expect(subject.windows?).to eq true
+      end
+    end
+  end
+
+  describe "#connect!" do
+    it "establishes the connection to the remote host by waiting for it" do
+      expect(subject.connection).to receive(:wait_until_ready)
+      subject.connect!
+    end
+  end
+
+  describe "#temp_dir" do
+    context "under windows" do
+      let(:family) { "windows" }
+      let(:name) { "windows" }
+
+      it "uses the windows command to create the temp dir" do
+        expected_command = Chef::Knife::Bootstrap::TrainConnector::MKTEMP_WIN_COMMAND
+        expect(subject).to receive(:run_command!).with(expected_command)
+          .and_return double("result", stdout: "C:/a/path")
+        expect(subject.temp_dir).to eq "C:/a/path"
+      end
+
+    end
+    context "under linux and unix-like" do
+      let(:family) { "debian" }
+      let(:name) { "ubuntu" }
+      it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
+        expected_command = Chef::Knife::Bootstrap::TrainConnector::MKTEMP_NIX_COMMAND
+        expect(subject).to receive(:run_command!).with(expected_command)
+          .and_return double("result", stdout: "/a/path")
+        expect(subject).to receive(:run_command!).with("chown user1 '/a/path'")
+        expect(subject.temp_dir).to eq "/a/path"
+      end
+
+    end
+  end
+  context "#upload_file_content!" do
+    it "creates a local file with expected content and uploads it" do
+      expect(subject).to receive(:upload_file!) do |local_path, remote_path|
+        expect(File.read(local_path)).to eq "test data"
+        expect(remote_path).to eq "/target/path"
+      end
+      subject.upload_file_content!("test data", "/target/path")
+    end
+  end
+
+  context "del_file" do
+    context "on windows" do
+      let(:family) { "windows" }
+      let(:name) { "windows" }
+      it "deletes the file with a windows command" do
+        expect(subject).to receive(:run_command!) do |cmd, &_handler|
+          expect(cmd).to match(/Test-Path "deleteme\.txt".*/)
+        end
+        subject.del_file!("deleteme.txt")
+      end
+    end
+    context "on unix-like" do
+      let(:family) { "debian" }
+      let(:name) { "ubuntu" }
+      it "deletes the file with a windows command" do
+        expect(subject).to receive(:run_command!) do |cmd, &_handler|
+          expect(cmd).to match(/rm -f "deleteme\.txt".*/)
+        end
+        subject.del_file!("deleteme.txt")
+      end
+    end
+  end
+
+  context "#run_command!" do
+    it "raises a RemoteExecutionFailed when the remote execution failed" do
+      command_result = double("results", stdout: "", stderr: "failed", exit_status: 1)
+      expect(subject).to receive(:run_command).and_return command_result
+
+      expect { subject.run_command!("test") }.to raise_error do |e|
+        expect(e.hostname).to eq subject.hostname
+        expect(e.class).to eq Chef::Knife::Bootstrap::RemoteExecutionFailed
+        expect(e.stderr).to eq "failed"
+        expect(e.stdout).to eq ""
+        expect(e.exit_status).to eq 1
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
### Description

This removes chef-core from bootstrap and replaces it with direct usage of train.  

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG