### PR TITLE
Update openSUSE testing in Buildkite

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -555,7 +555,22 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-opensuse-leap
+    - ~/.asdf/shims/bundle exec kitchen test end-to-end-opensuse-leap-42
+  artifact_paths:
+    - $PWD/.kitchen/logs/kitchen.log
+  env:
+      KITCHEN_YAML: kitchen.yml
+  expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
+
+- label: "Kitchen Tests openSUSE Leap: 15"
+  commands:
+    - scripts/bk_tests/bk_linux_exec.sh
+    - cd kitchen-tests
+    - ~/.asdf/shims/bundle exec kitchen test end-to-end-opensuse-leap-15
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:

--- a/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
@@ -75,4 +75,4 @@ default["resolver"]["search"] = "chef.io"
 # nscd cookbook overrides
 #
 
-default["nscd"]["server_user"] = "nobody"
+default["nscd"]["server_user"] = "nobody" unless platform_family?("suse") # this breaks SLES 15

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -127,9 +127,17 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: opensuse-leap
+- name: opensuse-leap-42
   driver:
-    image: dokken/opensuse-leap
+    image: dokken/opensuse-leap-42
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/zypper --non-interactive update
+      - RUN /usr/bin/zypper --non-interactive install cron
+
+- name: opensuse-leap-15
+  driver:
+    image: dokken/opensuse-leap-15
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/zypper --non-interactive update


### PR DESCRIPTION
Use the latest opensuse leap 42 image instead of the one we stopped pushing 6 months ago
Add openSUSE leap 15 testing

Signed-off-by: Tim Smith <tsmith@chef.io>