### PR TITLE
rename windows_ruby_platform? to windows_ruby?

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -82,12 +82,12 @@ There are helpers here which are also meta-families which group together multipl
 * `macos?`
 * `netbsd?`
 * `openbsd?`
-* `rhel?` - includes redhat, cnetos, scientific, oracle
+* `rhel?` - includes redhat, centos, scientific, oracle
 * `smartos?`
 * `solaris2?`
 * `suse?`
-* `windows?`
-* `windows_ruby_platform?` - this is always true if the ruby VM is running on a windows host and is not stubbed by chefspec
+* `windows?` - in a class context when called without a node object (ChefUtils.windows?) this is not stubbable by chefspec, when called with a node as the first argument or when called from the DSL it is stubabble by chefspec
+* `windows_ruby?` - this is always true if the ruby VM is running on a windows host and is not stubbed by chefspec
 
 Super Families:
 

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -198,7 +198,7 @@ module ChefUtils
         # As a result of this the `windows?` helper and the `ChefUtils.windows?` helper do not behave
         # the same way in that the latter is not stubbable by chefspec.
         #
-        node ? node["platform_family"] == "windows" : windows_ruby_platform?
+        node ? node["platform_family"] == "windows" : windows_ruby?
       end
 
       # Determine if the ruby VM is currently running on a windows node (chefspec can never stub
@@ -206,7 +206,7 @@ module ChefUtils
       #
       # @return [Boolean]
       #
-      def windows_ruby_platform?
+      def windows_ruby?
         !!(RUBY_PLATFORM =~ /mswin|mingw32|windows/)
       end
 

--- a/chef-utils/spec/unit/dsl/platform_family_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_family_spec.rb
@@ -24,7 +24,7 @@ def pf_reports_true_for(*args)
       expect(described_class.send(method, node)).to be true
     end
   end
-  (PLATFORM_FAMILY_HELPERS - [ :windows_ruby_platform? ] - args).each do |method|
+  (PLATFORM_FAMILY_HELPERS - [ :windows_ruby? ] - args).each do |method|
     it "reports false for #{method}" do
       expect(described_class.send(method, node)).to be false
     end
@@ -40,7 +40,7 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
     end
   end
 
-  ( PLATFORM_FAMILY_HELPERS - [ :windows_ruby_platform? ]).each do |helper|
+  ( PLATFORM_FAMILY_HELPERS - [ :windows_ruby? ]).each do |helper|
     it "has the #{helper} in the ChefUtils module" do
       expect(ChefUtils).to respond_to(helper)
     end
@@ -180,12 +180,12 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
 
   context "node-independent windows APIs" do
     if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-      it "reports true for :windows_ruby_platform?" do
-        expect(described_class.windows_ruby_platform?).to be true
+      it "reports true for :windows_ruby?" do
+        expect(described_class.windows_ruby?).to be true
       end
     else
-      it "reports false for :windows_ruby_platform?" do
-        expect(described_class.windows_ruby_platform?).to be false
+      it "reports false for :windows_ruby?" do
+        expect(described_class.windows_ruby?).to be false
       end
     end
   end


### PR DESCRIPTION
while it checks against the RUBY_PLATFORM to see if it is windows,
and so therefore the old name sort of makes sense, it does not make
sense in the context of all the rest of the chef platform helpers
that have the `_platform?` suffix.
