### PR TITLE
[CHEF-8432] Ensure default protocol is used properly. Use correct 'require' before accessing Net::SSH constants.

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -562,6 +562,7 @@ class Chef
         opts = connection_opts.dup
         do_connect(opts)
       rescue Train::Error => e
+        require "net/ssh"
         if e.cause && e.cause.class == Net::SSH::AuthenticationFailed
           if connection.password_auth?
             raise
@@ -578,7 +579,6 @@ class Chef
         end
       end
 
-      # TODO - maybe remove the footgun detection this was built on.
       # url values override CLI flags, if you provide both
       # we'll use the one that you gave in the URL.
       def connection_protocol
@@ -795,6 +795,7 @@ class Chef
       def ssh_opts
         opts = {}
         return opts if connection_protocol == "winrm"
+        opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config_value(:ssh_forward_agent) === true)
         opts
       end

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -44,27 +44,6 @@ class Chef
           @config = transport_config(host_url, opts.merge(uri_opts))
         end
 
-        # Because creating a valid train connection for testing is a two-step process in which
-        # we need to connect before mocking config,
-        # we expose test_instance as a way for tests to create actual instances
-        # but ensure that they don't connect to any back end.
-        def self.test_instance(url, protocol: "ssh",
-                               family: "unknown", name: "unknown",
-                               release: "unknown", arch: "x86_64",
-                               opts: {})
-          # Specifying sudo: false ensures that attempted operations
-          # don't fail because the mock platform doesn't support sudo
-          tc = TrainConnector.new(url, protocol, { sudo: false }.merge(opts))
-          tc.connect!
-          tc.connection.mock_os(
-            family: family,
-            name: name,
-            release: release,
-            arch: arch
-          )
-          tc
-        end
-
         def connect!
           # Force connection to establish
           connection.wait_until_ready

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -20,26 +20,31 @@ require "ostruct"
 require "chef/knife/bootstrap/train_connector"
 
 describe Chef::Knife::Bootstrap::TrainConnector do
-  let(:transport) { "mock" }
+  let(:protocol) { "mock" }
   let(:family) { "unknown" }
   let(:release) { "unknown" } # version
   let(:name) { "unknown" }
   let(:arch) { "x86_64" }
+  let(:connection_opts) { {} } # connection opts
   let(:host_url) { "mock://user1@example.com" }
-  let(:opts) { {} }
+  let(:mock_connection) { true }
+
   subject do
-    # Specifying sudo: false ensures that attempted operations
-    # don't fail because the mock platform doesn't support sudo.
-    # Example groups can still override by setting explicitly it in 'opts'
-    tc = Chef::Knife::Bootstrap::TrainConnector.new(host_url, transport, { sudo: false }.merge(opts))
-    tc.connect!
-    tc.connection.mock_os(
-      family: family,
-      name: name,
-      release: release,
-      arch: arch
-    )
+    # Example groups can still override by setting explicitly it in 'connection_opts'
+    tc = Chef::Knife::Bootstrap::TrainConnector.new(host_url, protocol, connection_opts)
     tc
+  end
+
+  before(:each) do
+    if mock_connection
+      subject.connect!
+      subject.connection.mock_os(
+        family: family,
+        name: name,
+        release: release,
+        arch: arch
+      )
+    end
   end
 
   describe "platform helpers" do
@@ -79,8 +84,59 @@ describe Chef::Knife::Bootstrap::TrainConnector do
     end
   end
 
-  describe "::new" do
+  describe "#initialize" do
+    let(:mock_connection) { false }
 
