### PR TITLE
more distro constants

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -331,7 +331,7 @@ class Chef
             " finishing converge to exit normally (send SIGINT to terminate immediately)")
         end
 
-        client_solo = chef_config[:solo] ? "chef-solo" : "#{Chef::Dist::CLIENT}"
+        client_solo = chef_config[:solo] ? "#{Chef::Dist::SOLOEXEC}" : "#{Chef::Dist::CLIENT}"
         $0 = "#{client_solo} worker: ppid=#{Process.ppid};start=#{Time.new.strftime("%R:%S")};"
         begin
           logger.trace "Forked instance now converging"

--- a/lib/chef/application/client.rb
+++ b/lib/chef/application/client.rb
@@ -352,7 +352,7 @@ class Chef::Application::Client < Chef::Application
         tarball_path = File.join(Chef::Config.chef_repo_path, "recipes.tgz")
         fetch_recipe_tarball(Chef::Config[:recipe_url], tarball_path)
         Mixlib::Archive.new(tarball_path).extract(Chef::Config.chef_repo_path, perms: false, ignore: /^\.$/)
-        config_path = File.join(Chef::Config.chef_repo_path, ".chef/config.rb")
+        config_path = File.join(Chef::Config.chef_repo_path, "#{Chef::Dist::USER_CONF_DIR}/config.rb")
         Chef::Config.from_string(IO.read(config_path), config_path) if File.file?(config_path)
       end
     end
@@ -395,7 +395,7 @@ class Chef::Application::Client < Chef::Application
       if config[:local_mode]
         config[:config_file] = Chef::WorkstationConfigLoader.new(nil, Chef::Log).config_location
       else
-        config[:config_file] = Chef::Config.platform_specific_path("/etc/chef/client.rb")
+        config[:config_file] = Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/client.rb")
       end
     end
 

--- a/lib/chef/application/solo.rb
+++ b/lib/chef/application/solo.rb
@@ -40,7 +40,7 @@ class Chef::Application::Solo < Chef::Application
   option :config_file,
     short: "-c CONFIG",
     long: "--config CONFIG",
-    default: Chef::Config.platform_specific_path("/etc/chef/solo.rb"),
+    default: Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/solo.rb"),
     description: "The configuration file to use."
 
   option :config_option,

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -30,5 +30,21 @@ class Chef
 
     # The chef-solo executable (legacy local mode)
     SOLOEXEC = "chef-solo".freeze
+
+    # The chef-shell executable
+    SHELL = "chef-shell".freeze
+
+    # Configuration related constants
+    # The chef-shell configuration file
+    SHELL_CONF = "chef_shell.rb".freeze
+
+    # The configuration directory
+    CONF_DIR = "/etc/#{Chef::Dist::EXEC}".freeze
+
+    # The user's configuration directory
+    USER_CONF_DIR = ".chef".freeze
+
+    # The server's configuration directory
+    SERVER_CONF_DIR = "/etc/chef-server".freeze
   end
 end

--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -20,6 +20,7 @@ require_relative "config"
 require_relative "data_bag_item"
 require_relative "encrypted_data_bag_item/decryptor"
 require_relative "encrypted_data_bag_item/encryptor"
+require_relative "dist"
 require "open-uri"
 
 # An EncryptedDataBagItem represents a read-only data bag item where
@@ -130,7 +131,7 @@ class Chef::EncryptedDataBagItem
   def self.load_secret(path = nil)
     path ||= Chef::Config[:encrypted_data_bag_secret]
     if !path
-      raise ArgumentError, "No secret specified and no secret found at #{Chef::Config.platform_specific_path('/etc/chef/encrypted_data_bag_secret')}"
+      raise ArgumentError, "No secret specified and no secret found at #{Chef::Config.platform_specific_path(Chef::Dist::CONF_DIR + '/encrypted_data_bag_secret')}"
     end
     secret = case path
              when /^\w+:\/\//

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -186,55 +186,55 @@ if test "x$tmp_dir" != "x"; then
   rm -r "$tmp_dir"
 fi
 
-mkdir -p /etc/chef
+mkdir -p <%= Chef::Dist::CONF_DIR %>
 
 <% if client_pem -%>
-cat > /etc/chef/client.pem <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/client.pem <<'EOP'
 <%= ::File.read(::File.expand_path(client_pem)) %>
 EOP
-chmod 0600 /etc/chef/client.pem
+chmod 0600 <%= Chef::Dist::CONF_DIR %>/client.pem
 <% end -%>
 
 <% if validation_key -%>
