### PR TITLE
Validate format option values using `in` attribute

### DIFF
--- a/lib/chef/application/knife.rb
+++ b/lib/chef/application/knife.rb
@@ -114,6 +114,7 @@ class Chef::Application::Knife < Chef::Application
     short: "-F FORMAT",
     long: "--format FORMAT",
     description: "Which format to use for output.",
+    in: %w{summary text json yaml pp},
     default: "summary"
 
   option :local_mode,

--- a/spec/unit/application/knife_spec.rb
+++ b/spec/unit/application/knife_spec.rb
@@ -77,6 +77,23 @@ describe Chef::Application::Knife do
     expect(Chef::Config[:color]).to be_truthy
   end
 
+  context "validate --format option" do
+    it "should set the default format summary" do
+      with_argv(*%w{noop knife command}) do
+        expect(@knife).to receive(:exit).with(0)
+        @knife.run
+        expect(@knife.default_config[:format]).to eq("summary")
+      end
+    end
+
+    it "should raise the error for invalid value" do
+      with_argv(*%w{noop knife command -F abc}) do
+        expect(STDOUT).to receive(:puts).at_least(2).times
+        expect { @knife.run }.to raise_error(SystemExit) { |e| expect(e.status).to eq(2) }
+      end
+    end
+  end
+
   context "when given fips flags" do
     context "when Chef::Config[:fips]=false" do
       before do


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
As we have supported `:summary`, `:text`, `:json`, `:yaml` and `:pp` format values but other than these values it raises error eg. `ERROR: ArgumentError: Unknown output format raw`.

After this fix it also does not allows any string starts with `s`, `t`, `y`, `j` and `p`
As per the code

https://github.com/chef/chef/blob/340ceac008bee94c053fd791175534a0b2a87ec2/lib/chef/knife/core/generic_presenter.rb#L112-L127

so previously it also taking following values as a valid format
 
```
=> knife cookbook list -F jjjjjjjjjjjjjjjjjj

=> knife cookbook list -F text_format_invalid

=> knife cookbook list -F p_but_not_exit
```
But after fixes, these raise an error?

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/2979

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>