### PR TITLE
service/systemd_unit: Don't try to reenable services in an indirect status

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -42,6 +42,7 @@ class Chef
         current_resource.active(active?)
         current_resource.masked(masked?)
         current_resource.static(static?)
+        current_resource.indirect(indirect?)
         current_resource.triggers_reload(new_resource.triggers_reload)
 
         current_resource
@@ -90,8 +91,11 @@ class Chef
         if current_resource.static
           logger.trace("#{new_resource.unit_name} is a static unit, enabling is a NOP.")
         end
+        if current_resource.indirect
+          logger.trace("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
+        end
 
-        unless current_resource.enabled || current_resource.static
+        unless current_resource.enabled || current_resource.static || current_resource.indirect
           converge_by("enabling unit: #{new_resource.unit_name}") do
             systemctl_execute!(:enable, new_resource.unit_name)
             logger.info("#{new_resource} enabled")
@@ -104,7 +108,11 @@ class Chef
           logger.trace("#{new_resource.unit_name} is a static unit, disabling is a NOP.")
         end
 
-        if current_resource.enabled && !current_resource.static
+        if current_resource.indirect
+          logger.trace("#{new_resource.unit_name} is an indirect unit, enabling is a NOP.")
+        end
+
+        if current_resource.enabled && !current_resource.static && !current_resource.indirect
           converge_by("disabling unit: #{new_resource.unit_name}") do
             systemctl_execute!(:disable, new_resource.unit_name)
             logger.info("#{new_resource} disabled")
@@ -208,6 +216,10 @@ class Chef
 
       def static?
         systemctl_execute("is-enabled", new_resource.unit_name).stdout.include?("static")
+      end
+
+      def indirect?
+        systemctl_execute("is-enabled", new_resource.unit_name).stdout.include?("indirect")
       end
 
       private

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -159,6 +159,15 @@ class Chef
         )
       end
 
+      # if the service is indirect or not
+      def indirect(arg = nil)
+        set_or_return(
+          :indirect,
+          arg,
+          kind_of: [ TrueClass, FalseClass ]
+        )
+      end
+
       def options(arg = nil)
         set_or_return(
           :options,

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -42,6 +42,7 @@ class Chef
       property :active, [TrueClass, FalseClass], skip_docs: true
       property :masked, [TrueClass, FalseClass], skip_docs: true
       property :static, [TrueClass, FalseClass], skip_docs: true
+      property :indirect, [TrueClass, FalseClass], skip_docs: true
 
       # User-provided properties
       property :user, String, desired_state: false,


### PR DESCRIPTION

Signed-off-by: Phil Dibowitz <phil@ipom.com>


## Description

This is a backport of #9047 

This follows this `is_masked` path to ensure we don't try to enable OR
disable systemd units if they are indirect

## Related Issue

Fixes #9041

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