-cat > /etc/chef/validation.pem <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
-chmod 0600 /etc/chef/validation.pem
+chmod 0600 <%= Chef::Dist::CONF_DIR %>/validation.pem
 <% end -%>
 
 <% if encrypted_data_bag_secret -%>
-cat > /etc/chef/encrypted_data_bag_secret <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
-chmod 0600 /etc/chef/encrypted_data_bag_secret
+chmod 0600 <%= Chef::Dist::CONF_DIR %>/encrypted_data_bag_secret
 <% end -%>
 
 <% unless trusted_certs.empty? -%>
-mkdir -p /etc/chef/trusted_certs
+mkdir -p <%= Chef::Dist::CONF_DIR %>/trusted_certs
 <%= trusted_certs %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>
 <% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
-mkdir -p /etc/chef/ohai/hints
+mkdir -p <%= Chef::Dist::CONF_DIR %>/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/ohai/hints/<%= name %>.json <<'EOP'
 <%= Chef::JSONCompat.to_json(hash) %>
 EOP
 <% end -%>
 <% end -%>
 
-cat > /etc/chef/client.rb <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/client.rb <<'EOP'
 <%= config_content %>
 EOP
 
-cat > /etc/chef/first-boot.json <<'EOP'
+cat > <%= Chef::Dist::CONF_DIR %>/first-boot.json <<'EOP'
 <%= Chef::JSONCompat.to_json(first_boot) %>
 EOP
 
 <% unless client_d.empty? -%>
-mkdir -p /etc/chef/client.d
+mkdir -p <%= Chef::Dist::CONF_DIR %>/client.d
 <%= client_d %>
 <% end -%>
 

--- a/lib/chef/knife/configure.rb
+++ b/lib/chef/knife/configure.rb
@@ -18,6 +18,7 @@
 
 require_relative "../knife"
 require_relative "../util/path_helper"
+require_relative "../dist"
 
 class Chef
   class Knife
@@ -116,7 +117,7 @@ class Chef
         if config[:initial]
           @new_client_name        = config[:node_name] || ask_question("Please enter a name for the new user: ", default: Etc.getlogin)
           @admin_client_name      = config[:admin_client_name] || ask_question("Please enter the existing admin name: ", default: "admin")
-          @admin_client_key       = config[:admin_client_key] || ask_question("Please enter the location of the existing admin's private key: ", default: "/etc/chef-server/admin.pem")
+          @admin_client_key       = config[:admin_client_key] || ask_question("Please enter the location of the existing admin's private key: ", default: "#{Chef::Dist::SERVER_CONF_DIR}/admin.pem")
           @admin_client_key       = File.expand_path(@admin_client_key)
         else
           @new_client_name        = config[:node_name] || ask_question("Please enter an existing username or clientname for the API: ", default: Etc.getlogin)

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -158,11 +158,11 @@ class Chef
           end
 
           if encrypted_data_bag_secret
-            client_rb << %Q{encrypted_data_bag_secret "/etc/chef/encrypted_data_bag_secret"\n}
+            client_rb << %Q{encrypted_data_bag_secret "#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret"\n}
           end
 
           unless trusted_certs.empty?
-            client_rb << %Q{trusted_certs_dir "/etc/chef/trusted_certs"\n}
+            client_rb << %Q{trusted_certs_dir "#{Chef::Dist::CONF_DIR}/trusted_certs"\n}
           end
 
           if Chef::Config[:fips]
@@ -175,7 +175,7 @@ class Chef
         def start_chef
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
           client_path = @chef_config[:chef_client_path] || "#{Chef::Dist::CLIENT}"
-          s = "#{client_path} -j /etc/chef/first-boot.json"
+          s = "#{client_path} -j #{Chef::Dist::CONF_DIR}/first-boot.json"
           if @config[:verbosity] && @config[:verbosity] >= 3
             s << " -l trace"
           elsif @config[:verbosity] && @config[:verbosity] >= 2
@@ -226,7 +226,7 @@ class Chef
           content = ""
           if @chef_config[:trusted_certs_dir]
             Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
-              content << "cat > /etc/chef/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
+              content << "cat > #{Chef::Dist::CONF_DIR}/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
                 IO.read(File.expand_path(cert)) + "\nEOP\n"
             end
           end
@@ -240,7 +240,7 @@ class Chef
             root.find do |f|
               relative = f.relative_path_from(root)
               if f != root
