### PR TITLE
Duration field in resource report needs to be String

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -35,7 +35,7 @@ class Chef
       as_hash["id"]       = new_resource.identity.to_s
       as_hash["after"]    = new_resource.state_for_resource_reporter
       as_hash["before"]   = current_resource ? current_resource.state_for_resource_reporter : {}
-      as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i
+      as_hash["duration"] = ( action_record.elapsed_time * 1000 ).to_i.to_s
       as_hash["delta"]    = new_resource.diff if new_resource.respond_to?("diff")
       as_hash["delta"]    = "" if as_hash["delta"].nil?
 

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -447,6 +447,7 @@ describe Chef::ResourceReporter do
         # TODO: API takes integer number of milliseconds as a string. This
         # should be an int.
         expect(@first_update_report).to have_key("duration")
+        expect(@first_update_report["duration"]).to be_kind_of(String)
         expect(@first_update_report["duration"].to_i).to be_within(100).of(0)
       end
 
@@ -585,6 +586,7 @@ describe Chef::ResourceReporter do
         # TODO: API takes integer number of milliseconds as a string. This
         # should be an int.
         expect(@first_update_report).to have_key("duration")
+        expect(@first_update_report["duration"]).to be_kind_of(String)
         expect(@first_update_report["duration"].to_i).to be_within(100).of(0)
       end
 


### PR DESCRIPTION
Somehow this got converted to a bare integer in Chef-15 refactoring
which causes the server-side to reject it, so reverting back to the
old format.

Closes #8532
