### PR TITLE
Use fauxhai-slim-ng

### DIFF
--- a/chef-utils/Gemfile
+++ b/chef-utils/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group(:development, :test) do
-  gem "fauxhai-ng"
+  gem "fauxhai-ng-slim"
   gem "rake"
   gem "rspec"
 end

--- a/chef-utils/chef-utils.gemspec
+++ b/chef-utils/chef-utils.gemspec
@@ -41,7 +41,4 @@ Gem::Specification.new do |spec|
 
   spec.files = %w{Rakefile LICENSE} + Dir.glob("*.gemspec") +
     Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
-
-  spec.bindir        = "bin"
-  spec.executables   = []
 end


### PR DESCRIPTION
This is 8 megs smaller. Let's see if it actually runs the tests in CI correctly. Works fine locally.

This is a short term bandaid until we can skip shipping dev deps into our packages.

Signed-off-by: Tim Smith <tsmith@chef.io>