### PR TITLE
[Resource::remote_file] Fix show_progress in remote_file is cau…

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -236,11 +236,11 @@ class Chef
       end
 
       def resource_update_progress(resource, current, total, interval)
-        @progress[resource] ||= 0
+        @progress[resource] ||= -1
 
-        percent_complete = (current.to_f / total.to_f * 100).to_i
+        percent_complete = (current.to_f / total.to_f * 100).to_i unless total.to_f == 0.0
 
-        if percent_complete > @progress[resource]
+        if percent_complete && percent_complete > @progress[resource]
 
           @progress[resource] = percent_complete
 

--- a/spec/unit/formatters/doc_spec.rb
+++ b/spec/unit/formatters/doc_spec.rb
@@ -76,6 +76,24 @@ describe Chef::Formatters::Base do
     expect(formatter.pretty_elapsed_time).to include("10 hours 10 minutes 10 seconds")
   end
 
+  it "shows nothing if total is nil" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 35, nil, 10)
+    expect(out.string).to eq("")
+  end
+
+  it "shows nothing if total is 0" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 35, 0, 10)
+    expect(out.string).to eq("")
+  end
+
+  it "shows nothing if current and total are 0" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 0, 0, 10)
+    expect(out.string).to eq("")
+  end
+
   it "shows the percentage completion of an action" do
     res = Chef::Resource::RemoteFile.new("canteloupe")
     formatter.resource_update_progress(res, 35, 50, 10)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
 - Add check to avoid total if zero or nil.
 - Set @progress[resource] default value to -1 so that it can start with 0%.
Before Fix: 
```
     - Progress: 10%
     - Progress: 20%
     - Progress: 30%
     - Progress: 40%
     - Progress: 50%
     - Progress: 60%
     - Progress: 70%
     - Progress: 80%
     - Progress: 90%
     - Progress: 100%
```
After Fix: 
```
     - Progress:  0%
     - Progress: 10%
     - Progress: 20%
     - Progress: 30%
     - Progress: 40%
     - Progress: 50%
     - Progress: 60%
     - Progress: 70%
     - Progress: 80%
     - Progress: 90%
     - Progress: 100%
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8831

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
