### PR TITLE
Chef 15: FATAL: Configuration error SyntaxError in client.rb during bootstrap

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -93,7 +93,7 @@ class Chef
           CONFIG
 
           unless @chef_config[:chef_license].nil?
-            client_rb << "chef_license \"#{@chef_config[:chef_license]}\""
+            client_rb << "chef_license \"#{@chef_config[:chef_license]}\"\n"
           end
 
           if !(@chef_config[:config_log_level].nil? || @chef_config[:config_log_level].empty?)

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -65,7 +65,7 @@ class Chef
           CONFIG
 
           unless @chef_config[:chef_license].nil?
-            client_rb << "chef_license \"#{@chef_config[:chef_license]}\""
+            client_rb << "chef_license \"#{@chef_config[:chef_license]}\"\n"
           end
 
           if @config[:chef_node_name]


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Fix syntax error raised due to while adding `chef_license` acceptance in client.rb new line is missing. 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8495

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
