### PR TITLE
correct typos in license headers

### DIFF
--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -11,7 +11,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific slanguage governing permissions and
+# See the License for the specific language governing permissions and
 # limitations under the License.
 #
 

--- a/spec/unit/knife/cookbook_show_spec.rb
+++ b/spec/unit/knife/cookbook_show_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Copyright:: Copyright 2008-2017, Chef Software Inc.
-# License:: Apache License, eersion 2.0
+# License:: Apache License, version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR contains two minor orthography fixes to license notices and tags.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

## Related Issue
FWIW, I ran a license scan on the tip of chef following a bug report in https://github.com/nexB/scancode-toolkit/issues/1777 and found these two oddities fixed here that were not detected exactly because of some typos on your side.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
