### PR TITLE
a Windows Habitat plan

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,5 +1,6 @@
 [chef-infra-client]
 build_targets = [
   "x86_64-linux",
-  "x86_64-linux-kernel2"
+  "x86_64-linux-kernel2",
+  "x86_64-windows"
 ]

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -90,21 +90,28 @@ merge_actions:
       only_if: built_in:bump_version
 
 subscriptions:
+  # the omnibus/docker/gem chain
   - workload: artifact_published:unstable:chef:{{version_constraint}}
     actions:
       - built_in:build_docker_image
   - workload: artifact_published:current:chef:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
+
+  # the habitat chain
+  - workload: buildkite_hab_build_group_published:{{agent_id}}:*
+    actions:
+      # when all of the hab package publish to the unstable channel, test and promote them
+      - trigger_pipeline:habitat/test
+
+  # subscriptions to Ruby gem dependencies' releases, open PR for updates
   - workload: ruby_gem_published:mixlib-archive-*
     actions:
       - bash:.expeditor/update_dep.sh

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -1,26 +1,6 @@
 ---
 steps:
 
-- label: ":linux: Validate Habitat Builds of Chef Infra"
-  commands:
-    - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX"
-    - powershell -File "./habitat/tests/test.sh" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX"
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
-- label: ":linux: :two: Validate Habitat Builds of Chef Infra"
-  commands:
-    - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"
-    - powershell -File "./habitat/tests/test.sh" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
     - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
@@ -30,3 +10,17 @@ steps:
       windows:
         privileged: true
         single-use: true
+
+# Wait for the package testing to succeed before promoting whatever was tested.
+- wait
+
+- label: ":habicat: Promoting packages to the current channel."
+  commands:
+    - hab pkg promote "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS" current
+  expeditor:
+    executor:
+      docker:
+    secrets:
+      HAB_AUTH_TOKEN:
+        path: account/static/habitat/chef-ci
+        field: auth_token

