### PR TITLE
Update Rubygems to 3.0.4

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.0.3"
+override :rubygems, version: "3.0.4"
 override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "nokogiri", version: "1.10.2"
 override "libffi", version: "3.2.1"


### PR DESCRIPTION
This is a really small release with just a few minor bugfixes and a
giant pile of fixes to their test / ci setup.

Signed-off-by: Tim Smith <tsmith@chef.io>