### PR TITLE
Switch expeditor gem updating to use bundle lock

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -143,6 +143,6 @@ subscriptions:
   - workload: ruby_gem_published:cheffish-*
     actions:
       - bash:.expeditor/update_dep.sh
-#  - workload: ruby_gem_published:license-acceptance-*
-#    actions:
-#      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:license-acceptance-*
+    actions:
+      - bash:.expeditor/update_dep.sh

--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -18,11 +18,9 @@ function new_gem_included() {
 branch="expeditor/${EXPEDITOR_GEM_NAME}_${EXPEDITOR_VERSION}"
 git checkout -b "$branch"
 
-bundle install
-
 tries=12
 for (( i=1; i<=$tries; i+=1 )); do
-  bundle exec rake dependencies:update_gemfile_lock
+  bundle lock --update
   new_gem_included && break || sleep 20
   if [ $i -eq $tries ]; then
     echo "Searching for '${EXPEDITOR_GEM_NAME} (${EXPEDITOR_VERSION})' ${i} times and did not find it"


### PR DESCRIPTION
This should still get us an update without removing the lockfile first which resulted in the new file being written out as a Bundler 2.x file.

Signed-off-by: Tim Smith <tsmith@chef.io>