### PR TITLE
Resolve non-zero "success" error code issues with linux_user re…

### DIFF
--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -60,10 +60,7 @@ class Chef
           ret_codes = [0]
           if updating_home?
             if new_resource.manage_home
-              home_dir_not_exist = shell_out("test", "-d", new_resource.home, returns: [1])
-              if home_dir_not_exist.error?
-                ret_codes << 12
-              end
+              ret_codes << 12 if Dir.exist?(new_resource.home)
             end
           end
           ret_codes

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -67,7 +67,7 @@ class Chef
             end
           end
           ret_codes
-        end    
+        end
 
         def usermod_options
           opts = []

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -28,7 +28,7 @@ class Chef
         end
 
         def manage_user
-          shell_out!("usermod", universal_options, usermod_options, new_resource.username, returns:  return_codes)
+          shell_out!("usermod", universal_options, usermod_options, new_resource.username, returns: return_codes)
         end
 
         def remove_user
@@ -60,13 +60,13 @@ class Chef
           ret_codes = [0]
           if updating_home?
             if new_resource.manage_home
-              home_dir_exist = shell_out!("test", "-d", new_resource.home, returns: [1])
-              if home_dir_exist.error?
+              home_dir_not_exist = shell_out("test", "-d", new_resource.home, returns: [1])
+              if home_dir_not_exist
                 ret_codes << 12
               end
             end
           end
-          ret_codes.to_s
+          ret_codes
         end    
 
         def usermod_options

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -60,7 +60,7 @@ class Chef
           ret_codes = [0]
           if updating_home?
             if new_resource.manage_home
-              home_dir_exist = shell_out!("test", "-d" new_resource.home, returns [1])
+              home_dir_exist = shell_out!("test", "-d", new_resource.home, returns: [1])
               if home_dir_exist.error?
                 opts << 12
               end

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -62,7 +62,7 @@ class Chef
             if new_resource.manage_home
               home_dir_exist = shell_out!("test", "-d", new_resource.home, returns: [1])
               if home_dir_exist.error?
-                opts << 12
+                ret_codes << 12
               end
             end
           end

--- a/lib/chef/provider/user/linux.rb
+++ b/lib/chef/provider/user/linux.rb
@@ -61,7 +61,7 @@ class Chef
           if updating_home?
             if new_resource.manage_home
               home_dir_not_exist = shell_out("test", "-d", new_resource.home, returns: [1])
-              if home_dir_not_exist
+              if home_dir_not_exist.error?
                 ret_codes << 12
               end
             end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -160,7 +160,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-d", "/Users/mud",
                        "-m",
                        "adam"])
-			command.concat([{:returns=>[0,12]}])
+			command.concat([{:returns=>[0]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
@@ -210,7 +210,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-			command.concat([{:returns=>[0,12]}])
+			command.concat([{:returns=>[0]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -222,7 +222,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-			command.concat([{:returns=>[0,12]}])
+			command.concat([{:returns=>[0]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -159,7 +159,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-u", "1000",
                        "-d", "/Users/mud",
                        "-m",
-                       "adam", {:returns=>[0,12]}])
+                       "adam"])
+			command.concat([{:returns=>[0,12]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
@@ -180,7 +181,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
         command.concat([ "-s", "/usr/bin/zsh",
                          "-u", "1000",
                          "-r", "-m",
-                         "adam", {:returns=>[0]} ])
+                         "adam"])
+				command.concat([{:returns=>[0]}])
         expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
         provider.create_user
       end
@@ -190,7 +192,11 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   end
 
   describe "when managing a user" do
-    before(:each) do
+		let(:passwd_s_status) do
+    	double("Mixlib::ShellOut command", exitstatus: 0, stdout: @stdout, stderr: @stderr, error!: nil)
+    end
+
+		before(:each) do
       provider.new_resource.manage_home true
       provider.new_resource.home "/Users/mud"
       provider.new_resource.gid "23"
@@ -203,7 +209,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-g", "23",
                   "-d", "/Users/mud",
                   "-m",
-                  "adam", {:returns=>[0,12]}]
+                  "adam"]
+			command.concat([{:returns=>[0,12]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -214,7 +221,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-g", "23",
                   "-d", "/Users/mud",
                   "-m",
-                  "adam", {:returns=>[0]}]
+                  "adam"]
+			command.concat([{:returns=>[0,12]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -223,7 +231,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       expect(provider).to receive(:updating_home?).at_least(:once).and_return(false)
       command = ["usermod",
                   "-g", "23",
-                  "adam", {:returns=>[0]} ]
+                  "adam"]
+			command.concat([{:returns=>[0]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -232,24 +241,24 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   describe "when removing a user" do
 
     it "should run userdel with the new resources user name" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, {:returns=>[0]}).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -r if manage_home is true" do
       @new_resource.manage_home true
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username, {:returns=>[0]}).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name if non_unique is true" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, {:returns=>[0]}).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -f if force is true" do
       @new_resource.force(true)
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username, {:returns=>[0]}).and_return(true)
       provider.remove_user
     end
   end
@@ -335,14 +344,14 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
 
   describe "when locking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username)
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username, {:returns=>[0]})
       provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username)
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username, {:returns=>[0]})
       provider.unlock_user
     end
   end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -160,7 +160,6 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-d", "/Users/mud",
                        "-m",
                        "adam"])
-      command.concat([ { returns: [0] } ])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
@@ -182,7 +181,6 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                          "-u", "1000",
                          "-r", "-m",
                          "adam"])
