### PR TITLE
Support to provide --local flag to gem installer.

### DIFF
--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -66,8 +66,13 @@ class Chef
                 tf.close
                 Chef::Log.trace("generated Gemfile contents:")
                 Chef::Log.trace(IO.read(tf.path))
-                so = shell_out!("bundle install", cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
-                Chef::Log.info(so.stdout)
+                # Skip installation only if Chef::Config[:skip_gem_metadata_installation] option is true
+                unless Chef::Config[:skip_gem_metadata_installation]
+                  # Add additional options to bundle install
+                  cmd = [ "bundle", "install", Chef::Config[:gem_installer_bundler_options] ]
+                  so = shell_out!(cmd, cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
+                  Chef::Log.info(so.stdout)
+                end
               end
             end
             Gem.clear_paths


### PR DESCRIPTION
Added support to provide options to gem installer.
Signed-off-by: Amol Shinde <amol.shinde@msystechnologies.com>

## Description
When cookbook is running in airgapped environment, even if all gem are already installed, the chef-client tries to connect `https://rubygems.org/`. Adding `--local` option will resolve dependency from local cache.
- Added `gem_installer_bundler_options`, set `--local` to install from local cache or any other option can be added to modify the behavior ex. ["--local", "--clean"]
- Added `skip_gem_metadata_installation`, set `true` to skip gem metadata installation in case if all gems are already installed and installing again have performance issues. 

The above-mentioned options can be added to `config.rb`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
