### PR TITLE
Specify item path in Node.read! error message

### DIFF
--- a/lib/chef/node/common_api.rb
+++ b/lib/chef/node/common_api.rb
@@ -100,7 +100,7 @@ class Chef
 
       # non-autovivifying reader that throws an exception if the attribute does not exist
       def read!(*path)
-        raise Chef::Exceptions::NoSuchAttribute unless exist?(*path)
+        raise Chef::Exceptions::NoSuchAttribute.new(path.join ".") unless exist?(*path)
 
         path.inject(self) do |memo, key|
           memo[key]

--- a/spec/unit/node/vivid_mash_spec.rb
+++ b/spec/unit/node/vivid_mash_spec.rb
@@ -163,15 +163,15 @@ describe Chef::Node::VividMash do
     end
 
     it "throws an exception when attributes do not exist" do
-      expect { vivid.read!("one", "five", "six") }.to raise_error(Chef::Exceptions::NoSuchAttribute)
+      expect { vivid.read!("one", "five", "six") }.to raise_error(Chef::Exceptions::NoSuchAttribute, "one.five.six")
     end
 
     it "throws an exception when traversing a non-container" do
-      expect { vivid.read!("one", "two", "three", "four") }.to raise_error(Chef::Exceptions::NoSuchAttribute)
+      expect { vivid.read!("one", "two", "three", "four") }.to raise_error(Chef::Exceptions::NoSuchAttribute, "one.two.three.four")
     end
 
     it "throws an exception when an array element does not exist" do
-      expect { vivid.read!("array", 3) }.to raise_error(Chef::Exceptions::NoSuchAttribute)
+      expect { vivid.read!("array", 3) }.to raise_error(Chef::Exceptions::NoSuchAttribute, "array.3")
     end
   end
 


### PR DESCRIPTION
## Description
The `Node.read!` method specifies an empty error message when it fails, which complicates debugging. I added the dot-separated path to the key it was attempting to read to the error message.

It is not perfect because ideally the user would like to know which key in the hierarchy does not exist; instead it always specifies the entire requested path. Since the code itself is not aware of which key exactly does not exist, retrieving this information and putting it into the error message would increase complexity, and require refactoring to prevent it from incurring a performance penalty for successful calls. This is why I decided for now to make a simple change that always returns the entire requested path instead. If we keep it this way, we may want to document it, but I could not find API docs or any comments that look like auto-generation sources for API docs, so I do not know where to document it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

( I am not sure, but I think it is a chore because it fixes a minor inconvenience that was never actually reported as a bug as far as I know.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass. -> I don't know which tests constitute "pre-merge" tests. I ran the unit tests locally at least.
- [ ] I have updated the documentation accordingly. -> I think there is one detail that deserves documentation, but i don't know where to document it (see Description).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. -> Some tests fail in the environment I tested in, but those same tests fail on `master` in the same environment, which has to do with `gem` somehow not reporting that `rspec` is installed. I have not re-run the tests after the most recent rebase on `master`. In the pipeline all tests pass.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco). -> I invoked the obvious fix clause, I'm guessing this is ok.