### PR TITLE
Give --bootstrap-version cli option precedence

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -195,6 +195,7 @@ class Chef
         #
         # @return [String] download version string
         def version_to_install
+          return @config[:bootstrap_version] if @config[:bootstrap_version]
           return knife_config[:bootstrap_version] if knife_config[:bootstrap_version]
 
           if @config[:channel] == "stable"

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -282,11 +282,20 @@ describe Chef::Knife::Core::BootstrapContext do
   end
 
   describe "#version_to_install" do
-    context "when bootstrap_version is provided" do
+    context "when bootstrap_version is provided in config.rb" do
       let(:chef_config) { { knife: { bootstrap_version: "awesome" } } }
 
-      it "returns bootstrap_version" do
+      it "returns bootstrap_version from config.rb" do
         expect(bootstrap_context.version_to_install).to eq "awesome"
+      end
+    end
+
+    context "when bootstrap_version is provided on the command line" do
+      let(:chef_config) { { knife: { bootstrap_version: "awesome" } } }
+      let(:config) { { bootstrap_version: "more_awesome" } }
+
+      it "returns bootstrap_version from the command line, not config.rb" do
+        expect(bootstrap_context.version_to_install).to eq "more_awesome"
       end
     end
 


### PR DESCRIPTION
When knife bootstrap specifies --bootstrap-version on the command line,
the value in config.rb is still used.

Fixes #8834

Signed-off-by: Chris Crebolder <ccrebolder@gmail.com>

## Description
The expected behaviour is for the command line option to override the configuration file option.

## Related Issue
#8834 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
