### PR TITLE
Require train-winrm >= 0.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ PATH
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
       train-core (~> 3.0)
-      train-winrm
+      train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
     chef (15.4.5-universal-mingw32)
@@ -87,7 +87,7 @@ PATH
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
       train-core (~> 3.0)
-      train-winrm
+      train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
@@ -332,7 +332,7 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
-    train-winrm (0.2.4)
+    train-winrm (0.2.5)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
     tty-box (0.4.1)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "train-core", "~> 3.0"
-  s.add_dependency "train-winrm"
+  s.add_dependency "train-winrm", ">= 0.2.5"
 
   s.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.215.0)
+    aws-partitions (1.218.0)
     aws-sdk-core (3.68.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)


### PR DESCRIPTION
0.2.4 and before are entirely broken for bootstrapping.

Closes #8903

Signed-off-by: Tim Smith <tsmith@chef.io>