### PR TITLE
Update omnibus-software to unbreak chef builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: d1a25fa525a4760609642d244cc729a46aa194ce
+  revision: 570fb2f076a420cab1e793e6849f80d2ba32722b
   branch: master
   specs:
     ohai (15.1.3)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 5cf947c96ffb97b0771df43c18190dbedac7f3a1
+  revision: 5a7c68f463b2b2cf553730ba146d5f512089d501
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.174.0)
-    aws-sdk-core (3.54.2)
+    aws-partitions (1.175.0)
+    aws-sdk-core (3.55.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -233,7 +233,7 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.0.35)
+    ohai (15.1.3)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
We need the updated appbundler definition with the correct license file.

Signed-off-by: Tim Smith <tsmith@chef.io>