### PR TITLE
Replace Chef Client by its constant in Chef::Dist

### DIFF
--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -2,7 +2,7 @@ class Chef
   class Dist
     # This class is not fully implemented, depending on it is not recommended!
     # When referencing a product directly, like Chef (Now Chef Infra)
-    PRODUCT = "Chef Infra".freeze
+    PRODUCT = "Chef Infra Client".freeze
 
     # The client's alias (chef-client)
     CLIENT = "chef-client".freeze

--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -1,5 +1,6 @@
 require "chef/formatters/base"
 require "chef/config"
+require "chef/dist"
 
 class Chef
   module Formatters
@@ -40,7 +41,7 @@ class Chef
       end
 
       def run_start(version, run_status)
-        puts_line "Starting Chef Client, version #{version}"
+        puts_line "Starting #{Chef::Dist::PRODUCT}, version #{version}"
         puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
       end
 
@@ -75,18 +76,18 @@ class Chef
           puts_line ""
         end
         if Chef::Config[:why_run]
-          puts_line "Chef Client finished, #{@updated_resources}/#{total_resources} resources would have been updated"
+          puts_line "#{Chef::Dist::PRODUCT} finished, #{@updated_resources}/#{total_resources} resources would have been updated"
         else
-          puts_line "Chef Client finished, #{@updated_resources}/#{total_resources} resources updated in #{pretty_elapsed_time}"
+          puts_line "#{Chef::Dist::PRODUCT} finished, #{@updated_resources}/#{total_resources} resources updated in #{pretty_elapsed_time}"
         end
       end
 
       def run_failed(exception)
         @end_time = Time.now
         if Chef::Config[:why_run]
-          puts_line "Chef Client failed. #{@updated_resources} resources would have been updated"
+          puts_line "#{Chef::Dist::PRODUCT} failed. #{@updated_resources} resources would have been updated"
         else
-          puts_line "Chef Client failed. #{@updated_resources} resources updated in #{pretty_elapsed_time}"
+          puts_line "#{Chef::Dist::PRODUCT} failed. #{@updated_resources} resources updated in #{pretty_elapsed_time}"
         end
       end
 

--- a/lib/chef/formatters/error_inspectors/api_error_formatting.rb
+++ b/lib/chef/formatters/error_inspectors/api_error_formatting.rb
@@ -112,10 +112,10 @@ class Chef
           max_server_version = version_header["max_version"]
 
           error_description.section("Incompatible server API version:", <<~E)
-            This version of the API that this Chef request specified is not supported by the Chef server you sent this request to.
+            This version of the API that this request specified is not supported by the server you sent this request to.
             The server supports a min API version of #{min_server_version} and a max API version of #{max_server_version}.
-            Chef just made a request with an API version of #{client_api_version}.
-            Please either update your Chef client or server to be a compatible set.
+            #{Chef::Dist::PRODUCT} just made a request with an API version of #{client_api_version}.
+            Please either update your #{Chef::Dist::PRODUCT} or the server to be a compatible set.
           E
         else
           describe_http_error(error_description)

--- a/lib/chef/formatters/minimal.rb
+++ b/lib/chef/formatters/minimal.rb
@@ -1,4 +1,5 @@
 require "chef/formatters/base"
+require "chef/dist"
 
 class Chef
 
@@ -27,18 +28,18 @@ class Chef
 
       # Called at the very start of a Chef Run
       def run_start(version, run_status)
-        puts_line "Starting Chef Client, version #{version}"
+        puts_line "Starting #{Chef::Dist::PRODUCT}, version #{version}"
         puts_line "OpenSSL FIPS 140 mode enabled" if Chef::Config[:fips]
       end
 
       # Called at the end of the Chef run.
       def run_completed(node)
-        puts "chef client finished, #{@updated_resources.size} resources updated"
+        puts "#{Chef::Dist::PRODUCT} finished, #{@updated_resources.size} resources updated"
       end
 
       # called at the end of a failed run
       def run_failed(exception)
