### PR TITLE
change with_clean_env to with_unbundled_env

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -28,7 +28,7 @@ $Env:TMP = "C:\cheftest"
 Remove-Item -Recurse -Force $Env:TEMP -ErrorAction SilentlyContinue
 New-Item -ItemType directory -Path $Env:TEMP
 
-# FIXME: we should really use Bundler.with_clean_env in the caller instead of re-inventing it here
+# FIXME: we should really use Bundler.with_unbundled_env in the caller instead of re-inventing it here
 Remove-Item Env:_ORIGINAL_GEM_PATH -ErrorAction SilentlyContinue
 Remove-Item Env:BUNDLE_BIN_PATH -ErrorAction SilentlyContinue
 Remove-Item Env:BUNDLE_GEMFILE -ErrorAction SilentlyContinue

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -65,7 +65,7 @@ end
 def system_windows_service_gem?
   windows_service_gem_check_command = %q{ruby -r "win32/daemon" -e ":noop"}
   if defined?(Bundler)
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       # This returns true if the gem can be loaded
       system(windows_service_gem_check_command)
     end

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -31,7 +31,7 @@ Dir.mktmpdir("chef-external-test") do |dir|
   shell_out!("git clone #{git_url} #{dir}", live_stream: STDOUT)
   Dir.chdir(dir) do
     shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       shell_out!("bundle install", live_stream: STDOUT, env: env)
       shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
     end

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ namespace :dependencies do
     desc "Update #{dir}/Gemfile.lock."
     task task_name do
       Dir.chdir(dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           rm_f "#{dir}/Gemfile.lock"
           sh "bundle lock --update --add-platform ruby"
           sh "bundle lock --update --add-platform x64-mingw32"
@@ -45,7 +45,7 @@ namespace :dependencies do
     desc "Update #{dir}/Gemfile.lock."
     task task_name do
       Dir.chdir(dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           sh "bundle update"
         end
       end

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ begin
   task :component_specs do
     %w{chef-utils chef-config}.each do |gem|
       Dir.chdir(gem) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           sh("bundle install")
           sh("bundle exec rake spec")
         end


### PR DESCRIPTION
I don't know how backwards compatible this is, but with_clean_env is now deprecated.