### PR TITLE
Target mode for systemd service helper

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -17,7 +17,6 @@
 
 require "mixlib/shellout" unless defined?(Mixlib::ShellOut::DEFAULT_READ_TIMEOUT)
 require_relative "path_sanity"
-require "shellwords" unless defined?(Shellwords)
 
 class Chef
   module Mixin
@@ -160,7 +159,7 @@ class Chef
 
       def self.shell_out_command(*args, **options)
         if Chef::Config.target_mode?
-          FakeShellOut.new(args, options, transport_connection.run_command(Shellwords.join(" "))) # FIXME: train should accept run_command(*args)
+          FakeShellOut.new(args, options, transport_connection.run_command(args.join(" "))) # FIXME: train should accept run_command(*args)
         else
           cmd = if options.empty?
                   Mixlib::ShellOut.new(*args)

--- a/lib/chef/mixin/train_helpers.rb
+++ b/lib/chef/mixin/train_helpers.rb
@@ -1,0 +1,44 @@
+#--
+# Author:: Lamont Granquist <lamont@chef.io>
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "stringio" unless defined?(StringIO)
+
+class Chef
+  module Mixin
+    module TrainHelpers
+      def file_exist?(*args)
+        if Chef::Config.target_mode?
+          Chef.run_context.transport_connection.file(args[0]).exist?
+        else
+          File.exist?(*args)
+        end
+      end
+
+      # XXX: modifications to the StringIO won't get written back
+      def file_open(*args, &block)
+        if Chef::Config.target_mode?
+          content = Chef.run_context.transport_connection.file(args[0]).content
+          string_io = StringIO.new content
+          yield string_io if block_given?
+          string_io
+        else
+          File.open(*args, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/chef/mixin/train_helpers.rb
+++ b/lib/chef/mixin/train_helpers.rb
@@ -1,6 +1,6 @@
 #--
 # Author:: Lamont Granquist <lamont@chef.io>
-# Copyright:: Copyright 2010-2018, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,15 +20,31 @@ require "stringio" unless defined?(StringIO)
 class Chef
   module Mixin
     module TrainHelpers
-      def file_exist?(*args)
+
+      #
+      # FIXME: generally these helpers all use the pattern of checking for target_mode?
+      # and then if it is we use train.  That approach should likely be flipped so that
+      # even when we're running without target mode we still use inspec in its local
+      # mode.
+      #
+
+      # Train wrapper around File.exist? to make it local mode aware.
+      #
+      # @param filename filename to check
+      # @return [Boolean] if it exists
+      #
+      def file_exist?(filename)
         if Chef::Config.target_mode?
-          Chef.run_context.transport_connection.file(args[0]).exist?
+          Chef.run_context.transport_connection.file(filename).exist?
         else
-          File.exist?(*args)
+          File.exist?(filename)
         end
       end
 
       # XXX: modifications to the StringIO won't get written back
+      # FIXME: this is very experimental and may be a bad idea and may break at any time
+      # @api private
+      #
       def file_open(*args, &block)
         if Chef::Config.target_mode?
           content = Chef.run_context.transport_connection.file(args[0]).content

--- a/lib/chef/node_map.rb
+++ b/lib/chef/node_map.rb
@@ -287,8 +287,6 @@ class Chef
     # "provides" lines with identical filters sort by class name (ascending).
     #
     def compare_matchers(key, new_matcher, matcher)
-      cmp = compare_matcher_properties(new_matcher[:target_mode], matcher[:target_mode])
-      return cmp if cmp != 0
       cmp = compare_matcher_properties(new_matcher[:block], matcher[:block])
       return cmp if cmp != 0
       cmp = compare_matcher_properties(new_matcher[:platform_version], matcher[:platform_version])

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -26,7 +26,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   include Chef::Mixin::Which
 
-  provides :service, os: "linux" do |node|
+  provides :service, os: "linux", target_mode: true do |node|
     Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
   end
 
@@ -77,6 +77,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
   def get_systemctl_options_args
     if new_resource.user
+      raise NotImplementedError, "#{new_resource} does not support the user property on a target_mode host (yet)" if Chef::Config.target_mode?
       uid = Etc.getpwnam(new_resource.user).uid
       options = {
         environment: {

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -24,6 +24,7 @@ require_relative "../dist"
 class Chef
   class Resource
     class Service < Chef::Resource
+      provides :service, target_mode: true
       identity_attr :service_name
 
       description "Use the service resource to manage a service."


### PR DESCRIPTION
Makes it so that local cookbook can bounce a remote service over
train/ssh/whatever.  Works at least for ubuntu.

Introduces a fairly rudimentary TrainHelpers class, using some
inspiration from ohbye.
