### PR TITLE
Ignore noisy outputs at create temp_dir during bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -117,7 +117,7 @@ class Chef
           cmd = windows? ? MKTEMP_WIN_COMMAND : MKTEMP_NIX_COMMAND
           @tmpdir ||= begin
                         res = run_command!(cmd)
-                        dir = res.stdout.chomp.strip
+                        dir = res.stdout.split.last
                         unless windows?
                           # Ensure that dir has the correct owner.  We are possibly
                           # running with sudo right now - so this directory would be owned by root.

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -117,6 +117,9 @@ class Chef
           cmd = windows? ? MKTEMP_WIN_COMMAND : MKTEMP_NIX_COMMAND
           @tmpdir ||= begin
                         res = run_command!(cmd)
+                        # Since pty is enabled in the connection, stderr to be merged into stdout.
+                        # So, there are cases where unnecessary multi-line output
+                        # is included before the result of mktemp.
                         dir = res.stdout.split.last
                         unless windows?
                           # Ensure that dir has the correct owner.  We are possibly

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -163,6 +163,15 @@ describe Chef::Knife::Bootstrap::TrainConnector do
         expect(subject.temp_dir).to eq "/a/path"
       end
 
+      context "with noise in stderr" do
+        it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
+          expected_command = Chef::Knife::Bootstrap::TrainConnector::MKTEMP_NIX_COMMAND
+          expect(subject).to receive(:run_command!).with(expected_command)
+            .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "/a/path\r\n")
+          expect(subject).to receive(:run_command!).with("chown user1 '/a/path'")
+          expect(subject.temp_dir).to eq "/a/path"
+        end
+      end
     end
   end
   context "#upload_file_content!" do


### PR DESCRIPTION
Signed-off-by: sawanoboly <sawanoboriyu@higanworks.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

When using the sudo option, bootstrap may fail. Since pty is enabled in the SSH connection, the path acquisition of temp_dir does not work well when stderr contains unnecessary output.


for example

```
$ sudo mktemp -d
sudo: unable to resolve host hostnamelocalhost  # << this message outs on stderr but merged into stdin due to pty is true
/tmp/tmp.FgLKVeE87G
```

This PR is changed to use only the last line to ignore such output.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

none.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).