### PR TITLE
dist constants in win logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ chef-bin/pkg
 
 # auto generated docs from the docs.rb rake task
 docs_site
+
+# Rendered Templates
+ext/win32-eventlog/chef-log.man
+
+# tool logs
+ext/win32-eventlog/mkmf.log

--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -1,6 +1,8 @@
 require "rubygems"
 require "rake"
 require "mkmf"
+require "erb"
+require "chef/dist"
 
 desc "Building event log dll"
 
@@ -11,6 +13,12 @@ def ensure_present(commands)
     end
   end
 end
+
+# Templating the windows event log messages
+# So we can inject distro constants in there
+template = ERB.new(IO.read("chef-log.man.erb"))
+chef_log_man = template.result
+File.open("chef-log.man", "w") { |f| f.write(chef_log_man) }
 
 EVT_MC_FILE = "chef-log.man".freeze
 EVT_RC_FILE = "chef-log.rc".freeze
@@ -43,7 +51,7 @@ task register: EVT_SHARED_OBJECT do
   begin
     Win32::EventLog.add_event_source(
       source: "Application",
-      key_name: "Chef",
+      key_name: Chef::Dist::PRODUCT,
       event_message_file: dll_file,
       category_message_file: dll_file
     )

--- a/ext/win32-eventlog/chef-log.man.erb
+++ b/ext/win32-eventlog/chef-log.man.erb
@@ -1,25 +1,25 @@
 MessageId=10000
 SymbolicName=RUN_START
 Language=English
-Starting Chef Infra Client run v%1
+Starting <%= Chef::Dist::PRODUCT %> run v%1
 .
 
 MessageId=10001
 SymbolicName=RUN_STARTED
 Language=English
-Started Chef Infra Client run %1
+Started <%= Chef::Dist::PRODUCT %> run %1
 .
 
 MessageId=10002
 SymbolicName=RUN_COMPLETED
 Language=English
-Completed Chef Infra Client run %1 in %2 seconds
+Completed <%= Chef::Dist::PRODUCT %> run %1 in %2 seconds
 .
 
 MessageId=10003
 SymbolicName=RUN_FAILED
 Language=English
-Failed Chef Infra Client run %1 in %2 seconds.%n
+Failed <%= Chef::Dist::PRODUCT %> run %1 in %2 seconds.%n
 Exception type: %3%n
 Exception message: %4%n
 Exception backtrace: %5%n


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

Adding distro constants to windows event logs.

## Description
Templating the .man event description file as ERB and editing the corresponding Rake job to allow windows events to display alternate distribution names.

## Related Issue
https://github.com/chef/chef/issues/8376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
