### PR TITLE
Tell people what file a link is pointing at.

### DIFF
--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -227,7 +227,7 @@ class Chef
         elsif file_class.symlink?(path) && new_resource.manage_symlink_source
           verify_symlink_sanity(path)
         elsif file_class.symlink?(new_resource.path) && new_resource.manage_symlink_source.nil?
-          logger.warn("File #{path} managed by #{new_resource} is really a symlink. Managing the source file instead.")
+          logger.warn("File #{path} managed by #{new_resource} is really a symlink (to #{file_class.realpath(new_resource.path)}). Managing the source file instead.")
           logger.warn("Disable this warning by setting `manage_symlink_source true` on the resource")
           logger.warn("In a future Chef release, 'manage_symlink_source' will not be enabled by default")
           verify_symlink_sanity(path)

--- a/lib/chef/win32/file.rb
+++ b/lib/chef/win32/file.rb
@@ -89,6 +89,14 @@ class Chef
         is_symlink
       end
 
+      def self.realpath(file_name)
+        if symlink?(file_name)
+          readlink(file_name)
+        else
+          file_name
+        end
+      end
+
       # Returns the path of the of the symbolic link referred to by +file+.
       #
       # Requires Windows Vista or later. On older versions of Windows it

--- a/spec/support/shared/unit/provider/file.rb
+++ b/spec/support/shared/unit/provider/file.rb
@@ -76,6 +76,7 @@ def setup_symlink
     allow(File).to receive(:directory?).with(path).and_return(false)
     allow(File).to receive(:writable?).with(path).and_return(true)
     allow(file_symlink_class).to receive(:symlink?).with(path).and_return(true)
+    allow(file_symlink_class).to receive(:realpath).with(path).and_return(path)
   end
   allow(File).to receive(:directory?).with(enclosing_directory).and_return(true)
 end


### PR DESCRIPTION
In the event you are managing a file `/etc/file` with a `file` resource,
but it turns out to be a link to `/etc/passwd` and you are trying to figure
out what overwrite `/etc/passwd`, there is no indication in the logs. Let's add
one.

Signed-off-by: Phil Dibowitz <phil@ipom.com>