### PR TITLE
Use /etc/chef for bootstrapping instead of CONF_DIR

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -185,55 +185,55 @@ if test "x$tmp_dir" != "x"; then
   rm -r "$tmp_dir"
 fi
 
-mkdir -p <%= Chef::Dist::CONF_DIR %>
+mkdir -p /etc/chef
 
 <% if client_pem -%>
-(umask 077 && (cat > <%= Chef::Dist::CONF_DIR %>/client.pem <<'EOP'
+(umask 077 && (cat > /etc/chef/client.pem <<'EOP'
 <%= ::File.read(::File.expand_path(client_pem)) %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if validation_key -%>
-(umask 077 && (cat > <%= Chef::Dist::CONF_DIR %>/validation.pem <<'EOP'
+(umask 077 && (cat > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if encrypted_data_bag_secret -%>
-(umask 077 && (cat > <%= Chef::Dist::CONF_DIR %>/encrypted_data_bag_secret <<'EOP'
+(umask 077 && (cat > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% unless trusted_certs.empty? -%>
-mkdir -p <%= Chef::Dist::CONF_DIR %>/trusted_certs
+mkdir -p /etc/chef/trusted_certs
 <%= trusted_certs %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>
 <% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
-mkdir -p <%= Chef::Dist::CONF_DIR %>/ohai/hints
+mkdir -p /etc/chef/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-cat > <%= Chef::Dist::CONF_DIR %>/ohai/hints/<%= name %>.json <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= Chef::JSONCompat.to_json(hash) %>
 EOP
 <% end -%>
 <% end -%>
 
-cat > <%= Chef::Dist::CONF_DIR %>/client.rb <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
 
-cat > <%= Chef::Dist::CONF_DIR %>/first-boot.json <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= Chef::JSONCompat.to_json(first_boot) %>
 EOP
 
 <% unless client_d.empty? -%>
-mkdir -p <%= Chef::Dist::CONF_DIR %>/client.d
+mkdir -p /etc/chef/client.d
 <%= client_d %>
 <% end -%>
 

--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -158,11 +158,11 @@ class Chef
           end
 
           if encrypted_data_bag_secret
-            client_rb << %Q{encrypted_data_bag_secret "#{Chef::Dist::CONF_DIR}/encrypted_data_bag_secret"\n}
+            client_rb << %Q{encrypted_data_bag_secret "/etc/chef/encrypted_data_bag_secret"\n}
           end
 
           unless trusted_certs.empty?
-            client_rb << %Q{trusted_certs_dir "#{Chef::Dist::CONF_DIR}/trusted_certs"\n}
+            client_rb << %Q{trusted_certs_dir "/etc/chef/trusted_certs"\n}
           end
 
           if Chef::Config[:fips]
@@ -175,7 +175,7 @@ class Chef
         def start_chef
           # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
           client_path = @chef_config[:chef_client_path] || "#{Chef::Dist::CLIENT}"
-          s = "#{client_path} -j #{Chef::Dist::CONF_DIR}/first-boot.json"
+          s = "#{client_path} -j /etc/chef/first-boot.json"
           if @config[:verbosity] && @config[:verbosity] >= 3
             s << " -l trace"
           elsif @config[:verbosity] && @config[:verbosity] >= 2
@@ -226,7 +226,7 @@ class Chef
           content = ""
           if @chef_config[:trusted_certs_dir]
             Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(@chef_config[:trusted_certs_dir]), "*.{crt,pem}")).each do |cert|
-              content << "cat > #{Chef::Dist::CONF_DIR}/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
+              content << "cat > /etc/chef/trusted_certs/#{File.basename(cert)} <<'EOP'\n" +
                 IO.read(File.expand_path(cert)) + "\nEOP\n"
             end
           end
@@ -240,7 +240,7 @@ class Chef
             root.find do |f|
               relative = f.relative_path_from(root)
               if f != root
-                file_on_node = "#{Chef::Dist::CONF_DIR}/client.d/#{relative}"
+                file_on_node = "/etc/chef/client.d/#{relative}"
                 if f.directory?
                   content << "mkdir #{file_on_node}\n"
                 else


### PR DESCRIPTION

## Description

`CONF_DIR` is resolved based on the host system running chef-client/knife.  When we
use it in bootstrap template/context, we need a value based on the
target system that is being bootstrapped so that the paths are correct
(so that we don't try to create C:\chef on a linux system).


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## TODO 
This needs to be verified cross environment (windows host, linux target; linux host, windows target). 

## Related Issue

Fixes #9224 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
