### PR TITLE
Gate requires with idempotency check

### DIFF
--- a/lib/chef/api_client/registration.rb
+++ b/lib/chef/api_client/registration.rb
@@ -19,7 +19,7 @@
 require_relative "../config"
 require_relative "../server_api"
 require_relative "../exceptions"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   class ApiClient

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -16,16 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "pp"
-require "socket"
+require "pp" unless defined?(PP)
+require "socket" unless defined?(Socket)
 require_relative "config"
 require_relative "config_fetcher"
 require_relative "exceptions"
 require_relative "local_mode"
 require_relative "log"
 require_relative "platform"
-require "mixlib/cli"
-require "tmpdir"
+require "mixlib/cli" unless defined?(Mixlib::CLI)
+require "tmpdir" unless defined?(Dir.mktmpdir)
 require "rbconfig"
 require_relative "application/exit_code"
 require_relative "dist"

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -22,8 +22,8 @@ require_relative "../application"
 require_relative "../client"
 require_relative "../config"
 require_relative "../log"
-require "fileutils"
-require "tempfile"
+require "fileutils" unless defined?(FileUtils)
+require "tempfile" unless defined?(Tempfile)
 require_relative "../providers"
 require_relative "../resources"
 require_relative "../dist"

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -27,8 +27,8 @@ require_relative "../handler/error_report"
 require_relative "../workstation_config_loader"
 require_relative "../mixin/shell_out"
 require "chef-config/mixin/dot_d"
-require "mixlib/archive"
-require "uri"
+require "mixlib/archive" unless defined?(Mixlib::Archive)
+require "uri" unless defined?(URI)
 require_relative "../dist"
 require "license_acceptance/cli_flags/mixlib_cli"
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -24,11 +24,11 @@ require_relative "../config"
 require_relative "../daemon"
 require_relative "../log"
 require_relative "../config_fetcher"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require_relative "../mixin/shell_out"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "chef-config/mixin/dot_d"
-require "mixlib/archive"
+require "mixlib/archive" unless defined?(Mixlib::Archive)
 require_relative "../dist"
 require "license_acceptance/cli_flags/mixlib_cli"
 

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -24,9 +24,9 @@ require_relative "../config"
 require_relative "../handler/error_report"
 require_relative "../log"
 require_relative "../http"
-require "mixlib/cli"
-require "socket"
-require "uri"
+require "mixlib/cli" unless defined?(Mixlib::CLI)
+require "socket" unless defined?(Socket)
+require "uri" unless defined?(URI)
 require "win32/daemon"
 require_relative "../mixin/shell_out"
 require_relative "../dist"

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -20,7 +20,7 @@ if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   require "win32/service"
 end
 require_relative "../config"
-require "mixlib/cli"
+require "mixlib/cli" unless defined?(Mixlib::CLI)
 require_relative "../dist"
 
 class Chef

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -24,7 +24,7 @@ require_relative "file_pattern"
 require_relative "file_system"
 require_relative "file_system/exceptions"
 require_relative "file_system/memory/memory_root"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   module ChefFS

--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -18,7 +18,7 @@
 
 require_relative "../base_fs_object"
 require_relative "../../../http/simple"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 class Chef
   module ChefFS

--- a/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
@@ -22,7 +22,7 @@ require_relative "../exceptions"
 require_relative "../repository/chef_repository_file_system_cookbook_dir"
 require_relative "../../../mixin/file_class"
 
-require "tmpdir"
+require "tmpdir" unless defined?(Dir.mktmpdir)
 
 class Chef
   module ChefFS

--- a/lib/chef/chef_fs/file_system/repository/file_system_entry.rb
+++ b/lib/chef/chef_fs/file_system/repository/file_system_entry.rb
@@ -20,7 +20,7 @@ require_relative "../base_fs_dir"
 require_relative "../chef_server/rest_list_dir"
 require_relative "../exceptions"
 require_relative "../../path_utils"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   module ChefFS

--- a/lib/chef/chef_fs/file_system_cache.rb
+++ b/lib/chef/chef_fs/file_system_cache.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "../client"
 
 class Chef

--- a/lib/chef/chef_fs/knife.rb
+++ b/lib/chef/chef_fs/knife.rb
@@ -17,7 +17,7 @@
 #
 
 require_relative "../knife"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 
 class Chef
   module ChefFS

--- a/lib/chef/chef_fs/path_utils.rb
+++ b/lib/chef/chef_fs/path_utils.rb
@@ -17,7 +17,7 @@
 #
 
 require_relative "../chef_fs"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 
 class Chef
   module ChefFS

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -52,10 +52,10 @@ require_relative "policy_builder"
 require_relative "request_id"
 require_relative "platform/rebooter"
 require_relative "mixin/deprecation"
-require "ohai"
+require "ohai" unless defined?(Ohai::System)
 require "rbconfig"
 require_relative "dist"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   # == Chef::Client

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "tmpdir"
+require "tmpdir" unless defined?(Dir.mktmpdir)
 require_relative "../mixin/shell_out"
 
 class Chef

