### PR TITLE
[knife config get] Fix TypeError: no implicit conversion of nil into String

### DIFF
--- a/lib/chef/knife/config_get.rb
+++ b/lib/chef/knife/config_get.rb
@@ -47,9 +47,10 @@ class Chef
           if wcl.config_location
             loading_from("configuration", wcl.config_location)
           end
+
           if Chef::Config[:config_d_dir]
             wcl.find_dot_d(Chef::Config[:config_d_dir]).each do |path|
-              loading_from(".d/ configuration", wcl.config_location)
+              loading_from(".d/ configuration", path)
             end
           end
         end

--- a/spec/integration/knife/config_get_spec.rb
+++ b/spec/integration/knife/config_get_spec.rb
@@ -110,6 +110,13 @@ describe "knife config get", :workstation do
     it { is_expected.to match(/^node_name:\s+one$/) }
   end
 
+  context "with a config dot d files" do
+    before { file(".chef/config.d/abc.rb", "node_name 'one'\n") }
+
+    it { is_expected.to match(%r{^Loading from .d/ configuration file .*/#{File.basename(path_to("."))}/.chef/config.d/abc.rb$}) }
+    it { is_expected.to match(/^node_name:\s+one$/) }
+  end
+
   context "with a credentials file and CHEF_HOME" do
     before do
       file(".chef/credentials", "[default]\nclient_name = \"three\"\n")


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- If `wcl.config_location` returns `nil` then it raises an error because of no nil checks before accessing `wcl.config_location`. Also for conf_dot_d we were passing `wcl.config_location` which is wrong so change it to `path` iteration attribute.
- After fixes showing relevant logs for config.d configuration files.

Before fix:
```
Loading from configuration file /.chef/config.rb
Loading from .d/ configuration file /.chef/config.rb
````

After fix:
```
Loading from configuration file /.chef/config.rb
Loading from .d/ configuration file /.chef/config.d/abc.rb
````
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/9009

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
