### PR TITLE
Stop building Chef Infra Client 14.x on FreeBSD 10

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -28,9 +28,9 @@ builder-to-testers-map:
     - el-7-s390x
   el-7-x86_64:
     - el-7-x86_64
-  freebsd-10-amd64:
-    - freebsd-10-amd64
+  freebsd-11-amd64:
     - freebsd-11-amd64
+    - freebsd-12-amd64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64


### PR DESCRIPTION
## Description

As of October 31st 2018, FreeBSD 10 is no longer generally supported. Per our
support process we will no longer officially support FreeBSD 10.

See https://docs.chef.io/platforms.html#platform-end-of-life-policy

It also adds support for FreeBSD 12.