### PR TITLE
Parse YAML recipes

### DIFF
--- a/lib/chef/mixin/from_file.rb
+++ b/lib/chef/mixin/from_file.rb
@@ -37,23 +37,6 @@ class Chef
         end
       end
 
-      # This will return an array of hashes or something that then needs to get inflated.
-      def from_yaml_file(filename)
-        self.source_file = filename
-        if File.file?(filename) && File.readable?(filename)
-          res = ::YAML.safe_load(IO.read(filename))
-          if res.is_a?(Hash)
-            from_hash(res)
-          elsif res.is_a?(Array)
-            from_array(res)
-          else
-            raise "boom"
-          end
-        else
-          raise IOError, "Cannot open or read #{filename}!"
-        end
-      end
-
       # Loads a given ruby file, and runs class_eval against it in the context of the current
       # object.
       #

--- a/lib/chef/mixin/from_file.rb
+++ b/lib/chef/mixin/from_file.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-require "erb"
-
 class Chef
   module Mixin
     module FromFile
@@ -43,9 +41,7 @@ class Chef
       def from_yaml_file(filename)
         self.source_file = filename
         if File.file?(filename) && File.readable?(filename)
-          tpl = ERB.new(IO.read(filename))
-          tpl.filename = filename
-          res = ::YAML.safe_load(tpl.result)
+          res = ::YAML.safe_load(IO.read(filename))
           if res.is_a?(Hash)
             from_hash(res)
           elsif res.is_a?(Array)

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -85,6 +85,22 @@ class Chef
       end
     end
 
+    def from_array(array)
+      array.each { |e| from_hash(e) }
+    end
+
+    def from_hash(hash)
+      hash["resources"].each do |rhash|
+        type = rhash.delete("type").to_sym
+        name = rhash.delete("name")
+        res = declare_resource(type, name)
+        rhash.each do |key, value|
+          # FIXME?: we probably need a way to instance_exec a string that contains block code against the property?
+          res.send(key, value)
+        end
+      end
+    end
+
     def to_s
       "cookbook: #{cookbook_name ? cookbook_name : "(none)"}, recipe: #{recipe_name ? recipe_name : "(none)"} "
     end

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -85,7 +85,28 @@ class Chef
       end
     end
 
+    def from_yaml_file(filename)
+      self.source_file = filename
+      if File.file?(filename) && File.readable?(filename)
+        from_yaml(IO.read(filename))
+      else
+        raise IOError, "Cannot open or read #{filename}!"
+      end
+    end
+
+    def from_yaml(string)
+      res = ::YAML.safe_load(string)
+      if res.is_a?(Hash)
+        from_hash(res)
+      elsif res.is_a?(Array)
+        from_array(res)
+      else
+        raise "boom"
+      end
+    end
+
     def from_array(array)
+      Chef::Log.warn "array yaml files are super duper experimental behavior"
       array.each { |e| from_hash(e) }
     end
 


### PR DESCRIPTION
YAML is now being supported.

This implementation is restrictive and does not support arbitrary ruby code embedded in the YAML.  It is being done that way to support writing a YAML-to-ruby autoconverter (so that users have an easy way to back out of YAML-land to ruby-land since YAML-land will inherently always be limited).

What this means is that the syntax is limited right now, no control flow, no looping, not even the ability to render the node object values into properties.  That would need to be done via extending the "YAML DSL" to support those, in a structured way that allowed for autoconversion to ruby later.