--- a/lib/chef/cookbook/synchronizer.rb
+++ b/lib/chef/cookbook/synchronizer.rb
@@ -16,7 +16,7 @@
 require_relative "../client"
 require_relative "../util/threaded_job_queue"
 require_relative "../server_api"
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "../dist"
 
 class Chef

--- a/lib/chef/cookbook/syntax_check.rb
+++ b/lib/chef/cookbook/syntax_check.rb
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-require "pathname"
-require "stringio"
-require "erubis"
+require "pathname" unless defined?(Pathname)
+require "stringio" unless defined?(StringIO)
+require "erubis" unless defined?(Erubis)
 require_relative "../mixin/shell_out"
 require_relative "../mixin/checksum"
 require_relative "../util/path_helper"

--- a/lib/chef/cookbook_manifest.rb
+++ b/lib/chef/cookbook_manifest.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require_relative "mixin/versioned_api"
 require_relative "util/path_helper"
 require_relative "cookbook/manifest_v0"

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -18,10 +18,10 @@
 # limitations under the License.
 #
 
-require "uri"
-require "net/http"
+require "uri" unless defined?(URI)
+require "net/http" unless defined?(Net::HTTP)
 require "mixlib/authentication/signedheaderauth"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 class Chef
   # == Chef::CookbookSiteStreamingUploader

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -1,5 +1,5 @@
 
-require "set"
+require "set" unless defined?(Set)
 require_relative "exceptions"
 require_relative "knife/cookbook_metadata"
 require_relative "digester"

--- a/lib/chef/daemon.rb
+++ b/lib/chef/daemon.rb
@@ -19,7 +19,7 @@
 
 require_relative "config"
 require_relative "run_lock"
-require "etc"
+require "etc" unless defined?(Etc)
 
 class Chef
   class Daemon

--- a/lib/chef/data_bag_item.rb
+++ b/lib/chef/data_bag_item.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 require_relative "config"
 require_relative "mixin/params_validate"

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -21,7 +21,7 @@
 require_relative "server_api"
 require_relative "http/simple_json"
 require_relative "event_dispatch/base"
-require "set"
+require "set" unless defined?(Set)
 require_relative "data_collector/run_end_message"
 require_relative "data_collector/run_start_message"
 require_relative "data_collector/config_validation"

--- a/lib/chef/data_collector/config_validation.rb
+++ b/lib/chef/data_collector/config_validation.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "uri"
+require "uri" unless defined?(URI)
 
 class Chef
   class DataCollector

--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-require "openssl"
-require "singleton"
+require "openssl" unless defined?(OpenSSL)
+require "singleton" unless defined?(Singleton)
 
 class Chef
   class Digester

--- a/lib/chef/encrypted_data_bag_item/decryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/decryptor.rb
@@ -18,9 +18,9 @@
 
 require "yaml"
 require_relative "../json_compat"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "base64"
-require "digest/sha2"
+require "digest/sha2" unless defined?(Digest::SHA2)
 require_relative "../encrypted_data_bag_item"
 require_relative "unsupported_encrypted_data_bag_item_format"
 require_relative "decryption_failure"

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -17,9 +17,9 @@
 #
 
 require "base64"
-require "digest/sha2"
-require "openssl"
-require "ffi_yajl"
+require "digest/sha2" unless defined?(Digest::SHA2)
+require "openssl" unless defined?(OpenSSL)
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../encrypted_data_bag_item"
 require_relative "unsupported_encrypted_data_bag_item_format"
 require_relative "encryption_failure"

--- a/lib/chef/file_cache.rb
+++ b/lib/chef/file_cache.rb
@@ -19,7 +19,7 @@ require_relative "mixin/params_validate"
 require_relative "mixin/create_path"
 require_relative "exceptions"
 require_relative "json_compat"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require_relative "util/path_helper"
 
 class Chef

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 
 class Chef
   class FileContentManagement

--- a/lib/chef/handler.rb
+++ b/lib/chef/handler.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 require_relative "client"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   # The base class for an Exception or Notification Handler. Create your own

--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -21,9 +21,9 @@
 # limitations under the License.
 #
 
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require "net/https"
-require "uri"
+require "uri" unless defined?(URI)
 require_relative "http/basic_client"
 require_relative "monkey_patches/net_http"
 require_relative "config"

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -18,7 +18,7 @@
 
 require_relative "auth_credentials"
 require_relative "../exceptions"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 
 class Chef
   class HTTP

--- a/lib/chef/http/basic_client.rb
+++ b/lib/chef/http/basic_client.rb
@@ -20,8 +20,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "uri"
-require "net/http"
+require "uri" unless defined?(URI)
+require "net/http" unless defined?(Net::HTTP)
 require_relative "ssl_policies"
 require_relative "http_request"
 

--- a/lib/chef/http/cookie_jar.rb
+++ b/lib/chef/http/cookie_jar.rb
@@ -20,7 +20,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 class Chef
   class HTTP

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -20,8 +20,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "uri"
-require "net/http"
+require "uri" unless defined?(URI)
+require "net/http" unless defined?(Net::HTTP)
 require_relative "../dist"
 
 # To load faster, we only want ohai's version string.
