### PR TITLE
Add distro constants for solo, zero and automate

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -316,7 +316,7 @@ class Chef
     end
 
     def fork_chef_client
-      logger.info "Forking chef instance to converge..."
+      logger.info "Forking #{Chef::Dist::PRODUCT} instance to converge..."
       pid = fork do
         # Want to allow forked processes to finish converging when
         # TERM singal is received (exit gracefully)

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -252,11 +252,11 @@ class Chef::Application::Client < Chef::Application
 
   option :chef_zero_host,
     long: "--chef-zero-host HOST",
-    description: "Host to start chef-zero on."
+    description: "Host to start #{Chef::Dist::ZERO} on."
 
   option :chef_zero_port,
     long: "--chef-zero-port PORT",
-    description: "Port (or port range) to start chef-zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
+    description: "Port (or port range) to start #{Chef::Dist::ZERO} on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
 
   option :disable_config,
     long: "--disable-config",

--- a/lib/chef/application/exit_code.rb
+++ b/lib/chef/application/exit_code.rb
@@ -145,8 +145,8 @@ class Chef
 
         def non_standard_exit_code_warning(exit_code)
           "#{Chef::Dist::CLIENT} attempted to exit with a non-standard exit code of #{exit_code}." \
-          " The Chef-Client Exit Codes design document (https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md)" \
-          " defines the exit codes that should be used with Chef. Chef::Application::ExitCode defines"  \
+          " The #{Chef::Dist::PRODUCT} Exit Codes design document (https://github.com/chef/chef-rfc/blob/master/rfc062-exit-status.md)" \
+          " defines the exit codes that should be used with #{Chef::Dist::CLIENT}. Chef::Application::ExitCode defines"  \
           " valid exit codes Non-standard exit codes are redefined as GENERIC_FAILURE."
         end
 

--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -124,11 +124,11 @@ class Chef::Application::Knife < Chef::Application
 
   option :chef_zero_host,
     long: "--chef-zero-host HOST",
-    description: "Host to start chef-zero on."
+    description: "Host to start #{Chef::Dist::ZERO} on."
 
   option :chef_zero_port,
     long: "--chef-zero-port PORT",
-    description: "Port (or port range) to start chef-zero on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
+    description: "Port (or port range) to start #{Chef::Dist::ZERO} on. Port ranges like 1000,1010 or 8889-9999 will try all given ports until one works."
 
   option :listen,
     long: "--[no-]listen",

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -124,7 +124,7 @@ class Chef::Application::Solo < Chef::Application
 
   option :lockfile,
     long: "--lockfile LOCKFILE",
-    description: "Set the lockfile location. Prevents multiple solo processes from converging at the same time.",
+    description: "Set the lockfile location. Prevents multiple #{Chef::Dist::SOLO} processes from converging at the same time.",
     proc: nil
 
   option :interval,
@@ -213,7 +213,7 @@ class Chef::Application::Solo < Chef::Application
 
   option :solo_legacy_mode,
     long: "--legacy-mode",
-    description: "Run chef-solo in legacy mode.",
+    description: "Run #{Chef::Dist::SOLO} in legacy mode.",
     boolean: true
 
   attr_reader :chef_client_json

--- a/lib/chef/chef_fs/knife.rb
+++ b/lib/chef/chef_fs/knife.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require "pathname" unless defined?(Pathname)
+require "chef/dist"
 
 class Chef
   module ChefFS
@@ -50,7 +51,7 @@ class Chef
 
       option :chef_repo_path,
         long: "--chef-repo-path PATH",
-        description: "Overrides the location of chef repo. Default is specified by chef_repo_path in the config"
+        description: "Overrides the location of #{Chef::Dist::PRODUCT} repo. Default is specified by chef_repo_path in the config"
 
       option :concurrency,
         long: "--concurrency THREADS",

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -192,7 +192,7 @@ class Chef
           raise
         else
           # Make the message non-scary for folks who don't have automate:
-          msg << " (This is normal if you do not have Chef Automate)"
+          msg << " (This is normal if you do not have #{Chef::Dist::AUTOMATE})"
           Chef::Log.info(msg)
         end
       end
@@ -312,7 +312,7 @@ class Chef
           return true
         when running_mode == :solo && !Chef::Config[:data_collector][:token]
           # we are in solo mode and are not logging to a file, so must have a token
-          Chef::Log.trace("Data collector token must be configured to use Chef Automate data collector with #{Chef::Dist::PRODUCT} Solo")
+          Chef::Log.trace("Data collector token must be configured to use #{Chef::Dist::AUTOMATE} data collector with #{Chef::Dist::SOLO}")
           return false
         else
           return true

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "message_helpers"
+require_relative "../../dist"
 
 class Chef
   class DataCollector
@@ -61,7 +62,7 @@ class Chef
             "policy_group" => node&.policy_group,
             "start_time" => run_status.start_time.utc.iso8601,
             "end_time" => run_status.end_time.utc.iso8601,
-            "source" => solo_run? ? "chef_solo" : "chef_client",
+            "source" => solo_run? ? Chef::Dist::SOLOEXEC : CHEF::DIST::CLIENT,
             "status" => status,
             "total_resource_count" => all_action_records(action_collection).count,
             "updated_resource_count" => updated_resource_count(action_collection),

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -16,7 +16,6 @@
 #
 
 require_relative "message_helpers"
-require_relative "../../dist"
 
 class Chef
   class DataCollector
@@ -62,7 +61,7 @@ class Chef
             "policy_group" => node&.policy_group,
             "start_time" => run_status.start_time.utc.iso8601,
             "end_time" => run_status.end_time.utc.iso8601,
-            "source" => solo_run? ? Chef::Dist::SOLOEXEC : CHEF::DIST::CLIENT,
+            "source" => solo_run? ? "chef_solo" : "chef_client",
             "status" => status,
             "total_resource_count" => all_action_records(action_collection).count,
             "updated_resource_count" => updated_resource_count(action_collection),

