### PR TITLE
Restore bootstrap pre-release support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -114,10 +114,11 @@ Using removed options will cause the command to fail.
 | --ssh-port | --connection-port | `knife[:ssh_port]` config setting remains available.
 | --ssh-user | --connection-user | `knife[:ssh_user]` config setting remains available.
 | --ssl-peer-fingerprint | --winrm-ssl-peer-fingerprint | |
+| --prerelease |--channel CHANNEL | This now allows you to specify the channel that Chef Infra Client gets installed from. Valid values: _stable_, current.  'current' has the same effect as using the old --prerelease. |
 | --winrm-authentication-protocol=PROTO | --winrm-auth-method=AUTH-METHOD | Valid values: plaintext, kerberos, ssl, _negotiate_|
 | --winrm-password| --connection-password | |
 | --winrm-port| --connection-port | `knife[:winrm_port]` config setting remains available.|
-| --winrm-ssl-verify-mode MODE | --winrm-no-verify-cert | [1] Mode is not accepted. When flag is present, SSL cert will not be verified. Same as original mode of 'verify_none'. |
+| --winrm-ssl-verify-mode MODE | --winrm-no-verify-cert | [1] Mode is not accepted. When flag is present, SSL cert will not be verified. Same as original mode of 'verify\_none'. |
 | --winrm-transport TRANSPORT | --winrm-ssl | [1] Use this flag if the target host is accepts WinRM connections over SSL.
 | --winrm-user | --connection-user | `knife[:winrm_user]` config setting remains available.|
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -131,7 +131,6 @@ Using removed options will cause the command to fail.
 |--kerberos-keytab-file| This option existed but was not implemented.|
 |--winrm-codepage| This was used under knife-windows because bootstrapping was performed over a `cmd` shell. It is now invoked from `powershell`, so this option is no longer used.|
 |--winrm-shell|This option was ignored for bootstrap.|
-|--prerelease|Chef now releases all development builds to our current channel and does not perform pre-release gem releases.|
 |--install-as-service|Installing Chef client as a service is not supported|
 
 #### Usage Changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -114,7 +114,7 @@ Using removed options will cause the command to fail.
 | --ssh-port | --connection-port | `knife[:ssh_port]` config setting remains available.
 | --ssh-user | --connection-user | `knife[:ssh_user]` config setting remains available.
 | --ssl-peer-fingerprint | --winrm-ssl-peer-fingerprint | |
-| --prerelease |--channel CHANNEL | This now allows you to specify the channel that Chef Infra Client gets installed from. Valid values: _stable_, current.  'current' has the same effect as using the old --prerelease. |
+| --prerelease |--channel CHANNEL | This now allows you to specify the channel that Chef Infra Client gets installed from. Valid values are _stable_, current, and unstable.  'current' has the same effect as using the old --prerelease. |
 | --winrm-authentication-protocol=PROTO | --winrm-auth-method=AUTH-METHOD | Valid values: plaintext, kerberos, ssl, _negotiate_|
 | --winrm-password| --connection-password | |
 | --winrm-port| --connection-port | `knife[:winrm_port]` config setting remains available.|

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -159,9 +159,9 @@ class Chef
 
       option :channel,
         long: "--channel CHANNEL",
-        description: "Install from the given channel. Valid values are 'current' and 'stable'. Default is 'stable'",
+        description: "Install from the given channel.  Valid values are 'stable, 'current', and 'unstable'. Default is 'stable'",
         default: "stable",
-        in: %w{stable current}
+        in: %w{stable current unstable}
 
       # client.rb content via chef-full/bootstrap_context
       option :bootstrap_proxy,

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -86,7 +86,8 @@ class Chef
         short: "-w AUTH-METHOD",
         long: "--winrm-auth-method AUTH-METHOD",
         description: "The WinRM authentication method to use. Valid choices are #{friendly_opt_list(WINRM_AUTH_PROTOCOL_LIST)}.",
