### PR TITLE
Remove duplicate constant for Chef::Dist::SHORT

### DIFF
--- a/lib/chef/dist.rb
+++ b/lib/chef/dist.rb
@@ -23,10 +23,6 @@ class Chef
     # The chef executable, as in `chef gem install` or `chef generate cookbook`
     EXEC = ChefConfig::Dist::EXEC.freeze
 
-    # A short name for the project, used in configurations
-    # Log messages, descriptions, etc...
-    SHORT = "chef".freeze
-
     # product website address
     WEBSITE = "https://chef.io".freeze
 


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
I somehow duplicated Chef::Dist::SHORT, this removes the  duplicate entry.

## Related Issue
Obvious fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
