### PR TITLE
When bootstrapping don't send an empty run_list if we are using policyfiles instead

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -205,15 +205,14 @@ class Chef
         end
 
         def first_boot
-          (@config[:first_boot_attributes] || {}).tap do |attributes|
+          (@config[:first_boot_attributes] = Mash.new(@config[:first_boot_attributes]) || Mash.new).tap do |attributes|
             if @config[:policy_name] && @config[:policy_group]
               attributes[:policy_name] = @config[:policy_name]
               attributes[:policy_group] = @config[:policy_group]
             else
               attributes[:run_list] = @run_list
             end
-
-            attributes.delete(:run_list) if ( attributes[:policy_name] && !attributes[:policy_name].empty? ) || ( attributes["policy_name"] && !attributes["policy_name"].empty? )
+            attributes.delete(:run_list) if attributes[:policy_name] && !attributes[:policy_name].empty?
             attributes.merge!(tags: @config[:tags]) if @config[:tags] && !@config[:tags].empty?
           end
         end

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -213,7 +213,7 @@ class Chef
               attributes[:run_list] = @run_list
             end
 
-            attributes.delete(:run_list) if attributes[:policy_name] && !attributes[:policy_name].empty?
+            attributes.delete(:run_list) if ( attributes[:policy_name] && !attributes[:policy_name].empty? ) || ( attributes["policy_name"] && !attributes["policy_name"].empty? )
             attributes.merge!(tags: @config[:tags]) if @config[:tags] && !@config[:tags].empty?
           end
         end

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -141,7 +141,7 @@ describe Chef::Knife::Core::BootstrapContext do
     let(:config) { { policy_name: "my_app_server", policy_group: "staging" } }
 
     it "includes them in the first_boot data and excludes run_list" do
-      expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json(config))
+      expect(Chef::JSONCompat.to_json(bootstrap_context.first_boot)).to eq(Chef::JSONCompat.to_json({ policy_name: "my_app_server", policy_group: "staging" }))
     end
 
   end


### PR DESCRIPTION
Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>

## Description
Don't send empty runlist if do not pass it.

## Related Issue
https://github.com/chef/chef/issues/9155

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ -] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
