### PR TITLE
Fix Bootstrap password prompt

### DIFF
--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1846,8 +1846,8 @@ describe Chef::Knife::Bootstrap do
 
       let(:expected_error_password_prompt) do
         e = Train::ClientError.new
-        message = "Your SSH Agent has no keys added, and you have not specified a password or a key file"
-        allow(e).to receive(:message).and_return(message)
+        reason = :no_ssh_password_or_key_available
+        allow(e).to receive(:reason).and_return(reason)
         e
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Bootstrap command was not prompting for the password when --connection-password option is not passed.

## Description
<!--- Describe your changes in detail, what problems does it solve? --> 
Bootstrap command was throwing error `ERROR: RuntimeError: password is a required option` when --connection-password option is not passed. The exception was not getting raised because of an incorrect method call.
- Done correct exception handling
- Fixed test case

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
