### PR TITLE
Chef 15: Fix ssh user set from cli

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -995,8 +995,8 @@ class Chef
           config[key]
         else
           lookup_key = knife_config_key || key
-          if Chef::Config[:knife].key?(lookup_key)
-            Chef::Config[:knife][lookup_key]
+          if Chef::Config[:knife].key?(lookup_key) || config.key?(lookup_key)
+            Chef::Config[:knife][lookup_key] || config[lookup_key]
           else
             default
           end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1002,7 +1002,7 @@ describe Chef::Knife::Bootstrap do
             let(:expected_result) do
               {
                 logger: Chef::Log, # not configurable
-                max_wait_until_ready: 9999,
+                max_wait_until_ready: 9999.0,
                 connection_timeout: 9999,
                 user: "sshbob",
                 bastion_host: "mygateway.local",
@@ -1012,7 +1012,7 @@ describe Chef::Knife::Bootstrap do
                 keys_only: true,
                 key_files: ["/identity.pem", "/gateway.pem"],
                 sudo: false,
-                verify_host_key: false,
+                verify_host_key: nil,
                 port: 9999,
                 non_interactive: true,
               }
@@ -1055,7 +1055,7 @@ describe Chef::Knife::Bootstrap do
             let(:expected_result) do
               {
                 logger: Chef::Log, # not configurable
-                max_wait_until_ready: 150, # cli
+                max_wait_until_ready: 150.0, # cli
                 connection_timeout: 120, # cli
                 user: "sshalice", # cli
                 password: "feta cheese", # cli
@@ -1066,7 +1066,7 @@ describe Chef::Knife::Bootstrap do
                 keys_only: false, # implied false from config password present
                 key_files: ["/identity.pem", "/gateway.pem"], # Config
                 sudo: true, # ccli
-                verify_host_key: false, # Config
+                verify_host_key: nil, # Config
                 port: 12, # cli
                 non_interactive: true,
               }


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

This fixes the `ssh_user` setting if we provide from CLI rather than on `knife.rb`

## Description
-- `config_value` now returns the `ssh_user` value too if set in CLI.

## Related Issue
Fixes https://github.com/chef/knife-ec2/issues/574

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
