### PR TITLE
Fix yum & dnf shellout if exit with nonzero status

### DIFF
--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -40,12 +40,9 @@ class Chef
             # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
             @dnf_command ||= begin
               cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-                res = shell_out("#{f} -c 'import dnf'")
-                raise res.stderr if res.exitstatus != 0
-
-                true
+                shell_out("#{f} -c 'import dnf'").exitstatus == 0
               end
-
+              raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd
               "#{cmd} #{DNF_HELPER}"
             end
           end

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -38,9 +38,16 @@ class Chef
 
           def dnf_command
             # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
-            @dnf_command ||= which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-              shell_out("#{f} -c 'import dnf'").exitstatus == 0
-            end + " #{DNF_HELPER}"
+            @dnf_command ||= begin
+              cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
+                res = shell_out("#{f} -c 'import dnf'")
+                raise res.stderr if res.exitstatus != 0
+
+                true
+              end
+
+              "#{cmd} #{DNF_HELPER}"
+            end
           end
 
           def start

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -43,6 +43,7 @@ class Chef
                 shell_out("#{f} -c 'import dnf'").exitstatus == 0
               end
               raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd
+
               "#{cmd} #{DNF_HELPER}"
             end
           end

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -45,6 +45,7 @@ class Chef
                 shell_out("#{f} -c 'import yum'").exitstatus == 0
               end
               raise Chef::Exceptions::Package, "cannot find yum libraries, you may need to use dnf_package" unless cmd
+
               "#{cmd} #{YUM_HELPER}"
             end
           end

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -40,9 +40,16 @@ class Chef
           YUM_HELPER = ::File.expand_path(::File.join(::File.dirname(__FILE__), "yum_helper.py")).freeze
 
           def yum_command
-            @yum_command ||= which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-              shell_out("#{f} -c 'import yum'").exitstatus == 0
-            end + " #{YUM_HELPER}"
+            @yum_command ||= begin
+              cmd = which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
+                res = shell_out("#{f} -c 'import yum'")
+                raise res.stderr if res.exitstatus != 0
+
+                true
+              end
+
+              "#{cmd} #{YUM_HELPER}"
+            end
           end
 
           def start

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -42,12 +42,9 @@ class Chef
           def yum_command
             @yum_command ||= begin
               cmd = which("platform-python", "python", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-                res = shell_out("#{f} -c 'import yum'")
-                raise res.stderr if res.exitstatus != 0
-
-                true
+                shell_out("#{f} -c 'import yum'").exitstatus == 0
               end
-
+              raise Chef::Exceptions::Package, "cannot find yum libraries, you may need to use dnf_package" unless cmd
               "#{cmd} #{YUM_HELPER}"
             end
           end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
If shell out of python yum & dnf helper is exited with nonzero status then raise an error with stderr message
Now it showing 

```
------
FATAL: RuntimeError: yum_package[yum-utils] ((chef-apply cookbook)::(chef-apply recipe) line 1) had an error: RuntimeError: Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'yum'
```
Instead of `"undefined method `+' for false:FalseClass"`
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/8965

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>