### PR TITLE
use mixlib-cli's deprecation mechanism

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: c9f82052de99484c69fdc368a0c239d03eb4e6d2
+  revision: 80dc0f94064ece591fcb8c437aa1d60e2881ba10
   branch: master
   specs:
-    chefstyle (0.12.1)
+    chefstyle (0.12.3)
       rubocop (= 0.62.0)
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 3734d441498e51dd44cefc21d842232cd0b5a47d
+  revision: f04de72cd0a1b8636ca60c238930c4ed60187516
   branch: master
   specs:
-    ohai (15.0.36)
+    ohai (15.0.39)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -44,7 +44,7 @@ PATH
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
-      mixlib-cli (>= 1.7, < 3.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
@@ -75,7 +75,7 @@ PATH
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (~> 2.1)
-      mixlib-cli (>= 1.7, < 3.0)
+      mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 2.4, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
@@ -169,7 +169,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashdiff (0.3.9)
+    hashdiff (0.4.0)
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -220,12 +220,12 @@ GEM
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
-    mixlib-cli (2.0.6)
+    mixlib-cli (2.1.1)
     mixlib-config (3.0.1)
       tomlrb
     mixlib-log (3.0.1)
-    mixlib-shellout (2.4.4)
-    mixlib-shellout (2.4.4-universal-mingw32)
+    mixlib-shellout (3.0.4)
+    mixlib-shellout (3.0.4-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)
@@ -264,7 +264,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
@@ -296,8 +296,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
-    ruby-prof (0.17.0)
-    ruby-progressbar (1.10.0)
+    ruby-prof (0.18.0)
+    ruby-prof (0.18.0-x64-mingw32)
+    ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
     rubyzip (1.2.3)
@@ -322,7 +323,7 @@ GEM
       tins (~> 1.0)
     thor (0.20.3)
     timers (4.3.0)
-    tins (1.20.2)
+    tins (1.20.3)
     tomlrb (1.2.8)
     train-core (2.1.7)
       json (>= 1.8, < 3.0)
@@ -357,10 +358,10 @@ GEM
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
-    webmock (3.5.1)
+    webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     win32-api (1.5.3-universal-mingw32)
     win32-certstore (0.3.0)
       ffi
@@ -437,4 +438,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "train-core", "~> 2.0", ">= 2.0.12"
 
   s.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
-  s.add_dependency "mixlib-cli", ">= 1.7", "< 3.0"
+  s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", "~> 2.1"
   s.add_dependency "mixlib-shellout", ">= 2.4", "< 4.0"


### PR DESCRIPTION
## Description

Deprecation logic is now available in `mixlib-cli`
via `deprecated_option`.  Let's use that instead
of keeping our custom deprecation behavior.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] (na) I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
