### PR TITLE
Bootstrap: Only use sudo when changing ownership if --sudo is passed

### DIFF
--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -128,8 +128,7 @@ class Chef
               # running with sudo right now - so this directory would be owned by root.
               # File upload is performed over SCP as the current logged-in user,
               # so we'll set ownership to ensure that works.
-              ownership = config[:sudo] ? "sudo chown" : "chown"
-              cmd += " && #{ownership} #{config[:user]} '#{dir}'"
+              cmd += " && sudo chown #{config[:user]} '#{dir}'" if config[:sudo]
 
               run_command!(cmd)
               dir

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -128,7 +128,9 @@ class Chef
               # running with sudo right now - so this directory would be owned by root.
               # File upload is performed over SCP as the current logged-in user,
               # so we'll set ownership to ensure that works.
-              cmd += " && sudo chown #{config[:user]} '#{dir}'"
+              ownership = config[:sudo] ? "sudo chown" : "chown"
+              cmd += " && #{ownership} #{config[:user]} '#{dir}'"
+
               run_command!(cmd)
               dir
             end

--- a/lib/chef/knife/bootstrap/train_connector.rb
+++ b/lib/chef/knife/bootstrap/train_connector.rb
@@ -123,14 +123,13 @@ class Chef
               # eg. /tmp/chef_XXXXXX.
               # Use mkdir to create TEMP dir to get rid of mktemp
               dir = "#{DEFAULT_REMOTE_TEMP}/chef_#{SecureRandom.alphanumeric(6)}"
-              cmd = "mkdir -p %s" % dir
+              run_command!("mkdir -p '#{dir}'")
               # Ensure that dir has the correct owner.  We are possibly
               # running with sudo right now - so this directory would be owned by root.
               # File upload is performed over SCP as the current logged-in user,
               # so we'll set ownership to ensure that works.
-              cmd += " && sudo chown #{config[:user]} '#{dir}'" if config[:sudo]
+              run_command!("chown #{config[:user]} '#{dir}'") if config[:sudo]
 
-              run_command!(cmd)
               dir
             end
           end

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -172,7 +172,7 @@ describe Chef::Knife::Bootstrap::TrainConnector do
         end
 
         it "without sudo privilege" do
-          expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
+          expected_command = "mkdir -p #{dir}"
           expect(subject).to receive(:run_command!).with(expected_command)
             .and_return double("result", stdout: "\r\n")
           expect(subject.temp_dir).to eq(dir)
@@ -180,8 +180,8 @@ describe Chef::Knife::Bootstrap::TrainConnector do
       end
 
       context "with noise in stderr" do
-        it "uses the *nix command to create the temp dir and sets ownership to logged-in user" do
-          expected_command = "mkdir -p #{dir} && chown user1 '#{dir}'"
+        it "uses the *nix command to create the temp dir" do
+          expected_command = "mkdir -p #{dir}"
           expect(subject).to receive(:run_command!).with(expected_command)
             .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "#{dir}\r\n")
           expect(subject.temp_dir).to eq(dir)

--- a/spec/unit/knife/bootstrap/train_connector_spec.rb
+++ b/spec/unit/knife/bootstrap/train_connector_spec.rb
@@ -165,14 +165,17 @@ describe Chef::Knife::Bootstrap::TrainConnector do
       context "uses the *nix command to create the temp dir and sets ownership to logged-in" do
         it "with sudo privilege" do
           subject.config[:sudo] = true
-          expected_command = "mkdir -p #{dir} && sudo chown user1 '#{dir}'"
-          expect(subject).to receive(:run_command!).with(expected_command)
+          expected_command1 = "mkdir -p '#{dir}'"
+          expected_command2 = "chown user1 '#{dir}'"
+          expect(subject).to receive(:run_command!).with(expected_command1)
+            .and_return double("result", stdout: "\r\n")
+          expect(subject).to receive(:run_command!).with(expected_command2)
             .and_return double("result", stdout: "\r\n")
           expect(subject.temp_dir).to eq(dir)
         end
 
         it "without sudo privilege" do
-          expected_command = "mkdir -p #{dir}"
+          expected_command = "mkdir -p '#{dir}'"
           expect(subject).to receive(:run_command!).with(expected_command)
             .and_return double("result", stdout: "\r\n")
           expect(subject.temp_dir).to eq(dir)
@@ -181,7 +184,7 @@ describe Chef::Knife::Bootstrap::TrainConnector do
 
       context "with noise in stderr" do
         it "uses the *nix command to create the temp dir" do
-          expected_command = "mkdir -p #{dir}"
+          expected_command = "mkdir -p '#{dir}'"
           expect(subject).to receive(:run_command!).with(expected_command)
             .and_return double("result", stdout: "sudo: unable to resolve host hostname.localhost\r\n" + "#{dir}\r\n")
           expect(subject.temp_dir).to eq(dir)


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
 - Add check to append `sudo` only if require `sudo` privilege.
 - Work fine with Ubuntu, CentOS, AIX nodes.
 - Add test case to ensure it requires sudo only if option `--sudo` provided.

## Related Issue
https://github.com/chef/chef/issues/8814

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
