### PR TITLE
Fix option parsing order for knife commands

### DIFF
--- a/spec/data/knife_subcommand/test_yourself.rb
+++ b/spec/data/knife_subcommand/test_yourself.rb
@@ -11,6 +11,8 @@ module KnifeSpecs
 
     option :scro, :short => '-s SCRO', :long => '--scro SCRO', :description => 'a configurable setting'
 
+    option :with_proc, :long => '--with-proc VALUE', proc: Proc.new { |v| Chef::Config[:knife][:with_proc] = v }
+
     attr_reader :ran
 
     def run

--- a/spec/unit/knife_spec.rb
+++ b/spec/unit/knife_spec.rb
@@ -347,6 +347,13 @@ describe Chef::Knife do
         expect(knife_command.config_source(:opt_with_default)).to eq(:cli)
       end
 
+      it "allows an option proc to set a value in Chef::Config" do
+        allow(config_loader).to receive(:load) { Chef::Config[:knife][:with_proc] = "from config file" }
+        knife_command = Chef::Knife.run(%w{test yourself --with-proc from-cli})
+        expect(Chef::Config[:knife][:with_proc]).to eq("from-cli")
+        expect(knife_command.config[:with_proc]).to eq("from-cli")
+      end
+
       it "merges `listen` config to Chef::Config" do
         knife_command = Chef::Knife.run(%w{test yourself --no-listen}, Chef::Application::Knife.options)
         expect(Chef::Config[:listen]).to be(false)


### PR DESCRIPTION
* https://docs.chef.io/plugin_knife_custom.html#config-rb-settings

A common pattern for mixlib-cli procs is to set the Chef::Config[:knife]
setting to the same as the command line argument, however Chef::Config
has not been fully loaded at the time the options are parsed, which
means if the config file has the same option it resets to that value
after the load.

Fixes #8834

Signed-off-by: Chris Crebolder <ccrebolder@gmail.com>

## Description
The expected behaviour is for the proc to be able to manually set a value in Chef::Config, however if the same option exists in the config file, it is loaded after the proc has run, setting it back to the original.

## Related Issue
#8834

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
