### PR TITLE
Do not build Chef Infra Client on Windows 2008 R2

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -52,7 +52,6 @@ builder-to-testers-map:
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:
-    - windows-2008r2-x86_64
     - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64


### PR DESCRIPTION
Windows 2008 R2 is no longer a supported a supported platform by
Microsoft https://support.microsoft.com/en-us/help/4456235/end-of-support-for-windows-server-2008-and-windows-server-2008-r2

Signed-off-by: Tim Smith <tsmith@chef.io>