### PR TITLE
convert chocolatey resource to use shell_out splat args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 15315e3e36f07062111faede26f2667ead8c723f
+  revision: 9982b1e62ed1afb8db57349f536da3fed759749f
   branch: master
   specs:
-    ohai (15.2.7)
+    ohai (15.3.1)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -46,7 +46,7 @@ PATH
       mixlib-authentication (~> 2.1)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
+      mixlib-shellout (>= 3.0.3, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -78,7 +78,7 @@ PATH
       mixlib-authentication (~> 2.1)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
+      mixlib-shellout (>= 3.0.3, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -332,7 +332,7 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
-    train-winrm (0.2.3)
+    train-winrm (0.2.4)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
     tty-box (0.4.1)
@@ -359,7 +359,7 @@ GEM
     unicode-display_width (1.6.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
-    webmock (3.7.0)
+    webmock (3.7.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", "~> 2.1"
-  s.add_dependency "mixlib-shellout", ">= 2.4", "< 4.0"
+  s.add_dependency "mixlib-shellout", ">= 3.0.3", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 15.0"
 

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ class Chef
       allowed_actions :install, :upgrade, :remove, :purge, :reconfig
 
       # windows can't take Array options yet
-      property :options, String,
+      property :options, [String, Array],
         description: "One (or more) additional options that are passed to the command."
 
       property :package_name, [String, Array],

--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Matt Wrock (<matt@mattwrock.com>)
-# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,6 +74,24 @@ describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
     it "raises if package is not found" do
       subject.package_name "blah"
       expect { subject.run_action(:install) }.to raise_error Chef::Exceptions::Package
+    end
+
+    it "installs with an option as a string" do
+      subject.options "--force --confirm"
+      subject.run_action(:install)
+      expect(package_list.call).to eq("#{package_name}|2.0")
+    end
+
+    it "installs with multiple options as a string" do
+      subject.options "--force --confirm"
+      subject.run_action(:install)
+      expect(package_list.call).to eq("#{package_name}|2.0")
+    end
+
+    it "installs with multiple options as an array" do
+      subject.options [ "--force", "--confirm" ]
+      subject.run_action(:install)
+      expect(package_list.call).to eq("#{package_name}|2.0")
     end
   end
 


### PR DESCRIPTION
This improves command line argument handling on windows.  Should correctly deal with arguments-with-spaces issus along with any windows metacharacters in any command line arguments.  I don't see any open issues surrounding those, but we definitely have some questionable handling here.  If this is successful we can more broadly apply this across the codebase as a standard (finally).