### PR TITLE
Generate metadata.json from metadata.rb if not exist before knife cookbook upload or knife upload or berkshelf upload

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
@@ -73,6 +73,7 @@ class Chef
 
           def upload_cookbook(other, options)
             cookbook = other.chef_object if other.chef_object
+            raise Chef::Exceptions::MetadataNotFound.new(cookbook.root_paths[0], cookbook.name) unless cookbook.has_metadata_file?
 
             if cookbook
               begin

--- a/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
@@ -76,7 +76,7 @@ class Chef
             tmp_cl = Chef::CookbookLoader.copy_to_tmp_dir_from_array([cookbook])
             tmp_cl.load_cookbooks
             tmp_cl.compile_metadata
-            tmp_cl.freeze_version if options[:freeze]
+            tmp_cl.freeze_versions if options[:freeze]
             cookbook_for_upload = []
             tmp_cl.each do |cookbook_name, cookbook|
               cookbook_for_upload << cookbook

--- a/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
@@ -72,12 +72,34 @@ class Chef
           end
 
           def upload_cookbook(other, options)
-            cookbook_to_upload = other.chef_object
-            cookbook_to_upload.freeze_version if options[:freeze]
-            uploader = Chef::CookbookUploader.new(cookbook_to_upload, force: options[:force], rest: chef_rest)
+            compiled_metadata = other.chef_object.compile_metadata
 
-            with_actual_cookbooks_dir(other.parent.file_path) do
-              uploader.upload_cookbooks
+            Dir.mktmpdir do |tmp_dir_path|
+              begin
+                if compiled_metadata
+                  proxy_cookbook_path = "#{tmp_dir_path}/#{other.name}"
+                  # Make a symlink
+                  file_class.symlink other.chef_object.root_dir, proxy_cookbook_path
+                  proxy_loader = Chef::Cookbook::CookbookVersionLoader.new(proxy_cookbook_path)
+                  proxy_loader.load_cookbooks
+                  cookbook_to_upload = proxy_loader.cookbook_version
+                else
+                  cookbook_to_upload = other.chef_object
+                end
+
+                cookbook_to_upload.freeze_version if options[:freeze]
+                uploader = Chef::CookbookUploader.new(cookbook_to_upload, force: options[:force], rest: chef_rest)
+
+                with_actual_cookbooks_dir(other.parent.file_path) do
+                  uploader.upload_cookbooks
+                end
+              ensure
+                # deletes the generated metadata from local repo.
+                if compiled_metadata
+                  GC.start
+                  File.unlink(compiled_metadata)
+                end
+              end
             end
           end
 

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -46,12 +46,6 @@ class Chef
     end
 
     def upload_cookbooks
-      cookbooks.each do |cookbook|
-        next if cookbook.all_files.include?("#{cookbook.root_paths[0]}/metadata.json")
-
-        generate_metadata_json(cookbook.name.to_s, cookbook)
-      end
-
       # Syntax Check
       validate_cookbooks
       # generate checksums of cookbook files and create a sandbox

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -49,7 +49,7 @@ class Chef
       cookbooks.each do |cookbook|
         next if cookbook.all_files.include?("#{cookbook.root_paths[0]}/metadata.json")
 
-        generate_metadata_json(cookbook.name.to_s,cookbook)
+        generate_metadata_json(cookbook.name.to_s, cookbook)
       end
 
       # Syntax Check
@@ -120,7 +120,7 @@ class Chef
       Chef::Log.info("Upload complete!")
     end
 
-    def generate_metadata_json(cookbook_name,cookbook)
+    def generate_metadata_json(cookbook_name, cookbook)
       metadata = Chef::Knife::CookbookMetadata.new
       metadata.generate_metadata_from_file(cookbook_name, "#{cookbook.root_paths[0]}/metadata.rb")
       cookbook.all_files << "#{cookbook.root_paths[0]}/metadata.json"

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -114,13 +114,6 @@ class Chef
       Chef::Log.info("Upload complete!")
     end
 
