### PR TITLE
make which/where be target-mode aware

### DIFF
--- a/lib/chef/mixin/which.rb
+++ b/lib/chef/mixin/which.rb
@@ -40,7 +40,7 @@ class Chef
 
       # for test stubbing
       def env_path
-        if Chef::Config.target_mode
+        if Chef::Config.target_mode?
           Chef.run_context.transport_connection.run_command("echo $PATH").stdout
         else
           ENV["PATH"]
@@ -49,7 +49,7 @@ class Chef
 
       def valid_executable?(filename, &block)
         is_executable =
-          if Chef::Config.target_mode
+          if Chef::Config.target_mode?
             connection = Chef.run_context.transport_connection
             connection.file(filename).stat[:mode] & 1 && !connection.file(filename).directory?
           else

--- a/lib/chef/mixin/which.rb
+++ b/lib/chef/mixin/which.rb
@@ -40,11 +40,22 @@ class Chef
 
       # for test stubbing
       def env_path
-        ENV["PATH"]
+        if Chef::Config.target_mode
+          Chef.run_context.transport_connection.run_command("echo $PATH").stdout
+        else
+          ENV["PATH"]
+        end
       end
 
       def valid_executable?(filename, &block)
-        return false unless File.executable?(filename) && !File.directory?(filename)
+        is_executable =
+          if Chef::Config.target_mode
+            connection = Chef.run_context.transport_connection
+            connection.file(filename).stat[:mode] & 1 && !connection.file(filename).directory?
+          else
+            File.executable?(filename) && !File.directory?(filename)
+          end
+        return false unless is_executable
         block ? yield(filename) : true
       end
     end


### PR DESCRIPTION
bit hacky since we're only testing the global execute-bit but doing this right will require porting File.executable? to work correctly in train and more or less copying
the logic in ruby's file.c to work across a train connection (which requires figuring out geteuid()/getegid()/getuid()/getgid() across a train connection which is "lolno" right now).