--- a/lib/chef/data_collector/run_start_message.rb
+++ b/lib/chef/data_collector/run_start_message.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "message_helpers"
+require_relative "../../dist"
 
 class Chef
   class DataCollector
@@ -50,7 +51,7 @@ class Chef
             "node_name" => node&.name || data_collector.node_name,
             "organization_name" => organization,
             "run_id" => run_status&.run_id,
-            "source" => solo_run? ? "chef_solo" : "chef_client",
+            "source" => solo_run? ? Chef::Dist::SOLOEXEC : Chef::Dist::CLIENT,
             "start_time" => run_status.start_time.utc.iso8601,
           }
         end

--- a/lib/chef/data_collector/run_start_message.rb
+++ b/lib/chef/data_collector/run_start_message.rb
@@ -16,7 +16,6 @@
 #
 
 require_relative "message_helpers"
-require_relative "../../dist"
 
 class Chef
   class DataCollector
@@ -51,7 +50,7 @@ class Chef
             "node_name" => node&.name || data_collector.node_name,
             "organization_name" => organization,
             "run_id" => run_status&.run_id,
-            "source" => solo_run? ? Chef::Dist::SOLOEXEC : Chef::Dist::CLIENT,
+            "source" => solo_run? ? "chef_solo" : "chef_client",
             "start_time" => run_status.start_time.utc.iso8601,
           }
         end

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -11,7 +11,7 @@ class Chef
     CLIENT = "chef-client".freeze
 
     # name of the automate product
-    AUTOMATE = "Chef Automate"
+    AUTOMATE = "Chef Automate".freeze
 
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
     EXEC = "chef".freeze
@@ -20,15 +20,15 @@ class Chef
     WEBSITE = "https://chef.io".freeze
 
     # Chef-Zero's product name
-    ZERO = "Chef Infra Zero"
+    ZERO = "Chef Infra Zero".freeze
 
     # Chef-Solo's product name
-    SOLO = "Chef Infra Solo"
+    SOLO = "Chef Infra Solo".freeze
 
     # The chef-zero executable (local mode)
-    ZEROEXEC = "chef-zero"
+    ZEROEXEC = "chef-zero".freeze
 
     # The chef-solo executable (legacy local mode)
-    SOLOEXEC = "chef-solo"
+    SOLOEXEC = "chef-solo".freeze
   end
 end

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -10,10 +10,25 @@ class Chef
     # The client's alias (chef-client)
     CLIENT = "chef-client".freeze
 
+    # name of the automate product
+    AUTOMATE = "Chef Automate"
+
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
     EXEC = "chef".freeze
 
     # product website address
     WEBSITE = "https://chef.io".freeze
+
+    # Chef-Zero's product name
+    ZERO = "Chef Infra Zero"
+
+    # Chef-Solo's product name
+    SOLO = "Chef Infra Solo"
+
+    # The chef-zero executable (local mode)
+    ZEROEXEC = "chef-zero"
+
+    # The chef-solo executable (legacy local mode)
+    SOLOEXEC = "chef-solo"
   end
 end

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -25,6 +25,7 @@ require_relative "mixin/params_validate"
 require_relative "mixin/from_file"
 require_relative "version_constraint"
 require_relative "server_api"
+require_relative "../dist"
 
 class Chef
   class Environment
@@ -306,7 +307,7 @@ class Chef
     def self.validate_cookbook_version(version)
       if Chef::Config[:solo_legacy_mode]
         raise Chef::Exceptions::IllegalVersionConstraint,
-              "Environment cookbook version constraints not allowed in chef-solo"
+              "Environment cookbook version constraints not allowed in #{Chef::Dist::SOLO}"
       else
         Chef::VersionConstraint.new version
         true

--- a/lib/chef/environment.rb
+++ b/lib/chef/environment.rb
@@ -25,7 +25,7 @@ require_relative "mixin/params_validate"
 require_relative "mixin/from_file"
 require_relative "version_constraint"
 require_relative "server_api"
-require_relative "../dist"
+require_relative "dist"
 
 class Chef
   class Environment

--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -19,6 +19,7 @@
 require_relative "base"
 require_relative "../platform/query_helpers"
 require_relative "../win32/eventlog"
+require_relative "../dist"
 
 class Chef
   module EventLoggers
@@ -35,7 +36,7 @@ class Chef
       LOG_CATEGORY_ID = 11001
 
       # Since we must install the event logger, this is not really configurable
-      SOURCE = "Chef".freeze
+      SOURCE = "#{Chef::Dist::PRODUCT}".freeze
 
       def self.available?
         Chef::Platform.windows?

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -301,7 +301,7 @@ class Chef
 
       def client_run_failure(exception)
         set_backtrace(exception.backtrace)
-        @all_failures << [ "chef run", exception ]
+        @all_failures << [ "#{Chef::Dist::PRODUCT} run", exception ]
       end
 
       def notification_failure(exception)

--- a/lib/chef/http/socketless_chef_zero_client.rb
+++ b/lib/chef/http/socketless_chef_zero_client.rb
@@ -44,6 +44,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require "chef_zero/server"
+require "chef/dist"
 
 class Chef
   class HTTP
@@ -63,7 +64,7 @@ class Chef
         # or else streaming-style responses won't work.
         def read_body(dest = nil, &block)
           if dest
-            raise "responses from socketless chef zero can't be written to specific destination"
+            raise "responses from socketless #{Chef::Dist::ZERO} can't be written to specific destination"
           end
 
           if block_given?

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -177,7 +177,7 @@ class Chef
       # client.rb content via bootstrap_context
       option :bootstrap_no_proxy,
         long: "--bootstrap-no-proxy [NO_PROXY_URL|NO_PROXY_IP]",
