### PR TITLE
Fix for knife subcommand --help don't work as intended. 

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -64,6 +64,12 @@ class Chef
     attr_accessor :name_args
     attr_accessor :ui
 
+    # knife acl subcommands are grouped in this category using this constant to verify.
+    OPSCODE_HOSTED_CHEF_ACCESS_CONTROL = %w{acl group user}.freeze
+
+    # knife opc subcommands are grouped in this category using this constant to verify.
+    CHEF_ORGANIZATION_MANAGEMENT = %w{opc}.freeze
+
     # Configure mixlib-cli to always separate defaults from user-supplied CLI options
     def self.use_separate_defaults?
       true
@@ -270,7 +276,11 @@ class Chef
           ui.info("If this is a recently installed plugin, please run 'knife rehash' to update the subcommands cache.")
         end
 
-        if category_commands = guess_category(args)
+        if CHEF_ORGANIZATION_MANAGEMENT.include?(args[0])
+          list_commands("CHEF ORGANIZATION MANAGEMENT")
+        elsif OPSCODE_HOSTED_CHEF_ACCESS_CONTROL.include?(args[0])
+          list_commands("OPSCODE HOSTED CHEF ACCESS CONTROL")
+        elsif category_commands = guess_category(args)
           list_commands(category_commands)
         elsif OFFICIAL_PLUGINS.include?(args[0]) # command was an uninstalled official chef knife plugin
           ui.info("Use `#{Chef::Dist::EXEC} gem install knife-#{args[0]}` to install the plugin into ChefDK")


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Fix for knife subcommand --help don't work as intended. If we run knife acl --help, knife group --help or knife opc --help command it does not list the commands even though this plugins are shipped with ChefDK. The reason behind this is the category under which these are listed does not 
match with the arguments passed by user. for e.g. acl commands are grouped under the category "OPSCODE_HOSTED_CHEF_ACCESS_CONTROL" and since acl as an argument doesn't match with this category as string, this does not gives valid output.

This methods groups the sub-command by category here https://github.com/chef/chef/blob/master/lib/chef/knife.rb#L165 and it fetches the category from the class for e.g. it has key and value like this in hash  "acl_remove"=>OpscodeAcl::AclRemove,
and klass here is OpscodeAcl::AclRemove and its fetched from here https://github.com/chef/knife-acl/blob/271ef64e30b5bad3f68a7e21cd940a2fe3bd289b/lib/chef/knife/acl_remove.rb#L22

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#8848 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
