### PR TITLE
add support for reinstall

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -65,7 +65,7 @@ class Chef
         end
 
         def define_resource_requirements
-          requirements.assert(:install, :upgrade, :remove, :purge) do |a|
+          requirements.assert(:install, :reinstall, :upgrade, :remove, :purge) do |a|
             a.assertion { !new_resource.source || ::File.exist?(new_resource.source) }
             a.failure_message Chef::Exceptions::Package, "Package #{new_resource.package_name} not found: #{new_resource.source}"
             a.whyrun "assuming #{new_resource.source} would have previously been created"
@@ -125,6 +125,12 @@ class Chef
 
         # yum upgrade does not work on uninstalled packaged, while install will upgrade
         alias upgrade_package install_package
+
+        def reinstall_package(names)
+          resolved_names = names.each_with_index.map { |name, i| installed_version(i).to_s unless name.nil? }
+          yum(options, "-y", "reinstall", resolved_names)
+          flushcache
+        end
 
         def remove_package(names, versions)
           resolved_names = names.each_with_index.map { |name, i| installed_version(i).to_s unless name.nil? }

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -41,10 +41,10 @@ class Chef
 
       provides :dnf_package
 
-      description "Use the dnf_package resource to install, upgrade, and remove packages with DNF for Fedora platforms. The dnf_package resource is able to resolve provides data for packages much like DNF can do when it is run from the command line. This allows a variety of options for installing packages, like minimum versions, virtual provides and library names."
+      description "Use the dnf_package resource to install, reinstall, upgrade, and remove packages with DNF for Fedora platforms. The dnf_package resource is able to resolve provides data for packages much like DNF can do when it is run from the command line. This allows a variety of options for installing packages, like minimum versions, virtual provides and library names."
       introduced "12.18"
 
-      allowed_actions :install, :upgrade, :remove, :purge, :reconfig, :lock, :unlock, :flush_cache
+      allowed_actions :install, :reinstall, :upgrade, :remove, :purge, :reconfig, :lock, :unlock, :flush_cache
 
       # Install a specific arch
       property :arch, [String, Array],

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -33,7 +33,7 @@ class Chef
                   " recommended to use the package resource as often as possible."
 
       default_action :install
-      allowed_actions :install, :upgrade, :remove, :purge, :reconfig, :lock, :unlock
+      allowed_actions :install, :reinstall, :upgrade, :remove, :purge, :reconfig, :lock, :unlock
 
       def initialize(name, *args)
         # We capture name here, before it gets coerced to name

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -25,11 +25,13 @@ class Chef
       resource_name :yum_package
       provides :package, platform_family: %w{rhel fedora amazon}
 
-      description "Use the yum_package resource to install, upgrade, and remove packages with Yum"\
+      description "Use the yum_package resource to install, reinstall, upgrade, and remove packages with Yum"\
                   " for the Red Hat and CentOS platforms. The yum_package resource is able to resolve"\
                   " provides data for packages much like Yum can do when it is run from the command line."\
                   " This allows a variety of options for installing packages, like minimum versions,"\
                   " virtual provides, and library names."
+
+      allowed_actions :install, :reinstall, :upgrade, :remove, :purge, :reconfig, :lock, :unlock, :flush_cache
 
       # XXX: the coercions here are due to the provider promiscuously updating the properties on the
       # new_resource which causes immutable modification exceptions when passed an immutable node array.

--- a/spec/functional/resource/dnf_package_spec.rb
+++ b/spec/functional/resource/dnf_package_spec.rb
@@ -487,6 +487,27 @@ describe Chef::Resource::RpmPackage, :requires_root, external: exclude_test do
     end
   end
 
+  describe ":reinstall" do
+    context "vanilla use case" do
+      let(:package_name) { "chef_rpm" }
+      it "does not reinstall if the package is not installed" do
+        flush_cache
+        dnf_package.run_action(:remove)
+        dnf_package.run_action(:reinstall)
+        expect(dnf_package.updated_by_last_action?).to be false
+        expect(shell_out("rpm -q chef_rpm").stdout.chomp).to eql("package chef_rpm is not installed")
+      end
+
+      it "reinstall the package if installed" do
+        flush_cache
+        dnf_package.run_action(:install)
+        dnf_package.run_action(:reinstall)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q chef_rpm").stdout.chomp).to eql("chef_rpm-1.10-1.x86_64")
+      end
+    end
+  end
+
   describe ":upgrade" do
     context "downgrades" do
       it "just work with DNF" do

--- a/spec/functional/resource/yum_package_spec.rb
+++ b/spec/functional/resource/yum_package_spec.rb
@@ -652,6 +652,27 @@ describe Chef::Resource::YumPackage, :requires_root, external: exclude_test do
     end
   end
 
+  describe ":reinstall" do
+    context "vanilla use case" do
+      let(:package_name) { "chef_rpm" }
+
+      it "do not reinstall if the package is not installed" do
+        flush_cache
+        yum_package.run_action(:remove)
+        yum_package.run_action(:reinstall)
+        expect(yum_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+      end
+
+      it "reinstall if package is installed" do
+        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        yum_package.run_action(:reinstall)
+        expect(yum_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+      end
+    end
+  end
+
   describe ":upgrade" do
 
     context "with source arguments" do

--- a/spec/unit/resource/dnf_package_spec.rb
+++ b/spec/unit/resource/dnf_package_spec.rb
@@ -43,9 +43,10 @@ describe Chef::Resource::DnfPackage, "defaults" do
     expect(resource.action).to eql([:install])
   end
 
-  it "supports :flush_cache, :install, :lock, :purge, :reconfig, :remove, :unlock, :upgrade actions" do
+  it "supports :flush_cache, :install, :reinstall, :lock, :purge, :reconfig, :remove, :unlock, :upgrade actions" do
     expect { resource.action :flush_cache }.not_to raise_error
     expect { resource.action :install }.not_to raise_error
+    expect { resource.action :reinstall }.not_to raise_error
     expect { resource.action :lock }.not_to raise_error
     expect { resource.action :purge }.not_to raise_error
     expect { resource.action :reconfig }.not_to raise_error


### PR DESCRIPTION
add support for reinstall to yum and dnf package resources

## Description
Will allow admins to reinstall a corrupted pkg

## Related Issue
https://stackoverflow.com/questions/28703217/how-reinstall-a-package-using-dpkg-package-chef-resource

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
