### PR TITLE
Add windows helpers for install type

### DIFF
--- a/chef-utils/lib/chef-utils.rb
+++ b/chef-utils/lib/chef-utils.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2015-2019, Chef Software Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@ require_relative "chef-utils/dsl/platform_family"
 require_relative "chef-utils/dsl/service"
 require_relative "chef-utils/dsl/train_helpers"
 require_relative "chef-utils/dsl/which"
+require_relative "chef-utils/dsl/windows"
 require_relative "chef-utils/mash"
 
 # This is the Chef Infra Client DSL, not everytihng needs to go in here
@@ -33,6 +34,7 @@ module ChefUtils
   include ChefUtils::DSL::PlatformFamily
   include ChefUtils::DSL::Platform
   include ChefUtils::DSL::Introspection
+  include ChefUtils::DSL::Windows
   # FIXME: include ChefUtils::DSL::Which in Chef 16.0
   # FIXME: include ChefUtils::DSL::PathSanity in Chef 16.0
   # FIXME: include ChefUtils::DSL::TrainHelpers in Chef 16.0

--- a/chef-utils/lib/chef-utils/dsl/windows.rb
+++ b/chef-utils/lib/chef-utils/dsl/windows.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../internal"
+
+module ChefUtils
+  module DSL
+    module Windows
+      include Internal
+
+      # Determine if the current node is Windows Server Core.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def windows_server_core?(node = __getnode)
+        node["kernel"]["server_core"] == true
+      end
+
+      # Determine if the current node is Windows Workstation
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def windows_workstation?(node = __getnode)
+        node["kernel"]["product_type"] == "Workstation"
+      end
+
+      # Determine if the current node is Windows Server
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def windows_server?(node = __getnode)
+        node["kernel"]["product_type"] == "Server"
+      end
+
+      extend self
+    end
+  end
+end

--- a/chef-utils/spec/spec_helper.rb
+++ b/chef-utils/spec/spec_helper.rb
@@ -10,6 +10,7 @@ HELPER_MODULES = [
   ChefUtils::DSL::PlatformFamily,
   ChefUtils::DSL::Service,
   ChefUtils::DSL::Which,
+  ChefUtils::DSL::Windows,
 ].freeze
 
 ARCH_HELPERS = (ChefUtils::DSL::Architecture.methods - Module.methods).freeze
@@ -17,6 +18,7 @@ OS_HELPERS = (ChefUtils::DSL::OS.methods - Module.methods).freeze
 PLATFORM_HELPERS = (ChefUtils::DSL::Platform.methods - Module.methods).freeze
 PLATFORM_FAMILY_HELPERS = (ChefUtils::DSL::PlatformFamily.methods - Module.methods).freeze
 INTROSPECTION_HELPERS = (ChefUtils::DSL::Introspection.methods - Module.methods).freeze
+WINDOWS_HELPERS = (ChefUtils::DSL::Windows.methods - Module.methods).freeze
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/chef-utils/spec/unit/dsl/windows_spec.rb
+++ b/chef-utils/spec/unit/dsl/windows_spec.rb
@@ -1,0 +1,63 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+def windows_reports_true_for(*args)
+  args.each do |method|
+    it "reports true for #{method}" do
+      expect(described_class.send(method, node)).to be true
+    end
+  end
+  (WINDOWS_HELPERS - args).each do |method|
+    it "reports false for #{method}" do
+      expect(described_class.send(method, node)).to be false
+    end
+  end
+end
+
+RSpec.describe ChefUtils::DSL::Windows do
+  ( HELPER_MODULES - [ described_class ] ).each do |klass|
+    it "does not have methods that collide with #{klass}" do
+      expect((klass.methods - Module.methods) & WINDOWS_HELPERS).to be_empty
+    end
+  end
+
+  WINDOWS_HELPERS.each do |helper|
+    it "has the #{helper} in the ChefUtils module" do
+      expect(ChefUtils).to respond_to(helper)
+    end
+  end
+
+  context "on Windows Server Core" do
+    let(:node) { { "kernel" => { "server_core" => true } } }
+
+    windows_reports_true_for(:windows_server_core?)
+  end
+
+  context "on Windows Workstation" do
+    let(:node) { { "kernel" => { "product_type" => "Workstation" } } }
+
+    windows_reports_true_for(:windows_workstation?)
+  end
+
+  context "on Windows Server" do
+    let(:node) { { "kernel" => { "product_type" => "Server" } } }
+
+    windows_reports_true_for(:windows_server?)
+  end
+end


### PR DESCRIPTION
I'm placing these in their own helper file since there are going to be
more of them and the only commonality is that they're for windows.

Signed-off-by: Tim Smith <tsmith@chef.io>