### PR TITLE
Pin bundler to 1.17.2 which is included in Ruby 2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 8d66449940f04237586b2f928231c6b26e2cc19a
+  revision: 62a879800c77cd6c1808e7a247976d7c910f6209
   branch: master
   specs:
-    ohai (15.0.34)
+    ohai (15.0.35)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -229,7 +229,7 @@ GEM
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)
-    multipart-post (2.0.0)
+    multipart-post (2.1.0)
     necromancer (0.4.0)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 330e1d8e37898577de97323bd1416f014c571289
+  revision: 02869232bd219e8018f7d16b222a6af7403f0ad8
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,13 +32,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.156.0)
-    aws-sdk-core (3.49.0)
+    aws-partitions (1.161.0)
+    aws-sdk-core (3.51.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.17.0)
+    aws-sdk-kms (1.18.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.36.1)
@@ -178,10 +178,10 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jmespath (1.4.0)
-    kitchen-vagrant (1.5.1)
+    kitchen-vagrant (1.5.2)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.2)
+    license-acceptance (1.0.5)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
@@ -203,7 +203,7 @@ GEM
     mixlib-cli (2.0.3)
     mixlib-config (3.0.1)
       tomlrb
-    mixlib-install (3.11.12)
+    mixlib-install (3.11.18)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -231,7 +231,7 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.8.11)
+    ohai (14.8.12)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -293,7 +293,7 @@ GEM
     solve (4.0.2)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
-    specinfra (2.77.0)
+    specinfra (2.77.1)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -306,10 +306,10 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.2.0)
+    test-kitchen (2.2.3)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
-      license-acceptance (>= 0.2.16, < 2.0)
+      license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (>= 1.1, < 3.0)
@@ -341,7 +341,7 @@ GEM
       tty-screen (~> 0.6.4)
       wisper (~> 2.0.0)
     tty-screen (0.6.5)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.3"
+override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "nokogiri", version: "1.10.2"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
This prevents us installing 1.17.3 in addition to 1.17.2. This *should* reduce the overall size of the install and prevent double gems. I'm waiting on an adhoc to see how this works out.