### PR TITLE
[Data-collector] Add cookbooks attribute to run_end_message

### DIFF
--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -57,7 +57,7 @@ class Chef
             "resources" => all_action_records(action_collection),
             "run_id" => run_status&.run_id,
             "run_list" => node&.run_list&.for_json || [],
-            "expanded_cookbooks" => node&.fetch("cookbooks", {}) || {},
+            "cookbooks" => ( node && node["cookbooks"] ) || {},
             "policy_name" => node&.policy_name,
             "policy_group" => node&.policy_group,
             "start_time" => run_status.start_time.utc.iso8601,

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -57,6 +57,7 @@ class Chef
             "resources" => all_action_records(action_collection),
             "run_id" => run_status&.run_id,
             "run_list" => node&.run_list&.for_json || [],
+            "expanded_cookbooks" => node&.fetch("cookbooks", {}) || {},
             "policy_name" => node&.policy_name,
             "policy_group" => node&.policy_group,
             "start_time" => run_status.start_time.utc.iso8601,

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -46,7 +46,7 @@ describe Chef::DataCollector do
 
   let(:run_list) { node.run_list }
 
-  let(:expanded_cookbooks) { node.fetch("cookbooks", {}) }
+  let(:cookbooks) { node.fetch("cookbooks", {}) }
 
   let(:run_id) { run_status.run_id }
 
@@ -214,7 +214,7 @@ describe Chef::DataCollector do
     end
 
     it "has a cookbooks" do
-      expect_converge_message("expanded_cookbooks" => expanded_cookbooks)
+      expect_converge_message("cookbooks" => cookbooks)
       send_run_failed_or_completed_event
     end
 

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -46,6 +46,8 @@ describe Chef::DataCollector do
 
   let(:run_list) { node.run_list }
 
+  let(:expanded_cookbooks) { node.fetch("cookbooks", {}) }
+
   let(:run_id) { run_status.run_id }
 
   let(:expansion) { Chef::RunList::RunListExpansion.new("_default", run_list.run_list_items) }
@@ -208,6 +210,11 @@ describe Chef::DataCollector do
 
     it "has a run_list" do
       expect_converge_message("run_list" => expected_run_list)
+      send_run_failed_or_completed_event
+    end
+
+    it "has a cookbooks" do
+      expect_converge_message("expanded_cookbooks" => expanded_cookbooks)
       send_run_failed_or_completed_event
     end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef Automate node run history not showing cookbook version if it already converges.

In every chef-client run, we have all cookbooks with the version in node object which synced to perform the operation.

So added "expanded_cookbooks" in run_end_message API to send the data to Chef collector.

The data format of the expanded_coobooks attribute
```
eg.
{"starter"=>{"version"=>"1.0.1"}, "learn_chef_apache2"=>{"version"=>"0.1.0"}}
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Added screenshot for reference.
![missing-cookbook-version](https://user-images.githubusercontent.com/44496937/65016921-15020180-d943-11e9-9eb6-34d9c86f7a54.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>