### PR TITLE
Chef-15: Add missing deprecated options

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -353,6 +353,8 @@ class Chef
         #   (--bool-option) to valued flag (--new-option VALUE)
         #   this will be the value that is assigned the new flag when the old flag is used.
         auth_timeout: [:max_wait, "--max-wait SECONDS" ],
+        forward_agent:
+          [:ssh_forward_agent, "--forward-agent"],
         host_key_verify:
           [:ssh_verify_host_key, "--[no-]host-key-verify"],
         prerelease:
@@ -362,7 +364,7 @@ class Chef
         ssh_password:
           [:connection_password, "--ssh-password PASSWORD"],
         ssh_port:
-          [:connection_port, "-ssh-port" ],
+          [:connection_port, "--ssh-port"],
         ssl_peer_fingerprint:
           [:winrm_ssl_peer_fingerprint, "--ssl-peer-fingerprint FINGERPRINT"],
         winrm_user:
@@ -375,6 +377,10 @@ class Chef
           [:winrm_auth_method, "--winrm-authentication-protocol PROTOCOL"],
         winrm_session_timeout:
           [:session_timeout, "--winrm-session-timeout MINUTES"],
+        winrm_ssl_verify_mode:
+          [:winrm_no_verify_cert, "--winrm-ssl-verify-mode MODE"],
+        winrm_transport:
+          [:winrm_ssl, "--winrm-transport TRANSPORT"]
       }.freeze
 
       DEPRECATED_FLAGS.each do |deprecated_key, deprecation_entry|

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -380,7 +380,7 @@ class Chef
         winrm_ssl_verify_mode:
           [:winrm_no_verify_cert, "--winrm-ssl-verify-mode MODE"],
         winrm_transport:
-          [:winrm_ssl, "--winrm-transport TRANSPORT"]
+          [:winrm_ssl, "--winrm-transport TRANSPORT"],
       }.freeze
 
       DEPRECATED_FLAGS.each do |deprecated_key, deprecation_entry|


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
As per the release note, we have following deprecated options:

| Flag        | New option |
| ------------- |:-------------:|
| --forward-agent | --ssh-forward-agent
| --ssh-port | --connection-port 
| --winrm-ssl-verify-mode MODE | --winrm-no-verify-cert 
| --winrm-transport TRANSPORT | --winrm-ssl 

These options must be properly added to deprecated flags.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8572

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
