### PR TITLE
[ci] Fix omnibus pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -12,8 +12,8 @@ builder-to-testers-map:
   debian-8-x86_64:
     - debian-8-x86_64
     - debian-9-x86_64
-  el-6-i386:
-    - el-6-i386
+  el-6-i686:
+    - el-6-i686
   el-6-s390x:
     - el-6-s390x
   el-6-x86_64:
@@ -29,9 +29,9 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
-  freebsd-10-x86_64:
-    - freebsd-10-x86_64
-    - freebsd-11-x86_64
+  freebsd-10-amd64:
+    - freebsd-10-amd64
+    - freebsd-11-amd64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
@@ -45,10 +45,10 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  solaris-11-i86pc:
-    - solaris-11-i86pc
-  solaris-11-sparc:
-    - solaris-11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "master"
+gem "artifactory"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 0077920a97ab9e5550f3c3767825f9c1f805bdce
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   branch: master
   specs:
-    omnibus (6.0.31)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,10 +30,11 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.194.0)
-    aws-sdk-core (3.61.2)
+    aws-partitions (1.196.0)
+    aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -371,6 +372,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  artifactory
   berkshelf (>= 7.0)
   kitchen-vagrant (>= 1.3.1)
   ohai


### PR DESCRIPTION
## Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage. Platform names in `release.omnibus.yml` are also fixed to conform with what the new package publishing code in the omnibus gem expects.

## Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22