-                file_on_node = "/etc/chef/client.d/#{relative}"
+                file_on_node = "#{Chef::Dist::CONF_DIR}/client.d/#{relative}"
                 if f.directory?
                   content << "mkdir #{file_on_node}\n"
                 else

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -25,7 +25,7 @@ class Chef
       provides :breakpoint, target_mode: true
       resource_name :breakpoint
 
-      description "Use the breakpoint resource to add breakpoints to recipes. Run the chef-shell in #{Chef::Dist::CLIENT} mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the #{Chef::Dist::CLIENT} during an actual #{Chef::Dist::CLIENT} run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."
+      description "Use the breakpoint resource to add breakpoints to recipes. Run the #{Chef::Dist::SHELL} in #{Chef::Dist::CLIENT} mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the #{Chef::Dist::CLIENT} during an actual #{Chef::Dist::CLIENT} run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."
       introduced "12.0"
 
       default_action :break

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -206,17 +206,17 @@ module Shell
       @footer
     end
 
-    banner("chef-shell #{Chef::VERSION}\n\nUsage: chef-shell [NAMED_CONF] (OPTIONS)")
+    banner("#{Chef::Dist::SHELL} #{Chef::VERSION}\n\nUsage: #{Chef::Dist::SHELL} [NAMED_CONF] (OPTIONS)")
 
     footer(<<~FOOTER)
-      When no CONFIG is specified, chef-shell attempts to load a default configuration file:
-      * If a NAMED_CONF is given, chef-shell will load ~/.chef/NAMED_CONF/chef_shell.rb
-      * If no NAMED_CONF is given chef-shell will load ~/.chef/chef_shell.rb if it exists
-      * If no chef_shell.rb can be found, chef-shell falls back to load:
-            /etc/chef/client.rb if -z option is given.
-            /etc/chef/solo.rb   if --solo-legacy-mode option is given.
-            .chef/config.rb     if -s option is given.
-            .chef/knife.rb      if -s option is given.
+      When no CONFIG is specified, #{Chef::Dist::SHELL} attempts to load a default configuration file:
+      * If a NAMED_CONF is given, #{Chef::Dist::SHELL} will load ~/#{Chef::Dist::USER_CONF_DIR}/NAMED_CONF/#{Chef::Dist::SHELL_CONF}
+      * If no NAMED_CONF is given #{Chef::Dist::SHELL} will load ~/#{Chef::Dist::USER_CONF_DIR}/#{Chef::Dist::SHELL_CONF} if it exists
+      * If no #{Chef::Dist::SHELL_CONF} can be found, #{Chef::Dist::SHELL} falls back to load:
+            #{Chef::Dist::CONF_DIR}/client.rb if -z option is given.
+            #{Chef::Dist::CONF_DIR}/solo.rb   if --solo-legacy-mode option is given.
+            #{Chef::Dist::USER_CONF_DIR}/config.rb     if -s option is given.
+            #{Chef::Dist::USER_CONF_DIR}/knife.rb      if -s option is given.
     FOOTER
 
     option :config_file,
@@ -330,18 +330,18 @@ module Shell
         config[:config_file]
       elsif environment
         Shell.env = environment
-        config_file_to_try = ::File.join(dot_chef_dir, environment, "chef_shell.rb")
+        config_file_to_try = ::File.join(dot_chef_dir, environment, Chef::Dist::SHELL_CONF)
         unless ::File.exist?(config_file_to_try)
-          puts "could not find chef-shell config for environment #{environment} at #{config_file_to_try}"
+          puts "could not find #{Chef::Dist::SHELL} config for environment #{environment} at #{config_file_to_try}"
           exit 1
         end
         config_file_to_try
-      elsif dot_chef_dir && ::File.exist?(File.join(dot_chef_dir, "chef_shell.rb"))
-        File.join(dot_chef_dir, "chef_shell.rb")
+      elsif dot_chef_dir && ::File.exist?(File.join(dot_chef_dir, Chef::Dist::SHELL_CONF))
+        File.join(dot_chef_dir, Chef::Dist::SHELL_CONF)
       elsif config[:solo_legacy_shell]
-        Chef::Config.platform_specific_path("/etc/chef/solo.rb")
+        Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/solo.rb")
       elsif config[:client]
-        Chef::Config.platform_specific_path("/etc/chef/client.rb")
+        Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/client.rb")
       elsif config[:solo_shell]
         Chef::WorkstationConfigLoader.new(nil, Chef::Log).config_location
       else

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -69,7 +69,7 @@ module Shell
       def help_banner
         banner = []
         banner << ""
