### PR TITLE
Remove old maintainer gems from the Gemfile

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,7 +9,7 @@ steps:
 #     - /workdir/scripts/bk_tests/bk_install.sh
 #     - sed '/ip6/d' /etc/hosts > /etc/hosts.noip6
 #     - cp /etc/hosts.noip6 /etc/hosts
-#     - cd /workdir; bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+#     - cd /workdir; bundle install --without ci docgen guard integration omnibus_package --frozen
 #     - bundle exec rake spec:integration
 #   expeditor:
 #     executor:
@@ -25,7 +25,7 @@ steps:
 #     - /workdir/scripts/bk_tests/bk_install.sh
 #     - sed '/ip6/d' /etc/hosts > /etc/hosts.noip6
 #     - cp /etc/hosts.noip6 /etc/hosts
-#     - cd /workdir; bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+#     - cd /workdir; bundle install --without ci docgen guard integration omnibus_package --frozen
 #     - bundle exec rake spec:functional
 #   expeditor:
 #     executor:
@@ -38,7 +38,7 @@ steps:
 - label: "Unit Specs :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+    - bundle install --without ci docgen guard integration omnibus_package --frozen
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -138,7 +138,7 @@ steps:
 #     - asdf local ruby 2.5.5
 #     - sed '/ip6/d' /etc/hosts > /etc/hosts.noip6
 #     - cp /etc/hosts.noip6 /etc/hosts
-#     - bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+#     - bundle install --without ci docgen guard integration omnibus_package --frozen
 #     - bundle exec rake spec:integration
 #   expeditor:
 #     executor:
@@ -154,7 +154,7 @@ steps:
 #     - /workdir/scripts/bk_tests/bk_install.sh
 #     - sed '/ip6/d' /etc/hosts > /etc/hosts.noip6
 #     - cp /etc/hosts.noip6 /etc/hosts
-#     - bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+#     - bundle install --without ci docgen guard integration omnibus_package --frozen
 #     - bundle exec rake spec:functional
 #   expeditor:
 #     executor:
@@ -168,7 +168,7 @@ steps:
   commands:
     - asdf local ruby 2.5.5
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without ci docgen guard integration maintenance omnibus_package --frozen
+    - bundle install --without ci docgen guard integration omnibus_package --frozen
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,26 +38,26 @@ matrix:
     rvm: 2.5.5
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       INTEGRATION_SPECS_26: 1
     rvm: 2.6.2
     sudo: true
     script: sudo -E $(which bundle) exec rake spec:integration;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_25: 1
     rvm: 2.5.5
     sudo: true
     # the travis apt proxy screws with our functional testing something fierce
     script: sudo rm -f /etc/apt/apt.conf.d/99-travis-apt-proxy; sudo -E $(which bundle) exec rake spec:functional;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       FUNCTIONAL_SPECS_26: 1
     rvm: 2.6.2
     sudo: true
     script: sudo rm -f /etc/apt/apt.conf.d/99-travis-apt-proxy; sudo -E $(which bundle) exec rake spec:functional;
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       UNIT_SPECS_25: 1
     rvm: 2.5.5
@@ -65,7 +65,7 @@ matrix:
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
       - sudo -E $(which bundle) exec rake component_specs
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       UNIT_SPECS_26: 1
     rvm: 2.6.2
@@ -73,13 +73,13 @@ matrix:
     script:
       - sudo -E $(which bundle) exec rake spec:unit;
       - sudo -E $(which bundle) exec rake component_specs
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   - env:
       CHEFSTYLE: 1
     rvm: 2.6.2
     script: bundle exec rake style
     # also remove integration / external tests
-    bundler_args: --without ci docgen guard integration maintenance omnibus_package --frozen
+    bundler_args: --without ci docgen guard integration omnibus_package --frozen
   #
   # External tests
   #

--- a/Gemfile
+++ b/Gemfile
@@ -42,14 +42,6 @@ group(:docgen) do
   gem "yard"
 end
 
-group(:maintenance) do
-  gem "tomlrb"
-
-  # To sync maintainers with github
-  gem "octokit"
-  gem "netrc"
-end
-
 # Everything except AIX
 group(:ruby_prof) do
   gem "ruby-prof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     appbundler (0.12.5)
       mixlib-cli (>= 1.4, < 3.0)
@@ -203,7 +203,7 @@ GEM
     jaro_winkler (1.5.2)
     json (2.2.0)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.0)
+    license-acceptance (1.0.2)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -239,10 +239,7 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    netrc (0.11.0)
     nori (2.6.0)
-    octokit (4.14.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -303,9 +300,6 @@ GEM
     rubyntlm (0.6.2)
     rubyzip (1.2.2)
     safe_yaml (1.0.5)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
     semverse (3.0.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -423,8 +417,6 @@ DEPENDENCIES
   chefstyle!
   ed25519
   inspec-core (>= 4.0.0.a, < 5)
-  netrc
-  octokit
   ohai!
   pry
   pry-byebug
@@ -439,7 +431,6 @@ DEPENDENCIES
   ruby-prof
   ruby-shadow
   simplecov
-  tomlrb
   webmock
   yard
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
   - echo %PATH%
   - appveyor DownloadFile http://curl.haxx.se/ca/cacert.pem -FileName C:\cacert.pem
   - set SSL_CERT_FILE=C:\cacert.pem
-  - SET BUNDLE_WITHOUT=server:docgen:maintenance:pry:travis:integration:ci
+  - SET BUNDLE_WITHOUT=server:docgen:pry:integration:ci
   - bundle config --local path vendor/bundle # use the cache we define above
   - bundle install || bundle install || bundle install
   - SET SPEC_OPTS=--format progress

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: b6e267d0554feca5fd0a09d306cccfac7f7e43b9
+  revision: 968307c129ee54416f5a4d07ca8f8ca2d2b12825
   branch: master
   specs:
-    omnibus (6.0.26)
+    omnibus (6.0.27)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -28,7 +28,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
@@ -181,7 +181,7 @@ GEM
     kitchen-vagrant (1.5.1)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.0)
+    license-acceptance (1.0.2)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -280,9 +280,9 @@ GEM
     ruby-progressbar (1.10.0)
     rubyntlm (0.6.2)
     rubyzip (1.2.2)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     semverse (3.0.0)
     serverspec (2.41.3)
       multi_json


### PR DESCRIPTION
These were used by our maintainer rake tasks. These are all gone now so there's no need for these gems.

Signed-off-by: Tim Smith <tsmith@chef.io>