### PR TITLE
Fix typo for knife download --[no]diff and --[-no]force options.

### DIFF
--- a/lib/chef/knife/download.rb
+++ b/lib/chef/knife/download.rb
@@ -43,7 +43,7 @@ class Chef
         long: "--[no-]force",
         boolean: true,
         default: false,
-        description: "Force upload of files even if they match (quicker and harmless, but doesn't print out what it changed)."
+        description: "Force download of files even if they match (quicker and harmless, but doesn't print out what it changed)."
 
       option :dry_run,
         long: "--dry-run",
@@ -56,7 +56,7 @@ class Chef
         long: "--[no-]diff",
         boolean: true,
         default: true,
-        description: "Turn off to avoid uploading existing files; only new (and possibly deleted) files with --no-diff."
+        description: "Turn off to avoid downloading existing files; only new (and possibly deleted) files with --no-diff."
 
       option :cookbook_version,
         long: "--cookbook-version VERSION",


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

## Description

Found this typo while working with knife download commands. knife download --[no]-diff and --[no-]force option should mention have download word in description.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