-        proc: Proc.new { |protocol| Chef::Config[:knife][:winrm_auth_method] = protocol }
+        proc: Proc.new { |protocol| Chef::Config[:knife][:winrm_auth_method] = protocol },
+        in: WINRM_AUTH_PROTOCOL_LIST
 
       option :winrm_basic_auth_only,
         long: "--winrm-basic-auth-only",
@@ -156,9 +157,11 @@ class Chef
         description: "The version of #{Chef::Dist::PRODUCT} to install.",
         proc: lambda { |v| Chef::Config[:knife][:bootstrap_version] = v }
 
-      option :prerelease,
-        long: "--prerelease",
-        description: "Install from 'current' channel"
+      option :channel,
+        long: "--channel CHANNEL",
+        description: "Install from the given channel. Valid values are 'current' and 'stable'. Default is 'stable'",
+        default: "stable",
+        in: %w{stable current}
 
       # client.rb content via chef-full/bootstrap_context
       option :bootstrap_proxy,
@@ -351,42 +354,45 @@ class Chef
 
       DEPRECATED_FLAGS = {
         # deprecated_key: [new_key, deprecated_long]
-        auth_timeout: [:max_wait, "--max-wait SECONDS"],
-        host_key_verify: [:ssh_verify_host_key,
-                          "--[no-]host-key-verify",
-                          ],
-        ssh_user: [:connection_user,
-                   "--ssh-user USER",
-                   ],
-        ssh_password: [:connection_password,
-                       "--ssh-password PASSWORD",
-                       ],
-        ssh_port: [:connection_port,
-                   "-ssh-port",
-                   ],
-        ssl_peer_fingerprint: [:winrm_ssl_peer_fingerprint,
-                               "--ssl-peer-fingerprint FINGERPRINT",
-                               ],
-        winrm_user: [:connection_user,
-                     "--winrm-user USER",
-                     ],
-        winrm_password: [:connection_password,
-                         "--winrm-password",
-                         ],
-        winrm_port: [:connection_port,
-                     "--winrm-port",
-                     ],
-        winrm_authentication_protocol: [:winrm_auth_method,
-                                        "--winrm-authentication-protocol PROTOCOL",
-                                        ],
+        # optional third element: replacement_value - if converting from bool
+        #   (--bool-option) to valued flag (--new-option VALUE)
+        #   this will be the value that is assigned the new flag when the old flag is used.
+        auth_timeout: [:max_wait, "--max-wait SECONDS" ],
+        host_key_verify:
+          [:ssh_verify_host_key, "--[no-]host-key-verify"],
+        prerelease:
+          [:channel, "--prerelease", "current"],
+        ssh_user:
+          [:connection_user, "--ssh-user USER"],
+        ssh_password:
+          [:connection_password, "--ssh-password PASSWORD"],
+        ssh_port:
+          [:connection_port, "-ssh-port" ],
+        ssl_peer_fingerprint:
+          [:winrm_ssl_peer_fingerprint, "--ssl-peer-fingerprint FINGERPRINT"],
+        winrm_user:
+          [:connection_user, "--winrm-user USER"],
+        winrm_password:
+          [:connection_password, "--winrm-password"],
+        winrm_port:
+          [:connection_port, "--winrm-port"],
+        winrm_authentication_protocol:
+          [:winrm_auth_method, "--winrm-authentication-protocol PROTOCOL"],
       }.freeze
 
       DEPRECATED_FLAGS.each do |deprecated_key, deprecation_entry|
-        new_key, deprecated_long = deprecation_entry
+        new_key, deprecated_long, replacement_value = deprecation_entry
         new_long = options[new_key][:long]
+        new_long_desc = if replacement_value.nil?
+                          new_long
+                        else
+                          "#{new_long.split(" ").first} #{replacement_value}"
+                        end
         option(deprecated_key, long: deprecated_long,
-                               description: "#{deprecated_long} is deprecated. Use #{new_long} instead.",
-                               boolean: options[new_key][:boolean])
+                               description: "This flag is deprecated. Please use '#{new_long_desc}' instead.",
+                               boolean: options[new_key][:boolean] || !replacement_value.nil?,
+                               # Put deprecated options at the end of the options list
+                               on: :tail)
       end
 
       attr_accessor :client_builder
