### PR TITLE
Turn on unified_mode for 35 core resources

### DIFF
--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -22,6 +22,8 @@ require_relative "../provider/script"
 class Chef
   class Resource
     class Bash < Chef::Resource::Script
+      unified_mode true
+
       description "Use the bash resource to execute scripts using the Bash interpreter. This resource may also use any of the actions and properties that are available to the execute resource. Commands that are executed with this resource are (by their nature) not idempotent, as they are typically unique to the environment in which they are run. Use not_if and only_if to guard this resource for idempotence."
 
       def initialize(name, run_context = nil)

--- a/lib/chef/resource/batch.rb
+++ b/lib/chef/resource/batch.rb
@@ -21,6 +21,8 @@ require_relative "windows_script"
 class Chef
   class Resource
     class Batch < Chef::Resource::WindowsScript
+      unified_mode true
+
       provides :batch
 
       description "Use the batch resource to execute a batch script using the cmd.exe interpreter on Windows. The batch resource creates and executes a temporary file (similar to how the script resource behaves), rather than running the command inline. Commands that are executed with this resource are (by their nature) not idempotent, as they are typically unique to the environment in which they are run. Use not_if and only_if to guard this resource for idempotence."

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -22,6 +22,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Breakpoint < Chef::Resource
+      unified_mode true
+
       provides :breakpoint, target_mode: true
       resource_name :breakpoint
 

--- a/lib/chef/resource/cookbook_file.rb
+++ b/lib/chef/resource/cookbook_file.rb
@@ -27,6 +27,7 @@ class Chef
   class Resource
     class CookbookFile < Chef::Resource::File
       include Chef::Mixin::Securable
+      unified_mode true
 
       resource_name :cookbook_file
 

--- a/lib/chef/resource/csh.rb
+++ b/lib/chef/resource/csh.rb
@@ -22,6 +22,8 @@ require_relative "../provider/script"
 class Chef
   class Resource
     class Csh < Chef::Resource::Script
+      unified_mode true
+
       description "Use the csh resource to execute scripts using the csh interpreter."\
                   " This resource may also use any of the actions and properties that are"\
                   " available to the execute resource. Commands that are executed with this"\

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -24,6 +24,8 @@ require_relative "../mixin/securable"
 class Chef
   class Resource
     class Directory < Chef::Resource
+      unified_mode true
+
       resource_name :directory
 
       description "Use the directory resource to manage a directory, which is a hierarchy"\

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -23,6 +23,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Execute < Chef::Resource
+      unified_mode true
+
       resource_name :execute
       provides :execute, target_mode: true
 

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -28,6 +28,7 @@ class Chef
   class Resource
     class File < Chef::Resource
       include Chef::Mixin::Securable
+      unified_mode true
 
       description "Use the file resource to manage files directly on a node."
 

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -21,6 +21,8 @@ require_relative "scm"
 class Chef
   class Resource
     class Git < Chef::Resource::Scm
+      unified_mode true
+
       description "Use the git resource to manage source control resources that exist in a git repository. git version 1.6.5 (or higher) is required to use all of the functionality in the git resource."
 
       property :additional_remotes, Hash,

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -20,6 +20,8 @@
 class Chef
   class Resource
     class Group < Chef::Resource
+      unified_mode true
+
       state_attrs :members
 
       description "Use the group resource to manage a local group."

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -22,6 +22,8 @@ require_relative "../resource"
 class Chef
   class Resource
     class HttpRequest < Chef::Resource
+      unified_mode true
+
       resource_name :http_request
       provides :http_request
 

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -26,6 +26,8 @@ class Chef
     #     device 'eth1'
     #   end
     class Ifconfig < Chef::Resource
+      unified_mode true
+
       resource_name :ifconfig
 
       description "Use the ifconfig resource to manage interfaces on Unix and Linux systems."

--- a/lib/chef/resource/ksh.rb
+++ b/lib/chef/resource/ksh.rb
@@ -21,6 +21,8 @@ require_relative "script"
 class Chef
   class Resource
     class Ksh < Chef::Resource::Script
+      unified_mode true
+
       description "Use the ksh resource to execute scripts using the Korn shell (ksh)"\
                   " interpreter. This resource may also use any of the actions and properties"\
                   " that are available to the execute resource. Commands that are executed"\

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -24,6 +24,8 @@ class Chef
   class Resource
     class Link < Chef::Resource
       include Chef::Mixin::Securable
+      unified_mode true
+
       resource_name :link
       provides :link
 

--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -29,6 +29,8 @@ class Chef
     #     level :debug
     #   end
     class Log < Chef::Resource
+      unified_mode true
+
       resource_name :log
       provides :log, target_mode: true
 

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -23,6 +23,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Ohai < Chef::Resource
+      unified_mode true
+
       resource_name :ohai
       provides :ohai
 

--- a/lib/chef/resource/perl.rb
+++ b/lib/chef/resource/perl.rb
@@ -22,6 +22,8 @@ require_relative "../provider/script"
 class Chef
   class Resource
     class Perl < Chef::Resource::Script
+      unified_mode true
+
       def initialize(name, run_context = nil)
         super
         @interpreter = "perl"

--- a/lib/chef/resource/python.rb
+++ b/lib/chef/resource/python.rb
@@ -21,6 +21,8 @@ require_relative "../provider/script"
 class Chef
   class Resource
     class Python < Chef::Resource::Script
