### PR TITLE
[ci] Fix omnibus pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -12,8 +12,8 @@ builder-to-testers-map:
   debian-8-x86_64:
     - debian-8-x86_64
     - debian-9-x86_64
-  el-6-i386:
-    - el-6-i386
+  el-6-i686:
+    - el-6-i686
   el-6-s390x:
     - el-6-s390x
   el-6-x86_64:
@@ -28,9 +28,9 @@ builder-to-testers-map:
     - el-7-s390x
   el-7-x86_64:
     - el-7-x86_64
-  freebsd-10-x86_64:
-    - freebsd-10-x86_64
-    - freebsd-11-x86_64
+  freebsd-10-amd64:
+    - freebsd-10-amd64
+    - freebsd-11-amd64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
@@ -44,10 +44,10 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  solaris-11-i86pc:
-    - solaris-11-i86pc
-  solaris-11-sparc:
-    - solaris-11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-14.04-i386:
     - ubuntu-14.04-i386
   ubuntu-14.04-ppc64le:

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "master"
+gem "artifactory"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 968307c129ee54416f5a4d07ca8f8ca2d2b12825
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   branch: master
   specs:
-    omnibus (6.0.27)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,19 +30,20 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.169.0)
-    aws-sdk-core (3.54.0)
+    aws-partitions (1.196.0)
+    aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.21.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.41.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-s3 (1.46.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
@@ -206,7 +207,7 @@ GEM
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
-    mixlib-cli (2.0.6)
+    mixlib-cli (2.1.1)
     mixlib-config (3.0.1)
       tomlrb
     mixlib-install (3.11.18)
@@ -270,7 +271,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.1.0)
+    public_suffix (3.1.1)
     rack (2.0.7)
     retryable (3.0.4)
     rspec (3.8.0)
@@ -410,6 +411,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  artifactory
   berkshelf (>= 7.0)
   kitchen-vagrant
   ohai (~> 14.0)


### PR DESCRIPTION
## Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage. Platform names in `release.omnibus.yml` are also fixed to conform with what the new package publishing code in the omnibus gem expects.

## Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22