### PR TITLE
Fix a typo in the hostname resource property descriptions

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -31,7 +31,7 @@ class Chef
                name_property: true
 
       property :compile_time, [ TrueClass, FalseClass ],
-               description: "Determines whether or not the resource shoul be run at compile time.",
+               description: "Determines whether or not the resource should be run at compile time.",
                default: true, desired_state: false
 
       property :ipaddress, String,


### PR DESCRIPTION
Fix this so we can fix the docs site

Signed-off-by: Tim Smith <tsmith@chef.io>