### PR TITLE
 Fix the dep bumping rake task to respect the bundler version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -283,7 +283,7 @@ We removed the system_profile plugin because it incorrectly returned data on mod
 
 We removed the Ohai::Util::Win32::GroupHelper helper class from Ohai. This class was intended for use internally in several Windows plugins, but it was never marked private in the codebase. If any of your Ohai plugins rely on this helper class, you will need to update your plugins for Ohai 15.
 
-# Chef Client Release Notes 14.11:
+# Chef Infra Client Release Notes 14.11:
 
 ## Updated Resources
 

--- a/tasks/announce.rb
+++ b/tasks/announce.rb
@@ -41,7 +41,7 @@ class ReleaseAnnouncement
   end
 
   def release_notes_from_file
-    File.read("RELEASE_NOTES.md").match(/^# Chef Client Release Notes #{@maj_minor}:\n\n(.*)/m)[1]
+    File.read("RELEASE_NOTES.md").match(/^# Chef Infra Client Release Notes #{@maj_minor}:\n\n(.*)/m)[1]
   end
 end
 

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -19,7 +19,6 @@ require "bundler"
 
 desc "Tasks to update and check dependencies"
 namespace :dependencies do
-
   # Update all dependencies to the latest constraint-matching version
   desc "Update all dependencies."
   task update: %w{
@@ -30,6 +29,11 @@ namespace :dependencies do
   def bundle_update_locked_multiplatform_task(task_name, dir)
     desc "Update #{dir}/Gemfile.lock."
     task task_name do
+      # make sure we execute this upgrade with the correct bundler version. Otherwise the bundler version
+      # in the lock file we be updated in an incompatible way. Bundler 2.1 *may* fix this issue for us.
+      bundler_version = `grep bundler omnibus_overrides.rb | cut -d'"' -f2`
+      gem "bundler", "~> #{bundler_version}"
+      
       Dir.chdir(dir) do
         Bundler.with_clean_env do
           rm_f "#{dir}/Gemfile.lock"
@@ -54,5 +58,4 @@ namespace :dependencies do
 
   bundle_update_locked_multiplatform_task :update_gemfile_lock, "."
   bundle_update_locked_multiplatform_task :update_omnibus_gemfile_lock, "omnibus"
-
 end


### PR DESCRIPTION
This prevents it from running with bundler 2.x and bumping the gemfile.lock to bundler 2.x.

This also updates the announce task for the new Infra name.