### PR TITLE
ifconfig: fix regex matching interface name with hyphen

### DIFF
--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -109,9 +109,11 @@ class Chef
           #       RX errors 0  dropped 0  overruns 0  frame 0
           #       TX packets 1244218  bytes 977339327 (932.0 MiB)
           #       TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+          #
+          # Permalink for addr_regex : https://rubular.com/r/JrykUpfjRnYeQD
           @status = shell_out("ifconfig")
           @status.stdout.each_line do |line|
-            addr_regex = /^(\w+)(-?):?(\d*):?\ .+$/
+            addr_regex = /^((\w|-)+):?(\d*):?\ .+$/
             if line =~ addr_regex
               if line.match(addr_regex).nil?
                 @int_name = "nil"

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -111,7 +111,7 @@ class Chef
           #       TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
           @status = shell_out("ifconfig")
           @status.stdout.each_line do |line|
-            addr_regex = /^(\w+):?(\d*):?\ .+$/
+            addr_regex = /^(\w+)(-?):?(\d*):?\ .+$/
             if line =~ addr_regex
               if line.match(addr_regex).nil?
                 @int_name = "nil"

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -117,12 +117,12 @@ class Chef
             if line =~ addr_regex
               if line.match(addr_regex).nil?
                 @int_name = "nil"
-              elsif line.match(addr_regex)[2] == ""
+              elsif line.match(addr_regex)[3] == ""
                 @int_name = line.match(addr_regex)[1]
                 @interfaces[@int_name] = {}
                 @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /mtu/ && @interfaces[@int_name]["mtu"].nil?
               else
-                @int_name = "#{line.match(addr_regex)[1]}:#{line.match(addr_regex)[2]}"
+                @int_name = "#{line.match(addr_regex)[1]}:#{line.match(addr_regex)[3]}"
                 @interfaces[@int_name] = {}
                 @interfaces[@int_name]["mtu"] = (line =~ /mtu (\S+)/ ? Regexp.last_match(1) : "nil") if line =~ /mtu/ && @interfaces[@int_name]["mtu"].nil?
               end

--- a/spec/unit/provider/ifconfig_spec.rb
+++ b/spec/unit/provider/ifconfig_spec.rb
@@ -94,6 +94,17 @@ describe Chef::Provider::Ifconfig do
       expect(@new_resource).not_to be_updated
     end
 
+    it "should add a bridge interface" do
+      allow(@provider).to receive(:load_current_resource)
+      @new_resource.device "br-1234"
+      command = "ifconfig br-1234 10.0.0.1 netmask 255.255.254.0 metric 1 mtu 1500"
+      expect(@provider).to receive(:shell_out_compacted!).with(*command.split(" "))
+      expect(@provider).to receive(:generate_config)
+
+      @provider.run_action(:add)
+      expect(@new_resource).to be_updated
+    end
+
     # We are not testing this case with the assumption that anyone writing the cookbook would not make a typo == lo
     # it "should add a blank command if the #{@new_resource.device} == lo" do
     # end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
- Updated regex to match the interface name with hyphen 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Updated regex will match with the output of `ifconfig` having device name `-` after any word character
 e.g. `br-1234`
- Ensured `chefstyle`
- Added test case.
- After regex update, data which is accommodated in array has shifted from index 2 to 3. Incorporated this change in commit https://github.com/chef/chef/pull/8756/commits/8e295ba6e3397add1ad26d92d97d66b58659424e 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://getchef.zendesk.com/agent/tickets/22294
## Error
`RHEL7: ifconfig provider fails with "undefined method [] for nil:NilClas`

## Recipe 
```
[root@ip-172-31-26-90 chef]# cat ../recipe-ifconfig.rb
ifconfig("52.34.83.20") do
action :add
device "br-1234"
onboot "yes"
mask "255.255.255.255"
target "52.34.83.20"
end
```
## Output after fix
```
[root@ip-172-31-26-90 chef]# bundle exec chef-apply ../recipe-ifconfig.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * ifconfig[52.34.83.20] action add
    - run ifconfig br-1234 52.34.83.20 netmask 255.255.255.255 to add ifconfig[52.34.83.20]
  Recipe: <Dynamically Defined Resource>
    * file[/etc/sysconfig/network-scripts/ifcfg-br-1234] action create
      - update content in file /etc/sysconfig/network-scripts/ifcfg-br-1234 from ef289f to c40ecd
      --- /etc/sysconfig/network-scripts/ifcfg-br-1234  2019-07-19 09:52:51.246737514 +0000
      +++ /etc/sysconfig/network-scripts/.chef-ifcfg-br-123420190719-23908-1btlw8j      2019-07-19 09:55:56.679533307 +0000
      @@ -1,11 +1,20 @@
      +
       DEVICE=br-1234
      -STP=no
      -TYPE=Bridge
      -BOOTPROTO=none
      -IPADDR=52.34.83.20
      -PREFIX=32
      -IPV6INIT=no
      -NAME=br1
       ONBOOT=yes
      -DELAY=0
      +
      +IPADDR=52.34.83.20
      +NETMASK=255.255.255.255
      +
      +
      +
      +
      +
      +
      +
      +
      +
      +
      +
      +
      +
      - restore selinux security context

[root@ip-172-31-26-90 chef]#
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
