### PR TITLE
Pin ruby_prof to < 0.18 to prevent appveyor failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 
 # Everything except AIX
 group(:ruby_prof) do
-  gem "ruby-prof"
+  gem "ruby-prof", "< 0.18.0" # 0.18 breaks appveyor tests
 end
 
 # Everything except AIX and Windows

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,8 +255,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-prof (0.18.0)
-    ruby-prof (0.18.0-x64-mingw32)
+    ruby-prof (0.17.0)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyzip (1.2.3)
@@ -370,7 +369,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake (<= 12.3.0)
   rb-readline
-  ruby-prof
+  ruby-prof (< 0.18.0)
   ruby-shadow
   simplecov
   webmock


### PR DESCRIPTION
The gem isn't loading correctly on the windows hosts.

Signed-off-by: Tim Smith <tsmith@chef.io>