-        puts "chef client failed. #{@updated_resources.size} resources updated"
+        puts "#{Chef::Dist::PRODUCT} failed. #{@updated_resources.size} resources updated"
       end
 
       # Called right after ohai runs.

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -530,10 +530,10 @@ class Chef
         client_api_version = version_header["request_version"]
         min_server_version = version_header["min_version"]
         max_server_version = version_header["max_version"]
-        ui.error "The version of #{Chef::Dist::PRODUCT} that Knife is using is not supported by the #{Chef::Dist::PRODUCT} server you sent this request to"
-        ui.info "The request that Knife sent was using API version #{client_api_version}"
-        ui.info "The #{Chef::Dist::PRODUCT} server you sent the request to supports a min API verson of #{min_server_version} and a max API version of #{max_server_version}"
-        ui.info "Please either update your #{Chef::Dist::PRODUCT} client or server to be a compatible set"
+        ui.error "The version of #{Chef::Dist::PRODUCT} API that Knife is using is not supported by the server you sent this request to."
+        ui.info "The request that Knife sent was using API version #{client_api_version}."
+        ui.info "The server you sent the request to supports a min API verson of #{min_server_version} and a max API version of #{max_server_version}."
+        ui.info "Please either update your #{Chef::Dist::PRODUCT} or the server to be a compatible set."
       else
         ui.error response.message
         ui.info "Response: #{format_rest_error(response)}"

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -474,7 +474,7 @@ class Chef
       when OpenSSL::SSL::SSLError
         ui.error "Could not establish a secure connection to the server."
         ui.info "Use `knife ssl check` to troubleshoot your SSL configuration."
-        ui.info "If your #{Chef::Dist::PRODUCT} Server uses a self-signed certificate, you can use"
+        ui.info "If your server uses a self-signed certificate, you can use"
         ui.info "`knife ssl fetch` to make knife trust the server's certificates."
         ui.info ""
         ui.info  "Original Exception: #{e.class.name}: #{e.message}"
@@ -507,7 +507,7 @@ class Chef
         ui.error "You authenticated successfully to #{server_url} as #{username} but you are not authorized for this action."
         proxy_env_vars = ENV.to_hash.keys.map(&:downcase) & %w{http_proxy https_proxy ftp_proxy socks_proxy no_proxy}
         unless proxy_env_vars.empty?
-          ui.error "There are proxy servers configured, your #{Chef::Dist::PRODUCT} server may need to be added to NO_PROXY."
+          ui.error "There are proxy servers configured, your server url may need to be added to NO_PROXY."
         end
         ui.info "Response:  #{format_rest_error(response)}"
       when Net::HTTPBadRequest
@@ -530,7 +530,7 @@ class Chef
         client_api_version = version_header["request_version"]
         min_server_version = version_header["min_version"]
         max_server_version = version_header["max_version"]
-        ui.error "The version of #{Chef::Dist::PRODUCT} API that Knife is using is not supported by the server you sent this request to."
+        ui.error "The API version that Knife is using is not supported by the server you sent this request to."
         ui.info "The request that Knife sent was using API version #{client_api_version}."
         ui.info "The server you sent the request to supports a min API verson of #{min_server_version} and a max API version of #{max_server_version}."
         ui.info "Please either update your #{Chef::Dist::PRODUCT} or the server to be a compatible set."

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -18,6 +18,7 @@
 
 require "chef/knife"
 require "chef/knife/data_bag_secret_options"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -286,7 +287,7 @@ class Chef
       option :msi_url, # Windows target only
         short: "-m URL",
         long: "--msi-url URL",
-        description: "Location of the Chef Client MSI. The default templates will prefer to download from this location. The MSI will be downloaded from chef.io if not provided (windows).",
+        description: "Location of the #{Chef::Dist::PRODUCT} MSI. The default templates will prefer to download from this location. The MSI will be downloaded from chef.io if not provided (windows).",
         default: ""
 
       # bootstrap override: Do this instead of our own setup.sh from omnitruck. Causes bootstrap_url to be ignored.

