### PR TITLE
remove windows executables from windows gemspec

### DIFF
--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -19,6 +19,4 @@ gemspec.add_dependency "win32-certstore", "~> 0.3"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")
 
-gemspec.executables += %w{ chef-service-manager chef-windows-service }
-
 gemspec


### PR DESCRIPTION
these are moved to chef-bin now.

it looks like these were always duplicated in the chef.gemspec and
probably unnecessary anyway?
