### PR TITLE
Add Windows PR testing in Buildkite

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,6 +2,9 @@
 expeditor:
   defaults:
     buildkite:
+      retry:
+        automatic:
+          limit: 1
       timeout_in_minutes: 30
 
 steps:
@@ -184,6 +187,40 @@ steps:
         image: rubydistros/fedora-latest
         environment:
           - FORCE_FFI_YAJL=ext
+          - CHEF_LICENSE=accept-no-persist
+
+- label: "Integration Specs Windows :ruby: 2.6"
+  commands:
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
+    - bundle exec rake spec:integration
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        environment:
+          - CHEF_LICENSE=accept-no-persist
+
+- label: "Functional Specs Windows :ruby: 2.6"
+  commands:
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
+    - bundle exec rake spec:functional
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        environment:
+          - CHEF_LICENSE=accept-no-persist
+
+- label: "Unit Specs Windows :ruby: 2.6"
+  commands:
+    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen ruby_prof
+    - bundle exec rake spec:unit
+    - bundle exec rake component_specs
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        environment:
           - CHEF_LICENSE=accept-no-persist
 
 - label: "Chefstyle :ruby: 2.6"


### PR DESCRIPTION
This allows us to turn off Appveyor and use a single CI system for
everything

Signed-off-by: Tim Smith <tsmith@chef.io>