### PR TITLE
resource archive_file: apply ownership to extracted files only

### DIFF
--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -102,8 +102,11 @@ class Chef
         end
 
         if new_resource.owner || new_resource.group
-          converge_by("set owner of #{new_resource.destination} to #{new_resource.owner}:#{new_resource.group}") do
-            FileUtils.chown_R(new_resource.owner, new_resource.group, new_resource.destination)
+          converge_by("set owner of files extracted in #{new_resource.destination} to #{new_resource.owner}:#{new_resource.group}") do
+            archive = Archive::Reader.open_filename(new_resource.path)
+            archive.each_entry do |e|
+              FileUtils.chown(new_resource.owner, new_resource.group, "#{new_resource.destination}/#{e.pathname}")
+            end
           end
         end
       end


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Currently, the `archive_file` file resource applies a `chown_R` to the entire destination directory, which could be dangerous if the user is extracting directly to places like `/etc` or `/bin`. This PR proposes fixing this by modifying ownership only of file listed in the archive, leaving the destination directory and anything else it contained prior to the run untouched.

## Related Issue
I cheated; I'm skipping right to the PR. The docs said `owner` and `group` would be applied to the extracted files, so  presumably editing the destination directory itself is considered a bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
