### PR TITLE
[yum_repository] Add indentation for multiple baseurls

### DIFF
--- a/lib/chef/provider/support/yum_repo.erb
+++ b/lib/chef/provider/support/yum_repo.erb
@@ -6,7 +6,7 @@ name=<%= @config.description %>
 <% if @config.baseurl %>
 baseurl=<%= case @config.baseurl
      when Array
-       @config.baseurl.join("\n")
+       @config.baseurl.join("\n        ")
      else
        @config.baseurl
      end %>


### PR DESCRIPTION
Properly indenting multiple baseurls for `yum_repository` resource

## Description
Fixes https://github.com/chef/chef/issues/9133

## Related Issue
https://github.com/chef/chef/issues/9133

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