-        description: "Do not proxy locations for the node being bootstrapped; this option is used internally by Chef.",
+        description: "Do not proxy locations for the node being bootstrapped; this option is used internally by #{Chef::Dist::PRODUCT}.",
         proc: Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
       # client.rb content via bootstrap_context

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -177,7 +177,7 @@ class Chef
       # client.rb content via bootstrap_context
       option :bootstrap_no_proxy,
         long: "--bootstrap-no-proxy [NO_PROXY_URL|NO_PROXY_IP]",
-        description: "Do not proxy locations for the node being bootstrapped; this option is used internally by #{Chef::Dist::PRODUCT}.",
+        description: "Do not proxy locations for the node being bootstrapped",
         proc: Proc.new { |np| Chef::Config[:knife][:bootstrap_no_proxy] = np }
 
       # client.rb content via bootstrap_context

--- a/lib/chef/knife/bootstrap/chef_vault_handler.rb
+++ b/lib/chef/knife/bootstrap/chef_vault_handler.rb
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 class Chef
   class Knife
     class Bootstrap < Knife
@@ -141,7 +140,7 @@ class Chef
         def require_chef_vault!
           @require_chef_vault ||=
             begin
-              error_message = "Knife bootstrap requires version 2.6.0 or higher of the chef-vault gem to configure chef vault items"
+              error_message = "Knife bootstrap requires version 2.6.0 or higher of the chef-vault gem to configure vault items"
               require "chef-vault"
               if Gem::Version.new(ChefVault::VERSION) < Gem::Version.new("2.6.0")
                 raise error_message

--- a/lib/chef/knife/cookbook_site_download.rb
+++ b/lib/chef/knife/cookbook_site_download.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_download"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -31,7 +32,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site download has been deprecated in favor of knife supermarket download. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site download has been deprecated in favor of knife supermarket download. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_install.rb
+++ b/lib/chef/knife/cookbook_site_install.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_install"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -31,7 +32,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site install has been deprecated in favor of knife supermarket install. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site install has been deprecated in favor of knife supermarket install. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_list.rb
+++ b/lib/chef/knife/cookbook_site_list.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_list"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -31,7 +32,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site list has been deprecated in favor of knife supermarket list. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site list has been deprecated in favor of knife supermarket list. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_search.rb
+++ b/lib/chef/knife/cookbook_site_search.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_search"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -31,7 +32,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site search has been deprecated in favor of knife supermarket search. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site search has been deprecated in favor of knife supermarket search. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_share.rb
+++ b/lib/chef/knife/cookbook_site_share.rb
@@ -19,6 +19,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_share"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -32,7 +33,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site share has been deprecated in favor of knife supermarket share. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site share has been deprecated in favor of knife supermarket share. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_show.rb
+++ b/lib/chef/knife/cookbook_site_show.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_show"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -31,7 +32,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site show has been deprecated in favor of knife supermarket show. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site show has been deprecated in favor of knife supermarket show. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/cookbook_site_unshare.rb
+++ b/lib/chef/knife/cookbook_site_unshare.rb
@@ -19,6 +19,7 @@
 
 require_relative "../knife"
 require_relative "supermarket_unshare"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -32,7 +33,7 @@ class Chef
       category "deprecated"
 
       def run
-        Chef::Log.warn("knife cookbook site unshare has been deprecated in favor of knife supermarket unshare. In Chef 16 (April 2020) this will result in an error!")
+        Chef::Log.warn("knife cookbook site unshare has been deprecated in favor of knife supermarket unshare. In #{Chef::Dist::PRODUCT} 16 (April 2020) this will result in an error!")
         super
       end
 

--- a/lib/chef/knife/exec.rb
+++ b/lib/chef/knife/exec.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "../util/path_helper"
+require_relative "../dist"
 
 class Chef::Knife::Exec < Chef::Knife
 
@@ -26,7 +27,7 @@ class Chef::Knife::Exec < Chef::Knife
   option :exec,
     short: "-E CODE",
     long: "--exec CODE",
-    description: "A string of Chef code to execute."
+    description: "A string of #{Chef::Dist::PRODUCT} code to execute."
 
   option :script_path,
     short: "-p PATH:PATH",

--- a/lib/chef/knife/node_show.rb
+++ b/lib/chef/knife/node_show.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "core/node_presenter"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -41,7 +42,7 @@ class Chef
       option :environment,
         short: "-E",
         long: "--environment",
-        description: "Show only the Chef environment."
+        description: "Show only the #{Chef::Dist::PRODUCT} environment."
 
       def run
         ui.use_presenter Knife::Core::NodePresenter

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -26,11 +26,11 @@ class Chef
 
       option :repo_mode,
         long: "--repo-mode MODE",
-        description: "Specifies the local repository layout. Values: static (only environments/roles/data_bags/cookbooks), everything (includes nodes/clients/users), hosted_everything (includes acls/groups/etc. for Enterprise/Hosted #{Chef::Dist::PRODUCT}). Default: everything/hosted_everything."
+        description: "Specifies the local repository layout. Values: static (only environments/roles/data_bags/cookbooks), everything (includes nodes/clients/users), hosted_everything (includes acls/groups/etc. for Enterprise/Hosted Chef). Default: everything/hosted_everything."
 
       option :chef_repo_path,
         long: "--chef-repo-path PATH",
-        description: "Overrides the location of chef repo. Default is specified by chef_repo_path in the config."
+        description: "Overrides the location of #{Chef::Dist::PRODUCT} repo. Default is specified by chef_repo_path in the config."
 
       option :chef_zero_host,
         long: "--chef-zero-host IP",

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -16,6 +16,7 @@
 
 require_relative "../knife"
 require_relative "../local_mode"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -33,7 +34,7 @@ class Chef
 
       option :chef_zero_host,
         long: "--chef-zero-host IP",
-        description: "Overrides the host upon which chef-zero listens. Default is 127.0.0.1."
+        description: "Overrides the host upon which #{Chef::Dist::ZERO} listens. Default is 127.0.0.1."
 
       def configure_chef
         super

--- a/lib/chef/knife/serve.rb
+++ b/lib/chef/knife/serve.rb
@@ -26,7 +26,7 @@ class Chef
 
       option :repo_mode,
         long: "--repo-mode MODE",
