### PR TITLE
Add pfx_properties property to windows_certificate resource

### DIFF
--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -38,6 +38,10 @@ class Chef
       property :pfx_password, String,
         description: "The password to access the source if it is a pfx file."
 
+      property :pfx_properties, Integer,
+        description: "The dwFlags value desired for PFX storage. Automatically assigned based on the user_store property if omitted. See https://docs.microsoft.com/en-us/windows/desktop/api/wincrypt/nf-wincrypt-pfximportcertstore PFXImportCertStore function for available values.",
+        default: lazy { user_store ? 0x00001000 : 0x00000020 }
+
       property :private_key_acl, Array,
         description: "An array of 'domain\account' entries to be granted read-only access to the certificate's private key. Not idempotent."
 
@@ -134,7 +138,7 @@ class Chef
 
         def add_pfx_cert
           store = ::Win32::Certstore.open(new_resource.store_name)
-          store.add_pfx(new_resource.source, new_resource.pfx_password)
+          store.add_pfx(new_resource.source, new_resource.pfx_password, new_resource.pfx_properties)
         end
 
         def delete_cert


### PR DESCRIPTION
Add pfx_properties property to windows_certificate resource to allow specifying of PFX key properties used when installing PFX certificates in Windows.

win32-certstore gem >=v0.4.0 allows these properties to be passed.
Gem updates to add_pfx function can be seen here: https://github.com/chef/win32-certstore/commit/fd9342e3e1d87011c29f8be1461642f85316043b

Signed-off-by: Alex Munoz <amunoz951@gmail.com>

## Description
This allows chef-client to install the certificate PFX key in the localsystem store even when being run as a user as well as any number of PFX key flags available to the PFXImportCertStore function.

See https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-pfximportcertstore 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
