### PR TITLE
Always use system rubygem to determine nodocument flag.

### DIFF
--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -604,7 +604,8 @@ class Chef
         end
 
         def needs_nodocument?
-          Gem::Requirement.new(">= 3.0.0.beta1").satisfied_by?(Gem::Version.new(gem_env.rubygems_version))
+          rubygem_version = shell_out!("#{gem_binary_path} --version").stdout.chomp
+          Gem::Requirement.new(">= 3.0.0.beta1").satisfied_by?(Gem::Version.new(rubygem_version))
         end
 
         def opts

--- a/spec/unit/provider/package/rubygems_spec.rb
+++ b/spec/unit/provider/package/rubygems_spec.rb
@@ -709,7 +709,7 @@ describe Chef::Provider::Package::Rubygems do
           it "unmockening needs_nodocument?" do
             expected = "gem install rspec-core -q --no-document -v \"#{target_version}\" --source=https://www.rubygems.org #{options}"
             expect(provider).to receive(:needs_nodocument?).and_call_original
-            stub_const("Gem::VERSION", "3.0.0")
+            expect(provider).to receive(:shell_out_compacted!).with("gem --version", { timeout: 900 }).and_return(instance_double(Mixlib::ShellOut, stdout: "3.0.0\n"))
             expect(provider).to receive(:shell_out_compacted!).with(expected, env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
@@ -718,7 +718,7 @@ describe Chef::Provider::Package::Rubygems do
           it "when the rubygems_version is old it uses the old flags" do
             expected = "gem install rspec-core -q --no-rdoc --no-ri -v \"#{target_version}\" --source=https://www.rubygems.org #{options}"
             expect(provider).to receive(:needs_nodocument?).and_call_original
-            stub_const("Gem::VERSION", "2.8.0")
+            expect(provider).to receive(:shell_out_compacted!).with("gem --version", { timeout: 900 }).and_return(instance_double(Mixlib::ShellOut, stdout: "2.8.0\n"))
             expect(provider).to receive(:shell_out_compacted!).with(expected, env: nil, timeout: 900)
             provider.run_action(:install)
             expect(new_resource).to be_updated_by_last_action
@@ -875,7 +875,7 @@ describe Chef::Provider::Package::Rubygems do
 
         it "unmockening needs_nodocument?" do
           expect(provider).to receive(:needs_nodocument?).and_call_original
-          expect(provider.gem_env).to receive(:shell_out!).with("#{gem_binary} --version").and_return(instance_double(Mixlib::ShellOut, stdout: "3.0.0\n"))
+          expect(provider).to receive(:shell_out_compacted!).with("#{gem_binary} --version", { timeout: 900 }).and_return(instance_double(Mixlib::ShellOut, stdout: "3.0.0\n"))
           expect(provider).to receive(:shell_out_compacted!).with("#{gem_binary} install rspec-core -q --no-document -v \"#{target_version}\" --source=https://www.rubygems.org", env: nil, timeout: 900)
           provider.run_action(:install)
           expect(new_resource).to be_updated_by_last_action
@@ -883,7 +883,7 @@ describe Chef::Provider::Package::Rubygems do
 
         it "when the rubygems_version is old it uses the old flags" do
           expect(provider).to receive(:needs_nodocument?).and_call_original
-          expect(provider.gem_env).to receive(:shell_out!).with("#{gem_binary} --version").and_return(instance_double(Mixlib::ShellOut, stdout: "2.8.0\n"))
+          expect(provider).to receive(:shell_out_compacted!).with("#{gem_binary} --version", { timeout: 900 }).and_return(instance_double(Mixlib::ShellOut, stdout: "2.8.0\n"))
           expect(provider).to receive(:shell_out_compacted!).with("#{gem_binary} install rspec-core -q --no-rdoc --no-ri -v \"#{target_version}\" --source=https://www.rubygems.org", env: nil, timeout: 900)
           provider.run_action(:install)
           expect(new_resource).to be_updated_by_last_action


### PR DESCRIPTION
(This could only happen on chef `14.x` at this moment)

Currently if the user doesn't specify custom rubygem binary path,
chef uses `Gem::VERSION` to determine if the rubygem version is
compatiable with old nodocument flags like `--no-rdoc`.

https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/provider/package/rubygems.rb#L601-L611

If the user doesn't specify rubygem binary path:
https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/provider/package/rubygems.rb#L272-L274

If the user specifies rubygem binary path:
https://github.com/chef/chef/blob/7558c414030d082194d0d2b5f74279ce151517e9/lib/chef/provider/package/rubygems.rb#L303-L305

This doesn't work because the `Gem::VERSION` always points to chef's
embedded rubygem version. But the binary we use to install gems is
the system's rubygem, which might be different from chef's embedded
version **even though the user doesn't specify custom binary path**.

So when a user upgrades his Ruby version to 2.6 (rubygem 3.0.x) with
Chef 14.x (rubygem 2.7.x), an error will occur:

```
 STDOUT:
   STDERR: ERROR:  While executing gem ... (OptionParser::InvalidOption)
       invalid option: --no-rdoc
```

This is because `Gem::VERSION` would make chef think that it's ok to use
`--no-rdoc` while it's not. The solution is to always perform the check with
system rubygem's version.

Signed-off-by: st0012 <stan001212@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).