### PR TITLE
Additional chef-utils helpers for rhel6/7/8

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -82,7 +82,10 @@ There are helpers here which are also meta-families which group together multipl
 * `macos?`
 * `netbsd?`
 * `openbsd?`
-* `rhel?` - includes redhat, centos, scientific, oracle
+* `rhel?` - includes redhat, centos, scientific, oracle, clearos
+* `rhel6?` - includes redhat6, centos6, scientifc6, oracle6, clearos6
+* `rhel7?` - includes redhat7, centos7, scientifc7, oracle7, clearos7
+* `rhel8?` - includes redhat8, centos8, scientifc8, oracle8, clearos8
 * `smartos?`
 * `solaris2?`
 * `suse?`

--- a/chef-utils/lib/chef-utils/dsl/platform_family.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_family.rb
@@ -77,7 +77,9 @@ module ChefUtils
       alias_method :mac?, :macos?
       alias_method :mac_os_x?, :macos?
 
-      # Determine if the current node is a member of the redhat family.
+      # Determine if the current node is a member of the rhel family (RHEL, CentOS, Oracle or Scientific Linux, no Amazon or Fedora).
+      #
+      # The platform_versions for these operating systems must match (rhel7 == centos7 == oracle7 == scientfic7), modulo additional packages
       #
       # @param [Chef::Node] node
       #
@@ -87,6 +89,36 @@ module ChefUtils
         node["platform_family"] == "rhel"
       end
       alias_method :el?, :rhel?
+
+      # Determine if the current node is a rhel6 compatible build (RHEL, CentOS, Oracle or Scientific Linux)
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def rhel6?(node = __getnode)
+        node["platform_family"] == "rhel" && node["platform_version"].to_f >= 6.0 && node["platform_version"].to_f < 7.0
+      end
+
+      # Determine if the current node is a rhel7 compatible build (RHEL, CentOS, Oracle or Scientific Linux)
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def rhel7?(node = __getnode)
+        node["platform_family"] == "rhel" && node["platform_version"].to_f >= 7.0 && node["platform_version"].to_f < 8.0
+      end
+
+      # Determine if the current node is a rhel8 compatible build (RHEL, CentOS, Oracle or Scientific Linux)
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def rhel8?(node = __getnode)
+        node["platform_family"] == "rhel" && node["platform_version"].to_f >= 8.0 && node["platform_version"].to_f < 9.0
+      end
 
       # Determine if the current node is a member of the amazon family.
       #

--- a/chef-utils/spec/unit/dsl/platform_family_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_family_spec.rb
@@ -88,16 +88,28 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
     pf_reports_true_for(:arch?, :arch_linux?)
   end
 
-  context "on centos" do
-    let(:options) { { platform: "centos" } }
+  context "on centos6" do
+    let(:options) { { platform: "centos", version: "6.9" } }
 
-    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?)
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel6?)
   end
 
-  context "on clearos" do
-    let(:options) { { platform: "clearos" } }
+  context "on centos7" do
+    let(:options) { { platform: "centos", version: "7.7.1908" } }
 
-    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?)
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel7?)
+  end
+
+  context "on centos8" do
+    let(:options) { { platform: "centos", version: "8" } }
+
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel8?)
+  end
+
+  context "on clearos7" do
+    let(:options) { { platform: "clearos", version: "7.4" } }
+
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel7?)
   end
 
   context "on dragonfly4" do
@@ -142,16 +154,34 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
     pf_reports_true_for(:suse?, :rpm_based?)
   end
 
-  context "on oracle" do
-    let(:options) { { platform: "oracle" } }
+  context "on oracle6" do
+    let(:options) { { platform: "oracle", version: "6.10" } }
 
-    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?)
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel6?)
   end
 
-  context "on redhat" do
-    let(:options) { { platform: "redhat" } }
+  context "on oracle7" do
+    let(:options) { { platform: "oracle", version: "7.6" } }
 
-    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?)
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel7?)
+  end
+
+  context "on redhat6" do
+    let(:options) { { platform: "redhat", version: "6.9" } }
+
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel6?)
+  end
+
+  context "on redhat7" do
+    let(:options) { { platform: "redhat", version: "7.6" } }
+
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel7?)
+  end
+
+  context "on redhat8" do
+    let(:options) { { platform: "redhat", version: "8" } }
+
+    pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel8?)
   end
 
   context "on smartos" do


### PR DESCRIPTION
Kind of mixes up the distinction between platform_family vs platform_version helpers, but these seem to overwhelmingly make sense and are the kinds of things people will look for, and are common.

Stolen somewhat from facebook's helpers where they have `centos6/7/8?` helpers, but generalized instead to the rhel platform_family.  To get more specific users should probably `rhel6? && centos?` if they deeply care about centos versus actual redhat.