### PR TITLE
update license-acceptance gem

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "train-core", "~> 2.0", ">= 2.0.12"
 
-  s.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
+  s.add_dependency "license-acceptance", "~> 1.0.10", ">= 1.0.11"
   s.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", "~> 2.1"


### PR DESCRIPTION
## Description
This fixes the license acceptance for windows where you haven't set the HOMEDRIVE environment variable

## Related Issue
 #8548

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
