### PR TITLE
Move more DSL helpers into universal so they're available everywhere

### DIFF
--- a/lib/chef/dsl/data_query.rb
+++ b/lib/chef/dsl/data_query.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,9 +25,9 @@ require "chef/encrypted_data_bag_item/check_encrypted"
 class Chef
   module DSL
 
-    # ==Chef::DSL::DataQuery
-    # Provides DSL for querying data from the chef-server via search or data
-    # bag.
+    # Provides DSL helper methods for querying the search interface, data bag
+    # interface or node interface.
+    #
     module DataQuery
       include Chef::EncryptedDataBagItem::CheckEncrypted
 
@@ -78,6 +78,24 @@ class Chef
       rescue Exception
         Log.error("Failed to load data bag item: #{bag.inspect} #{item.inspect}")
         raise
+      end
+
+      #
+      # Note that this is mixed into the Universal DSL so access to the node needs to be done
+      # through the run_context and not accessing the node method directly, since the node method
+      # is not as universal as the run_context.
+      #
+
+      # True if all the tags are set on the node.
+      #
+      # @param [Array<String>] tags to check against
+      # @return boolean
+      #
+      def tagged?(*tags)
+        tags.each do |tag|
+          return false unless run_context.node.tags.include?(tag)
+        end
+        true
       end
 
     end

--- a/lib/chef/dsl/recipe.rb
+++ b/lib/chef/dsl/recipe.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,11 +20,8 @@
 require "chef/exceptions"
 require "chef/dsl/resources"
 require "chef/dsl/definitions"
-require "chef/dsl/data_query"
 require "chef/dsl/include_recipe"
-require "chef/dsl/registry_helper"
 require "chef/dsl/reboot_pending"
-require "chef/dsl/powershell"
 require "chef/dsl/core"
 require "chef/mixin/lazy_module_include"
 
@@ -50,11 +47,8 @@ class Chef
     #
     module Recipe
       include Chef::DSL::Core
-      include Chef::DSL::DataQuery
       include Chef::DSL::IncludeRecipe
-      include Chef::DSL::RegistryHelper
       include Chef::DSL::RebootPending
-      include Chef::DSL::Powershell
       include Chef::DSL::Resources
       include Chef::DSL::Definitions
       extend Chef::Mixin::LazyModuleInclude

--- a/lib/chef/dsl/universal.rb
+++ b/lib/chef/dsl/universal.rb
@@ -18,6 +18,9 @@
 #
 
 require "chef/dsl/platform_introspection"
+require "chef/dsl/data_query"
+require "chef/dsl/registry_helper"
+require "chef/dsl/powershell"
 require "chef/mixin/powershell_exec"
 require "chef/mixin/powershell_out"
 require "chef/mixin/shell_out"
@@ -45,17 +48,13 @@ class Chef
     #
     module Universal
       include Chef::DSL::PlatformIntrospection
+      include Chef::DSL::DataQuery
+      include Chef::DSL::RegistryHelper
+      include Chef::DSL::Powershell
       include Chef::Mixin::PowershellExec
       include Chef::Mixin::PowershellOut
       include Chef::Mixin::ShellOut
       extend Chef::Mixin::LazyModuleInclude
-
-      def tagged?(*tags)
-        tags.each do |tag|
-          return false unless run_context.node.tags.include?(tag)
-        end
-        true
-      end
     end
   end
 end


### PR DESCRIPTION
Move the data_query, powershell and registry_helper DSLs up to universal.

Move the `tagged?` helper into data_query for organizational purposes.

closes #8356