### PR TITLE
Chef- 15: Change knife suggestion to use -VV instead of -VVV

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -498,7 +498,7 @@ class Chef
       when NameError, NoMethodError
         ui.error "knife encountered an unexpected error"
         ui.info  "This may be a bug in the '#{self.class.common_name}' knife command or plugin"
-        ui.info  "Please collect the output of this command with the `-VVV` option before filing a bug report."
+        ui.info  "Please collect the output of this command with the `-VV` option before filing a bug report."
         ui.info  "Exception: #{e.class.name}: #{e.message}"
       when Chef::Exceptions::PrivateKeyMissing
         ui.error "Your private key could not be loaded from #{api_key}"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
During bootstrap seems logged info to use `-VVV` trace level instead of `-VV`. `-VV` does not provide raised exception trace so it might not use for the community to debug the code to in first go so `-VV` is useful before logging the issue.

https://github.com/chef/chef/blob/66c0fdeb65c19d267bd501550e60cd16d7bb4901/lib/chef/knife.rb#L487

Well, we can document it a cleaner way. something similar to: 
 - -V: log level info
- -VV: log level debug, allow exceptions to raise
- -VVV: log level trace, do not allow exceptions to raise

instead
    -V, --verbose                    More verbose output. Use twice for max verbosity.

in `knife bootstrap --help` command?

## Related Issue
Fixed https://github.com/chef/chef/issues/8433
