### PR TITLE
Symbolize config for ssl_verify_mode in credentials

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -562,6 +562,16 @@ module ChefConfig
     # SSL verification settings. When set to :verify_none no HTTPS requests will
     # be validated.
     default :ssl_verify_mode, :verify_peer
+   
+    # Needed to coerce string value to a symbol when loading settings from the 
+    # credentials toml files which doesn't allow ruby symbol values
+    configurable(:ssl_verify_mode).writes_value do |value|
+      if value.is_a?(String) && value[0] == ":"
+        value[1..-1].to_sym
+      else
+        value.to_sym
+      end 
+    end
 
     # Whether or not to verify the SSL cert for HTTPS requests to the Chef
     # server API. If set to `true`, the server's cert will be validated

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -177,7 +177,7 @@ module ChefConfig
       @credentials_found = true
     end
 
-    def symbolize_value(value) 
+    def symbolize_value(value)
       if value.is_a?(String) && value[0] == ":"
         value[1..-1].to_sym
       else

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -168,11 +168,21 @@ module ChefConfig
           extract_key(value, :client_key, :client_key_contents)
         when "knife"
           Config.knife.merge!(Hash[value.map { |k, v| [k.to_sym, v] }])
+        when "ssl_verify_mode"
+          Config[key.to_sym] = symbolize_value(value)
         else
           Config[key.to_sym] = value
         end
       end
       @credentials_found = true
+    end
+
+    def symbolize_value(value) 
+      if value.is_a?(String) && value[0] == ":"
+        value[1..-1].to_sym
+      else
+        value.to_sym
+      end
     end
 
     def extract_key(key_value, config_path, config_contents)

--- a/chef-config/lib/chef-config/workstation_config_loader.rb
+++ b/chef-config/lib/chef-config/workstation_config_loader.rb
@@ -168,21 +168,11 @@ module ChefConfig
           extract_key(value, :client_key, :client_key_contents)
         when "knife"
           Config.knife.merge!(Hash[value.map { |k, v| [k.to_sym, v] }])
-        when "ssl_verify_mode"
-          Config[key.to_sym] = symbolize_value(value)
         else
           Config[key.to_sym] = value
         end
       end
       @credentials_found = true
-    end
-
-    def symbolize_value(value)
-      if value.is_a?(String) && value[0] == ":"
-        value[1..-1].to_sym
-      else
-        value.to_sym
-      end
     end
 
     def extract_key(key_value, config_path, config_contents)

--- a/chef-config/spec/unit/workstation_config_loader_spec.rb
+++ b/chef-config/spec/unit/workstation_config_loader_spec.rb
@@ -583,6 +583,36 @@ RSpec.describe ChefConfig::WorkstationConfigLoader do
         end
       end
 
+      context "and ssl_verify_mode is a symbol string" do
+        let(:content) do
+          content = <<~EOH
+            [default]
+            ssl_verify_mode = ":verify_none"
+          EOH
+          content
+        end
+
+        it "raises a ConfigurationError" do
+          expect { config_loader.load_credentials }.not_to raise_error
+          expect(ChefConfig::Config.ssl_verify_mode).to eq(:verify_none)
+        end
+      end
+
+      context "and ssl_verify_mode is a string" do
+        let(:content) do
+          content = <<~EOH
+            [default]
+            ssl_verify_mode = "verify_none"
+          EOH
+          content
+        end
+
+        it "raises a ConfigurationError" do
+          expect { config_loader.load_credentials }.not_to raise_error
+          expect(ChefConfig::Config.ssl_verify_mode).to eq(:verify_none)
+        end
+      end
+
       context "and has a syntax error" do
         let(:content) { "<<<<<" }
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When loading the configs using `~/.chef/credentials`, any value set for `ssl_verify_mode` is always ignored, and `:verify_peer` is always used. Chef expects the value to be a ruby symbol, which we can't set via the TOML `credentials` file.

This takes the value for that config and converts it to a symbol along with handling if the user specifies a string that looks like a symbol.

Example configs: 
```
[default]
client_name     = "someuser"
client_key      = "/home/user/.chef/userkey.pem"
chef_server_url = "https://CHEF_SERVER_URL/organizations/SOMEORG"
ssl_verify_mode = "verify_none"
```
or
```
[default]
client_name     = "someuser"
client_key      = "/home/user/.chef/userkey.pem"
chef_server_url = "https://CHEF_SERVER_URL/organizations/SOMEORG"
ssl_verify_mode = ":verify_none"
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).