### PR TITLE
Turn off version bump subscriptions

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -85,51 +85,51 @@ subscriptions:
       - built_in:promote_habitat_packages
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
-  - workload: ruby_gem_published:mixlib-archive-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:mixlib-authentication-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:mixlib-cli-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:mixlib-log-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:mixlib-shellout-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:chef-vault-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:chef-zero-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:ohai-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:inspec-core-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:train-core-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:win32-process-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:win32-service-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:win32-taskscheduler-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:ffi-yajl-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:libyajl2-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
-  - workload: ruby_gem_published:cheffish-*
-    actions:
-      - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:mixlib-archive-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:mixlib-authentication-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:mixlib-cli-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:mixlib-log-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:mixlib-shellout-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:chef-vault-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:chef-zero-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:ohai-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:inspec-core-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:train-core-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:win32-process-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:win32-service-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:win32-taskscheduler-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:ffi-yajl-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:libyajl2-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master
+  # - workload: ruby_gem_published:cheffish-*
+  #   actions:
+  #     - bash:.expeditor/update_dep.sh@chef/chef@master


### PR DESCRIPTION
These aren't working at the moment on N-1 branches.

Signed-off-by: Tim Smith <tsmith@chef.io>