### PR TITLE
Fix mac_user breakage and logging

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -154,4 +154,7 @@ fi
 
 cd "$chef_gem"
 sudo -E bundle install
-sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional
+# NOTE: we have unit tests in chef/chef which ARE NOT unit tests.  We need to run them on the actual shipping production artifact on the
+# actual distro that they're expected to run on, or we lose test coverage, which leads to shipping regressions.  We need to run all the
+# tests here before shipping.
+sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation


### PR DESCRIPTION
We need more defensive coding around the absense of the ShadowHashData.

Unfortunately I wasn't able to fix the tests on my mac where this
happens, and don't know how to introduce tests that would fail on
buildkite, so we have no coverage for this.  Testing was done
manually on the CLI.

Also removed some useless converge_by statements that were
effectively double-logging.  The methods that the converge_by's
were in are already wrapped by converge_by's in the superclass
so the resource is already "dirty" in the sense that it knows
that it is being updated, and the log message that e.g. the
user is being removed is already being printed.  Some of the
sub-action logging with sub-converge_by's here is still good
since it shows the details of how the user is being added or
removed or modified which makes sense (still sort of abusing
converge_by to get only logging, but that doesn't matter because
we're in a block where we MUST be updating the resource anyway).

This commit also re-adds testing of unit+integration testing to the
omnibus pipeline.