@@ -30,7 +30,7 @@ require_relative "../dist"
 begin
   require "ohai/version" # used in user agent string.
 rescue LoadError
-  require "ohai"
+  require "ohai" unless defined?(Ohai::System)
 end
 
 require_relative "../version"

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -21,7 +21,7 @@
 # limitations under the License.
 #
 
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require_relative "../util/path_helper"
 
 class Chef

--- a/lib/chef/http/validate_content_length.rb
+++ b/lib/chef/http/validate_content_length.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "pp"
+require "pp" unless defined?(PP)
 require_relative "../log"
 
 class Chef

--- a/lib/chef/json_compat.rb
+++ b/lib/chef/json_compat.rb
@@ -17,7 +17,7 @@
 
 # Wrapper class for interacting with JSON.
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "exceptions"
 # We're requiring this to prevent breaking consumers using Hash.to_json
 require "json"

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require_relative "version"
-require "mixlib/cli"
+require "mixlib/cli" unless defined?(Mixlib::CLI)
 require_relative "workstation_config_loader"
 require_relative "mixin/convert_to_class_name"
 require_relative "mixin/path_sanity"
@@ -30,7 +30,7 @@ require_relative "server_api"
 require_relative "http/authenticator"
 require_relative "http/http_request"
 require_relative "http"
-require "pp"
+require "pp" unless defined?(PP)
 require_relative "dist"
 
 class Chef

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -395,7 +395,7 @@ class Chef
       attr_reader :connection
 
       deps do
-        require "erubis"
+        require "erubis" unless defined?(Erubis)
 
         require_relative "../json_compat"
         require_relative "../util/path_helper"

--- a/lib/chef/knife/bootstrap/client_builder.rb
+++ b/lib/chef/knife/bootstrap/client_builder.rb
@@ -20,7 +20,7 @@ require_relative "../../node"
 require_relative "../../server_api"
 require_relative "../../api_client/registration"
 require_relative "../../api_client"
-require "tmpdir"
+require "tmpdir" unless defined?(Dir.mktmpdir)
 
 class Chef
   class Knife

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -16,8 +16,8 @@
 #
 
 require "train"
-require "tempfile"
-require "uri"
+require "tempfile" unless defined?(Tempfile)
+require "uri" unless defined?(URI)
 
 class Chef
   class Knife
@@ -305,7 +305,7 @@ class Chef
         # Having this as a method makes it easier to mock
         # SSH Config for testing.
         def ssh_config_for_host(host)
-          require "net/ssh"
+          require "net/ssh" unless defined?(Net::SSH)
           Net::SSH::Config.for(host)
         end
       end

--- a/lib/chef/knife/config_use_profile.rb
+++ b/lib/chef/knife/config_use_profile.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 require_relative "../knife"
 

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -26,7 +26,7 @@ class Chef
       attr_reader :chef_repo, :new_client_key, :validation_client_name, :validation_key
 
       deps do
-        require "ohai"
+        require "ohai" unless defined?(Ohai::System)
         Chef::Knife::ClientCreate.load_deps
         Chef::Knife::UserCreate.load_deps
       end

--- a/lib/chef/knife/cookbook_show.rb
+++ b/lib/chef/knife/cookbook_show.rb
@@ -24,7 +24,7 @@ class Chef
 
       deps do
         require_relative "../json_compat"
-        require "uri"
+        require "uri" unless defined?(URI)
         require_relative "../cookbook_version"
       end
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -18,7 +18,7 @@
 
 require_relative "../../run_list"
 require_relative "../../util/path_helper"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "../../dist"
 
 class Chef

--- a/lib/chef/knife/core/gem_glob_loader.rb
+++ b/lib/chef/knife/core/gem_glob_loader.rb
@@ -39,7 +39,7 @@ class Chef
         # subcommand loader has been modified to load the plugins by using Kernel.load
         # with the absolute path.
         def gem_and_builtin_subcommands
-          require "rubygems"
+          require "rubygems" unless defined?(Gem)
           find_subcommands_via_rubygems
         rescue LoadError
           find_subcommands_via_dirglob

--- a/lib/chef/knife/core/generic_presenter.rb
+++ b/lib/chef/knife/core/generic_presenter.rb
@@ -89,7 +89,7 @@ class Chef
             require "yaml"
             YAML.dump(data)
           when :pp
-            require "stringio"
+            require "stringio" unless defined?(StringIO)
             # If you were looking for some attribute and there is only one match
             # just dump the attribute value
             if config[:attribute] && data.length == 1

--- a/lib/chef/knife/core/object_loader.rb
+++ b/lib/chef/knife/core/object_loader.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../../util/path_helper"
 require_relative "../../data_bag_item"
 

--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -18,10 +18,10 @@
 # limitations under the License.
 #
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require_relative "../../platform/query_helpers"
 require_relative "generic_presenter"
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 
 class Chef
   class Knife

