### PR TITLE
Raise knife exceptions when verbosity is 3 (-VVV)

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -474,7 +474,7 @@ class Chef
         run
       end
     rescue Exception => e
-      raise if raise_exception || Chef::Config[:verbosity] == 2
+      raise if raise_exception || ( Chef::Config[:verbosity] && Chef::Config[:verbosity] >= 2 )
       humanize_exception(e)
       exit 100
     end

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -372,11 +372,14 @@ describe Chef::Knife do
         end
       end
 
-      it "does not humanize the exception if Chef::Config[:verbosity] is two" do
-        Chef::Config[:verbosity] = 2
-        allow(knife).to receive(:run).and_raise(Exception)
-        expect(knife).not_to receive(:humanize_exception)
-        expect { knife.run_with_pretty_exceptions }.to raise_error(Exception)
+      # -VV (2) is debug, -VVV (3) is trace
+      [ 2, 3 ].each do |verbosity|
+        it "does not humanize the exception if Chef::Config[:verbosity] is #{verbosity}" do
+          Chef::Config[:verbosity] = verbosity
+          allow(knife).to receive(:run).and_raise(Exception)
+          expect(knife).not_to receive(:humanize_exception)
+          expect { knife.run_with_pretty_exceptions }.to raise_error(Exception)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #8433

When we added trace this check wasn't changed, which means you only saw
the stacktrace for 2 (-VV) but not for 3 (-VVV)