### PR TITLE
Chef-15: Make temp dir using mkdir instead of mktemp

### DIFF
--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -128,7 +128,7 @@ class Chef
               # running with sudo right now - so this directory would be owned by root.
               # File upload is performed over SCP as the current logged-in user,
               # so we'll set ownership to ensure that works.
-              cmd += " && chown #{config[:user]} '#{dir}'"
+              cmd += " && sudo chown #{config[:user]} '#{dir}'"
               run_command!(cmd)
               dir
             end

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -155,21 +155,26 @@ describe Chef::Knife::Bootstrap::TrainConnector do
     context "under linux and unix-like" do
       let(:family) { "debian" }
       let(:name) { "ubuntu" }
+      let(:random) { "wScHX6" }
+      let(:dir) { "/tmp/chef_#{random}" }
+
+      before do
+        allow(SecureRandom).to receive(:alphanumeric).with(6).and_return(random)
+      end
+
       it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
-        expected_command = Chef::Knife::Bootstrap::TrainConnector::MKTEMP_NIX_COMMAND
+        expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
         expect(subject).to receive(:run_command!).with(expected_command)
-          .and_return double("result", stdout: "/a/path")
-        expect(subject).to receive(:run_command!).with("chown user1 '/a/path'")
-        expect(subject.temp_dir).to eq "/a/path"
+          .and_return double("result", stdout: "\r\n")
+        expect(subject.temp_dir).to eq(dir)
       end
 
       context "with noise in stderr" do
         it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
-          expected_command = Chef::Knife::Bootstrap::TrainConnector::MKTEMP_NIX_COMMAND
+          expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
           expect(subject).to receive(:run_command!).with(expected_command)
-            .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "/a/path\r\n")
-          expect(subject).to receive(:run_command!).with("chown user1 '/a/path'")
-          expect(subject.temp_dir).to eq "/a/path"
+            .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "#{dir}\r\n")
+          expect(subject.temp_dir).to eq(dir)
         end
       end
     end

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -163,7 +163,7 @@ describe Chef::Knife::Bootstrap::TrainConnector do
       end
 
       it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
-        expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
+        expected_command = "mkdir -p #{dir} && sudo chown user1 '#{dir}'"
         expect(subject).to receive(:run_command!).with(expected_command)
           .and_return double("result", stdout: "\r\n")
         expect(subject.temp_dir).to eq(dir)
@@ -171,7 +171,7 @@ describe Chef::Knife::Bootstrap::TrainConnector do
 
       context "with noise in stderr" do
         it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
-          expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
+          expected_command = "mkdir -p #{dir} && sudo chown user1 '#{dir}'"
           expect(subject).to receive(:run_command!).with(expected_command)
             .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "#{dir}\r\n")
           expect(subject.temp_dir).to eq(dir)


### PR DESCRIPTION
## Description 
- In order to get rid of `mktemp` use `mkdir` for Linux and Unix host.
- `mktemp` does not exist for AIX host.
 - `mkdir` does not return the created path so return the dir itself.

Note: working on to fix `chown: /tmp/chef_Xr0QpL: Operation not permitted.` 

seems run_command! created dir with `root:system` user privileges 
but when ssh login on AIX host and run the same command to created dir it get created with `user:staff` permission.

```
drwxr-xr-x    2 vsingh   staff           256 Aug 06 08:36 chef_Xr0Q
drwxr-xr-x    2 root     system          256 Aug 06 08:35 chef_Xr0QpL
```
 
Any suggestions would be helpful?

Thanks!
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8764

Issue found while creating temp dir https://github.com/chef/chef/blob/3284e9067aacbe42f96afc78b06e523b46b98d2f/lib/chef/knife/bootstrap/train_connector.rb#L35

ERROR: `bash: mktemp: command not found`

In order to make it work, we have to update the command for creating temp dir

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
