### PR TITLE
Remove support for Windows 7 / 2008 from windows_feature

### DIFF
--- a/spec/unit/resource/windows_feature_dism_spec.rb
+++ b/spec/unit/resource/windows_feature_dism_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software, Inc.
+# Copyright:: Copyright 2018-2020, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,6 @@ describe Chef::Resource::WindowsFeatureDism do
   end
 
   it "the feature_name property is the name_property" do
-    node.automatic[:platform_version] = "6.2.9200"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
@@ -46,27 +45,13 @@ describe Chef::Resource::WindowsFeatureDism do
     expect { resource.action :remove }.not_to raise_error
   end
 
-  it "coerces comma separated lists of features to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2.9200"
+  it "coerces comma separated lists of features to a lowercase array" do
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces a single feature as a String to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2.9200"
+  it "coerces a single feature as a String to a lowercase array" do
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["snmp"])
-  end
-
-  it "coerces comma separated lists of features to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1.7601"
-    resource.feature_name "SNMP, DHCP"
-    expect(resource.feature_name).to eql(%w{SNMP DHCP})
-  end
-
-  it "coerces a single feature as a String to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1.7601"
-    resource.feature_name "SNMP"
-    expect(resource.feature_name).to eql(["SNMP"])
   end
 end

--- a/spec/unit/resource/windows_feature_powershell_spec.rb
+++ b/spec/unit/resource/windows_feature_powershell_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software, Inc.
+# Copyright:: Copyright 2018-2020, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +32,6 @@ describe Chef::Resource::WindowsFeaturePowershell do
   end
 
   it "the feature_name property is the name_property" do
-    node.automatic[:platform_version] = "6.2.9200"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
@@ -46,27 +45,13 @@ describe Chef::Resource::WindowsFeaturePowershell do
     expect { resource.action :remove }.not_to raise_error
   end
 
-  it "coerces comma separated lists of features to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2.9200"
+  it "coerces comma separated lists of features to a lowercase array" do
     resource.feature_name "SNMP, DHCP"
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "coerces a single feature as a String to a lowercase array on 2012+" do
-    node.automatic[:platform_version] = "6.2.9200"
+  it "coerces a single feature as a String to a lowercase array" do
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["snmp"])
-  end
-
-  it "coerces comma separated lists of features to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1.7601"
-    resource.feature_name "SNMP, DHCP"
-    expect(resource.feature_name).to eql(%w{SNMP DHCP})
-  end
-
-  it "coerces a single feature as a String to an array, but preserves case on < 2012" do
-    node.automatic[:platform_version] = "6.1.7601"
-    resource.feature_name "SNMP"
-    expect(resource.feature_name).to eql(["SNMP"])
   end
 end


### PR DESCRIPTION
These are EOL platforms that we no longer produce artifacts for. Let's
simplify / speedup these resources by removing legacy platform checks.

Signed-off-by: Tim Smith <tsmith@chef.io>