### PR TITLE
[CHEF-8423] Upgrade train-core to 2.1.0 for windows detection over ssh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     timers (4.3.0)
     tins (1.20.2)
     tomlrb (1.2.8)
-    train-core (2.0.12)
+    train-core (2.1.0)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)


### PR DESCRIPTION
## Description

This corrects CHEF-4823 by upgrading train-core to a version
with support for detecting windows over ssh.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Related Issue(s)

[chef/8423](https://github.com/chef/chef/issues/8423)
[train/416](https://github.com/inspec/train/pull/416)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
