### PR TITLE
expeditor/buildkite: turn on debug level for builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -27,10 +27,13 @@ pipelines:
       public: true
   - habitat/build
   - omnibus/release
+      env:
+        - BUILD_OPTIONS: -l debug
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
+        - BUILD_OPTIONS: -l debug
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,7 +26,7 @@ pipelines:
   - verify:
       public: true
   - habitat/build
-  - omnibus/release
+  - omnibus/release:
       env:
         - BUILD_OPTIONS: -l debug
   - omnibus/adhoc:


### PR DESCRIPTION
Need to get debug level output from the actual omnibus builds so that we can grep and see e.g. which step is installing which gems...