-        banner << "chef-shell Help"
+        banner << "#{Chef::Dist::SHELL} Help"
         banner << "".ljust(80, "=")
         banner << "| " + "Command".ljust(25) + "| " + "Description"
         banner << "".ljust(80, "=")
@@ -194,7 +194,7 @@ module Shell
       explain(<<~E)
         ## SUMMARY ##
           When called with no argument, +help+ prints a table of all
-          chef-shell commands. When called with an argument COMMAND, +help+
+          #{Chef::Dist::SHELL} commands. When called with an argument COMMAND, +help+
           prints a detailed explanation of the command if available, or the
           description if no explanation is available.
       E
@@ -210,7 +210,7 @@ module Shell
 
       desc "prints information about chef"
       def version
-        puts "This is the chef-shell.\n" +
+        puts "This is the #{Chef::Dist::SHELL}.\n" +
           " Chef Version: #{::Chef::VERSION}\n" +
           " https://www.chef.io/\n" +
           " https://docs.chef.io/"
@@ -311,9 +311,9 @@ module Shell
               new_node = edit(existing_node)
 
         ## EDITOR SELECTION ##
-          chef-shell looks for an editor using the following logic
+          #{Chef::Dist::SHELL} looks for an editor using the following logic
           1. Looks for an EDITOR set by Shell.editor = "EDITOR"
-          2. Looks for an EDITOR configured in your chef-shell config file
+          2. Looks for an EDITOR configured in your #{Chef::Dist::SHELL} config file
           3. Uses the value of the EDITOR environment variable
       E
       def edit(object)
@@ -322,7 +322,7 @@ module Shell
           return :failburger
         end
 
-        filename = "chef-shell-edit-#{object.class.name}-"
+        filename = "#{Chef::Dist::SHELL}-edit-#{object.class.name}-"
         if object.respond_to?(:name)
           filename += object.name
         elsif object.respond_to?(:id)

--- a/lib/chef/shell/shell_session.rb
+++ b/lib/chef/shell/shell_session.rb
@@ -28,6 +28,7 @@ require_relative "../run_list/run_list_expansion"
 require_relative "../formatters/base"
 require_relative "../formatters/doc"
 require_relative "../formatters/minimal"
+require_relative "../dist"
 
 module Shell
   class ShellSession
@@ -87,7 +88,7 @@ module Shell
     end
 
     def save_node
-      raise "Not Supported! #{self.class.name} doesn't support #save_node, maybe you need to run chef-shell in client mode?"
+      raise "Not Supported! #{self.class.name} doesn't support #save_node, maybe you need to run #{Chef::Dist::SHELL} in client mode?"
     end
 
     def rebuild_context

--- a/lib/chef/train_transport.rb
+++ b/lib/chef/train_transport.rb
@@ -17,6 +17,7 @@
 
 require "chef-config/mixin/credentials"
 require "train"
+require_relative "dist"
 
 class Chef
   class TrainTransport
@@ -76,8 +77,8 @@ class Chef
       credentials_file =
         if tm_config.credentials_file && File.exist?(tm_config.credentials_file)
           tm_config.credentials_file
-        elsif File.exist?(Chef::Config.platform_specific_path("/etc/chef/#{profile}/credentials"))
-          Chef::Config.platform_specific_path("/etc/chef/#{profile}/credentials")
+        elsif File.exist?(Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/#{profile}/credentials"))
+          Chef::Config.platform_specific_path("#{Chef::Dist::CONF_DIR}/#{profile}/credentials")
         else
           super
         end

--- a/spec/integration/client/exit_code_spec.rb
+++ b/spec/integration/client/exit_code_spec.rb
@@ -21,7 +21,7 @@ describe "chef-client" do
   # machine that has omnibus chef installed. In that case we need to ensure
   # we're running `chef-client` from the source tree and not the external one.
   # cf. CHEF-4914
-  let(:chef_client) { "bundle exec chef-client --no-fork --minimal-ohai" }
+  let(:chef_client) { "bundle exec #{Chef::Dist::CLIENT} --no-fork --minimal-ohai" }
 
   let(:critical_env_vars) { %w{PATH RUBYOPT BUNDLE_GEMFILE GEM_PATH}.map { |o| "#{o}=#{ENV[o]}" } .join(" ") }
 


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <mchamberland@pbsc.com>

Another batch of distro constant changes. Mostly `chef-shell` and `/etc/chef` related, plus a few missed references of other wordmarks.

## Description
This brings us a bit closer to easily configurable distribution names.

## Related Issue
https://github.com/chef/chef/issues/8376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
