### PR TITLE
chocolatey_source: Add additional actions and propereties for configuring sources

### DIFF
--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -17,6 +17,7 @@
 class Chef
   class Resource
     class ChocolateySource < Chef::Resource
+      preview_resource true
       resource_name :chocolatey_source
 
       description "Use the chocolatey_source resource to add or remove Chocolatey sources."
@@ -31,8 +32,16 @@ class Chef
       property :bypass_proxy, [TrueClass, FalseClass], default: false,
                description: "Whether or not to bypass the system's proxy settings to access the source."
 
+      property :admin_only, [TrueClass, FalseClass], default: false,
+               description: "Whether or not to set the source to be accessible to only admins."
+
+      property :allow_self_service, [TrueClass, FalseClass], default: false,
+               description: "Whether or not to set the source to be used for self service."
+
       property :priority, Integer, default: 0,
                description: "The priority level of the source."
+
+      property :source_state, [TrueClass, FalseClass], default: false, desired_state: false, skip_docs: true
 
       load_current_value do
         element = fetch_source_element(source_name)
@@ -41,13 +50,16 @@ class Chef
         source_name element["id"]
         source element["value"]
         bypass_proxy element["bypassProxy"] == "true"
+        admin_only element["adminOnly"] == "true"
+        allow_self_service element["selfService"] == "true"
         priority element["priority"].to_i
+        source_state element["disabled"] == "true"
       end
 
       # @param [String] id the source name
       # @return [REXML::Attributes] finds the source element with the
       def fetch_source_element(id)
-        require "rexml/document" unless defined?(REXML::Document)
+        require "rexml/document"
 
         config_file = "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\config\\chocolatey.config"
         raise "Could not find the Chocolatey config at #{config_file}!" unless ::File.exist?(config_file)
@@ -77,6 +89,26 @@ class Chef
         end
       end
 
+      action :disable do
+        description "Disables a Chocolatey source."
+
+        if current_resource.source_state != true
+          converge_by("disable Chocolatey source '#{new_resource.source_name}'") do
+            shell_out!(choco_cmd("disable"))
+          end
+        end
+      end
+
+      action :enable do
+        description "Enables a Chocolatey source."
+
+        if current_resource.source_state == true
+          converge_by("enable Chocolatey source '#{new_resource.source_name}'") do
+            shell_out!(choco_cmd("enable"))
+          end
+        end
+      end
+
       action_class do
         # @param [String] action the name of the action to perform
         # @return [String] the choco source command string
@@ -85,6 +117,8 @@ class Chef
           if action == "add"
             cmd << " -s #{new_resource.source} --priority=#{new_resource.priority}"
             cmd << " --bypassproxy" if new_resource.bypass_proxy
+            cmd << " --allowselfservice" if new_resource.allow_self_service
+            cmd << " --adminonly" if new_resource.admin_only
           end
           cmd
         end

--- a/spec/unit/resource/chocolatey_source_spec.rb
+++ b/spec/unit/resource/chocolatey_source_spec.rb
@@ -97,22 +97,22 @@ describe Chef::Resource::ChocolateySource do
   end
 
   describe "#load_current_resource" do
-    it "sets the source_state to true when the XML disabled property is true" do
+    it "sets disabled to true when the XML disabled property is true" do
       allow(current_resource).to receive(:fetch_source_element).with("fakey_fakerton").and_return(OpenStruct.new(disabled: "true"))
       disable_provider.load_current_resource
-      expect(current_resource.source_state).to be true
+      expect(current_resource.disabled).to be true
     end
 
-    it "sets the source_state to false when the XML disabled property is false" do
+    it "sets disabled to false when the XML disabled property is false" do
       allow(current_resource).to receive(:fetch_source_element).with("fakey_fakerton").and_return(OpenStruct.new(disabled: "false"))
       enable_provider.load_current_resource
-      expect(current_resource.source_state).to be false
+      expect(current_resource.disabled).to be false
     end
   end
 
   describe "run_action(:enable)" do
     it "when source is disabled, it enables it correctly" do
-      resource.source_state true
+      resource.disabled true
       allow(current_resource).to receive(:fetch_source_element).with("fakey_fakerton").and_return(OpenStruct.new(disabled: "true"))
       expect(enable_provider).to receive(:shell_out!).with("C:\\ProgramData\\chocolatey\\bin\\choco source enable -n \"fakey_fakerton\"")
       resource.run_action(:enable)
@@ -120,7 +120,7 @@ describe Chef::Resource::ChocolateySource do
     end
 
     it "when source is enabled, it is idempotent when trying to enable" do
-      resource.source_state false
+      resource.disabled false
       allow(current_resource).to receive(:fetch_source_element).with("fakey_fakerton").and_return(OpenStruct.new(disabled: "false"))
       resource.run_action(:enable)
       expect(resource.updated_by_last_action?).to be false


### PR DESCRIPTION
## Description
This provides the ability to set additional properties for a Chocolatey
source with properties `admin_only` and `allow_self_service`.  As well
as the ability to enable/disable a source.

## Related Issue

https://github.com/chef/chef/issues/8634

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