-        description: "Specifies the local repository layout. Values: static (only environments/roles/data_bags/cookbooks), everything (includes nodes/clients/users), hosted_everything (includes acls/groups/etc. for Enterprise/Hosted Chef). Default: everything/hosted_everything."
+        description: "Specifies the local repository layout. Values: static (only environments/roles/data_bags/cookbooks), everything (includes nodes/clients/users), hosted_everything (includes acls/groups/etc. for Enterprise/Hosted #{Chef::Dist::PRODUCT}). Default: everything/hosted_everything."
 
       option :chef_repo_path,
         long: "--chef-repo-path PATH",

--- a/lib/chef/knife/ssl_check.rb
+++ b/lib/chef/knife/ssl_check.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "../config"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -233,7 +234,7 @@ class Chef
       end
 
       def debug_chef_ssl_config
-        ui.err "Chef SSL Configuration:"
+        ui.err "#{Chef::Dist::PRODUCT} SSL Configuration:"
         ui.err "* ssl_ca_path: #{configuration.ssl_ca_path.inspect}"
         ui.err "* ssl_ca_file: #{configuration.ssl_ca_file.inspect}"
         ui.err "* trusted_certs_dir: #{configuration.trusted_certs_dir.inspect}"

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -19,6 +19,7 @@
 require_relative "../knife"
 require_relative "core/status_presenter"
 require_relative "core/node_presenter"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -43,7 +44,7 @@ class Chef
 
       option :hide_by_mins,
         long: "--hide-by-mins MINS",
-        description: "Hide nodes that have run chef in the last MINS minutes"
+        description: "Hide nodes that have run #{Chef::Dist::CLIENT} in the last MINS minutes"
 
       def append_to_query(term)
         @query << " AND " unless @query.empty?

--- a/lib/chef/local_mode.rb
+++ b/lib/chef/local_mode.rb
@@ -17,6 +17,7 @@
 
 require_relative "config"
 require_relative "monkey_patches/webrick-utils" if Chef::Platform.windows?
+require_relative "dist"
 
 class Chef
   module LocalMode
@@ -78,7 +79,7 @@ class Chef
 
         local_mode_url = @chef_zero_server.local_mode_url
 
-        Chef::Log.info("Started chef-zero at #{local_mode_url} with #{@chef_fs.fs_description}")
+        Chef::Log.info("Started #{Chef::Dist::ZERO} at #{local_mode_url} with #{@chef_fs.fs_description}")
         Chef::Config.chef_server_url = local_mode_url
       end
     end

--- a/lib/chef/log/winevt.rb
+++ b/lib/chef/log/winevt.rb
@@ -19,6 +19,7 @@
 require_relative "../event_loggers/base"
 require_relative "../platform/query_helpers"
 require_relative "../mixin/unformatter"
+require_relative "../dist"
 
 class Chef
   class Log
@@ -36,7 +37,7 @@ class Chef
       FATAL_EVENT_ID = 10104
 
       # Since we must install the event logger, this is not really configurable
-      SOURCE = "Chef".freeze
+      SOURCE = Chef::Dist::PRODUCT.freeze
 
       include Chef::Mixin::Unformatter
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -103,7 +103,7 @@ class Chef
         end
 
         if Chef::Config[:environment] && !Chef::Config[:environment].chomp.empty?
-          raise UnsupportedFeature, "Policyfile does not work with #{Chef::Dist::PRODUCT} Environments."
+          raise UnsupportedFeature, "Policyfile does not work with an Environment configured."
         end
       end
 

--- a/lib/chef/policy_builder/policyfile.rb
+++ b/lib/chef/policy_builder/policyfile.rb
@@ -103,7 +103,7 @@ class Chef
         end
 
         if Chef::Config[:environment] && !Chef::Config[:environment].chomp.empty?
-          raise UnsupportedFeature, "Policyfile does not work with Chef Environments."
+          raise UnsupportedFeature, "Policyfile does not work with #{Chef::Dist::PRODUCT} Environments."
         end
       end
 

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -230,7 +230,7 @@ class Chef
         elsif file_class.symlink?(new_resource.path) && new_resource.manage_symlink_source.nil?
           logger.warn("File #{path} managed by #{new_resource} is really a symlink (to #{file_class.realpath(new_resource.path)}). Managing the source file instead.")
           logger.warn("Disable this warning by setting `manage_symlink_source true` on the resource")
-          logger.warn("In a future Chef release, 'manage_symlink_source' will not be enabled by default")
+          logger.warn("In a future #{Chef::Dist::PRODUCT} release, 'manage_symlink_source' will not be enabled by default")
           verify_symlink_sanity(path)
         elsif new_resource.force_unlink
           [nil, nil, nil]

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -230,7 +230,7 @@ class Chef
         elsif file_class.symlink?(new_resource.path) && new_resource.manage_symlink_source.nil?
           logger.warn("File #{path} managed by #{new_resource} is really a symlink (to #{file_class.realpath(new_resource.path)}). Managing the source file instead.")
           logger.warn("Disable this warning by setting `manage_symlink_source true` on the resource")
-          logger.warn("In a future #{Chef::Dist::PRODUCT} release, 'manage_symlink_source' will not be enabled by default")
+          logger.warn("In a future release, 'manage_symlink_source' will not be enabled by default")
           verify_symlink_sanity(path)
         elsif new_resource.force_unlink
           [nil, nil, nil]

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -22,6 +22,7 @@ require_relative "../package"
 require_relative "../../resource/package"
 require_relative "../../mixin/get_source_from_package"
 require_relative "../../mixin/which"
+require_relative "../../dist"
 
 # Class methods on Gem are defined in rubygems
 require "rubygems" unless defined?(Gem)