--- a/.expeditor/verify.habitat.pipeline.yml
+++ b/.expeditor/verify.habitat.pipeline.yml
@@ -1,1 +1,20 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 60
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+
+- label: "Windows plan"
+  commands:
+    - scripts/ci/verify-plan.ps1
+  expeditor:
+    executor:
+      windows:
+        privileged: true
+        single-use: true
+        shell: ["powershell", "-Command"]

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -30,6 +30,7 @@ function Invoke-Begin {
 function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
 
+    Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
     Set-RuntimeEnv -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -1,0 +1,138 @@
+$pkg_name="chef-infra-client"
+$pkg_origin="chef"
+$pkg_version=(Get-Content $PLAN_CONTEXT/../VERSION)
+$pkg_description="Chef Infra Client is an agent that runs locally on every node that is under management by Chef Infra. This package is binary-only to provide Chef Infra Client executables. It does not define a service to run."
+$pkg_maintainer="The Chef Maintainers <maintainers@chef.io>"
+$pkg_upstream_url="https://github.com/chef/chef"
+$pkg_license=@("Apache-2.0")
+$pkg_filename="${pkg_name}-${pkg_version}.zip"
+$pkg_bin_dirs=@(
+    "bin"
+    "vendor/bin"
+)
+$pkg_deps=@(
+  "core/cacerts"
+  "chef/ruby-plus-devkit"
+)
+
+function Invoke-Begin {
+    $hab_version = (hab --version)
+    $hab_minor_version = $hab_version.split('.')[1]
+    if ( -not $? -Or $hab_minor_version -lt 85 ) {
+        Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
+        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
+        throw "unable to build: required minimum version of Habitat not installed"
+    } else {
+        Write-BuildLine ":habicat: I think I have the version I need to build."
+    }
+}
+
+function Invoke-SetupEnvironment {
+    Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
+
+    Set-RuntimeEnv -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
+    Set-RuntimeEnv LANG "en_US.UTF-8"
+    Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"
+}
+
+function Invoke-Download() {
+    Write-BuildLine " ** Locally creating archive of latest repository commit at ${HAB_CACHE_SRC_PATH}/${pkg_filename}"
+    # source is in this repo, so we're going to create an archive from the
+    # appropriate path within the repo and place the generated tarball in the
+    # location expected by do_unpack
+    try {
+        Push-Location (Resolve-Path "$PLAN_CONTEXT/../").Path
+        git archive --format=zip --output="${HAB_CACHE_SRC_PATH}/${pkg_filename}" HEAD
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-Verify() {
+    Write-BuildLine " ** Skipping checksum verification on the archive we just created."
+    return 0
+}
+
+function Invoke-Prepare {
+    $env:GEM_HOME = "$pkg_prefix/vendor"
+
+    try {
+        Push-Location "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
+
+        Write-BuildLine " ** Configuring bundler for this build environment"
+        bundle config --local without server docgen maintenance pry travis integration ci chefstyle
+        bundle config --local jobs 4
+        bundle config --local retry 5
+        bundle config --local silence_root_warning 1
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-Build {
+    try {
+        Push-Location "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
+
+        Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
+        bundle install
+        Write-BuildLine " ** Running the chef project's 'rake install' to install the path-based gems so they look like any other installed gem."
+        bundle exec rake install # this needs to be 'bundle exec'd because a Rakefile makes reference to Bundler
+        Write-BuildLine " ** Also 'rake install' any gem sourced as a git reference."
+        foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {
+            try {
+                Push-Location $git_gem
+                Write-BuildLine " -- and $git_gem too"
+                rake install # this needs to NOT be 'bundle exec'd else bundler complains about dev deps not being installed
+            } finally {
+                Pop-Location
+            }
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-Install {
+    try {
+        Push-Location $pkg_prefix
+        $env:BUNDLE_GEMFILE="${HAB_CACHE_SRC_PATH}/${pkg_dirname}/Gemfile"
+
+        foreach($gem in ("chef-bin", "chef", "inspec-core-bin", "ohai")) {
+            Write-BuildLine "** generating binstubs for $gem with precise version pins"
+            appbundler.bat "${HAB_CACHE_SRC_PATH}/${pkg_dirname}" $pkg_prefix/bin $gem
+            if (-not $?) { throw "Failed to create appbundled binstubs for $gem"}
+        }
+        Remove-StudioPathFrom -File $pkg_prefix/vendor/gems/chef-$pkg_version*/Gemfile
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-After {
+    # Trim the fat before packaging
+
+    # We don't need the cache of downloaded .gem files ...
+    Remove-Item $pkg_prefix/vendor/cache -Recurse -Force
+    # ... or bundler's cache of git-ref'd gems
+    Remove-Item $pkg_prefix/vendor/bundler -Recurse -Force
+
+    # We don't need the gem docs.
+    Remove-Item $pkg_prefix/vendor/doc -Recurse -Force
+    # We don't need to ship the test suites for every gem dependency,
+    # only Chef's for package verification.
+    Get-ChildItem $pkg_prefix/vendor/gems -Filter "spec" -Directory -Recurse -Depth 1 `
+        | Where-Object -FilterScript { $_.FullName -notlike "*chef-$pkg_version*" }   `
+        | Remove-Item -Recurse -Force
+    # Remove the byproducts of compiling gems with extensions
+    Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
+        | Remove-Item -Force
+}
+
+function Remove-StudioPathFrom {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $File
+    )
+    (Get-Content $File) -replace ($env:FS_ROOT -replace "\\","/"),"" | Set-Content $File
+}

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -31,6 +31,7 @@ function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
+    Set-RuntimeEnv FORCE_FFI_YAJL "ext" # Always use the C-extensions because we use MRI on all the things and C is fast.
     Set-RuntimeEnv -IsPath SSL_CERT_FILE "$(Get-HabPackagePath cacerts)/ssl/cert.pem"
     Set-RuntimeEnv LANG "en_US.UTF-8"
     Set-RuntimeEnv LC_CTYPE "en_US.UTF-8"

--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -1,0 +1,17 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929")
+)
+
+# some of the functional tests require that winrm be configured
+winrm quickconfig -quiet
+
+$chef_gem_root = (hab pkg exec $PackageIdentifier gem.cmd which chef | Split-Path | Split-Path)
+try {
+    Push-Location $chef_gem_root
+    hab pkg binlink --force $PackageIdentifier
+    /hab/bin/rspec --format progress --tag ~executables --tag ~choco_installed spec/functional
+    if (-not $?) { throw "functional testing failed"}
+} finally {
+    Pop-Location
+}

--- a/habitat/tests/test.pester.ps1
+++ b/habitat/tests/test.pester.ps1
@@ -1,0 +1,55 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+
+Describe "chef-infra-client" {
+    Context "chef-client" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier chef-client.bat --version
+            $? | Should be $true
+        }
+
+        It "is the expected version" {
+            $the_version = (hab pkg exec $PackageIdentifier chef-client.bat --version | Out-String).split(':')[1].Trim()
+            $the_version | Should be $PackageVersion
+        }
+    }
+
+    Context "ohai" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier ohai.bat --version
+            $? | Should be $true
+        }
+    }
+
+    Context "chef-shell" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier chef-shell.bat --version
+            $? | Should be $true
+        }
+    }
+
+    Context "chef-apply" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier chef-apply.bat --version
+            $? | Should be $true
+        }
+    }
+
+    Context "knife" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier knife.bat --version
+            $? | Should be $true
+        }
+    }
+
+    Context "chef-solo" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier chef-solo.bat --version
+            $? | Should be $true
+        }
+    }
+}

