### PR TITLE
Switch Travis testing to the new opensuse-42 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,7 +276,7 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test end-to-end-opensuse-leap
+      - bundle exec kitchen test end-to-end-opensuse-leap-42
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
@@ -330,7 +330,7 @@ matrix:
       - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       - cd kitchen-tests
     script:
-      - bundle exec kitchen test rspec-opensuse-leap
+      - bundle exec kitchen test rspec-opensuse-leap-42
     after_failure:
       - cat .kitchen/logs/kitchen.log
     env:
@@ -348,7 +348,7 @@ matrix:
         - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
         - cd kitchen-tests
       script:
-        - bundle exec kitchen test rspec-opensuse-leap
+        - bundle exec kitchen test rspec-opensuse-leap-42
       after_failure:
         - cat .kitchen/logs/kitchen.log
       env:

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -95,13 +95,10 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: opensuse-leap
+- name: opensuse-leap-42
   driver:
-    image: dokken/opensuse-leap
+    image: dokken/opensuse-leap-42
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/zypper --non-interactive update
-      - RUN /usr/bin/zypper --non-interactive install cron
 
 suites:
   - name: end-to-end


### PR DESCRIPTION
The old image isn't being generated anymore and is based off an
unmaintained docker container from the opensuse project.

Signed-off-by: Tim Smith <tsmith@chef.io>