### PR TITLE
Add connstant for Chef Server and improve help messaging

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -35,49 +35,49 @@ class Chef::Application::Apply < Chef::Application
   option :execute,
     short: "-e RECIPE_TEXT",
     long: "--execute RECIPE_TEXT",
-    description: "Execute resources supplied in a string",
+    description: "Execute resources supplied in a string.",
     proc: nil
 
   option :stdin,
     short: "-s",
     long: "--stdin",
-    description: "Execute resources read from STDIN",
+    description: "Execute resources read from STDIN.",
     boolean: true
 
   option :json_attribs,
     short: "-j JSON_ATTRIBS",
     long: "--json-attributes JSON_ATTRIBS",
-    description: "Load attributes from a JSON file or URL",
+    description: "Load attributes from a JSON file or URL.",
     proc: nil
 
   option :force_logger,
     long: "--force-logger",
-    description: "Use logger output instead of formatter output",
+    description: "Use logger output instead of formatter output.",
     boolean: true,
     default: false
 
   option :force_formatter,
     long: "--force-formatter",
-    description: "Use formatter output instead of logger output",
+    description: "Use formatter output instead of logger output.",
     boolean: true,
     default: false
 
   option :formatter,
     short: "-F FORMATTER",
     long: "--format FORMATTER",
-    description: "output format to use",
+    description: "The output format to use.",
     proc: lambda { |format| Chef::Config.add_formatter(format) }
 
   option :log_level,
     short: "-l LEVEL",
     long: "--log_level LEVEL",
-    description: "Set the log level (trace, debug, info, warn, error, fatal)",
+    description: "Set the log level (trace, debug, info, warn, error, fatal).",
     proc: lambda { |l| l.to_sym }
 
   option :help,
     short: "-h",
     long: "--help",
-    description: "Show this message",
+    description: "Show this help message.",
     on: :tail,
     boolean: true,
     show_options: true,
@@ -86,7 +86,7 @@ class Chef::Application::Apply < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show #{Chef::Dist::PRODUCT} version",
+    description: "Show #{Chef::Dist::PRODUCT} version.",
     boolean: true,
     proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
@@ -94,12 +94,12 @@ class Chef::Application::Apply < Chef::Application
   option :why_run,
     short: "-W",
     long: "--why-run",
-    description: "Enable whyrun mode",
+    description: "Enable whyrun mode.",
     boolean: true
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only).",
     boolean: true,
     default: false
 
@@ -107,11 +107,11 @@ class Chef::Application::Apply < Chef::Application
     long: "--[no-]color",
     boolean: true,
     default: true,
-    description: "Use colored output, defaults to enabled"
+    description: "Use colored output, defaults to enabled."
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins #{Chef::Dist::CLIENT} needs to function",
+    description: "Only run the bare minimum Ohai plugins #{Chef::Dist::PRODUCT} needs to function.",
     boolean: true
 
   attr_reader :json_attribs

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -41,11 +41,11 @@ class Chef::Application::Client < Chef::Application
   option :config_file,
     short: "-c CONFIG",
     long: "--config CONFIG",
-    description: "The configuration file to use"
+    description: "The configuration file to use."
 
   option :config_option,
     long: "--config-option OPTION=VALUE",
-    description: "Override a single configuration option",
+    description: "Override a single configuration option.",
     proc: lambda { |option, existing|
       (existing ||= []) << option
       existing
@@ -54,24 +54,24 @@ class Chef::Application::Client < Chef::Application
   option :formatter,
     short: "-F FORMATTER",
     long: "--format FORMATTER",
-    description: "output format to use",
+    description: "The output format to use.",
     proc: lambda { |format| Chef::Config.add_formatter(format) }
 
   option :force_logger,
     long: "--force-logger",
-    description: "Use logger output instead of formatter output",
+    description: "Use logger output instead of formatter output.",
     boolean: true,
     default: false
 
   option :force_formatter,
     long: "--force-formatter",
-    description: "Use formatter output instead of logger output",
+    description: "Use formatter output instead of logger output.",
     boolean: true,
     default: false
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only).",
     boolean: true,
     default: false
 
@@ -79,24 +79,24 @@ class Chef::Application::Client < Chef::Application
     long: "--[no-]color",
     boolean: true,
     default: true,
-    description: "Use colored output, defaults to enabled"
+    description: "Use colored output, defaults to enabled."
 
   option :log_level,
     short: "-l LEVEL",
     long: "--log_level LEVEL",
-    description: "Set the log level (auto, trace, debug, info, warn, error, fatal)",
+    description: "Set the log level (auto, trace, debug, info, warn, error, fatal).",
     proc: lambda { |l| l.to_sym }
 
   option :log_location,
     short: "-L LOGLOCATION",
     long: "--logfile LOGLOCATION",
-    description: "Set the log file location, defaults to STDOUT - recommended for daemonizing",
+    description: "Set the log file location, defaults to STDOUT - recommended for daemonizing.",
     proc: nil
 
   option :help,
     short: "-h",
     long: "--help",
-    description: "Show this message",
+    description: "Show this help message.",
     on: :tail,
     boolean: true,
     show_options: true,
@@ -105,20 +105,20 @@ class Chef::Application::Client < Chef::Application
   option :user,
     short: "-u USER",
     long: "--user USER",
-    description: "User to set privilege to",
+    description: "User to set privilege to.",
     proc: nil
 
   option :group,
     short: "-g GROUP",
     long: "--group GROUP",
-    description: "Group to set privilege to",
+    description: "Group to set privilege to.",
     proc: nil
 
   unless Chef::Platform.windows?
     option :daemonize,
       short: "-d [WAIT]",
       long: "--daemonize [WAIT]",
-      description:         "Daemonize the process. Accepts an optional integer which is the " \
+      description: "Daemonize the process. Accepts an optional integer which is the " \
         "number of seconds to wait before the first daemonized run.",
       proc: lambda { |wait| wait =~ /^\d+$/ ? wait.to_i : true }
   end
@@ -126,75 +126,75 @@ class Chef::Application::Client < Chef::Application
   option :pid_file,
     short: "-P PID_FILE",
     long: "--pid PIDFILE",
-    description: "Set the PID file location, for the #{Chef::Dist::CLIENT} daemon process. Defaults to /tmp/chef-client.pid",
+    description: "Set the PID file location, for the #{Chef::Dist::CLIENT} daemon process. Defaults to /tmp/chef-client.pid.",
     proc: nil
 
   option :lockfile,
     long: "--lockfile LOCKFILE",
-    description: "Set the lockfile location. Prevents multiple client processes from converging at the same time",
+    description: "Set the lockfile location. Prevents multiple client processes from converging at the same time.",
     proc: nil
 
   option :interval,
     short: "-i SECONDS",
     long: "--interval SECONDS",
-    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds",
+    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds.",
     proc: lambda { |s| s.to_i }
 
   option :once,
     long: "--once",
-    description: "Cancel any interval or splay options, run #{Chef::Dist::CLIENT} once and exit",
+    description: "Cancel any interval or splay options, run #{Chef::Dist::CLIENT} once and exit.",
     boolean: true
 
   option :json_attribs,
     short: "-j JSON_ATTRIBS",
     long: "--json-attributes JSON_ATTRIBS",
-    description: "Load attributes from a JSON file or URL",
+    description: "Load attributes from a JSON file or URL.",
     proc: nil
 
   option :node_name,
     short: "-N NODE_NAME",
     long: "--node-name NODE_NAME",
