### PR TITLE
Add time_out property in cron resource

### DIFF
--- a/lib/chef/provider/cron/aix.rb
+++ b/lib/chef/provider/cron/aix.rb
@@ -33,8 +33,11 @@ class Chef
             raise Chef::Exceptions::Cron, "Aix cron entry does not support environment variables. Please set them in script and use script in cron."
           end
 
-          newcron = ""
-          newcron << "# Chef Name: #{new_resource.name}\n"
+          if time_out_set?
+            raise Chef::Exceptions::Cron, "Aix cron entry does not support timeout."
+          end
+
+          newcron = "# Chef Name: #{new_resource.name}\n"
           newcron << "#{@new_resource.minute} #{@new_resource.hour} #{@new_resource.day} #{@new_resource.month} #{@new_resource.weekday}"
 
           newcron << " #{@new_resource.command}\n"
@@ -43,6 +46,10 @@ class Chef
 
         def env_vars_are_set?
           @new_resource.environment.length > 0 || !@new_resource.mailto.nil? || !@new_resource.path.nil? || !@new_resource.shell.nil? || !@new_resource.home.nil?
+        end
+
+        def time_out_set?
+          !@new_resource.time_out.empty?
         end
       end
     end

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -162,6 +162,34 @@ class Chef
         description: "A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'}).",
         default: lazy { {} }
 
+      TIMEOUT_OPTS = %w{duration preserve-status foreground kill-after signal}.freeze
+      TIMEOUT_REGEX = /\A\S+/.freeze
+
+      property :time_out, Hash,
+        description: "A Hash of timeouts in the form of ({'OPTION' => 'VALUE'}).
+        Accepted valid options are:
+        preserve-status (BOOL, default: 'false'),
+        foreground (BOOL, default: 'false'),
+        kill-after (in seconds),
+        signal (a name like 'HUP' or a number)",
+        default: lazy { {} },
+        coerce: proc { |h|
+          if h.is_a?(Hash)
+            invalid_keys = h.keys - TIMEOUT_OPTS
+            unless invalid_keys.empty?
+              error_msg = "Key of option time_out must be equal to one of: \"#{TIMEOUT_OPTS.join('", "')}\"!  You passed \"#{invalid_keys.join(", ")}\"."
+              raise Chef::Exceptions::ValidationFailed, error_msg
+            end
+            unless h.values.all? { |x| x =~ TIMEOUT_REGEX }
+              error_msg = "Values of option time_out should be non-empty string without any leading whitespaces."
+              raise Chef::Exceptions::ValidationFailed, error_msg
+            end
+            h
+          elsif h.is_a?(Integer) || h.is_a?(String)
+            { "duration" => h }
+          end
+        }
+
       private
 
       def integerize(integerish)


### PR DESCRIPTION
- Property accepts hash with timeout options as keys and their values in string
- Property also accepts Integer or String value
- Working fine for Linux, Need to check for AIX platforms

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Add a possibility to set a max execution time for cron job

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes [Chef-Client#324](https://github.com/chef-cookbooks/chef-client/issues/324)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
