### PR TITLE
Enable target mode on ruby_block, log and breakpoint

### DIFF
--- a/lib/chef/provider/log.rb
+++ b/lib/chef/provider/log.rb
@@ -21,7 +21,7 @@ class Chef
     class Log
       # Chef log provider, allows logging to chef's logs
       class ChefLog < Chef::Provider
-        provides :log
+        provides :log, target_mode: true
 
         # No concept of a 'current' resource for logs, this is a no-op
         #

--- a/lib/chef/provider/ruby_block.rb
+++ b/lib/chef/provider/ruby_block.rb
@@ -20,7 +20,7 @@
 class Chef
   class Provider
     class RubyBlock < Chef::Provider
-      provides :ruby_block
+      provides :ruby_block, target_mode: true
 
       def load_current_resource
         true

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -22,7 +22,7 @@ require_relative "../dist"
 class Chef
   class Resource
     class Breakpoint < Chef::Resource
-      provides :breakpoint
+      provides :breakpoint, target_mode: true
       resource_name :breakpoint
 
       description "Use the breakpoint resource to add breakpoints to recipes. Run the chef-shell in #{Chef::Dist::CLIENT} mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the #{Chef::Dist::CLIENT} during an actual #{Chef::Dist::CLIENT} run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."

--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -30,6 +30,7 @@ class Chef
     #   end
     class Log < Chef::Resource
       resource_name :log
+      provides :log, target_mode: true
 
       description "Use the log resource to create log entries. The log resource behaves"\
                   " like any other resource: built into the resource collection during the"\

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -24,6 +24,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class RubyBlock < Chef::Resource
+      provides :ruby_block, target_mode: true
+
       description "Use the ruby_block resource to execute Ruby code during a #{Chef::Dist::CLIENT} run."\
                   " Ruby code in the ruby_block resource is evaluated with other resources during"\
                   " convergence, whereas Ruby code outside of a ruby_block resource is evaluated"\


### PR DESCRIPTION
breakpoint and log have to be executed locally so they're safe to run unmodified in target_mode.

ruby_block is superficially debatable since there's the obvious question as to "should it run remotely?"

however there is a simple answer which is "hell no".

we'd have to ship the variable binding to the remote server and then ship it back.

consider:

```ruby
filename = "/etc/passwd"

ruby_block "nuke /etc/passwd because I hate logging into my box" do
  block do
    FileUtils.rm_rf(filename)
  end
end
```

That block can't be eval'd by the local ruby interpreter or you'll nuke /etc/passwd on the local machine you're running on.  If you ship it up to the target host then it'll fail with a NoMethodError on filename.  You'd have to ship the full binding up to a remote instance (even just setting aside the question of if you have a ruby on the target and what kind of ruby you have on the target).

So instead the ruby_block in target mode is executed entirely locally.  Which enables this kind of use of ruby_block to lazy setting things:

```ruby
ruby_block "do something lazy" do
  block do
    node.force_override['foo'] = my_variable
  end
end

execute "run command" do
  command lazy { node.force_override['foo'] }
end

my_variable = "/bin/true"
```

Which is the pattern of abusing ruby_block to mutate variables at converge time that makes me cry, but it is what we do.  To make this work with remote execution we would have to ship the ruby binding up to the remote somehow then eval the block, and then ship the binding back and apply it.   That is certainly not going into v1.0.

This stackoverflow question+answer I think is useful and blunt:

https://stackoverflow.com/questions/38617396/persist-ruby-binding

"The idea of serializing a binding is in many ways incoherent, because a binding is intimately connected to the run-time stack"

Also note that if we have train-aware helpers for things like rm_rf that this could be the correct way to write the first use case:

```ruby
filename = "/etc/passwd"

ruby_block "nuke /etc/passwd because I hate logging into my box" do
  block do
    TrainFileUtils.rm_rf(filename)
  end
end
```

The ruby all executes locally but it is the file operation that gets sent remotely.  That is the sane way to accomplish running things inside of a ruby_block remotely.