-    def generate_metadata_json(cookbook_name, cookbook)
-      metadata = Chef::Knife::CookbookMetadata.new
-      metadata.generate_metadata_from_file(cookbook_name, "#{cookbook.root_paths[0]}/metadata.rb")
-      cookbook.all_files << "#{cookbook.root_paths[0]}/metadata.json"
-      cookbook.cookbook_manifest.send(:generate_manifest)
-    end
-
     def uploader_function_for(file, checksum, url, checksums_to_upload)
       lambda do
         # Checksum is the hexadecimal representation of the md5,

--- a/lib/chef/cookbook_uploader.rb
+++ b/lib/chef/cookbook_uploader.rb
@@ -46,6 +46,12 @@ class Chef
     end
 
     def upload_cookbooks
+      cookbooks.each do |cookbook|
+        next if cookbook.all_files.include?("#{cookbook.root_paths[0]}/metadata.json")
+
+        generate_metadata_json(cookbook.name.to_s,cookbook)
+      end
+
       # Syntax Check
       validate_cookbooks
       # generate checksums of cookbook files and create a sandbox
@@ -112,6 +118,13 @@ class Chef
       end
 
       Chef::Log.info("Upload complete!")
+    end
+
+    def generate_metadata_json(cookbook_name,cookbook)
+      metadata = Chef::Knife::CookbookMetadata.new
+      metadata.generate_metadata_from_file(cookbook_name, "#{cookbook.root_paths[0]}/metadata.rb")
+      cookbook.all_files << "#{cookbook.root_paths[0]}/metadata.json"
+      cookbook.cookbook_manifest.send(:generate_manifest)
     end
 
     def uploader_function_for(file, checksum, url, checksums_to_upload)

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -513,6 +513,19 @@ class Chef
       @cookbook_manifest ||= CookbookManifest.new(self)
     end
 
+    def compile_metadata(path = root_dir)
+      json_file = "#{path}/metadata.json"
+      rb_file = "#{path}/metadata.rb"
+      return nil if File.exist?(json_file)
+
+      md = Chef::Cookbook::Metadata.new
+      md.from_file(rb_file)
+      f = File.open(json_file, "w")
+      f.write(Chef::JSONCompat.to_json_pretty(md))
+      f.close
+      f.path
+    end
+
     private
 
     def find_preferred_manifest_record(node, segment, filename)

--- a/lib/chef/cookbook_version.rb
+++ b/lib/chef/cookbook_version.rb
@@ -445,6 +445,10 @@ class Chef
       end
     end
 
+    def has_metadata_file?
+      all_files.include?(metadata_json_file) || all_files.include?(metadata_rb_file)
+    end
+
     ##
     # REST API
     ##

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -22,7 +22,6 @@ require_relative "../knife"
 require_relative "../cookbook_uploader"
 require_relative "../mixin/file_class"
 
-
 class Chef
   class Knife
     class CookbookUpload < Knife

--- a/spec/data/cookbooks/apache2/metadata.json
+++ b/spec/data/cookbooks/apache2/metadata.json
@@ -1,0 +1,33 @@
+{
+  "name": "apache2",
+  "description": "",
+  "long_description": "",
+  "maintainer": "",
+  "maintainer_email": "",
+  "license": "All rights reserved",
+  "platforms": {
+
+  },
+  "dependencies": {
+
+  },
+  "providing": {
+
+  },
+  "recipes": {
+
+  },
+  "version": "0.0.1",
+  "source_url": "",
+  "issues_url": "",
+  "privacy": false,
+  "chef_versions": [
+
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+
+  ]
+}

--- a/spec/data/cookbooks/java/metadata.json
+++ b/spec/data/cookbooks/java/metadata.json
@@ -1,0 +1,33 @@
+{
+  "name": "java",
+  "description": "",
+  "long_description": "",
+  "maintainer": "",
+  "maintainer_email": "",
+  "license": "All rights reserved",
+  "platforms": {
+
+  },
+  "dependencies": {
+
+  },
+  "providing": {
+
+  },
+  "recipes": {
+
+  },
+  "version": "0.0.1",
+  "source_url": "",
+  "issues_url": "",
+  "privacy": false,
+  "chef_versions": [
+
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+
+  ]
+}

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -194,7 +194,7 @@ describe "ChefFSDataStore tests", :workstation do
             Uploading x              [1.0.0]
             Uploaded 1 cookbook.
           EOM
