### PR TITLE
Fix for MSYS-1094 user resource does not handle a gid specified as a string

### DIFF
--- a/lib/chef/provider/user.rb
+++ b/lib/chef/provider/user.rb
@@ -34,7 +34,7 @@ class Chef
       end
 
       def convert_group_name
-        if new_resource.gid.is_a? String
+        if new_resource.gid.is_a?(String) && new_resource.gid.to_i == 0
           new_resource.gid(Etc.getgrnam(new_resource.gid).gid)
         end
       rescue ArgumentError


### PR DESCRIPTION
Signed-off-by: Kapil chouhan <kapil.chouhan@msystechnologies.com>