### PR TITLE
restoring correct value to windows event source

### DIFF
--- a/ext/win32-eventlog/Rakefile
+++ b/ext/win32-eventlog/Rakefile
@@ -51,7 +51,7 @@ task register: EVT_SHARED_OBJECT do
   begin
     Win32::EventLog.add_event_source(
       source: "Application",
-      key_name: Chef::Dist::PRODUCT,
+      key_name: Chef::Dist::SHORT,
       event_message_file: dll_file,
       category_message_file: dll_file
     )

--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -4,6 +4,10 @@ class Chef
     # When referencing a product directly, like Chef (Now Chef Infra)
     PRODUCT = "Chef Infra Client".freeze
 
+    # A short designation for the product, used in Windows event logs
+    # and some nomenclature.
+    SHORT = "chef".freeze
+
     # The name of the server product
     SERVER_PRODUCT = "Chef Infra Server".freeze
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Making sure windows event source defaults to `chef` once again

## Related Issue
discussed in slack

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
