### PR TITLE
Fix failures in build_essential on rhel platforms

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: end_to_end
 # Recipe:: default
 #
-# Copyright:: 2014-2019, Chef Software, Inc.
+# Copyright:: 2014-2019, Chef Software Inc.
 #
 
 hostname "chef-bk-ci.chef.io"
@@ -36,7 +36,9 @@ yum_repository "epel" do
   only_if { platform_family?("rhel") }
 end
 
-build_essential
+build_essential do
+  raise_if_unsupported true
+end
 
 include_recipe "::packages"
 

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -56,12 +56,11 @@ class Chef
         case
         when debian?
           package %w{ autoconf binutils-doc bison build-essential flex gettext ncurses-dev }
-        when false # rubocop:disable Lint/LiteralAsCondition
-        # when fedora_derived?
-          package %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch }
+         when fedora_derived?
+           package %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch }
 
           # Ensure GCC 4 is available on older pre-6 EL
-          package %w{ gcc44 gcc44-c++ } if platform_family?("rhel") && node["platform_version"].to_i < 6
+           package %w{ gcc44 gcc44-c++ } if platform_family?("rhel") && node["platform_version"].to_i < 6
         when freebsd?
           package "devel/gmake"
           package "devel/autoconf"

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -587,6 +587,7 @@ describe Chef::ProviderResolver do
         windows_service: [ Chef::Resource::WindowsService, Chef::Provider::Service::Windows ],
         windows_user: [ Chef::Resource::User::WindowsUser, Chef::Provider::User::Windows ],
         yum_package: [ Chef::Resource::YumPackage, Chef::Provider::Package::Yum ],
+        build_essential: [ Chef::Resource::BuildEssential ],
 
         "linux" => {
           "debian" => {
@@ -678,7 +679,6 @@ describe Chef::ProviderResolver do
     #        service: [ Chef::Resource::SystemdService, Chef::Provider::Service::Systemd ],
             package: [ Chef::Resource::DnfPackage, Chef::Provider::Package::Dnf ],
             ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig::Redhat ],
-            build_essential: [ Chef::Resource::BuildEssential ],
 
             %w{amazon xcp xenserver ibm_powerkvm cloudlinux parallels} => {
               "3.1.4" => {

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2014-2018, Chef Software Inc.
+# Copyright:: Copyright 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,6 +131,10 @@ describe Chef::ProviderResolver do
               expect(provider).to receive(:action=).with(action)
               expect(expected_provider).to receive(:new).with(resource, run_context).and_return(provider)
               expect(resolved_provider).to eql(expected_provider)
+            end
+          elsif expected_resource
+            it "'#{name}' resolves to resource #{expected_resource}", *tags do
+              expect(resource.class).to eql(expected_resource)
             end
           else
             it "'#{name}' fails to resolve (since #{name.inspect} is unsupported on #{platform} #{platform_version})", *tags do
@@ -674,6 +678,7 @@ describe Chef::ProviderResolver do
     #        service: [ Chef::Resource::SystemdService, Chef::Provider::Service::Systemd ],
             package: [ Chef::Resource::DnfPackage, Chef::Provider::Package::Dnf ],
             ifconfig: [ Chef::Resource::Ifconfig, Chef::Provider::Ifconfig::Redhat ],
+            build_essential: [ Chef::Resource::BuildEssential ],
 
             %w{amazon xcp xenserver ibm_powerkvm cloudlinux parallels} => {
               "3.1.4" => {


### PR DESCRIPTION
- fixes bug inside the action which was breaking build_essential on rhel
- wires up some more testing in the provider resolver spec
- adds a property that we can turn on so that this kind of breakage will raise an error in our end-to-end testing

i'm not entirely sure raise_if_unsupported true should be the default behavior, but that would be a breaking change and we definitely need to be able to bypass that for testing.

closes #9107 