### PR TITLE
Remove the Chef 11 admin flag from knife client create

### DIFF
--- a/lib/chef/knife/client_create.rb
+++ b/lib/chef/knife/client_create.rb
@@ -30,13 +30,7 @@ class Chef
       option :file,
              short: "-f FILE",
              long: "--file FILE",
-             description: "Write the private key to a file if the server generated one."
-
-      option :admin,
-             short: "-a",
-             long: "--admin",
-             description: "Open Source Chef Server 11 only. Create the client as an admin.",
-             boolean: true
+             description: "Write the private key to a file if the #{Chef::Dist::SERVER_PRODUCT} generated one."
 
       option :validator,
              long: "--validator",
@@ -51,7 +45,7 @@ class Chef
       option :prevent_keygen,
              short: "-k",
              long: "--prevent-keygen",
-             description: "API V1 (#{Chef::Dist::SERVER_PRODUCT} 12.1+) only. Prevent server from generating a default key pair for you. Cannot be passed with --public-key.",
+             description: "Prevent #{Chef::Dist::SERVER_PRODUCT} from generating a default key pair for you. Cannot be passed with --public-key.",
              boolean: true
 
       banner "knife client create CLIENTNAME (options)"
@@ -77,10 +71,6 @@ class Chef
 
         if !config[:prevent_keygen] && !config[:public_key]
           client.create_key(true)
-        end
-
-        if config[:admin]
-          client.admin(true)
         end
 
         if config[:validator]

--- a/spec/unit/knife/client_create_spec.rb
+++ b/spec/unit/knife/client_create_spec.rb
@@ -28,7 +28,6 @@ describe Chef::Knife::ClientCreate do
     {
       "name" => "adam",
       "validator" => false,
-      "admin" => false,
     }
   end
 
@@ -102,14 +101,9 @@ describe Chef::Knife::ClientCreate do
         expect(client.name).to eq("adam")
       end
 
-      it "by default it is not an admin" do
-        knife.run
-        expect(client.admin).to be_falsey
-      end
-
       it "by default it is not a validator" do
         knife.run
-        expect(client.admin).to be_falsey
+        expect(client.validator).to be_falsey
       end
 
       it "by default it should set create_key to true" do
@@ -133,17 +127,6 @@ describe Chef::Knife::ClientCreate do
           expect(filehandle).to receive(:print).with("woot")
           expect(File).to receive(:open).with("/tmp/monkeypants", "w").and_yield(filehandle)
           knife.run
-        end
-      end
-
-      describe "with -a or --admin" do
-        before do
-          knife.config[:admin] = true
-        end
-
-        it "should create an admin client" do
-          knife.run
-          expect(client.admin).to be_truthy
         end
       end
 


### PR DESCRIPTION
We've already removed the other support for setting up users on a Chef 11 server. This just further drops support for old Server installs.

Signed-off-by: Tim Smith <tsmith@chef.io>