### PR TITLE
Update openssl to 1.0.2t

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     nori (2.6.0)
     parallel (1.17.0)
-    parser (2.6.4.0)
+    parser (2.6.4.1)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.3)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 82ff3963cf4624afd77dfd283a187e25d21325b9
+  revision: b9e06cf4c0f6cbd5e5bd5e9bc41b30262dfe635f
   branch: master
   specs:
     omnibus-software (4.0.0)


### PR DESCRIPTION
    Fixed a padding oracle in PKCS7_dataDecode and CMS_decrypt_set1_pkey (CVE-2019-1563)
    For built-in EC curves, ensure an EC_GROUP built from the curve name is used even when parsing explicit parameters
    Compute ECC cofactors if not provided during EC_GROUP construction (CVE-2019-1547)
    Document issue with installation paths in diverse Windows builds (CVE-2019-1552)

Signed-off-by: Tim Smith <tsmith@chef.io>