### PR TITLE
sudo: perform config validation on the overall sudoers state

### DIFF
--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -166,7 +166,7 @@ class Chef
             source new_resource.template
             mode "0440"
             variables new_resource.variables
-            verify "#{new_resource.visudo_binary} -cf %{path}" if visudo_present?
+            verify "cat #{new_resource.config_prefix}/sudoers %{path} | #{new_resource.visudo_binary} -cf -" if visudo_present?
             action :create
           end
         else
@@ -185,7 +185,7 @@ class Chef
                       setenv:             new_resource.setenv,
                       env_keep_add:       new_resource.env_keep_add,
                       env_keep_subtract:  new_resource.env_keep_subtract
-            verify "#{new_resource.visudo_binary} -cf %{path}" if visudo_present?
+            verify "cat #{new_resource.config_prefix}/sudoers %{path} | #{new_resource.visudo_binary} -cf -" if visudo_present?
             action :create
           end
         end


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
`visudo` was only checking the individual file which is being generated using sudo resource, but it was not checking overall state of sudoers.
- Added overall state verification with `visudo`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #8763 #7042
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
