### PR TITLE
Fix for Chef::Exceptions::Win32APIError: The operation completed successfully.

### DIFF
--- a/lib/chef/win32/security.rb
+++ b/lib/chef/win32/security.rb
@@ -404,7 +404,7 @@ class Chef
         system_name = system_name.to_wstring if system_name
         if LookupAccountNameW(system_name, name.to_wstring, nil, sid_size, nil, referenced_domain_name_size, nil)
           raise "Expected ERROR_INSUFFICIENT_BUFFER from LookupAccountName, and got no error!"
-        elsif FFI::LastError.error != ERROR_INSUFFICIENT_BUFFER
+        elsif !([NO_ERROR, ERROR_INSUFFICIENT_BUFFER].include?(FFI::LastError.error))
           Chef::ReservedNames::Win32::Error.raise!
         end
 


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

## Description
- In `lookup_account_name` method, whenever `FFI::LastError.error` returns 0, on that time we are geting an exception like ` Chef::Exceptions::Win32APIError: The operation completed successfully.`
- Added a private method `error_insufficient_buffer` in `Chef::ReservedNames::Win32::Security` for handling this exception
- Added unit test cases for this
- Ensured chef-style on the code changes made

## Related Issue
Fixes:
https://chefio.atlassian.net/browse/MSYS-996
https://getchef.zendesk.com/agent/tickets/21641

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
