### PR TITLE
windows_share: make path idempotent by coercing to backwhacks

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -38,7 +38,8 @@ class Chef
 
       # Specifies the path of the location of the folder to share. The path must be fully qualified. Relative paths or paths that contain wildcard characters are not permitted.
       property :path, String,
-        description: "The path of the folder to share. Required when creating. If the share already exists on a different path then it is deleted and re-created."
+        description: "The path of the folder to share. Required when creating. If the share already exists on a different path then it is deleted and re-created.",
+        coerce: proc { |p| p.gsub!(%r{/}, "\\") || p }
 
       # Specifies an optional description of the SMB share. A description of the share is displayed by running the Get-SmbShare cmdlet. The description may not contain more than 256 characters.
       property :description, String,

--- a/spec/unit/resource/windows_share_spec.rb
+++ b/spec/unit/resource/windows_share_spec.rb
@@ -36,4 +36,11 @@ describe Chef::Resource::WindowsShare do
     expect { resource.action :create }.not_to raise_error
     expect { resource.action :delete }.not_to raise_error
   end
+
+  it "coerces path to a single path separator format" do
+    resource.path("C:/chef")
+    expect(resource.path).to eql("C:\\chef")
+    resource.path("C:\\chef")
+    expect(resource.path).to eql("C:\\chef")
+  end
 end


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tor.magnus@outlook.com>

## Description

The cmdlet doesn't care about the path separator format, but it should be the same everywhere for idempotency purposes.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/8879

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
