### PR TITLE
[knife] Deprecate data bag secret (-s) short option due to conflict with --server-url option

### DIFF
--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -35,8 +35,7 @@ class Chef
 
       def self.included(base)
         base.option :secret,
-          short: "-s SECRET",
-          long: "--secret ",
+          long: "--secret SECRET",
           description: "The secret key to use to encrypt data bag item values. Can also be defaulted in your config with the key 'secret'.",
           # Need to store value from command line in separate variable - knife#merge_configs populates same keys
           # on config object from

--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -35,6 +35,7 @@ class Chef
 
       def self.included(base)
         base.option :secret,
+          short: "-s SECRET",
           long: "--secret SECRET",
           description: "The secret key to use to encrypt data bag item values. Can also be defaulted in your config with the key 'secret'.",
           # Need to store value from command line in separate variable - knife#merge_configs populates same keys
@@ -79,9 +80,16 @@ class Chef
       end
 
       def validate_secrets
-        if has_cl_secret? && has_cl_secret_file?
-          ui.fatal("Please specify only one of --secret, --secret-file")
-          exit(1)
+        if has_cl_secret?
+          if opt_parser.default_argv.include?("-s")
+            ui.warn("Secret short option -s is deprecated and will remove in the future. Please use --secret instead.
+")
+          end
+
+          if has_cl_secret_file?
+            ui.fatal("Please specify only one of --secret, --secret-file")
+            exit(1)
+          end
         end
 
         if knife_config[:secret] && knife_config[:secret_file]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
For `knife data bag` subcommands `-s` have different behavior for different subcommands.
1. `-s` refers  to as `--secret SECRET` for the following:
  - knife data bag create 
  - knife data bag edit
  - knife data bag show
  - knife data bag from file

2. `-s` refers to as `--chef-server-rul URL` for the following:
  - knife data bag delete
  - knife data bag list
 
Seems both `--server-url` and `--secret` has short option `-s` and mixlib-cli override the first one.
https://github.com/chef/chef/blob/cc6c31616126c38d93dafd1f0475ac3ae5815a65/lib/chef/application/knife.rb#L95-L98

https://github.com/chef/chef/blob/cc6c31616126c38d93dafd1f0475ac3ae5815a65/lib/chef/knife/data_bag_secret_options.rb#L37-L43


Also, some other subcommands like `knife bootstrap` included both helpers so `-s` refers to as `--secret`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8647

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
