### PR TITLE
service/systemd_unit: Don't try to reenable services in an indirect status

### DIFF
--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -51,6 +51,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         current_resource.running(false)
         current_resource.enabled(false)
         current_resource.masked(false)
+        current_resource.indirect(false)
       end
     else
       current_resource.running(is_active?)
@@ -58,6 +59,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
 
     current_resource.enabled(is_enabled?)
     current_resource.masked(is_masked?)
+    current_resource.indirect(is_indirect?)
     current_resource
   end
 
@@ -143,11 +145,19 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
   end
 
   def enable_service
+    if current_resource.masked || current_resource.indirect
+      logger.trace("#{new_resource} cannot be enabled: it is masked or indirect")
+      return
+    end
     options, args = get_systemctl_options_args
     shell_out!("#{systemctl_path} #{args} enable #{Shellwords.escape(new_resource.service_name)}", **options)
   end
 
   def disable_service
+    if current_resource.masked || current_resource.indirect
+      logger.trace("#{new_resource} cannot be disabled: it is masked or indirect")
+      return
+    end
     options, args = get_systemctl_options_args
     shell_out!("#{systemctl_path} #{args} disable #{Shellwords.escape(new_resource.service_name)}", **options)
   end
@@ -170,6 +180,12 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
   def is_enabled?
     options, args = get_systemctl_options_args
     shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)} --quiet", **options).exitstatus == 0
+  end
+
+  def is_indirect?
+    options, args = get_systemctl_options_args
+    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", **options)
+    s.stdout.include?("indirect")
   end
 
   def is_masked?

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -90,6 +90,9 @@ class Chef
       # if the service is masked or not
       property :masked, [ TrueClass, FalseClass ], skip_docs: true
 
+      # if the service is indirect or not
+      property :indirect, [ TrueClass, FalseClass ], skip_docs: true
+
       property :options, [ Array, String ],
         description: "Solaris platform only. Options to pass to the service command. See the svcadm manual for details of possible options.",
         coerce: proc { |x| x.respond_to?(:split) ? x.shellsplit : x }

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -43,6 +43,7 @@ class Chef
       property :active, [TrueClass, FalseClass], skip_docs: true
       property :masked, [TrueClass, FalseClass], skip_docs: true
       property :static, [TrueClass, FalseClass], skip_docs: true
+      property :indirect, [TrueClass, FalseClass], skip_docs: true
 
       # User-provided properties
       property :user, String, desired_state: false,

--- a/spec/unit/provider/systemd_unit_spec.rb
+++ b/spec/unit/provider/systemd_unit_spec.rb
@@ -65,11 +65,19 @@ describe Chef::Provider::SystemdUnit do
   end
 
   let(:shell_out_masked) do
-    double("shell_out", exit_status: 0, error?: false, stdout: "masked")
+    double("shell_out", exitstatus: 0, error?: false, stdout: "masked")
   end
 
   let(:shell_out_static) do
-    double("shell_out", exit_status: 0, error?: false, stdout: "static")
+    double("shell_out", exitstatus: 0, error?: false, stdout: "static")
+  end
+
+  let(:shell_out_disabled) do
+    double("shell_out", exitstatus: 1, error?: true, stdout: "disabled")
+  end
+
+  let(:shell_out_indirect) do
+    double("shell_out", exitstatus: 0, error?: true, stdout: "indirect")
   end
 
   before(:each) do
@@ -859,7 +867,7 @@ describe Chef::Provider::SystemdUnit do
             current_resource.user(user_name)
             expect(provider).to receive(:shell_out_compacted)
               .with(systemctl_path, "--user", "is-enabled", unit_name, user_cmd_opts)
-              .and_return(shell_out_failure)
+              .and_return(shell_out_disabled)
             expect(provider.enabled?).to be false
           end
         end
@@ -875,7 +883,7 @@ describe Chef::Provider::SystemdUnit do
           it "returns false when unit is not enabled" do
             expect(provider).to receive(:shell_out_compacted)
               .with(systemctl_path, "--system", "is-enabled", unit_name)
-              .and_return(shell_out_failure)
+              .and_return(shell_out_disabled)
             expect(provider.enabled?).to be false
           end
         end
@@ -959,6 +967,47 @@ describe Chef::Provider::SystemdUnit do
               .with(systemctl_path, "--system", "is-enabled", unit_name)
               .and_return(shell_out_masked)
             expect(provider.static?).to be false
+          end
+        end
+      end
+
+      describe "#indirect?" do
+        before(:each) do
+          provider.current_resource = current_resource
+          allow(provider).to receive(:which).with("systemctl").and_return(systemctl_path.to_s)
+        end
+
+        context "when a user is specified" do
+          it "returns true when the unit is indirect" do
+            current_resource.user(user_name)
+            expect(provider).to receive(:shell_out_compacted)
+              .with(systemctl_path, "--user", "is-enabled", unit_name, user_cmd_opts)
+              .and_return(shell_out_indirect)
+            expect(provider.indirect?).to be true
+          end
+
+          it "returns false when the unit is not indirect" do
+            current_resource.user(user_name)
+            expect(provider).to receive(:shell_out_compacted)
+              .with(systemctl_path, "--user", "is-enabled", unit_name, user_cmd_opts)
+              .and_return(shell_out_static)
+            expect(provider.indirect?).to be false
+          end
+        end
+
+        context "when no user is specified" do
+          it "returns true when the unit is indirect" do
+            expect(provider).to receive(:shell_out_compacted)
+              .with(systemctl_path, "--system", "is-enabled", unit_name)
+              .and_return(shell_out_indirect)
+            expect(provider.indirect?).to be true
+          end
+
+          it "returns false when the unit is not indirect" do
+            expect(provider).to receive(:shell_out_compacted)
+              .with(systemctl_path, "--system", "is-enabled", unit_name)
+              .and_return(shell_out_static)
+            expect(provider.indirect?).to be false
           end
         end
       end


### PR DESCRIPTION
`systemd_unit` and `service` both try to disable `indirect` units on every run.

Closes #9041