### PR TITLE
Create bootstrap template in binmode to fix line endings

### DIFF
--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -148,6 +148,7 @@ class Chef
         # @return NilClass
         def upload_file_content!(content, remote_path)
           t = Tempfile.new("chef-content")
+          t.binmode
           t << content
           t.close
           upload_file!(t.path, remote_path)

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -171,6 +171,7 @@ describe Chef::Knife::Bootstrap::TrainConnector do
         expect(File.read(local_path)).to eq "test data"
         expect(remote_path).to eq "/target/path"
       end
+      expect_any_instance_of(Tempfile).to receive(:binmode)
       subject.upload_file_content!("test data", "/target/path")
     end
   end


### PR DESCRIPTION
Tempfile will create a file with CRLF on Windows, which when we upload to a
linux system then cannot be executed because of the line endings. Setting to
binmode prevents this.

Fixes chef/knife-ec2#580