### PR TITLE
Remove the use of Chef Sugar from the Kitchen tests

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/attributes/default.rb
@@ -1,5 +1,5 @@
-puts "CHEF SUGAR THINKS WE ARE ON UBUNTU" if ubuntu?
-puts "CHEF SUGAR THINKS WE ARE ON RHEL" if rhel?
+puts "CHEF UTILS THINKS WE ARE ON UBUNTU" if ubuntu?
+puts "CHEF UTILS THINKS WE ARE ON RHEL" if rhel?
 
 #
 # ubuntu cookbook overrides

--- a/kitchen-tests/cookbooks/end_to_end/libraries/chef-sugar.rb
+++ b/kitchen-tests/cookbooks/end_to_end/libraries/chef-sugar.rb
@@ -1,4 +1,0 @@
-require "chef/sugar"
-
-# hack until this gets baked into chef-sugar so we can use chef-sugar in attributes files
-Chef::Node.send(:include, Chef::Sugar::DSL)


### PR DESCRIPTION
No need for this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>