### PR TITLE
Consistently use NOT_PASSED over alternatives

### DIFF
--- a/lib/chef.rb
+++ b/lib/chef.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 
 require_relative "chef/version"
 
-require_relative "chef/nil_argument"
 require_relative "chef/mash"
 require_relative "chef/exceptions"
 require_relative "chef/log"

--- a/lib/chef/decorator.rb
+++ b/lib/chef/decorator.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016 Chef Software, Inc.
+# Copyright:: Copyright 2016-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,13 @@
 #
 
 require "delegate"
+require_relative "constants"
 
 class Chef
   class Decorator < SimpleDelegator
-    NULL = ::Object.new
-
-    def initialize(obj = NULL)
+    def initialize(obj = NOT_PASSED)
       @__defined_methods__ = []
-      super unless obj.equal?(NULL)
+      super unless obj.equal?(NOT_PASSED)
     end
 
     # if we wrap a nil then decorator.nil? should be true

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 
 require "chef-config/exceptions"
 require_relative "dist"
+require_relative "constants"
 
 class Chef
   # == Chef::Exceptions
@@ -264,14 +265,12 @@ class Chef
     end
 
     class MissingRole < RuntimeError
-      NULL = Object.new
-
       attr_reader :expansion
 
-      def initialize(message_or_expansion = NULL)
+      def initialize(message_or_expansion = NOT_PASSED)
         @expansion = nil
         case message_or_expansion
-        when NULL
+        when NOT_PASSED
           super()
         when String
           super

--- a/lib/chef/nil_argument.rb
+++ b/lib/chef/nil_argument.rb
@@ -1,3 +1,0 @@
-class Chef
-  NIL_ARGUMENT = Object.new
-end

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -20,8 +20,8 @@
 
 require "forwardable" unless defined?(Forwardable)
 require "securerandom" unless defined?(SecureRandom)
+require_relative "constants"
 require_relative "config"
-require_relative "nil_argument"
 require_relative "mixin/params_validate"
 require_relative "mixin/from_file"
 require_relative "mixin/deep_merge"
@@ -65,8 +65,6 @@ class Chef
     include Chef::DSL::Universal
 
     include Chef::Mixin::ParamsValidate
-
-    NULL_ARG = Object.new
 
     # Create a new Chef::Node object.
     def initialize(chef_server_rest: nil, logger: nil)
@@ -152,8 +150,8 @@ class Chef
     #
     # @param arg [String] the new policy_name value
     # @return [String] the current policy_name, or the one you just set
-    def policy_name(arg = NULL_ARG)
-      return @policy_name if arg.equal?(NULL_ARG)
+    def policy_name(arg = NOT_PASSED)
+      return @policy_name if arg.equal?(NOT_PASSED)
 
       validate({ policy_name: arg }, { policy_name: { kind_of: [ String, NilClass ], regex: /^[\-:.[:alnum:]_]+$/ } })
       @policy_name = arg
@@ -175,8 +173,8 @@ class Chef
     #
     # @param arg [String] the new policy_group value
     # @return [String] the current policy_group, or the one you just set
-    def policy_group(arg = NULL_ARG)
-      return @policy_group if arg.equal?(NULL_ARG)
+    def policy_group(arg = NOT_PASSED)
+      return @policy_group if arg.equal?(NOT_PASSED)
 
       validate({ policy_group: arg }, { policy_group: { kind_of: [ String, NilClass ], regex: /^[\-:.[:alnum:]_]+$/ } })
       @policy_group = arg

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
We have four different versions of this now, and this converts to
just using the one convention in `lib/chef/constants.rb`

Interestingly `Chef::NIL_ARGUMENT` is used nowhere in the codebase, that
probably got refactored out in 12.5.1.

Node objects still use `NIL` but that is a different kind of `Object.new`
which really is semantically private to the implementation of
attributes.
