### PR TITLE
Switch our tests back to chef-sugar

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -298,7 +298,7 @@ steps:
   # EXTERNAL GEM TESTING
 #########################################################################
 
-- label: "Test chef-sugar-ng gem :ruby: 2.6"
+- label: "Test chef-sugar gem :ruby: 2.6"
   commands:
     - /workdir/scripts/bk_tests/bk_container_prep.sh
     - bundle install --jobs=3 --retry=3 --without omnibus_package docgen

--- a/kitchen-tests/cookbooks/end_to_end/metadata.rb
+++ b/kitchen-tests/cookbooks/end_to_end/metadata.rb
@@ -3,7 +3,7 @@ license          "Apache-2.0"
 description      "Installs/Configures base"
 version          "1.0.0"
 
-gem              "chef-sugar-ng"
+gem              "chef-sugar"
 
 depends          "chef-client"
 depends          "logrotate"


### PR DESCRIPTION
The repo is defaulting to chef-sugar now. We'll continue to ship -ng to
support anyone that switched to it, but it's not the main gem.

Signed-off-by: Tim Smith <tsmith@chef.io>