### PR TITLE
 when calling process_events_until_done, skip events that are empty (nil) in event_list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,12 @@ Lint/IneffectiveAccessModifier:
   Enabled: false
 Lint/ShadowedException:
   Enabled: false
+Layout/AlignHash:
+  Enabled: true
+  EnforcedLastArgumentHashStyle: ignore_implicit
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/lib/chef/event_dispatch/dispatcher.rb
+++ b/lib/chef/event_dispatch/dispatcher.rb
@@ -2,13 +2,11 @@ require_relative "base"
 
 class Chef
   module EventDispatch
-
     # == EventDispatch::Dispatcher
     # The Dispatcher handles receiving event data from the sources
     # (Chef::Client, Resources and Providers, etc.) and publishing the data to
     # the registered subscribers.
     class Dispatcher < Base
-
       attr_reader :subscribers
       attr_reader :event_list
 
@@ -27,7 +25,7 @@ class Chef
       end
 
       def enqueue(method_name, *args)
-        event_list << [ method_name, *args ]
+        event_list << [method_name, *args]
         process_events_until_done unless @in_call
       end
 
@@ -81,9 +79,13 @@ class Chef
       # empty, rather than iterating over the list.
       #
       def process_events_until_done
-        call_subscribers(*event_list.shift) until event_list.empty?
-      end
+        until event_list.empty?
+          event = event_list.shift
+          next if event[0].nil?
 
+          call_subscribers(*event)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This is a proposed fix to #8825 

In the case where the event_list is empty, it errors out and gets this stack trace:

```
sh-4.2$ sudo cat /var/chef/.chef/local-mode-cache/cache/chef-stacktrace.out
Generated at 2019-08-16 15:12:23 +0000
ArgumentError: wrong number of arguments (given 0, expected 1+)
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/event_dispatch/dispatcher.rb:59:in `call_subscribers'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/event_dispatch/dispatcher.rb:84:in `process_events_until_done'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/event_dispatch/dispatcher.rb:31:in `enqueue'
(eval):2:in `updated_cookbook_file'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/cookbook/synchronizer.rb:290:in `sync_file'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/cookbook/synchronizer.rb:176:in `block (2 levels) in sync_cookbooks'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/util/threaded_job_queue.rb:52:in `block (3 levels) in process'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/util/threaded_job_queue.rb:50:in `loop'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.2.20/lib/chef/util/threaded_job_queue.rb:50:in `block (2 levels) in process'
```

## Description
return sentinel clause to not do anything if the event_list is empty when process_events_until_done is invoked

## Related Issue
https://github.com/chef/chef/issues/8825

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