@@ -400,8 +401,8 @@ class Chef
             if new_resource.options && new_resource.options.is_a?(Hash)
               msg = [
                 "Gem options must be passed to gem_package as a string instead of a hash when",
-                "using this installation of Chef because it runs with its own packaged Ruby. A hash",
-                "may only be used when installing a gem to the same Ruby installation that Chef is",
+                "using this installation of #{Chef::Dist::PRODUCT} because it runs with its own packaged Ruby. A hash",
+                "may only be used when installing a gem to the same Ruby installation that #{Chef::Dist::PRODUCT} is",
                 "running under.  See https://docs.chef.io/resource_gem_package.html for more information.",
                 "Error raised at #{new_resource} from #{new_resource.source_line}",
               ].join("\n")

--- a/lib/chef/provider/zypper_repository.rb
+++ b/lib/chef/provider/zypper_repository.rb
@@ -21,6 +21,7 @@ require_relative "../dsl/declare_resource"
 require_relative "noop"
 require_relative "../mixin/shell_out"
 require "shellwords" unless defined?(Shellwords)
+require_relative "../dist"
 
 class Chef
   class Provider
@@ -111,7 +112,7 @@ class Chef
           logger.trace("Will use :cookbook_file resource to cache the gpg key locally")
           :cookbook_file
         else
-          raise Chef::Exceptions::FileNotFound, "Cannot determine location of gpgkey. Must start with 'http' or be a file managed by Chef."
+          raise Chef::Exceptions::FileNotFound, "Cannot determine location of gpgkey. Must start with 'http' or be a file managed by #{Chef::Dist::PRODUCT}."
         end
       end
 

--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "../resource"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -23,7 +24,7 @@ class Chef
       resource_name :chef_handler
       provides(:chef_handler) { true }
 
-      description "Use the chef_handler resource to install or uninstall Chef reporting/exception handlers."
+      description "Use the chef_handler resource to install or uninstall reporting/exception handlers."
       introduced "14.0"
 
       property :class_name, String,
@@ -38,7 +39,7 @@ class Chef
                default: lazy { [] }
 
       property :type, Hash,
-               description: "The type of Chef Handler to register as, i.e. :report, :exception or both.",
+               description: "The type of handler to register as, i.e. :report, :exception or both.",
                default: { report: true, exception: true }
 
       # supports means a different thing in chef-land so we renamed it but
@@ -48,7 +49,7 @@ class Chef
       # This action needs to find an rb file that presumably contains the indicated class in it and the
       # load that file. It then instantiates that class by name and registers it as a handler.
       action :enable do
-        description "Enables the Chef handler for the current Chef run on the current node"
+        description "Enables the handler for the current #{Chef::Dist::PRODUCT} run on the current node"
 
         class_name = new_resource.class_name
         new_resource.type.each do |type, enable|
@@ -71,7 +72,7 @@ class Chef
       end
 
       action :disable do
-        description "Disables the Chef handler for the current Chef run on the current node"
+        description "Disables the handler for the current #{Chef::Dist::PRODUCT} run on the current node"
 
         new_resource.type.each_key do |type|
           unregister_handler(type, new_resource.class_name)

--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -17,6 +17,7 @@
 
 require_relative "../resource"
 require "shellwords" unless defined?(Shellwords)
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -162,7 +163,7 @@ class Chef
 
       # warn if someone passes the deprecated cookbook property
       def after_created
-        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that this resource ships in Chef itself." if cookbook
+        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that this resource ships in #{Chef::Dist::PRODUCT} itself." if cookbook
       end
 
       action :create do

--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -163,7 +163,7 @@ class Chef
 
       # warn if someone passes the deprecated cookbook property
       def after_created
-        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that this resource ships in #{Chef::Dist::PRODUCT} itself." if cookbook
+        raise ArgumentError, "The 'cookbook' property for the cron_d resource is no longer supported now that it ships as a core resource." if cookbook
       end
 
       action :create do

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 require_relative "../dsl/powershell"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -23,7 +24,7 @@ class Chef
       resource_name :dsc_resource
       provides :dsc_resource
 
-      description "The dsc_resource resource allows any DSC resource to be used in a Chef recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft frequently adds new resources to the DSC resource collection."
+      description "The dsc_resource resource allows any DSC resource to be used in a #{Chef::Dist::PRODUCT} recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft frequently adds new resources to the DSC resource collection."
       introduced "12.2"
 
       # This class will check if the object responds to

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -24,7 +24,7 @@ class Chef
       resource_name :dsc_resource
       provides :dsc_resource
 
-      description "The dsc_resource resource allows any DSC resource to be used in a #{Chef::Dist::PRODUCT} recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft frequently adds new resources to the DSC resource collection."
+      description "The dsc_resource resource allows any DSC resource to be used in a recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft frequently adds new resources to the DSC resource collection."
       introduced "12.2"
 
       # This class will check if the object responds to

--- a/lib/chef/resource/dsc_script.rb
+++ b/lib/chef/resource/dsc_script.rb
@@ -19,6 +19,7 @@
 require_relative "../resource"
 require_relative "../exceptions"
 require_relative "../dsl/powershell"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -28,7 +29,7 @@ class Chef
       resource_name :dsc_script
       provides :dsc_script
 
-      description "Many DSC resources are comparable to built-in Chef resources. For example, both DSC and Chef have file, package, and service resources. The dsc_script resource is most useful for those DSC resources that do not have a direct comparison to a resource in Chef, such as the Archive resource, a custom DSC resource, an existing DSC script that performs an important task, and so on. Use the dsc_script resource to embed the code that defines a DSC configuration directly within a Chef recipe."
+      description "Many DSC resources are comparable to built-in #{Chef::Dist::PRODUCT} resources. For example, both DSC and #{Chef::Dist::PRODUCT} have file, package, and service resources. The dsc_script resource is most useful for those DSC resources that do not have a direct comparison to a resource in #{Chef::Dist::PRODUCT}, such as the Archive resource, a custom DSC resource, an existing DSC script that performs an important task, and so on. Use the dsc_script resource to embed the code that defines a DSC configuration directly within a #{Chef::Dist::PRODUCT} recipe."
 
       default_action :run
 

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -85,7 +85,7 @@ class Chef
 
       property :domain, String,
                introduced: "12.21",