-    description: "The node name for this client",
+    description: "The node name for this client.",
     proc: nil
 
   option :splay,
     short: "-s SECONDS",
     long: "--splay SECONDS",
-    description: "The splay time for running at intervals, in seconds",
+    description: "The splay time for running at intervals, in seconds.",
     proc: lambda { |s| s.to_i }
 
   option :chef_server_url,
     short: "-S CHEFSERVERURL",
     long: "--server CHEFSERVERURL",
-    description: "The #{Chef::Dist::PRODUCT} server URL",
+    description: "The #{Chef::Dist::SERVER_PRODUCT} URL.",
     proc: nil
 
   option :validation_key,
     short: "-K KEY_FILE",
     long: "--validation_key KEY_FILE",
-    description: "Set the validation key file location, used for registering new clients",
+    description: "Set the validation key file location, used for registering new clients.",
     proc: nil
 
   option :client_key,
     short: "-k KEY_FILE",
     long: "--client_key KEY_FILE",
-    description: "Set the client key file location",
+    description: "Set the client key file location.",
     proc: nil
 
   option :named_run_list,
     short: "-n NAMED_RUN_LIST",
     long: "--named-run-list NAMED_RUN_LIST",
-    description: "Use a policyfile's named run list instead of the default run list"
+    description: "Use a policyfile's named run list instead of the default run list."
 
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the #{Chef::Dist::PRODUCT} Environment on the node"
+    description: "Set the #{Chef::Dist::PRODUCT} environment on the node."
 
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show #{Chef::Dist::PRODUCT} version",
+    description: "Show #{Chef::Dist::PRODUCT} version.",
     boolean: true,
     proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
@@ -202,7 +202,7 @@ class Chef::Application::Client < Chef::Application
   option :override_runlist,
     short: "-o RunlistItem,RunlistItem...",
     long: "--override-runlist RunlistItem,RunlistItem...",
