### PR TITLE
Chef 15: Add --session-timeout bootstrap option for both ssh & winrm

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -69,8 +69,7 @@ class Chef
       option :session_timeout,
         long: "--session-timeout SECONDS",
         description: "The number of seconds to wait for each connection operation to be acknowledged while running bootstrap.",
-        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol },
-        default: 60
+        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol }
 
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,
@@ -839,7 +838,7 @@ class Chef
         return opts if connection_protocol == "winrm"
         opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config_value(:ssh_forward_agent) === true)
-        opts[:connection_timeout] = config_value(:session_timeout).to_i
+        opts[:connection_timeout] = config_value(:session_timeout)&.to_i || 60
         opts
       end
 
@@ -938,7 +937,7 @@ class Chef
           opts[:ca_trust_file] = config_value(:ca_trust_file)
         end
 
-        opts[:operation_timeout] = config_value(:session_timeout).to_i
+        opts[:operation_timeout] = config_value(:session_timeout)&.to_i || 60
 
         opts
       end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -69,7 +69,8 @@ class Chef
       option :session_timeout,
         long: "--session-timeout SECONDS",
         description: "The number of seconds to wait for each connection operation to be acknowledged while running bootstrap.",
-        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol }
+        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol },
+        default: 60
 
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,
@@ -382,7 +383,7 @@ class Chef
         winrm_authentication_protocol:
           [:winrm_auth_method, "--winrm-authentication-protocol PROTOCOL"],
         winrm_session_timeout:
-          [:session_timeout, "--winrm-session-timeout SECONDS"],
+          [:session_timeout, "--winrm-session-timeout MINUTES"],
       }.freeze
 
       DEPRECATED_FLAGS.each do |deprecated_key, deprecation_entry|
@@ -838,7 +839,7 @@ class Chef
         return opts if connection_protocol == "winrm"
         opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config_value(:ssh_forward_agent) === true)
-        opts[:connection_timeout] = config_value(:session_timeout)&.to_i || 60
+        opts[:connection_timeout] = config_value(:session_timeout).to_i
         opts
       end
 
@@ -937,7 +938,7 @@ class Chef
           opts[:ca_trust_file] = config_value(:ca_trust_file)
         end
 
-        opts[:operation_timeout] = config_value(:session_timeout)&.to_i || 60
+        opts[:operation_timeout] = config_value(:session_timeout).to_i
 
         opts
       end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -69,7 +69,8 @@ class Chef
       option :session_timeout,
         long: "--session-timeout SECONDS",
         description: "The number of seconds to wait for each connection operation to be acknowledged while running bootstrap.",
-        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol }
+        proc: Proc.new { |protocol| Chef::Config[:knife][:session_timeout] = protocol },
+        default: 60
 
       # WinRM Authentication
       option :winrm_ssl_peer_fingerprint,
@@ -838,7 +839,7 @@ class Chef
         return opts if connection_protocol == "winrm"
         opts[:non_interactive] = true # Prevent password prompts from underlying net/ssh
         opts[:forward_agent] = (config_value(:ssh_forward_agent) === true)
-        opts[:connection_timeout] = config_value(:session_timeout)&.to_i || 60
+        opts[:connection_timeout] = config_value(:session_timeout).to_i
         opts
       end
 
@@ -937,7 +938,7 @@ class Chef
           opts[:ca_trust_file] = config_value(:ca_trust_file)
         end
 
-        opts[:operation_timeout] = config_value(:session_timeout)&.to_i || 60
+        opts[:operation_timeout] = config_value(:session_timeout).to_i
 
         opts
       end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -880,7 +880,7 @@ describe Chef::Knife::Bootstrap do
                 logger: Chef::Log, # not configurable
                 ca_trust_file: "no trust",
                 max_wait_until_ready: 9999,
-                operation_timeout: 9999,
+                operation_timeout: 60,
                 ssl_peer_fingerprint: "ABCDEF",
                 winrm_transport: "kerberos",
                 winrm_basic_auth_only: true,
@@ -956,7 +956,9 @@ describe Chef::Knife::Bootstrap do
 
         context "and no values are provided from Chef::Config or CLI" do
           before do
-            knife.config = {}
+            # We will use knife's actual config since these tests
+            # have assumptions based on CLI default values
+	    knife.merge_configs 
           end
           let(:expected_result) do
             {
@@ -1128,7 +1130,9 @@ describe Chef::Knife::Bootstrap do
         end
         context "and no values are provided from Chef::Config or CLI" do
           before do
-            knife.config = {}
+            # We will use knife's actual config since these tests
+            # have assumptions based on CLI default values
+	    knife.merge_configs 
           end
 
           let(:expected_result) do

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -958,7 +958,7 @@ describe Chef::Knife::Bootstrap do
           before do
             # We will use knife's actual config since these tests
             # have assumptions based on CLI default values
-	    knife.merge_configs 
+            knife.merge_configs
           end
           let(:expected_result) do
             {
@@ -1132,7 +1132,7 @@ describe Chef::Knife::Bootstrap do
           before do
             # We will use knife's actual config since these tests
             # have assumptions based on CLI default values
-	    knife.merge_configs 
+            knife.merge_configs
           end
 
           let(:expected_result) do
@@ -1659,6 +1659,7 @@ describe Chef::Knife::Bootstrap do
       expect(knife).to receive(:validate_winrm_transport_opts!).ordered
       expect(knife).to receive(:validate_policy_options!).ordered
       expect(knife).to receive(:winrm_warn_no_ssl_verification).ordered
+      expect(knife).to receive(:warn_on_short_session_timeout).ordered
       expect(knife).to receive(:register_client).ordered
       expect(knife).to receive(:connect!).ordered
       expect(knife).to receive(:render_template).and_return "content"
@@ -2130,6 +2131,28 @@ describe Chef::Knife::Bootstrap do
             knife.winrm_warn_no_ssl_verification
           end
         end
+      end
+    end
+  end
+
+  describe "#warn_on_short_session_timeout" do
+    let(:session_timeout) { 0 }
+    before do
+      allow(knife).to receive(:config).and_return(session_timeout: session_timeout)
+    end
+
+    context "timeout is more than 15" do
+      let(:session_timeout) { 16 }
+      it "does not issue a warning" do
+        expect(knife.ui).to_not receive(:warn)
+        knife.warn_on_short_session_timeout
+      end
+    end
+    context "timeout is 15 or less" do
+      let(:session_timeout) { 15 }
+      it "issues a warning" do
+        expect(knife.ui).to receive(:warn)
+        knife.warn_on_short_session_timeout
       end
     end
   end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1055,7 +1055,7 @@ describe Chef::Knife::Bootstrap do
               {
                 logger: Chef::Log, # not configurable
                 max_wait_until_ready: 150, # cli
-                connection_timeout: 120, #cli
+                connection_timeout: 120, # cli
                 user: "sshalice", # cli
                 password: "feta cheese", # cli
                 bastion_host: "mygateway.local", # Config


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
 - Added bootstrap option `--session-timeout`.
 - Added `--winrm-session-timeout` to deprecations.
 - Default --session-timeout value is 60 secs(same was added for `--winrm-session-timeout`).
 - Modified existing specs related to old `--winrm-session-timeout` key and add specs for `--session-timeout`.
 - To fix `ERROR: TypeError: can't convert String into time interval` parse it to `to_i`. (Float not supported on terminal `ssh user@host -o 'ConnectTimeoit=14.5'` raise error `invalid time value`  )
## Related Issue
https://github.com/chef/chef/issues/8491

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
