### PR TITLE
Make sure to ship the inspec binary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"
   gem "inspec-core", "~> 4.3"
+  gem "inspec-core-bin", "~> 4.3" # need to provide the binaries for inspec
   gem "chef-vault"
   gem "ed25519" # ed25519 ssh key support done here as it's a native gem we can't put in train
   gem "bcrypt_pbkdf" # ed25519 ssh key support done here as it's a native gem we can't put in train

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
       train-core (~> 2.0)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
+    inspec-core-bin (4.3.2)
+      inspec-core (= 4.3.2)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jaro_winkler (1.5.2)
@@ -420,6 +422,7 @@ DEPENDENCIES
   chefstyle!
   ed25519
   inspec-core (~> 4.3)
+  inspec-core-bin (~> 4.3)
   ohai!
   pry
   pry-byebug


### PR DESCRIPTION
We need to add the inspec-core-bin now that the binaries aren't part of
the inspec-core gem.

Fixes https://github.com/chef/chef/issues/8652

Signed-off-by: Tim Smith <tsmith@chef.io>