### PR TITLE
update the ci verify tasks for chef-15

### DIFF
--- a/ci/verify-chef.bat
+++ b/ci/verify-chef.bat
@@ -68,13 +68,6 @@ cd %CHEFDIR%
 
 cd
 
-type Gemfile.lock
-
-IF NOT EXIST "Gemfile.lock" (
-  ECHO "Chef gem does not contain a Gemfile.lock! This is needed to run any tests."
-  GOTO :error
-)
-
 IF "%PIPELINE_NAME%" == "chef-fips" (
   set CHEF_FIPS=1
 )
@@ -82,12 +75,8 @@ IF "%PIPELINE_NAME%" == "chef-fips" (
 REM ; ffi-yajl must run in c-extension mode for perf, so force it so we don't accidentally fall back to ffi
 set FORCE_FFI_YAJL=ext
 
-REM ; we should use bundler, but aren't because of a bug
-REM ; this should be `bundle exec rspec yadda yadda...`
-REM ; the bug is here: https://github.com/bundler/bundler/issues/5644
-REM ; while this opens us up to some testing edge conditions if we're doing our job right to build the omnibus package and its gems correct that shouldn't matter
-REM ; since that assumption has gone wrong before we should really go back to using bundler at some point
-call %EMBEDDED_BIN_DIR%\rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional
+call %EMBEDDED_BIN_DIR%\bundle install
+call %EMBEDDED_BIN_DIR%\bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o %WORKSPACE%\test.xml -f documentation spec/functional
 
 GOTO :EOF
 

--- a/ci/verify-chef.sh
+++ b/ci/verify-chef.sh
@@ -110,4 +110,5 @@ CHEF_GEM=`dirname $lib_dir`
 
 
 cd $CHEF_GEM
+sudo bundle install
 sudo bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o $WORKSPACE/test.xml -f documentation spec/functional


### PR DESCRIPTION
we need to bundle install now in both places (ChefDK style of
appbundling means there is no Gemfile.lock here and we do the
install against the somewhat novel-looking Gemfile that kinda
looks like Gemfile.lock).

and on windows side since there is no Gemfile.lock any more we need
to avoid that test.
