### PR TITLE
kernel_module: Add new options property

### DIFF
--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -67,7 +67,7 @@ class Chef
         name_property: true, identity: true
 
       property :options, Array,
-        description: "An optional property to set options for the kernel module."
+        description: "An optional property to set options for the kernel module.",
         introduced: "15.4"
 
       property :load_dir, String,

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -36,10 +36,11 @@ class Chef
         description "Load kernel module, and ensure it loads on reboot."
 
         # create options file before loading the module
-        file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
-          content "options #{new_resource.modname} #{new_resource.options.join(" ")}\n"
-          not_if { new_resource.options.nil? }
-        end.run_action(:create)
+        unless new_resource.options.nil?
+          file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
+            content "options #{new_resource.modname} #{new_resource.options.join(" ")}\n"
+          end.run_action(:create)
+        end
 
         # load the module first before installing
         new_resource.run_action(:load)

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -15,6 +15,52 @@ class Chef
 
       description "Use the kernel_module resource to manage kernel modules on Linux systems. This resource can load, unload, blacklist, disable, install, and uninstall modules."
       introduced "14.3"
+      examples <<~DOC
+        Install and load a kernel module, and ensure it loads on reboot.
+        ```ruby
+        kernel_module 'loop'
+        ```
+        Install and load a kernel with a specific set of options, and ensure it loads on reboot. Consult kernel module
+        documentation for specific options that are supported.
+        ```ruby
+        kernel_module 'loop' do
+          options [
+            'max_loop=4',
+            'max_part=8'
+          ]
+        end
+        ```
+        Load a kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :load
+        end
+        ```
+        Unload a kernel module and remove module config, so it doesn’t load on reboot.
+        ```ruby
+        kernel_module 'loop' do
+          action :uninstall
+        end
+        ```
+        Unload kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :unload
+        end
+        ```
+        Blacklist a module from loading.
+        ```ruby
+        kernel_module 'loop' do
+          action :blacklist
+        end
+        ```
+        Disable a kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :disable
+        end
+        ```
+      DOC
 
       property :modname, String,
         description: "An optional property to set the kernel module name if it differs from the resource block's name.",

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -22,6 +22,7 @@ class Chef
 
       property :options, Array,
         description: "An optional property to set options for the kernel module."
+        introduced: "15.4"
 
       property :load_dir, String,
         description: "The directory to load modules from.",


### PR DESCRIPTION
This adds a new parameter called ``options`` which allows users to set module
specific parameters and settings. This option file needs to be run before
loading the module so that the settings get loaded properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
