### PR TITLE
Stop building Chef Infra Client on SLES 11

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -36,10 +36,6 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  sles-11-s390x:
-    - sles-11-s390x
-  sles-11-x86_64:
-    - sles-11-x86_64
   sles-12-s390x:
     - sles-12-s390x
   sles-12-x86_64:


### PR DESCRIPTION
As of March 31st 2019, SLES 11 is no longer generally supported. Per our
support process we will no longer officially support SLES 11.

See https://docs.chef.io/platforms.html#platform-end-of-life-policy

Signed-off-by: Tim Smith <tsmith@chef.io>