### PR TITLE
Remove resource collision deprecations

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -216,9 +216,9 @@ class Chef
       end
     end
 
-    class MapCollision < Base
-      target 25
-    end
+    # id 25 was deleted
+
+    # id 3694 was deleted
 
     class ShellOut < Base
       target 26

--- a/lib/chef/node_map.rb
+++ b/lib/chef/node_map.rb
@@ -55,7 +55,7 @@ EOH
     #
     # @return [NodeMap] Returns self for possible chaining
     #
-    def set(key, klass, platform: nil, platform_version: nil, platform_family: nil, os: nil, canonical: nil, override: nil, chef_version: nil, target_mode: nil, &block)
+    def set(key, klass, platform: nil, platform_version: nil, platform_family: nil, os: nil, canonical: nil, override: nil, chef_version: nil, &block)
       new_matcher = { klass: klass }
       new_matcher[:platform] = platform if platform
       new_matcher[:platform_version] = platform_version if platform_version

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1346,12 +1346,6 @@ class Chef
         remove_canonical_dsl
       end
 
-      # If a resource is in preview mode, set allow_cookbook_override on all its
-      # mappings by default.
-      if preview_resource && !options.include?(:allow_cookbook_override)
-        options[:allow_cookbook_override] = true
-      end
-
       if @chef_version_for_provides && !options.include?(:chef_version)
         options[:chef_version] = @chef_version_for_provides
       end

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1166,10 +1166,9 @@ class Chef
 
     # Set or return if this resource is in preview mode.
     #
-    # This is used in Chef core as part of the process of migrating resources
-    # from a cookbook into core. It should be set to `true` when a cookbook
-    # resource is added to core, and then removed (set to `false`) in the next
-    # major release.
+    # This only has value in the resource_inspector to mark a resource as being new-to-chef-core.
+    # Its meaning is probably more equivalent to "experimental" in that the API might change even
+    # in minor versions due to bugfixing and is NOT considered "stable" yet.
     #
     # @param value [nil, Boolean] If nil, get the current value. If not nil, set
     #   the value of the flag.

--- a/spec/unit/node_map_spec.rb
+++ b/spec/unit/node_map_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2014-2018, Chef Software Inc.
+# Copyright:: Copyright 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -145,14 +145,22 @@ describe Chef::NodeMap do
   describe "deleting classes" do
     it "deletes a class and removes the mapping completely" do
       node_map.set(:thing, Bar)
+<<<<<<< HEAD
       expect( node_map.delete_class(Bar) ).to include({ thing: [{ klass: Bar, cookbook_override: false, core_override: false }] })
+=======
+      expect( node_map.delete_class(Bar) ).to include({ thing: [{ klass: Bar, target_mode: nil }] })
+>>>>>>> 896c67a9d... Remove resource collision deprecations
       expect( node_map.get(node, :thing) ).to eql(nil)
     end
 
     it "deletes a class and leaves the mapping that still has an entry" do
       node_map.set(:thing, Bar)
       node_map.set(:thing, Foo)
+<<<<<<< HEAD
       expect( node_map.delete_class(Bar) ).to eql({ thing: [{ klass: Bar, cookbook_override: false, core_override: false }] })
+=======
+      expect( node_map.delete_class(Bar) ).to eql({ thing: [{ klass: Bar, target_mode: nil }] })
+>>>>>>> 896c67a9d... Remove resource collision deprecations
       expect( node_map.get(node, :thing) ).to eql(Foo)
     end
 
@@ -160,7 +168,11 @@ describe Chef::NodeMap do
       node_map.set(:thing1, Bar)
       node_map.set(:thing2, Bar)
       node_map.set(:thing2, Foo)
+<<<<<<< HEAD
       expect( node_map.delete_class(Bar) ).to eql({ thing1: [{ klass: Bar, cookbook_override: false, core_override: false }], thing2: [{ klass: Bar, cookbook_override: false, core_override: false }] })
+=======
+      expect( node_map.delete_class(Bar) ).to eql({ thing1: [{ klass: Bar, target_mode: nil }], thing2: [{ klass: Bar, target_mode: nil }] })
+>>>>>>> 896c67a9d... Remove resource collision deprecations
       expect( node_map.get(node, :thing1) ).to eql(nil)
       expect( node_map.get(node, :thing2) ).to eql(Foo)
     end
@@ -213,7 +225,7 @@ describe Chef::NodeMap do
   describe "locked mode" do
     context "while unlocked" do
       it "allows setting the same key twice" do
-        expect(Chef).to_not receive(:deprecated)
+        expect(Chef::Log).to_not receive(:warn)
         node_map.set(:foo, FooResource)
         node_map.set(:foo, BarResource)
         expect(node_map.get(node, :foo)).to eql(BarResource)
@@ -221,53 +233,20 @@ describe Chef::NodeMap do
     end
 
     context "while locked" do
-      # Uncomment the commented `expect`s in 15.0.
-      it "rejects setting the same key twice" do
-        expect(Chef).to receive(:deprecated).with(:map_collision, /Resource foo/)
+      it "warns on setting the same key twice" do
+        expect(Chef::Log).to receive(:warn).with(/Resource foo/)
         node_map.set(:foo, FooResource)
         node_map.lock!
         node_map.set(:foo, BarResource)
-        # expect(node_map.get(node, :foo)).to eql(FooResource)
-      end
-
-      it "allows setting the same key twice when the first has allow_cookbook_override" do
-        expect(Chef).to_not receive(:deprecated)
-        node_map.set(:foo, FooResource, allow_cookbook_override: true)
-        node_map.lock!
-        node_map.set(:foo, BarResource)
         expect(node_map.get(node, :foo)).to eql(BarResource)
       end
 
