### PR TITLE
Print warning for platform detection error

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -621,6 +621,9 @@ class Chef
           # FIXME: this should save the key to known_hosts but doesn't appear to be
           config[:ssh_verify_host_key] = :accept_new
           do_connect(connection_opts(reset: true))
+        elsif e.message == "Sorry, we are unable to detect your platform" # Train::PlatformDetectionFailed
+          ui.warn("Could not connect with 'root'. Please provide valid user_name")
+          exit
         elsif ssh? && e.cause && e.cause.class == Net::SSH::AuthenticationFailed
           if connection.password_auth?
             raise


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

Print warning for platform detection error if user is not provided.

## Description
Handles `Train::PlatformDetectionFailed` error

## Related Issue
fixes https://github.com/chef/chef/issues/8550

## Output
```
INFO: Using configuration from E:/Backup/Project/chef-starter/chef-repo/.chef/knife.rb
Connecting to 34.219.121.27
WARN: [SSH] PTY requested: stderr will be merged into stdout
WARNING: Could not connect with 'root'. Please provide valid user_name
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
