### PR TITLE
More speedups to the Buildkite PR verification tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,6 +18,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
         privileged: true
         environment:
           - FORCE_FFI_YAJL=ext
@@ -32,6 +33,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
         privileged: true
         environment:
           - FORCE_FFI_YAJL=ext
@@ -46,6 +48,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
@@ -73,6 +76,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.5-stretch
         privileged: true
         environment:
           - FORCE_FFI_YAJL=ext
@@ -88,6 +92,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.5-stretch
         privileged: true
         environment:
           - FORCE_FFI_YAJL=ext
@@ -104,6 +109,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.5-stretch
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
@@ -121,6 +127,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
 
 - label: "Test chef-zero gem :ruby: 2.6"
   commands:
@@ -130,6 +137,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
         environment:
           - PEDANT_OPTS=--skip-oc_id
           - CHEF_FS=true
@@ -142,6 +150,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
 
 - label: "Test chefspec gem :ruby: 2.6"
   commands:
@@ -151,6 +160,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
 
 - label: "Test knife-windows gem :ruby: 2.6"
   commands:
@@ -160,6 +170,7 @@ steps:
   expeditor:
     executor:
       docker:
+        image: ruby:2.6-stretch
 
 #########################################################################
   # START TEST KITCHEN ONLY

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -70,7 +70,6 @@ steps:
 - label: "Integration Specs :ruby: 2.5"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - asdf local ruby 2.5.5
     - bundle install --without docgen integration omnibus_package --frozen
     - bundle exec rake spec:integration
   expeditor:
@@ -85,7 +84,6 @@ steps:
 #
 - label: "Functional Specs :ruby: 2.5"
   commands:
-    - asdf local ruby 2.5.5
     - /workdir/scripts/bk_tests/bk_install.sh
     - bundle install --without docgen integration omnibus_package --frozen
     - bundle exec rake spec:functional
@@ -101,7 +99,6 @@ steps:
 
 - label: "Unit Specs :ruby: 2.5"
   commands:
-    - asdf local ruby 2.5.5
     - /workdir/scripts/bk_tests/bk_install.sh
     - bundle install --without docgen integration omnibus_package --frozen
     - bundle exec rake spec:unit

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -121,8 +121,6 @@ steps:
   expeditor:
     executor:
       docker:
-        environment:
-          - TEST_GEM=sethvargo/chef-sugar
 
 - label: "Test chef-zero gem :ruby: 2.6"
   commands:
@@ -133,7 +131,6 @@ steps:
     executor:
       docker:
         environment:
-          - TEST_GEM=chef/chef-zero
           - PEDANT_OPTS=--skip-oc_id
           - CHEF_FS=true
 
@@ -145,8 +142,6 @@ steps:
   expeditor:
     executor:
       docker:
-        environment:
-          - TEST_GEM=chef/cheffish
 
 - label: "Test chefspec gem :ruby: 2.6"
   commands:
@@ -156,8 +151,6 @@ steps:
   expeditor:
     executor:
       docker:
-        environment:
-          - TEST_GEM=chefspec/chefspec
 
 - label: "Test knife-windows gem :ruby: 2.6"
   commands:
@@ -167,8 +160,6 @@ steps:
   expeditor:
     executor:
       docker:
-        environment:
-          - TEST_GEM=chef/knife-windows
 
 #########################################################################
   # START TEST KITCHEN ONLY

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -176,7 +176,7 @@ steps:
   # START TEST KITCHEN ONLY
 #########################################################################
 
-- label: "Kitchen Tests :amazon: 2 :ruby: 2.5"
+- label: "Kitchen Tests :amazon: 2"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -184,7 +184,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      AMAZON: "2"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -192,7 +191,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests :amazon: 201X :ruby: 2.5"
+- label: "Kitchen Tests :amazon: 201X"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -200,7 +199,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      AMAZON: 201X
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -208,7 +206,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Ubuntu: 16.04 :ruby: 2.5"
+- label: "Kitchen Tests Ubuntu: 16.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -224,7 +222,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Ubuntu: 18.04 :ruby: 2.5"
+- label: "Kitchen Tests Ubuntu: 18.04"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -232,7 +230,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      UBUNTU: "18.04"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -240,7 +237,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Debian: 8 :ruby: 2.5"
+- label: "Kitchen Tests Debian: 8"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -248,7 +245,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      DEBIAN: "8"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -256,7 +252,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Debian: 9 :ruby: 2.5"
+- label: "Kitchen Tests Debian: 9"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -264,7 +260,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      DEBIAN: "9"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -272,7 +267,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Debian: 10 :ruby: 2.5"
+- label: "Kitchen Tests Debian: 10"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -280,7 +275,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      DEBIAN: "10"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -288,7 +282,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Centos: 6 :ruby: 2.5"
+- label: "Kitchen Tests CentOS: 6"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -296,7 +290,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      CENTOS: "6"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -304,7 +297,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Centos: 7 :ruby: 2.5"
+- label: "Kitchen Tests CentOS: 7"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -312,7 +305,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      CENTOS: "7"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -320,7 +312,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Fedora: latest :ruby: 2.5"
+- label: "Kitchen Tests Fedora: latest"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -328,7 +320,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      FEDORA: "latest"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -336,7 +327,7 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests OPENSUSELEAP: 42 :ruby: 2.5"
+- label: "Kitchen Tests openSUSE Leap: 42"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
@@ -344,7 +335,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      OPENSUSELEAP: "42"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -360,7 +350,6 @@ steps:
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
-      RSPEC_CENTOS: "7"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:
@@ -377,7 +366,6 @@ steps:
   artifact_paths:
   - $PWD/.kitchen/logs/kitchen.log
   env:
