### PR TITLE
Swap test gem install of fpm for chef-ruby-lvm

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/packages.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/packages.rb
@@ -15,7 +15,7 @@ pkgs.each do |pkg|
   multipackage pkgs
 end
 
-gems = %w{fpm community_cookbook_releaser}
+gems = %w{chef-ruby-lvm community_cookbook_releaser}
 
 gems.each do |gem|
   chef_gem gem do


### PR DESCRIPTION
fpm has some deps that are failing to compile now on centos 6 and
opensuse 42

Signed-off-by: Tim Smith <tsmith@chef.io>