### PR TITLE
Remove useless search arg mangling

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -126,9 +126,6 @@ class Chef
         return args.first if args.first.is_a?(Hash)
 
         args_h = {}
-        # If we have 4 arguments, the first is the now-removed sort option, so
-        # just ignore it.
-        args.pop(0) if args.length == 4
         args_h[:start] = args[0] if args[0]
         args_h[:rows] = args[1]
         args_h[:filter_result] = args[2]


### PR DESCRIPTION
This doesn't actually do anything and repetitively confuses me every
6 months when I look at it.

Array#pop(0) does nothing at all (in python it removes the first element
from the list):

```
[2] pry(main)> a = [ 1, 2, 3 ]
=> [1, 2, 3]
[3] pry(main)> a.pop(0)
=> []
[4] pry(main)> a
=> [1, 2, 3]
```