### PR TITLE
Allow for the mixlib-authentication 3.x gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ PATH
       iniparse (~> 1.4)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
+      mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.0.3, < 4.0)
@@ -75,7 +75,7 @@ PATH
       iso8601 (~> 0.12.1)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
+      mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
       mixlib-shellout (>= 3.0.3, < 4.0)
@@ -225,7 +225,7 @@ GEM
       mixlib-log
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
-    mixlib-authentication (2.1.1)
+    mixlib-authentication (3.0.4)
     mixlib-cli (2.1.1)
     mixlib-config (3.0.1)
       tomlrb

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "license-acceptance", "~> 1.0", ">= 1.0.5"
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
-  s.add_dependency "mixlib-authentication", "~> 2.1"
+  s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
   s.add_dependency "mixlib-shellout", ">= 3.0.3", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 15.0"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: e066879935237c4c43ba22696e6b1deda5752d2f
+  revision: c5c10bff2b34bcf530a7cb215eb819ac6a3913c6
   branch: master
   specs:
-    omnibus (6.1.7)
+    omnibus (6.1.9)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar-ng (>= 3.3)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 433a18fa1fe9690ad939e570f301771a804d0cf8
+  revision: a16abe91fac43170f5c9ecc97d55cd0c0fa9a0c6
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -33,8 +33,8 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.231.0)
-    aws-sdk-core (3.72.0)
+    aws-partitions (1.232.0)
+    aws-sdk-core (3.72.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.228.0)
       aws-sigv4 (~> 1.1)
@@ -42,7 +42,7 @@ GEM
     aws-sdk-kms (1.25.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.52.0)
+    aws-sdk-s3 (1.53.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
This gem is 70k smaller than the 2.x gem since it doesn't ship extra
files

Signed-off-by: Tim Smith <tsmith@chef.io>