-      RSPEC_OPENSUSELEAP: "42"
       KITCHEN_YAML: kitchen.yml
   expeditor:
     executor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -28,6 +28,7 @@ steps:
 - label: "Functional Specs :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
+    - apt-get install -y cron locales # needed for functional tests to pass
     - cd /workdir; bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
     - bundle exec rake spec:functional
   expeditor:
@@ -70,7 +71,7 @@ steps:
 - label: "Integration Specs :ruby: 2.5"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without docgen integration omnibus_package --frozen
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec rake spec:integration
   expeditor:
     executor:
@@ -85,7 +86,8 @@ steps:
 - label: "Functional Specs :ruby: 2.5"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without docgen integration omnibus_package --frozen
+    - apt-get install -y cron locales # needed for functional tests to pass
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec rake spec:functional
   expeditor:
     executor:
@@ -100,7 +102,7 @@ steps:
 - label: "Unit Specs :ruby: 2.5"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --without docgen integration omnibus_package --frozen
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec rake spec:unit
     - bundle exec rake component_specs
   expeditor:
@@ -119,7 +121,7 @@ steps:
 - label: "Test chef-sugar gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec tasks/bin/run_external_test sethvargo/chef-sugar master rake
   expeditor:
     executor:
@@ -129,7 +131,7 @@ steps:
 - label: "Test chef-zero gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec tasks/bin/run_external_test chef/chef-zero master rake pedant
   expeditor:
     executor:
@@ -142,7 +144,7 @@ steps:
 - label: "Test cheffish gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec tasks/bin/run_external_test chef/cheffish master rake spec
   expeditor:
     executor:
@@ -152,7 +154,7 @@ steps:
 - label: "Test chefspec gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec tasks/bin/run_external_test chefspec/chefspec master rake
   expeditor:
     executor:
@@ -162,7 +164,7 @@ steps:
 - label: "Test knife-windows gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec tasks/bin/run_external_test chef/knife-windows master rake unit_spec
   expeditor:
     executor:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -122,7 +122,7 @@ steps:
 - label: "Test chef-sugar gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test sethvargo/chef-sugar master rake
   expeditor:
     executor:
@@ -132,7 +132,7 @@ steps:
 - label: "Test chef-zero gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/chef-zero master rake pedant
   expeditor:
     executor:
@@ -145,7 +145,7 @@ steps:
 - label: "Test cheffish gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/cheffish master rake spec
   expeditor:
     executor:
@@ -155,7 +155,7 @@ steps:
 - label: "Test chefspec gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chefspec/chefspec master rake
   expeditor:
     executor:
@@ -165,7 +165,7 @@ steps:
 - label: "Test knife-windows gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_install.sh
-    - bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+    - bundle install --jobs=3 --retry=3
     - bundle exec tasks/bin/run_external_test chef/knife-windows master rake unit_spec
   expeditor:
     executor:

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
 
+# This script helps to test external gems in the content of the current
+# Chef install. We want to make sure that the external gems will still function
+# once we release Chef so we run *their* specs against the current contents
+# of the chef / ohai repos. It let's us know if we need to update downstream
+# gems or fix regressions in chef *before* we release.
+
 $:.unshift(File.expand_path("../../lib", File.dirname(__FILE__)))
 
 require "tmpdir"


### PR DESCRIPTION
Switch more things over to the ruby containers which pull a minute faster
Remove more env vars that we used for naming in Travis
Simplify our bundler commands
Remove the Ruby version from the dokken commands since this will change any time the default ruby changes.