### PR TITLE
Accept-no-persist the license in the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,8 @@ require_relative "tasks/rspec"
 require_relative "tasks/dependencies"
 require_relative "tasks/announce"
 
+ENV['CHEF_LICENSE'] = "accept-no-persist"
+
 # hack the chef-config install to run before the traditional install task
 task :super_install do
   chef_config_path = ::File.join(::File.dirname(__FILE__), "chef-config")


### PR DESCRIPTION
We should probably push all the travis tests through the rakefile at
some point and centralize this, and make rake the entrypoint which
sets the env var, but we'd need rake tasks for the external and
kitchen tests.
