### PR TITLE
Fix license acceptance in `omnibus/kitchen.yml`

### DIFF
--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -27,6 +27,7 @@ provisioner:
   product_name: angrychef
   product_version: latest
   chef_omnibus_root: /opt/angrychef
+  chef_license: accept-no-persist
 
 platforms:
   - name: centos-6


### PR DESCRIPTION
This PR adds an explicit license acceptance in `omnibus/kitchen.yml` reported in #9029 

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>