-          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.rb\n"
+          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/x/\n/cookbooks/x/metadata.json\n/cookbooks/x/metadata.rb\n"
         end
 
         it "knife raw -z -i empty.json -m PUT /data/x/y" do
@@ -251,7 +251,7 @@ describe "ChefFSDataStore tests", :workstation do
             Uploading z            [1.0.0]
             Uploaded 1 cookbook.
           EOM
-          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.rb\n"
+          knife("list --local -Rfp /cookbooks").should_succeed "/cookbooks/z/\n/cookbooks/z/metadata.json\n/cookbooks/z/metadata.rb\n"
         end
 
         it "knife raw -z -i empty.json -m POST /data" do

--- a/spec/integration/knife/cookbook_upload_spec.rb
+++ b/spec/integration/knife/cookbook_upload_spec.rb
@@ -86,5 +86,15 @@ describe "knife cookbook upload", :workstation do
         EOM
       end
     end
+
+    when_the_repository "has cookbook metadata without name attribute in metadata file" do
+      before do
+        file "cookbooks/x/metadata.rb", cb_metadata(nil, "1.0.0")
+      end
+
+      it "knife cookbook upload x " do
+        expect { knife("cookbook upload x -o #{cb_dir}") }.to raise_error(Chef::Exceptions::MetadataNotValid)
+      end
+    end
   end
 end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -209,7 +209,10 @@ describe "knife upload", :workstation do
               Created /roles/y.json
               Created /users/y.json
             EOM
-            knife("diff /").should_succeed ""
+            knife("diff --name-status /").should_succeed <<~EOM
+              D\t/cookbooks/x/metadata.json
+              D\t/cookbooks/y/metadata.json
+            EOM
           end
 
           it "knife upload --no-diff adds the new files" do
@@ -225,7 +228,10 @@ describe "knife upload", :workstation do
               Created /roles/y.json
               Created /users/y.json
             EOM
-            knife("diff --name-status /").should_succeed ""
+            knife("diff --name-status /").should_succeed <<~EOM
+              D\t/cookbooks/x/metadata.json
+              D\t/cookbooks/y/metadata.json
+            EOM
           end
         end
       end
@@ -462,6 +468,7 @@ describe "knife upload", :workstation do
           knife("upload /cookbooks/x/y.rb").should_fail "ERROR: /cookbooks/x cannot have a child created under it.\n"
           knife("upload --purge /cookbooks/x/z.rb").should_fail "ERROR: /cookbooks/x/z.rb cannot be deleted.\n"
         end
+
         # TODO this is a bit of an inconsistency: if we didn't specify --purge,
         # technically we shouldn't have deleted missing files.  But ... cookbooks
         # are a special case.
@@ -469,13 +476,18 @@ describe "knife upload", :workstation do
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
+
         it "knife upload --purge of the cookbook itself succeeds" do
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
       when_the_repository "has a missing file for the cookbook" do
@@ -488,7 +500,9 @@ describe "knife upload", :workstation do
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
       when_the_repository "has an extra file for the cookbook" do
@@ -503,7 +517,9 @@ describe "knife upload", :workstation do
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
 
@@ -602,7 +618,6 @@ describe "knife upload", :workstation do
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
-            A\t/cookbooks/x/metadata.json
             A\t/cookbooks/x/onlyin1.0.0.rb
           EOM
         end
@@ -614,11 +629,13 @@ describe "knife upload", :workstation do
           cookbook "x", "0.9.9", { "onlyin0.9.9.rb" => "hi" }
         end
 
-        it "knife upload /cookbooks/x uploads the local version" do
+        it "knife upload /cookbooks/x uploads the local version generates metadata.json and uploads it." do
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
 
