### PR TITLE
Fix undefined method `each' for String

### DIFF
--- a/lib/chef/knife/exec.rb
+++ b/lib/chef/knife/exec.rb
@@ -40,7 +40,7 @@ class Chef::Knife::Exec < Chef::Knife
   end
 
   def run
-    config[:script_path] ||= Array(Chef::Config[:script_path])
+    config[:script_path] = Array(config[:script_path] || Chef::Config[:script_path])
 
     # Default script paths are chef-repo/.chef/scripts and ~/.chef/scripts
     config[:script_path] << File.join(Chef::Knife.chef_config_dir, "scripts") if Chef::Knife.chef_config_dir
@@ -57,6 +57,14 @@ class Chef::Knife::Exec < Chef::Knife
         context.instance_eval(IO.read(file), file, 0)
       end
     else
+      puts "An interactive shell is opened"
+      puts
+      puts "Type your script and do:"
+      puts
+      puts "1. To run the script, use 'Ctrl D'"
+      puts "2. To exit, use 'Ctrl/Shift C'"
+      puts
+      puts "Type here a script..."
       script = STDIN.read
       context.instance_eval(script, "STDIN", 0)
     end


### PR DESCRIPTION
 - Fix `undefined method 'each' for #<String:> (NoMethodError) ` while providing script path as follow

```
knife[:script_path] = "/home/myself/work/scripts"
```

 - Better UI when no args provided for knife exec.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/5148
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
