### PR TITLE
Implement disable for disabling kernel_modules

### DIFF
--- a/spec/unit/resource/kernel_module_spec.rb
+++ b/spec/unit/resource/kernel_module_spec.rb
@@ -36,6 +36,7 @@ describe Chef::Resource::KernelModule do
     expect { resource.action :install }.not_to raise_error
     expect { resource.action :uninstall }.not_to raise_error
     expect { resource.action :blacklist }.not_to raise_error
+    expect { resource.action :disable }.not_to raise_error
     expect { resource.action :load }.not_to raise_error
     expect { resource.action :unload }.not_to raise_error
     expect { resource.action :delete }.to raise_error(ArgumentError)


### PR DESCRIPTION
This allows inspec kernel_module be_disabled to work

Signed-off-by: Tom Doherty <tom.doherty@fixnetix.com>

## Description
Add's disable method which matches inspec test

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