@@ -642,12 +648,13 @@ class Chef
       end
 
       # If any deprecated flags are used, let the user know and
-      # update config[new-key] to the value given to the deprecated flag.
+      # update config[new-key] to the value given to the deprecated flag,
+      # or to the mapped value in case of changing flag type.
       # If a deprecated flag and its corresponding replacement
-      # are both used, raise an error.
+      # are both used, exit
       def verify_deprecated_flags!
         DEPRECATED_FLAGS.each do |deprecated_key, deprecation_entry|
-          new_key, deprecated_long = deprecation_entry
+          new_key, deprecated_long, replacement_value = deprecation_entry
           if config.key?(deprecated_key) && config_source(deprecated_key) == :cli
             if config.key?(new_key) && config_source(new_key) == :cli
               new_long = options[new_key][:long].split(" ").first
@@ -660,9 +667,9 @@ class Chef
               EOM
               exit 1
             else
-              config[new_key] = config[deprecated_key]
+              config[new_key] = replacement_value || config[deprecated_key]
               unless Chef::Config[:silence_deprecation_warnings] == true
-                ui.warn options[deprecated_key][:description]
+                ui.warn "You provided #{deprecated_long.split(" ").first}. #{options[deprecated_key][:description]}"
               end
             end
           end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -156,6 +156,10 @@ class Chef
         description: "The version of #{Chef::Dist::PRODUCT} to install.",
         proc: lambda { |v| Chef::Config[:knife][:bootstrap_version] = v }
 
+      option :prerelease,
+        long: "--prerelease",
+        description: "Install from 'current' channel"
+
       # client.rb content via chef-full/bootstrap_context
       option :bootstrap_proxy,
         long: "--bootstrap-proxy PROXY_URL",

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -175,9 +175,9 @@ do_download() {
   if test -f /usr/bin/<%= Chef::Dist::CLIENT %>}; then
     echo "-----> Existing <%= Chef::Dist::PRODUCT %> installation detected"
   else
-    echo "-----> Installing Chef Omnibus (<%= latest_current_chef_version_string %>)"
+    echo "-----> Installing Chef Omnibus (<%= @config[:channel] %>/<%= version_to_install %>)"
     do_download ${install_sh} $tmp_dir/install.sh
-    sh $tmp_dir/install.sh -P chef <%= latest_current_chef_version_string %>
+    sh $tmp_dir/install.sh -P chef -c <%= @config[:channel] %> -v <%= version_to_install %>
   fi
 <% end %>
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -190,13 +190,24 @@ class Chef
         # chef version string to fetch the latest current version from omnitruck
         # If user is on X.Y.Z, bootstrap will use the latest X release
         def latest_current_chef_version_string
-          chef_version_string = if knife_config[:bootstrap_version]
-                                  knife_config[:bootstrap_version]
-                                else
-                                  Chef::VERSION.split(".").first
-                                end
+          installer_version_string = nil
+          if @config[:prerelease]
+            installer_version_string = ["-p"]
+          else
+            chef_version_string = if knife_config[:bootstrap_version]
+                                    knife_config[:bootstrap_version]
+                                  else
+                                    Chef::VERSION.split(".").first
+                                  end
 
-          "-v #{chef_version_string}"
+            installer_version_string = ["-v", chef_version_string]
+
+            # If bootstrapping a pre-release version add -p to the installer string
+            if chef_version_string.split(".").length > 3
+              installer_version_string << "-p"
+            end
+          end
+          installer_version_string.join(" ")
         end
 
         def first_boot

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -187,32 +187,17 @@ class Chef
         end
 
         #
