### PR TITLE
Target mode code tweaks

### DIFF
--- a/lib/chef/dsl/universal.rb
+++ b/lib/chef/dsl/universal.rb
@@ -55,6 +55,7 @@ class Chef
       include Chef::Mixin::PowershellExec
       include Chef::Mixin::PowershellOut
       include Chef::Mixin::ShellOut
+      include Chef::Mixin::TrainOrShell
       extend Chef::Mixin::LazyModuleInclude
     end
   end

--- a/lib/chef/guard_interpreter/default_guard_interpreter.rb
+++ b/lib/chef/guard_interpreter/default_guard_interpreter.rb
@@ -16,23 +16,18 @@
 # limitations under the License.
 #
 
-require "chef/mixin/shell_out"
 require "chef/mixin/train_or_shell"
+require "chef/exceptions"
 
 class Chef
   class GuardInterpreter
     class DefaultGuardInterpreter
-      include Chef::Mixin::ShellOut
       include Chef::Mixin::TrainOrShell
-
-      protected
 
       def initialize(command, opts)
         @command = command
         @command_opts = opts
       end
-
-      public
 
       def evaluate
         result = train_or_shell(@command, default_env: false, **@command_opts)

--- a/lib/chef/mixin/train_or_shell.rb
+++ b/lib/chef/mixin/train_or_shell.rb
@@ -17,20 +17,16 @@
 #
 
 require "ostruct"
+require "chef/mixin/shell_out"
+require "chef/mixin/powershell_out"
+require "chef/config"
 
 class Chef
   module Mixin
     module TrainOrShell
-      #
-      # Train #run_command returns a Train::Extras::CommandResult which
-      # includes `exit_status` but Mixlib::Shellout returns exitstatus
-      # This wrapper makes the result look like Mixlib::ShellOut to make it
-      # easier to swap providers from #shell_out to #train_or_shell
-      #
-      def train_to_shellout_result(stdout, stderr, exit_status)
-        status = OpenStruct.new(success?: ( exit_status == 0 ))
-        OpenStruct.new(stdout: stdout, stderr: stderr, exitstatus: exit_status, status: status)
-      end
+
+      include Chef::Mixin::ShellOut
+      include Chef::Mixin::PowershellOut
 
       def train_or_shell(*args, **opts)
         if Chef::Config.target_mode?
@@ -68,6 +64,19 @@ class Chef
         else
           powershell_out!(*args)
         end
+      end
+
+      private
+
+      #
+      # Train #run_command returns a Train::Extras::CommandResult which
+      # includes `exit_status` but Mixlib::Shellout returns exitstatus
+      # This wrapper makes the result look like Mixlib::ShellOut to make it
+      # easier to swap providers from #shell_out to #train_or_shell
+      #
+      def train_to_shellout_result(stdout, stderr, exit_status)
+        status = OpenStruct.new(success?: ( exit_status == 0 ))
+        OpenStruct.new(stdout: stdout, stderr: stderr, exitstatus: exit_status, status: status)
       end
     end
   end


### PR DESCRIPTION
The train_or_shell mixin should mixin its dependent mixins and
require them, which removes the need to do that in the calling classes.

Include TrainOrShell correctly in the Universal DSL.

Few more code tweaks ("protected" is largely worthless in ruby and was
always being misused here).
