### PR TITLE
Clear password flags when setting the password on aix

### DIFF
--- a/lib/chef/provider/user/aix.rb
+++ b/lib/chef/provider/user/aix.rb
@@ -110,7 +110,7 @@ class Chef
           return unless current_resource.password != new_resource.password && new_resource.password
 
           logger.trace("#{new_resource.username} setting password to #{new_resource.password}")
-          command = "echo '#{new_resource.username}:#{new_resource.password}' | chpasswd -e"
+          command = "echo '#{new_resource.username}:#{new_resource.password}' | chpasswd -c -e"
           shell_out!(command)
         end
 


### PR DESCRIPTION
## Description
When a password is changed on aix using the chpasswd command the ADMCHG flag is set on the user. This flag will cause the user to be prompted to change their password on next login. This behaviour is different from for example the linux implementation where no reset is required on next login.

Adding the `-c` flag to the `chpasswd` command will clear this flag on the user and therefore makes sure that no password reset is required on next login

This might be a breaking change if people rely on the fact that a reset will be required on next login. But that seems unlikely to me. This could probably be solved by adding an option to the resource, but I do not know if this is desirable nor how to add such an option.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