--- a/habitat/tests/test.ps1
+++ b/habitat/tests/test.ps1
@@ -1,0 +1,22 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929")
+)
+
+# ensure Pester is available for test use
+if (-Not (Get-Module -ListAvailable -Name Pester)){
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+Write-Host "--- :fire: Smokish Pestering"
+# Pester the Package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+if ($test_result.FailedCount -ne 0) { Exit $test_result.FailedCount }
+
+Write-Host "--- :alembic: Functional Tests"
+powershell -File "./habitat/tests/spec.ps1" -PackageIdentifier $PackageIdentifier

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -82,14 +82,12 @@ Get-Location
 # ffi-yajl must run in c-extension mode for perf, so force it so we don't accidentally fall back to ffi
 $Env:FORCE_FFI_YAJL = "ext"
 
-# chocolatey functional tests fail so delete the chocolatey binary to avoid triggering them
-Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyContinue
-
 # some tests need winrm configured
 winrm quickconfig -quiet
 
 bundle
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional
+# chocolatey functional tests fail so disable that tag directly
+bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation --tag ~choco_installed spec/functional
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/scripts/ci/verify-plan.ps1
+++ b/scripts/ci/verify-plan.ps1
@@ -1,0 +1,37 @@
+#!/usr/bin/env powershell
+
+#Requires -Version 5
+
+param(
+    # The name of the plan that is to be built.
+    [string]$Plan
+)
+
+$env:HAB_ORIGIN = 'ci'
+$Plan = 'chef-infra-client'
+
+Write-Host "--- :8ball: :windows: Verifying $Plan"
+
+Write-Host "--- :habicat: Installing the version of Habitat required"
+Install-Habitat --version 0.85.0.20190916
+
+Write-Host "--- :key: Generating fake origin key"
+hab origin key generate $env:HAB_ORIGIN
+
+
+$project_root = "$(git rev-parse --show-toplevel)"
+Set-Location $project_root
+
+Write-Host "--- :construction: Building $Plan"
+$env:DO_CHECK=$true; hab pkg build .
+if (-not $?) { throw "unable to build"}
+
+. results/last_build.ps1
+if (-not $?) { throw "unable to determine details about this build"}
+
+Write-Host "--- :hammer_and_wrench: Installing $pkg_ident"
+hab pkg install results/$pkg_artifact
+if (-not $?) { throw "unable to install this build"}
+
+Write-Host "--- :mag_right: Testing $Plan"
+powershell -File "./habitat/tests/test.ps1" -PackageIdentifier $pkg_ident

--- a/scripts/ci/verify-plan.ps1
+++ b/scripts/ci/verify-plan.ps1
@@ -12,8 +12,15 @@ $Plan = 'chef-infra-client'
 
 Write-Host "--- :8ball: :windows: Verifying $Plan"
 
-Write-Host "--- :habicat: Installing the version of Habitat required"
-Install-Habitat --version 0.85.0.20190916
+$hab_version = (hab --version)
+$hab_minor_version = $hab_version.split('.')[1]
+if ( -not $? -Or $hab_minor_version -lt 85 ) {
+    Write-Host "--- :habicat: Installing the version of Habitat required"
+    install-habitat --version 0.85.0.20190916
+} else {
+    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+}
+
 
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -21,7 +21,7 @@ require "chef/version"
 require "ohai/version"
 require "chef/dist"
 
-describe "Chef Versions" do
+describe "Chef Versions", :executables do
   include Chef::Mixin::ShellOut
   let(:chef_dir) { File.join(File.dirname(__FILE__), "..", "..") }
 


### PR DESCRIPTION
## Description

A Windows Habitat plan to produce Windows-flavored `chef/chef-infra-client`.

## Related Issue

#8731 

# ~Blockers~ ✅ 

- [x] resolve how to get the system's existing `%PATH%` to be included at the end of the `PATH` used in the habitat execution environments
  - **within a supervised process**: The `PATH` set by the thing that starts the hab-supervisor might already [be included in the execution environment](https://github.com/habitat-sh/habitat/blob/5d4fc16c7abce0a2ffda505ba6518d042d8f889b/components/common/src/util/path.rs#L148-L151). I think.
  - **when executed via hab-generated binlink**: Works as of 0.85.0
  - **when executed via hab pkg exec**: Might not be needed? See https://github.com/habitat-sh/habitat/issues/6657#issuecomment-530106046
- [x] an official home for the `ruby-plus-devkit` plan to live, be reviewed, and institute a pipeline around, related to (probably a sub-task of) https://github.com/chef/release-engineering/issues/831

# TODO ✔️ 

- [x] add tests to `habitat/tests/` for validating package post-build, in the spirit of https://github.com/chef/effortless/tree/master/scaffolding-chef-infra/tests
- ~Judicious testing with the effortless scaffolding~
- [x] rebase to latest master and squash commits appropriately to make a clearer story

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
