### PR TITLE
[CHEF-8422] Fix incorrect deprecation warnings

### DIFF
--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1571,7 +1571,7 @@ describe Chef::Knife::Bootstrap do
     end
 
     it "performs the steps we expect to run a bootstrap" do
-      expect(knife).to receive(:warn_and_map_deprecated_flags).ordered
+      expect(knife).to receive(:verify_deprecated_flags!).ordered
       expect(knife).to receive(:validate_name_args!).ordered
       expect(knife).to receive(:validate_protocol!).ordered
       expect(knife).to receive(:validate_first_boot_attributes!).ordered
@@ -1593,7 +1593,7 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
-  describe "#warn_and_map_deprecated_flags" do
+  describe "#verify_deprecated_flags!" do
     before do
       Chef::Config[:silence_deprecation_warnings] = false
     end
@@ -1605,7 +1605,7 @@ describe Chef::Knife::Bootstrap do
       end
       it "maps the key value to the new key and points the human to the new flag" do
         expect(knife.ui).to receive(:warn).with(/--ssh-user USER is deprecated. Use --connection-user USERNAME instead./)
-        knife.warn_and_map_deprecated_flags
+        knife.verify_deprecated_flags!
         expect(knife.config[:connection_user]).to eq "sshuser"
       end
     end
@@ -1616,10 +1616,10 @@ describe Chef::Knife::Bootstrap do
         knife.config[:connection_user] = "real-user"
         knife.merge_configs
       end
-      it "warns that both are provided and takes the non-deprecated value" do
-        expect(knife.ui).to receive(:warn).with(/You provided both --connection-user and --ssh-user.*'--connection-user real-user'/m)
-        knife.warn_and_map_deprecated_flags
-        expect(knife.config[:connection_user]).to eq "real-user"
+
+      it "informs the human that both are provided and exits" do
+        expect(knife.ui).to receive(:error).with(/You provided both --connection-user and --ssh-user.*Please use.*/m)
+        expect { knife.verify_deprecated_flags! }.to raise_error SystemExit
       end
     end
   end


### PR DESCRIPTION
## Description

Fixed incorrect option mapping where deprecated flags
would have a 'long' taken from the replacement flag. This caused 
mixlib-cli to duplicate the `long` flag - which caused lots of 
assignment confusion, including warning the operator about using flags they never used. 

This also updates the behavior in case of conflicting flags
(for example --ssh-user and --connection-user) to raise an error 
instead of choosing which one to use.This seems less likely to surprise.

Renamed deprecation variables and methods for readability/consistency.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Related Issue

Fixes #8422 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have ~added~ updated to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
