### PR TITLE
fix the habitat package promotion tests

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -3,6 +3,8 @@ steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"
   commands:
+    - powershell -File "./scripts/ci/ensure-minimum-viable-hab.ps1"
+    - 'Write-Host "--- :hammer_and_wrench: Installing $EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"'
     - hab pkg install "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
     - powershell -File "./habitat/tests/test.ps1" -PackageIdentifier "$EXPEDITOR_PKG_IDENTS_CHEFINFRACLIENTX86_64WINDOWS"
   expeditor:

--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -1,4 +1,12 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 60
+      retry:
+        automatic:
+          limit: 1
+
 steps:
 
 - label: ":windows: Validate Habitat Builds of Chef Infra"

--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -9,6 +9,7 @@ winrm quickconfig -quiet
 $chef_gem_root = (hab pkg exec $PackageIdentifier gem.cmd which chef | Split-Path | Split-Path)
 try {
     Push-Location $chef_gem_root
+    $env:PATH = "C:\hab\bin;$env:PATH"
     hab pkg binlink --force $PackageIdentifier
     /hab/bin/rspec --format progress --tag ~executables --tag ~choco_installed spec/functional
     if (-not $?) { throw "functional testing failed"}

--- a/habitat/tests/test.ps1
+++ b/habitat/tests/test.ps1
@@ -20,3 +20,4 @@ if ($test_result.FailedCount -ne 0) { Exit $test_result.FailedCount }
 
 Write-Host "--- :alembic: Functional Tests"
 powershell -File "./habitat/tests/spec.ps1" -PackageIdentifier $PackageIdentifier
+if (-not $?) { throw "functional spec suite failed" }

--- a/scripts/ci/ensure-minimum-viable-hab.ps1
+++ b/scripts/ci/ensure-minimum-viable-hab.ps1
@@ -1,0 +1,9 @@
+$hab_version = (hab --version)
+$hab_minor_version = $hab_version.split('.')[1]
+if ( -not $? -Or $hab_minor_version -lt 85 ) {
+    Write-Host "--- :habicat: Installing the version of Habitat required"
+    install-habitat --version 0.85.0.20190916
+    if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }
+} else {
+    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
+}

--- a/scripts/ci/verify-plan.ps1
+++ b/scripts/ci/verify-plan.ps1
@@ -12,19 +12,11 @@ $Plan = 'chef-infra-client'
 
 Write-Host "--- :8ball: :windows: Verifying $Plan"
 
-$hab_version = (hab --version)
-$hab_minor_version = $hab_version.split('.')[1]
-if ( -not $? -Or $hab_minor_version -lt 85 ) {
-    Write-Host "--- :habicat: Installing the version of Habitat required"
-    install-habitat --version 0.85.0.20190916
-} else {
-    Write-Host "--- :habicat: :thumbsup: Minimum required version of Habitat already installed"
-}
-
+powershell -File "./scripts/ci/ensure-minimum-viable-hab.ps1"
+if (-not $?) { throw "Could not ensure the minimum hab version required is installed." }
 
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
-
 
 $project_root = "$(git rev-parse --show-toplevel)"
 Set-Location $project_root

--- a/scripts/ci/verify-plan.ps1
+++ b/scripts/ci/verify-plan.ps1
@@ -42,3 +42,4 @@ if (-not $?) { throw "unable to install this build"}
 
 Write-Host "--- :mag_right: Testing $Plan"
 powershell -File "./habitat/tests/test.ps1" -PackageIdentifier $pkg_ident
+if (-not $?) { throw "package didn't pass the test suite" }


### PR DESCRIPTION
## Description

We had a few problems with the `habitat/test` pipeline. 

* The PowerShell scripts calling PowerShell scripts was apparently swallowing the errors being thrown from inner layers. Check the error level of those scripts and throw another error if need be.

* Test hosts haven't necessarily had "hab setup" run for \hab\bin to be on the system PATH. For the purposes on this test, we would like that to be the case. So, put Hab's bin directory at the start of the PATH and carry on.

* Move the minimum hab check/install to a reusable script.
  - `verify/habitat` needs hab >= 0.85 to both [build with environment variables that don't include the studio path](https://github.com/habitat-sh/habitat/pull/6850) and to [binlink the runtime
with stubs that include the package and system environment](https://github.com/habitat-sh/habitat/pull/6826).
  - `habitat/test` needs hab >= 0.85 to binlink the runtime with stubs that
include the package and system environment.

* Increase the timeout for `habitat/test`; the Windows hab tests take a long time.

## Types of changes

- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
