### PR TITLE
Use new Net:SSH host key verify values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -149,12 +149,13 @@ Using removed options will cause the command to fail.
 | --connection-user | user to authenticate as, regardless of protocol |
 | --connection-password| Password to authenticate as, regardless of protocol |
 | --connection-port | port to connect to, regardless of protocol |
+| --ssh-verify-host-key VALUE | Verify host key. Default is 'always'. Valid values are 'accept', 'accept\_new', 'accept\_new\_or\_local\_tunnel', and 'never'. |
 
 #### Changed Flags
 
 | Flag | New Option | Notes |
 |-----:|:-----------|:------|
-| --[no-]host-key-verify |--[no-]ssh-verify-host-key| |
+| --[no-]host-key-verify |--ssh-verify-host-key VALUE | See above for valid values. |
 | --forward-agent | --ssh-forward-agent| |
 | --session-timeout MINUTES | --session-timeout SECONDS|New for ssh, existing for winrm. The unit has changed from MINUTES to SECONDS for consistency with other timeouts.|
 | --ssh-password | --connection-password | |

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -31,15 +31,6 @@ class Chef
       SUPPORTED_CONNECTION_PROTOCOLS = %w{ssh winrm}.freeze
       WINRM_AUTH_PROTOCOL_LIST = %w{plaintext kerberos ssl negotiate}.freeze
 
-      # @param opt_arry [Array]
-      #
-      # @return [String] a friendly quoted list of items complete with "and"
-      def self.friendly_opt_list(opt_array)
-        opts = opt_array.map { |x| "'#{x}'" }
-        return opts.join(" and ") if opts.size < 3
-        opts[0..-2].join(", ") + " and " + opts[-1]
-      end
-
       # Common connectivity options
       option :connection_user,
         short: "-U USERNAME",
@@ -59,7 +50,8 @@ class Chef
       option :connection_protocol,
         short: "-o PROTOCOL",
         long: "--connection-protocol PROTOCOL",
-        description: "The protocol to use to connect to the target node. Supports: #{friendly_opt_list(SUPPORTED_CONNECTION_PROTOCOLS)}."
+        description: "The protocol to use to connect to the target node.",
+        in: SUPPORTED_CONNECTION_PROTOCOLS
 
       option :max_wait,
         short: "-W SECONDS",

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1131,7 +1131,7 @@ describe Chef::Knife::Bootstrap do
               logger: Chef::Log,
               keys_only: false,
               sudo: false,
-              verify_host_key: true,
+              verify_host_key: "always",
               non_interactive: true,
             }
           end
@@ -1229,7 +1229,7 @@ describe Chef::Knife::Bootstrap do
         expect(knife.host_verify_opts).to eq( { verify_host_key: false } )
       end
       it "provides a correct default when no option given" do
-        expect(knife.host_verify_opts).to eq( { verify_host_key: true } )
+        expect(knife.host_verify_opts).to eq( { verify_host_key: "always"} )
       end
     end
   end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1229,7 +1229,7 @@ describe Chef::Knife::Bootstrap do
         expect(knife.host_verify_opts).to eq( { verify_host_key: false } )
       end
       it "provides a correct default when no option given" do
-        expect(knife.host_verify_opts).to eq( { verify_host_key: "always"} )
+        expect(knife.host_verify_opts).to eq( { verify_host_key: "always" } )
       end
     end
   end


### PR DESCRIPTION
Fixes #8482 by prompting to continue if the host key is not recognized.

This attempts to tell Net:SSH to accept and write the key but it is only
temporarily accepting.

This changes the parameters of --ssh-verify-host-key (which is new) to
take the Net::SSH values, which get passed through by train. This allows
the user more options than only verifying or not.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>