### PR TITLE
support Catalina softwareupdate output ("Label: ") and support updating CLI tools

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -158,7 +158,7 @@ class Chef
         #
         # @return [String]
         def xcode_cli_package
-          cmd = <<-EOH.gsub(/^ {14}/, '')
+          cmd = <<-EOH.gsub(/^ {14}/, "")
           softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n' | sed 's/Label: //g'
           EOH
           cmd.run_command

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -152,9 +152,7 @@ class Chef
           # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
         end
-
-        def parse_xcode_cli_label(output)
-        end
+        
         #
         # Return to package label of the latest XCode Command Line Tools update, if available
         #

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -161,6 +161,7 @@ class Chef
           cmd = <<-EOH.gsub(/^ {14}/, "")
           softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n' | sed 's/Label: //g'
           EOH
+          cmd = Mixlib::ShellOut.new(cmd)
           cmd.run_command
           cmd.error!
           cmd.stdout


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
My proposed fix for #9177 

An example of Catalina output that this resource should support:

```
Software Update Tool

Finding available software
Software Update found the following new or updated software:
* Label: Command Line Tools for Xcode-11.2
	Title: Command Line Tools for Xcode, Version: 11.2, Size: 224942K, Recommended: YES,
* Label: Command Line Tools for Xcode-11.3
	Title: Command Line Tools for Xcode, Version: 11.3, Size: 224878K, Recommended: YES,
```

This resource will continue to work on Sierra and Mojave.

This PR also extracts the call to `softwareupdate` checking for packages, and uses that as a second criteria for deciding whether to install CL Tools. This has the effect of keeping the package updated by triggering a new install whenever one is available. I'm not sure if that's the behavior chef wants, however.

## Related Issue
#9177 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

I'll need some guidance on where to put this test.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