@@ -639,7 +656,6 @@ describe "knife upload", :workstation do
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
-            A\t/cookbooks/x/metadata.json
             A\t/cookbooks/x/onlyin1.0.0.rb
           EOM
         end
@@ -654,7 +670,9 @@ describe "knife upload", :workstation do
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
     end
@@ -754,7 +772,9 @@ describe "knife upload", :workstation do
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Created /cookbooks/x
           EOM
-          knife("diff --name-status /cookbooks").should_succeed ""
+          knife("diff --name-status /cookbooks").should_succeed <<~EOM
+            D\t/cookbooks/x/metadata.json
+          EOM
         end
       end
     end

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -452,9 +452,28 @@ describe "knife upload", :workstation do
     # upload of a file is designed not to work at present.  Make sure that is the
     # case.
     when_the_chef_server "has a cookbook" do
-
       before do
         cookbook "x", "1.0.0", { "z.rb" => "" }
+      end
+
+      when_the_repository "does not have metadata file" do
+        before do
+          file "cookbooks/x/y.rb", "hi"
+        end
+
+        it "raises MetadataNotFound exception" do
+          expect { knife("upload /cookbooks/x") }.to raise_error(Chef::Exceptions::MetadataNotFound)
+        end
+      end
+
+      when_the_repository "does not have valid metadata" do
+        before do
+          file "cookbooks/x/metadata.rb", cb_metadata(nil, "1.0.0")
+        end
+
+        it "raises exception for invalid metadata" do
+          expect { knife("upload /cookbooks/x") }.to raise_error(Chef::Exceptions::MetadataNotValid)
+        end
       end
 
       when_the_repository "has a modified, extra and missing file for the cookbook" do

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -23,7 +23,12 @@ require "chef/cookbook_uploader"
 require "timeout"
 
 describe Chef::Knife::CookbookUpload do
-  let(:cookbook) { Chef::CookbookVersion.new("test_cookbook", "/tmp/blah") }
+  let(:cookbook) do
+    cookbook = Chef::CookbookVersion.new("test_cookbook", "/tmp/blah")
+    allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+    allow(cookbook.metadata).to receive(:name).and_return(cookbook.name)
+    cookbook
+  end
 
   let(:cookbooks_by_name) do
     { cookbook.name => cookbook }
@@ -86,6 +91,34 @@ describe Chef::Knife::CookbookUpload do
       expect { knife.run }.to raise_error(SystemExit)
     end
 
+    describe "when specifying cookbook without metadata.rb or metadata.json" do
+      let(:name_args) { ["test_cookbook1"] }
+      let(:cookbook) do
+        cookbook = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
+        allow(cookbook).to receive(:has_metadata_file?).and_return(false)
+        cookbook
+      end
+
+      it "should upload the cookbook" do
+        expect { knife.run }.to raise_error(Chef::Exceptions::MetadataNotFound)
+      end
+    end
+
+    describe "when name attribute in metadata not set" do
+      let(:name_args) { ["test_cookbook1"] }
+
+      let(:cookbook) do
+        cookbook = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
+        allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+        allow(cookbook.metadata).to receive(:name).and_return(nil)
+        cookbook
+      end
+
+      it "should upload the cookbook" do
+        expect { knife.run }.to raise_error(Chef::Exceptions::MetadataNotValid)
+      end
+    end
+
     describe "when specifying a cookbook name" do
       it "should upload the cookbook" do
         expect(knife).to receive(:upload).once
@@ -110,8 +143,15 @@ describe Chef::Knife::CookbookUpload do
     describe "when specifying a cookbook name among many" do
       let(:name_args) { ["test_cookbook1"] }
 
+      let(:cookbook) do
+        cookbook = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
+        allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+        allow(cookbook.metadata).to receive(:name).and_return(cookbook.name)
+        cookbook
+      end
+
       let(:cookbooks_by_name) do
