### PR TITLE
Move some the test package installation into the container

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -28,6 +28,7 @@ steps:
 - label: "Functional Specs Ubuntu :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
+    - apt-get update
     - apt-get install -y cron locales # needed for functional tests to pass
     - cd /workdir; bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
     - bundle exec rake spec:functional
@@ -218,6 +219,7 @@ steps:
 - label: "Functional Specs :ruby: 2.5"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
+    - apt-get update
     - apt-get install -y cron locales # needed for functional tests to pass
     - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
     - bundle exec rake spec:functional

--- a/scripts/bk_tests/bk_container_prep.sh
+++ b/scripts/bk_tests/bk_container_prep.sh
@@ -1,13 +1,5 @@
 # This script gets a container ready to run our various tests in BuildKite
 
-# make sure we have the network tools in place for various network specs
-if [ -f /etc/debian_version ]; then
-  apt-get update -y && apt-get install -y net-tools iproute2
-  touch /etc/network/interfaces
-elif [ -f /etc/redhat-release ]; then
-  yum install -y net-tools
-fi
-
 # make sure we have the omnibus_overrides specified version of rubygems / bundler
 gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
 gem --version


### PR DESCRIPTION
This should speed up the builds a little bit since these things are now
pre-installed in the containers vs. being installed during the test run.
We'll see.

Signed-off-by: Tim Smith <tsmith@chef.io>