### PR TITLE
ChefFS & knife environment matching the output

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/rest_list_entry.rb
@@ -101,7 +101,7 @@ class Chef
 
           def read
             # Minimize the value (get rid of defaults) so the results don't look terrible
-            Chef::JSONCompat.to_json_pretty(minimize_value(_read_json))
+            Chef::JSONCompat.to_json_pretty(normalize_value(_read_json))
           end
 
           def _read_json
@@ -122,7 +122,11 @@ class Chef
           end
 
           def minimize_value(value)
-            data_handler.minimize(data_handler.normalize(value, self), self)
+            data_handler.minimize(normalize_value(value), self)
+          end
+
+          def normalize_value(value)
+            data_handler.normalize(value, self)
           end
 
           def compare_to(other)

--- a/spec/integration/knife/raw_spec.rb
+++ b/spec/integration/knife/raw_spec.rb
@@ -142,7 +142,21 @@ describe "knife raw", :workstation do
           /roles/x.json:
           {
             "name": "x",
-            "description": "eek"
+            "description": "eek",
+            "json_class": "Chef::Role",
+            "chef_type": "role",
+            "default_attributes": {
+
+            },
+            "override_attributes": {
+
+            },
+            "run_list": [
+
+            ],
+            "env_run_lists": {
+
+            }
           }
         EOM
       end
@@ -178,7 +192,21 @@ describe "knife raw", :workstation do
           /roles/y.json:
           {
             "name": "y",
-            "description": "eek"
+            "description": "eek",
+            "json_class": "Chef::Role",
+            "chef_type": "role",
+            "default_attributes": {
+
+            },
+            "override_attributes": {
+
+            },
+            "run_list": [
+
+            ],
+            "env_run_lists": {
+
+            }
           }
         EOM
       end

--- a/spec/integration/knife/show_spec.rb
+++ b/spec/integration/knife/show_spec.rb
@@ -80,7 +80,19 @@ describe "knife show", :workstation do
         knife("show /environments/x.json").should_succeed <<~EOM
           /environments/x.json:
           {
-            "name": "x"
+            "name": "x",
+            "description": "",
+            "cookbook_versions": {
+
+            },
+            "default_attributes": {
+
+            },
+            "override_attributes": {
+
+            },
+            "json_class": "Chef::Environment",
+            "chef_type": "environment"
           }
         EOM
       end
@@ -96,7 +108,22 @@ describe "knife show", :workstation do
         knife("show /roles/x.json").should_succeed <<~EOM
           /roles/x.json:
           {
-            "name": "x"
+            "name": "x",
+            "description": "",
+            "json_class": "Chef::Role",
+            "chef_type": "role",
+            "default_attributes": {
+
+            },
+            "override_attributes": {
+
+            },
+            "run_list": [
+
+            ],
+            "env_run_lists": {
+
+            }
           }
         EOM
       end
@@ -149,7 +176,9 @@ describe "knife show", :workstation do
           },
           "override_attributes": {
             "x": "y"
-          }
+          },
+          "json_class": "Chef::Environment",
+          "chef_type": "environment"
         }
       EOM
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added default params in `knife download /environments` so that it's matched with `knife environment show  --format=json`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/4213

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
