### PR TITLE
Preserve train connection in target mode to prevent running duplicate OS detection commands

### DIFF
--- a/lib/chef/run_context.rb
+++ b/lib/chef/run_context.rb
@@ -604,7 +604,7 @@ class Chef
     # @return [Train::Plugins::Transport::BaseConnection]
     #
     def transport_connection
-      transport.connection
+      @transport_connection ||= transport.connection
     end
 
     #


### PR DESCRIPTION
We need to save the train connection object as that represents the ssh
connection that we want to reuse.

Fixes #8579