### PR TITLE
Remove EOL openSUSE Leap 42 testing

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -551,21 +551,6 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests openSUSE Leap: 42"
-  commands:
-    - scripts/bk_tests/bk_linux_exec.sh
-    - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-opensuse-leap-42
-  artifact_paths:
-    - $PWD/.kitchen/logs/kitchen.log
-  env:
-      KITCHEN_YAML: kitchen.yml
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: "Kitchen Tests openSUSE Leap: 15"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -127,14 +127,6 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: opensuse-leap-42
-  driver:
-    image: dokken/opensuse-leap-42
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/zypper --non-interactive update
-      - RUN /usr/bin/zypper --non-interactive install cron
-
 - name: opensuse-leap-15
   driver:
     image: dokken/opensuse-leap-15


### PR DESCRIPTION
openSUSE Leap 42 went EOL July 1st, 2019.

Signed-off-by: Tim Smith <tsmith@chef.io>