### PR TITLE
Enable Habitat build promotion in Expeditor again

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -85,13 +85,13 @@ subscriptions:
   - workload: artifact_published:current:chef:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
-      # - built_in:promote_habitat_packages Disable until we fix our hab package
+      - built_in:promote_habitat_packages
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - built_in:tag_docker_image
-      # - built_in:promote_habitat_packages Disable until we fix our hab package
+      - built_in:promote_habitat_packages
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
   - workload: ruby_gem_published:mixlib-archive-*


### PR DESCRIPTION
We have a working habitat build.

Signed-off-by: Tim Smith <tsmith@chef.io>