-               description: "Windows only: The domain of the user user specified by the user property. If not specified, the user name and password specified by the user and password properties will be used to resolve that user against the domain in which the system running Chef client is joined, or if that system is not joined to a domain it will resolve the user as a local account on that system. An alternative way to specify the domain is to leave this property unspecified and specify the domain as part of the user property."
+               description: "Windows only: The domain of the user user specified by the user property. If not specified, the user name and password specified by the user and password properties will be used to resolve that user against the domain in which the system running #{Chef::Dist::PRODUCT} is joined, or if that system is not joined to a domain it will resolve the user as a local account on that system. An alternative way to specify the domain is to leave this property unspecified and specify the domain as part of the user property."
 
       property :password, String, sensitive: true,
                introduced: "12.21",
@@ -97,7 +97,7 @@ class Chef
                default: lazy { |r| r.password ? true : false }, default_description: "True if the password property is set. False otherwise."
 
       property :elevated, [ TrueClass, FalseClass ], default: false,
-               description: "Determines whether the script will run with elevated permissions to circumvent User Access Control (UAC) interactively blocking the process.\nThis will cause the process to be run under a batch login instead of an interactive login. The user running Chef needs the “Replace a process level token” and “Adjust Memory Quotas for a process” permissions. The user that is running the command needs the “Log on as a batch job” permission.\nBecause this requires a login, the user and password properties are required.",
+               description: "Determines whether the script will run with elevated permissions to circumvent User Access Control (UAC) interactively blocking the process.\nThis will cause the process to be run under a batch login instead of an interactive login. The user running #{Chef::Dist::CLIENT} needs the “Replace a process level token” and “Adjust Memory Quotas for a process” permissions. The user that is running the command needs the “Log on as a batch job” permission.\nBecause this requires a login, the user and password properties are required.",
                introduced: "13.3"
 
       alias :env :environment

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -73,7 +73,7 @@ class Chef
                description: "How the #{Chef::Dist::CLIENT} handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to true for the #{Chef::Dist::CLIENT} delete the non-file target and replace it with the specified file. Set to false for the #{Chef::Dist::CLIENT} to raise an error."
 
       property :manage_symlink_source, [ TrueClass, FalseClass ], desired_state: false,
-               description: "Change the behavior of the file resource if it is pointed at a symlink. When this value is set to true, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to false, Chef will follow the symlink and will manage the permissions and content of symlink's target file. The default behavior is true but emits a warning that the default value will be changed to false in a future version; setting this explicitly to true or false suppresses this warning."
+               description: "Change the behavior of the file resource if it is pointed at a symlink. When this value is set to true, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to false, #{Chef::Dist::PRODUCT} will follow the symlink and will manage the permissions and content of symlink's target file. The default behavior is true but emits a warning that the default value will be changed to false in a future version; setting this explicitly to true or false suppresses this warning."
 
       property :verifications, Array, default: lazy { [] }
 

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -73,7 +73,7 @@ class Chef
                description: "How the #{Chef::Dist::CLIENT} handles certain situations when the target file turns out not to be a file. For example, when a target file is actually a symlink. Set to true for the #{Chef::Dist::CLIENT} delete the non-file target and replace it with the specified file. Set to false for the #{Chef::Dist::CLIENT} to raise an error."
 
       property :manage_symlink_source, [ TrueClass, FalseClass ], desired_state: false,
-               description: "Change the behavior of the file resource if it is pointed at a symlink. When this value is set to true, the Chef client will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to false, #{Chef::Dist::PRODUCT} will follow the symlink and will manage the permissions and content of symlink's target file. The default behavior is true but emits a warning that the default value will be changed to false in a future version; setting this explicitly to true or false suppresses this warning."
+               description: "Change the behavior of the file resource if it is pointed at a symlink. When this value is set to true, #{Chef::Dist::PRODUCT} will manage the symlink's permissions or will replace the symlink with a normal file if the resource has content. When this value is set to false, #{Chef::Dist::PRODUCT} will follow the symlink and will manage the permissions and content of symlink's target file. The default behavior is true but emits a warning that the default value will be changed to false in a future version; setting this explicitly to true or false suppresses this warning."
 
       property :verifications, Array, default: lazy { [] }
 

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "../resource"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -59,7 +60,7 @@ class Chef
       #
       def lc_all(arg = nil)
         unless arg.nil?
-          Chef.deprecated(:locale_lc_all, "Changing LC_ALL can break Chef's parsing of command output in unexpected ways.\n Use one of the more specific LC_ properties as needed.")
+          Chef.deprecated(:locale_lc_all, "Changing LC_ALL can break #{Chef::Dist::PRODUCT}'s parsing of command output in unexpected ways.\n Use one of the more specific LC_ properties as needed.")
         end
       end
 

--- a/lib/chef/resource/reboot.rb
+++ b/lib/chef/resource/reboot.rb
@@ -17,6 +17,7 @@
 #
 
 require_relative "../resource"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -36,7 +37,7 @@ class Chef
 
       property :reason, String,
                description: "A string that describes the reboot action.",
-               default: "Reboot by Chef"
+               default: "Reboot by #{Chef::Dist::PRODUCT}"
 
       property :delay_mins, Integer,
                description: "The amount of time (in minutes) to delay a reboot request.",

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 require_relative "../resource"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -111,7 +112,7 @@ class Chef
 
       # all this does is send an immediate run_action(:create) to the template resource
       action :flush do
-        description "Immediately flush the entries to the config file. Without this the actual writing of the file is delayed in the Chef run so all entries can be accumulated before writing the file out."
+        description "Immediately flush the entries to the config file. Without this the actual writing of the file is delayed in the #{Chef::Dist::PRODUCT} run so all entries can be accumulated before writing the file out."
 
         with_run_context :root do
           # if you haven't ever called ssh_known_hosts_entry before you're definitely doing it wrong so we blow up hard.

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -17,6 +17,7 @@
 #
 
 require_relative "../resource"
