### PR TITLE
[ci] Remove explicit debug log level from omnibus pipelines

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,14 +26,11 @@ pipelines:
   - verify:
       public: true
   - habitat/build
-  - omnibus/release:
-      env:
-        - BUILD_OPTIONS: -l debug
+  - omnibus/release
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
-        - BUILD_OPTIONS: -l debug
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch


### PR DESCRIPTION
The omnibus pipelines now default to "internal" log level so setting this here is no longer necessary.