-        # Determine that CLI arguments to retrieve the correct version of Chef Infra Client from omnitruck
-        # By default, bootstrap will look for the latest version of the currently-running major release of on stable.
+        # Returns the version of Chef to install (as recognized by the Omnitruck API)
         #
-        # @return [String] CLI arguments to pass into the chef download helper script
-        def latest_current_chef_version_string
-          # NOTE: Changes here should also be reflected in Knife::Core::BootstrapContext#latest_current_chef_version_string
-          installer_version_string = []
-          use_current_channel = (@config[:channel] == "current")
-          installer_version_string << "-p" if use_current_channel
-          version = if knife_config[:bootstrap_version]
-                      knife_config[:bootstrap_version]
-                    else
-                      # We will take the latest current by default,
-                      # if no specific version is given.
-                      if use_current_channel
-                        # Take the latest stable version from the current major release.
-                        # Note that if the current major release is not yet in stable,
-                        # you must also specify channel "current".
-                        nil
-                      else
-                        Chef::VERSION.split(".").first
-                      end
-                    end
+        # @return [String] download version string
+        def version_to_install
+          return knife_config[:bootstrap_version] if knife_config[:bootstrap_version]
 
-          installer_version_string.concat(["-v", version]) unless version.nil?
-          installer_version_string.join(" ")
+          if @config[:channel] == "stable"
+            Chef::VERSION.split(".").first
+          else
+            "latest"
+          end
         end
 
         def first_boot

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -159,13 +159,25 @@ class Chef
         end
 
         def latest_current_windows_chef_version_query
-          chef_version_string = if knife_config[:bootstrap_version]
-                                  knife_config[:bootstrap_version]
-                                else
-                                  Chef::VERSION.split(".").first
-                                end
+          installer_version_string = nil
+          if @config[:prerelease]
+            installer_version_string = "&prerelease=true"
+          else
+            chef_version_string = if knife_config[:bootstrap_version]
+                                    knife_config[:bootstrap_version]
+                                  else
+                                    Chef::VERSION.split(".").first
+                                  end
 
-          "&v=#{chef_version_string}"
+            installer_version_string = "&v=#{chef_version_string}"
+
+            # If bootstrapping a pre-release version add the prerelease query string
+            if chef_version_string.split(".").length > 3
+              installer_version_string << "&prerelease=true"
+            end
+          end
+
+          installer_version_string
         end
 
         def win_wget

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -158,37 +158,6 @@ class Chef
           start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}\n"
         end
 
-        #
-        # Provide the query arguments to a URL that will be appeded to the URL in #msi_url().  This is used
-        # to get the latest version of Chef Infra Client via omnitruck
-        # By default, bootstrap will look for the latest version of the currently-running major release of on stable.
-        #
-        # @return [String] query arguments to append to the download request.
-        def latest_current_windows_chef_version_query
-          # NOTE: Changes here should also be reflected in Knife::Core::BootstrapContext#latest_current_chef_version_string
-          use_current_channel = (@config[:channel] == "current")
-          installer_version_string = use_current_channel ? "&prerelease=true" : ""
-
-          chef_version_string = if knife_config[:bootstrap_version]
-                                  knife_config[:bootstrap_version]
-                                else
-                                  if use_current_channel
-                                    # We will take the latest current by default,
-                                    # if no specific version is given.
-                                    nil
-                                  else
-                                    # Take the latest stable version from the current major release.
-                                    # Note that if the current major release is not yet in stable,
-                                    # you must also specify channel "current".
-                                    Chef::VERSION.split(".").first
-                                  end
-                                end
-
-          installer_version_string << "&v=#{chef_version_string}" if chef_version_string
-
-          installer_version_string
-        end
-
         def win_wget
           # I tried my best to figure out how to properly url decode and switch / to \
           # but this is VBScript - so I don't really care that badly.
@@ -294,16 +263,16 @@ class Chef
           "%TEMP%\\#{Chef::Dist::CLIENT}-latest.msi"
         end
 
