### PR TITLE
Improve habitat test pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,7 +26,7 @@ pipelines:
   - verify:
       public: true
   - habitat/build
-  - habitat-test:
+  - habitat/test:
       definition: .expeditor/habitat-test.pipeline.yml
   - omnibus/release
   - omnibus/adhoc:

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -3,7 +3,18 @@ steps:
 
 - label: ":linux: Validate Habitat Builds of Chef Infra"
   commands:
-    - hab pkg install chef/chef-infra-client
+    - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX"
+    - powershell -File "./habitat/tests/test.sh" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUX"
+  expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
+
+- label: ":linux: :two: Validate Habitat Builds of Chef Infra"
+  commands:
+    - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"
+    - powershell -File "./habitat/tests/test.sh" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64LINUXKERNEL2"
   expeditor:
     executor:
       linux:
@@ -12,10 +23,10 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
-    - hab pkg install chef/chef-infra-client
+    - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
+    - powershell -File "./habitat/tests/test.ps1" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
   expeditor:
     executor:
       windows:
-        os-version: 2016
         privileged: true
         single-use: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This improves on the existing pipeline by specifying which version of chef-infra-client's habitat package to install and test. The package ident environment variables will be populated automatically by expeditor when expeditor triggers the `habitat/test` pipeline which will be an action subscribed to the `buildkite_hab_build_group_published` workload.

The following subscription will need to be added to the expeditor config.yml once we are ready to start using the `habitat/test` pipeline.

```
subscriptions:
  - workload: buildkite_hab_build_group_published:{{agent_id}}:*
    actions:
      - trigger_pipeline:habitat/test
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
