### PR TITLE
Better target mode no-creds errors

### DIFF
--- a/spec/unit/train_transport_spec.rb
+++ b/spec/unit/train_transport_spec.rb
@@ -50,7 +50,7 @@ describe Chef::TrainTransport do
 
   describe "credentials_file_path" do
     let(:config_cred_file_path) { "/somewhere/credentials" }
-    let(:host_cred_file_path) { "/etc/chef/foo.example.org/credentials" }
+    let(:host_cred_file_path) { Chef::Platform.windows? ? "C:\\chef\\foo.example.org\\credentials" : "/etc/chef/foo.example.org/credentials" }
 
     context "when a file path is specified by a config" do
       before do


### PR DESCRIPTION
Changes the target mode error in the case of no creds at all to:

```
FATAL: ArgumentError: Credentials file specified for target mode does not exist: '/Users/lamont/.chef/credentials'
```

From:

```
[2019-05-20T17:30:41-07:00] FATAL: NoMethodError: undefined method `[]' for nil:NilClass
```

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>