-        command.concat([ { returns: [0] } ])
         expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
         provider.create_user
       end
@@ -192,7 +190,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   end
 
   describe "when managing a user" do
-    let(:passwd_s_status) do
+    let(:manage_u_status) do
       double("Mixlib::ShellOut command", exitstatus: 0, stdout: @stdout, stderr: @stderr, error!: nil)
     end
 
@@ -200,6 +198,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       provider.new_resource.manage_home true
       provider.new_resource.home "/Users/mud"
       provider.new_resource.gid "23"
+      @stderr = ""
     end
 
     # CHEF-3423, -m must come before the username
@@ -210,8 +209,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-      command.concat([ { returns: [0] } ])
-      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
+      command.concat([ { returns: [0, 12] } ])
+      expect(provider).to receive(:shell_out_compacted).with(*command).and_return(manage_u_status)
       provider.manage_user
     end
 
@@ -222,8 +221,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-      command.concat([ { returns: [0] } ])
-      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
+      command.concat([ { returns: [0, 12] } ])
+      expect(provider).to receive(:shell_out_compacted).with(*command).and_return(manage_u_status)
       provider.manage_user
     end
 
@@ -232,8 +231,8 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       command = ["usermod",
                   "-g", "23",
                   "adam"]
-      command.concat([ { returns: [0] } ])
-      expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
+      command.concat([ { returns: [0, 12] } ])
+      expect(provider).to receive(:shell_out_compacted).with(*command).and_return(manage_u_status)
       provider.manage_user
     end
   end
@@ -241,24 +240,24 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   describe "when removing a user" do
 
     it "should run userdel with the new resources user name" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, { returns: [0] }).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -r if manage_home is true" do
       @new_resource.manage_home true
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username, { returns: [0] }).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name if non_unique is true" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, { returns: [0] }).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -f if force is true" do
       @new_resource.force(true)
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username, { returns: [0] }).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username).and_return(true)
       provider.remove_user
     end
   end
@@ -344,14 +343,14 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
 
   describe "when locking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username, { returns: [0] })
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username)
       provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username, { returns: [0] })
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username)
       provider.unlock_user
     end
   end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -160,7 +160,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-d", "/Users/mud",
                        "-m",
                        "adam"])
-			command.concat([{:returns=>[0]}])
+      command.concat([ { returns: [0] } ])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
@@ -182,7 +182,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                          "-u", "1000",
                          "-r", "-m",
                          "adam"])
-				command.concat([{:returns=>[0]}])
+        command.concat([ { returns: [0] } ])
         expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
         provider.create_user
       end
@@ -192,11 +192,11 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   end
 
   describe "when managing a user" do
-		let(:passwd_s_status) do
-    	double("Mixlib::ShellOut command", exitstatus: 0, stdout: @stdout, stderr: @stderr, error!: nil)
+    let(:passwd_s_status) do
+      double("Mixlib::ShellOut command", exitstatus: 0, stdout: @stdout, stderr: @stderr, error!: nil)
     end
 
-		before(:each) do
+    before(:each) do
       provider.new_resource.manage_home true
       provider.new_resource.home "/Users/mud"
       provider.new_resource.gid "23"
@@ -210,7 +210,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-			command.concat([{:returns=>[0]}])
+      command.concat([ { returns: [0] } ])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -222,7 +222,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-d", "/Users/mud",
                   "-m",
                   "adam"]
