### PR TITLE
Take angrychef out of the expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,7 +7,7 @@ project:
 # The name of the product keys for this product (from mixlib-install)
 product_key:
   - chef
-  - angrychef
+#  - angrychef # this entirely broke promotions.
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:


### PR DESCRIPTION
Angrychef 15.0.293 never built so we can't properly promote chef right
now and we're in a half released state. This hopefully gets us out of
it.

Signed-off-by: Tim Smith <tsmith@chef.io>