### PR TITLE
Pass yum_package options to underlying python helper

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -93,10 +93,8 @@ class Chef
             next if n.nil?
 
             av = available_version(i)
-
             name = av.name # resolve the name via the available/candidate version
-
-            iv = python_helper.package_query(:whatinstalled, av.name_with_arch)
+            iv = python_helper.package_query(:whatinstalled, av.name_with_arch, options: options)
 
             method = "install"
 
@@ -237,9 +235,9 @@ class Chef
         def installed_version(index)
           @installed_version ||= []
           @installed_version[index] ||= if new_resource.source
-                                          python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index])
+                                          python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index], options: options)
                                         else
-                                          python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index])
+                                          python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index], options: options)
                                         end
           @installed_version[index]
         end


### PR DESCRIPTION
## Description
When working with custom repo that are disabled by default, we need to enable them on-demand. The python helper handles that properly but the yum package provider does not pass user's options in all cases.

Most of the time there is no issue because in normal cases you should not need to enable any repository to work with "installed" packages.

However in some rare cases, you may have multiple installed versions of a given package. In that situation, python libraries used by the helper will do some extra work that may (will) requires to enable the repo.
See call to _compare_providers in http://yum.baseurl.org/download/docs/yum-api/3.2.27/yum-pysrc.html#YumBase._bestPackageFromList

Not passing the options in that case, will result in an unclear error:
  > ' * No candidate version available for "package" '

And often will lock/corrupt the rpm db.

## Related Issue
I think this should fix #7215, at least the symptoms are the same.
By fixing the above behavior it should also avoid to trigger #8515 in that one case.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
