### PR TITLE
Bump Ruby to 2.5.7 to address CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     parallel (1.17.0)
-    parser (2.6.4.1)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.3)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,7 +43,7 @@ The `remote_file` resource now properly shows download progress when the `show_p
 
 ## Custom Resource Unified Mode
 
-Chef Infra Client 15.3 introduces an exciting new way to easily write custom resources that mix built-in Chef Infra resources with Ruby code. Previously, custom resources would use Chef Infra's standard compile and converge phases, which meant that Ruby would be evaluated first and then the resources would be converged. This often results in confusing and undesirable behavior when you are trying to mix resources with Ruby logic. Many custom resource authors would attempt to get around this by forcing resources to run at compile time so that all the code in their resource would execute during the compile phase.
+Chef Infra Client 14.14 introduces an exciting new way to easily write custom resources that mix built-in Chef Infra resources with Ruby code. Previously, custom resources would use Chef Infra's standard compile and converge phases, which meant that Ruby would be evaluated first and then the resources would be converged. This often results in confusing and undesirable behavior when you are trying to mix resources with Ruby logic. Many custom resource authors would attempt to get around this by forcing resources to run at compile time so that all the code in their resource would execute during the compile phase.
 
 An example of forcing a resource to run at compile time:
 
@@ -87,7 +87,13 @@ Knife now fails with a descriptive error message when attempting to bootstrap no
 
 ### Ruby
 
-Ruby has been updated from 2.6.3 to 2.6.4 in order to resolve [CVE-2012-6708](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6708) and [CVE-2015-9251](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251).
+Ruby has been updated from 2.5.5 to 2.5.7 in order to resolve the following CVEs:
+  - [CVE-2012-6708](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6708)
+  - [CVE-2015-9251](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251).
+  - [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845).
+  - [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251).
+  - [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254).
+  - [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255).
 
 ### openssl
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 4b4e11aeaaa63525d9d79d33fb016468fbd0b660
+  revision: 3e901694559a2f3a64105b204ed79f0ffb3410d5
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -34,7 +34,7 @@ GEM
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.220.0)
-    aws-sdk-core (3.68.0)
+    aws-sdk-core (3.68.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,6 +1,5 @@
 # THIS IS NOW HAND MANAGED, JUST EDIT THE THING
-# .travis.yml and appveyor.yml consume this,
-# try to keep it machine-parsable.
+# keep it machine-parsable since CI uses it
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
@@ -17,7 +16,7 @@ override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.5.6"
+override "ruby", version: "2.5.7"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
@@ -30,4 +29,4 @@ override "openssl", version: "1.0.2t"
 # definition. This pin will ensure that ohai and chef-client commands use the
 # same (released) version of ohai.
 gemfile_lock = File.join(File.expand_path(File.dirname(__FILE__)), "Gemfile.lock")
-override "ohai", version: "#{::File.readlines(gemfile_lock).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1}" # rubocop: disable Layout/SpaceInsideStringInterpolation
+override "ohai", version: "#{::File.readlines(gemfile_lock).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; "v" + $1}" # rubocop: disable Layout/SpaceInsideStringInterpolation

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -30,11 +30,11 @@ sudo git clone https://github.com/asdf-vm/asdf.git /opt/asdf
 . /opt/asdf/completions/asdf.bash
 
 echo "--- Installing Ruby ASDF plugin"
-/opt/asdf/bin/asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git 
+/opt/asdf/bin/asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
 
-echo "--- Installing Ruby 2.5.5"
-/opt/asdf/bin/asdf install ruby 2.5.5
-/opt/asdf/bin/asdf global ruby 2.5.5
+echo "--- Installing Ruby 2.5.6"
+/opt/asdf/bin/asdf install ruby 2.5.6
+/opt/asdf/bin/asdf global ruby 2.5.6
 
 # Update Gems
 gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)


### PR DESCRIPTION
Ruby 2.5.7 is out with fixes for:
  - [CVE-2019-16201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15845).
  - [CVE-2019-15845](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9251).
  - [CVE-2019-16254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16254).
  - [CVE-2019-16255](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16255).

Signed-off-by: Tim Smith <tsmith@chef.io>