### PR TITLE
Add chef version debug info in the kitchen tests

### DIFF
--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -16,9 +16,15 @@ provisioner:
 
 lifecycle:
   pre_converge:
+    - remote: echo "Chef container's Chef / Ohai release:"
+    - remote: /opt/chef/embedded/bin/chef-client -v
+    - remote: /opt/chef/embedded/bin/ohai -v
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater
     - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
     - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['TRAVIS_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github chef/chef
+    - remote: echo "Installed Chef / Ohai release:"
+    - remote: /opt/chef/embedded/bin/chef-client -v
+    - remote: /opt/chef/embedded/bin/ohai -v
 
 verifier:
   name: inspec


### PR DESCRIPTION
This way we know what version we started with and confirm we end up with
the right version

Signed-off-by: Tim Smith <tsmith@chef.io>