### PR TITLE
Disable AngryChef builds and promotions

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,7 +7,6 @@ project:
 # The name of the product keys for this product (from mixlib-install)
 product_key:
   - chef
-  - angrychef
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:


### PR DESCRIPTION
Releng has decided it's best to stop building/promoting AngryChef right
alongside Chef for a number of reasons:

* Increases the fragility of the pipeline and requires a Chef build to
  pass on the already large platform matrix times 2.
* AngryChef builds will not be required in our new Buildkite based
  pipeline as Chef is not used to manage the underlying instances in the
  elastic queues.

We just built/promoted AngryChef 15.0.293 out of band and will continue
to do this if future AngryChef builds are required.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
