### PR TITLE
kernel_module: Add new options property (backport from chef-15 to chef-14)

### DIFF
--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -23,6 +23,7 @@ class Chef
 
       property :options, Array,
         description: "An optional property to set options for the kernel module."
+        introduced: "15.4"
 
       property :load_dir, String,
                description: "The directory to load modules from.",

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -69,7 +69,7 @@ class Chef
 
       property :options, Array,
         description: "An optional property to set options for the kernel module.",
-        introduced: "15.4"
+        introduced: "14.15"
 
       property :load_dir, String,
                description: "The directory to load modules from.",

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -68,7 +68,7 @@ class Chef
                name_property: true, identity: true
 
       property :options, Array,
-        description: "An optional property to set options for the kernel module."
+        description: "An optional property to set options for the kernel module.",
         introduced: "15.4"
 
       property :load_dir, String,

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -37,10 +37,11 @@ class Chef
         description "Load kernel module, and ensure it loads on reboot."
 
         # create options file before loading the module
-        file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
-          content "options #{new_resource.modname} #{new_resource.options.join(" ")}\n"
-          not_if { new_resource.options.nil? }
-        end.run_action(:create)
+        unless new_resource.options.nil?
+          file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
+            content "options #{new_resource.modname} #{new_resource.options.join(" ")}\n"
+          end.run_action(:create)
+        end
 
         # load the module first before installing
         new_resource.run_action(:load)

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -21,6 +21,9 @@ class Chef
                description: "An optional property to set the kernel module name if it differs from the resource block's name.",
                name_property: true, identity: true
 
+      property :options, Array,
+        description: "An optional property to set options for the kernel module."
+
       property :load_dir, String,
                description: "The directory to load modules from.",
                default: "/etc/modules-load.d"
@@ -31,6 +34,12 @@ class Chef
 
       action :install do
         description "Load kernel module, and ensure it loads on reboot."
+
+        # create options file before loading the module
+        file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
+          content "options #{new_resource.modname} #{new_resource.options.join(" ")}\n"
+          not_if { new_resource.options.nil? }
+        end.run_action(:create)
 
         # load the module first before installing
         new_resource.run_action(:load)
@@ -63,6 +72,10 @@ class Chef
         file "#{new_resource.unload_dir}/blacklist_#{new_resource.modname}.conf" do
           action :delete
           notifies :run, "execute[update initramfs]", :delayed
+        end
+
+        file "#{new_resource.unload_dir}/options_#{new_resource.modname}.conf" do
+          action :delete
         end
 
         with_run_context :root do

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -16,6 +16,52 @@ class Chef
 
       description "Use the kernel_module resource to manage kernel modules on Linux systems. This resource can load, unload, blacklist, install, and uninstall modules."
       introduced "14.3"
+      examples <<~DOC
+        Install and load a kernel module, and ensure it loads on reboot.
+        ```ruby
+        kernel_module 'loop'
+        ```
+        Install and load a kernel with a specific set of options, and ensure it loads on reboot. Consult kernel module
+        documentation for specific options that are supported.
+        ```ruby
+        kernel_module 'loop' do
+          options [
+            'max_loop=4',
+            'max_part=8'
+          ]
+        end
+        ```
+        Load a kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :load
+        end
+        ```
+        Unload a kernel module and remove module config, so it doesn’t load on reboot.
+        ```ruby
+        kernel_module 'loop' do
+          action :uninstall
+        end
+        ```
+        Unload kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :unload
+        end
+        ```
+        Blacklist a module from loading.
+        ```ruby
+        kernel_module 'loop' do
+          action :blacklist
+        end
+        ```
+        Disable a kernel module.
+        ```ruby
+        kernel_module 'loop' do
+          action :disable
+        end
+        ```
+      DOC
 
       property :modname, String,
                description: "An optional property to set the kernel module name if it differs from the resource block's name.",


### PR DESCRIPTION
This backports #8887 for Chef 14. I'm not sure what the policy is for backporting something like this, so please let me know if I did it correctly or if it's even possible.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
