### PR TITLE
Fix delete_resource for resources

### DIFF
--- a/lib/chef/resource_collection.rb
+++ b/lib/chef/resource_collection.rb
@@ -60,8 +60,9 @@ class Chef
     end
 
     def delete(key)
-      resource_list.delete(key)
-      resource_set.delete(key)
+      res = resource_set.delete(key)
+      resource_list.delete(res.to_s)
+      res
     end
 
     # @deprecated

--- a/spec/unit/resource_collection_spec.rb
+++ b/spec/unit/resource_collection_spec.rb
@@ -183,6 +183,14 @@ describe Chef::ResourceCollection do
       expect(rc).to be_empty
     end
 
+    it "should allow to delete resources with different providers" do
+      pkg = Chef::Resource::YumPackage.new("monkey")
+      rc.insert(pkg, instance_name: "monkey", resource_type: "package")
+      expect(rc).not_to be_empty
+      expect(rc.delete("package[monkey]")).to eql(pkg)
+      expect(rc).to be_empty
+    end
+
     it "should raise an exception if you send something strange to delete" do
       expect { rc.delete(:symbol) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
with multiple providers

Fixes: https://github.com/chef/chef/issues/6158

## Description
Then a resource with multiple providers (e.g. package) is used, delete_resource doesn't work.

## Related Issue
https://github.com/chef/chef/issues/6158

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).