### PR TITLE
Chef 16: Remove the ability to write encrypted data bag V1 / V2 formats

### DIFF
--- a/lib/chef/encrypted_data_bag_item.rb
+++ b/lib/chef/encrypted_data_bag_item.rb
@@ -52,20 +52,10 @@ class Chef::EncryptedDataBagItem
   AEAD_ALGORITHM = "aes-256-gcm".freeze
 
   #
-  # === Synopsis
+  # EncryptedDataBagItem.new(hash, secret)
   #
-  #   EncryptedDataBagItem.new(hash, secret)
-  #
-  # === Args
-  #
-  # +enc_hash+::
-  #   The encrypted hash to be decrypted
-  # +secret+::
-  #   The raw secret key
-  #
-  # === Description
-  #
-  # Create a new encrypted data bag item for reading (decryption)
+  # @param [String] enc_hash The encrypted hash to be decrypted
+  # @param [String] secret The raw secret key
   #
   def initialize(enc_hash, secret)
     @enc_hash = enc_hash
@@ -85,6 +75,9 @@ class Chef::EncryptedDataBagItem
     raise ArgumentError, "assignment not supported for #{self.class}"
   end
 
+  #
+  # @return Hash
+  #
   def to_h
     @enc_hash.keys.inject({}) { |hash, key| hash[key] = self[key]; hash }
   end
@@ -103,24 +96,13 @@ class Chef::EncryptedDataBagItem
   end
 
   #
-  # === Synopsis
-  #
-  #   EncryptedDataBagItem.load(data_bag, name, secret = nil)
-  #
-  # === Args
-  #
-  # +data_bag+::
-  #   The name of the data bag to fetch
-  # +name+::
-  #   The name of the data bag item to fetch
-  # +secret+::
-  #   The raw secret key. If the +secret+ is nil, the value of the file at
-  #   +Chef::Config[:encrypted_data_bag_secret]+ is loaded. See +load_secret+
-  #   for more information.
-  #
-  # === Description
-  #
   # Loads and decrypts the data bag item with the given name.
+  #
+  # @see Chef::EncryptedDataBagItem.load_secret
+  #
+  # @param [<Type>] data_bag The name of the data bag to fetch
+  # @param [<Type>] name The name of the data bag item to fetch
+  # @param [<Type>] secret The raw secret key. If the `secret` is nil, the value of the file at `Chef::Config[:encrypted_data_bag_secret]` is loaded.
   #
   def self.load(data_bag, name, secret = nil)
     raw_hash = Chef::DataBagItem.load(data_bag, name)
@@ -128,6 +110,9 @@ class Chef::EncryptedDataBagItem
     new(raw_hash, secret)
   end
 
+  #
+  # @param [String] path Path to the encrypted data bag secret
+  #
   def self.load_secret(path = nil)
     path ||= Chef::Config[:encrypted_data_bag_secret]
     unless path

--- a/lib/chef/encrypted_data_bag_item/check_encrypted.rb
+++ b/lib/chef/encrypted_data_bag_item/check_encrypted.rb
@@ -24,17 +24,24 @@ class Chef::EncryptedDataBagItem
     #
     # Tries to autodetect if the item's raw hash appears to be encrypted.
     #
-    # @param [String] raw_data
+    # @param [Hash] raw_data The raw encrypted data bag hash
     #
     # @return [Boolean]
     #
     def encrypted?(raw_data)
-      data = raw_data.reject { |k, _| k == "id" } # Remove the "id" key.
+      data = raw_data
+
+      data.delete("id") # Remove the "id" key.
+
       # Assume hashes containing only the "id" key are not encrypted.
-      # Otherwise, remove the keys that don't appear to be encrypted and compare
-      # the result with the hash. If some entry has been removed, then some entry
-      # doesn't appear to be encrypted and we assume the entire hash is not encrypted.
-      data.empty? ? false : data.reject { |_, v| !looks_like_encrypted?(v) } == data
+      return false if data.empty?
+
+      # return false if any of the keys don't appear to be encrypted
+      data.each_value do |v|
+        return false unless looks_like_encrypted?(v)
+      end
+
+      return true
     end
 
     private

--- a/lib/chef/encrypted_data_bag_item/check_encrypted.rb
+++ b/lib/chef/encrypted_data_bag_item/check_encrypted.rb
@@ -58,9 +58,9 @@ class Chef::EncryptedDataBagItem
 
       case data["version"]
         when 1
