### PR TITLE
Replace hardcoded /etc/chef with Chef::Dist::CONF_DIR

### DIFF
--- a/chef-bin/bin/chef-service-manager
+++ b/chef-bin/bin/chef-service-manager
@@ -21,6 +21,7 @@
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "chef"
 require "chef/application/windows_service_manager"
+require "chef/dist"
 
 if Chef::Platform.windows?
   chef_client_service = {

--- a/chef-bin/bin/chef-service-manager
+++ b/chef-bin/bin/chef-service-manager
@@ -24,9 +24,9 @@ require "chef/application/windows_service_manager"
 
 if Chef::Platform.windows?
   chef_client_service = {
-    service_name: "chef-client",
-    service_display_name: "Chef Client Service",
-    service_description: "Runs Chef Client on regular, configurable intervals.",
+    service_name: Chef::Dist::CLIENT,
+    service_display_name: "#{Chef::Dist::PRODUCT} Service",
+    service_description: "Runs #{Chef::Dist::PRODUCT} on regular, configurable intervals.",
     service_file_path: File.expand_path("../chef-windows-service", $PROGRAM_NAME),
     delayed_start: true,
     dependencies: ["Winmgmt"],

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -34,7 +34,7 @@ require "uri" unless defined?(URI)
 require "addressable/uri" unless defined?(Addressable::URI)
 require "openssl" unless defined?(OpenSSL)
 require "yaml"
-require "chef/dist"
+require_relative "dist"
 
 module ChefConfig
 
@@ -646,9 +646,9 @@ module ChefConfig
       if chef_zero.enabled
         nil
       elsif target_mode?
-        platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/client.pem")
+        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/client.pem")
       else
-        platform_specific_path("#{Chef::Dist::CONF_DIR}/client.pem")
+        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/client.pem")
       end
     end
 
@@ -670,10 +670,10 @@ module ChefConfig
 
     # This secret is used to decrypt encrypted data bag items.
     default(:encrypted_data_bag_secret) do
-      if target_mode? && File.exist?(platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret"))
-        platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret")
-      elsif File.exist?(platform_specific_path("#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret"))
-        platform_specific_path("#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret")
+      if target_mode? && File.exist?(platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret"))
+        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret")
+      elsif File.exist?(platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/encrypted_data_bag_secret"))
+        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/encrypted_data_bag_secret")
       else
         nil
       end
@@ -700,7 +700,7 @@ module ChefConfig
     # The `validation_key` is never used if the `client_key` exists.
     #
     # If chef-zero is enabled, this defaults to nil (no authentication).
-    default(:validation_key) { chef_zero.enabled ? nil : platform_specific_path("#{Chef::Dist::CONF_DIR}/validation.pem") }
+    default(:validation_key) { chef_zero.enabled ? nil : platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/validation.pem") }
     default :validation_client_name do
       # If the URL is set and looks like a normal Chef Server URL, extract the
       # org name and use that as part of the default.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -34,6 +34,7 @@ require "uri" unless defined?(URI)
 require "addressable/uri" unless defined?(Addressable::URI)
 require "openssl" unless defined?(OpenSSL)
 require "yaml"
+require "chef/dist"
 
 module ChefConfig
 
@@ -645,9 +646,9 @@ module ChefConfig
       if chef_zero.enabled
         nil
       elsif target_mode?
-        platform_specific_path("/etc/chef/#{target_mode.host}/client.pem")
+        platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/client.pem")
       else
-        platform_specific_path("/etc/chef/client.pem")
+        platform_specific_path("#{Chef::Dist::CONF_DIR}/client.pem")
       end
     end
 
@@ -669,10 +670,10 @@ module ChefConfig
 
     # This secret is used to decrypt encrypted data bag items.
     default(:encrypted_data_bag_secret) do
-      if target_mode? && File.exist?(platform_specific_path("/etc/chef/#{target_mode.host}/encrypted_data_bag_secret"))
-        platform_specific_path("/etc/chef/#{target_mode.host}/encrypted_data_bag_secret")
-      elsif File.exist?(platform_specific_path("/etc/chef/encrypted_data_bag_secret"))
-        platform_specific_path("/etc/chef/encrypted_data_bag_secret")
+      if target_mode? && File.exist?(platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret"))
+        platform_specific_path("#{Chef::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret")
+      elsif File.exist?(platform_specific_path("#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret"))
+        platform_specific_path("#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret")
       else
         nil
       end
@@ -699,7 +700,7 @@ module ChefConfig
     # The `validation_key` is never used if the `client_key` exists.
     #
     # If chef-zero is enabled, this defaults to nil (no authentication).
-    default(:validation_key) { chef_zero.enabled ? nil : platform_specific_path("/etc/chef/validation.pem") }
+    default(:validation_key) { chef_zero.enabled ? nil : platform_specific_path("#{Chef::Dist::CONF_DIR}/validation.pem") }
     default :validation_client_name do
       # If the URL is set and looks like a normal Chef Server URL, extract the
       # org name and use that as part of the default.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -74,6 +74,31 @@ module ChefConfig
       path
     end
 
+    # On *nix, /etc/chef
+    def self.etc_chef_dir
+      path = ChefUtils.windows? ? c_chef_dir : PathHelper.join("/etc", ChefConfig::Dist::DIR_SUFFIX)
+      PathHelper.cleanpath(path)
+    end
+
+    # On *nix, /var/chef
+    def self.var_chef_dir
+      path = ChefUtils.windows? ? c_chef_dir : PathHelper.join("/var", ChefConfig::Dist::DIR_SUFFIX)
+      PathHelper.cleanpath(path)
+    end
+
+    # On *nix, the root of /var/, used to test if we can create and write in /var/chef
+    def self.var_root_dir
+      path = ChefUtils.windows? ? c_chef_dir : "/var"
+      PathHelper.cleanpath(path)
+    end
+
+    # On windows, C:/chef/
+    def self.c_chef_dir
+      drive = windows_installation_drive || "C:"
+      path = PathHelper.join(drive, ChefConfig::Dist::DIR_SUFFIX)
+      PathHelper.cleanpath(path)
+    end
+
     # the drive where Chef is installed on a windows host. This is determined
     # either by the drive containing the current file or by the SYSTEMDRIVE ENV
     # variable
@@ -285,8 +310,8 @@ module ChefConfig
       if local_mode
         PathHelper.join(config_dir, "local-mode-cache")
       else
-        primary_cache_root = platform_specific_path("/var")
-        primary_cache_path = platform_specific_path("/var/chef")
+        primary_cache_root = var_root_dir
+        primary_cache_path = var_chef_dir
         # Use /var/chef as the cache path only if that folder exists and we can read and write
         # into it, or /var exists and we can read and write into it (we'll create /var/chef later).
         # Otherwise, we'll create .chef under the user's home directory and use that as
@@ -646,9 +671,9 @@ module ChefConfig
       if chef_zero.enabled
         nil
       elsif target_mode?
-        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/client.pem")
+        PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/client.pem")
       else
-        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/client.pem")
+        PathHelper.cleanpath("#{etc_chef_dir}/client.pem")
       end
     end
 
@@ -670,10 +695,10 @@ module ChefConfig
 
     # This secret is used to decrypt encrypted data bag items.
     default(:encrypted_data_bag_secret) do
-      if target_mode? && File.exist?(platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret"))
-        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/#{target_mode.host}/encrypted_data_bag_secret")
-      elsif File.exist?(platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/encrypted_data_bag_secret"))
-        platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/encrypted_data_bag_secret")
+      if target_mode? && File.exist?(PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/encrypted_data_bag_secret"))
+       PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/encrypted_data_bag_secret")
+      elsif File.exist?(PathHelper.cleanpath("#{etc_chef_dir}/encrypted_data_bag_secret"))
+        PathHelper.cleanpath("#{etc_chef_dir}/encrypted_data_bag_secret")
       else
         nil
       end
@@ -700,7 +725,7 @@ module ChefConfig
     # The `validation_key` is never used if the `client_key` exists.
     #
     # If chef-zero is enabled, this defaults to nil (no authentication).
-    default(:validation_key) { chef_zero.enabled ? nil : platform_specific_path("#{ChefConfig::Dist::CONF_DIR}/validation.pem") }
+    default(:validation_key) { chef_zero.enabled ? nil : PathHelper.cleanpath("#{etc_chef_dir}/validation.pem") }
     default :validation_client_name do
       # If the URL is set and looks like a normal Chef Server URL, extract the
       # org name and use that as part of the default.

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -696,7 +696,7 @@ module ChefConfig
     # This secret is used to decrypt encrypted data bag items.
     default(:encrypted_data_bag_secret) do
       if target_mode? && File.exist?(PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/encrypted_data_bag_secret"))
-       PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/encrypted_data_bag_secret")
+        PathHelper.cleanpath("#{etc_chef_dir}/#{target_mode.host}/encrypted_data_bag_secret")
       elsif File.exist?(PathHelper.cleanpath("#{etc_chef_dir}/encrypted_data_bag_secret"))
         PathHelper.cleanpath("#{etc_chef_dir}/encrypted_data_bag_secret")
       else

--- a/chef-config/lib/chef-config/dist.rb
+++ b/chef-config/lib/chef-config/dist.rb
@@ -1,0 +1,8 @@
+module ChefConfig
+  class Dist
+    # The chef executable name. Also used in directory names.
+    EXEC = "chef".freeze
+    # The Chef configuration directory. It will be used by Chef's dist.rb.
+    CONF_DIR = "/etc/#{ChefConfig::Dist::EXEC}".freeze
+  end
+end

--- a/chef-config/lib/chef-config/dist.rb
+++ b/chef-config/lib/chef-config/dist.rb
@@ -2,7 +2,9 @@ module ChefConfig
   class Dist
     # The chef executable name. Also used in directory names.
     EXEC = "chef".freeze
-    # The Chef configuration directory. It will be used by Chef's dist.rb.
-    CONF_DIR = "/etc/#{ChefConfig::Dist::EXEC}".freeze
+
+    # The suffix for Chef's /etc/chef, /var/chef and C:\\Chef directories
+    # "cinc" => /etc/cinc, /var/cinc, C:\\cinc
+    DIR_SUFFIX = "chef".freeze
   end
 end

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -343,7 +343,7 @@ class Chef
           exit 0
         end
       end
-      logger.trace "Fork successful. Waiting for new chef pid: #{pid}"
+      logger.trace "Fork successful. Waiting for new #{Chef::Dist::CLIENT} pid: #{pid}"
       result = Process.waitpid2(pid)
       handle_child_exit(result)
       logger.trace "Forked instance successfully reaped (pid: #{pid})"
@@ -355,9 +355,9 @@ class Chef
       return true if status.success?
 
       message = if status.signaled?
-                  "Chef run process terminated by signal #{status.termsig} (#{Signal.list.invert[status.termsig]})"
+                  "#{Chef::Dist::PRODUCT} run process terminated by signal #{status.termsig} (#{Signal.list.invert[status.termsig]})"
                 else
-                  "Chef run process exited unsuccessfully (exit code #{status.exitstatus})"
+                  "#{Chef::Dist::PRODUCT} run process exited unsuccessfully (exit code #{status.exitstatus})"
                 end
       raise Exceptions::ChildConvergeError, message
     end

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -389,8 +389,8 @@ class Chef
         chef_stacktrace_out = "Generated at #{Time.now}\n"
         chef_stacktrace_out += message
 
-        Chef::FileCache.store("chef-stacktrace.out", chef_stacktrace_out)
-        logger.fatal("Stacktrace dumped to #{Chef::FileCache.load("chef-stacktrace.out", false)}")
+        Chef::FileCache.store("#{Chef::Dist::SHORT}-stacktrace.out", chef_stacktrace_out)
+        logger.fatal("Stacktrace dumped to #{Chef::FileCache.load("#{Chef::Dist::SHORT}-stacktrace.out", false)}")
         logger.fatal("Please provide the contents of the stacktrace.out file if you file a bug report")
         logger.debug(message)
         true

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -40,7 +40,7 @@ class Chef
       option :config_file,
         short: "-c CONFIG",
         long: "--config CONFIG",
-        default: "#{Chef::Config::etc_chef_dir}/client.rb",
+        default: "#{Chef::Config.etc_chef_dir}/client.rb",
         description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,
@@ -60,7 +60,7 @@ class Chef
         description: "Set the number of seconds to wait between #{Chef::Dist::PRODUCT} runs.",
         proc: lambda { |s| s.to_i }
 
-      DEFAULT_LOG_LOCATION ||= "#{Chef::Config::c_chef_dir}/client.log".freeze
+      DEFAULT_LOG_LOCATION ||= "#{Chef::Config.c_chef_dir}/client.log".freeze
 
       def service_init
         @service_action_mutex = Mutex.new

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -40,7 +40,7 @@ class Chef
       option :config_file,
         short: "-c CONFIG",
         long: "--config CONFIG",
-        default: "#{ENV["SYSTEMDRIVE"]}/chef/client.rb",
+        default: "#{Chef::Config::etc_chef_dir}/client.rb",
         description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,
@@ -60,7 +60,7 @@ class Chef
         description: "Set the number of seconds to wait between #{Chef::Dist::PRODUCT} runs.",
         proc: lambda { |s| s.to_i }
 
-      DEFAULT_LOG_LOCATION ||= "#{ENV["SYSTEMDRIVE"]}/chef/client.log".freeze
+      DEFAULT_LOG_LOCATION ||= "#{Chef::Config::c_chef_dir}/client.log".freeze
 
       def service_init
         @service_action_mutex = Mutex.new

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -46,7 +46,7 @@ class Chef
       option :config_file,
         short: "-c CONFIG",
         long: "--config CONFIG",
-        default: "#{ChefConfig::Config::c_chef_dir}/client.rb",
+        default: "#{ChefConfig::Config.c_chef_dir}/client.rb",
         description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,

--- a/lib/chef/application/windows_service_manager.rb
+++ b/lib/chef/application/windows_service_manager.rb
@@ -41,18 +41,18 @@ class Chef
         short: "-a ACTION",
         long: "--action ACTION",
         default: "status",
-        description: "Action to carry out on chef-service (install, uninstall, status, start, stop, pause, or resume)."
+        description: "Action to carry out on #{Chef::Dist::SHORT}-service (install, uninstall, status, start, stop, pause, or resume)."
 
       option :config_file,
         short: "-c CONFIG",
         long: "--config CONFIG",
-        default: "#{ENV["SYSTEMDRIVE"]}/chef/client.rb",
+        default: "#{ChefConfig::Config::c_chef_dir}/client.rb",
         description: "The configuration file to use for #{Chef::Dist::PRODUCT} runs."
 
       option :log_location,
         short: "-L LOGLOCATION",
         long: "--logfile LOGLOCATION",
-        description: "Set the log file location for chef-service."
+        description: "Set the log file location for #{Chef::Dist::SHORT}-service."
 
       option :help,
         short: "-h",

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -22,6 +22,7 @@ require "uri" unless defined?(URI)
 require "net/http" unless defined?(Net::HTTP)
 require "mixlib/authentication/signedheaderauth"
 require "openssl" unless defined?(OpenSSL)
+require_relative "dist"
 
 class Chef
   # == Chef::CookbookSiteStreamingUploader
@@ -36,7 +37,7 @@ class Chef
     class << self
 
       def create_build_dir(cookbook)
-        tmp_cookbook_path = Tempfile.new("chef-#{cookbook.name}-build")
+        tmp_cookbook_path = Tempfile.new("#{Chef::Dist::SHORT}-#{cookbook.name}-build")
         tmp_cookbook_path.close
         tmp_cookbook_dir = tmp_cookbook_path.path
         File.unlink(tmp_cookbook_dir)

--- a/lib/chef/deprecation/warnings.rb
+++ b/lib/chef/deprecation/warnings.rb
@@ -21,11 +21,12 @@ class Chef
     module Warnings
 
       require_relative "../version"
+      require_relative "../dist"
 
       def add_deprecation_warnings_for(method_names)
         method_names.each do |name|
           define_method(name) do |*args|
-            message = "Method '#{name}' of '#{self.class}' is deprecated. It will be removed in Chef #{Chef::VERSION.to_i.next}."
+            message = "Method '#{name}' of '#{self.class}' is deprecated. It will be removed in #{Chef::Dist::PRODUCT} #{Chef::VERSION.to_i.next}."
             message << " Please update your cookbooks accordingly."
             Chef.deprecated(:internal_api, message)
             super(*args)

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -1,6 +1,8 @@
 class Chef
   class Dist
     require "chef-config/dist"
+    require "chef-config/config"
+
     # This class is not fully implemented, depending on it is not recommended!
     # When referencing a product directly, like Chef (Now Chef Infra)
     PRODUCT = "Chef Infra Client".freeze
@@ -48,7 +50,7 @@ class Chef
     SHELL_CONF = "chef_shell.rb".freeze
 
     # The configuration directory
-    CONF_DIR = ChefConfig::Dist::CONF_DIR.freeze
+    CONF_DIR = ChefConfig::Config::etc_chef_dir.freeze
 
     # The user's configuration directory
     USER_CONF_DIR = ".chef".freeze

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -21,6 +21,10 @@ class Chef
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
     EXEC = ChefConfig::Dist::EXEC.freeze
 
+    # A short name for the project, used in configurations
+    # Log messages, descriptions, etc...
+    SHORT = "chef".freeze
+
     # product website address
     WEBSITE = "https://chef.io".freeze
 

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -50,7 +50,7 @@ class Chef
     SHELL_CONF = "chef_shell.rb".freeze
 
     # The configuration directory
-    CONF_DIR = ChefConfig::Config::etc_chef_dir.freeze
+    CONF_DIR = ChefConfig::Config.etc_chef_dir.freeze
 
     # The user's configuration directory
     USER_CONF_DIR = ".chef".freeze

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -1,5 +1,6 @@
 class Chef
   class Dist
+    require "chef-config/dist"
     # This class is not fully implemented, depending on it is not recommended!
     # When referencing a product directly, like Chef (Now Chef Infra)
     PRODUCT = "Chef Infra Client".freeze
@@ -18,7 +19,7 @@ class Chef
     AUTOMATE = "Chef Automate".freeze
 
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
-    EXEC = "chef".freeze
+    EXEC = ChefConfig::Dist::EXEC.freeze
 
     # product website address
     WEBSITE = "https://chef.io".freeze
@@ -43,7 +44,7 @@ class Chef
     SHELL_CONF = "chef_shell.rb".freeze
 
     # The configuration directory
-    CONF_DIR = "/etc/#{Chef::Dist::EXEC}".freeze
+    CONF_DIR = ChefConfig::Dist::CONF_DIR.freeze
 
     # The user's configuration directory
     USER_CONF_DIR = ".chef".freeze

--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -475,7 +475,7 @@ class Chef
     class CookbookChefVersionMismatch < RuntimeError
       def initialize(chef_version, cookbook_name, cookbook_version, *constraints)
         constraint_str = constraints.map { |c| c.requirement.as_list.to_s }.join(", ")
-        super "Cookbook '#{cookbook_name}' version '#{cookbook_version}' depends on chef version #{constraint_str}, but the running chef version is #{chef_version}"
+        super "Cookbook '#{cookbook_name}' version '#{cookbook_version}' depends on #{Chef::Dist::PRODUCT} version #{constraint_str}, but the running #{Chef::Dist::PRODUCT} version is #{chef_version}"
       end
     end
 

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -208,7 +208,7 @@ module Shell
       end
       alias :halp :help
 
-      desc "prints information about chef"
+      desc "prints information about #{Chef::Dist::PRODUCT}"
       def version
         puts "This is the #{Chef::Dist::SHELL}.\n" +
           " #{Chef::Dist::PRODUCT} Version: #{::Chef::VERSION}\n" +


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
More work towards https://github.com/chef/chef/issues/8376

This one replaces the last known occurrences that need addressing of `/etc/chef` with a distro constant in chef-config.

I validated there's no more occurrences of `/opt/chef` too. Windows paths could also be addressed in this PR (another commit), or another PR if maintainers prefer that.

## Related Issue
https://github.com/chef/chef/issues/8376
https://github.com/chef/chef/issues/9094

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
