### PR TITLE
[ci] include the platform target in the hab package promotion command

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -16,7 +16,7 @@ steps:
 
 - label: ":habicat: Promoting packages to the current channel."
   commands:
-    - hab pkg promote "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS" current
+    - hab pkg promote "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS" current x86_64-windows
   expeditor:
     executor:
       docker:


### PR DESCRIPTION
## Description

Gotta include the target platform or else it won't work when there are multiple platform targets for a
package.

We saw the pipeline attempt to promote without it:

```

hab pkg promote "chef/chef-infra-client/15.4.59/20191101204957" current'
--
  | Updating 'ci-studio-common'
  | ci-studio-common is up-to-date
  | Updating 'hab'
  | Chef Habitat is already up-to-date
  | » Promoting chef/chef-infra-client/15.4.59/20191101204957 (x86_64-linux) to channel 'current'
  | Failed to promote 'chef/chef-infra-client/15.4.59/20191101204957': APIError(NotFound, "")
  | You may need to specify a platform target argument
  | ✗✗✗
  | ✗✗✗ [404 Not Found]
  | ✗✗✗
```

Confirmed that the update to the command in this PR is correct.

```
> hab pkg promote chef/chef-infra-client/15.4.59/20191101204957 current x86_64-windows
» Promoting chef/chef-infra-client/15.4.59/20191101204957 (x86_64-windows) to channel 'current'
Failed to create 'current' channel: APIError(401, "Please check that you have specified a valid Personal Access Token.")
✗✗✗
✗✗✗ [401 Unauthorized] Please check that you have specified a valid Personal Access Token.
✗✗✗
```

I _do_ have a token specified, my token does not have access to the `chef` origin. So, "Unauthorized" is the expected response to a correct command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
