### PR TITLE
Fix event log message description format

### DIFF
--- a/lib/chef/event_loggers/windows_eventlog.rb
+++ b/lib/chef/event_loggers/windows_eventlog.rb
@@ -36,7 +36,7 @@ class Chef
       LOG_CATEGORY_ID = 11001
 
       # Since we must install the event logger, this is not really configurable
-      SOURCE = "#{Chef::Dist::PRODUCT}".freeze
+      SOURCE = Chef::Dist::SHORT.freeze
 
       def self.available?
         ChefUtils.windows?

--- a/lib/chef/log/winevt.rb
+++ b/lib/chef/log/winevt.rb
@@ -37,7 +37,7 @@ class Chef
       FATAL_EVENT_ID = 10104
 
       # Since we must install the event logger, this is not really configurable
-      SOURCE = Chef::Dist::PRODUCT.freeze
+      SOURCE = Chef::Dist::SHORT.freeze
 
       include Chef::Mixin::Unformatter
 

--- a/spec/functional/event_loggers/windows_eventlog_spec.rb
+++ b/spec/functional/event_loggers/windows_eventlog_spec.rb
@@ -49,7 +49,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_start(version, run_status)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == Chef::Dist::PRODUCT && e.event_id == 10000 &&
+      e.source == Chef::Dist::SHORT && e.event_id == 10000 &&
                                         e.string_inserts[0].include?(version)
     end ).to be_truthy
   end
@@ -58,7 +58,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_started(run_status)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == Chef::Dist::PRODUCT && e.event_id == 10001 &&
+      e.source == Chef::Dist::SHORT && e.event_id == 10001 &&
                                         e.string_inserts[0].include?(run_id)
     end ).to be_truthy
   end
@@ -68,7 +68,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_completed(node)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == Chef::Dist::PRODUCT && e.event_id == 10002 &&
+      e.source == Chef::Dist::SHORT && e.event_id == 10002 &&
                                          e.string_inserts[0].include?(run_id) &&
                                          e.string_inserts[1].include?(elapsed_time.to_s)
     end).to be_truthy
@@ -79,7 +79,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_failed(mock_exception)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == Chef::Dist::PRODUCT && e.event_id == 10003 &&
+      e.source == Chef::Dist::SHORT && e.event_id == 10003 &&
         e.string_inserts[0].include?(run_id) &&
         e.string_inserts[1].include?(elapsed_time.to_s) &&
         e.string_inserts[2].include?(mock_exception.class.name) &&
@@ -93,7 +93,7 @@ describe Chef::EventLoggers::WindowsEventLogger, :windows_only do
     logger.run_failed(mock_exception)
 
     expect(event_log.read(flags, offset).any? do |e|
-      e.source == Chef::Dist::PRODUCT && e.event_id == 10003 &&
+      e.source == Chef::Dist::SHORT && e.event_id == 10003 &&
         e.string_inserts[0].include?("UNKNOWN") &&
         e.string_inserts[1].include?("UNKNOWN") &&
         e.string_inserts[2].include?(mock_exception.class.name) &&


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

This change fixes the description format of event logged message in event logger which originated due to name change of product from `chef` to `chef infra client`

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Due to constant `SOURCE`  change from 'Chef' to `Chef Infra Client`, Registry Key Sub key mismatched with event data source in `Chef v15`. This resulted into a weird message description like 
```
The description for Event ID 10000 from source Chef Infra Client cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer. 
 If the event originated on another computer, the display information had to be saved with the event. 
 The following information was included with the event: 
 15.3.14
``` 
- This change resolves this issue by using CONSTANT `Chef::Dist::SHORT` instead of `Chef::Dist::PRODUCT`
- Another CONSTANT `Chef::Dist::EXEC` could also be used here which resolves to `ChefConfig::Dist::EXEC` and ultimately to `Chef` .

## Post Fix
- Message log we get is as expected.
```
Completed Chef Infra Client run 4dc2f4e6-5a79-4e74-8df9-042ace12236e in 0.7355557 seconds
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/8845
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