-			command.concat([{:returns=>[0]}])
+      command.concat([ { returns: [0] } ])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -232,7 +232,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       command = ["usermod",
                   "-g", "23",
                   "adam"]
-			command.concat([{:returns=>[0]}])
+      command.concat([ { returns: [0] } ])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -241,24 +241,24 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
   describe "when removing a user" do
 
     it "should run userdel with the new resources user name" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, {:returns=>[0]}).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, { returns: [0] }).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -r if manage_home is true" do
       @new_resource.manage_home true
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username, {:returns=>[0]}).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-r", @new_resource.username, { returns: [0] }).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name if non_unique is true" do
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, {:returns=>[0]}).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", @new_resource.username, { returns: [0] }).and_return(true)
       provider.remove_user
     end
 
     it "should run userdel with the new resources user name and -f if force is true" do
       @new_resource.force(true)
-      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username, {:returns=>[0]}).and_return(true)
+      expect(provider).to receive(:shell_out_compacted!).with("userdel", "-f", @new_resource.username, { returns: [0] }).and_return(true)
       provider.remove_user
     end
   end
@@ -344,14 +344,14 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
 
   describe "when locking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username, {:returns=>[0]})
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-L", @new_resource.username, { returns: [0] })
       provider.lock_user
     end
   end
 
   describe "when unlocking the user" do
     it "should run usermod -L with the new resources username" do
-      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username, {:returns=>[0]})
+      expect(provider).to receive(:shell_out_compacted!).with("usermod", "-U", @new_resource.username, { returns: [0] })
       provider.unlock_user
     end
   end

--- a/spec/support/shared/unit/provider/useradd_based_user_provider.rb
+++ b/spec/support/shared/unit/provider/useradd_based_user_provider.rb
@@ -159,7 +159,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                        "-u", "1000",
                        "-d", "/Users/mud",
                        "-m",
-                       "adam" ])
+                       "adam", {:returns=>[0,12]}])
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.create_user
     end
@@ -180,7 +180,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
         command.concat([ "-s", "/usr/bin/zsh",
                          "-u", "1000",
                          "-r", "-m",
-                         "adam" ])
+                         "adam", {:returns=>[0]} ])
         expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
         provider.create_user
       end
@@ -203,7 +203,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-g", "23",
                   "-d", "/Users/mud",
                   "-m",
-                  "adam" ]
+                  "adam", {:returns=>[0,12]}]
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -214,7 +214,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
                   "-g", "23",
                   "-d", "/Users/mud",
                   "-m",
-                  "adam" ]
+                  "adam", {:returns=>[0]}]
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end
@@ -223,7 +223,7 @@ shared_examples_for "a useradd-based user provider" do |supported_useradd_option
       expect(provider).to receive(:updating_home?).at_least(:once).and_return(false)
       command = ["usermod",
                   "-g", "23",
-                  "adam" ]
+                  "adam", {:returns=>[0]} ]
       expect(provider).to receive(:shell_out_compacted!).with(*command).and_return(true)
       provider.manage_user
     end

--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -26,7 +26,7 @@ namespace :docs_site do
       if default.is_a?(String)
 
         # .inspect wraps the value in quotes which we want for strings, but not sentences or symbols as strings
-        return default.inspect unless default[0] == ":" || default.end_with?('.')
+        return default.inspect unless default[0] == ":" || default.end_with?(".")
       end
       default
     end


### PR DESCRIPTION
This fixes an issue related to certain usermod commands returning non-0 exit codes but still functioning as expected.
Signed-off-by: Jonathan Jones <gitmaster@thespooky.house>

## Description
`usermod`, specifically, has the potential to issue non-zero return codes, despite the command functioning as expected. This can be seen here: https://github.com/shadow-maint/shadow/blob/b49712ed328ded0cd8161542ca13cf5d4cf55e5f/src/usermod.c#L92

Error code 12 fires when a user is modified to have a different home directory and that directory already exists. `shell_out` only accepts `0` return codes as success, when in this case it will receive `12`. Any error code 12 from usermod is now evaluated for the "already exists" stderr. It will still fail on error code 12 if this is not the error message. 

I am not sure if I need to do anything for additional test coverage - I don't _think_ so, but this is my first contribution. 

## Related Issue
Addresses https://github.com/chef/chef/issues/9080

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).