### PR TITLE
yum_package: Better handle yum exceptions in our helper so we always close the rpmdb

### DIFF
--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -185,27 +185,30 @@ else:
   inpipe = os.fdopen(int(sys.argv[1]), "r")
   outpipe = os.fdopen(int(sys.argv[2]), "w")
 
-while 1:
-    # kill self if we get orphaned (tragic)
-    ppid = os.getppid()
-    if ppid == 1:
-        sys.exit(0)
-    setup_exit_handler()
-    line = inpipe.readline()
+try:
+    while 1:
+        # kill self if we get orphaned (tragic)
+        ppid = os.getppid()
+        if ppid == 1:
+            raise RuntimeError("orphaned")
 
-    try:
-        command = json.loads(line)
-    except ValueError, e:
-        base.closeRpmDB()
-        sys.exit(0)
+        setup_exit_handler()
+        line = inpipe.readline()
 
-    if command['action'] == "whatinstalled":
-        query(command)
-    elif command['action'] == "whatavailable":
-        query(command)
-    elif command['action'] == "versioncompare":
-        versioncompare(command['versions'])
-    elif command['action'] == "installonlypkgs":
-         install_only_packages(command['package'])
-    else:
-        raise RuntimeError("bad command")
+        try:
+            command = json.loads(line)
+        except ValueError, e:
+            raise RuntimeError("bad json parse")
+
+        if command['action'] == "whatinstalled":
+            query(command)
+        elif command['action'] == "whatavailable":
+            query(command)
+        elif command['action'] == "versioncompare":
+            versioncompare(command['versions'])
+        elif command['action'] == "installonlypkgs":
+             install_only_packages(command['package'])
+        else:
+            raise RuntimeError("bad command")
+finally:
+    base.closeRpmDB()

--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -169,7 +169,8 @@ def query(command):
 # to keep process tables clean.  additional error handling should probably be added to the retry loop
 # on the ruby side.
 def exit_handler(signal, frame):
-    base.closeRpmDB()
+    if base is not None:
+        base.closeRpmDB()
     sys.exit(0)
 
 def setup_exit_handler():

--- a/lib/chef/provider/package/yum/yum_helper.py
+++ b/lib/chef/provider/package/yum/yum_helper.py
@@ -211,4 +211,5 @@ try:
         else:
             raise RuntimeError("bad command")
 finally:
-    base.closeRpmDB()
+    if base is not None:
+        base.closeRpmDB()


### PR DESCRIPTION
Add more careful exception handling around always closing the rpm database.

Convert some of the hard exits to just raise and then use a finally block to close the rpm database if it is open.

Tested this manually through exercising some of the exceptions (bad json and bad command).

Very difficult to create a test case which exercises this code in CI.

Closes #8515 