-          Chef::EncryptedDataBagItem::Encryptor::Version1Encryptor.encryptor_keys.sort == data.keys.sort
+          %w{ cipher encrypted_data iv version } == data.keys.sort
         when 2
-          Chef::EncryptedDataBagItem::Encryptor::Version2Encryptor.encryptor_keys.sort == data.keys.sort
+          %w{ cipher encrypted_data hmac iv version } == data.keys.sort
         when 3
           Chef::EncryptedDataBagItem::Encryptor::Version3Encryptor.encryptor_keys.sort == data.keys.sort
         else

--- a/lib/chef/encrypted_data_bag_item/check_encrypted.rb
+++ b/lib/chef/encrypted_data_bag_item/check_encrypted.rb
@@ -21,8 +21,13 @@ require_relative "encryptor"
 class Chef::EncryptedDataBagItem
   # Common code for checking if a data bag appears encrypted
   module CheckEncrypted
-
+    #
     # Tries to autodetect if the item's raw hash appears to be encrypted.
+    #
+    # @param [String] raw_data
+    #
+    # @return [Boolean]
+    #
     def encrypted?(raw_data)
       data = raw_data.reject { |k, _| k == "id" } # Remove the "id" key.
       # Assume hashes containing only the "id" key are not encrypted.
@@ -34,10 +39,13 @@ class Chef::EncryptedDataBagItem
 
     private
 
+    #
     # Checks if data looks like it has been encrypted by
     # Chef::EncryptedDataBagItem::Encryptor::VersionXEncryptor. Returns
-    # true only when there is an exact match between the VersionXEncryptor
-    # keys and the hash's keys.
+    # true only when
+    #
+    # @return [Boolean] There is an exact match between the VersionXEncryptor keys and the hash's keys.
+    #
     def looks_like_encrypted?(data)
       return false unless data.is_a?(Hash) && data.key?("version")
 

--- a/lib/chef/encrypted_data_bag_item/decryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/decryptor.rb
@@ -28,7 +28,6 @@ require_relative "assertions"
 
 class Chef::EncryptedDataBagItem
 
-  #=== Decryptor
   # For backwards compatibility, Chef implements decryption/deserialization for
   # older encrypted data bag item formats in addition to the current version.
   # Each decryption/deserialization strategy is implemented as a class in this
@@ -78,7 +77,9 @@ class Chef::EncryptedDataBagItem
         @key = key
       end
 
-      # Returns the used decryption algorithm
+      #
+      # @return [String] the used decryption algorithm
+      #
       def algorithm
         ALGORITHM
       end
@@ -173,6 +174,9 @@ class Chef::EncryptedDataBagItem
         super
       end
 
+      #
+      # @return [Boolean] is the hmac valid
+      #
       def validate_hmac!
         digest = OpenSSL::Digest.new("sha256")
         raw_hmac = OpenSSL::HMAC.digest(digest, key, @encrypted_data["encrypted_data"])
@@ -204,7 +208,7 @@ class Chef::EncryptedDataBagItem
         assert_aead_requirements_met!(algorithm)
       end
 
-      # Returns the used decryption algorithm
+      # @return [String] the used decryption algorithm
       def algorithm
         AEAD_ALGORITHM
       end

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -83,9 +83,7 @@ class Chef::EncryptedDataBagItem
       end
 
       #
-      # Returns the used encryption algorithm
-      #
-      # @return [String]
+      # @return [String] the used decryption algorithm
       #
       def algorithm
         AEAD_ALGORITHM

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -143,7 +143,7 @@ class Chef::EncryptedDataBagItem
       end
 
       def self.encryptor_keys
-        %w{ encrypted_data iv version cipher auth_tag }
+        %w{ auth_tag cipher encrypted_data iv version }
       end
     end
   end

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -41,7 +41,7 @@ class Chef::EncryptedDataBagItem
         Version3Encryptor.new(value, secret, iv)
       else
         raise UnsupportedEncryptedDataBagItemFormat,
-          "Invalid encrypted data bag format version `#{format_version}'. Supported versions is '3'. If you require writing encrypted data bags in version '1' or '2' you will need to use a version of knife before 16.0."
+          "Invalid encrypted data bag format version `#{format_version}'. Supported version is '3'. If you require writing encrypted data bags in version '1' or '2' formats you will need to use a version of knife before 16.0."
       end
     end
 
