### PR TITLE
Property: Reorder comparison with NOT_PASSED.

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -347,7 +347,7 @@ class Chef
     #   `get`, the non-lazy, coerced, validated value will always be returned.
     #
     def call(resource, value = NOT_PASSED)
-      if value == NOT_PASSED
+      if NOT_PASSED == value
         get(resource)
       else
         set(resource, value)


### PR DESCRIPTION
The original comparison `value == NOT_PASSED` ends up calling `.<=>` on
`value` under the hood. This relies on the implementation of `<=>`/`cmp`
not being broken in that class.

Unfortunately, some classes like OpenSSL::X509::Name have broken
implementations of `<=>` that raise TypeError instead of returning nil
for mismatched types. https://github.com/ruby/openssl/pull/264

As a result, currently, if you attempt to set a resource property to an
OpenSSL::X509::Name object, the result is a TypeError.

```ruby
>> require 'openssl'
>> require './lib/chef/constants.rb'
>> name = OpenSSL::X509::Name.new

>> name == Chef::NOT_PASSED
TypeError: wrong argument type Object (expected OpenSSL/X509/NAME)
>> Chef::NOT_PASSED == name
=> false
```

With this change, we use the implementation of comparison from the
NOT_PASSED object instead, which we know will work no matter what.

Signed-off-by: Andy Brody <git@abrody.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
