### PR TITLE
[knife supermarket] set tarballs to uid/gid 0 to avoid large uid/gid errors on consumer machines

### DIFF
--- a/lib/chef/knife/supermarket_share.rb
+++ b/lib/chef/knife/supermarket_share.rb
@@ -151,11 +151,11 @@ class Chef
 
       def tar_cmd
         unless @tar_cmd
-          @tar_cmd = "tar"
+          @tar_cmd = "tar --numeric-owner --uid 0 --gid 0"
           begin
             # Unix and Mac only - prefer gnutar
             if shell_out("which gnutar").exitstatus.equal?(0)
-              @tar_cmd = "gnutar"
+              @tar_cmd = "gnutar --numeric-owner --owner 0 --group 0"
             end
           rescue Errno::ENOENT
           end


### PR DESCRIPTION
## Description

The tar commands default to storing the user and group IDs--and the user/group names associated with them--of the directories and files being archived. This change updates the BSD and GNU forms for the tar command to set the owner and group to 0 and to not store the user/group name mapping in the resultant archive.

There is also has a benefit of avoiding bugs in tar readers that do not behave well when large uid/gid values are stored in tar's extended metadata headers. While this won't fix cookbooks that have already been published, it will minimize the bug's appearance in clients with older dependency resolvers as fewer latest cookbook versions will include large IDs.

## Related Issue

To reiterate, this PR won't fix the issue for cookbooks already published. Any code that expands a cookbook—clients, Supermarkets, etc—must still handle tarballs with large IDs. These issues exhibit the downstream pain of the large uid/gid values being included in the cookbook tarballs.
 
* https://github.com/chef/supermarket/issues/1806
* https://github.com/chef/chef-dk/issues/1549
* https://github.com/chef/chef-dk/issues/2018
* https://github.com/chef/effortless/issues/54

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
