### PR TITLE
Remove the gemfile.local logic from the omnibus gemfile

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -22,9 +22,3 @@ group :development do
   gem "kitchen-vagrant", ">= 1.3.1"
   gem "winrm-fs", "~> 1.0"
 end
-
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
This allows dependabot to handle all our bumping PRs for omnibus and gives us really nice changelogs of the changes that are happening with each omnibus-software update.

Signed-off-by: Tim Smith <tsmith@chef.io>