### PR TITLE
Update the omnibus build license to the Chef EULA

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -18,8 +18,8 @@ name "chef"
 friendly_name "Chef Client"
 maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
-license "Apache-2.0"
-license_file "../LICENSE"
+license "Chef EULA"
+license_file "https://www.chef.io/end-user-license-agreement/"
 
 build_iteration 1
 # Do not use __FILE__ after this point, use current_file. If you use __FILE__


### PR DESCRIPTION
The resulting distribuions are licensed under the Chef EULA.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>