--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/cli"
+require "mixlib/cli" unless defined?(Mixlib::CLI)
 require_relative "../config"
 require_relative "../encrypted_data_bag_item/check_encrypted"
 

--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -18,7 +18,7 @@
 
 require_relative "../knife"
 require_relative "core/node_presenter"
-require "addressable/uri"
+require "addressable/uri" unless defined?(Addressable::URI)
 
 class Chef
   class Knife

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -24,13 +24,13 @@ class Chef
     class Ssh < Knife
 
       deps do
-        require "net/ssh"
+        require "net/ssh" unless defined?(Net::SSH)
         require "net/ssh/multi"
         require "readline"
         require_relative "../exceptions"
         require_relative "../search/query"
         require_relative "../util/path_helper"
-        require "mixlib/shellout"
+        require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
       end
 
       include Chef::Mixin::ShellOut
@@ -498,7 +498,7 @@ class Chef
 
       def macterm
         begin
-          require "appscript"
+          require "appscript" unless defined?(Appscript)
         rescue LoadError
           STDERR.puts "You need the rb-appscript gem to use knife ssh macterm. `(sudo) gem install rb-appscript` to install"
           raise

--- a/lib/chef/knife/ssl_check.rb
+++ b/lib/chef/knife/ssl_check.rb
@@ -24,11 +24,11 @@ class Chef
     class SslCheck < Chef::Knife
 
       deps do
-        require "pp"
-        require "socket"
-        require "uri"
+        require "pp" unless defined?(PP)
+        require "socket" unless defined?(Socket)
+        require "uri" unless defined?(URI)
         require_relative "../http/ssl_policies"
-        require "openssl"
+        require "openssl" unless defined?(OpenSSL)
         require_relative "../mixin/proxified_socket"
         include Chef::Mixin::ProxifiedSocket
       end

--- a/lib/chef/knife/ssl_fetch.rb
+++ b/lib/chef/knife/ssl_fetch.rb
@@ -24,10 +24,10 @@ class Chef
     class SslFetch < Chef::Knife
 
       deps do
-        require "pp"
-        require "socket"
-        require "uri"
-        require "openssl"
+        require "pp" unless defined?(PP)
+        require "socket" unless defined?(Socket)
+        require "uri" unless defined?(URI)
+        require "openssl" unless defined?(OpenSSL)
         require_relative "../mixin/proxified_socket"
         include Chef::Mixin::ProxifiedSocket
       end

--- a/lib/chef/knife/supermarket_download.rb
+++ b/lib/chef/knife/supermarket_download.rb
@@ -26,7 +26,7 @@ class Chef
       category "supermarket"
 
       deps do
-        require "fileutils"
+        require "fileutils" unless defined?(FileUtils)
       end
 
       option :file,

--- a/lib/chef/knife/supermarket_install.rb
+++ b/lib/chef/knife/supermarket_install.rb
@@ -24,8 +24,8 @@ class Chef
     class SupermarketInstall < Knife
 
       deps do
-        require "shellwords"
-        require "mixlib/archive"
+        require "shellwords" unless defined?(Shellwords)
+        require "mixlib/archive" unless defined?(Mixlib::Archive)
         require_relative "core/cookbook_scm_repo"
         require_relative "../cookbook/metadata"
       end

--- a/lib/chef/mixin/checksum.rb
+++ b/lib/chef/mixin/checksum.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "digest/sha2"
+require "digest/sha2" unless defined?(Digest::SHA2)
 require_relative "../digester"
 
 class Chef

--- a/lib/chef/mixin/homebrew_user.rb
+++ b/lib/chef/mixin/homebrew_user.rb
@@ -23,7 +23,7 @@
 # awkward to use modules elsewhere (e.g., chef/provider/package/homebrew/owner)
 
 require_relative "shell_out"
-require "etc"
+require "etc" unless defined?(Etc)
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require_relative "path_sanity"
 
 class Chef

--- a/lib/chef/mixin/template.rb
+++ b/lib/chef/mixin/template.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "tempfile"
-require "erubis"
+require "tempfile" unless defined?(Tempfile)
+require "erubis" unless defined?(Erubis)
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/uris.rb
+++ b/lib/chef/mixin/uris.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "addressable/uri"
+require "uri" unless defined?(URI)
+require "addressable/uri" unless defined?(Addressable::URI)
 
 class Chef
   module Mixin

--- a/lib/chef/monkey_patches/net_http.rb
+++ b/lib/chef/monkey_patches/net_http.rb
@@ -9,7 +9,7 @@ unless defined?(Net::HTTPClientException)
   Net::HTTPClientException = Net::HTTPServerException
 end
 
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 module Net
   class HTTPError
     include ChefNetHTTPExceptionExtensions

--- a/lib/chef/monkey_patches/win32/registry.rb
+++ b/lib/chef/monkey_patches/win32/registry.rb
@@ -17,7 +17,7 @@
 
 require_relative "../../win32/api/registry"
 require_relative "../../win32/unicode"
-require "win32/registry"
+require "win32/registry" unless defined?(Win32::Registry)
 
 module Win32
   class Registry

