### PR TITLE
Only set client_pem in bootstrap_context when validatorless

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -546,9 +546,6 @@ class Chef
         register_client
         connect!
 
-        unless client_builder.client_path.nil?
-          bootstrap_context.client_pem = client_builder.client_path
-        end
         content = render_template
         bootstrap_path = upload_bootstrap(content)
         perform_bootstrap(bootstrap_path)
@@ -569,6 +566,8 @@ class Chef
           end
           client_builder.run
           chef_vault_handler.run(client_builder.client)
+
+          bootstrap_context.client_pem = client_builder.client_path
         else
           ui.info <<~EOM
             Performing legacy client registration with the validation key at #{Chef::Config[:validation_key]}...

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1654,10 +1654,6 @@ describe Chef::Knife::Bootstrap do
     end
   end
   describe "#run" do
-    before do
-      allow(knife.client_builder).to receive(:client_path).and_return("/key.pem")
-    end
-
     it "performs the steps we expect to run a bootstrap" do
       expect(knife).to receive(:check_license)
       expect(knife).to receive(:verify_deprecated_flags!).ordered
@@ -1678,7 +1674,6 @@ describe Chef::Knife::Bootstrap do
       knife.run
 
       # Post-run verify expected state changes (not many directly in #run)
-      expect(knife.bootstrap_context.client_pem).to eq "/key.pem"
       expect($stdout.sync).to eq true
     end
   end
@@ -1731,12 +1726,20 @@ describe Chef::Knife::Bootstrap do
         let(:node_name) { "test" }
         before do
           allow(client_builder_mock).to receive(:client).and_return "client"
+          allow(client_builder_mock).to receive(:client_path).and_return "/key.pem"
         end
 
         it "runs client_builder and vault_handler" do
           expect(client_builder_mock).to receive(:run)
           expect(vault_handler_mock).to receive(:run).with("client")
           knife.register_client
+        end
+
+        it "sets the path to the client key in the bootstrap context" do
+          allow(client_builder_mock).to receive(:run)
+          allow(vault_handler_mock).to receive(:run).with("client")
+          knife.register_client
+          expect(knife.bootstrap_context.client_pem).to eq "/key.pem"
         end
       end
 


### PR DESCRIPTION
We should only set bootstrap_context.client_pem if we're a validatorless
bootstrap.

Fixes #8534

Signed-off-by: Bryan McLellan <btm@loftninjas.org>