### PR TITLE
Fix habitat test pipeline name

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,7 +26,7 @@ pipelines:
   - verify:
       public: true
   - habitat/build
-  - habitat/test:
+  - habitat-test:
       definition: .expeditor/habitat-test.pipeline.yml
   - omnibus/release
   - omnibus/adhoc:


### PR DESCRIPTION

We can't use a name that starts with "habitat/" because
that causes it to be treated like a habitat build pipeline.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>