### PR TITLE
Fix habitat test pipeline name for real this time

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,8 +26,9 @@ pipelines:
   - verify:
       public: true
   - habitat/build
-  - habitat-test:
+  - habitat/test:
       definition: .expeditor/habitat-test.pipeline.yml
+      trigger: default
   - omnibus/release
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml


### PR DESCRIPTION

Any pipeline name starting with "habitat" will be treated as
a habitat build pipeline. The simplest way to override this is
to explicitly set the trigger value to "default".

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>