+      unified_mode true
+
       def initialize(name, run_context = nil)
         super
         @interpreter = "python"

--- a/lib/chef/resource/reboot.rb
+++ b/lib/chef/resource/reboot.rb
@@ -22,6 +22,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Reboot < Chef::Resource
+      unified_mode true
+
       resource_name :reboot
 
       description "Use the reboot resource to reboot a node, a necessary step with some"\

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -22,6 +22,8 @@ require_relative "../digester"
 class Chef
   class Resource
     class RegistryKey < Chef::Resource
+      unified_mode true
+
       resource_name :registry_key
       provides(:registry_key) { true }
 

--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -25,6 +25,7 @@ class Chef
   class Resource
     class RemoteDirectory < Chef::Resource::Directory
       include Chef::Mixin::Securable
+      unified_mode true
 
       description "Use the remote_directory resource to incrementally transfer a directory from a cookbook to a node. The director that is copied from the cookbook should be located under COOKBOOK_NAME/files/default/REMOTE_DIRECTORY. The remote_directory resource will obey file specificity."
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -27,6 +27,7 @@ class Chef
   class Resource
     class RemoteFile < Chef::Resource::File
       include Chef::Mixin::Securable
+      unified_mode true
 
       description "Use the remote_file resource to transfer a file from a remote location"\
                   " using file specificity. This resource is similar to the file resource."

--- a/lib/chef/resource/ruby.rb
+++ b/lib/chef/resource/ruby.rb
@@ -22,6 +22,8 @@ require_relative "../provider/script"
 class Chef
   class Resource
     class Ruby < Chef::Resource::Script
+      unified_mode true
+
       description "Use the ruby resource to execute scripts using the Ruby interpreter. This"\
                   " resource may also use any of the actions and properties that are available"\
                   " to the execute resource. Commands that are executed with this resource are (by"\

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -24,6 +24,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class RubyBlock < Chef::Resource
+      unified_mode true
+
       provides :ruby_block, target_mode: true
 
       description "Use the ruby_block resource to execute Ruby code during a #{Chef::Dist::PRODUCT} run."\

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -21,6 +21,8 @@ require_relative "../resource"
 class Chef
   class Resource
     class Scm < Chef::Resource
+      unified_mode true
+
       default_action :sync
       allowed_actions :checkout, :export, :sync, :diff, :log
 

--- a/lib/chef/resource/script.rb
+++ b/lib/chef/resource/script.rb
@@ -22,6 +22,8 @@ require_relative "execute"
 class Chef
   class Resource
     class Script < Chef::Resource::Execute
+      unified_mode true
+
       resource_name :script
 
       identity_attr :name

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -23,6 +23,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Subversion < Chef::Resource::Scm
+      unified_mode true
+
       description "Use the subversion resource to manage source control resources that exist in a Subversion repository."
 
       allowed_actions :force_export

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -34,6 +34,8 @@ class Chef
     # chef-client. This resource includes actions and properties from the file resource. Template files managed by the
     # template resource follow the same file specificity rules as the remote_file and file resources.
     class Template < Chef::Resource::File
+      unified_mode true
+
       resource_name :template
       provides :template
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -21,6 +21,8 @@ require_relative "../resource"
 class Chef
   class Resource
     class User < Chef::Resource
+      unified_mode true
+
       resource_name :user_resource_abstract_base_class # this prevents magickal class name DSL wiring
 
       description "Use the user resource to add users, update existing users, remove users, and to lock/unlock user passwords."

--- a/lib/chef/resource/user/aix_user.rb
+++ b/lib/chef/resource/user/aix_user.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class User
       class AixUser < Chef::Resource::User
+        unified_mode true
+
         resource_name :aix_user
 
         provides :aix_user

--- a/lib/chef/resource/user/linux_user.rb
+++ b/lib/chef/resource/user/linux_user.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class User
       class LinuxUser < Chef::Resource::User
+        unified_mode true
+
         resource_name :linux_user
 
         provides :linux_user

--- a/lib/chef/resource/user/pw_user.rb
+++ b/lib/chef/resource/user/pw_user.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class User
       class PwUser < Chef::Resource::User
+        unified_mode true
+
         resource_name :pw_user
 
         provides :pw_user

--- a/lib/chef/resource/user/solaris_user.rb
+++ b/lib/chef/resource/user/solaris_user.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class User
       class SolarisUser < Chef::Resource::User
+        unified_mode true
+
         resource_name :solaris_user
 
         provides :solaris_user

--- a/lib/chef/resource/user/windows_user.rb
+++ b/lib/chef/resource/user/windows_user.rb
@@ -21,6 +21,8 @@ class Chef
   class Resource
     class User
       class WindowsUser < Chef::Resource::User
+        unified_mode true
+
         resource_name :windows_user
 
         provides :windows_user

--- a/lib/chef/resource/whyrun_safe_ruby_block.rb
+++ b/lib/chef/resource/whyrun_safe_ruby_block.rb
@@ -19,6 +19,7 @@
 class Chef
   class Resource
     class WhyrunSafeRubyBlock < Chef::Resource::RubyBlock
+      unified_mode true
     end
   end
 end


### PR DESCRIPTION
These are the ones that off of the top of my head it should be perfectly
safe to turn on `unifed_mode` with minimal auditing.

Most of these are so old that they do not use any sub-resources at all.
