### PR TITLE
[chef-client] [scaffolding-chef] add new build configuration for scaffolding-chef

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -4,10 +4,35 @@ build_targets = [
   "x86_64-linux",
   "x86_64-linux-kernel2"
 ]
+paths = [
+  "bin",
+  "chef-bin",
+  "chef-config",
+  "ci",
+  "distro",
+  "ext",
+  "habitat-packages",
+  "lib",
+  "omnibus", # TODO: Evaluate if we really need this in the future
+  "tasks",
+]
+
 [scaffolding-chef]
 plan_path = "habitat-packages/scaffolding-chef"
 build_targets = [
   "x86_64-linux",
   "x86_64-linux-kernel2"
   # "x86_64-windows" --- TODO: Expeditor does not currently support Windows, but will in the coming weeks. Uncomment me soon!
+]
+paths = [
+  "bin",
+  "chef-bin",
+  "chef-config",
+  "ci",
+  "distro",
+  "ext",
+  "habitat-packages",
+  "lib",
+  "omnibus", # TODO: Evaluate if we really need this in the future
+  "tasks",
 ]

--- a/habitat-packages/chef-client/plan.sh
+++ b/habitat-packages/chef-client/plan.sh
@@ -3,14 +3,32 @@ pkg_origin=chef
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="The Chef Client"
 pkg_license=('Apache-2.0')
-pkg_filename=${pkg_dirname}.tar.gz
+pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
 pkg_bin_dirs=(bin)
-pkg_build_deps=(core/make core/gcc core/git)
-pkg_deps=(core/glibc core/ruby26 core/libxml2 core/libxslt core/libiconv core/xz core/zlib core/bundler core/openssl core/cacerts core/libffi core/coreutils core/libarchive)
+pkg_build_deps=(
+  core/make
+  core/gcc
+  core/git
+)
+pkg_deps=(
+  core/glibc
+  core/ruby26
+  core/libxml2
+  core/libxslt
+  core/libiconv
+  core/xz
+  core/zlib
+  core/bundler
+  core/openssl
+  core/cacerts
+  core/libffi
+  core/coreutils
+  core/libarchive
+)
 pkg_svc_user=root
 
 pkg_version() {
-  cat "$SRC_PATH/VERSION"
+  cat "${SRC_PATH}/../../VERSION"
 }
 
 do_before() {
@@ -19,12 +37,12 @@ do_before() {
 }
 
 do_download() {
-  build_line "Fake download! Creating archive of latest repository commit."
+  build_line "Locally creating archive of latest repository commit."
   # source is in this repo, so we're going to create an archive from the
   # appropriate path within the repo and place the generated tarball in the
   # location expected by do_unpack
-  cd $PLAN_CONTEXT/../
-  git archive --prefix=${pkg_name}-${pkg_version}/ --output=$HAB_CACHE_SRC_PATH/${pkg_filename} HEAD
+  cd ${PLAN_CONTEXT}/../../
+  git archive --prefix=${pkg_name}-${pkg_version}/ --output=${HAB_CACHE_SRC_PATH}/${pkg_filename} HEAD
 }
 
 do_verify() {
@@ -59,7 +77,7 @@ do_build() {
 
   bundle config --local silence_root_warning 1
 
-  pushd chef-config > /dev/null
+  pushd ${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}/chef-config > /dev/null
   _bundle_install "${pkg_prefix}/bundle"
   popd > /dev/null
 
@@ -69,7 +87,7 @@ do_build() {
 do_install() {
   mkdir -p "${pkg_prefix}/chef"
   for dir in bin chef-bin chef-config lib chef.gemspec Gemfile Gemfile.lock; do
-    cp -rv "${PLAN_CONTEXT}/../${dir}" "${pkg_prefix}/chef/"
+    cp -rv "${PLAN_CONTEXT}/../../${dir}" "${pkg_prefix}/chef/"
   done
 
   # This is just generating binstubs with the correct path.

--- a/habitat-packages/chef-client/plan.sh
+++ b/habitat-packages/chef-client/plan.sh
@@ -2,13 +2,16 @@ pkg_name=chef-client
 pkg_origin=chef
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="The Chef Client"
-pkg_version=$(cat ../VERSION)
 pkg_license=('Apache-2.0')
 pkg_filename=${pkg_dirname}.tar.gz
 pkg_bin_dirs=(bin)
 pkg_build_deps=(core/make core/gcc core/git)
 pkg_deps=(core/glibc core/ruby26 core/libxml2 core/libxslt core/libiconv core/xz core/zlib core/bundler core/openssl core/cacerts core/libffi core/coreutils core/libarchive)
 pkg_svc_user=root
+
+pkg_version() {
+  cat "$SRC_PATH/VERSION"
+}
 
 do_before() {
   do_default_before


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

When having expeditor paths in the .bldr.toml that aren't the default in `/`, we need to be more explicit about which directories are being watched for new events to fire builds.

Additionally, we layered `chef-client` one more folder deeper, and I realized this would break the usage of the VERSION file. So I fixed that.

![tenor-82158748](https://user-images.githubusercontent.com/3253989/59869062-43257480-9347-11e9-9a95-1c664ad04273.gif)
