### PR TITLE
[knife-ec2-547] Update config_source to support using knife classes without requiring merge_config

### DIFF
--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -280,6 +280,31 @@ describe Chef::Knife do
       expect(other_deps_loaded).to be_truthy
     end
 
+    describe "working with unmerged configuration in #config_source" do
+      let(:command) { KnifeSpecs::TestYourself.new([]) }
+
+      before do
+        KnifeSpecs::TestYourself.option(:opt_with_default,
+                                        short: "-D VALUE",
+                                        default: "default-value")
+      end
+      # This supports a use case used by plugins, where the pattern
+      # seems to follow:
+      #   cmd = KnifeCommand.new
+      #   cmd.config[:config_key] = value
+      #   cmd.run
+      #
+      # This bypasses Knife::run and the `merge_configs` call it
+      # performs - config_source should break when that happens.
+      context "when config is fed in directly without a merge" do
+        it "retains the value but returns nil as a config source" do
+          command.config[:test1] = "value"
+          expect(command.config[:test1]).to eq "value"
+          expect(command.config_source(:test1)).to eq nil
+        end
+      end
+
+    end
     describe "merging configuration options" do
       before do
         KnifeSpecs::TestYourself.option(:opt_with_default,


### PR DESCRIPTION
## Description

This moves initialization of @original_config out of
merge_configs and into the constructor.

A common access pattern running knife commands directly in code is:

    cmd = KnifeCommand.new
    cmd.config[:something] = value
    cmd.run

This bypasses the `Knife.run` class method, which does extra config
initialization - including `merge_configs`.
With this change,  `config_source` will now return `nil` as the
source instead of exploding when `merge_configs` is bypassed. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Related Issue
* Fixes https://github.com/chef/knife-ec2/issues/567
* Fixes https://github.com/chef/knife-google/issues/145
* Replaces https://github.com/chef/chef/pull/8494

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