--- a/lib/chef/monologger.rb
+++ b/lib/chef/monologger.rb
@@ -1,4 +1,4 @@
 require "mixlib/log/logger"
-require "pp"
+require "pp" unless defined?(PP)
 
 MonoLogger = Mixlib::Log::Logger

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-require "forwardable"
-require "securerandom"
+require "forwardable" unless defined?(Forwardable)
+require "securerandom" unless defined?(SecureRandom)
 require_relative "config"
 require_relative "nil_argument"
 require_relative "mixin/params_validate"

--- a/lib/chef/platform/provider_handler_map.rb
+++ b/lib/chef/platform/provider_handler_map.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "../node_map"
 
 class Chef

--- a/lib/chef/platform/provider_priority_map.rb
+++ b/lib/chef/platform/provider_priority_map.rb
@@ -1,4 +1,4 @@
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "priority_map"
 
 class Chef

--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -26,7 +26,7 @@ class Chef
 
       def windows_nano_server?
         return false unless windows?
-        require "win32/registry"
+        require "win32/registry" unless defined?(Win32::Registry)
 
         # This method may be called before ohai runs (e.g., it may be used to
         # determine settings in config.rb). Chef::Win32::Registry.new uses
@@ -48,7 +48,7 @@ class Chef
 
       def supports_msi?
         return false unless windows?
-        require "win32/registry"
+        require "win32/registry" unless defined?(Win32::Registry)
 
         key = "System\\CurrentControlSet\\Services\\msiserver"
         access = ::Win32::Registry::KEY_QUERY_VALUE
@@ -90,7 +90,7 @@ class Chef
 
       def supported_powershell_version?(node, version_string)
         return false unless node[:languages] && node[:languages][:powershell]
-        require "rubygems"
+        require "rubygems" unless defined?(Gem)
         Gem::Version.new(node[:languages][:powershell][:version]) >=
           Gem::Version.new(version_string)
       end

--- a/lib/chef/platform/resource_handler_map.rb
+++ b/lib/chef/platform/resource_handler_map.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "../node_map"
 
 class Chef

--- a/lib/chef/platform/resource_priority_map.rb
+++ b/lib/chef/platform/resource_priority_map.rb
@@ -1,4 +1,4 @@
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "priority_map"
 
 class Chef

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 require_relative "../log"
 require_relative "../run_context"

--- a/lib/chef/powershell.rb
+++ b/lib/chef/powershell.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "ffi"
+require "ffi" unless defined?(FFI)
 require_relative "json_compat"
 
 class Chef

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -26,7 +26,7 @@ require_relative "mixin/provides"
 require_relative "dsl/core"
 require_relative "platform/service_helpers"
 require_relative "node_map"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   class Provider

--- a/lib/chef/provider/apt_repository.rb
+++ b/lib/chef/provider/apt_repository.rb
@@ -21,7 +21,7 @@ require_relative "../dsl/declare_resource"
 require_relative "../mixin/shell_out"
 require_relative "../http/simple"
 require_relative "noop"
-require "tmpdir"
+require "tmpdir" unless defined?(Dir.mktmpdir)
 
 class Chef
   class Provider

--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -21,7 +21,7 @@ require_relative "../log"
 require_relative "../resource/directory"
 require_relative "../provider"
 require_relative "file"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   class Provider

--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -18,7 +18,7 @@
 
 require_relative "../log"
 require_relative "../provider"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 require_relative "../mixin/train_or_shell"
 
 class Chef

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -21,8 +21,8 @@ require_relative "../config"
 require_relative "../log"
 require_relative "../resource/file"
 require_relative "../provider"
-require "etc"
-require "fileutils"
+require "etc" unless defined?(Etc)
+require "fileutils" unless defined?(FileUtils)
 require_relative "../scan_access_control"
 require_relative "../mixin/checksum"
 require_relative "../mixin/file_class"

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -19,7 +19,7 @@
 require_relative "../exceptions"
 require_relative "../log"
 require_relative "../provider"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   class Provider
@@ -314,7 +314,7 @@ class Chef
           # user who is executing `git` not the user running Chef.
           env["HOME"] =
             begin
-              require "etc"
+              require "etc" unless defined?(Etc)
               case new_resource.user
               when Integer
                 Etc.getpwuid(new_resource.user).dir

--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -18,7 +18,7 @@
 
 require_relative "../provider"
 require_relative "../mixin/shell_out"
-require "etc"
+require "etc" unless defined?(Etc)
 
 class Chef
   class Provider

--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -17,7 +17,7 @@
 #
 
 require_relative "groupadd"
-require "etc"
+require "etc" unless defined?(Etc)
 
 class Chef
   class Provider

--- a/lib/chef/provider/http_request.rb
+++ b/lib/chef/provider/http_request.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require_relative "../http/simple"
 
 class Chef

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -21,7 +21,7 @@ require_relative "../resource/file"
 require_relative "../resource/cookbook_file"
 require_relative "../resource/macosx_service"
 require "plist"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   class Provider