-      it "allows setting the same key twice when the first has allow_cookbook_override with a future version" do
-        expect(Chef).to_not receive(:deprecated)
-        node_map.set(:foo, FooResource, allow_cookbook_override: "< 100")
-        node_map.lock!
-        node_map.set(:foo, BarResource)
-        expect(node_map.get(node, :foo)).to eql(BarResource)
-      end
-
-      it "rejects setting the same key twice when the first has allow_cookbook_override with a past version" do
-        expect(Chef).to receive(:deprecated).with(:map_collision, /Resource foo/)
-        node_map.set(:foo, FooResource, allow_cookbook_override: "< 1")
-        node_map.lock!
-        node_map.set(:foo, BarResource)
-        # expect(node_map.get(node, :foo)).to eql(FooResource)
-      end
-
-      it "allows setting the same key twice when the second has __core_override__" do
-        expect(Chef).to_not receive(:deprecated)
-        node_map.set(:foo, FooResource)
-        node_map.lock!
-        node_map.set(:foo, BarResource, __core_override__: true)
-        expect(node_map.get(node, :foo)).to eql(BarResource)
-      end
-
-      it "rejects setting the same key twice for a provider" do
-        expect(Chef).to receive(:deprecated).with(:map_collision, /Provider foo/)
+      it "warns on setting the same key twice for a provider" do
+        expect(Chef::Log).to receive(:warn).with(/Provider foo/)
         node_map.set(:foo, FooProvider)
         node_map.lock!
         node_map.set(:foo, BarProvider)
-        # expect(node_map.get(node, :foo)).to eql(FooProvider)
+        expect(node_map.get(node, :foo)).to eql(BarProvider)
       end
     end
   end

--- a/spec/unit/node_map_spec.rb
+++ b/spec/unit/node_map_spec.rb
@@ -145,22 +145,14 @@ describe Chef::NodeMap do
   describe "deleting classes" do
     it "deletes a class and removes the mapping completely" do
       node_map.set(:thing, Bar)
-<<<<<<< HEAD
-      expect( node_map.delete_class(Bar) ).to include({ thing: [{ klass: Bar, cookbook_override: false, core_override: false }] })
-=======
-      expect( node_map.delete_class(Bar) ).to include({ thing: [{ klass: Bar, target_mode: nil }] })
->>>>>>> 896c67a9d... Remove resource collision deprecations
+      expect( node_map.delete_class(Bar) ).to include({ thing: [{ klass: Bar }] })
       expect( node_map.get(node, :thing) ).to eql(nil)
     end
 
     it "deletes a class and leaves the mapping that still has an entry" do
       node_map.set(:thing, Bar)
       node_map.set(:thing, Foo)
-<<<<<<< HEAD
-      expect( node_map.delete_class(Bar) ).to eql({ thing: [{ klass: Bar, cookbook_override: false, core_override: false }] })
-=======
-      expect( node_map.delete_class(Bar) ).to eql({ thing: [{ klass: Bar, target_mode: nil }] })
->>>>>>> 896c67a9d... Remove resource collision deprecations
+      expect( node_map.delete_class(Bar) ).to eql({ thing: [{ klass: Bar }] })
       expect( node_map.get(node, :thing) ).to eql(Foo)
     end
 
@@ -168,11 +160,7 @@ describe Chef::NodeMap do
       node_map.set(:thing1, Bar)
       node_map.set(:thing2, Bar)
       node_map.set(:thing2, Foo)
-<<<<<<< HEAD
-      expect( node_map.delete_class(Bar) ).to eql({ thing1: [{ klass: Bar, cookbook_override: false, core_override: false }], thing2: [{ klass: Bar, cookbook_override: false, core_override: false }] })
-=======
-      expect( node_map.delete_class(Bar) ).to eql({ thing1: [{ klass: Bar, target_mode: nil }], thing2: [{ klass: Bar, target_mode: nil }] })
->>>>>>> 896c67a9d... Remove resource collision deprecations
+      expect( node_map.delete_class(Bar) ).to eql({ thing1: [{ klass: Bar }], thing2: [{ klass: Bar }] })
       expect( node_map.get(node, :thing1) ).to eql(nil)
       expect( node_map.get(node, :thing2) ).to eql(Foo)
     end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -867,7 +867,7 @@ describe Chef::Resource do
       snitch_var1 = snitch_var2 = 0
       runner = Chef::Runner.new(run_context)
 
-      Chef::Provider::SnakeOil.provides :cat, __core_override__: true
+      Chef::Provider::SnakeOil.provides :cat
 
       resource1.only_if { snitch_var1 = 1 }
       resource1.not_if { snitch_var2 = 2 }
@@ -1190,18 +1190,6 @@ describe Chef::Resource do
     it "does not affect provides by default" do
       expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass, { canonical: true })
       klass.resource_name(:test_resource)
-    end
-
-    it "adds allow_cookbook_override when true" do
-      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass, { canonical: true, allow_cookbook_override: true })
-      klass.preview_resource(true)
-      klass.resource_name(:test_resource)
-    end
-
-    it "allows manually overriding back to false" do
-      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass, { allow_cookbook_override: false })
-      klass.preview_resource(true)
-      klass.provides(:test_resource, allow_cookbook_override: false)
     end
   end
 end


### PR DESCRIPTION
Switch to only doing warnings. Remove the features in the node_map that
we never used.