### PR TITLE
Fix crash when showing error about missing profile

### DIFF
--- a/chef-config/lib/chef-config/mixin/credentials.rb
+++ b/chef-config/lib/chef-config/mixin/credentials.rb
@@ -89,7 +89,8 @@ module ChefConfig
           # Unknown profile name. For "default" just silently ignore, otherwise
           # raise an error.
           return if profile == "default"
-          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file}."
+
+          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{credentials_file_path}."
         end
         apply_credentials(config[profile], profile)
       end


### PR DESCRIPTION
Before:

    /opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/chef-config-15.1.36/lib/chef-config/mixin/credentials.rb:92:in `load_credentials': undefined local variable or method `credentials_file' for #<ChefConfig::WorkstationConfigLoader:0x00007fe01c8321e8> (NameError)

After:

    ERROR: CONFIGURATION ERROR:Profile xyz doesn't exist. Please add it to /Users/developer/.chef/credentials.

It looks like this was missed as part of the refactoring in
d730505bb0d53d14c7b005c756ed4993b95fdf94.

Signed-off-by: Andrew Neitsch <andrew@neitsch.ca>

Backport https://github.com/chef/chef/pull/8828 from master