--- a/lib/chef/provider/mount/solaris.rb
+++ b/lib/chef/provider/mount/solaris.rb
@@ -20,7 +20,7 @@
 
 require_relative "../mount"
 require_relative "../../log"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   class Provider

--- a/lib/chef/provider/ohai.rb
+++ b/lib/chef/provider/ohai.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "ohai"
+require "ohai" unless defined?(Ohai::System)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -22,7 +22,7 @@ require_relative "../log"
 require_relative "../file_cache"
 require_relative "../platform"
 require_relative "../decorator/lazy_array"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -18,7 +18,7 @@
 require_relative "../../../mixin/which"
 require_relative "../../../mixin/shell_out"
 require_relative "version"
-require "timeout"
+require "timeout" unless defined?(Timeout)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require "etc"
+require "etc" unless defined?(Etc)
 require_relative "../../mixin/homebrew_user"
 
 class Chef

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -17,14 +17,14 @@
 # limitations under the License.
 #
 
-require "uri"
+require "uri" unless defined?(URI)
 require_relative "../package"
 require_relative "../../resource/package"
 require_relative "../../mixin/get_source_from_package"
 require_relative "../../mixin/which"
 
 # Class methods on Gem are defined in rubygems
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 # Ruby 1.9's gem_prelude can interact poorly with loading the full rubygems
 # explicitly like this. Make sure rubygems/specification is always last in this
 # list

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -19,7 +19,7 @@
 require_relative "../package"
 require_relative "../../resource/snap_package"
 require_relative "../../mixin/shell_out"
-require "socket"
+require "socket" unless defined?(Socket)
 require "json"
 
 class Chef

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -18,8 +18,8 @@
 require_relative "../../../mixin/which"
 require_relative "../../../mixin/shell_out"
 require_relative "version"
-require "singleton"
-require "timeout"
+require "singleton" unless defined?(Singleton)
+require "timeout" unless defined?(Timeout)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/yum/yum_cache.rb
+++ b/lib/chef/provider/package/yum/yum_cache.rb
@@ -18,7 +18,7 @@
 
 require_relative "python_helper"
 require_relative "../../package"
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 #
 # These are largely historical APIs, the YumCache object no longer exists and this is a

--- a/lib/chef/provider/registry_key.rb
+++ b/lib/chef/provider/registry_key.rb
@@ -22,8 +22,8 @@ require_relative "../log"
 require_relative "../resource/file"
 require_relative "../mixin/checksum"
 require_relative "../provider"
-require "etc"
-require "fileutils"
+require "etc" unless defined?(Etc)
+require "fileutils" unless defined?(FileUtils)
 require_relative "../scan_access_control"
 require_relative "../win32/registry"
 

--- a/lib/chef/provider/remote_directory.rb
+++ b/lib/chef/provider/remote_directory.rb
@@ -24,7 +24,7 @@ require_relative "../mixin/file_class"
 require_relative "../platform/query_helpers"
 require_relative "../util/path_helper"
 
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   class Provider

--- a/lib/chef/provider/remote_file/cache_control_data.rb
+++ b/lib/chef/provider/remote_file/cache_control_data.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-require "stringio"
+require "stringio" unless defined?(StringIO)
 require_relative "../../file_cache"
 require_relative "../../json_compat"
 require_relative "../../digester"

--- a/lib/chef/provider/remote_file/content.rb
+++ b/lib/chef/provider/remote_file/content.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "tempfile" unless defined?(Tempfile)
 require_relative "../../file_content_management/content_base"
 require_relative "../../mixin/uris"
 

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "tempfile" unless defined?(Tempfile)
 require "net/ftp"
 require_relative "../remote_file"
 require_relative "../../file_content_management/tempfile"

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "tempfile" unless defined?(Tempfile)
 require_relative "../remote_file"
 
 class Chef

--- a/lib/chef/provider/remote_file/network_file.rb
+++ b/lib/chef/provider/remote_file/network_file.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "tempfile" unless defined?(Tempfile)
 require_relative "../remote_file"
 require_relative "../../mixin/user_context"
 

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "tempfile"
+require "uri" unless defined?(URI)
+require "tempfile" unless defined?(Tempfile)
 require "net/sftp"
 require_relative "../remote_file"
 require_relative "../../file_content_management/tempfile"

--- a/lib/chef/provider/script.rb
+++ b/lib/chef/provider/script.rb
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require_relative "execute"
 require_relative "../win32/security" if Chef::Platform.windows?
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
   class Provider

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "etc"
-require "rexml/document"
+require "etc" unless defined?(Etc)
+require "rexml/document" unless defined?(REXML::Document)
 require_relative "../../resource/service"
 require_relative "../../resource/macosx_service"
 require_relative "simple"

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -20,7 +20,7 @@
 require_relative "../../resource/service"
 require_relative "simple"
 require_relative "../../mixin/which"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 

