### PR TITLE
launchd: add launch_events property

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -195,6 +195,7 @@ class Chef
           "inetd_compatibility" => "inetdCompatibility",
           "init_groups" => "InitGroups",
           "keep_alive" => "KeepAlive",
+          "launch_events" => "LaunchEvents",
           "launch_only_once" => "LaunchOnlyOnce",
           "limit_load_from_hosts" => "LimitLoadFromHosts",
           "limit_load_to_hosts" => "LimitLoadToHosts",

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -161,6 +161,9 @@ class Chef
                introduced: "12.14",
                description: "Keep a job running continuously (true) or allow demand and conditions on the node to determine if the job keeps running (false)."
 
+      property :launch_events, [ Hash ],
+               description: "Specify higher-level event types to be used as launch-on-demand event sources."
+
       property :launch_only_once, [ TrueClass, FalseClass ],
                description: "Specify if a job can be run only one time. Set this value to true if a job cannot be restarted without a full machine reboot."
 


### PR DESCRIPTION

## Description
Adding support for the LaunchEvents key in launchd. From `man launchd.plist`:

```
LaunchEvents <dictionary of dictionaries of dictionaries>
Specifies higher-level event types to be used as launch-on-demand event sources.  Each sub-dictionary defines events for a particular event subsystem, such as "com.apple.iokit.match-ing", which can be used to launch jobs based on the appearance of nodes in the IORegistry. Each dictionary within the sub-dictionary specifies an event descriptor that is specified to each event subsystem. With this key, the job promises to use the xpc_set_event_stream_handler(3) API to consume events. See xpc_events(3) for more details on event sources.
``` 

Allows for having a LaunchDaemon with something like the following

```
	<key>LaunchEvents</key>
	<dict>
		<key>com.apple.iokit.matching</key>
		<dict>
			<key>com.example.iOS-device-attached</key>
			<dict>
				<key>IOMatchLaunchStream</key>
				<true/>
				<key>IOProviderClass</key>
				<string>IOUSBDevice</string>
			</dict>
		</dict>
	</dict>
```

## Related Issue
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
