### PR TITLE
reserve a number for chef-sugar deprecation warnings

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -229,6 +229,10 @@ class Chef
       target 27
     end
 
+    class ChefSugar < Base
+      target 28
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client.html"


### PR DESCRIPTION
the work of implementing the warnings is happening in the chef-sugar gem but we need to not have an id collision.