--- a/lib/chef/provider/subversion.rb
+++ b/lib/chef/provider/subversion.rb
@@ -21,7 +21,7 @@
 require_relative "../log"
 require_relative "../provider"
 require "chef-config/mixin/fuzzy_hostname_matcher"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   class Provider

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -22,7 +22,7 @@ require_relative "../mixin/shell_out"
 require_relative "../resource/file"
 require_relative "../resource/file/verification/systemd_unit"
 require "iniparse"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef
   class Provider

--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -17,7 +17,7 @@
 #
 
 require_relative "../provider"
-require "etc"
+require "etc" unless defined?(Etc)
 
 class Chef
   class Provider

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -19,7 +19,7 @@
 require_relative "../../mixin/shell_out"
 require_relative "../user"
 require_relative "../../resource/user/dscl_user"
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "plist"
 require_relative "../../util/path_helper"
 

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -17,7 +17,7 @@
 #
 
 require_relative "../mixin/shell_out"
-require "rexml/document"
+require "rexml/document" unless defined?(REXML::Document)
 require "iso8601" if Chef::Platform.windows?
 require_relative "../mixin/powershell_out"
 require_relative "../provider"

--- a/lib/chef/provider/zypper_repository.rb
+++ b/lib/chef/provider/zypper_repository.rb
@@ -20,7 +20,7 @@ require_relative "../resource"
 require_relative "../dsl/declare_resource"
 require_relative "noop"
 require_relative "../mixin/shell_out"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef
   class Provider

--- a/lib/chef/request_id.rb
+++ b/lib/chef/request_id.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "securerandom"
-require "singleton"
+require "securerandom" unless defined?(SecureRandom)
+require "singleton" unless defined?(Singleton)
 
 class Chef
   class RequestID

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -38,7 +38,7 @@ require_relative "resource/resource_notification"
 require_relative "provider_resolver"
 require_relative "resource_resolver"
 require_relative "provider"
-require "set"
+require "set" unless defined?(Set)
 
 require_relative "mixin/deprecation"
 require_relative "mixin/properties"

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -62,7 +62,7 @@ class Chef
       alias_method :extract_options, :options
       alias_method :extract_to, :destination
 
-      require "fileutils"
+      require "fileutils" unless defined?(FileUtils)
 
       action :extract do
         description "Extract and archive file."

--- a/lib/chef/resource/chocolatey_config.rb
+++ b/lib/chef/resource/chocolatey_config.rb
@@ -39,7 +39,7 @@ class Chef
       # @param [String] id the config name
       # @return [String] the element's value field
       def fetch_config_element(id)
-        require "rexml/document"
+        require "rexml/document" unless defined?(REXML::Document)
         config_file = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\config\\chocolatey.config"
         raise "Could not find the Chocolatey config at #{config_file}!" unless ::File.exist?(config_file)
 

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -47,7 +47,7 @@ class Chef
       # @param [String] id the source name
       # @return [REXML::Attributes] finds the source element with the
       def fetch_source_element(id)
-        require "rexml/document"
+        require "rexml/document" unless defined?(REXML::Document)
 
         config_file = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\config\\chocolatey.config"
         raise "Could not find the Chocolatey config at #{config_file}!" unless ::File.exist?(config_file)

--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -16,7 +16,7 @@
 #
 
 require_relative "../resource"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef
   class Resource

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -21,7 +21,7 @@ require_relative "../resource"
 require_relative "../platform/query_helpers"
 require_relative "../mixin/securable"
 require_relative "file/verification"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require_relative "../dist"
 
 class Chef

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -65,7 +65,7 @@ class Chef
         # @return [String]
         def updated_ec2_config_xml
           begin
-            require "rexml/document"
+            require "rexml/document" unless defined?(REXML::Document)
             config_file = 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml'
             config = REXML::Document.new(::File.read(config_file))
             # find an element named State with a sibling element whose value is Ec2SetComputerName

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "uri"
+require "uri" unless defined?(URI)
 require_relative "file"
 require_relative "../provider/remote_file"
 require_relative "../mixin/securable"

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -16,7 +16,7 @@
 #
 
 require_relative "../resource"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 
 class Chef
   class Resource

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -18,7 +18,7 @@
 #
 
 require_relative "../resource"
-require "shellwords"
+require "shellwords" unless defined?(Shellwords)
 require_relative "../dist"
 
 class Chef

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -20,7 +20,7 @@
 require_relative "../util/path_helper"
 require_relative "../resource"
 require "win32-certstore" if Chef::Platform.windows?
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require_relative "../dist"
 
 class Chef

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -108,7 +108,7 @@ class Chef
         # @return [String] path to the font
         def source_uri
           begin
-            require "uri"
+            require "uri" unless defined?(URI)
             if remote_file_schema?(URI.parse(new_resource.source).scheme)
               logger.trace("source property starts with ftp/http. Using source property unmodified")
               return new_resource.source

--- a/lib/chef/resource_collection.rb
+++ b/lib/chef/resource_collection.rb
@@ -21,7 +21,7 @@ require_relative "resource_collection/resource_set"
 require_relative "resource_collection/resource_list"
 require_relative "resource_collection/resource_collection_serialization"
 require_relative "log"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 ##
 # ResourceCollection currently handles two tasks:

