### PR TITLE
[Do not merge] Fix for Control characters detected. (Net::SCP::Error)

### DIFF
--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -195,7 +195,9 @@ class Chef
         #
         # @return [Train::Extras::CommandResult] an object containing stdout, stderr, and exit_status
         def run_command(command, &data_handler)
-          connection.run_command(command, &data_handler)
+          # windows ssh need to be pty as false.
+          opts = windows? ? { pty: false } : {}
+          connection.run_command(command, opts, &data_handler)
         end
 
         #


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Set `pty` as false for windows ssh

## Related Issue
Fixes #8683