### PR TITLE
Fix the build arguments in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM busybox
-MAINTAINER Chef Software, Inc. <docker@chef.io>
+LABEL maintainer="Chef Software, Inc. <docker@chef.io>"
 
+ARG EXPEDITOR_CHANNEL
 ARG CHANNEL=stable
+ARG EXPEDITOR_VERSION
 ARG VERSION=14.13.11
+
+# Allow the build arg below to be controlled by either build arguments
+ENV VERSION ${EXPEDITOR_VERSION:-${VERSION}}
+ENV CHANNEL ${EXPEDITOR_CHANNEL:-${CHANNEL}}
 
 RUN wget "http://packages.chef.io/files/${CHANNEL}/chef/${VERSION}/el/6/chef-${VERSION}-1.el6.x86_64.rpm" -O /tmp/chef-client.rpm && \
     rpm2cpio /tmp/chef-client.rpm | cpio -idmv && \


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix the build arguments in the Dockerfile

We need to support the prefixed `EXPEDITOR_` build arguments in our
Dockerfile. We are leaving the non-prefixed arguments in there for
back-compat.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
