### PR TITLE
Chef 15: Fix order of connection before registering node

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -543,8 +543,8 @@ class Chef
         warn_on_short_session_timeout
 
         $stdout.sync = true
-        register_client
         connect!
+        register_client
 
         content = render_template
         bootstrap_path = upload_bootstrap(content)

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1664,8 +1664,8 @@ describe Chef::Knife::Bootstrap do
       expect(knife).to receive(:validate_policy_options!).ordered
       expect(knife).to receive(:winrm_warn_no_ssl_verification).ordered
       expect(knife).to receive(:warn_on_short_session_timeout).ordered
-      expect(knife).to receive(:register_client).ordered
       expect(knife).to receive(:connect!).ordered
+      expect(knife).to receive(:register_client).ordered
       expect(knife).to receive(:render_template).and_return "content"
       expect(knife).to receive(:upload_bootstrap).with("content").and_return "/remote/path.sh"
       expect(knife).to receive(:perform_bootstrap).with("/remote/path.sh")


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

Correct the order of `connection` before `registration`

## Description
Updates order of `connection`  before `registration` for any node, Ensures the `connection` object to be live.

## Related Issue
Fixes https://github.com/chef/knife-ec2/issues/579

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