+require_relative "../dist"
 require "iniparse"
 
 class Chef
@@ -48,7 +49,7 @@ class Chef
                description: "The user account that the systemd unit process is run under. The path to the unit for that user would be something like '/etc/systemd/user/sshd.service'. If no user account is specified, the systemd unit will run under a 'system' account, with the path to the unit being something like '/etc/systemd/system/sshd.service'."
 
       property :content, [String, Hash],
-                description: "A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In Chef 14.4 or later, repeatable options can be implemented with an array."
+                description: "A string or hash that contains a systemd `unit file <https://www.freedesktop.org/software/systemd/man/systemd.unit.html>`_ definition that describes the properties of systemd-managed entities, such as services, sockets, devices, and so on. In #{Chef::Dist::PRODUCT} 14.4 or later, repeatable options can be implemented with an array."
 
       property :triggers_reload, [TrueClass, FalseClass],
                description: "Specifies whether to trigger a daemon reload when creating or deleting a unit.",

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -17,6 +17,7 @@
 
 require_relative "../resource"
 require_relative "../mixin/powershell_out"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -48,8 +49,8 @@ class Chef
 
       property :reboot, Symbol,
                equal_to: [:immediate, :delayed, :never, :request_reboot, :reboot_now],
-               validation_message: "The reboot property accepts :immediate (reboot as soon as the resource completes), :delayed (reboot once the Chef run completes), and :never (Don't reboot)",
-               description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.",
+               validation_message: "The reboot property accepts :immediate (reboot as soon as the resource completes), :delayed (reboot once the #{Chef::Dist::PRODUCT} run completes), and :never (Don't reboot)",
+               description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the #{Chef::Dist::PRODUCT} run completes, or never. Note that a reboot is necessary for changes to take effect.",
                default: :immediate
 
       property :new_hostname, String,

--- a/lib/chef/resource/windows_workgroup.rb
+++ b/lib/chef/resource/windows_workgroup.rb
@@ -17,6 +17,7 @@
 
 require_relative "../resource"
 require_relative "../mixin/powershell_out"
+require_relative "../dist"
 
 class Chef
   class Resource
@@ -45,8 +46,8 @@ class Chef
 
       property :reboot, Symbol,
                equal_to: [:never, :request_reboot, :reboot_now],
-               validation_message: "The reboot property accepts :immediate (reboot as soon as the resource completes), :delayed (reboot once the Chef run completes), and :never (Don't reboot)",
-               description: "Controls the system reboot behavior post workgroup joining. Reboot immediately, after the Chef run completes, or never. Note that a reboot is necessary for changes to take effect.",
+               validation_message: "The reboot property accepts :immediate (reboot as soon as the resource completes), :delayed (reboot once the #{Chef::Dist::PRODUCT} run completes), and :never (Don't reboot)",
+               description: "Controls the system reboot behavior post workgroup joining. Reboot immediately, after the #{Chef::Dist::PRODUCT} run completes, or never. Note that a reboot is necessary for changes to take effect.",
                coerce: proc { |x| clarify_reboot(x) },
                default: :immediate, desired_state: false
 

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -248,7 +248,7 @@ module Shell
     option :solo_shell,
       short: "-s",
       long: "--solo",
-      description: "chef-solo session",
+      description: "#{Chef::Dist::SOLO} session",
       boolean: true,
       proc: proc { Chef::Config[:solo] = true }
 
@@ -260,7 +260,7 @@ module Shell
 
     option :solo_legacy_shell,
       long: "--solo-legacy-mode",
-      description: "chef-solo legacy session",
+      description: "#{Chef::Dist::SOLO} legacy session",
       boolean: true,
       proc: proc { Chef::Config[:solo_legacy_mode] = true }
 

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -25,6 +25,7 @@ require_relative "shell_session"
 require_relative "model_wrapper"
 require_relative "../server_api"
 require_relative "../json_compat"
+require_relative "../dist"
 
 module Shell
   module Extensions
@@ -229,7 +230,7 @@ module Shell
         :attributes
       end
 
-      desc "run chef using the current recipe"
+      desc "run #{Chef::Dist::PRODUCT} using the current recipe"
       def run_chef
         Chef::Log.level = :debug
         session = Shell.session
@@ -238,8 +239,8 @@ module Shell
         runrun
       end
 
-      desc "returns an object to control a paused chef run"
-      subcommands resume: "resume the chef run",
+      desc "returns an object to control a paused #{Chef::Dist::PRODUCT} run"
+      subcommands resume: "resume the #{Chef::Dist::PRODUCT} run",
                   step: "run only the next resource",
                   skip_back: "move back in the run list",
                   skip_forward: "move forward in the run list"

--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -49,7 +49,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_start(version, run_status)
 
     expect(event_log.read(flags, offset).any? do |e|
-             e.source == "Chef" && e.event_id == 10000 &&
+             e.source == Chef::Dist::PRODUCT && e.event_id == 10000 &&
                                                e.string_inserts[0].include?(version) end).to be_truthy
   end
 
@@ -57,7 +57,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_started(run_status)
 
     expect(event_log.read(flags, offset).any? do |e|
-             e.source == "Chef" && e.event_id == 10001 &&
+             e.source == Chef::Dist::PRODUCT && e.event_id == 10001 &&
                                                e.string_inserts[0].include?(run_id) end).to be_truthy
   end
 
@@ -66,7 +66,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_completed(node)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == "Chef" && e.event_id == 10002 &&
+      e.source == Chef::Dist::PRODUCT && e.event_id == 10002 &&
                                          e.string_inserts[0].include?(run_id) &&
                                          e.string_inserts[1].include?(elapsed_time.to_s)
     end).to be_truthy
