### PR TITLE
Bumped mixlib-shellout to 3.0.7 to fix a windows process bug.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,8 +228,8 @@ GEM
     mixlib-config (3.0.1)
       tomlrb
     mixlib-log (3.0.1)
-    mixlib-shellout (3.0.4)
-    mixlib-shellout (3.0.4-universal-mingw32)
+    mixlib-shellout (3.0.7)
+    mixlib-shellout (3.0.7-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     multi_json (1.13.1)


### PR DESCRIPTION
Signed-off-by: Ryan Davis <zenspider@chef.io>