### PR TITLE
🚧 WIP: remove Oracle 8 from TK tests run in CI

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -536,21 +536,6 @@ steps:
         privileged: true
         single-use: true
 
-- label: "Kitchen Tests Oracle Linux: 8"
-  commands:
-    - scripts/bk_tests/bk_linux_exec.sh
-    - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-oraclelinux-8
-  artifact_paths:
-    - $PWD/.kitchen/logs/kitchen.log
-  env:
-      KITCHEN_YAML: kitchen.yml
-  expeditor:
-    executor:
-      linux:
-        privileged: true
-        single-use: true
-
 - label: "Kitchen Tests Fedora: latest"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -112,6 +112,7 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN yum -y install e2fsprogs
+      - RUN yum -y reinstall systemd
       - RUN sed -i -e "s/Defaults.*requiretty.*/Defaults    !requiretty/g" /etc/sudoers
 
 - name: fedora-latest


### PR DESCRIPTION
## Description

The oraclelinux:8 image has had many of the files laid down by the systemd package removed from its filesystem. The package must be reinstalled because the system thinks it already has been.

```
> docker run -it --rm --name oracle8 oraclelinux:8 bash
[root@a86be7dd7120 /]# ls -l /sbin/init
lrwxrwxrwx 1 root root 22 Jul  6 00:43 /sbin/init -> ../lib/systemd/systemd

[root@a86be7dd7120 /]# /sbin/init
bash: /sbin/init: No such file or directory

[root@a86be7dd7120 /]# ls -l /sbin/../lib/systemd/systemd
ls: cannot access '/sbin/../lib/systemd/systemd': No such file or directory
```

This seems to be new in v8. The filesystems used for each of the v7 images—on the [dist-amd64 branch of oracle/container-images](https://github.com/oracle/container-images/tree/dist-amd64)—have a systemd executable while v8's does not:

```
oracle-container-images | dist-amd64 > find ./ -name \*-rootfs.tar.xz -print0 | xargs -P6 -0 -n1 -I{} sh -c 'tar tJf "{}" ./usr/lib/systemd/systemd > /dev/null 2>&1 && echo "{} has a systemd executable" || echo "{} does not have a systemd executable"' | sort
.//5.11/oraclelinux-5.11-rootfs.tar.xz does not have a systemd executable
.//6.10/oraclelinux-6.10-rootfs.tar.xz does not have a systemd executable
.//6.7/oraclelinux-6.7-rootfs.tar.xz does not have a systemd executable
.//6.8/oraclelinux-6.8-rootfs.tar.xz does not have a systemd executable
.//6.9/oraclelinux-6.9-rootfs.tar.xz does not have a systemd executable
.//7.2/oraclelinux-7.2-rootfs.tar.xz has a systemd executable
.//7.3/oraclelinux-7.3-rootfs.tar.xz has a systemd executable
.//7.4/oraclelinux-7.4-rootfs.tar.xz has a systemd executable
.//7.5/oraclelinux-7.5-rootfs.tar.xz has a systemd executable
.//7.6/oraclelinux-7.6-rootfs.tar.xz has a systemd executable
.//8.0/oraclelinux-8.0-rootfs.tar.xz does not have a systemd executable
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
