### PR TITLE
Add empty chefcli config_context to fix commands with chefcli in knife.rb

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -954,12 +954,16 @@ module ChefConfig
       default :watchdog_timeout, 2 * (60 * 60) # 2 hours
     end
 
-    # Add an empty and non-strict config_context for chefdk. This lets the user
-    # have code like `chefdk.generator_cookbook "/path/to/cookbook"` in their
-    # config.rb, and it will be ignored by tools like knife and ohai. ChefDK
-    # itself can define the config options it accepts and enable strict mode,
+    # Add an empty and non-strict config_context for chefdk and chefcli.
+    # This lets the user have code like `chefdk.generator_cookbook "/path/to/cookbook"` or
+    # `chefcli[:generator_cookbook] = "/path/to/cookbook"` in their config.rb,
+    # and it will be ignored by tools like knife and ohai. ChefDK and ChefCLI
+    # themselves can define the config options it accepts and enable strict mode,
     # and that will only apply when running `chef` commands.
     config_context :chefdk do
+    end
+
+    config_context :chefcli do
     end
 
     # Configuration options for Data Collector reporting. These settings allow


### PR DESCRIPTION
## Description
I have added an empty config_context for chefcli similar to chefdk so that commands do not fail with chefcli parameters in the knife.rb file. I have done the fix on my local machine and I no longer get errors when trying to do commands with `chefcli[:generator_cookbook] = "/path/to/generator"` in it. I specifically ran into this issue when trying to use test kitchen with this value in my knife.rb file.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
