### PR TITLE
fix chef-bin bundling in omnibus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,13 @@ gem "chef", path: "."
 gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master"
 
 gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.exist?(File.expand_path("../chef-config", __FILE__))
-gem "chef-bin", path: File.expand_path("../chef-bin", __FILE__) if File.exist?(File.expand_path("../chef-bin", __FILE__))
+
+if File.exist?(File.expand_path("../chef-bin", __FILE__))
+  gem "chef-bin", path: File.expand_path("../chef-bin", __FILE__) # bundling in a git checkout
+else
+  gem "chef-bin" # bundling in omnibus
+end
+
 gem "cheffish", "~> 14"
 
 group(:omnibus_package) do

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,11 @@ gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master"
 gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.exist?(File.expand_path("../chef-config", __FILE__))
 
 if File.exist?(File.expand_path("../chef-bin", __FILE__))
-  gem "chef-bin", path: File.expand_path("../chef-bin", __FILE__) # bundling in a git checkout
+  # bundling in a git checkout
+  gem "chef-bin", path: File.expand_path("../chef-bin", __FILE__)
 else
-  gem "chef-bin" # bundling in omnibus
+  # bundling in omnibus
+  gem "chef-bin" # rubocop:disable Bundler/DuplicatedGem
 end
 
 gem "cheffish", "~> 14"


### PR DESCRIPTION
this file winds up in the embedded lib at:

/opt/chef/embedded/lib/ruby/gems/x.y.0/gems/chef-X.Y.Z/Gemfile

It needs to find the chef-bin gem from the same library, rather than
simply omitting it.

The chef-config gem comes in through the chef.gemspec so the lines are
different.