### PR TITLE
Backwards compatibility code in Chef::Query::Search fixed (hashify_args)

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -127,9 +127,13 @@ class Chef
         return args.first if args.first.is_a?(Hash)
 
         args_h = Hash.new
-        # If we have 4 arguments, the first is the now-removed sort option, so
+        # If we have 3 arguments, the first is the now-removed sort option, so
         # just ignore it.
-        args.pop(0) if args.length == 4
+        if args.length == 3
+          Chef::Log.warn("Removing deprecated sort arg to search from #{args}\n");
+          args.shift()
+        end
+
         args_h[:start] = args[0] if args[0]
         args_h[:rows] = args[1]
         args_h[:filter_result] = args[2]


### PR DESCRIPTION
## Description

The number of args to check for is 3, not 4, as first 2/5 args to
search are special-cased and not passed to hashify_args.

Array.pop doesn't remove args from the beginning of the list.
Array.shift matches what the comments actually _say_ is being done.

Without these changes search stanzas in recipes fail with 400 Bad Request
when they try to call the REST service backing them.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I couldn't figure out how to run the tests without rake/bundle wanting to install gems system wide and/or failing to complete, but adding the patch to the debian 13.8.7 package and building it resulted in no test failures.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