+        # Build a URL to query www.chef.io that will redirect to the correct
+        # Chef Infra msi download.
         def msi_url(machine_os = nil, machine_arch = nil, download_context = nil)
-          # The default msi path has a number of url query parameters - we attempt to substitute
-          # such parameters in as long as they are provided by the template.
-
           if @config[:msi_url].nil? || @config[:msi_url].empty?
             url = "https://www.chef.io/chef/download?p=windows"
             url += "&pv=#{machine_os}" unless machine_os.nil?
             url += "&m=#{machine_arch}" unless machine_arch.nil?
             url += "&DownloadContext=#{download_context}" unless download_context.nil?
-            url += latest_current_windows_chef_version_query
+            url += "&channel=#{@config[:channel]}"
+            url += "&v=#{version_to_install}"
           else
             @config[:msi_url]
           end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1603,10 +1603,7 @@ describe Chef::Knife::Bootstrap do
     end
 
     context "when a deprecated CLI flag is given on the CLI" do
-      before do
-        knife.config[:ssh_user] = "sshuser"
-        knife.merge_configs
-      end
+      let(:bootstrap_cli_options) { %w{--ssh-user sshuser} }
       it "maps the key value to the new key and points the human to the new flag" do
         expect(knife.ui).to receive(:warn).with(/You provided --ssh-user. This flag is deprecated. Please use '--connection-user USERNAME' instead./)
         knife.verify_deprecated_flags!
@@ -1616,11 +1613,6 @@ describe Chef::Knife::Bootstrap do
 
     context "when a deprecated CLI flag is given on the CLI, along with its replacement" do
       let(:bootstrap_cli_options) { %w{--connection-user a --ssh-user b} }
-      before do
-        knife.config[:ssh_user] = "sshuser"
-        knife.config[:connection_user] = "real-user"
-        knife.merge_configs
-      end
 
       it "informs the human that both are provided and exits" do
         expect(knife.ui).to receive(:error).with(/You provided both --connection-user and --ssh-user.*Please use.*/m)

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1608,13 +1608,14 @@ describe Chef::Knife::Bootstrap do
         knife.merge_configs
       end
       it "maps the key value to the new key and points the human to the new flag" do
-        expect(knife.ui).to receive(:warn).with(/--ssh-user USER is deprecated. Use --connection-user USERNAME instead./)
+        expect(knife.ui).to receive(:warn).with(/You provided --ssh-user. This flag is deprecated. Please use '--connection-user USERNAME' instead./)
         knife.verify_deprecated_flags!
         expect(knife.config[:connection_user]).to eq "sshuser"
       end
     end
 
     context "when a deprecated CLI flag is given on the CLI, along with its replacement" do
+      let(:bootstrap_cli_options) { %w{--connection-user a --ssh-user b} }
       before do
         knife.config[:ssh_user] = "sshuser"
         knife.config[:connection_user] = "real-user"
@@ -1624,6 +1625,15 @@ describe Chef::Knife::Bootstrap do
       it "informs the human that both are provided and exits" do
         expect(knife.ui).to receive(:error).with(/You provided both --connection-user and --ssh-user.*Please use.*/m)
         expect { knife.verify_deprecated_flags! }.to raise_error SystemExit
+      end
+    end
+
+    context "when a deprecated boolean CLI flag is given on the CLI, and its non-boolean replacement is used" do
+      let(:bootstrap_cli_options) { %w{--prerelease} }
+      it "correctly maps the old boolean value to the new value" do
+        expect(knife.ui).to receive(:warn)
+        knife.verify_deprecated_flags!
+        expect(knife.config[:channel]).to eq "current"
       end
     end
   end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -166,6 +166,27 @@ describe Chef::Knife::Core::BootstrapContext do
     it "should send the full version to the installer" do
       expect(bootstrap_context.latest_current_chef_version_string).to eq("-v 11.12.4")
     end
