### PR TITLE
Event dispatcher thread local storage

### DIFF
--- a/lib/chef/event_dispatch/dispatcher.rb
+++ b/lib/chef/event_dispatch/dispatcher.rb
@@ -10,11 +10,13 @@ class Chef
     class Dispatcher < Base
 
       attr_reader :subscribers
-      attr_reader :event_list
 
       def initialize(*subscribers)
         @subscribers = subscribers
-        @event_list = []
+      end
+
+      def event_list
+        Thread.current[:chef_client_event_list] ||= []
       end
 
       # Add a new subscriber to the list of registered subscribers

--- a/lib/chef/event_dispatch/dispatcher.rb
+++ b/lib/chef/event_dispatch/dispatcher.rb
@@ -15,6 +15,11 @@ class Chef
         @subscribers = subscribers
       end
 
+      # Since the cookbook synchronizer will call this object from threads, we
+      # have to deal with concurrent access to this object.  Since we don't want
+      # threads to handle events from other threads, we just use thread local
+      # storage.
+      #
       def event_list
         Thread.current[:chef_client_event_list] ||= []
       end


### PR DESCRIPTION
Validated that it works:

"I rebuilt the chef/chef docker volume and the kube-jenkins builds have been passing 24 hours. Prior to the patch, 3 of the 8 builds in 24 hours would have failed."

Closes #8825 
