### PR TITLE
Require relative in the win32-eventlog rakefile

### DIFF
--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -2,7 +2,7 @@ require "rubygems"
 require "rake"
 require "mkmf"
 require "erb"
-require "chef/dist"
+require_relative "../../lib/chef/dist"
 
 desc "Building event log dll"
 


### PR DESCRIPTION
The chef source isn't in the load path. Make sure we get the file we're
expecting here.

Signed-off-by: Tim Smith <tsmith@chef.io>