### PR TITLE
Modify #8901 to not use arrays with mixlib-shellout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tags
 *~
 .chef
 results
+*.gem
 
 # You should check in your Gemfile.lock in applications, and not in gems
 external_tests/*.lock
@@ -61,3 +62,6 @@ nodes/
 # chef-config
 chef-config/.bundle
 chef-config/Gemfile.lock
+
+# docs site generation from master
+docs_site/**

--- a/lib/chef/cookbook/gem_installer.rb
+++ b/lib/chef/cookbook/gem_installer.rb
@@ -69,7 +69,8 @@ class Chef
                 # Skip installation only if Chef::Config[:skip_gem_metadata_installation] option is true
                 unless Chef::Config[:skip_gem_metadata_installation]
                   # Add additional options to bundle install
-                  cmd = [ "bundle", "install", Chef::Config[:gem_installer_bundler_options] ]
+                  cmd = "bundle install"
+                  cmd += " #{Chef::Config[:gem_installer_bundler_options]}" if Chef::Config[:gem_installer_bundler_options]
                   so = shell_out!(cmd, cwd: dir, env: { "PATH" => path_with_prepended_ruby_bin })
                   Chef::Log.info(so.stdout)
                 end

--- a/spec/unit/cookbook/gem_installer_spec.rb
+++ b/spec/unit/cookbook/gem_installer_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "bundler/dsl"
+require "bundler"
 
 describe Chef::Cookbook::GemInstaller do
   let(:cookbook_collection) do
@@ -106,7 +106,7 @@ describe Chef::Cookbook::GemInstaller do
 
   it "install from local cache when Chef::Config[:gem_installer_bundler_options] is set to local" do
     Chef::Config[:gem_installer_bundler_options] = "--local"
-    expect(gem_installer).to receive(:shell_out!).with(["bundle", "install", "--local"], any_args).and_return(shell_out)
+    expect(gem_installer).to receive(:shell_out!).with("bundle install --local", any_args).and_return(shell_out)
     expect(Chef::Log).to receive(:info).and_return("")
     expect(gem_installer.install).to be_empty
   end


### PR DESCRIPTION
Chef-14 has to work with mixlib-shellout 2.x which does not support the array form of shelling out. Use a string instead. I also updated the gitignore to avoid some junk coming in and swapped the spec's bundler require to be the full bundler gem since it needs a giant pile of stuff in Bundler and bundler doesn't have proper requires in the DSL class to make that happen.

Signed-off-by: Tim Smith <tsmith@chef.io>