@@ -77,7 +77,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_failed(mock_exception)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == "Chef" && e.event_id == 10003 &&
+      e.source == Chef::Dist::PRODUCT && e.event_id == 10003 &&
         e.string_inserts[0].include?(run_id) &&
         e.string_inserts[1].include?(elapsed_time.to_s) &&
         e.string_inserts[2].include?(mock_exception.class.name) &&
@@ -91,7 +91,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_failed(mock_exception)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == "Chef" && e.event_id == 10003 &&
+      e.source == Chef::Dist::PRODUCT && e.event_id == 10003 &&
         e.string_inserts[0].include?("UNKNOWN") &&
         e.string_inserts[1].include?("UNKNOWN") &&
         e.string_inserts[2].include?(mock_exception.class.name) &&

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -19,12 +19,13 @@ require File.expand_path("../../spec_helper", __FILE__)
 require "chef/mixin/shell_out"
 require "chef/version"
 require "ohai/version"
+require "chef/dist"
 
 describe "Chef Versions" do
   include Chef::Mixin::ShellOut
   let(:chef_dir) { File.join(File.dirname(__FILE__), "..", "..") }
 
-  binaries = [ "chef-client", "chef-shell", "chef-apply", "knife", "chef-solo" ]
+  binaries = [ Chef::Dist::CLIENT, "chef-shell", "chef-apply", "knife", Chef::Dist::SOLOEXEC ]
 
   binaries.each do |binary|
     it "#{binary} version should be sane" do

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -2,6 +2,7 @@ require "support/shared/integration/integration_helper"
 require "chef/mixin/shell_out"
 require "tiny_server"
 require "tmpdir"
+require "chef/dist"
 
 describe "chef-client" do
 
@@ -45,8 +46,8 @@ describe "chef-client" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
-  let(:chef_solo) { "bundle exec chef-solo --legacy-mode --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{Chef::Dist::CLIENT} --minimal-ohai" }
+  let(:chef_solo) { "bundle exec #{Chef::Dist::SOLOEXEC} --legacy-mode --minimal-ohai" }
 
   when_the_repository "has a cookbook with a no-op recipe" do
     before { file "cookbooks/x/recipes/default.rb", "" }

--- a/spec/integration/solo/solo_spec.rb
+++ b/spec/integration/solo/solo_spec.rb
@@ -5,8 +5,9 @@ require "chef/config"
 require "timeout"
 require "fileutils"
 require "chef/win32/security" if Chef::Platform.windows?
+require "chef/dist"
 
-describe "chef-solo" do
+describe Chef::Dist::SOLOEXEC do
   include IntegrationSupport
   include Chef::Mixin::ShellOut
 
@@ -16,7 +17,7 @@ describe "chef-solo" do
 
   let(:cookbook_ancient_100_metadata_rb) { cb_metadata("ancient", "1.0.0") }
 
-  let(:chef_solo) { "bundle exec chef-solo --legacy-mode --minimal-ohai" }
+  let(:chef_solo) { "bundle exec #{Chef::Dist::SOLOEXEC} --legacy-mode --minimal-ohai" }
 
   when_the_repository "creates nodes" do
     let(:nodes_dir) { File.join(@repository_dir, "nodes") }

--- a/spec/unit/cookbook/synchronizer_spec.rb
+++ b/spec/unit/cookbook/synchronizer_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "chef/cookbook/synchronizer"
 require "chef/cookbook_version"
+require "chef/dist"
 
 describe Chef::CookbookCacheCleaner do
   describe "when cleaning up unused cookbook components" do
@@ -49,7 +50,7 @@ describe Chef::CookbookCacheCleaner do
       cleaner.cleanup_file_cache
     end
 
-    it "does not remove anything on chef-solo" do
+    it "does not remove anything on #{Chef::Dist::SOLOEXEC}" do
       Chef::Config[:solo_legacy_mode] = true
       allow(cleaner.cache).to receive(:find).and_return(%w{cookbooks/valid1/recipes/default.rb cookbooks/valid2/recipes/default.rb})
       expect(cleaner.cache).not_to receive(:delete)

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -299,7 +299,7 @@ describe Chef::Environment do
         expect do
           Chef::Environment.validate_cookbook_version("= 1.2.3.4")
         end.to raise_error Chef::Exceptions::IllegalVersionConstraint,
-                             "Environment cookbook version constraints not allowed in chef-solo"
+                             "Environment cookbook version constraints not allowed in .*"
       end
     end
 

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -299,7 +299,7 @@ describe Chef::Environment do
         expect do
           Chef::Environment.validate_cookbook_version("= 1.2.3.4")
         end.to raise_error Chef::Exceptions::IllegalVersionConstraint,
-                             "Environment cookbook version constraints not allowed in .*"
+                             /Environment cookbook version constraints not allowed in .*/
       end
     end
 

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -150,7 +150,7 @@ describe Chef::PolicyBuilder::Policyfile do
       expect(initialize_pb.temporary_policy?).to be_falsey
     end
 
-    context "#{Chef::Dist::SOLOEXEC}" do
+    context "chef-solo" do
       before { Chef::Config[:solo_legacy_mode] = true }
 
       it "errors on create" do

--- a/spec/unit/policy_builder/policyfile_spec.rb
+++ b/spec/unit/policy_builder/policyfile_spec.rb
@@ -150,7 +150,7 @@ describe Chef::PolicyBuilder::Policyfile do
       expect(initialize_pb.temporary_policy?).to be_falsey
     end
 
-    context "chef-solo" do
+    context "#{Chef::Dist::SOLOEXEC}" do
       before { Chef::Config[:solo_legacy_mode] = true }
 
       it "errors on create" do


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <mchamberland@pbsc.com>
Adding distro constants for Chef Infra Zero, Chef Infra Solo and their CLI counterparts. Also Automate.

## Description
More progress towards making easily Chef easily distributable in compliance with the Trademarks Policy 

## Related Issue
https://github.com/chef/chef/issues/8376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