-        { "test_cookbook1" => Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah") }
+        { cookbook.name => cookbook }
       end
 
       it "should read only one cookbook" do
@@ -134,17 +174,18 @@ describe Chef::Knife::CookbookUpload do
     describe "when specifying a cookbook name with dependencies" do
       let(:name_args) { ["test_cookbook2"] }
 
-      let(:cookbooks_by_name) do
-        { "test_cookbook1" => test_cookbook1,
-          "test_cookbook2" => test_cookbook2,
-          "test_cookbook3" => test_cookbook3 }
+      let(:test_cookbook1) do
+        cookbook = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
+        allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+        allow(cookbook.metadata).to receive(:name).and_return(cookbook.name)
+        cookbook
       end
-
-      let(:test_cookbook1) { Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah") }
 
       let(:test_cookbook2) do
         c = Chef::CookbookVersion.new("test_cookbook2")
         c.metadata.depends("test_cookbook3")
+        allow(c).to receive(:has_metadata_file?).and_return(true)
+        allow(c.metadata).to receive(:name).and_return(c.name)
         c
       end
 
@@ -152,7 +193,15 @@ describe Chef::Knife::CookbookUpload do
         c = Chef::CookbookVersion.new("test_cookbook3")
         c.metadata.depends("test_cookbook1")
         c.metadata.depends("test_cookbook2")
+        allow(c).to receive(:has_metadata_file?).and_return(true)
+        allow(c.metadata).to receive(:name).and_return(c.name)
         c
+      end
+
+      let(:cookbooks_by_name) do
+        { "test_cookbook1" => test_cookbook1,
+          "test_cookbook2" => test_cookbook2,
+          "test_cookbook3" => test_cookbook3 }
       end
 
       it "should upload all dependencies once" do
@@ -224,10 +273,22 @@ describe Chef::Knife::CookbookUpload do
       end
 
       context "when cookbooks exist in the cookbook path" do
+        let(:test_cookbook1) do
+          cookbook = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
+          allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+          allow(cookbook.metadata).to receive(:name).and_return(cookbook.name)
+          cookbook
+        end
+
+        let(:test_cookbook2) do
+          cookbook = Chef::CookbookVersion.new("test_cookbook2", "/tmp/blah")
+          allow(cookbook).to receive(:has_metadata_file?).and_return(true)
+          allow(cookbook.metadata).to receive(:name).and_return(cookbook.name)
+          cookbook
+        end
+
         before(:each) do
-          @test_cookbook1 = Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
-          @test_cookbook2 = Chef::CookbookVersion.new("test_cookbook2", "/tmp/blah")
-          allow(cookbook_loader).to receive(:each).and_yield("test_cookbook1", @test_cookbook1).and_yield("test_cookbook2", @test_cookbook2)
+          allow(cookbook_loader).to receive(:each).and_yield("test_cookbook1", test_cookbook1).and_yield("test_cookbook2", test_cookbook2)
           allow(cookbook_loader).to receive(:cookbook_names).and_return(%w{test_cookbook1 test_cookbook2})
         end
 

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -183,7 +183,6 @@ describe Chef::Knife::CookbookUpload do
 
       it "should exit and not upload the cookbook" do
         expect(cookbook_loader).to receive(:[]).once.with("test_cookbook")
-        # expect(cookbook_loader).not_to receive(:load_cookbooks)
         expect(cookbook_uploader).not_to receive(:upload_cookbooks)
         expect { knife.run }.to raise_error(SystemExit)
       end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -111,9 +111,7 @@ describe Chef::Knife::CookbookUpload do
       let(:name_args) { ["test_cookbook1"] }
 
       let(:cookbooks_by_name) do
-        {
-          "test_cookbook1" => Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah")
-        }
+        { "test_cookbook1" => Chef::CookbookVersion.new("test_cookbook1", "/tmp/blah") }
       end
 
       it "should read only one cookbook" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Berkshelf generates metadata.json at the time of upload but knife cookbook upload / knife upload do not have similar behaviour.  

This change generates the metadata.json if it does not exist at the time of knife upload and knife cookbook upload and since it has the metadata.json uploaded on Chef Server it gets downloaded at the time of knife download.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#9003 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
