### PR TITLE
x509_certificate : Add the capability to automatically renew a certificate

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -408,8 +408,8 @@ class Chef
       # @param [integer] renew_before_expiry number of days before expiration
       # @return [true, false]
       def cert_need_renewall?(cert_file, renew_before_expiry)
-        raise TypeError, 'cert_file must be a String object' unless cert_file.is_a?(String)
-        raise TypeError, 'renew_before_expiry must be a Integer object' unless renew_before_expiry.is_a?(Integer)
+        raise TypeError, "cert_file must be a String object" unless cert_file.is_a?(String)
+        raise TypeError, "renew_before_expiry must be a Integer object" unless renew_before_expiry.is_a?(Integer)
 
         resp = true
         cert_content = ::File.exist?(cert_file) ? File.read(cert_file) : cert_file

--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -408,9 +408,6 @@ class Chef
       # @param [integer] renew_before_expiry number of days before expiration
       # @return [true, false]
       def cert_need_renewall?(cert_file, renew_before_expiry)
-        raise TypeError, "cert_file must be a String object" unless cert_file.is_a?(String)
-        raise TypeError, "renew_before_expiry must be a Integer object" unless renew_before_expiry.is_a?(Integer)
-
         resp = true
         cert_content = ::File.exist?(cert_file) ? File.read(cert_file) : cert_file
         begin

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -125,7 +125,7 @@ class Chef
           content cert.to_pem
         end
 
-        unless new_resource.renew_before_expiry.nil?
+        if !new_resource.renew_before_expiry.nil? && cert_need_renewall?(new_resource.path, new_resource.renew_before_expiry)
           file new_resource.path do
             action :create
             owner new_resource.owner unless new_resource.owner.nil?
@@ -133,7 +133,6 @@ class Chef
             mode new_resource.mode unless new_resource.mode.nil?
             sensitive true
             content cert.to_pem
-            only_if { cert_need_renewall?(new_resource.path, new_resource.renew_before_expiry) }
           end
         end
 

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -110,7 +110,8 @@ class Chef
         description: "The passphrase for CA private key's passphrase."
 
       property :renew_before_expiry, Integer,
-        description: "The number of days before the expiry. The certificate will be automaticaly renewed when the value is reached."
+        description: "The number of days before the expiry. The certificate will be automaticaly renewed when the value is reached.",
+        introduced: "15.7"
 
       action :create do
         description "Generate a certificate"

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -109,13 +109,17 @@ class Chef
       property :ca_key_pass, String,
         description: "The passphrase for CA private key's passphrase."
 
+      property :renew_before_expiry, Integer,
+        description: "The number of days before the expiry. The certificate will be automaticaly renewed when the value is reached.",
+        default: 5
+
       action :create do
         description "Generate a certificate"
 
-        unless ::File.exist? new_resource.path
+        if cert_need_renewall?(new_resource.path, new_resource.renew_before_expiry)
           converge_by("Create #{@new_resource}") do
             file new_resource.path do
-              action :create_if_missing
+              action :create
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode new_resource.mode unless new_resource.mode.nil?

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -854,4 +854,46 @@ describe Chef::Mixin::OpenSSLHelper do
       end
     end
   end
