### PR TITLE
Update the changelog to not mention Rubygems

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -53,7 +53,7 @@ github:
         version_constraint: 14*
 
 changelog:
-  rollup_header: Changes not yet released to rubygems.org
+  rollup_header: Changes not yet released to stable
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:


### PR DESCRIPTION
Released to stable is what we care about not Rubygems

Signed-off-by: Tim Smith <tsmith@chef.io>