### PR TITLE
Fix chef-config requires lines

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -19,19 +19,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/config"
-require "pathname"
+require "mixlib/config" unless defined?(Mixlib::Config)
+require "pathname" unless defined?(Pathname)
 
-require "chef-config/fips"
-require "chef-config/logger"
-require "chef-config/windows"
-require "chef-config/path_helper"
-require "chef-config/mixin/fuzzy_hostname_matcher"
+require_relative "fips"
+require_relative "logger"
+require_relative "windows"
+require_relative "path_helper"
+require_relative "mixin/fuzzy_hostname_matcher"
 
-require "mixlib/shellout"
-require "uri"
-require "addressable/uri"
-require "openssl"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "uri" unless defined?(URI)
+require "addressable/uri" unless defined?(Addressable::URI)
+require "openssl" unless defined?(OpenSSL)
 require "yaml"
 
 module ChefConfig

--- a/chef-config/lib/chef-config/exceptions.rb
+++ b/chef-config/lib/chef-config/exceptions.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "chef-config/windows"
-require "chef-config/logger"
+require_relative "windows"
+require_relative "logger"
 
 module ChefConfig
 

--- a/chef-config/lib/chef-config/fips.rb
+++ b/chef-config/lib/chef-config/fips.rb
@@ -21,7 +21,7 @@ module ChefConfig
   def self.fips?
     if ChefConfig.windows?
       begin
-        require "win32/registry"
+        require "win32/registry" unless defined?(Win32::Registry)
       rescue LoadError
         return false
       end

--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -16,7 +16,7 @@
 #
 
 require "tomlrb"
-require "chef-config/path_helper"
+require_relative "../path_helper"
 
 module ChefConfig
   module Mixin

--- a/chef-config/lib/chef-config/mixin/dot_d.rb
+++ b/chef-config/lib/chef-config/mixin/dot_d.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "chef-config/path_helper"
+require_relative "../path_helper"
 
 module ChefConfig
   module Mixin

--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "chef-config/windows"
-require "chef-config/logger"
-require "chef-config/exceptions"
+require_relative "windows"
+require_relative "logger"
+require_relative "exceptions"
 
 module ChefConfig
   class PathHelper

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -16,13 +16,13 @@
 # limitations under the License.
 #
 
-require "chef-config/config"
-require "chef-config/exceptions"
-require "chef-config/logger"
-require "chef-config/path_helper"
-require "chef-config/windows"
-require "chef-config/mixin/dot_d"
-require "chef-config/mixin/credentials"
+require_relative "config"
+require_relative "exceptions"
+require_relative "logger"
+require_relative "path_helper"
+require_relative "windows"
+require_relative "mixin/dot_d"
+require_relative "mixin/credentials"
 
 module ChefConfig
   class WorkstationConfigLoader


### PR DESCRIPTION
does the same fixing of require_relative and manual idempotency checking
that has been applied to the chef gem