+
+  describe '#cert_need_renewall?' do
+    require 'tempfile'
+
+    before(:each) do
+      @certfile = Tempfile.new('certfile')
+    end
+
+    context 'When the cert file doesnt not exist' do
+      it 'returns true' do
+        expect(instance.cert_need_renewall?('/tmp/bad_filename', 3650)).to be_truthy
+      end
+    end
+
+    context 'When the cert file does exist, but does not contain a valid Certificate' do
+      it 'returns true' do
+        @certfile.write('I_am_not_a_cert_I_am_a_free_man')
+        @certfile.close
+        expect(instance.cert_need_renewall?(@certfile.path, 3650)).to be_truthy
+      end
+    end
+
+    context 'When the cert file does exist, and does not contain a soon to expire certficitate' do
+      it 'returns false' do
+        @certfile.write("-----BEGIN CERTIFICATE-----\nMIIDODCCAiCgAwIBAgIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEB\nCwUAMA0xCzAJBgNVBAMMAkNBMB4XDTE5MTIyNTEyNTY1NVoXDTI5MTIyMjEyNTY1\nNVowDTELMAkGA1UEAwwCQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\nAQC9bDWs5akf85UEMj8kry4DYNuAnaL4GnMs6XukQtp3dso+FgbKprgVogyepnet\nE+GlQq32u/n4y8K228kB6NoCn+c/yP+4QlKUBt0xSzQbSUuAE/5xZoKi/kH1ZsQ/\nuKXN/tIHagApEUGn5zqc8WBvWPliRAqiklwj8WtSw1WRa5eCdaVtln3wKuvPnYR5\n/V4YBHyHNhtlfXJBMtEaXm1rRzJGun+FdcrsCfcIFXp8lWobF+EVP8fRwqFTEtT6\nRXv6RT8sHy53a0KNTm8qnbacfr1MofgUuhzLjOrbIVvXpnRLeOkv8XW5rSH+zgsC\nZFK3bJ3j6UVbFQV4jXwlAWVrAgMBAAGjgY4wgYswDgYDVR0PAQH/BAQDAgGmMA8G\nA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFK4S2PNu6bpjxkJxedNaxfCrwtD4MEkG\nA1UdIwRCMECAFK4S2PNu6bpjxkJxedNaxfCrwtD4oRGkDzANMQswCQYDVQQDDAJD\nQYIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEBCwUAA4IBAQBGk+u3\n9N3PLWNOwYrqK7fD4yceWnz4UsV9uN1IU5PQTgYBaGyAZvU+VJluZZeDj7QjwbUW\ngISclvW/pSWpUVW3O0sfAM97u+5UMYHz4W5Bgq8CtdOKHgdZHKhzBePhmou11zO0\nZ6uQ7bkh0/REqKO7TFKaMMnakEhFXoDrS1EiB4W69KVXyrBVzVm5LK7uvOAQAeMp\nnEk3Oz+5pmKjSCf1cEd2jzAgDbaVrIvxICPgXAlNrKukmRW/0UHqDDVBfF7PioD2\nptlQFxWIkih6s/clwhsBFBwV1yyCirYfjhzmKPPLZUmx10okudLzaKrRbkPxrzbC\nmKEZoV+Nz2CNrGm5\n-----END CERTIFICATE-----\n")
+        @certfile.close
+        expect(instance.cert_need_renewall?(@certfile.path, 5)).to be_falsey
+      end
+    end
+
+    context 'When the cert file does exist, and does contain a soon to expire certficitate' do
+      it 'returns true' do
+        @certfile.write("-----BEGIN CERTIFICATE-----\nMIIDODCCAiCgAwIBAgIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEB\nCwUAMA0xCzAJBgNVBAMMAkNBMB4XDTE5MTIyNTEyNTY1NVoXDTI5MTIyMjEyNTY1\nNVowDTELMAkGA1UEAwwCQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\nAQC9bDWs5akf85UEMj8kry4DYNuAnaL4GnMs6XukQtp3dso+FgbKprgVogyepnet\nE+GlQq32u/n4y8K228kB6NoCn+c/yP+4QlKUBt0xSzQbSUuAE/5xZoKi/kH1ZsQ/\nuKXN/tIHagApEUGn5zqc8WBvWPliRAqiklwj8WtSw1WRa5eCdaVtln3wKuvPnYR5\n/V4YBHyHNhtlfXJBMtEaXm1rRzJGun+FdcrsCfcIFXp8lWobF+EVP8fRwqFTEtT6\nRXv6RT8sHy53a0KNTm8qnbacfr1MofgUuhzLjOrbIVvXpnRLeOkv8XW5rSH+zgsC\nZFK3bJ3j6UVbFQV4jXwlAWVrAgMBAAGjgY4wgYswDgYDVR0PAQH/BAQDAgGmMA8G\nA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFK4S2PNu6bpjxkJxedNaxfCrwtD4MEkG\nA1UdIwRCMECAFK4S2PNu6bpjxkJxedNaxfCrwtD4oRGkDzANMQswCQYDVQQDDAJD\nQYIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEBCwUAA4IBAQBGk+u3\n9N3PLWNOwYrqK7fD4yceWnz4UsV9uN1IU5PQTgYBaGyAZvU+VJluZZeDj7QjwbUW\ngISclvW/pSWpUVW3O0sfAM97u+5UMYHz4W5Bgq8CtdOKHgdZHKhzBePhmou11zO0\nZ6uQ7bkh0/REqKO7TFKaMMnakEhFXoDrS1EiB4W69KVXyrBVzVm5LK7uvOAQAeMp\nnEk3Oz+5pmKjSCf1cEd2jzAgDbaVrIvxICPgXAlNrKukmRW/0UHqDDVBfF7PioD2\nptlQFxWIkih6s/clwhsBFBwV1yyCirYfjhzmKPPLZUmx10okudLzaKrRbkPxrzbC\nmKEZoV+Nz2CNrGm5\n-----END CERTIFICATE-----\n")
+        @certfile.close
+        expect(instance.cert_need_renewall?(@certfile.path, 3650)).to be_truthy
+      end
+    end
+
+    after(:each) do
+      @certfile.unlink
+    end
+  end
 end

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -855,37 +855,37 @@ describe Chef::Mixin::OpenSSLHelper do
     end
   end
 
