### PR TITLE
Enable angrychef again, but disable hab builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,7 +7,7 @@ project:
 # The name of the product keys for this product (from mixlib-install)
 product_key:
   - chef
-#  - angrychef # this entirely broke promotions.
+  - angrychef
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
@@ -86,13 +86,13 @@ subscriptions:
   - workload: artifact_published:current:chef:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
+      # - built_in:promote_habitat_packages Disable until we fix our hab package
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
+      # - built_in:promote_habitat_packages Disable until we fix our hab package
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
   - workload: ruby_gem_published:mixlib-archive-*


### PR DESCRIPTION
Hab builds failing prevents rubygems from promoting right now.

Signed-off-by: Tim Smith <tsmith@chef.io>