### PR TITLE
Enhance knife supermarket list & search

### DIFF
--- a/lib/chef/knife/supermarket_list.rb
+++ b/lib/chef/knife/supermarket_list.rb
@@ -48,29 +48,25 @@ class Chef
         description: "Show cookbooks that are owned by the USER"
 
       def run
-        url_params = []
-        url_params << "&order=#{config[:sort_by]}" if config[:sort_by]
-        url_params << "&user=#{config[:owned_by]}" if config[:owned_by]
-
-        query = url_params.join unless url_params.empty?
-        cookbooks_list = get_cookbook_list(query)
         if config[:with_uri]
-          ui.output(format_for_display(cookbooks_list))
+          ui.output(format_for_display(get_cookbook_list))
         else
-          ui.msg(ui.list(cookbooks_list.keys, :columns_down))
+          ui.msg(ui.list(get_cookbook_list.keys, :columns_down))
         end
       end
 
-      def get_cookbook_list(query, items = 1000, start = 0, cookbook_collection = {})
+      def get_cookbook_list(items = 1000, start = 0, cookbook_collection = {})
         cookbooks_url = "#{config[:supermarket_site]}/api/v1/cookbooks?items=#{items}&start=#{start}"
-        cookbooks_url << query if query
+        cookbooks_url << "&order=#{config[:sort_by]}" if config[:sort_by]
+        cookbooks_url << "&user=#{config[:owned_by]}" if config[:owned_by]
         cr = noauth_rest.get(cookbooks_url)
+
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook["cookbook"]
         end
         new_start = start + items
         if new_start < cr["total"]
-          get_cookbook_list(query, items, new_start, cookbook_collection)
+          get_cookbook_list(items, new_start, cookbook_collection)
         else
           cookbook_collection
         end

--- a/lib/chef/knife/supermarket_list.rb
+++ b/lib/chef/knife/supermarket_list.rb
@@ -55,7 +55,8 @@ class Chef
         end
       end
 
-      def get_cookbook_list(items = 1000, start = 0, cookbook_collection = {})
+      # In order to avoid pagination items limit set to 9999999
+      def get_cookbook_list(items = 9999999, start = 0, cookbook_collection = {})
         cookbooks_url = "#{config[:supermarket_site]}/api/v1/cookbooks?items=#{items}&start=#{start}"
         cookbooks_url << "&order=#{config[:sort_by]}" if config[:sort_by]
         cookbooks_url << "&user=#{config[:owned_by]}" if config[:owned_by]

--- a/lib/chef/knife/supermarket_search.rb
+++ b/lib/chef/knife/supermarket_search.rb
@@ -35,7 +35,8 @@ class Chef
         output(search_cookbook(name_args[0]))
       end
 
-      def search_cookbook(query, items = 1000, start = 0, cookbook_collection = {})
+      # In order to avoid pagination items limit set to 9999999
+      def search_cookbook(query, items = 9999999, start = 0, cookbook_collection = {})
         cookbooks_url = "#{config[:supermarket_site]}/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
         cr = noauth_rest.get(cookbooks_url)
         cr["items"].each do |cookbook|

--- a/lib/chef/knife/supermarket_search.rb
+++ b/lib/chef/knife/supermarket_search.rb
@@ -35,13 +35,13 @@ class Chef
         output(search_cookbook(name_args[0]))
       end
 
-      def search_cookbook(query, items = 10, start = 0, cookbook_collection = {})
+      def search_cookbook(query, items = 1000, start = 0, cookbook_collection = {})
         cookbooks_url = "#{config[:supermarket_site]}/api/v1/search?q=#{query}&items=#{items}&start=#{start}"
         cr = noauth_rest.get(cookbooks_url)
         cr["items"].each do |cookbook|
           cookbook_collection[cookbook["cookbook_name"]] = cookbook
         end
-        new_start = start + cr["items"].length
+        new_start = start + items
         if new_start < cr["total"]
           search_cookbook(query, items, new_start, cookbook_collection)
         else

