### PR TITLE
Fix policy settings from config file

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -241,12 +241,14 @@ class Chef
       option :policy_name,
         long: "--policy-name POLICY_NAME",
         description: "Policyfile name to use (--policy-group must also be given).",
+        proc: Proc.new { |u| Chef::Config[:knife][:policy_name] = u },
         default: nil
 
       # runtime - client_builder - set policy group when creating node
       option :policy_group,
         long: "--policy-group POLICY_GROUP",
         description: "Policy group name to use (--policy-name must also be given).",
+        proc: Proc.new { |u| Chef::Config[:knife][:policy_group] = u },
         default: nil
 
       # runtime - client_builder -  node tags


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

- Chef Client cookbook doesn't address the policy file settings like `policy_name` & `policy_group` when given in `config.rb/knife.rb`

## Description
- Updated options `policy_name` & `policy_group`  so that it can fetch the details from `config`
## Related Issue
Fixes https://github.com/chef-cookbooks/chef-client/issues/588
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
