### PR TITLE
Fix for rhsm_repo disable does not support wildcard

### DIFF
--- a/lib/chef/resource/rhsm_repo.rb
+++ b/lib/chef/resource/rhsm_repo.rb
@@ -57,7 +57,7 @@ class Chef
         def repo_enabled?(repo)
           cmd = Mixlib::ShellOut.new("subscription-manager repos --list-enabled", env: { LANG: "en_US" })
           cmd.run_command
-          !cmd.stdout.match(/Repo ID:\s+#{repo}$/).nil?
+          repo == "*" || !cmd.stdout.match(/Repo ID:\s+#{repo}$/).nil?
         end
       end
     end

--- a/spec/unit/resource/rhsm_repo_spec.rb
+++ b/spec/unit/resource/rhsm_repo_spec.rb
@@ -60,5 +60,11 @@ describe Chef::Resource::RhsmRepo do
         expect(provider.repo_enabled?("differentrepo")).to eq(false)
       end
     end
+
+    context "when user pass wildcard" do
+      it "returns true" do
+        expect(provider.repo_enabled?("*")).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: Kapil chouhan <kapil.chouhan@msystechnologies.com>

## Description
- Whenever the user passes `repo_name` as wildcards `*` in the `rhsm_repo` resource, so it didn't work at that time due to the `not_if` block. So we have fixed it.
- Added test cases
- Ensured chef-style on the code changes made

## Related Issue
Fixes #8323 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
