### PR TITLE
Check for directories on Windows before creating

### DIFF
--- a/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
@@ -235,13 +235,19 @@ echo Validation key written.
 <% end -%>
 
 <% unless trusted_certs_script.empty? -%>
-mkdir <%= bootstrap_directory %>\trusted_certs
+  @if NOT EXIST <%= bootstrap_directory %>\trusted_certs (
+      mkdir <%= bootstrap_directory %>\trusted_certs
+    )
+  )
+
 <%= trusted_certs_script %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>
 <% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
-mkdir <%= bootstrap_directory %>\ohai\hints
+  @if NOT EXIST <%= bootstrap_directory %>\ohai\hints (
+      mkdir <%= bootstrap_directory %>\ohai\hints
+   )
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
 > <%= bootstrap_directory %>\ohai\hints\<%= name %>.json (
@@ -259,7 +265,10 @@ mkdir <%= bootstrap_directory %>\ohai\hints
 )
 
 <% unless client_d.empty? -%>
-  mkdir <%= bootstrap_directory %>\client.d
+  @if NOT EXIST <%= bootstrap_directory %>\client.d (
+      mkdir <%= bootstrap_directory %>\client.d
+   )
+
   <%= client_d %>
 <% end -%>
 


### PR DESCRIPTION
## Description
Under Chef 14 bootstrap, creation of directories
that already existed in Windows would log an error,
but not raise an error.

With the Chef 15 bootstrap change to run the bootstrap
script under powershell, any error in the script now causes
an error to be raised up. Even though the bootstrap complets
successfully - the script execution does not halt on error -
it presents a confusing error to the human that makes it look like
bootstrap failed.

## Related Issue
Fixes #8469 


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
