### PR TITLE
Improving error handling for template render

### DIFF
--- a/spec/data/templates/failed.erb
+++ b/spec/data/templates/failed.erb
@@ -1,0 +1,5 @@
+This is a template
+
+Which includes some content
+
+And will fail <%= nil[] %>


### PR DESCRIPTION
## Description
While Chef already implements a nice amount of information
in `TemplateError#to_s`, when using ChefSpec with RSpec, the `#to_s`
is not called, leaving us with no source information for template
errors.

By adding the filename to `Erubis::Eruby` initialization, we can get
a better backtrace that will show up in RSpec output.

## Related Issue
#8561

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
