### PR TITLE
Fix crash when showing error about missing profile

### DIFF
--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -92,7 +92,7 @@ module ChefConfig
           # raise an error.
           return if profile == "default"
 
-          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file}."
+          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file_path}."
         end
         apply_credentials(config[profile], profile)
       end


### PR DESCRIPTION
## Description

Before:

    /opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/chef-config-15.1.36/lib/chef-config/mixin/credentials.rb:92:in `load_credentials': undefined local variable or method `credentials_file' for #<ChefConfig::WorkstationConfigLoader:0x00007fe01c8321e8> (NameError)

After:

    ERROR: CONFIGURATION ERROR:Profile xyz doesn't exist. Please add it to /Users/developer/.chef/credentials.

It looks like this was missed as part of the refactoring in
d730505bb0d53d14c7b005c756ed4993b95fdf94.

Signed-off-by: Andrew Neitsch <andrew@neitsch.ca>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).