### PR TITLE
Update habitat/plan.sh to allow building of Chef Infra Client 15

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('Apache-2.0')
 pkg_filename=${pkg_dirname}.tar.gz
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc core/git)
-pkg_deps=(core/glibc core/ruby core/libxml2 core/libxslt core/libiconv core/xz core/zlib core/bundler core/openssl core/cacerts core/libffi core/coreutils core/libarchive)
+pkg_deps=(core/glibc core/ruby26 core/libxml2 core/libxslt core/libiconv core/xz core/zlib core/bundler core/openssl core/cacerts core/libffi core/coreutils core/libarchive)
 pkg_svc_user=root
 
 do_before() {
@@ -80,7 +80,7 @@ do_install() {
   popd > /dev/null
 
   fix_interpreter "${pkg_prefix}/bin/*" core/coreutils bin/env
-  fix_interpreter "${pkg_prefix}/bin/*" core/ruby bin/ruby
+  fix_interpreter "${pkg_prefix}/bin/*" core/ruby26 bin/ruby
 }
 
 do_end() {
@@ -104,7 +104,7 @@ _bundle_install() {
     --jobs "$(nproc)" \
     --without development:test \
     --path "$path" \
-    --shebang="$(pkg_path_for "core/ruby")/bin/ruby" \
+    --shebang="$(pkg_path_for "core/ruby26")/bin/ruby" \
     --no-clean \
     --retry 5 \
     --standalone

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -65,7 +65,7 @@ do_build() {
 
 do_install() {
   mkdir -p "${pkg_prefix}/chef"
-  for dir in bin chef-config lib chef.gemspec Gemfile Gemfile.lock; do
+  for dir in bin chef-bin chef-config lib chef.gemspec Gemfile Gemfile.lock; do
     cp -rv "${PLAN_CONTEXT}/../${dir}" "${pkg_prefix}/chef/"
   done
 


### PR DESCRIPTION
## Description
This updates the dependencies to explicitly use `core/ruby26`, rather than `core/ruby.` At the time of this PR `core/ruby` is still tracking 2.5 and _may_ move ahead before chef-client is ready to consume new releases of Ruby. 

I've also included `chef-bin` in the copied directories in order to get the `bundle install` to function. 

## Related Issue
Closes #8542 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
