### PR TITLE
Build as chef-client in habitat again

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,4 +1,4 @@
-[chef-infra-client]
+[chef-client]
 build_targets = [
   "x86_64-linux",
   "x86_64-linux-kernel2"


### PR DESCRIPTION
This let's folks continue to consume the old chef-client packages

Signed-off-by: Tim Smith <tsmith@chef.io>