### PR TITLE
Pin to ruby-prof 0.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 
 # Everything except AIX
 group(:ruby_prof) do
-  gem "ruby-prof"
+  gem "ruby-prof", "< 0.18" # 0.18 includes a x64-mingw32 gem, which doesn't load correctly. See https://github.com/ruby-prof/ruby-prof/issues/255
 end
 
 # Everything except AIX and Windows

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,8 +300,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
-    ruby-prof (0.18.0)
-    ruby-prof (0.18.0-x64-mingw32)
+    ruby-prof (0.17.0)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
@@ -436,7 +435,7 @@ DEPENDENCIES
   rspec-expectations (~> 3.5)
   rspec-mocks (~> 3.5)
   rspec_junit_formatter (~> 0.2.0)
-  ruby-prof
+  ruby-prof (< 0.18)
   ruby-shadow
   simplecov
   webmock

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.177.0)
+    aws-partitions (1.178.0)
     aws-sdk-core (3.56.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)


### PR DESCRIPTION
ruby-prof 0.18 fails to load on Windows. See https://github.com/ruby-prof/ruby-prof/issues/255

Signed-off-by: Tim Smith <tsmith@chef.io>