### PR TITLE
Improving error handling for template render

### DIFF
--- a/spec/data/templates/failed.erb
+++ b/spec/data/templates/failed.erb
@@ -1,0 +1,5 @@
+This is a template
+
+Which includes some content
+
+And will fail <%= nil[] %>


### PR DESCRIPTION
While Chef already implements a nice amount of information
in `TemplateError#to_s`, when using ChefSpec with RSpec, the `#to_s`
is not called, leaving us with no source information for template
errors.

By adding the filename to `Erubis::Eruby` initialization, we can get
a better backtrace that will show up in RSpec output.

Signed-off-by: Gabriel Mazetto <brodock@gmail.com>