### PR TITLE
Return empty hash when action_collection is undefined

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -183,7 +183,11 @@ class Chef
 
     # get only the top level resources and strip out the subcollections
     def updated_resources
-      @updated_resources ||= action_collection&.filtered_collection(max_nesting: 0, up_to_date: false, skipped: false, unprocessed: false) || {}
+      @updated_resources ||= if action_collection.respond_to?(:filtered_collection)
+            action_collection.filtered_collection(max_nesting: 0, up_to_date: false, skipped: false, unprocessed: false)
+          else
+            {}
+          end
     end
 
     def total_res_count

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -183,7 +183,7 @@ class Chef
 
     # get only the top level resources and strip out the subcollections
     def updated_resources
-      @updated_resources ||= action_collection.filtered_collection(max_nesting: 0, up_to_date: false, skipped: false, unprocessed: false)
+      @updated_resources ||= action_collection&.filtered_collection(max_nesting: 0, up_to_date: false, skipped: false, unprocessed: false) || {}
     end
 
     def total_res_count


### PR DESCRIPTION
## Description
Resolves an issue with error handling during chef-client runs when the chef_version metadata attribute is violated. See related issue for details.

## Related Issue
https://github.com/chef/chef/issues/9038

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Jeremy Kimber Jeremy.Kimber@cerner.com