@@ -51,15 +51,13 @@ class Chef::EncryptedDataBagItem
 
       include Chef::EncryptedDataBagItem::Assertions
 
-      # Create a new Encryptor for +data+, which will be encrypted with the given
-      # +key+.
       #
-      # === Arguments:
-      # * data: An object of any type that can be serialized to json
-      # * key: A String representing the desired passphrase
-      # * iv: The optional +iv+ parameter is intended for testing use only. When
-      # *not* supplied, Encryptor will use OpenSSL to generate a secure random
-      # IV, which is what you want.
+      # Create a new Encryptor for +data+, which will be encrypted with the given +key+.
+      #
+      # @param plaintext_data An object of any type that can be serialized to json
+      # @param key A String representing the desired passphrase
+      # @param iv <description> The optional +iv+ parameter is intended for testing use only. When *not* supplied, Encryptor will use OpenSSL to generate a secure random IV, which is what you want.
+      #
       def initialize(plaintext_data, key, iv = nil)
         @plaintext_data = plaintext_data
         @key = key
@@ -68,8 +66,12 @@ class Chef::EncryptedDataBagItem
         @auth_tag = nil
       end
 
+      #
       # Returns a wrapped and encrypted version of +plaintext_data+ suitable for
       # using as the value in an encrypted data bag item.
+      #
+      # @return [Hash]
+      #
       def for_encrypted_item
         {
           "encrypted_data" => encrypted_data,
@@ -80,7 +82,11 @@ class Chef::EncryptedDataBagItem
         }
       end
 
+      #
       # Returns the used encryption algorithm
+      #
+      # @return [String]
+      #
       def algorithm
         AEAD_ALGORITHM
       end

--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -99,7 +99,7 @@ class Chef
         if need_encrypt_flag
           if config[:encrypt]
             unless config[:secret] || config[:secret_file]
-              ui.fatal("No secret or secret_file specified in config, unable to encrypt item.")
+              ui.fatal("No secret or secret_file specified in config, unable to encrypt data bag item. See https://docs.chef.io/data_bags.html for information on creating your encryption key if you have not yet done so.")
               exit(1)
             end
             return true

--- a/spec/unit/encrypted_data_bag_item_spec.rb
+++ b/spec/unit/encrypted_data_bag_item_spec.rb
@@ -38,7 +38,7 @@ describe Chef::EncryptedDataBagItem::Encryptor do
   let(:plaintext_data) { { "foo" => "bar" } }
   let(:key) { "passwd" }
 
-  it "encrypts to format version 1 by default" do
+  it "encrypts to format version 3 by default" do
     expect(encryptor).to be_a_instance_of(Chef::EncryptedDataBagItem::Encryptor::Version3Encryptor)
   end
 
@@ -68,27 +68,6 @@ describe Chef::EncryptedDataBagItem::Encryptor do
       expect(final_data["iv"]).to eq Base64.encode64(encryptor.iv)
       expect(final_data["version"]).to eq 3
       expect(final_data["cipher"]).to eq "aes-256-gcm"
-    end
-  end
-
-  describe "when using version 2 format" do
-
-    before do
-      Chef::Config[:data_bag_encrypt_version] = 2
-    end
-
-    it "creates a version 2 encryptor" do
-      expect(encryptor).to be_a_instance_of(Chef::EncryptedDataBagItem::Encryptor::Version2Encryptor)
-    end
-
-    it "generates an hmac based on ciphertext with different iv" do
-      encryptor2 = Chef::EncryptedDataBagItem::Encryptor.new(plaintext_data, key)
-      expect(encryptor.hmac).not_to eq(encryptor2.hmac)
-    end
-
-    it "includes the hmac in the envelope" do
-      final_data = encryptor.for_encrypted_item
-      expect(final_data["hmac"]).to eq(encryptor.hmac)
     end
   end
 


### PR DESCRIPTION
We can still read existing encrypted data bags, but we shouldn't write to the legacy formats anymore. There's just no reasons to continue to support these legacy formats. V3 was introduced in Chef 12 and became the default in Chef 13.

Signed-off-by: Tim Smith <tsmith@chef.io>