+
+    describe "and it is a prerelease version" do
+      let(:chef_config) do
+        {
+          knife: { bootstrap_version: "11.12.4.xyz" },
+        }
+      end
+
+      it "should set the version and set -p" do
+        expect(bootstrap_context.latest_current_chef_version_string).to eq("-v 11.12.4.xyz -p")
+      end
+    end
+
+  end
+
+  describe "when prerelease is specified" do
+    let(:config) { { prerelease: true } }
+
+    it "should send -p to the installer" do
+      expect(bootstrap_context.latest_current_chef_version_string).to eq("-p")
+    end
   end
 
   describe "when a bootstrap_version is not specified" do

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -163,30 +163,29 @@ describe Chef::Knife::Core::BootstrapContext do
       }
     end
 
-    it "should send the full version to the installer" do
+    it "should return full version installer specified with -v" do
       expect(bootstrap_context.latest_current_chef_version_string).to eq("-v 11.12.4")
     end
+  end
 
-    describe "and it is a prerelease version" do
+  describe "when current channel is specified" do
+    let(:config) { { channel: "current" } }
+
+    it "should return only the -p flag" do
+      expect(bootstrap_context.latest_current_chef_version_string).to eq("-p")
+    end
+    context "and a bootstrap version is specified" do
       let(:chef_config) do
         {
-          knife: { bootstrap_version: "11.12.4.xyz" },
+          knife: { bootstrap_version: "16.2.2" },
         }
       end
 
-      it "should set the version and set -p" do
-        expect(bootstrap_context.latest_current_chef_version_string).to eq("-v 11.12.4.xyz -p")
+      it "should return both full version and prerelease flags" do
+        expect(bootstrap_context.latest_current_chef_version_string).to eq("-p -v 16.2.2")
       end
     end
 
-  end
-
-  describe "when prerelease is specified" do
-    let(:config) { { prerelease: true } }
-
-    it "should send -p to the installer" do
-      expect(bootstrap_context.latest_current_chef_version_string).to eq("-p")
-    end
   end
 
   describe "when a bootstrap_version is not specified" do

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -156,45 +156,6 @@ describe Chef::Knife::Core::BootstrapContext do
     end
   end
 
-  describe "when a bootstrap_version is specified" do
-    let(:chef_config) do
-      {
-        knife: { bootstrap_version: "11.12.4" },
-      }
-    end
-
-    it "should return full version installer specified with -v" do
-      expect(bootstrap_context.latest_current_chef_version_string).to eq("-v 11.12.4")
-    end
-  end
-
-  describe "when current channel is specified" do
-    let(:config) { { channel: "current" } }
-
-    it "should return only the -p flag" do
-      expect(bootstrap_context.latest_current_chef_version_string).to eq("-p")
-    end
-    context "and a bootstrap version is specified" do
-      let(:chef_config) do
-        {
-          knife: { bootstrap_version: "16.2.2" },
-        }
-      end
-
-      it "should return both full version and prerelease flags" do
-        expect(bootstrap_context.latest_current_chef_version_string).to eq("-p -v 16.2.2")
-      end
-    end
-
-  end
-
-  describe "when a bootstrap_version is not specified" do
-    it "should send the latest current to the installer" do
-      # Intentionally hard coded in order not to replicate the logic.
-      expect(bootstrap_context.latest_current_chef_version_string).to eq("-v #{Chef::VERSION.to_i}")
-    end
-  end
-
   describe "ssl_verify_mode" do
     it "isn't set in the config_content by default" do
       expect(bootstrap_context.config_content).not_to include("ssl_verify_mode")
@@ -311,5 +272,29 @@ describe Chef::Knife::Core::BootstrapContext do
       end
     end
 
