### PR TITLE
zypper_package upgrade action not working

### DIFF
--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -49,7 +49,7 @@ class Chef
               logger.trace("#{new_resource} out of date version #{current_version}")
             end
           end
-          current_version = candidate_version if is_installed
+          current_version ||= candidate_version if is_installed
           { current_version: current_version, candidate_version: candidate_version }
         end
 

--- a/spec/unit/provider/package/zypper_spec.rb
+++ b/spec/unit/provider/package/zypper_spec.rb
@@ -112,6 +112,15 @@ describe Chef::Provider::Package::Zypper do
       expect(provider.candidate_version).to eql(["1.0"])
     end
 
+    it "should have differing current and candidate versions if zypper detects an upgrade" do
+      status = double(stdout: "Version        : 1.0                             \nInstalled      : Yes                              \nStatus         : out-of-date (version 0.9 installed)", exitstatus: 0)
+
+      allow(provider).to receive(:shell_out_compacted!).and_return(status)
+      provider.load_current_resource
+      expect(provider.get_current_versions).to eq(["0.9"])
+      expect(provider.get_candidate_versions).to eq(["1.0"])
+    end
+
     it "should return the current resouce" do
       expect(provider.load_current_resource).to eql(current_resource)
     end


### PR DESCRIPTION
Signed-off-by: Jeremy Chalfant <jchalfan@us.ibm.com>

## Description

As discussed in https://github.com/chef/chef/issues/4863, `zypper_package` is not upgrading some (or all?) packages in SUSE based systems.

Adding an `out_of_date`  boolean, similar to the `is_installed` variable in the zypper package provider allows the provider to properly detect whether the currently installed package is out of date.

Here's an example of a SuSe 12.3 system before any changes to the zypper package provider:

```
cms3xcfgsles123:~/cheftests # chef-client -v
Chef: 14.12.9
cms3xcfgsles123:~/cheftests # cat /etc/SuSE-release
SUSE Linux Enterprise Server 12 (x86_64)
VERSION = 12
PATCHLEVEL = 3
# This file is deprecated and will be removed in a future service pack or release.
# Please check /etc/os-release for details about this release.
cms3xcfgsles123:~/cheftests # cat upgrade.rb

%w(tar krb5).each do |p|
  zypper_package p do
    action :upgrade
  end
end
cms3xcfgsles123:~/cheftests # chef-client -z upgrade.rb 
[2019-05-06T16:20:38+00:00] WARN: No config file found or specified on command line. Using command line options instead.
[2019-05-06T16:20:38+00:00] WARN: No cookbooks directory found at or above current directory.  Assuming /root/cheftests.
Starting Chef Client, version 14.12.9
resolving cookbooks for run list: []
Synchronizing Cookbooks:
Installing Cookbook Gems:
Compiling Cookbooks...
[2019-05-06T16:20:40+00:00] WARN: Node cms3xcfgsles123 has an empty run list.
Converging 2 resources
Recipe: @recipe_files::/root/cheftests/upgrade.rb
  * zypper_package[tar] action upgrade (up to date)
  * zypper_package[krb5] action upgrade (up to date)

Running handlers:
Running handlers complete
Chef Client finished, 0/2 resources updated in 02 seconds
```

Now after the changes proposed in this pull request:

```
cms3xcfgsles123:~/cheftests # chef-client -z upgrade.rb 
[2019-05-06T16:23:21+00:00] WARN: No config file found or specified on command line. Using command line options instead.
[2019-05-06T16:23:21+00:00] WARN: No cookbooks directory found at or above current directory.  Assuming /root/cheftests.
Starting Chef Client, version 14.12.9
resolving cookbooks for run list: []
Synchronizing Cookbooks:
Installing Cookbook Gems:
Compiling Cookbooks...
[2019-05-06T16:23:22+00:00] WARN: Node cms3xcfgsles123 has an empty run list.
Converging 2 resources
Recipe: @recipe_files::/root/cheftests/upgrade.rb
  * zypper_package[tar] action upgrade
    - upgrade package tar from 1.27.1-14.1 to 1.27.1-15.3.7
  * zypper_package[krb5] action upgrade
    - upgrade package krb5 from 1.12.5-39.1 to 1.12.5-40.34.1

Running handlers:
Running handlers complete
Chef Client finished, 2/2 resources updated in 05 seconds
cms3xcfgsles123:~/cheftests # chef-client -z upgrade.rb 
[2019-05-06T16:23:29+00:00] WARN: No config file found or specified on command line. Using command line options instead.
[2019-05-06T16:23:29+00:00] WARN: No cookbooks directory found at or above current directory.  Assuming /root/cheftests.
Starting Chef Client, version 14.12.9
resolving cookbooks for run list: []
Synchronizing Cookbooks:
Installing Cookbook Gems:
Compiling Cookbooks...
[2019-05-06T16:23:30+00:00] WARN: Node cms3xcfgsles123 has an empty run list.
Converging 2 resources
Recipe: @recipe_files::/root/cheftests/upgrade.rb
  * zypper_package[tar] action upgrade (up to date)
  * zypper_package[krb5] action upgrade (up to date)

Running handlers:
Running handlers complete
Chef Client finished, 0/2 resources updated in 02 seconds
```

## Related Issue
https://github.com/chef/chef/issues/4863

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