-  describe '#cert_need_renewall?' do
-    require 'tempfile'
+  describe "#cert_need_renewall?" do
+    require "tempfile"
 
     before(:each) do
-      @certfile = Tempfile.new('certfile')
+      @certfile = Tempfile.new("certfile")
     end
 
-    context 'When the cert file doesnt not exist' do
-      it 'returns true' do
-        expect(instance.cert_need_renewall?('/tmp/bad_filename', 3650)).to be_truthy
+    context "When the cert file doesnt not exist" do
+      it "returns true" do
+        expect(instance.cert_need_renewall?("/tmp/bad_filename", 3650)).to be_truthy
       end
     end
 
-    context 'When the cert file does exist, but does not contain a valid Certificate' do
-      it 'returns true' do
-        @certfile.write('I_am_not_a_cert_I_am_a_free_man')
+    context "When the cert file does exist, but does not contain a valid Certificate" do
+      it "returns true" do
+        @certfile.write("I_am_not_a_cert_I_am_a_free_man")
         @certfile.close
         expect(instance.cert_need_renewall?(@certfile.path, 3650)).to be_truthy
       end
     end
 
-    context 'When the cert file does exist, and does not contain a soon to expire certficitate' do
-      it 'returns false' do
+    context "When the cert file does exist, and does not contain a soon to expire certficitate" do
+      it "returns false" do
         @certfile.write("-----BEGIN CERTIFICATE-----\nMIIDODCCAiCgAwIBAgIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEB\nCwUAMA0xCzAJBgNVBAMMAkNBMB4XDTE5MTIyNTEyNTY1NVoXDTI5MTIyMjEyNTY1\nNVowDTELMAkGA1UEAwwCQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\nAQC9bDWs5akf85UEMj8kry4DYNuAnaL4GnMs6XukQtp3dso+FgbKprgVogyepnet\nE+GlQq32u/n4y8K228kB6NoCn+c/yP+4QlKUBt0xSzQbSUuAE/5xZoKi/kH1ZsQ/\nuKXN/tIHagApEUGn5zqc8WBvWPliRAqiklwj8WtSw1WRa5eCdaVtln3wKuvPnYR5\n/V4YBHyHNhtlfXJBMtEaXm1rRzJGun+FdcrsCfcIFXp8lWobF+EVP8fRwqFTEtT6\nRXv6RT8sHy53a0KNTm8qnbacfr1MofgUuhzLjOrbIVvXpnRLeOkv8XW5rSH+zgsC\nZFK3bJ3j6UVbFQV4jXwlAWVrAgMBAAGjgY4wgYswDgYDVR0PAQH/BAQDAgGmMA8G\nA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFK4S2PNu6bpjxkJxedNaxfCrwtD4MEkG\nA1UdIwRCMECAFK4S2PNu6bpjxkJxedNaxfCrwtD4oRGkDzANMQswCQYDVQQDDAJD\nQYIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEBCwUAA4IBAQBGk+u3\n9N3PLWNOwYrqK7fD4yceWnz4UsV9uN1IU5PQTgYBaGyAZvU+VJluZZeDj7QjwbUW\ngISclvW/pSWpUVW3O0sfAM97u+5UMYHz4W5Bgq8CtdOKHgdZHKhzBePhmou11zO0\nZ6uQ7bkh0/REqKO7TFKaMMnakEhFXoDrS1EiB4W69KVXyrBVzVm5LK7uvOAQAeMp\nnEk3Oz+5pmKjSCf1cEd2jzAgDbaVrIvxICPgXAlNrKukmRW/0UHqDDVBfF7PioD2\nptlQFxWIkih6s/clwhsBFBwV1yyCirYfjhzmKPPLZUmx10okudLzaKrRbkPxrzbC\nmKEZoV+Nz2CNrGm5\n-----END CERTIFICATE-----\n")
         @certfile.close
         expect(instance.cert_need_renewall?(@certfile.path, 5)).to be_falsey
       end
     end
 