+  end
+
+  describe "#version_to_install" do
+    context "when bootstrap_version is provided" do
+      let(:chef_config) { { knife: { bootstrap_version: "awesome" } } }
+
+      it "returns bootstrap_version" do
+        expect(bootstrap_context.version_to_install).to eq "awesome"
+      end
+    end
+
+    context "when bootstrap_version is not provided" do
+      let(:config) { { channel: "stable" } }
+      it "returns the currently running major version out of Chef::VERSION" do
+        expect(bootstrap_context.version_to_install).to eq Chef::VERSION.split(".").first
+      end
+    end
+
+    context "and channel is other than stable" do
+      let(:config) { { channel: "unstable" } }
+      it "returns the version string 'latest'" do
+        expect(bootstrap_context.version_to_install).to eq "latest"
+      end
+    end
   end
 end

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -191,19 +191,18 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
       end
     end
 
-    context "when prerelease is true" do
-      let(:config) { { prerelease: true } }
+    context "when channel is current" do
+      let(:config) { { channel: "current" } }
       it "includes prerelease indicator " do
         expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&prerelease=true")
       end
-    end
-
-    context "when a prerelease bootstrap_version is specified" do
-      before do
-        Chef::Config[:knife][:bootstrap_version] = "15.1.2.xyz"
-      end
-      it "includes prerelease indicator and the given version" do
-        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15.1.2.xyz&prerelease=true")
+      context "and bootstrap_version is given" do
+        before do
+          Chef::Config[:knife][:bootstrap_version] = "16.2.2"
+        end
+        it "includes the requested version" do
+          expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&prerelease=true&v=16.2.2")
+        end
       end
     end
 

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -177,9 +177,34 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
   end
 
   describe "latest_current_windows_chef_version_query" do
-    it "returns the major version of the current version of Chef" do
+    it "includes the major version of the current version of Chef" do
       stub_const("Chef::VERSION", "15.1.2")
       expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15")
+    end
+
+    context "when bootstrap_version is given" do
+      before do
+        Chef::Config[:knife][:bootstrap_version] = "15.1.2"
+      end
+      it "includes the requested version" do
+        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15.1.2")
+      end
+    end
+
+    context "when prerelease is true" do
+      let(:config) { { prerelease: true } }
+      it "includes prerelease indicator " do
+        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&prerelease=true")
+      end
+    end
+
+    context "when a prerelease bootstrap_version is specified" do
+      before do
+        Chef::Config[:knife][:bootstrap_version] = "15.1.2.xyz"
+      end
+      it "includes prerelease indicator and the given version" do
+        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15.1.2.xyz&prerelease=true")
+      end
     end
 
   end

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -176,52 +176,29 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
     end
   end
 
-  describe "latest_current_windows_chef_version_query" do
-    it "includes the major version of the current version of Chef" do
-      stub_const("Chef::VERSION", "15.1.2")
-      expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15")
-    end
-
-    context "when bootstrap_version is given" do
-      before do
-        Chef::Config[:knife][:bootstrap_version] = "15.1.2"
-      end
-      it "includes the requested version" do
-        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&v=15.1.2")
-      end
-    end
-
-    context "when channel is current" do
-      let(:config) { { channel: "current" } }
-      it "includes prerelease indicator " do
-        expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&prerelease=true")
-      end
-      context "and bootstrap_version is given" do
-        before do
-          Chef::Config[:knife][:bootstrap_version] = "16.2.2"
-        end
-        it "includes the requested version" do
-          expect(bootstrap_context.latest_current_windows_chef_version_query).to eq("&prerelease=true&v=16.2.2")
-        end
-      end
-    end
-
-  end
-
   describe "msi_url" do
-    context "when config option is not set" do
+    context "when msi_url config option is not set" do
+      let(:config) { { channel: "stable" } }
       before do
-        expect(bootstrap_context).to receive(:latest_current_windows_chef_version_query).and_return("&v=something")
+        expect(bootstrap_context).to receive(:version_to_install).and_return("something")
       end
 
       it "returns a chef.io msi url with minimal url parameters" do
-        reference_url = "https://www.chef.io/chef/download?p=windows&v=something"
+        reference_url = "https://www.chef.io/chef/download?p=windows&channel=stable&v=something"
         expect(bootstrap_context.msi_url).to eq(reference_url)
       end
 
       it "returns a chef.io msi url with provided url parameters substituted" do
