### PR TITLE
Support multiple profiles in windows_firewall_rule

### DIFF
--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -74,7 +74,7 @@ class Chef
         callbacks: {
           "contains values not in :public, :private :domain, :any or :notapplicable" => lambda { |p|
             p.all? { |e| %i{public private domain any notapplicable}.include?(e) }
-          }
+          },
         }
 
       property :program, String,

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -70,15 +70,8 @@ class Chef
       property :profile, [Symbol, String, Array],
         default: :any,
         description: "The profile the firewall rule applies to.",
-        coerce: proc { |p|
-          if p.is_a?(Array)
-            p.map(&:downcase).map(&:to_sym).sort
-          elsif p.is_a?(String)
-            Array(p.downcase.to_sym).sort
-          else
-            Array(p).sort
-          end
-        }
+        coerce: proc { |p| Array(p).map(&:downcase).map(&:to_sym).sort }
+
       property :program, String,
         description: "The program the firewall rule applies to."
 

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -67,11 +67,18 @@ class Chef
         description: "The action of the firewall rule.",
         coerce: proc { |f| f.is_a?(String) ? f.downcase.to_sym : f }
 
-      property :profile, [Symbol, String],
-        default: :any, equal_to: %i{public private domain any notapplicable},
+      property :profile, [Symbol, String, Array],
+        default: :any,
         description: "The profile the firewall rule applies to.",
-        coerce: proc { |p| p.is_a?(String) ? p.downcase.to_sym : p }
-
+        coerce: proc { |p|
+          if p.is_a?(Array)
+            p.map(&:downcase).map(&:to_sym).sort
+          elsif p.is_a?(String)
+            Array(p.downcase.to_sym).sort
+          else
+            Array(p).sort
+          end
+        }
       property :program, String,
         description: "The program the firewall rule applies to."
 
@@ -158,7 +165,7 @@ class Chef
           cmd << " -Direction '#{new_resource.direction}'" if new_resource.direction
           cmd << " -Protocol '#{new_resource.protocol}'" if new_resource.protocol
           cmd << " -Action '#{new_resource.firewall_action}'" if new_resource.firewall_action
-          cmd << " -Profile '#{new_resource.profile}'" if new_resource.profile
+          cmd << " -Profile '#{new_resource.profile.join("', '")}'" if new_resource.profile
           cmd << " -Program '#{new_resource.program}'" if new_resource.program
           cmd << " -Service '#{new_resource.service}'" if new_resource.service
           cmd << " -InterfaceType '#{new_resource.interface_type}'" if new_resource.interface_type

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -70,7 +70,12 @@ class Chef
       property :profile, [Symbol, String, Array],
         default: :any,
         description: "The profile the firewall rule applies to.",
