### PR TITLE
Deprecate Ubuntu 14 + SLES 11

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -48,12 +48,6 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
-  ubuntu-14.04-i386:
-    - ubuntu-14.04-i386
-  ubuntu-14.04-ppc64le:
-    - ubuntu-14.04-ppc64le
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -35,10 +35,6 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  sles-11-s390x:
-    - sles-11-s390x
-  sles-11-x86_64:
-    - sles-11-x86_64
   sles-12-s390x:
     - sles-12-s390x
   sles-12-x86_64:

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 33bddeefb10afe23a57ea72807625881ab01990f
+  revision: a0fb4a162261f57ffd7b1fff980911b474970cb9
   branch: master
   specs:
     omnibus (6.1.0)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 34e5138a5676dcaa3146a5a45aac4651ea2950ae
+  revision: 5fa35959f6efb0a5a745c46e4b0431a2826934da
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -33,7 +33,7 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.196.0)
+    aws-partitions (1.200.0)
     aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -67,7 +67,7 @@ The default build environment requires Test Kitchen and VirtualBox for local dev
 Once you have tweaked your `kitchen.yml` (or `kitchen.local.yml`) to your liking, you can bring up an individual build environment using the `kitchen` command.
 
 ```shell
-$ bundle exec kitchen converge chef-ubuntu-1404
+$ bundle exec kitchen converge chef-ubuntu-1604
 ```
 
 Additional settings are required if using the kitchen-vagrant driver with the Hyper-V provider:
@@ -87,7 +87,7 @@ $ bundle exec kitchen login <PROJECT>-ubuntu-1204
 ```
 
 ```shell
-$ kitchen login chef-ubuntu-1404
+$ kitchen login chef-ubuntu-1604
 [vagrant@ubuntu...] $ source load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ cd chef/omnibus
 [vagrant@ubuntu...] $ bundle install --without development # Don't install dev tools!

--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -95,11 +95,11 @@ package :msi do
   upgrade_code msi_upgrade_code
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
-  signing_identity "E05FF095D07F233B78EB322132BFF0F035E11B5B", machine_store: true
+  signing_identity "AF21BA8C9E50AE20DA9907B6E2D4B0CC3306CA03", machine_store: true
   parameters ChefLogDllPath: windows_safe_path(gem_path("chef-[0-9]*-mingw32/ext/win32-eventlog/chef-log.dll")),
              ProjectLocationDir: project_location_dir
 end
 
 package :appx do
-  signing_identity "E05FF095D07F233B78EB322132BFF0F035E11B5B", machine_store: true
+  signing_identity "AF21BA8C9E50AE20DA9907B6E2D4B0CC3306CA03", machine_store: true
 end

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -147,6 +147,9 @@ elif [[ -d /usr/local/etc/sudoers.d ]]; then
   sudo chmod 440 "/usr/local/etc/sudoers.d/$(id -un)-preserve_path"
 fi
 
+# REDO 20190813 - this ulimit can be removed once the macos anka images are updated to support more than 256 open files
+ulimit -S -n 512
+
 cd "$chef_gem"
 sudo -E bundle install
 sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "2.7.9"
-override :bundler, version: "1.17.3"
+override :bundler, version: "1.16.6"
 override "nokogiri", version: "1.10.2"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
Deprecate Ubuntu 14 + SLES 11 in the Chef-14 branch

## Description
This PR includes additional changes to fix broken builds on the new queues

## Related Issue
https://github.com/chef/release-engineering/issues/607

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
