### PR TITLE
[ci] Revert the zypper test failures fix

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -152,18 +152,6 @@ elif [[ -d /usr/local/etc/sudoers.d ]]; then
   sudo chmod 440 "/usr/local/etc/sudoers.d/$(id -un)-preserve_path"
 fi
 
-# Remove the ec2 cloud zypper repos before running functional tests
-if [[ ! $(grep s390 /etc/SuSE-release) ]] > /dev/null 2>&1; then   # Don't delete repos on s390x
-  if [[ $(grep -i suse /etc/SuSE-release /etc/os-release) ]] > /dev/null 2>&1; then
-    echo "Removing zypper repos for Amazon SLES nodes"
-    sleep 5  # Allow some time for repo setup to complete
-    for i in $(zypper lr |grep -v "Alias" |awk -F "|" '{print $2}'); do
-      sudo zypper rr $i
-    done
-    sudo rm /usr/lib/zypp/plugins/services/* || true
-  fi
-fi
-
 cd "$chef_gem"
 sudo -E bundle install
 sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional


### PR DESCRIPTION
## Description

We don't need this fix in `omnibus-test.sh` anymore. We updated the systems we use to run the test and that resolved the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
