### PR TITLE
chocolatey_feature: feature_state -> state and only support single action

### DIFF
--- a/spec/unit/policy_builder/dynamic_spec.rb
+++ b/spec/unit/policy_builder/dynamic_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/resource/chocolatey_feature_spec.rb
+++ b/spec/unit/resource/chocolatey_feature_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019, Chef Software, Inc.
+# Copyright:: Copyright 2019-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,13 +57,12 @@ describe Chef::Resource::ChocolateyFeature do
     expect(resource.feature_name).to eql("fakey_fakerton")
   end
 
-  it "sets the default action as :enable" do
-    expect(resource.action).to eql([:enable])
+  it "sets the default action as :set" do
+    expect(resource.action).to eql([:set])
   end
 
-  it "supports :enable and :disable actions" do
-    expect { resource.action :enable }.not_to raise_error
-    expect { resource.action :disable }.not_to raise_error
+  it "supports :set action" do
+    expect { resource.action :set }.not_to raise_error
   end
 
   describe "#fetch_feature_element" do


### PR DESCRIPTION
chef/chef#8597 made it obvious what was wrong about the way the
resource was written before.

the desired enabled/disable state needs to be property, not an action.

the human desire to express things imperatively instead of declaratively
strikes again.

this changes the API from:

```
chocolatey_feature "whatever" do
  action :enable
end

chocolatey_feature "whatever" do
  action :disable
end
```

to:

```
chocolatey_feature "whatever" do
  state :enabled
end

chocolatey_feature "whatever" do
  state :disabled
end
```
