### PR TITLE
windows_task: Fix for :day option is not accepting integer value

### DIFF
--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -446,7 +446,7 @@ class Chef
         def days_of_month
           days_of_month = []
           if new_resource.day
-            days = new_resource.day.split(",")
+            days = new_resource.day.to_s.split(",")
             days.map! { |day| day.to_s.strip.upcase }
             days.delete("LAST") if days.include?("LAST")
             days.delete("LASTDAY") if days.include?("LASTDAY")
@@ -466,7 +466,7 @@ class Chef
           if new_resource.day
             # this line of code is just to support backward compatibility of wild card *
             new_resource.day = "mon, tue, wed, thu, fri, sat, sun" if new_resource.day == "*" && new_resource.frequency == :weekly
-            days = new_resource.day.split(",")
+            days = new_resource.day.to_s.split(",")
             days.map! { |day| day.to_s.strip.upcase }
             weeks_days = get_binary_values_from_constants(days, DAYS_OF_WEEK)
           else

--- a/spec/unit/provider/windows_task_spec.rb
+++ b/spec/unit/provider/windows_task_spec.rb
@@ -265,8 +265,13 @@ describe Chef::Provider::WindowsTask, :windows_only do
 
   # REF: https://msdn.microsoft.com/en-us/library/windows/desktop/aa382063(v=vs.85).aspx
   describe "#days_of_month" do
-    it "returns the binary value 1 if day is set as 1" do
+    it "returns the binary value 1 if day is set as string 1" do
       new_resource.day "1"
+      expect(provider.send(:days_of_month)).to eq(1)
+    end
+
+    it "returns the binary value 1 if day is set as integer 1" do
+      new_resource.day 1
       expect(provider.send(:days_of_month)).to eq(1)
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
As per the docs https://docs.chef.io/resource_windows_task.html. `day` can be an integer as well as a string value. But while setting `day: 1` as an integer it raises an error NoMethodError: undefined method `split' for 1:Integer.

To fixed this parse `day` value `to_s` first and then call `split`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixed https://github.com/chef/chef/issues/8431

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>