### PR TITLE
windows_task: Add start_when_available support

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -334,7 +334,8 @@ class Chef
             task.parameters != new_resource.command_arguments.to_s ||
             task.principals[:run_level] != run_level ||
             task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_if_on_batteries ||
-            task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries)
+            task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries ||
+            task.settings[:start_when_available] != new_resource.start_when_available)
           else
             current_task_trigger = task.trigger(0)
             new_task_trigger = trigger
@@ -360,7 +361,8 @@ class Chef
                 task.principals[:run_level] != run_level ||
                 PRIORITY[task.priority] != new_resource.priority ||
                 task.settings[:disallow_start_if_on_batteries] != new_resource.disallow_start_if_on_batteries ||
-                task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries
+                task.settings[:stop_if_going_on_batteries] != new_resource.stop_if_going_on_batteries ||
+                task.settings[:start_when_available] != new_resource.start_when_available
               if trigger_type == TaskScheduler::MONTHLYDATE
                 flag = true if current_task_trigger[:run_on_last_day_of_month] != new_task_trigger[:run_on_last_day_of_month]
               end
@@ -560,12 +562,13 @@ class Chef
           settings[:priority] = new_resource.priority
           settings[:disallow_start_if_on_batteries] = new_resource.disallow_start_if_on_batteries
           settings[:stop_if_going_on_batteries] = new_resource.stop_if_going_on_batteries
+          settings[:start_when_available] = new_resource.start_when_available
           settings
         end
 
         def principal_settings
           settings = {}
-          settings [:run_level] = run_level
+          settings[:run_level] = run_level
           settings[:logon_type] = logon_type
           settings
         end

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -120,6 +120,10 @@ class Chef
                introduced: "14.7",
                description: "The task description."
 
+      property :start_when_available, [TrueClass, FalseClass],
+               introduced: "15.0", default: false,
+               description: "To start the task at any time after its scheduled time has passed."
+
       attr_accessor :exists, :task, :command_arguments
 
       VALID_WEEK_DAYS = %w{ mon tue wed thu fri sat sun * }.freeze

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -61,6 +61,10 @@ describe Chef::Resource::WindowsTask, :windows_only do
     expect(resource.stop_if_going_on_batteries).to eql(false)
   end
 
+  it "sets the default value for start_when_available as false" do
+    expect(resource.start_when_available).to eql(false)
+  end
+
   context "when frequency is not provided" do
     it "raises ArgumentError to provide frequency" do
       expect { resource.after_created }.to raise_error(ArgumentError, "Frequency needs to be provided. Valid frequencies are :minute, :hourly, :daily, :weekly, :monthly, :once, :on_logon, :onstart, :on_idle, :none." )


### PR DESCRIPTION
### Description
 - Add `start_when_available` option in `windows_task` resource. 
 -  `start_when_available` is already avaibale in https://github.com/chef/win32-taskscheduler.
 - Add Unit/Functional test cases.
### Issues Resolved
https://github.com/chef/chef/issues/8377
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>