--- a/spec/unit/knife/supermarket_list_spec.rb
+++ b/spec/unit/knife/supermarket_list_spec.rb
@@ -1,0 +1,70 @@
+#
+# Author:: Vivek Singh (<vivek.singh@msystechnologies.com>)
+# Copyright:: Copyright 2018-2019, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/knife/supermarket_list"
+require "spec_helper"
+
+describe Chef::Knife::SupermarketList do
+  let(:knife) { described_class.new }
+  let(:noauth_rest) { double("no auth rest") }
+  let(:stdout) { StringIO.new }
+  let(:cookbooks_data) {
+    [
+    { "cookbook_name" => "1password", "cookbook_maintainer" => "jtimberman", "cookbook_description" => "Installs 1password", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/1password" },
+    { "cookbook_name" => "301", "cookbook_maintainer" => "markhuge", "cookbook_description" => "Installs/Configures 301", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/301" },
+    { "cookbook_name" => "3cx", "cookbook_maintainer" => "obay", "cookbook_description" => "Installs/Configures 3cx", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/3cx" },
+    { "cookbook_name" => "7dtd", "cookbook_maintainer" => "gregf", "cookbook_description" => "Installs/Configures the 7 Days To Die server", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/7dtd" },
+    { "cookbook_name" => "7-zip", "cookbook_maintainer" => "sneal", "cookbook_description" => "Installs/Configures the 7-zip file archiver", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/7-zip" },
+  ]
+  }
+
+  let(:response_text) {
+    {
+      "start" => 0,
+      "total" => 5,
+      "items" => cookbooks_data,
+    }
+  }
+
+  describe "run" do
+    before do
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife).to receive(:noauth_rest).and_return(noauth_rest)
+      expect(noauth_rest).to receive(:get).and_return(response_text)
+      knife.configure_chef
+    end
+
+    it "should display all supermarket cookbooks" do
+      knife.run
+      cookbooks_data.each do |item|
+        expect(stdout.string).to match /#{item["cookbook_name"]}\s/
+      end
+    end
+
+    describe "with -w or --with-uri" do
+      it "should display the cookbook uris" do
+        knife.config[:with_uri] = true
+        knife.run
+        cookbooks_data.each do |item|
+          expect(stdout.string).to match /#{item["cookbook_name"]}\s/
+          expect(stdout.string).to match /#{item["cookbook"]}\s/
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/knife/supermarket_search_spec.rb
+++ b/spec/unit/knife/supermarket_search_spec.rb
@@ -1,0 +1,85 @@
+#
+# Author:: Vivek Singh (<vivek.singh@msystechnologies.com>)
+# Copyright:: Copyright 2018-2019, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/knife/supermarket_search"
+require "spec_helper"
+
+describe Chef::Knife::SupermarketSearch do
+  let(:knife) { described_class.new }
+  let(:noauth_rest) { double("no auth rest") }
+  let(:stdout) { StringIO.new }
+  let(:cookbooks_data) {
+    [
+    { "cookbook_name" => "mysql", "cookbook_maintainer" => "sous-chefs", "cookbook_description" => "Provides mysql_service, mysql_config, and mysql_client resources", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/mysql" },
+    { "cookbook_name" => "mw_mysql", "cookbook_maintainer" => "car", "cookbook_description" => "Installs/Configures mw_mysql", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/mw_mysql" },
+    { "cookbook_name" => "L7-mysql", "cookbook_maintainer" => "szelcsanyi", "cookbook_description" => "Installs/Configures MySQL server", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/l7-mysql" },
+    { "cookbook_name" => "mysql-sys", "cookbook_maintainer" => "ovaistariq", "cookbook_description" => "Installs the mysql-sys tool. Description of the tool is available here https://github.com/MarkLeith/mysql-sys", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/mysql-sys" },
+    { "cookbook_name" => "cg_mysql", "cookbook_maintainer" => "phai", "cookbook_description" => "Installs/Configures mysql with master and slave", "cookbook" => "https://supermarket.chef.io/api/v1/cookbooks/cg_mysql" },
+  ]
+  }
+
+  let(:response_text) {
+    {
+      "start" => 0,
+      "total" => 5,
+      "items" => cookbooks_data,
+    }
+  }
+
+  let(:empty_response_text) {
+    {
+      "start" => 0,
+      "total" => 0,
+      "items" => [],
+    }
+  }
+
+  describe "run" do
+    before do
+      allow(knife.ui).to receive(:stdout).and_return(stdout)
+      allow(knife).to receive(:noauth_rest).and_return(noauth_rest)
+      knife.configure_chef
+    end
+
+    context "when name_args is present" do
+      before do
+        expect(noauth_rest).to receive(:get).and_return(response_text)
+      end
+
+      it "should display cookbooks with given name value" do
+        knife.name_args = ["mysql"]
+        knife.run
+        cookbooks_data.each do |item|
+          expect(stdout.string).to match /#{item["cookbook_name"]}\s/
+        end
+      end
+    end
+
+    context "when name_args is empty string" do
+      before do
+        expect(noauth_rest).to receive(:get).and_return(empty_response_text)
+      end
+
+      it "display nothing with name arg empty string" do
+        knife.name_args = [""]
+        knife.run
+        expect(stdout.string).to eq("\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Increase items count 10 to 1000.  
- Remove #sort from cookbook collection because data is already sorted.
- Add `--sort-by` & `--owned-by` options
- Update the `new_start` count if total records are less so that it can prevent an infinite loop.


**Note:** Removing the limit from the cookbooks supermarket API is not possible because it always returns with default limit 10.

eg:  `https://supermarket.chef.io/api/v1/cookbooks` 
```
{"start":0,"total":3863,"items":[ 10 records...]}
```
We can bypass it by providing items limit something  `999999` or `9999999` but it's not feasible solution. 

## Related Issue
Fixes https://github.com/chef/chef/issues/8958

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
