### PR TITLE
Add license CLI options to chef-apply command

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -27,8 +27,10 @@ require "tempfile"
 require_relative "../providers"
 require_relative "../resources"
 require_relative "../dist"
+require "license_acceptance/cli_flags/mixlib_cli"
 
 class Chef::Application::Apply < Chef::Application
+  include LicenseAcceptance::CLIFlags::MixlibCLI
 
   banner "Usage: chef-apply [RECIPE_FILE | -e RECIPE_TEXT | -s] [OPTIONS]"
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -30,10 +30,12 @@ require "pathname"
 require "chef-config/mixin/dot_d"
 require "mixlib/archive"
 require_relative "../dist"
+require "license_acceptance/cli_flags/mixlib_cli"
 
 class Chef::Application::Solo < Chef::Application
   include Chef::Mixin::ShellOut
   include ChefConfig::Mixin::DotD
+  include LicenseAcceptance::CLIFlags::MixlibCLI
 
   option :config_file,
     short: "-c CONFIG",


### PR DESCRIPTION
You could accept the license interactively but you could not do it via
the CLI flag

Signed-off-by: Tim Smith <tsmith@chef.io>