### PR TITLE
Speed up buildkite tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -13,7 +13,7 @@ steps:
 - label: "Integration Specs :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - cd /workdir; bundle install --without docgen integration omnibus_package --frozen --path vendor/bundle
+    - cd /workdir; bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -22,13 +22,12 @@ steps:
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
-          - INTEGRATION_SPECS_26=1
           - BUNDLE_GEMFILE=/workdir/Gemfile
 
 - label: "Functional Specs :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - cd /workdir; bundle install --without docgen integration omnibus_package --frozen --path vendor/bundle
+    - cd /workdir; bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -37,10 +36,67 @@ steps:
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
-          - FUNCTIONAL_SPECS_26=1
 
 - label: "Unit Specs :ruby: 2.6"
   commands:
+    - /workdir/scripts/bk_tests/bk_install.sh
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
+    - bundle exec rake spec:unit
+    - bundle exec rake component_specs
+  expeditor:
+    executor:
+      docker:
+        environment:
+          - FORCE_FFI_YAJL=ext
+          - CHEF_LICENSE=accept-no-persist
+
+- label: "Chefstyle :ruby: 2.6"
+  commands:
+    - /workdir/scripts/bk_tests/bk_install.sh
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
+    - bundle exec rake style
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.6-stretch
+
+#########################################################################
+  # Tests Ruby 2.5
+#########################################################################
+
+- label: "Integration Specs :ruby: 2.5"
+  commands:
+    - /workdir/scripts/bk_tests/bk_install.sh
+    - asdf local ruby 2.5.5
+    - bundle install --without docgen integration omnibus_package --frozen
+    - bundle exec rake spec:integration
+  expeditor:
+    executor:
+      docker:
+        privileged: true
+        environment:
+          - FORCE_FFI_YAJL=ext
+          - CHEF_LICENSE=accept-no-persist
+          - INTEGRATION_SPECS_25=1
+#
+- label: "Functional Specs :ruby: 2.5"
+  commands:
+    - asdf local ruby 2.5.5
+    - /workdir/scripts/bk_tests/bk_install.sh
+    - bundle install --without docgen integration omnibus_package --frozen
+    - bundle exec rake spec:functional
+  expeditor:
+    executor:
+      docker:
+        privileged: true
+        environment:
+          - FORCE_FFI_YAJL=ext
+          - CHEF_LICENSE=accept-no-persist
+          - FUNCTIONAL_SPECS_25=1
+
+- label: "Unit Specs :ruby: 2.5"
+  commands:
+    - asdf local ruby 2.5.5
     - /workdir/scripts/bk_tests/bk_install.sh
     - bundle install --without docgen integration omnibus_package --frozen
     - bundle exec rake spec:unit
@@ -51,18 +107,11 @@ steps:
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
-          - UNIT_SPECS_26=1
+          - UNIT_SPECS_25=1
 
-- label: "Chefstyle :ruby: 2.6"
-  commands:
-    - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
-    - bundle exec rake style
-  expeditor:
-    executor:
-      docker:
-        environment:
-          - CHEFSTYLE=1
+#########################################################################
+  # EXTERNAL GEM TESTING
+#########################################################################
 
 - label: "Test chef-sugar gem :ruby: 2.6"
   commands:
@@ -120,55 +169,6 @@ steps:
       docker:
         environment:
           - TEST_GEM=chef/knife-windows
-
-#########################################################################
-  # Tests Ruby 2.5
-#########################################################################
-
-- label: "Integration Specs :ruby: 2.5"
-  commands:
-    - /workdir/scripts/bk_tests/bk_install.sh
-    - asdf local ruby 2.5.5
-    - bundle install --without docgen integration omnibus_package --frozen
-    - bundle exec rake spec:integration
-  expeditor:
-    executor:
-      docker:
-        privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - INTEGRATION_SPECS_25=1
-#
-- label: "Functional Specs :ruby: 2.5"
-  commands:
-    - asdf local ruby 2.5.5
-    - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without docgen integration omnibus_package --frozen
-    - bundle exec rake spec:functional
-  expeditor:
-    executor:
-      docker:
-        privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - FUNCTIONAL_SPECS_25=1
-
-- label: "Unit Specs :ruby: 2.5"
-  commands:
-    - asdf local ruby 2.5.5
-    - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without docgen integration omnibus_package --frozen
-    - bundle exec rake spec:unit
-    - bundle exec rake component_specs
-  expeditor:
-    executor:
-      docker:
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - UNIT_SPECS_25=1
 
 #########################################################################
   # START TEST KITCHEN ONLY
@@ -350,7 +350,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Rspec Centos: 7 :ruby: 2.5"
+- label: "rspec on CentOS 7 :ruby: 2.5"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -363,10 +363,11 @@ steps:
   expeditor:
     executor:
       linux:
+        image: centos/ruby-25-centos7
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Rspec OPENSUSELEAP: 42 :ruby: 2.5"
+- label: "rspec on openSUSE Leap 42 :ruby: 2.5"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests


### PR DESCRIPTION
Use the minimal container for the chefstyle tests
Remove extra env vars that were for travis
Exclude gem groups we don't care about
Parallelize the bundler commands

Signed-off-by: Tim Smith <tsmith@chef.io>