### PR TITLE
Add raise an error on Chef 14 when trying to bootstrap Chef 15

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -30,6 +30,7 @@ class Chef
 
       SUPPORTED_CONNECTION_PROTOCOLS ||= %w{ssh winrm}.freeze
       WINRM_AUTH_PROTOCOL_LIST ||= %w{plaintext kerberos ssl negotiate}.freeze
+      CHEF_15 ||= 15
 
       # Common connectivity options
       option :connection_user,
@@ -559,6 +560,7 @@ class Chef
         validate_first_boot_attributes!
         validate_winrm_transport_opts!
         validate_policy_options!
+        validate_bootstrap_version_options!
         plugin_validate_options!
 
         winrm_warn_no_ssl_verification
@@ -714,6 +716,22 @@ class Chef
           ui.error("Must pass an FQDN or ip to bootstrap")
           exit 1
         end
+      end
+
+      # Ensure options are valid by checking bootstrap version values.
+      #
+      # The method call will cause the program to exit(1) if:
+      #   * Bootstrap version is greater than or equal to 15 for chef 14 or lower
+      #   * Pre-release options is passed for chef 14 or lower
+      #
+      # @return [TrueClass] If options are valid.
+      def validate_bootstrap_version_options!
+        if target_node_gt_15?
+          ui.error("You must use Chef 15 or later to bootstrap Chef 15 nodes")
+          exit 1
+        end
+
+        true
       end
 
       # Ensure options are valid by checking policyfile values.
@@ -1093,6 +1111,18 @@ class Chef
         return options[:session_timeout][:default] if timeout.nil?
 
         timeout.to_i
+      end
+
+      def bootstrap_version_gt_15?
+        !!config[:bootstrap_version] &&
+          (config[:bootstrap_version] == "latest" ||
+           config[:bootstrap_version].split(".").first.to_i >= CHEF_15)
+      end
+
+      def target_node_gt_15?
+        if Chef::VERSION.split(".").first.to_i < CHEF_15
+          config[:prerelease] || bootstrap_version_gt_15?
+        end
       end
     end
   end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -778,6 +778,92 @@ describe Chef::Knife::Bootstrap do
     end
   end
 
+  describe "#validate_bootstrap_version_options!" do
+    describe "chef-14 or lower" do
+      before do
+        stub_const("Chef::VERSION", "14.0")
+      end
+
+      context "when bootstrap version not given" do
+        it "passes the validation" do
+          knife.config[:bootstrap_version] = nil
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when bootstrap version is given" do
+        it "passes the validation for chef 14.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "14.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 13.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "13.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "raise an error for latest bootstrap version" do
+          knife.config[:bootstrap_version] = "latest"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+
+        it "raise an error for chef 15.0+ bootstrap version" do
+          knife.config[:bootstrap_version] = "15.0.1"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+
+        it "raise an error for chef 15.1+ bootstrap version" do
+          knife.config[:bootstrap_version] = "15.1"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+      end
+
+      context "when prerelease option is given" do
+        it "raise an error" do
+          knife.config[:prerelease] = true
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    describe "chef-15+" do
+      before do
+        stub_const("Chef::VERSION", "15.0")
+      end
+
+      context "when bootstrap version not given" do
+        it "passes the validation" do
+          knife.config[:bootstrap_version] = nil
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when bootstrap version is given" do
+        it "passes the validation for chef 14.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "14.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 15.2 bootstrap version" do
+          knife.config[:bootstrap_version] = "15.2"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 16.2 bootstrap version" do
+          knife.config[:bootstrap_version] = "16.2"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when prerelease option is given" do
+        it "passes the validation" do
+          knife.config[:prerelease] = true
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+    end
+  end
+
   # TODO - this is the only cli option we validate the _option_ itself -
   #        so we'll know if someone accidentally deletes or renames use_sudo_password
   #        Is this worht keeping?  If so, then it seems we should expand it


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Validate only if chef version is less than 15.
- If the chef version is 14 or lower add validation based on `bootstrap_version` & `prerelease` 

Note: This fixes is mainly for chef-14 so need to back-port it into chef-14.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8623

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>