### PR TITLE
[Do Not Merge] Expand paths provided in file_cache_path setting to allow for relative paths

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -146,6 +146,7 @@ class Chef
       end
       extra_config_options = config.delete(:config_option)
       chef_config.merge!(config)
+      chef_config[:file_cache_path] = File.expand_path(chef_config[:file_cache_path])
       apply_extra_config_options(extra_config_options)
     end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -130,6 +130,7 @@ describe Chef::Application do
 
         before do
           @app.config[:config_file] = config_location
+          @app.config[:file_cache_path] = "/root/.chef/local-mode-cache/cache"
 
           # force let binding to get evaluated or else we stub Pathname.new before we try to use it.
           config_location_pathname
@@ -521,6 +522,7 @@ describe Chef::Application do
 
       default :test_config_1, "config default"
       default :test_config_2, "config default"
+      default :file_cache_path, "/root/.chef/local-mode-cache/cache"
     end
 
     class MyAppClass < Chef::Application
@@ -576,6 +578,12 @@ describe Chef::Application do
       @app.parse_options
       @app.load_config_file
       expect(MyTestConfig[:test_config_2]).to eql("cli-setting")
+    end
+
+    it "should be expanded the file_cache_path" do
+      expect(fake_config_fetcher).to receive(:read_config).and_return(%q{file_cache_path "~/test/.chef/cache"})
+      @app.load_config_file
+      expect(MyTestConfig[:file_cache_path]).to eql("/root/test/.chef/cache")
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Kapil chouhan <kapil.chouhan@msystechnologies.com>

## Description
- Minor fixes, now `file_cache_path` will work with ".." and "~".
- Ensured chef-style on the code changes made

## Related Issue
Fixes: #3890 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)