### PR TITLE
update bldr config with new hab package name

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,4 +1,4 @@
-[chef-client]
+[chef-infra-client]
 plan_path = "habitat/chef-infra-client"
 build_targets = [
   "x86_64-linux",


### PR DESCRIPTION
## Description

The table name in `.bldr.toml` apparently needs to match the package name being built. 

## Related Issue

This should fix package promotion from unstable->current in expeditor, too.

## Types of changes

- ~Bug fix (non-breaking change which fixes an issue)~
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