-    description: "Replace current run list with specified items for a single run",
+    description: "Replace current run list with specified items for a single run.",
     proc: lambda { |items|
       items = items.split(",")
       items.compact.map do |item|
@@ -213,7 +213,7 @@ class Chef::Application::Client < Chef::Application
   option :runlist,
     short: "-r RunlistItem,RunlistItem...",
     long: "--runlist RunlistItem,RunlistItem...",
-    description: "Permanently replace current run list with specified items",
+    description: "Permanently replace current run list with specified items.",
     proc: lambda { |items|
       items = items.split(",")
       items.compact.map do |item|
@@ -223,13 +223,13 @@ class Chef::Application::Client < Chef::Application
   option :why_run,
     short: "-W",
     long: "--why-run",
-    description: "Enable whyrun mode",
+    description: "Enable whyrun mode.",
     boolean: true
 
   option :client_fork,
     short: "-f",
     long: "--[no-]fork",
-    description: "Fork client"
+    description: "Fork #{Chef::Dist::CLIENT} process."
 
   option :recipe_url,
     long: "--recipe-url=RECIPE_URL",
@@ -238,26 +238,26 @@ class Chef::Application::Client < Chef::Application
   option :enable_reporting,
     short: "-R",
     long: "--enable-reporting",
-    description: "Enable reporting data collection for #{Chef::Dist::PRODUCT} runs",
+    description: "Enable reporting data collection for #{Chef::Dist::PRODUCT} runs.",
     boolean: true
 
   option :local_mode,
     short: "-z",
     long: "--local-mode",
-    description: "Point #{Chef::Dist::CLIENT} at local repository",
+    description: "Point #{Chef::Dist::CLIENT} at local repository.",
     boolean: true
 
   option :chef_zero_host,
     long: "--chef-zero-host HOST",
-    description: "Host to start chef-zero on"
+    description: "Host to start chef-zero on."
 
   option :chef_zero_port,
     long: "--chef-zero-port PORT",
-    description: "Port (or port range) to start chef-zero on.  Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
+    description: "Port (or port range) to start chef-zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
 
   option :disable_config,
     long: "--disable-config",
-    description: "Refuse to load a config file and use defaults. This is for development and not a stable API",
+    description: "Refuse to load a config file and use defaults. This is for development and not a stable API.",
     boolean: true
 
   option :run_lock_timeout,
@@ -269,33 +269,33 @@ class Chef::Application::Client < Chef::Application
     option :fatal_windows_admin_check,
       short: "-A",
       long: "--fatal-windows-admin-check",
-      description: "Fail the run when #{Chef::Dist::CLIENT} doesn't have administrator privileges on Windows",
+      description: "Fail the run when #{Chef::Dist::CLIENT} doesn't have administrator privileges on Windows.",
       boolean: true
   end
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins #{Chef::Dist::CLIENT} needs to function",
+    description: "Only run the bare minimum Ohai plugins #{Chef::Dist::PRODUCT} needs to function.",
     boolean: true
 
   option :listen,
     long: "--[no-]listen",
-    description: "Whether a local mode (-z) server binds to a port",
+    description: "Whether a local mode (-z) server binds to a port.",
     boolean: false
 
   option :fips,
     long: "--[no-]fips",
-    description: "Enable fips mode",
+    description: "Enable FIPS mode.",
     boolean: true
 
   option :delete_entire_chef_repo,
     long: "--delete-entire-chef-repo",
-    description: "DANGEROUS: does what it says, only useful with --recipe-url",
+    description: "DANGEROUS: does what it says, only useful with --recipe-url.",
     boolean: true
 
   option :skip_cookbook_sync,
     long: "--[no-]skip-cookbook-sync",
-    description: "Use cached cookbooks without overwriting local differences from the server",
+    description: "Use cached cookbooks without overwriting local differences from the #{Chef::Dist::SERVER_PRODUCT}.",
     boolean: false
 
   IMMEDIATE_RUN_SIGNAL = "1".freeze
@@ -504,7 +504,7 @@ class Chef::Application::Client < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled by default." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -2,7 +2,7 @@
 # Author:: AJ Christensen (<aj@chef.io)
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/application/exit_code.rb
+++ b/lib/chef/application/exit_code.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Murawski (<smurawski@chef.io>)
-# Copyright:: Copyright 2016, Chef Software, Inc.
+# Copyright:: Copyright 2016-2019, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/application/exit_code.rb
+++ b/lib/chef/application/exit_code.rb
@@ -22,6 +22,7 @@ class Chef
     # These are the exit codes defined in Chef RFC 062
     # https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md
     class ExitCode
+      require "chef/dist"
 
       # -1 is defined as DEPRECATED_FAILURE in RFC 062, so it is
       # not enumerated in an active constant.
@@ -143,10 +144,10 @@ class Chef
         end
 
         def non_standard_exit_code_warning(exit_code)
-          "Chef attempted to exit with a non-standard exit code of #{exit_code}." \
-          " Chef RFC 062 (https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md) defines the" \
-          " exit codes that should be used with Chef.  Chef::Application::ExitCode defines valid exit codes"  \
-          " Non-standard exit codes are redefined as GENERIC_FAILURE."
+          "#{Chef::Dist::CLIENT} attempted to exit with a non-standard exit code of #{exit_code}." \
+          " The Chef-Client Exit Codes design document (https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md)" \
+          " defines the exit codes that should be used with Chef. Chef::Application::ExitCode defines"  \
+          " valid exit codes Non-standard exit codes are redefined as GENERIC_FAILURE."
         end
 
       end

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -31,12 +31,12 @@ class Chef::Application::Knife < Chef::Application
   option :config_file,
     short: "-c CONFIG",
     long: "--config CONFIG",
-    description: "The configuration file to use",
+    description: "The configuration file to use.",
     proc: lambda { |path| File.expand_path(path, Dir.pwd) }
 
   option :config_option,
     long: "--config-option OPTION=VALUE",
-    description: "Override a single configuration option",
+    description: "Override a single configuration option.",
     proc: lambda { |option, existing|
       (existing ||= []) << option
       existing
@@ -46,7 +46,7 @@ class Chef::Application::Knife < Chef::Application
   option :verbosity,
     short: "-V",
     long: "--verbose",
-    description: "More verbose output. Use twice for max verbosity",
+    description: "More verbose output. Use twice for max verbosity.",
     proc: Proc.new { verbosity_level += 1 },
     default: 0
 
@@ -54,104 +54,104 @@ class Chef::Application::Knife < Chef::Application
     long: "--[no-]color",
     boolean: true,
     default: true,
-    description: "Use colored output, defaults to enabled"
+    description: "Use colored output, defaults to enabled."
 
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the #{Chef::Dist::PRODUCT} environment (except for in searches, where this will be flagrantly ignored)"
+    description: "Set the #{Chef::Dist::PRODUCT} environment (except for in searches, where this will be flagrantly ignored)."
 
   option :editor,
     short: "-e EDITOR",
     long: "--editor EDITOR",
-    description: "Set the editor to use for interactive commands",
+    description: "Set the editor to use for interactive commands.",
     default: ENV["EDITOR"]
 
   option :disable_editing,
     short: "-d",
     long: "--disable-editing",
-    description: "Do not open EDITOR, just accept the data as is",
+    description: "Do not open EDITOR, just accept the data as is.",
     boolean: true,
     default: false
 
   option :help,
     short: "-h",
     long: "--help",
-    description: "Show this message",
+    description: "Show this help message.",
     on: :tail,
     boolean: true
 
   option :node_name,
     short: "-u USER",
     long: "--user USER",
-    description: "API Client Username"
+    description: "#{Chef::Dist::SERVER_PRODUCT} API client username."
 
   option :client_key,
     short: "-k KEY",
     long: "--key KEY",
-    description: "API Client Key",
+    description: "#{Chef::Dist::SERVER_PRODUCT} API client key.",
     proc: lambda { |path| File.expand_path(path, Dir.pwd) }
 
   option :chef_server_url,
     short: "-s URL",
     long: "--server-url URL",
-    description: "#{Chef::Dist::PRODUCT} Server URL"
+    description: "#{Chef::Dist::SERVER_PRODUCT} URL."
 
   option :yes,
     short: "-y",
     long: "--yes",
-    description: "Say yes to all prompts for confirmation"
+    description: "Say yes to all prompts for confirmation."
 
   option :defaults,
     long: "--defaults",
-    description: "Accept default values for all questions"
+    description: "Accept default values for all questions."
 
   option :print_after,
     long: "--print-after",
-    description: "Show the data after a destructive operation"
+    description: "Show the data after a destructive operation."
 
   option :format,
     short: "-F FORMAT",
     long: "--format FORMAT",
-    description: "Which format to use for output",
+    description: "Which format to use for output.",
     default: "summary"
 
   option :local_mode,
     short: "-z",
     long: "--local-mode",
-    description: "Point knife commands at local repository instead of server",
+    description: "Point knife commands at local repository instead of #{Chef::Dist::SERVER_PRODUCT}.",
     boolean: true
 
   option :chef_zero_host,
     long: "--chef-zero-host HOST",
-    description: "Host to start chef-zero on"
+    description: "Host to start chef-zero on."
 
   option :chef_zero_port,
     long: "--chef-zero-port PORT",
-    description: "Port (or port range) to start chef-zero on.  Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
+    description: "Port (or port range) to start chef-zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
 
   option :listen,
     long: "--[no-]listen",
-    description: "Whether a local mode (-z) server binds to a port",
+    description: "Whether a local mode (-z) server binds to a port.",
     boolean: false
 
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show #{Chef::Dist::PRODUCT} version",
+    description: "Show #{Chef::Dist::PRODUCT} version.",
     boolean: true,
     proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
 
   option :fips,
     long: "--[no-]fips",
-    description: "Enable fips mode",
+    description: "Enable FIPS mode.",
     boolean: true,
     default: nil
 
   option :profile,
     long: "--profile PROFILE",
-    description: "The credentials profile to select"
+    description: "The credentials profile to select."
 
   # Run knife
   def run

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -176,7 +176,7 @@ class Chef::Application::Solo < Chef::Application
   option :client_fork,
     short: "-f",
     long: "--[no-]fork",
-    description: "Fork client."
+    description: "Fork #{Chef::Dist::CLIENT} process."
 
   option :why_run,
     short: "-W",

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -366,7 +366,7 @@ class Chef::Application::Solo < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled bvy default." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled by default." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -39,11 +39,11 @@ class Chef::Application::Solo < Chef::Application
     short: "-c CONFIG",
     long: "--config CONFIG",
     default: Chef::Config.platform_specific_path("/etc/chef/solo.rb"),
-    description: "The configuration file to use"
+    description: "The configuration file to use."
 
   option :config_option,
     long: "--config-option OPTION=VALUE",
-    description: "Override a single configuration option",
+    description: "Override a single configuration option.",
     proc: lambda { |option, existing|
       (existing ||= []) << option
       existing
@@ -52,24 +52,24 @@ class Chef::Application::Solo < Chef::Application
   option :formatter,
     short: "-F FORMATTER",
     long: "--format FORMATTER",
-    description: "output format to use",
+    description: "The output format to use.",
     proc: lambda { |format| Chef::Config.add_formatter(format) }
 
   option :force_logger,
     long: "--force-logger",
-    description: "Use logger output instead of formatter output",
+    description: "Use logger output instead of formatter output.",
     boolean: true,
     default: false
 
   option :force_formatter,
     long: "--force-formatter",
-    description: "Use formatter output instead of logger output",
+    description: "Use formatter output instead of logger output.",
     boolean: true,
     default: false
 
   option :profile_ruby,
     long: "--[no-]profile-ruby",
-    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only)",
+    description: "Dump complete Ruby call graph stack of entire #{Chef::Dist::PRODUCT} run (expert only).",
     boolean: true,
     default: false
 
@@ -77,24 +77,24 @@ class Chef::Application::Solo < Chef::Application
     long: "--[no-]color",
     boolean: true,
     default: true,
-    description: "Use colored output, defaults to enabled"
+    description: "Use colored output, defaults to enabled."
 
   option :log_level,
     short: "-l LEVEL",
     long: "--log_level LEVEL",
-    description: "Set the log level (auto, trace, debug, info, warn, error, fatal)",
+    description: "Set the log level (auto, trace, debug, info, warn, error, fatal).",
     proc: lambda { |l| l.to_sym }
 
   option :log_location,
     short: "-L LOGLOCATION",
     long: "--logfile LOGLOCATION",
-    description: "Set the log file location, defaults to STDOUT - recommended for daemonizing",
+    description: "Set the log file location, defaults to STDOUT - recommended for daemonizing.",
     proc: nil
 
   option :help,
     short: "-h",
     long: "--help",
-    description: "Show this message",
+    description: "Show this help message.",
     on: :tail,
     boolean: true,
     show_options: true,
@@ -103,50 +103,50 @@ class Chef::Application::Solo < Chef::Application
   option :user,
     short: "-u USER",
     long: "--user USER",
-    description: "User to set privilege to",
+    description: "User to set privilege to.",
     proc: nil
 
   option :group,
     short: "-g GROUP",
     long: "--group GROUP",
-    description: "Group to set privilege to",
+    description: "Group to set privilege to.",
     proc: nil
 
   unless Chef::Platform.windows?
     option :daemonize,
       short: "-d",
       long: "--daemonize",
-      description: "Daemonize the process",
+      description: "Daemonize the process.",
       proc: lambda { |p| true }
   end
 
   option :lockfile,
     long: "--lockfile LOCKFILE",
-    description: "Set the lockfile location. Prevents multiple solo processes from converging at the same time",
+    description: "Set the lockfile location. Prevents multiple solo processes from converging at the same time.",
     proc: nil
 
   option :interval,
     short: "-i SECONDS",
     long: "--interval SECONDS",
-    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds",
+    description: "Run #{Chef::Dist::CLIENT} periodically, in seconds.",
     proc: lambda { |s| s.to_i }
 
   option :json_attribs,
     short: "-j JSON_ATTRIBS",
     long: "--json-attributes JSON_ATTRIBS",
-    description: "Load attributes from a JSON file or URL",
+    description: "Load attributes from a JSON file or URL.",
     proc: nil
 
   option :node_name,
     short: "-N NODE_NAME",
     long: "--node-name NODE_NAME",
-    description: "The node name for this client",
+    description: "The node name for this client.",
     proc: nil
 
   option :splay,
     short: "-s SECONDS",
     long: "--splay SECONDS",
-    description: "The splay time for running at intervals, in seconds",
+    description: "The splay time for running at intervals, in seconds.",
     proc: lambda { |s| s.to_i }
 
   option :recipe_url,
@@ -157,7 +157,7 @@ class Chef::Application::Solo < Chef::Application
   option :version,
     short: "-v",
     long: "--version",
-    description: "Show #{Chef::Dist::EXEC} version",
+    description: "Show #{Chef::Dist::PRODUCT} version.",
     boolean: true,
     proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
     exit: 0
@@ -165,7 +165,7 @@ class Chef::Application::Solo < Chef::Application
   option :override_runlist,
     short: "-o RunlistItem,RunlistItem...",
     long: "--override-runlist RunlistItem,RunlistItem...",
-    description: "Replace current run list with specified items for a single run",
+    description: "Replace current run list with specified items for a single run.",
     proc: lambda { |items|
       items = items.split(",")
       items.compact.map do |item|
@@ -176,23 +176,23 @@ class Chef::Application::Solo < Chef::Application
   option :client_fork,
     short: "-f",
     long: "--[no-]fork",
-    description: "Fork client"
+    description: "Fork client."
 
   option :why_run,
     short: "-W",
     long: "--why-run",
-    description: "Enable whyrun mode",
+    description: "Enable whyrun mode.",
     boolean: true
 
   option :ez,
     long: "--ez",
-    description: "A memorial for Ezra Zygmuntowicz",
+    description: "A memorial for Ezra Zygmuntowicz.",
     boolean: true
 
   option :environment,
     short: "-E ENVIRONMENT",
     long: "--environment ENVIRONMENT",
-    description: "Set the #{Chef::Dist::PRODUCT} Environment on the node"
+    description: "Set the #{Chef::Dist::PRODUCT} environment on the node."
 
   option :run_lock_timeout,
     long: "--run-lock-timeout SECONDS",
@@ -201,17 +201,17 @@ class Chef::Application::Solo < Chef::Application
 
   option :minimal_ohai,
     long: "--minimal-ohai",
-    description: "Only run the bare minimum ohai plugins #{Chef::Dist::PRODUCT} needs to function",
+    description: "Only run the bare minimum Ohai plugins #{Chef::Dist::PRODUCT} needs to function.",
     boolean: true
 
   option :delete_entire_chef_repo,
     long: "--delete-entire-chef-repo",
-    description: "DANGEROUS: does what it says, only useful with --recipe-url",
+    description: "DANGEROUS: does what it says, only useful with --recipe-url.",
     boolean: true
 
   option :solo_legacy_mode,
     long: "--legacy-mode",
-    description: "Run chef-solo in legacy mode",
+    description: "Run chef-solo in legacy mode.",
     boolean: true
 
   attr_reader :chef_client_json
@@ -366,7 +366,7 @@ class Chef::Application::Solo < Chef::Application
   end
 
   def unforked_interval_error_message
-    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled in #{Chef::Dist::PRODUCT} 12." +
+    "Unforked #{Chef::Dist::CLIENT} interval runs are disabled bvy default." +
       "\nConfiguration settings:" +
       ("\n  interval  = #{Chef::Config[:interval]} seconds" if Chef::Config[:interval]).to_s +
       "\nEnable #{Chef::Dist::CLIENT} interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options."

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -41,23 +41,23 @@ class Chef
         short: "-c CONFIG",
         long: "--config CONFIG",
         default: "#{ENV['SYSTEMDRIVE']}/chef/client.rb",
-        description: ""
+        description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,
         short: "-L LOGLOCATION",
         long: "--logfile LOGLOCATION",
-        description: "Set the log file location"
+        description: "Set the log file location."
 
       option :splay,
         short: "-s SECONDS",
         long: "--splay SECONDS",
-        description: "The splay time for running at intervals, in seconds",
+        description: "The splay time for running at intervals, in seconds.",
         proc: lambda { |s| s.to_i }
 
       option :interval,
         short: "-i SECONDS",
         long: "--interval SECONDS",
-        description: "Set the number of seconds to wait between #{Chef::Dist::CLIENT} runs",
+        description: "Set the number of seconds to wait between #{Chef::Dist::PRODUCT} runs.",
         proc: lambda { |s| s.to_i }
 
       DEFAULT_LOG_LOCATION ||= "#{ENV['SYSTEMDRIVE']}/chef/client.log".freeze
@@ -136,7 +136,7 @@ class Chef
               run_warning_displayed = true
             end
 
-            Chef::Log.trace("Waiting for #{Chef::Dist::CLIENT} run...")
+            Chef::Log.trace("Waiting for #{Chef::Dist::PRODUCT} run...")
             sleep 1
           end
         end
@@ -150,7 +150,7 @@ class Chef
         # since this is a PAUSE signal.
 
         if @service_action_mutex.locked?
-          Chef::Log.info("Currently a #{Chef::Dist::CLIENT} run is happening.")
+          Chef::Log.info("Currently a #{Chef::Dist::PRODUCT} run is happening.")
           Chef::Log.info("Service will pause once it's completed.")
         else
           Chef::Log.info("Service is pausing....")

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2011-2016, Chef Software, Inc.
+# Copyright:: Copyright 2011-2019, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 end
 require "chef/config"
 require "mixlib/cli"
+require "chef/dist"
 
 class Chef
   class Application
@@ -40,23 +41,23 @@ class Chef
         short: "-a ACTION",
         long: "--action ACTION",
         default: "status",
-        description: "Action to carry out on chef-service (install, uninstall, status, start, stop, pause, or resume)"
+        description: "Action to carry out on chef-service (install, uninstall, status, start, stop, pause, or resume)."
 
       option :config_file,
         short: "-c CONFIG",
         long: "--config CONFIG",
         default: "#{ENV['SYSTEMDRIVE']}/chef/client.rb",
-        description: "The configuration file to use for chef runs"
+        description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,
         short: "-L LOGLOCATION",
         long: "--logfile LOGLOCATION",
-        description: "Set the log file location for chef-service"
+        description: "Set the log file location for chef-service."
 
       option :help,
         short: "-h",
         long: "--help",
-        description: "Show this message",
+        description: "Show this help message.",
         on: :tail,
         boolean: true,
         show_options: true,
@@ -65,9 +66,9 @@ class Chef
       option :version,
         short: "-v",
         long: "--version",
-        description: "Show chef version",
+        description: "Show #{Chef::Dist::PRODUCT} version.",
         boolean: true,
-        proc: lambda { |v| puts "Chef: #{::Chef::VERSION}" },
+        proc: lambda { |v| puts "#{Chef::Dist::PRODUCT}: #{::Chef::VERSION}" },
         exit: 0
 
       def initialize(service_options)

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -4,6 +4,9 @@ class Chef
     # When referencing a product directly, like Chef (Now Chef Infra)
     PRODUCT = "Chef Infra Client".freeze
 
+    # The name of the server product
+    SERVER_PRODUCT = "Chef Infra Server".freeze
+
     # The client's alias (chef-client)
     CLIENT = "chef-client".freeze
 

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -28,6 +28,15 @@ class Chef
       SUPPORTED_CONNECTION_PROTOCOLS = %w{ssh winrm}.freeze
       WINRM_AUTH_PROTOCOL_LIST = %w{plaintext kerberos ssl negotiate}.freeze
 
+      # @param opt_arry [Array]
+      #
+      # @return [String] a friendly quoted list of items complete with "and"
+      def self.friendly_opt_list(opt_array)
+        opts = opt_array.map { |x| "'#{x}'" }
+        return opts.join(" and ") if opts.size < 3
+        opts[0..-2].join(", ") + " and " + opts[-1]
+      end
+
       # Common connectivity options
       option :connection_user,
         short: "-U USERNAME",
@@ -47,7 +56,7 @@ class Chef
       option :connection_protocol,
         short: "-o PROTOCOL",
         long: "--connection-protocol PROTOCOL",
-        description: "The protocol to use to connect to the target node.  Supports: #{SUPPORTED_CONNECTION_PROTOCOLS.join(" ")}"
+        description: "The protocol to use to connect to the target node. Supports: #{friendly_opt_list(SUPPORTED_CONNECTION_PROTOCOLS)}."
 
       option :max_wait,
         short: "-W SECONDS",
@@ -76,7 +85,7 @@ class Chef
       option :winrm_auth_method,
         short: "-w AUTH-METHOD",
         long: "--winrm-auth-method AUTH-METHOD",
-        description: "The WinRM authentication method to use. Valid choices are #{WINRM_AUTH_PROTOCOL_LIST}",
+        description: "The WinRM authentication method to use. Valid choices are #{friendly_opt_list(WINRM_AUTH_PROTOCOL_LIST)}.",
         proc: Proc.new { |protocol| Chef::Config[:knife][:winrm_auth_method] = protocol }
 
       option :winrm_basic_auth_only,

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -547,8 +547,8 @@ class Chef
           chef_vault_handler.run(client_builder.client)
         else
           ui.info <<~EOM
-            Doing old-style registration with the validation key at #{Chef::Config[:validation_key]}..."
-            Delete your validation key in order to use your user credentials instead
+            Performing legacy client registration with the validation key at #{Chef::Config[:validation_key]}..."
+            Delete your validation key in order to use your user credentials for client registration instead.
           EOM
 
         end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -41,12 +41,12 @@ class Chef
       option :connection_user,
         short: "-U USERNAME",
         long: "--connection-user USERNAME",
-        description: "Authenticate to the target host with this user account"
+        description: "Authenticate to the target host with this user account."
 
       option :connection_password,
         short: "-P PASSWORD",
         long: "--connection-password PASSWORD",
-        description: "Authenticate to the target host with this password"
+        description: "Authenticate to the target host with this password."
 
       option :connection_port,
         short: "-p PORT",
@@ -71,7 +71,7 @@ class Chef
       option :ca_trust_file,
         short: "-f CA_TRUST_PATH",
         long: "--ca-trust-file CA_TRUST_PATH",
-        description: "The Certificate Authority (CA) trust file used for SSL transport"
+        description: "The Certificate Authority (CA) trust file used for SSL transport."
 
       option :winrm_no_verify_cert,
         long: "--winrm-no-verify-cert",
@@ -80,7 +80,7 @@ class Chef
 
       option :winrm_ssl,
         long: "--winrm-ssl",
-        description: "Connect to WinRM using SSL"
+        description: "Use SSL in the WinRM connection."
 
       option :winrm_auth_method,
         short: "-w AUTH-METHOD",
@@ -90,7 +90,7 @@ class Chef
 
       option :winrm_basic_auth_only,
         long: "--winrm-basic-auth-only",
-        description: "For WinRM basic authentication when using the 'ssl' auth method",
+        description: "For WinRM basic authentication when using the 'ssl' auth method.",
         boolean: true
 
         # This option was provided in knife bootstrap windows winrm,
@@ -104,42 +104,42 @@ class Chef
       option :kerberos_realm,
         short: "-R KERBEROS_REALM",
         long: "--kerberos-realm KERBEROS_REALM",
-        description: "The Kerberos realm used for authentication",
+        description: "The Kerberos realm used for authentication.",
         proc: Proc.new { |protocol| Chef::Config[:knife][:kerberos_realm] = protocol }
 
       option :kerberos_service,
         short: "-S KERBEROS_SERVICE",
         long: "--kerberos-service KERBEROS_SERVICE",
-        description: "The Kerberos service used for authentication",
+        description: "The Kerberos service used for authentication.",
         proc: Proc.new { |protocol| Chef::Config[:knife][:kerberos_service] = protocol }
 
       option :winrm_session_timeout,
         long: "--winrm-session-timeout SECONDS",
-        description: "The number of seconds to wait for each WinRM operation to be acknowledged while running bootstrap",
+        description: "The number of seconds to wait for each WinRM operation to be acknowledged while running bootstrap.",
         proc: Proc.new { |protocol| Chef::Config[:knife][:winrm_session_timeout] = protocol }
 
       ## SSH Authentication
       option :ssh_gateway,
         short: "-G GATEWAY",
         long: "--ssh-gateway GATEWAY",
-        description: "The ssh gateway",
+        description: "The SSH gateway.",
         proc: Proc.new { |key| Chef::Config[:knife][:ssh_gateway] = key }
 
       option :ssh_gateway_identity,
         long: "--ssh-gateway-identity SSH_GATEWAY_IDENTITY",
-        description: "The SSH identity file used for gateway authentication",
+        description: "The SSH identity file used for gateway authentication.",
         proc: Proc.new { |key| Chef::Config[:knife][:ssh_gateway_identity] = key }
 
       option :ssh_forward_agent,
         short: "-A",
         long: "--ssh-forward-agent",
-        description: "Enable SSH agent forwarding",
+        description: "Enable SSH agent forwarding.",
         boolean: true
 
       option :ssh_identity_file,
         short: "-i IDENTITY_FILE",
         long: "--ssh-identity-file IDENTITY_FILE",
-        description: "The SSH identity file used for authentication"
+        description: "The SSH identity file used for authentication."
 
       option :ssh_verify_host_key,
         long: "--[no-]ssh-verify-host-key",
@@ -153,36 +153,36 @@ class Chef
       # client.rb content via chef-full/bootstrap_context
       option :bootstrap_version,
         long: "--bootstrap-version VERSION",
-        description: "The version of Chef to install",
+        description: "The version of #{Chef::Dist::PRODUCT} to install.",
         proc: lambda { |v| Chef::Config[:knife][:bootstrap_version] = v }
 
       # client.rb content via chef-full/bootstrap_context
       option :bootstrap_proxy,
         long: "--bootstrap-proxy PROXY_URL",
-        description: "The proxy server for the node being bootstrapped",
+        description: "The proxy server for the node being bootstrapped.",
         proc: Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy] = p }
 
       # client.rb content via bootstrap_context
       option :bootstrap_proxy_user,
         long: "--bootstrap-proxy-user PROXY_USER",
-        description: "The proxy authentication username for the node being bootstrapped"
+        description: "The proxy authentication username for the node being bootstrapped."
 
       # client.rb content via bootstrap_context
       option :bootstrap_proxy_pass,
         long: "--bootstrap-proxy-pass PROXY_PASS",
-        description: "The proxy authentication password for the node being bootstrapped"
+        description: "The proxy authentication password for the node being bootstrapped."
 
       # client.rb content via bootstrap_context
       option :bootstrap_no_proxy,
         long: "--bootstrap-no-proxy [NO_PROXY_URL|NO_PROXY_IP]",
-        description: "Do not proxy locations for the node being bootstrapped; this option is used internally by Chef",
+        description: "Do not proxy locations for the node being bootstrapped; this option is used internally by Chef.",
         proc: Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
       # client.rb content via bootstrap_context
       option :bootstrap_template,
         short: "-t TEMPLATE",
         long: "--bootstrap-template TEMPLATE",
-        description: "Bootstrap Chef using a built-in or custom template. Set to the full path of an erb template or use one of the built-in templates."
+        description: "Bootstrap #{Chef::Dist::PRODUCT} using a built-in or custom template. Set to the full path of an erb template or use one of the built-in templates."
 
       # client.rb content via bootstrap_context
       option :node_ssl_verify_mode,
@@ -199,57 +199,57 @@ class Chef
       # bootstrap_context - client.rb
       option :node_verify_api_cert,
         long: "--[no-]node-verify-api-cert",
-        description: "Verify the SSL cert for HTTPS requests to the Chef server API.",
+        description: "Verify the SSL cert for HTTPS requests to the #{Chef::Dist::SERVER_PRODUCT} API.",
         boolean: true
 
       # runtime - sudo settings (train handles sudo)
       option :use_sudo,
         long: "--sudo",
-        description: "Execute the bootstrap via sudo",
+        description: "Execute the bootstrap via sudo.",
         boolean: true
 
       # runtime - sudo settings (train handles sudo)
       option :preserve_home,
         long: "--sudo-preserve-home",
-        description: "Preserve non-root user HOME environment variable with sudo",
+        description: "Preserve non-root user HOME environment variable with sudo.",
         boolean: true
 
       # runtime - sudo settings (train handles sudo)
       option :use_sudo_password,
         long: "--use-sudo-password",
-        description: "Execute the bootstrap via sudo with password",
+        description: "Execute the bootstrap via sudo with password.",
         boolean: false
 
       # runtime - client_builder
       option :chef_node_name,
         short: "-N NAME",
         long: "--node-name NAME",
-        description: "The Chef node name for your new node"
+        description: "The node name for your new node."
 
       # runtime - client_builder - set runlist when creating node
       option :run_list,
         short: "-r RUN_LIST",
         long: "--run-list RUN_LIST",
-        description: "Comma separated list of roles/recipes to apply",
+        description: "Comma separated list of roles/recipes to apply.",
         proc: lambda { |o| o.split(/[\s,]+/) },
         default: []
 
       # runtime - client_builder - set policy name when creating node
       option :policy_name,
         long: "--policy-name POLICY_NAME",
-        description: "Policyfile name to use (--policy-group must also be given)",
+        description: "Policyfile name to use (--policy-group must also be given).",
         default: nil
 
       # runtime - client_builder - set policy group when creating node
       option :policy_group,
         long: "--policy-group POLICY_GROUP",
-        description: "Policy group name to use (--policy-name must also be given)",
+        description: "Policy group name to use (--policy-name must also be given).",
         default: nil
 
       # runtime - client_builder -  node tags
       option :tags,
         long: "--tags TAGS",
-        description: "Comma separated list of tags to apply to the node",
+        description: "Comma separated list of tags to apply to the node.",
         proc: lambda { |o| o.split(/[\s,]+/) },
         default: []
 
@@ -257,14 +257,14 @@ class Chef
       option :first_boot_attributes,
         short: "-j JSON_ATTRIBS",
         long: "--json-attributes",
-        description: "A JSON string to be added to the first run of #{Chef::Dist::CLIENT}",
+        description: "A JSON string to be added to the first run of #{Chef::Dist::CLIENT}.",
         proc: lambda { |o| Chef::JSONCompat.parse(o) },
         default: nil
 
       # bootstrap template
       option :first_boot_attributes_from_file,
         long: "--json-attribute-file FILE",
-        description: "A JSON file to be used to the first run of #{Chef::Dist::CLIENT}",
+        description: "A JSON file to be used to the first run of #{Chef::Dist::CLIENT}.",
         proc: lambda { |o| Chef::JSONCompat.parse(File.read(o)) },
         default: nil
 
@@ -278,7 +278,7 @@ class Chef
       # Create ohai hints in /etc/chef/ohai/hints, fname=hintname, content=value
       option :hint,
         long: "--hint HINT_NAME[=HINT_FILE]",
-        description: "Specify Ohai Hint to be set on the bootstrap target. Use multiple --hint options to specify multiple hints.",
+        description: "Specify an Ohai hint to be set on the bootstrap target. Use multiple --hint options to specify multiple hints.",
         proc: Proc.new { |h|
           Chef::Config[:knife][:hints] ||= Hash.new
           name, path = h.split("=")
@@ -290,53 +290,53 @@ class Chef
       # the provided options to knife bootstrap, so we set the Chef::Config option here.
       option :bootstrap_url,
         long: "--bootstrap-url URL",
-        description: "URL to a custom installation script",
+        description: "URL to a custom installation script.",
         proc: Proc.new { |u| Chef::Config[:knife][:bootstrap_url] = u }
 
       option :msi_url, # Windows target only
         short: "-m URL",
         long: "--msi-url URL",
-        description: "Location of the #{Chef::Dist::PRODUCT} MSI. The default templates will prefer to download from this location. The MSI will be downloaded from chef.io if not provided (windows).",
+        description: "Location of the #{Chef::Dist::PRODUCT} MSI. The default templates will prefer to download from this location. The MSI will be downloaded from #{Chef::Dist::WEBSITE} if not provided (Windows).",
         default: ""
 
       # bootstrap override: Do this instead of our own setup.sh from omnitruck. Causes bootstrap_url to be ignored.
       option :bootstrap_install_command,
         long: "--bootstrap-install-command COMMANDS",
-        description: "Custom command to install #{Chef::Dist::CLIENT}",
+        description: "Custom command to install #{Chef::Dist::PRODUCT}.",
         proc: Proc.new { |ic| Chef::Config[:knife][:bootstrap_install_command] = ic }
 
       # bootstrap template: Run this command first in the bootstrap script
       option :bootstrap_preinstall_command,
         long: "--bootstrap-preinstall-command COMMANDS",
-        description: "Custom commands to run before installing #{Chef::Dist::CLIENT}",
+        description: "Custom commands to run before installing #{Chef::Dist::PRODUCT}.",
         proc: Proc.new { |preic| Chef::Config[:knife][:bootstrap_preinstall_command] = preic }
 
       # bootstrap template
       option :bootstrap_wget_options,
         long: "--bootstrap-wget-options OPTIONS",
-        description: "Add options to wget when installing #{Chef::Dist::CLIENT}",
+        description: "Add options to wget when installing #{Chef::Dist::PRODUCT}.",
         proc: Proc.new { |wo| Chef::Config[:knife][:bootstrap_wget_options] = wo }
 
       # bootstrap template
       option :bootstrap_curl_options,
         long: "--bootstrap-curl-options OPTIONS",
-        description: "Add options to curl when install #{Chef::Dist::CLIENT}",
+        description: "Add options to curl when install #{Chef::Dist::PRODUCT}.",
         proc: Proc.new { |co| Chef::Config[:knife][:bootstrap_curl_options] = co }
 
       # chef_vault_handler
       option :bootstrap_vault_file,
         long: "--bootstrap-vault-file VAULT_FILE",
-        description: "A JSON file with a list of vault(s) and item(s) to be updated"
+        description: "A JSON file with a list of vault(s) and item(s) to be updated."
 
       # chef_vault_handler
       option :bootstrap_vault_json,
         long: "--bootstrap-vault-json VAULT_JSON",
-        description: "A JSON string with the vault(s) and item(s) to be updated"
+        description: "A JSON string with the vault(s) and item(s) to be updated."
 
       # chef_vault_handler
       option :bootstrap_vault_item,
         long: "--bootstrap-vault-item VAULT_ITEM",
-        description: 'A single vault and item to update as "vault:item"',
+        description: 'A single vault and item to update as "vault:item".',
         proc: Proc.new { |i|
           (vault, item) = i.split(/:/)
           Chef::Config[:knife][:bootstrap_vault_item] ||= {}

--- a/lib/chef/knife/client_bulk_delete.rb
+++ b/lib/chef/knife/client_bulk_delete.rb
@@ -29,7 +29,7 @@ class Chef
       option :delete_validators,
        short: "-D",
        long: "--delete-validators",
-       description: "Force deletion of clients if they're validators"
+       description: "Force deletion of clients if they're validators."
 
       banner "knife client bulk delete REGEX (options)"
 

--- a/lib/chef/knife/client_create.rb
+++ b/lib/chef/knife/client_create.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef/knife"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -50,7 +51,7 @@ class Chef
       option :prevent_keygen,
              short: "-k",
              long: "--prevent-keygen",
-             description: "API V1 (Chef Server 12.1+) only. Prevent server from generating a default key pair for you. Cannot be passed with --public-key.",
+             description: "API V1 (#{Chef::Dist::SERVER_PRODUCT} 12.1+) only. Prevent server from generating a default key pair for you. Cannot be passed with --public-key.",
              boolean: true
 
       banner "knife client create CLIENTNAME (options)"

--- a/lib/chef/knife/client_delete.rb
+++ b/lib/chef/knife/client_delete.rb
@@ -29,7 +29,7 @@ class Chef
       option :delete_validators,
        short: "-D",
        long: "--delete-validators",
-       description: "Force deletion of client if it's a validator"
+       description: "Force deletion of client if it's a validator."
 
       banner "knife client delete [CLIENT [CLIENT]] (options)"
 

--- a/lib/chef/knife/client_list.rb
+++ b/lib/chef/knife/client_list.rb
@@ -31,7 +31,7 @@ class Chef
       option :with_uri,
         short: "-w",
         long: "--with-uri",
-        description: "Show corresponding URIs"
+        description: "Show corresponding URIs."
 
       def run
         output(format_list_for_display(Chef::ApiClientV1.list))

--- a/lib/chef/knife/client_reregister.rb
+++ b/lib/chef/knife/client_reregister.rb
@@ -31,7 +31,7 @@ class Chef
       option :file,
         short: "-f FILE",
         long: "--file FILE",
-        description: "Write the key to a file"
+        description: "Write the key to a file."
 
       def run
         @client_name = @name_args[0]

--- a/lib/chef/knife/cookbook_download.rb
+++ b/lib/chef/knife/cookbook_download.rb
@@ -35,19 +35,19 @@ class Chef
       option :latest,
        short: "-N",
        long: "--latest",
-       description: "The version of the cookbook to download",
+       description: "The version of the cookbook to download.",
        boolean: true
 
       option :download_directory,
        short: "-d DOWNLOAD_DIRECTORY",
        long: "--dir DOWNLOAD_DIRECTORY",
-       description: "The directory to download the cookbook into",
+       description: "The directory to download the cookbook into.",
        default: Dir.pwd
 
       option :force,
        short: "-f",
        long: "--force",
-       description: "Force download over the download directory if it exists"
+       description: "Force download over the download directory if it exists."
 
       # TODO: tim/cw: 5-23-2010: need to implement knife-side
       # specificity for downloads - need to implement --platform and

--- a/lib/chef/knife/cookbook_list.rb
+++ b/lib/chef/knife/cookbook_list.rb
@@ -28,7 +28,7 @@ class Chef
       option :with_uri,
         short: "-w",
         long: "--with-uri",
-        description: "Show corresponding URIs"
+        description: "Show corresponding URIs."
 
       option :all_versions,
         short: "-a",

--- a/lib/chef/knife/cookbook_metadata.rb
+++ b/lib/chef/knife/cookbook_metadata.rb
@@ -32,13 +32,13 @@ class Chef
       option :cookbook_path,
         short: "-o PATH:PATH",
         long: "--cookbook-path PATH:PATH",
-        description: "A colon-separated path to look for cookbooks in",
+        description: "A colon-separated path to look for cookbooks in.",
         proc: lambda { |o| o.split(":") }
 
       option :all,
         short: "-a",
         long: "--all",
-        description: "Generate metadata for all cookbooks, rather than just a single cookbook"
+        description: "Generate metadata for all cookbooks, rather than just a single cookbook."
 
       def run
         config[:cookbook_path] ||= Chef::Config[:cookbook_path]

--- a/lib/chef/knife/cookbook_show.rb
+++ b/lib/chef/knife/cookbook_show.rb
@@ -33,22 +33,22 @@ class Chef
       option :fqdn,
        short: "-f FQDN",
        long: "--fqdn FQDN",
-       description: "The FQDN of the host to see the file for"
+       description: "The FQDN of the host to see the file for."
 
       option :platform,
        short: "-p PLATFORM",
        long: "--platform PLATFORM",
-       description: "The platform to see the file for"
+       description: "The platform to see the file for."
 
       option :platform_version,
        short: "-V VERSION",
        long: "--platform-version VERSION",
-       description: "The platform version to see the file for"
+       description: "The platform version to see the file for."
 
       option :with_uri,
         short: "-w",
         long: "--with-uri",
-        description: "Show corresponding URIs"
+        description: "Show corresponding URIs."
 
       def run
         cookbook_name, cookbook_version, segment, filename = @name_args

--- a/lib/chef/knife/deps.rb
+++ b/lib/chef/knife/deps.rb
@@ -32,14 +32,16 @@ class Chef
         long: "--[no-]recurse",
         boolean: true,
         description: "List dependencies recursively (default: true). Only works with --tree."
+
       option :tree,
         long: "--tree",
         boolean: true,
         description: "Show dependencies in a visual tree. May show duplicates."
+
       option :remote,
         long: "--remote",
         boolean: true,
-        description: "List dependencies on the server instead of the local filesystem"
+        description: "List dependencies on the server instead of the local filesystem."
 
       attr_accessor :exit_code
 

--- a/lib/chef/knife/diff.rb
+++ b/lib/chef/knife/diff.rb
@@ -45,12 +45,11 @@ class Chef
 
       option :diff_filter,
         long: "--diff-filter=[(A|D|M|T)...[*]]",
-        description: "Select only files that are Added (A), Deleted (D), Modified (M), or have their type (i.e. regular file, directory) changed (T). Any combination of the filter characters (including none) can be used. When * (All-or-none) is added to the combination, all paths are selected if
-           there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
+        description: "Select only files that are Added (A), Deleted (D), Modified (M), or have their type (i.e. regular file, directory) changed (T). Any combination of the filter characters (including none) can be used. When * (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 
       option :cookbook_version,
         long: "--cookbook-version VERSION",
-        description: "Version of cookbook to download (if there are multiple versions and cookbook_versions is false)"
+        description: "Version of cookbook to download (if there are multiple versions and cookbook_versions is false)."
 
       def run
         if config[:name_only]

--- a/lib/chef/knife/exec.rb
+++ b/lib/chef/knife/exec.rb
@@ -26,12 +26,12 @@ class Chef::Knife::Exec < Chef::Knife
   option :exec,
     short: "-E CODE",
     long: "--exec CODE",
-    description: "a string of Chef code to execute"
+    description: "A string of Chef code to execute."
 
   option :script_path,
     short: "-p PATH:PATH",
     long: "--script-path PATH:PATH",
-    description: "A colon-separated path to look for scripts in",
+    description: "A colon-separated path to look for scripts in.",
     proc: lambda { |o| o.split(":") }
 
   deps do

--- a/lib/chef/knife/list.rb
+++ b/lib/chef/knife/list.rb
@@ -31,33 +31,33 @@ class Chef
       option :recursive,
         short: "-R",
         boolean: true,
-        description: "List directories recursively"
+        description: "List directories recursively."
 
       option :bare_directories,
         short: "-d",
         boolean: true,
-        description: "When directories match the pattern, do not show the directories' children"
+        description: "When directories match the pattern, do not show the directories' children."
 
       option :local,
         long: "--local",
         boolean: true,
-        description: "List local directory instead of remote"
+        description: "List local directory instead of remote."
 
       option :flat,
         short: "-f",
         long: "--flat",
         boolean: true,
-        description: "Show a list of filenames rather than the prettified ls-like output normally produced"
+        description: "Show a list of filenames rather than the prettified ls-like output normally produced."
 
       option :one_column,
         short: "-1",
         boolean: true,
-        description: "Show only one column of results"
+        description: "Show only one column of results."
 
       option :trailing_slashes,
         short: "-p",
         boolean: true,
-        description: "Show trailing slashes after directories"
+        description: "Show trailing slashes after directories."
 
       attr_accessor :exit_code
 

--- a/lib/chef/knife/node_edit.rb
+++ b/lib/chef/knife/node_edit.rb
@@ -35,7 +35,7 @@ class Chef
         short: "-a",
         long: "--all",
         boolean: true,
-        description: "Display all attributes when editing"
+        description: "Display all attributes when editing."
 
       def run
         if node_name.nil?

--- a/lib/chef/knife/node_list.rb
+++ b/lib/chef/knife/node_list.rb
@@ -32,7 +32,7 @@ class Chef
       option :with_uri,
         short: "-w",
         long: "--with-uri",
-        description: "Show corresponding URIs"
+        description: "Show corresponding URIs."
 
       def run
         env = Chef::Config[:environment]

--- a/lib/chef/knife/node_run_list_add.rb
+++ b/lib/chef/knife/node_run_list_add.rb
@@ -32,12 +32,12 @@ class Chef
       option :after,
         short: "-a ITEM",
         long: "--after ITEM",
-        description: "Place the ENTRY in the run list after ITEM"
+        description: "Place the ENTRY in the run list after ITEM."
 
       option :before,
-             short: "-b ITEM",
-             long: "--before ITEM",
-             description: "Place the ENTRY in the run list before ITEM"
+        short: "-b ITEM",
+        long: "--before ITEM",
+        description: "Place the ENTRY in the run list before ITEM."
 
       def run
         node = Chef::Node.load(@name_args[0])

--- a/lib/chef/knife/user_create.rb
+++ b/lib/chef/knife/user_create.rb
@@ -18,6 +18,7 @@
 #
 
 require "chef/knife"
+require "chef/dist"
 
 class Chef
   class Knife
@@ -41,7 +42,7 @@ class Chef
       option :prevent_keygen,
         short: "-k",
         long: "--prevent-keygen",
-        description: "API V1 (Chef Server 12.1+) only. Prevent server from generating a default key pair for you. Cannot be passed with --user-key.",
+        description: "API V1 (#{Chef::Dist::SERVER_PRODUCT} 12.1+) only. Prevent server from generating a default key pair for you. Cannot be passed with --user-key.",
         boolean: true
 
       banner "knife user create USERNAME DISPLAY_NAME FIRST_NAME LAST_NAME EMAIL PASSWORD (options)"

--- a/lib/chef/knife/user_reregister.rb
+++ b/lib/chef/knife/user_reregister.rb
@@ -31,7 +31,7 @@ class Chef
       option :file,
         short: "-f FILE",
         long: "--file FILE",
-        description: "Write the private key to a file"
+        description: "Write the private key to a file."
 
       def run
         @user_name = @name_args[0]

--- a/lib/chef/knife/xargs.rb
+++ b/lib/chef/knife/xargs.rb
@@ -32,7 +32,7 @@ class Chef
       option :local,
         long: "--local",
         boolean: true,
-        description: "Xargs local files instead of remote"
+        description: "Xargs local files instead of remote."
 
       option :patterns,
         long: "--pattern [PATTERN]",

--- a/spec/unit/application/client_spec.rb
+++ b/spec/unit/application/client_spec.rb
@@ -326,7 +326,7 @@ describe Chef::Application::Client, "reconfigure" do
       Chef::Config[:interval] = 600
       allow(ChefConfig).to receive(:windows?).and_return(false)
       expect(Chef::Application).to receive(:fatal!).with(
-        /Unforked .* interval runs are disabled in .* 12\.
+        /Unforked .* interval runs are disabled by default\.
 Configuration settings:
   interval  = 600 seconds
 Enable .* interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options\./

--- a/spec/unit/application/exit_code_spec.rb
+++ b/spec/unit/application/exit_code_spec.rb
@@ -70,7 +70,7 @@ describe Chef::Application::ExitCode do
 
     it "does write a warning on non-standard exit codes" do
       expect(Chef::Log).to receive(:warn).with(
-        /^Chef attempted to exit with a non-standard exit code of 151/)
+        /attempted to exit with a non-standard exit code of 151/)
       expect(exit_codes.normalize_exit_code(151)).to eq(1)
     end
 

--- a/spec/unit/application/solo_spec.rb
+++ b/spec/unit/application/solo_spec.rb
@@ -64,7 +64,7 @@ describe Chef::Application::Solo do
 
           it "should terminate with message" do
             expect(Chef::Application).to receive(:fatal!).with(
-              /Unforked .* interval runs are disabled in .* 12\.
+              /Unforked .* interval runs are disabled by default\.
 Configuration settings:
   interval  = 600 seconds
 Enable .* interval runs by setting `:client_fork = true` in your config file or adding `--fork` to your command line options\./


### PR DESCRIPTION
We talk about the server in messages and we need to brand that appropriately.

In the help:

- Periods after each sentence
- Use the branding better
- Fix some weird capitalization

The final bit is the removal of a link to the RFC docs since those are in the boneyard now.