### PR TITLE
Use exports compatibile with /bin/sh in the bootstrap script

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -1,5 +1,6 @@
 sh -c '
-<%= "export https_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+<%= "https_proxy=\"#{knife_config[:bootstrap_proxy]}\" export https_proxy" if knife_config[:bootstrap_proxy] %>
+<%= "no_proxy=\"#{knife_config[:bootstrap_no_proxy]}\" export no_proxy" if knife_config[:bootstrap_no_proxy] %>
 
 if test "x$TMPDIR" = "x"; then
   tmp="/tmp"

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -96,6 +96,28 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
+  context "with --bootstrap-proxy" do
+    let(:bootstrap_cli_options) { [ "--bootstrap-proxy", "1.1.1.1" ] }
+    let(:rendered_template) do
+      knife.merge_configs
+      knife.render_template
+    end
+    it "configures the https_proxy environment variable in the bootstrap template correctly" do
+      expect(rendered_template).to match(%r{https_proxy="1.1.1.1" export https_proxy})
+    end
+  end
+
+  context "with --bootstrap-no-proxy" do
+    let(:bootstrap_cli_options) { [ "--bootstrap-no-proxy", "localserver" ] }
+    let(:rendered_template) do
+      knife.merge_configs
+      knife.render_template
+    end
+    it "configures the https_proxy environment variable in the bootstrap template correctly" do
+      expect(rendered_template).to match(%r{no_proxy="localserver" export no_proxy})
+    end
+  end
+
   context "with :bootstrap_template and :template_file cli options" do
     let(:bootstrap_cli_options) { [ "--bootstrap-template", "my-template", "other-template" ] }
 


### PR DESCRIPTION
The bootstrap script is explicitly using /bin/sh.
On some solaris servers the version of /bin/sh exporting environment variables
using "export id=value" fails. The form "id=value export id" does work.
Bootstrap fails when the wrong form is used.

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>