### PR TITLE
Chef-14: Raise an error on Chef 14 when trying to bootstrap Chef 15

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -22,6 +22,7 @@ require "erubis"
 require "chef/knife/bootstrap/chef_vault_handler"
 require "chef/knife/bootstrap/client_builder"
 require "chef/util/path_helper"
+require_relative "../version_string"
 
 class Chef
   class Knife
@@ -517,7 +518,7 @@ class Chef
       def bootstrap_version_gte_15?
         config[:prerelease] ||
           (!!config[:bootstrap_version] &&
-           (config[:bootstrap_version] == "latest" || config[:bootstrap_version].to_i >= 15))
+           (config[:bootstrap_version] == "latest" || Chef::VersionString.new(config[:bootstrap_version]) >= 15.0))
       end
     end
   end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -443,7 +443,7 @@ class Chef
       # @return [TrueClass] If options are valid.
       def validate_bootstrap_version_options!
         if Chef::VERSION.to_i < 15 && bootstrap_version_gte_15?
-          ui.error("You must use Chef 15 or later to bootstrap Chef 15 nodes")
+          ui.error("You must use Chef Infra Client 15 or later to bootstrap Chef Infra Client 15 nodes")
           exit 1
         end
 

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -28,7 +28,6 @@ class Chef
     class Bootstrap < Knife
       include DataBagSecretOptions
 
-      CHEF_15 ||= 15
       attr_accessor :client_builder
       attr_accessor :chef_vault_handler
 
@@ -442,7 +441,7 @@ class Chef
       #
       # @return [TrueClass] If options are valid.
       def validate_bootstrap_version_options!
-        if target_node_gt_15?
+        if Chef::VERSION.to_i < 15 && bootstrap_version_gte_15?
           ui.error("You must use Chef 15 or later to bootstrap Chef 15 nodes")
           exit 1
         end
@@ -515,18 +514,10 @@ class Chef
       end
 
       # True if the bootstrap version is greater than or equal to 15 or latest.
-      def bootstrap_version_gt_15?
-        !!config[:bootstrap_version] &&
-          (config[:bootstrap_version] == "latest" ||
-           config[:bootstrap_version].split(".").first.to_i >= CHEF_15)
-      end
-
-      # Consider only if current chef version less than 15.
-      # True if both bootstrap node version greater than or equal to 15 or pre-release is set.
-      def target_node_gt_15?
-        if Chef::VERSION.split(".").first.to_i < CHEF_15
-          config[:prerelease] || bootstrap_version_gt_15?
-        end
+      def bootstrap_version_gte_15?
+        config[:prerelease] ||
+          (!!config[:bootstrap_version] &&
+           (config[:bootstrap_version] == "latest" || config[:bootstrap_version].to_i >= 15))
       end
     end
   end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -633,6 +633,92 @@ describe Chef::Knife::Bootstrap do
 
   end
 
+  describe "#validate_bootstrap_version_options!" do
+    describe "chef-14 or lower" do
+      before do
+        stub_const("Chef::VERSION", "14.0")
+      end
+
+      context "when bootstrap version not given" do
+        it "passes the validation" do
+          knife.config[:bootstrap_version] = nil
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when bootstrap version is given" do
+        it "passes the validation for chef 14.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "14.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 13.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "13.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "raise an error for latest bootstrap version" do
+          knife.config[:bootstrap_version] = "latest"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+
+        it "raise an error for chef 15.0+ bootstrap version" do
+          knife.config[:bootstrap_version] = "15.0.1"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+
+        it "raise an error for chef 15.1+ bootstrap version" do
+          knife.config[:bootstrap_version] = "15.1"
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+      end
+
+      context "when prerelease option is given" do
+        it "raise an error" do
+          knife.config[:prerelease] = true
+          expect { knife.validate_bootstrap_version_options! }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    describe "chef-15+" do
+      before do
+        stub_const("Chef::VERSION", "15.0")
+      end
+
+      context "when bootstrap version not given" do
+        it "passes the validation" do
+          knife.config[:bootstrap_version] = nil
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when bootstrap version is given" do
+        it "passes the validation for chef 14.12.0 bootstrap version" do
+          knife.config[:bootstrap_version] = "14.12.0"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 15.2 bootstrap version" do
+          knife.config[:bootstrap_version] = "15.2"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+
+        it "passes the validation for chef 16.2 bootstrap version" do
+          knife.config[:bootstrap_version] = "16.2"
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+
+      context "when prerelease option is given" do
+        it "passes the validation" do
+          knife.config[:prerelease] = true
+          expect { knife.validate_bootstrap_version_options! }.to_not raise_error
+        end
+      end
+    end
+  end
+
   describe "when configuring the underlying knife ssh command" do
     context "from the command line" do
       let(:knife_ssh) do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Validate only if chef version is less than 15.
- If the chef version is 14 or lower add validation based on bootstrap_version & prerelease.
- PR against chef-14 only.

Referenced PR: https://github.com/chef/chef/pull/8777

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8623

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>