### PR TITLE
Revert habitat builder artifact to chef-client

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,4 +1,4 @@
-[chef-infra-client]
+[chef-client]
 build_targets = [
   "x86_64-linux",
   "x86_64-linux-kernel2"


### PR DESCRIPTION
This PR is related to issue #8966 and reverts the Chef-14 habitat package to the original artifact name `chef-client` from the new branding of `chef-infra-client`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>