### PR TITLE
Fix RDoc copy-pasta in Chef::Mixin::ParamsValidate#validate

### DIFF
--- a/lib/chef/mixin/params_validate.rb
+++ b/lib/chef/mixin/params_validate.rb
@@ -42,7 +42,7 @@ class Chef
       #     (`opts[:is].any? { |v| v === value }`). (See #_pv_is.)
       #   @option opts [Object,Array] :equal_to An object, or list
       #     of objects, that must be equal to the value using Ruby's `==`
-      #     operator (`opts[:is].any? { |v| v == value }`)  (See #_pv_equal_to.)
+      #     operator (`opts[:equal_to].any? { |v| v == value }`)  (See #_pv_equal_to.)
       #   @option opts [Regexp,Array<Regexp>] :regex An object, or
       #     list of objects, that must match the value with `regex.match(value)`.
       #     (See #_pv_regex)


### PR DESCRIPTION
The RDoc for `Chef::Mixin::ParamsValidate#validate` appears to have inadvertently copied the (helpful) inline pseudocode of the `:is` option to the `:equal_to` option (in commit 28f17b36a9d041be8ed50e20ae06fa5f5ea1fb38):
https://github.com/chef/chef/blob/6bbf42b0ff11eabdb72067e78e4101ad93820b71/lib/chef/mixin/params_validate.rb#L43-L45

Quick edit for obvious fix of documentation typo :)