### PR TITLE
Modify release notes for 14.14.25 promotion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes.
 
-# Chef Client Release Notes 14.14.22
+# Chef Client Release Notes 14.14.25
 
 ## Bug Fixes
 
 - Resolved a regression introduced in Chef Infra Client 14.14.14 that broke installation of gems in some scenarios
+- Fixed Habitat packaging of `chef-client` artifacts
 - Fixed crash in knife when displaying a missing profile error message
 - Fixed knife subcommand --help not working as intended for some commands
 - Fixed knife ssh interactive mode exit error


### PR DESCRIPTION
Now that habitat packaging is working again we are promoting `14.14.25` rather than `14.14.22`

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>