### PR TITLE
Trace output the actual bootstrap template filename

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -495,7 +495,7 @@ class Chef
           raise Errno::ENOENT
         end
 
-        Chef::Log.trace("Found bootstrap template in #{File.dirname(template_file)}")
+        Chef::Log.trace("Found bootstrap template: #{template_file}")
 
         template_file
       end


### PR DESCRIPTION
We're currently logging the directory we found the bootstrap template
in, but not actually the name of the file that we've chose. Minor change
to fix that.