### PR TITLE
Update Habitat Build

### DIFF
--- a/habitat/config/client.rb
+++ b/habitat/config/client.rb
@@ -6,6 +6,7 @@ data_collector.token "{{cfg.data_collector.token}}"
 data_collector.mode "{{cfg.data_collector.mode}}".to_sym
 data_collector.raise_on_failure {{cfg.data_collector.raise_on_failure}}
 minimal_ohai {{cfg.minimal_ohai}}
+local_mode {{cfg.local_mode}}
 {{#if cfg.chef-client.node_name ~}}
 node_name "{{cfg.node_name}}"
 {{/if ~}}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,6 +1,14 @@
 pid_file = "chef.pid"
 run_list = ""
 
+local_mode = true
+
+# Positive License Acceptance.  See https://docs.chef.io/chef_license_accept.html
+chef_license = "donotaccept"
+
+# Path to the chef client config on disk.  If blank, will default to the one built by habitat.
+config_path = ""
+
 # The location in which nodes are stored when the chef-client is run in local mode
 
 log_location = "STDOUT"
@@ -18,11 +26,11 @@ minimal_ohai = false
 
 # The name of the node. Determines which configuration should be applied and sets the client_name,
 # which is the name used when authenticating to a Chef server. The default value is the FQDN of the chef-client,
-#as detected by Ohai. In general, Chef recommends that you leave this setting blank and let Ohai 
+# as detected by Ohai. In general, Chef recommends that you leave this setting blank and let Ohai
 # assign the FQDN of the node as the node_name during each chef-clientrun.
 node_name = ""
 
-#The name of the environment
+# The name of the environment
 environment = "_default"
 
 use_member_id_as_uuid = false

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -9,4 +9,8 @@ else
   CLIENT_CONFIG="{{cfg.config_path}}"
 fi
 
-exec chef-client --fork -c ${CLIENT_CONFIG}/client.rb --chef-license {{cfg.chef_license}}
+if [[ "${CLIENT_CONFIG##*.}" != "rb" ]]; then
+  CLIENT_CONFIG=${CLIENT_CONFIG}/client.rb
+fi
+
+exec chef-client --fork -c ${CLIENT_CONFIG} --chef-license {{cfg.chef_license}}

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -3,4 +3,10 @@ exec 2>&1
 
 export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 
-exec chef-solo --fork -c {{pkg.svc_config_path}}/client.rb
+if [[ -z "{{cfg.config_path}}" ]]; then
+  CLIENT_CONFIG="{{pkg.svc_config_path}}/client.rb"
+else
+  CLIENT_CONFIG="{{cfg.config_path}}/client.rb"
+fi
+
+exec chef-client --fork -c ${CLIENT_CONFIG}/client.rb --chef-license {{cfg.chef_license}}

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -4,9 +4,9 @@ exec 2>&1
 export SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/cert.pem"
 
 if [[ -z "{{cfg.config_path}}" ]]; then
-  CLIENT_CONFIG="{{pkg.svc_config_path}}/client.rb"
+  CLIENT_CONFIG="{{pkg.svc_config_path}}"
 else
-  CLIENT_CONFIG="{{cfg.config_path}}/client.rb"
+  CLIENT_CONFIG="{{cfg.config_path}}"
 fi
 
 exec chef-client --fork -c ${CLIENT_CONFIG}/client.rb --chef-license {{cfg.chef_license}}


### PR DESCRIPTION
* Add in License Acceptance for Chef 15.
* Make package more flexible for running chef-client in alternative models.

Signed-off-by: Nathan Cerny <ncerny@gmail.com>

## Description
Adds in license acceptance by creating a config value in habitat, that passes the acceptance in to the command line in the run hook.

Adds in flexibility to the habitat build:
* Calls chef-client (with local_mode defined as a configurable) instead of chef-solo
* Allows overriding of the configuration file, to allow running in "hybrid" models, giving customers a migration path to fully effortless.

## Related Issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
