### PR TITLE
Tweak data collector exception handling

### DIFF
--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -198,7 +198,7 @@ class Chef
           if code == "404"
             # Make the message non-scary for folks who don't have automate:
             msg << " (This is normal if you do not have #{Chef::Dist::AUTOMATE})"
-            Chef::Log.info(msg)
+            Chef::Log.debug(msg)
           else
             Chef::Log.warn(msg)
           end

--- a/lib/chef/data_collector.rb
+++ b/lib/chef/data_collector.rb
@@ -177,14 +177,17 @@ class Chef
 
         @http ||= setup_http_client(Chef::Config[:data_collector][:server_url])
         @http.post(nil, message, headers)
-      rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
-        Errno::ECONNREFUSED, EOFError, Net::HTTPBadResponse,
-        Net::HTTPHeaderSyntaxError, Net::ProtocolError, OpenSSL::SSL::SSLError,
-        Errno::EHOSTDOWN => e
+      rescue => e
         # Do not disable data collector reporter if additional output_locations have been specified
         events.unregister(self) unless Chef::Config[:data_collector][:output_locations]
 
-        code = e&.response&.code&.to_s || "Exception Code Empty"
+        begin
+          code = e&.response&.code&.to_s
+        rescue
+          # i really dont care
+        end
+
+        code ||= "No HTTP Code"
 
         msg = "Error while reporting run start to Data Collector. URL: #{Chef::Config[:data_collector][:server_url]} Exception: #{code} -- #{e.message} "
 
@@ -192,9 +195,13 @@ class Chef
           Chef::Log.error(msg)
           raise
         else
-          # Make the message non-scary for folks who don't have automate:
-          msg << " (This is normal if you do not have #{Chef::Dist::AUTOMATE})"
-          Chef::Log.info(msg)
+          if code == "404"
+            # Make the message non-scary for folks who don't have automate:
+            msg << " (This is normal if you do not have #{Chef::Dist::AUTOMATE})"
+            Chef::Log.info(msg)
+          else
+            Chef::Log.warn(msg)
+          end
         end
       end
 

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -956,7 +956,7 @@ describe Chef::DataCollector do
       # this is different specifically for 404s
       it "logs an info message and does not raise an exception when raise_on_failure is disabled" do
         Chef::Config[:data_collector][:raise_on_failure] = false
-        expect(Chef::Log).to receive(:info).with(/This is normal if you do not have Chef Automate/)
+        expect(Chef::Log).to receive(:debug).with(/This is normal if you do not have Chef Automate/)
         data_collector.send(:send_to_data_collector, message)
       end
     end


### PR DESCRIPTION
    This isn't Java and Net::HTTP can throw a billion things, so just rescue
    (nearly) everything.  I have a hard time imagining that there's a
    failure here that we wouldn't want to ignore, other than the ones like
    OOM thrown by Exception that indicate internal failures.

    Also only throw the "this is normal" info message on 404s, other
    responses like 500s should be warns even if it is set to ignore
    failures (people with data collectors correctly setup need to know about
    500s even if we keep going, since that is abnormal).

    This also fixes a bug in handling exceptions like Timeout::Error which
    do not have a response.code at all which would throw NoMethodError.

closes #8749