### PR TITLE
Use the right class in knife supermarket install

### DIFF
--- a/lib/chef/knife/supermarket_install.rb
+++ b/lib/chef/knife/supermarket_install.rb
@@ -137,7 +137,7 @@ class Chef
       end
 
       def download_cookbook_to(download_path)
-        downloader = Chef::Knife::CookbookSiteDownload.new
+        downloader = Chef::Knife::SupermarketDownload.new
         downloader.config[:file] = download_path
         downloader.config[:supermarket_site] = config[:supermarket_site]
         downloader.name_args = name_args


### PR DESCRIPTION
A user on discourse is seeing errors related to this old class. I'm not able to reproduce that failure, but we shouldn't be calling the deprecated class here. Changing this avoids a bogus deprecation warning that tells the user to stop using the legacy command when they're actually using the new command.

Signed-off-by: Tim Smith <tsmith@chef.io>