-        reference_url = "https://www.chef.io/chef/download?p=windows&pv=machine&m=arch&DownloadContext=ctx&v=something"
+        reference_url = "https://www.chef.io/chef/download?p=windows&pv=machine&m=arch&DownloadContext=ctx&channel=stable&v=something"
         expect(bootstrap_context.msi_url("machine", "arch", "ctx")).to eq(reference_url)
+      end
+
+      context "when a channel is provided in config" do
+        let(:config) { { channel: "current" } }
+        it "returns a chef.io msi url with the requested channel" do
+          reference_url = "https://www.chef.io/chef/download?p=windows&channel=current&v=something"
+          expect(bootstrap_context.msi_url).to eq(reference_url)
+        end
       end
     end
 

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -299,37 +299,26 @@ describe Chef::Knife do
         expect(Chef::Config[:log_level]).to eql(:warn)
       end
 
-      it "prefers the default value if no config or command line value is present and reports the source as default" do
+      it "prefers the default value from option definition if no config or command line value is present and reports the source as default" do
         knife_command = KnifeSpecs::TestYourself.new([]) # empty argv
         knife_command.configure_chef
         expect(knife_command.config[:opt_with_default]).to eq("default-value")
+        expect(knife_command.config_source(:opt_with_default)).to eq(:cli_default)
       end
 
-      it "prefers a value in Chef::Config[:knife] to the default" do
+      it "prefers a value in Chef::Config[:knife] to the default and reports the source as config" do
         Chef::Config[:knife][:opt_with_default] = "from-knife-config"
         knife_command = KnifeSpecs::TestYourself.new([]) # empty argv
         knife_command.configure_chef
         expect(knife_command.config[:opt_with_default]).to eq("from-knife-config")
-        expect(knife_command.config_source(:opt_with_default)).to eq (:config)
-      end
-
-      it "correctly reports Chef::Config as the source when a a config entry comes from there" do
-        Chef::Config[:knife][:opt_with_default] = "from-knife-config"
-        knife_command = KnifeSpecs::TestYourself.new([]) # empty argv
-        knife_command.configure_chef
-        expect(knife_command.config_source(:opt_with_default)).to eq (:config)
+        expect(knife_command.config_source(:opt_with_default)).to eq(:config)
       end
 
       it "prefers a value from command line over Chef::Config and the default and reports the source as CLI" do
         knife_command = KnifeSpecs::TestYourself.new(["-D", "from-cli"])
         knife_command.configure_chef
         expect(knife_command.config[:opt_with_default]).to eq("from-cli")
-        expect(knife_command.config_source(:opt_with_default)).to eq (:cli)
-      end
-      it "correctly reports CLI as the source when a config entry comes from the CLI" do
-        knife_command = KnifeSpecs::TestYourself.new(["-D", "from-cli"])
-        knife_command.configure_chef
-        expect(knife_command.config_source(:opt_with_default)).to eq (:cli)
+        expect(knife_command.config_source(:opt_with_default)).to eq(:cli)
       end
 
       it "merges `listen` config to Chef::Config" do


### PR DESCRIPTION
## Description

Bootstrap prerelease support was originally removed after
 discussion in community slack, but it turns out to have a little more 
utility than we thought at the time. When enabled, it will cause the 
package to be downloaded from the `current` channel - the latest by default,
but otherwise the specified `--bootstrap-version`.

`Knife#config_source` has been updated to not use a separate hash to store config sources,
and now knows about `:cli_default` value source, which maps to defaulted CLI options that are not in config or used on the CLI by the operator.  This was necessary to prevent `knife bootstrap` from thinking that `--channel` had been set by the operator when it only had a default value.

The CLI flag is now `--channel CHANNEL`; `--prerelease` has been deprecated. If use, will set `channel` to "current". Default is `stable`.

This PR otherwise restores the original behavior (minus the bits that were specific to gem prerelease)  and adds some tests.



Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