+    context "when provided target is a proper URL" do
+      let(:protocol) { "ssh" }
+      let(:host_url) { "mock://user1@localhost:2200" }
+      it "correctly configures the instance from the URL" do
+        expect(subject.config[:backend]).to eq "mock"
+        expect(subject.config[:port]).to eq 2200
+        expect(subject.config[:host]).to eq "localhost"
+        expect(subject.config[:user]).to eq "user1"
+      end
+
+      context "and conflicting options are given" do
+        let(:connection_opts) { { user: "user2", host: "example.com", port: 15 } }
+        it "resolves them from the URI" do
+          expect(subject.config[:backend]).to eq "mock"
+          expect(subject.config[:port]).to eq 2200
+          expect(subject.config[:host]).to eq "localhost"
+          expect(subject.config[:user]).to eq "user1"
+        end
+      end
+    end
+
+    context "when provided target is just a hostname" do
+      let(:host_url) { "localhost" }
+      let(:protocol) { "mock" }
+      it "correctly sets backend protocol from the default" do
+        expect(subject.config[:backend]).to eq "mock"
+      end
+
+      context "and options have been provided that are supported by the transport" do
+        let(:protocol) { "ssh" }
+        let(:connection_opts) { { port: 15, user: "user2" } }
+
+        it "sets hostname and transport from arguments and provided fields from options" do
+          expect(subject.config[:backend]).to eq "ssh"
+          expect(subject.config[:host]).to eq "localhost"
+          expect(subject.config[:user]).to eq "user2"
+          expect(subject.config[:port]).to eq 15
+        end
+
+      end
+
+    end
+
+    context "when provided target is just a an IP address" do
+      let(:host_url) { "127.0.0.1" }
+      let(:protocol) { "mock" }
+      it "correctly sets backend protocol from the default" do
+        expect(subject.config[:backend]).to eq "mock"
+      end
+    end
   end
 
   describe "#temp_dir" do

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -961,6 +961,7 @@ describe Chef::Knife::Bootstrap do
                 sudo: false,
                 verify_host_key: false,
                 port: 9999,
+                non_interactive: true,
               }
             end
 
@@ -1012,6 +1013,7 @@ describe Chef::Knife::Bootstrap do
                 sudo: true, # ccli
                 verify_host_key: false, # Config
                 port: 12, # cli
+                non_interactive: true,
               }
             end
 
@@ -1060,6 +1062,7 @@ describe Chef::Knife::Bootstrap do
                 sudo_options: "-H",
                 sudo_password: "blah",
                 verify_host_key: true,
+                non_interactive: true,
               }
             end
             it "generates a config hash using the CLI options and pulling nothing from Chef::Config" do
@@ -1079,6 +1082,7 @@ describe Chef::Knife::Bootstrap do
               keys_only: false,
               sudo: false,
               verify_host_key: true,
+              non_interactive: true,
             }
           end
           it "populates appropriate defaults" do
@@ -1430,13 +1434,13 @@ describe Chef::Knife::Bootstrap do
         before do
           knife.config[:ssh_forward_agent] = true
         end
-        it "returns a configuration hash with forward_agent set to true" do
-          expect(knife.ssh_opts).to eq({ forward_agent: true })
+        it "returns a configuration hash with forward_agent set to true. non-interactive is always true" do
+          expect(knife.ssh_opts).to eq({ forward_agent: true, non_interactive: true })
         end
       end
       context "when ssh_forward_agent is not set" do
-        it "returns a configuration hash with forward_agent set to false" do
-          expect(knife.ssh_opts).to eq({ forward_agent: false })
+        it "returns a configuration hash with forward_agent set to false. non-interactive is always true" do
+          expect(knife.ssh_opts).to eq({ forward_agent: false, non_interactive: true })
         end
       end
     end


### PR DESCRIPTION
## Description

This PR corrects two problems found in #8432: 
1. when protocol was not given in the URL (winrm://hostname) set the default protoocol - even if '-o' was given - because it was lost in incorrect order of operations. 
2. when a `TrainConnector#connect!` failed, if protocol was not `ssh` we would  would receive undefined constant `Net::SSH` - we check for a specific `Net::SSH` exception, but if we don't hit ssh path in train `net/ssh` is not loaded. 
3. In addition, it cleans up TrainConnector a bit: 
* remove `#test_instance` -- we can do the same setup in tests
* finish moving config setup to a lazy load 
* Naming was made more consistent within the module 
* Removed a couple helper methods that didn't make sense anymore
* add yard doc

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#8432 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] (na) I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
