### PR TITLE
Fix config setting which was returning nil

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -375,7 +375,7 @@ class Chef
     #   - :cli_default - came from a declared CLI `option`'s `default` value.
     #   - nil - if they key does not exist
     def config_source(key)
-      return :cli if @original_config.include? key
+      return :cli if config.include? key
       return :config if config_file_settings.key? key
       return :cli_default if default_config.include? key
       nil


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

- `@original_config` was nil so return value poses `undefined method `include?' for nil:NilClass (NoMethodError)`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes https://github.com/chef/knife-ec2/issues/567#issuecomment-490042696

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