--- a/lib/chef/resource_collection/resource_list.rb
+++ b/lib/chef/resource_collection/resource_list.rb
@@ -19,7 +19,7 @@
 require_relative "../resource"
 require_relative "stepable_iterator"
 require_relative "resource_collection_serialization"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 # This class keeps the list of all known Resources in the order they are to be executed in.  It also keeps a pointer
 # to the most recently executed resource so we can add resources-to-execute after this point.

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -19,8 +19,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "securerandom"
+require "uri" unless defined?(URI)
+require "securerandom" unless defined?(SecureRandom)
 require_relative "event_dispatch/base"
 
 class Chef

--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -26,7 +26,7 @@ require_relative "recipe"
 require_relative "run_context/cookbook_compiler"
 require_relative "event_dispatch/events_output_stream"
 require_relative "train_transport"
-require "forwardable"
+require "forwardable" unless defined?(Forwardable)
 
 class Chef
 

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "set"
+require "set" unless defined?(Set)
 require_relative "../log"
 require_relative "../recipe"
 require_relative "../resource/lwrp_base"

--- a/lib/chef/run_lock.rb
+++ b/lib/chef/run_lock.rb
@@ -22,7 +22,7 @@ if Chef::Platform.windows?
 end
 require_relative "config"
 require_relative "exceptions"
-require "timeout"
+require "timeout" unless defined?(Timeout)
 require_relative "dist"
 
 class Chef

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -20,8 +20,8 @@ require_relative "../config"
 require_relative "../exceptions"
 require_relative "../server_api"
 
-require "uri"
-require "addressable/uri"
+require "uri" unless defined?(URI)
+require "addressable/uri" unless defined?(Addressable::URI)
 
 class Chef
   class Search

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 class Chef
   class ServerAPIVersions

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-require "singleton"
-require "pp"
-require "etc"
-require "mixlib/cli"
+require "singleton" unless defined?(Singleton)
+require "pp" unless defined?(PP)
+require "etc" unless defined?(Etc)
+require "mixlib/cli" unless defined?(Mixlib::CLI)
 
 require_relative "../chef"
 require_relative "version"

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require_relative "../recipe"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require_relative "../dsl/platform_introspection"
 require_relative "../version"
 require_relative "shell_session"

--- a/lib/chef/util/file_edit.rb
+++ b/lib/chef/util/file_edit.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require_relative "editor"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 class Chef
   class Util

--- a/lib/chef/util/powershell/cmdlet.rb
+++ b/lib/chef/util/powershell/cmdlet.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require_relative "../../mixin/windows_architecture_helper"
 require_relative "cmdlet_result"
 

--- a/lib/chef/win32/api.rb
+++ b/lib/chef/win32/api.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "ffi"
+require "ffi" unless defined?(FFI)
 require_relative "../reserved_names"
 require_relative "../exceptions"
 

--- a/lib/chef/win32/api/installer.rb
+++ b/lib/chef/win32/api/installer.rb
@@ -19,7 +19,7 @@
 require_relative "../../exceptions"
 require_relative "../api"
 require_relative "../error"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 
 class Chef
   module ReservedNames::Win32

--- a/lib/chef/win32/process.rb
+++ b/lib/chef/win32/process.rb
@@ -20,7 +20,7 @@ require_relative "api/process"
 require_relative "api/psapi"
 require_relative "error"
 require_relative "handle"
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 class Chef
   module ReservedNames::Win32

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -23,7 +23,7 @@ require_relative "../mixin/wide_string"
 if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   require_relative "../monkey_patches/win32/registry"
   require_relative "api/registry"
-  require "win32/registry"
+  require "win32/registry" unless defined?(Win32::Registry)
   require "win32/api"
 end
 

--- a/lib/chef/win32/security/ace.rb
+++ b/lib/chef/win32/security/ace.rb
@@ -20,7 +20,7 @@ require_relative "../security"
 require_relative "sid"
 require_relative "../memory"
 
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 class Chef
   module ReservedNames::Win32

--- a/lib/chef/win32/security/acl.rb
+++ b/lib/chef/win32/security/acl.rb
@@ -18,7 +18,7 @@
 
 require_relative "../security"
 require_relative "ace"
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 class Chef
   module ReservedNames::Win32

--- a/lib/chef/win32/security/token.rb
+++ b/lib/chef/win32/security/token.rb
@@ -19,7 +19,7 @@
 require_relative "../security"
 require_relative "../api/security"
 require_relative "../unicode"
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 class Chef
   module ReservedNames::Win32

--- a/lib/chef/win32/system.rb
+++ b/lib/chef/win32/system.rb
@@ -18,7 +18,7 @@
 
 require_relative "api/system"
 require_relative "error"
-require "ffi"
+require "ffi" unless defined?(FFI)
 
 class Chef
   module ReservedNames::Win32


### PR DESCRIPTION
This hits the ones that are most frequently required.

Stops the kernel from scanning through all the activated gems every time in order
to resolve names into pathnames.

See rubygems/rubygems#2762