-    context 'When the cert file does exist, and does contain a soon to expire certficitate' do
-      it 'returns true' do
+    context "When the cert file does exist, and does contain a soon to expire certficitate" do
+      it "returns true" do
         @certfile.write("-----BEGIN CERTIFICATE-----\nMIIDODCCAiCgAwIBAgIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEB\nCwUAMA0xCzAJBgNVBAMMAkNBMB4XDTE5MTIyNTEyNTY1NVoXDTI5MTIyMjEyNTY1\nNVowDTELMAkGA1UEAwwCQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\nAQC9bDWs5akf85UEMj8kry4DYNuAnaL4GnMs6XukQtp3dso+FgbKprgVogyepnet\nE+GlQq32u/n4y8K228kB6NoCn+c/yP+4QlKUBt0xSzQbSUuAE/5xZoKi/kH1ZsQ/\nuKXN/tIHagApEUGn5zqc8WBvWPliRAqiklwj8WtSw1WRa5eCdaVtln3wKuvPnYR5\n/V4YBHyHNhtlfXJBMtEaXm1rRzJGun+FdcrsCfcIFXp8lWobF+EVP8fRwqFTEtT6\nRXv6RT8sHy53a0KNTm8qnbacfr1MofgUuhzLjOrbIVvXpnRLeOkv8XW5rSH+zgsC\nZFK3bJ3j6UVbFQV4jXwlAWVrAgMBAAGjgY4wgYswDgYDVR0PAQH/BAQDAgGmMA8G\nA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFK4S2PNu6bpjxkJxedNaxfCrwtD4MEkG\nA1UdIwRCMECAFK4S2PNu6bpjxkJxedNaxfCrwtD4oRGkDzANMQswCQYDVQQDDAJD\nQYIVAPCkjE+wlZ1PgXwgvFgXKzhSpUkvMA0GCSqGSIb3DQEBCwUAA4IBAQBGk+u3\n9N3PLWNOwYrqK7fD4yceWnz4UsV9uN1IU5PQTgYBaGyAZvU+VJluZZeDj7QjwbUW\ngISclvW/pSWpUVW3O0sfAM97u+5UMYHz4W5Bgq8CtdOKHgdZHKhzBePhmou11zO0\nZ6uQ7bkh0/REqKO7TFKaMMnakEhFXoDrS1EiB4W69KVXyrBVzVm5LK7uvOAQAeMp\nnEk3Oz+5pmKjSCf1cEd2jzAgDbaVrIvxICPgXAlNrKukmRW/0UHqDDVBfF7PioD2\nptlQFxWIkih6s/clwhsBFBwV1yyCirYfjhzmKPPLZUmx10okudLzaKrRbkPxrzbC\nmKEZoV+Nz2CNrGm5\n-----END CERTIFICATE-----\n")
         @certfile.close
         expect(instance.cert_need_renewall?(@certfile.path, 3650)).to be_truthy


### PR DESCRIPTION
## Description
This change add the capability to automatically renew a certificate in the x509_certificate resource. It adds a new property (renew_before_expiry) wich contains the number of days before expiration. If this limit is reached, the certificate will be renewed.

Merry christmas ! 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).