### PR TITLE
Rename the windows_dfs :install actions to :create

### DIFF
--- a/lib/chef/resource/windows_dfs_folder.rb
+++ b/lib/chef/resource/windows_dfs_folder.rb
@@ -41,7 +41,7 @@ class Chef
       property :description, String,
                description: "Description for the share."
 
-      action :install do
+      action :create do
         description "Creates the folder in dfs namespace."
 
         raise "target_path is required for install" unless property_is_set?(:target_path)

--- a/lib/chef/resource/windows_dfs_namespace.rb
+++ b/lib/chef/resource/windows_dfs_namespace.rb
@@ -51,7 +51,7 @@ class Chef
                description: "The root from which to create the DFS tree. Defaults to C:\\DFSRoots.",
                default: 'C:\\DFSRoots'
 
-      action :install do
+      action :create do
         description "Creates the dfs namespace on the server."
 
         directory file_path do

--- a/spec/unit/resource/windows_dfs_folder_spec.rb
+++ b/spec/unit/resource/windows_dfs_folder_spec.rb
@@ -28,12 +28,12 @@ describe Chef::Resource::WindowsDfsFolder do
     expect(resource.folder_path).to eql("fakey_fakerton")
   end
 
-  it "sets the default action as :install" do
-    expect(resource.action).to eql([:install])
+  it "sets the default action as :create" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "supports :install and :delete actions" do
-    expect { resource.action :install }.not_to raise_error
+  it "supports :create and :delete actions" do
+    expect { resource.action :create }.not_to raise_error
     expect { resource.action :delete }.not_to raise_error
   end
 end

--- a/spec/unit/resource/windows_dfs_namespace_spec.rb
+++ b/spec/unit/resource/windows_dfs_namespace_spec.rb
@@ -28,12 +28,12 @@ describe Chef::Resource::WindowsDfsNamespace do
     expect(resource.namespace_name).to eql("fakey_fakerton")
   end
 
-  it "sets the default action as :install" do
-    expect(resource.action).to eql([:install])
+  it "sets the default action as :create" do
+    expect(resource.action).to eql([:create])
   end
 
-  it "supports :install and :delete actions" do
-    expect { resource.action :install }.not_to raise_error
+  it "supports :create and :delete actions" do
+    expect { resource.action :create }.not_to raise_error
     expect { resource.action :delete }.not_to raise_error
   end
 end


### PR DESCRIPTION
We're creating these dfs shares so it makes a lot more sense to make the action create. This is probably what people using Chef would expect.

Signed-off-by: Tim Smith <tsmith@chef.io>