### PR TITLE
Updated knife cookbook metadata from file command banner

### DIFF
--- a/lib/chef/knife/cookbook_metadata_from_file.rb
+++ b/lib/chef/knife/cookbook_metadata_from_file.rb
@@ -28,7 +28,7 @@ class Chef
         require_relative "../cookbook/metadata"
       end
 
-      banner "knife cookbook metadata from FILE (options)"
+      banner "knife cookbook metadata from file FILE (options)"
 
       def run
         file = @name_args[0]


### PR DESCRIPTION
`file` was missing in `knife cookbook metadata from file FILE` command banner.

Signed-off-by: Amol Shinde <amol.shinde@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
- Added `file` in `knife cookbook metadata from file FILE` command banner.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
- #8798 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
