### PR TITLE
Revert Gemfile.lock to Bundler 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,4 +440,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.2
+   1.17.3


### PR DESCRIPTION
Expeditor bumped this to 2.0.2 for some reason.

Signed-off-by: Tim Smith <tsmith@chef.io>