### PR TITLE
Resolve directory provider failing to differentiate between files and directories

### DIFF
--- a/lib/chef/provider/directory.rb
+++ b/lib/chef/provider/directory.rb
@@ -122,7 +122,7 @@ class Chef
       end
 
       def action_create
-        unless ::File.exists?(new_resource.path)
+        unless ::File.directory?(new_resource.path)
           converge_by("create new directory #{new_resource.path}") do
             if new_resource.recursive == true
               ::FileUtils.mkdir_p(new_resource.path)
@@ -138,7 +138,7 @@ class Chef
       end
 
       def action_delete
-        if ::File.exists?(new_resource.path)
+        if ::File.directory?(new_resource.path)
           converge_by("delete existing directory #{new_resource.path}") do
             if new_resource.recursive == true
               # we don't use rm_rf here because it masks all errors, including

--- a/spec/unit/provider/directory_spec.rb
+++ b/spec/unit/provider/directory_spec.rb
@@ -212,7 +212,6 @@ describe Chef::Provider::Directory do
       it "os x 10.10 can write to sip locations" do
         allow(node).to receive(:[]).with("platform_version").and_return("10.10")
         allow(Dir).to receive(:mkdir).and_return([true], [])
-        allow(::File).to receive(:directory?).and_return(true)
         allow(Chef::FileAccessControl).to receive(:writable?).and_return(true)
         directory.run_action(:create)
         expect(new_resource).to be_updated
@@ -228,7 +227,6 @@ describe Chef::Provider::Directory do
       it "os x 10.11 can write to sip exlcusions" do
         new_resource.path "/usr/local/chef_test"
         allow(node).to receive(:[]).with("platform_version").and_return("10.11")
-        allow(::File).to receive(:directory?).and_return(true)
         allow(Dir).to receive(:mkdir).and_return([true], [])
         allow(Chef::FileAccessControl).to receive(:writable?).and_return(false)
         directory.run_action(:create)


### PR DESCRIPTION
## Description
This change will update behavior of directory resource to stop improperly reading files as directories

File.directory? will still return false in the event that the object is a file OR if the file/directory does not exist. See below pry output.
```
[skippy@dev-thespooky cheftest]$ touch file.txt
[skippy@dev-thespooky cheftest]$ ls
file.txt
[skippy@dev-thespooky cheftest]$ pry
[1] pry(main)> File.directory?("/home/skippy/cheftest/file.txt")
=> false
[2] pry(main)> File.directory?("/home/skippy/cheftest/file_that_doesnot_exist")
=> false
```

## Related Issue
Addresses: https://github.com/chef/chef/issues/9175

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly. [N/A]
- [ ] I have added tests to cover my changes. [N/A]
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
