### PR TITLE
Bootstrap: Set pty true only if required

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -670,14 +670,12 @@ class Chef
       end
 
       def do_connect(conn_options)
-        retry_require = true
         begin
           @connection = TrainConnector.new(host_descriptor, connection_protocol, conn_options)
           connection.connect!
         rescue Train::UserError => e
-          if retry_require && e.message =~ /Sudo requires a TTY/
+          if !conn_options.key?(:pty) && e.message =~ /Sudo requires a TTY/
             ui.warn("#{e.message} - trying with pty request")
-            retry_require = false
             conn_options[:pty] = true # ensure we can talk to systems with requiretty set true in sshd config
             retry
           else

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -670,17 +670,15 @@ class Chef
       end
 
       def do_connect(conn_options)
-        begin
-          @connection = TrainConnector.new(host_descriptor, connection_protocol, conn_options)
-          connection.connect!
-        rescue Train::UserError => e
-          if !conn_options.key?(:pty) && e.message =~ /Sudo requires a TTY/
-            ui.warn("#{e.message} - trying with pty request")
-            conn_options[:pty] = true # ensure we can talk to systems with requiretty set true in sshd config
-            retry
-          else
-            raise
-          end
+        @connection = TrainConnector.new(host_descriptor, connection_protocol, conn_options)
+        connection.connect!
+      rescue Train::UserError => e
+        if !conn_options.key?(:pty) && e.message =~ /Sudo requires a TTY/
+          ui.warn("#{e.message} - trying with pty request")
+          conn_options[:pty] = true # ensure we can talk to systems with requiretty set true in sshd config
+          retry
+        else
+          raise
         end
       end
 

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -673,7 +673,7 @@ class Chef
         @connection = TrainConnector.new(host_descriptor, connection_protocol, conn_options)
         connection.connect!
       rescue Train::UserError => e
-        if !conn_options.key?(:pty) && e.message =~ /Sudo requires a TTY/
+        if !conn_options.key?(:pty) && e.reason == :sudo_no_tty
           ui.warn("#{e.message} - trying with pty request")
           conn_options[:pty] = true # ensure we can talk to systems with requiretty set true in sshd config
           retry

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -2001,7 +2001,7 @@ describe Chef::Knife::Bootstrap do
 
     context "when sshd confgiured with requiretty" do
       let(:pty_err_msg) { "Sudo requires a TTY. Please see the README on how to configure sudo to allow for non-interactive usage." }
-      let(:expected_error) { Train::UserError.new(pty_err_msg) }
+      let(:expected_error) { Train::UserError.new(pty_err_msg, :sudo_no_tty) }
       before do
         allow(connection).to receive(:connect!).and_raise(expected_error)
       end

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1021,7 +1021,6 @@ describe Chef::Knife::Bootstrap do
                 verify_host_key: nil,
                 port: 9999,
                 non_interactive: true,
-                pty: true,
               }
             end
 
@@ -1076,7 +1075,6 @@ describe Chef::Knife::Bootstrap do
                 verify_host_key: nil, # Config
                 port: 12, # cli
                 non_interactive: true,
-                pty: true,
               }
             end
 
@@ -1128,7 +1126,6 @@ describe Chef::Knife::Bootstrap do
                 sudo_password: "blah",
                 verify_host_key: true,
                 non_interactive: true,
-                pty: true,
               }
             end
             it "generates a config hash using the CLI options and pulling nothing from Chef::Config" do
@@ -1152,7 +1149,6 @@ describe Chef::Knife::Bootstrap do
               sudo: false,
               verify_host_key: "always",
               non_interactive: true,
-              pty: true,
               connection_timeout: 60,
             }
           end
@@ -1504,7 +1500,6 @@ describe Chef::Knife::Bootstrap do
       let(:default_opts) do
         {
           non_interactive: true,
-          pty: true,
           forward_agent: false,
           connection_timeout: 60,
         }

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1998,6 +1998,19 @@ describe Chef::Knife::Bootstrap do
       expect(connection).to receive(:connect!)
       knife.do_connect({})
     end
+
+    context "when sshd confgiured with requiretty" do
+      let(:pty_err_msg) { "Sudo requires a TTY. Please see the README on how to configure sudo to allow for non-interactive usage." }
+      let(:expected_error) { Train::UserError.new(pty_err_msg) }
+      before do
+        allow(connection).to receive(:connect!).and_raise(expected_error)
+      end
+      it "retry with pty true request option" do
+        expect(Chef::Knife::Bootstrap::TrainConnector).to receive(:new).and_return(connection).exactly(2).times
+        expect(knife.ui).to receive(:warn).with("#{pty_err_msg} - trying with pty request")
+        expect { knife.do_connect({}) }.to raise_error(expected_error)
+      end
+    end
   end
 
   describe "validate_winrm_transport_opts!" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
 - `rescue` the exception and retry with pty: true if host configured with `requiretty`.
 - Remove the default pty: true for all node that causes the error in the window and other hosts while detecting the system.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Earlier we provided `pty: true` for all node to bootstrap. But seems issue noticed for `Windows`, `AIX` or other `Unix` system.
- First tried without pty params.
- If fails with exception "_Sudo requires a TTY. Please see the README on how to configure_ "
https://github.com/inspec/train/blob/3ab9ad867972106f419a28ffd44d4291747dd360/lib/train/extras/command_wrapper.rb#L68 retry with `pty: true`.
- Add begin..rescue in `do_connect` seems unable to catch inside the `connect!` method.

### Note:
 - Warn message about pty request
 ```
WARNING: Sudo failed: Sudo requires a TTY. Please see the README on how to configure sudo to allow for non-interactive usage. - trying with pty request
```
- Pending to add test cases to cover these changes if any.
- Boolean check to retry again

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Issues: https://github.com/chef/chef/issues/8683, https://github.com/chef/chef/issues/8764

Dependent PRs: 
1. https://github.com/inspec/train/pull/508 which require to get the correct error message.
2. https://github.com/chef/chef/pull/8816 & https://github.com/chef/chef/pull/8795 to create temp dir.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
