### PR TITLE
Avoid a PATH environment variable update before a windows package install

### DIFF
--- a/lib/chef/provider/package/windows/exe.rb
+++ b/lib/chef/provider/package/windows/exe.rb
@@ -64,7 +64,7 @@ class Chef
                 unattended_flags,
                 expand_options(new_resource.options),
                 "& exit %%%%ERRORLEVEL%%%%",
-              ].join(" "), timeout: new_resource.timeout, returns: new_resource.returns, sensitive: new_resource.sensitive
+              ].join(" "), default_env: false, timeout: new_resource.timeout, returns: new_resource.returns, sensitive: new_resource.sensitive
             )
           end
 
@@ -73,7 +73,7 @@ class Chef
             uninstall_entries.select { |entry| [uninstall_version].flatten.include?(entry.display_version) }
               .map(&:uninstall_string).uniq.each do |uninstall_string|
                 logger.trace("Registry provided uninstall string for #{new_resource} is '#{uninstall_string}'")
-                shell_out!(uninstall_command(uninstall_string), timeout: new_resource.timeout, returns: new_resource.returns)
+                shell_out!(uninstall_command(uninstall_string), default_env: false, timeout: new_resource.timeout, returns: new_resource.returns)
               end
           end
 

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -70,14 +70,14 @@ class Chef
           def install_package
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             logger.trace("#{new_resource} installing MSI package '#{new_resource.source}'")
-            shell_out!("msiexec /qn /i \"#{new_resource.source}\" #{expand_options(new_resource.options)}", timeout: new_resource.timeout, returns: new_resource.returns)
+            shell_out!("msiexec /qn /i \"#{new_resource.source}\" #{expand_options(new_resource.options)}", default_env: false, timeout: new_resource.timeout, returns: new_resource.returns)
           end
 
           def remove_package
             # We could use MsiConfigureProduct here, but we'll start off with msiexec
             if !new_resource.source.nil? && ::File.exist?(new_resource.source)
               logger.trace("#{new_resource} removing MSI package '#{new_resource.source}'")
-              shell_out!("msiexec /qn /x \"#{new_resource.source}\" #{expand_options(new_resource.options)}", timeout: new_resource.timeout, returns: new_resource.returns)
+              shell_out!("msiexec /qn /x \"#{new_resource.source}\" #{expand_options(new_resource.options)}", default_env: false, timeout: new_resource.timeout, returns: new_resource.returns)
             else
               uninstall_version = new_resource.version || installed_version
               uninstall_entries.select { |entry| [uninstall_version].flatten.include?(entry.display_version) }
@@ -86,7 +86,7 @@ class Chef
                   uninstall_string += expand_options(new_resource.options)
                   uninstall_string += " /q" unless uninstall_string.downcase =~ %r{ /q}
                   logger.trace("#{new_resource} removing MSI package version using '#{uninstall_string}'")
-                  shell_out!(uninstall_string, timeout: new_resource.timeout, returns: new_resource.returns)
+                  shell_out!(uninstall_string, default_env: false, timeout: new_resource.timeout, returns: new_resource.returns)
                 end
             end
           end

--- a/spec/unit/provider/package/windows/exe_spec.rb
+++ b/spec/unit/provider/package/windows/exe_spec.rb
@@ -126,7 +126,7 @@ describe Chef::Provider::Package::Windows::Exe do
       it "removes installed package and quotes uninstall string" do
         new_resource.timeout = 300
         allow(::File).to receive(:exist?).with("uninst_dir/uninst_file").and_return(true)
-        expect(provider).to receive(:shell_out!).with(%r{start \"\" /wait \"uninst_dir/uninst_file\" /S /NCRC & exit %%%%ERRORLEVEL%%%%}, timeout: 300, returns: [0])
+        expect(provider).to receive(:shell_out!).with(%r{start \"\" /wait \"uninst_dir/uninst_file\" /S /NCRC & exit %%%%ERRORLEVEL%%%%}, default_env: false, timeout: 300, returns: [0])
         provider.remove_package
       end
     end


### PR DESCRIPTION
Avoid a PATH environment variable update before a windows package install

## Description
During a windows package install we need the PATH environment variable to be preserved. By default, shell_out updates the PATH by putting the Chef bin directory at the first place. It could break an install if a system command with the same name as a binary file embedded in Chef is used (like find.exe for example). 

Setting default_env to false into shell_out options in windows_package resource fix this issue. 

By default shell_out also updates the env vars LC_ALL, LANGUAGE and LANG which are not windows related variables.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
