### PR TITLE
Remove some references to Travis from code comments

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,6 +1,5 @@
 # THIS IS NOW HAND MANAGED, JUST EDIT THE THING
-# .travis.yml and appveyor.yml consume this,
-# try to keep it machine-parsable.
+# keep it machine-parsable since CI uses it
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock

--- a/spec/functional/resource/ifconfig_spec.rb
+++ b/spec/functional/resource/ifconfig_spec.rb
@@ -24,8 +24,6 @@ require "chef/mixin/shell_out"
 include_flag = !(%w{amazon debian aix}.include?(ohai[:platform_family]) || (ohai[:platform_family] == "rhel" && ohai[:platform_version].to_i < 7))
 
 describe Chef::Resource::Ifconfig, :requires_root, external: include_flag do
-  # This test does not work in travis because there is no eth0
-
   include Chef::Mixin::ShellOut
 
   let(:new_resource) do

--- a/spec/functional/resource/mount_spec.rb
+++ b/spec/functional/resource/mount_spec.rb
@@ -25,13 +25,9 @@ require "tmpdir"
 include_flag = !(%w{debian rhel amazon aix solaris2}.include?(ohai[:platform_family]))
 
 describe Chef::Resource::Mount, :requires_root, external: include_flag do
-  # Disabled in travis because it refuses to let us mount a ramdisk. /dev/ramX does not
-  # exist even after loading the kernel module
-
   include Chef::Mixin::ShellOut
 
   # Platform specific setup, cleanup and validation helpers.
-
   def setup_device_for_mount
     # use ramdisk for creating a test device for mount.
     # This can cleaner if we have chef resource/provider for ramdisk.


### PR DESCRIPTION
I removed the travis skips, but the comments were still there.

Signed-off-by: Tim Smith <tsmith@chef.io>