-        coerce: proc { |p| Array(p).map(&:downcase).map(&:to_sym).sort }
+        coerce: proc { |p| Array(p).map(&:downcase).map(&:to_sym).sort },
+        callbacks: {
+          'contains values not in :public, :private :domain, :any or :notapplicable' => lambda {
+            |p| p.all? { |e| %i{public private domain any notapplicable}.include?(e) }
+          }
+        }
 
       property :program, String,
         description: "The program the firewall rule applies to."

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -72,8 +72,8 @@ class Chef
         description: "The profile the firewall rule applies to.",
         coerce: proc { |p| Array(p).map(&:downcase).map(&:to_sym).sort },
         callbacks: {
-          'contains values not in :public, :private :domain, :any or :notapplicable' => lambda {
-            |p| p.all? { |e| %i{public private domain any notapplicable}.include?(e) }
+          "contains values not in :public, :private :domain, :any or :notapplicable" => lambda { |p|
+            p.all? { |e| %i{public private domain any notapplicable}.include?(e) }
           }
         }
 

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -152,9 +152,9 @@ class Chef
           cmd << " -DisplayName '#{new_resource.rule_name}'" if cmdlet_type == "New"
           cmd << " -Description '#{new_resource.description}'" if new_resource.description
           cmd << " -LocalAddress '#{new_resource.local_address}'" if new_resource.local_address
-          cmd << " -LocalPort #{new_resource.local_port.join(",")}" if new_resource.local_port
+          cmd << " -LocalPort '#{new_resource.local_port.join("', '")}'" if new_resource.local_port
           cmd << " -RemoteAddress '#{new_resource.remote_address}'" if new_resource.remote_address
-          cmd << " -RemotePort #{new_resource.remote_port.join(",")}" if new_resource.remote_port
+          cmd << " -RemotePort '#{new_resource.remote_port.join("', '")}'" if new_resource.remote_port
           cmd << " -Direction '#{new_resource.direction}'" if new_resource.direction
           cmd << " -Protocol '#{new_resource.protocol}'" if new_resource.protocol
           cmd << " -Action '#{new_resource.firewall_action}'" if new_resource.firewall_action

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -244,7 +244,17 @@ describe Chef::Resource::WindowsFirewallRule do
 
       it "sets LocalPort" do
         resource.local_port("80")
-        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -LocalPort 80 -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -LocalPort '80' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets LocalPort with int" do
+        resource.local_port(80)
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -LocalPort '80' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets multiple LocalPorts" do
+        resource.local_port(["80", "RPC"])
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -LocalPort '80', 'RPC' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
       it "sets RemoteAddress" do
@@ -254,7 +264,17 @@ describe Chef::Resource::WindowsFirewallRule do
 
       it "sets RemotePort" do
         resource.remote_port("443")
-        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -RemotePort 443 -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -RemotePort '443' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets RemotePort with int" do
+        resource.remote_port(443)
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -RemotePort '443' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets multiple RemotePorts" do
+        resource.remote_port(["443", "445"])
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -RemotePort '443', '445' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
       it "sets Direction" do
@@ -317,7 +337,7 @@ describe Chef::Resource::WindowsFirewallRule do
         resource.service("SomeService")
         resource.interface_type(:remoteaccess)
         resource.enabled(false)
-        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule_the_second' -DisplayName 'test_rule_the_second' -Description 'some other rule' -LocalAddress '192.168.40.40' -LocalPort 80 -RemoteAddress '8.8.4.4' -RemotePort 8081 -Direction 'outbound' -Protocol 'UDP' -Action 'notconfigured' -Profile 'domain' -Program '%WINDIR%\\System32\\lsass.exe' -Service 'SomeService' -InterfaceType 'remoteaccess' -Enabled 'false'")
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule_the_second' -DisplayName 'test_rule_the_second' -Description 'some other rule' -LocalAddress '192.168.40.40' -LocalPort '80' -RemoteAddress '8.8.4.4' -RemotePort '8081' -Direction 'outbound' -Protocol 'UDP' -Action 'notconfigured' -Profile 'domain' -Program '%WINDIR%\\System32\\lsass.exe' -Service 'SomeService' -InterfaceType 'remoteaccess' -Enabled 'false'")
       end
     end
 
@@ -338,7 +358,17 @@ describe Chef::Resource::WindowsFirewallRule do
 
       it "sets LocalPort" do
         resource.local_port("80")
-        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort 80 -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets LocalPort with int" do
+        resource.local_port(80)
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets multiple LocalPorts" do
+        resource.local_port(["80", "8080"])
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80', '8080' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
       it "sets RemoteAddress" do
@@ -348,7 +378,17 @@ describe Chef::Resource::WindowsFirewallRule do
 
       it "sets RemotePort" do
         resource.remote_port("443")
-        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort 443 -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets RemotePort with int" do
+        resource.remote_port(443)
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
+      end
+
+      it "sets multiple RemotePorts" do
+        resource.remote_port(["443", "445"])
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443', '445' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
       it "sets Direction" do
@@ -406,7 +446,7 @@ describe Chef::Resource::WindowsFirewallRule do
         resource.service("SomeService")
         resource.interface_type(:remoteaccess)
         resource.enabled(false)
-        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule_the_second' -Description 'some other rule' -LocalAddress '192.168.40.40' -LocalPort 80 -RemoteAddress '8.8.4.4' -RemotePort 8081 -Direction 'outbound' -Protocol 'UDP' -Action 'notconfigured' -Profile 'domain' -Program '%WINDIR%\\System32\\lsass.exe' -Service 'SomeService' -InterfaceType 'remoteaccess' -Enabled 'false'")
+        expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule_the_second' -Description 'some other rule' -LocalAddress '192.168.40.40' -LocalPort '80' -RemoteAddress '8.8.4.4' -RemotePort '8081' -Direction 'outbound' -Protocol 'UDP' -Action 'notconfigured' -Profile 'domain' -Program '%WINDIR%\\System32\\lsass.exe' -Service 'SomeService' -InterfaceType 'remoteaccess' -Enabled 'false'")
       end
     end
   end

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -154,19 +154,19 @@ describe Chef::Resource::WindowsFirewallRule do
 
   it "the profile property raises on any unknown values" do
     expect { resource.profile(:other) }.to raise_error(Chef::Exceptions::ValidationFailed)
-    expect { resource.profile([:public, :other]) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    expect { resource.profile(%i{public other}) }.to raise_error(Chef::Exceptions::ValidationFailed)
   end
 
   it "the profile property coerces strings to symbols" do
     resource.profile("Public")
     expect(resource.profile).to eql([:public])
     resource.profile([:private, "Public"])
-    expect(resource.profile).to eql([:private, :public])
+    expect(resource.profile).to eql(%i{private public})
   end
 
   it "the profile property supports multiple profiles" do
-    resource.profile(["Private", "Public"])
-    expect(resource.profile).to eql([:private, :public])
+    resource.profile(%w{Private Public})
+    expect(resource.profile).to eql(%i{private public})
   end
 
   it "the program property accepts strings" do
@@ -258,7 +258,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets multiple LocalPorts" do
-        resource.local_port(["80", "RPC"])
+        resource.local_port(%w{80 RPC})
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -LocalPort '80', 'RPC' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -278,7 +278,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets multiple RemotePorts" do
-        resource.remote_port(["443", "445"])
+        resource.remote_port(%w{443 445})
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -RemotePort '443', '445' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -301,9 +301,9 @@ describe Chef::Resource::WindowsFirewallRule do
         resource.profile(:private)
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private' -InterfaceType 'any' -Enabled 'true'")
       end
-      
+
       it "sets multiple Profiles" do
-        resource.profile([:private, :public])
+        resource.profile(%i{private public})
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private', 'public' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -372,7 +372,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets multiple LocalPorts" do
-        resource.local_port(["80", "8080"])
+        resource.local_port(%w{80 8080})
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80', '8080' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
@@ -392,7 +392,7 @@ describe Chef::Resource::WindowsFirewallRule do
       end
 
       it "sets multiple RemotePorts" do
-        resource.remote_port(["443", "445"])
+        resource.remote_port(%w{443 445})
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443', '445' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -302,7 +302,7 @@ describe Chef::Resource::WindowsFirewallRule do
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private' -InterfaceType 'any' -Enabled 'true'")
       end
 
-      it "sets multiple Profiles" do
+      it "sets multiple Profiles (must be comma-plus-space delimited for PowerShell to treat as an array)" do
         resource.profile(%i{private public})
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private', 'public' -InterfaceType 'any' -Enabled 'true'")
       end
@@ -371,7 +371,7 @@ describe Chef::Resource::WindowsFirewallRule do
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
-      it "sets multiple LocalPorts" do
+      it "sets multiple LocalPorts (must be comma-plus-space delimited for PowerShell to treat as an array)" do
         resource.local_port(%w{80 8080})
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -LocalPort '80', '8080' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
@@ -391,7 +391,7 @@ describe Chef::Resource::WindowsFirewallRule do
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end
 
-      it "sets multiple RemotePorts" do
+      it "sets multiple RemotePorts (must be comma-plus-space delimited for PowerShell to treat as an array)" do
         resource.remote_port(%w{443 445})
         expect(provider.firewall_command("Set")).to eql("Set-NetFirewallRule -Name 'test_rule' -Description 'Firewall rule' -RemotePort '443', '445' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'any' -InterfaceType 'any' -Enabled 'true'")
       end

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -141,20 +141,27 @@ describe Chef::Resource::WindowsFirewallRule do
 
   it "the profile property accepts :public, :private, :domain, :any and :notapplicable" do
     resource.profile(:public)
-    expect(resource.profile).to eql(:public)
+    expect(resource.profile).to eql([:public])
     resource.profile(:private)
-    expect(resource.profile).to eql(:private)
+    expect(resource.profile).to eql([:private])
     resource.profile(:domain)
-    expect(resource.profile).to eql(:domain)
+    expect(resource.profile).to eql([:domain])
     resource.profile(:any)
-    expect(resource.profile).to eql(:any)
+    expect(resource.profile).to eql([:any])
     resource.profile(:notapplicable)
-    expect(resource.profile).to eql(:notapplicable)
+    expect(resource.profile).to eql([:notapplicable])
   end
 
   it "the profile property coerces strings to symbols" do
     resource.profile("Public")
-    expect(resource.profile).to eql(:public)
+    expect(resource.profile).to eql([:public])
+    resource.profile([:private, "Public"])
+    expect(resource.profile).to eql([:private, :public])
+  end
+
+  it "the profile property supports multiple profiles" do
+    resource.profile(["Private", "Public"])
+    expect(resource.profile).to eql([:private, :public])
   end
 
   it "the program property accepts strings" do
@@ -268,6 +275,11 @@ describe Chef::Resource::WindowsFirewallRule do
       it "sets Profile" do
         resource.profile(:private)
         expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private' -InterfaceType 'any' -Enabled 'true'")
+      end
+      
+      it "sets multiple Profiles" do
+        resource.profile([:private, :public])
+        expect(provider.firewall_command("New")).to eql("New-NetFirewallRule -Name 'test_rule' -DisplayName 'test_rule' -Description 'Firewall rule' -Direction 'inbound' -Protocol 'TCP' -Action 'allow' -Profile 'private', 'public' -InterfaceType 'any' -Enabled 'true'")
       end
 
       it "sets Program" do

--- a/spec/unit/resource/windows_firewall_rule_spec.rb
+++ b/spec/unit/resource/windows_firewall_rule_spec.rb
@@ -152,6 +152,11 @@ describe Chef::Resource::WindowsFirewallRule do
     expect(resource.profile).to eql([:notapplicable])
   end
 
+  it "the profile property raises on any unknown values" do
+    expect { resource.profile(:other) }.to raise_error(Chef::Exceptions::ValidationFailed)
+    expect { resource.profile([:public, :other]) }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
   it "the profile property coerces strings to symbols" do
     resource.profile("Public")
     expect(resource.profile).to eql([:public])


### PR DESCRIPTION
## Description
Adds Array support to the `profile` property

## Related Issue
https://github.com/chef/chef/issues/8808

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
