### PR TITLE
Don't ship the extra rake tasks in the gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,14 @@
 # limitations under the License.
 #
 
-require_relative "tasks/rspec"
-require_relative "tasks/dependencies"
-require_relative "tasks/announce"
-require_relative "tasks/docs"
+begin
+  require_relative "tasks/rspec"
+  require_relative "tasks/dependencies"
+  require_relative "tasks/announce"
+  require_relative "tasks/docs"
+rescue LoadError => e
+  puts "Skipping missing rake dep: #{e}"
+end
 
 ENV["CHEF_LICENSE"] = "accept-no-persist"
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -58,5 +58,8 @@ Gem::Specification.new do |s|
   s.executables  = %w{ knife }
 
   s.require_paths = %w{ lib }
-  s.files = %w{Gemfile Rakefile LICENSE README.md} + Dir.glob("{lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } + Dir.glob("*.gemspec")
+  s.files = %w{Gemfile Rakefile LICENSE README.md} +
+    Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) } +
+    Dir.glob("*.gemspec") +
+    Dir.glob("tasks/rspec.rb")
 end


### PR DESCRIPTION
We only need the rspec task which gets run from within the gem artifact
in the test phase. Skips all the other stuff.

Signed-off-by: Tim Smith <tsmith@chef.io>