--- a/lib/chef/run_lock.rb
+++ b/lib/chef/run_lock.rb
@@ -96,7 +96,7 @@ class Chef
     # Waits until acquiring the system-wide lock.
     #
     def wait
-      Chef::Log.warn("#{Chef::Dist::PRODUCT} client #{runpid} is running, will wait for it to finish and then run.")
+      Chef::Log.warn("#{Chef::Dist::PRODUCT} #{runpid} is running, will wait for it to finish and then run.")
       if Chef::Platform.windows?
         mutex.wait
       else

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -163,7 +163,7 @@ describe "chef-solo" do
         ruby_block "sleeping" do
           block do
             retries = 200
-            while IO.read(Chef::Config[:log_location]) !~ /.* client .* is running, will wait for it to finish and then run./
+            while IO.read(Chef::Config[:log_location]) !~ /.* is running, will wait for it to finish and then run./
               sleep 0.1
               raise "we ran out of retries" if ( retries -= 1 ) <= 0
             end
@@ -207,7 +207,7 @@ describe "chef-solo" do
       run_log = File.read(path_to("logs/runs.log"))
 
       # second run should have a message which indicates it's waiting for the first run
-      expect(run_log).to match(/.* client .* is running, will wait for it to finish and then run./)
+      expect(run_log).to match(/.* is running, will wait for it to finish and then run./)
 
       # both of the runs should succeed
       expect(run_log.lines.reject { |l| !l.include? "Run complete in" }.length).to eq(2)

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -472,7 +472,7 @@ describe Chef::Knife do
         allow(knife).to receive(:username).and_return("sadpanda")
         knife.run_with_pretty_exceptions
         expect(stderr.string).to match(%r{ERROR: You authenticated successfully to http.+ as sadpanda but you are not authorized for this action})
-        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your .* server may need to be added to NO_PROXY.})
+        expect(stderr.string).to match(%r{ERROR: There are proxy servers configured, your server url may need to be added to NO_PROXY.})
         expect(stderr.string).to match(%r{Response:  y u no administrator})
       end
     end
@@ -508,9 +508,9 @@ describe Chef::Knife do
       allow(knife).to receive(:run).and_raise(Net::HTTPClientException.new("406 Not Acceptable", response))
 
       knife.run_with_pretty_exceptions
-      expect(stderr.string).to match(/The request that .* sent was using API version 10000000/)
-      expect(stderr.string).to match(/The .* server you sent the request to supports a min API verson of 0 and a max API version of 1/)
-      expect(stderr.string).to match(/Please either update your .* client or server to be a compatible set/)
+      expect(stderr.string).to match(/The request that .* sent was using API version 10000000./)
+      expect(stderr.string).to match(/The server you sent the request to supports a min API verson of 0 and a max API version of 1./)
+      expect(stderr.string).to match(/Please either update your .* or the server to be a compatible set./)
     end
 
     it "formats 500s nicely" do
@@ -588,7 +588,7 @@ describe Chef::Knife do
       expected_message = <<~MSG
         ERROR: Could not establish a secure connection to the server.
         Use `.* ssl check` to troubleshoot your SSL configuration.
-        If your .* Server uses a self-signed certificate, you can use
+        If your server uses a self-signed certificate, you can use
         `.* ssl fetch` to make .* trust the server's certificates.
       MSG
       expect(stderr.string).to match(expected_message)


### PR DESCRIPTION
Signed-off-by: Tensibai <tensibai@iabis.net>

Replace products reference by its constant in chef/dist.rb. 
## Description
Makes replacing the brand for other distribution easier by replacing hard coded string by corresponding constant in the file chef/dist.rb.

Voluntarily not changing the unit tests not documentation at this point.

## Related Issue
In line with #8376


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
