### PR TITLE
Fix show_progress in remote_file is causing FloatDomainError: Infinity

### DIFF
--- a/lib/chef/formatters/doc.rb
+++ b/lib/chef/formatters/doc.rb
@@ -290,11 +290,11 @@ class Chef
       end
 
       def resource_update_progress(resource, current, total, interval)
-        @progress[resource] ||= 0
+        @progress[resource] ||= -1
 
-        percent_complete = (current.to_f / total.to_f * 100).to_i
+        percent_complete = (current.to_f / total.to_f * 100).to_i unless total.to_f == 0.0
 
-        if percent_complete > @progress[resource]
+        if percent_complete && percent_complete > @progress[resource]
 
           @progress[resource] = percent_complete
 

--- a/spec/unit/formatters/doc_spec.rb
+++ b/spec/unit/formatters/doc_spec.rb
@@ -76,6 +76,24 @@ describe Chef::Formatters::Base do
     expect(formatter.pretty_elapsed_time).to include("10 hours 10 minutes 10 seconds")
   end
 
+  it "shows nothing if total is nil" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 35, nil, 10)
+    expect(out.string).to eq("")
+  end
+
+  it "shows nothing if total is 0" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 35, 0, 10)
+    expect(out.string).to eq("")
+  end
+
+  it "shows nothing if current and total are 0" do
+    res = Chef::Resource::RemoteFile.new("canteloupe")
+    formatter.resource_update_progress(res, 0, 0, 10)
+    expect(out.string).to eq("")
+  end
+
   it "shows the percentage completion of an action" do
     res = Chef::Resource::RemoteFile.new("canteloupe")
     formatter.resource_update_progress(res, 35, 50, 10)


### PR DESCRIPTION
 - Add check to avoid total if zero or nil.
 - Set @progress[resource] default value to -1 so that it can start with 0%.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>