### PR TITLE
launchd: Fix capitalization of HardResourceLimits

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -194,7 +194,7 @@ class Chef
           "environment_variables" => "EnvironmentVariables",
           "exit_timeout" => "ExitTimeout",
           "ld_group" => "GroupName",
-          "hard_resource_limits" => "HardreSourceLimits",
+          "hard_resource_limits" => "HardResourceLimits",
           "inetd_compatibility" => "inetdCompatibility",
           "init_groups" => "InitGroups",
           "keep_alive" => "KeepAlive",


### PR DESCRIPTION
Changes the capitalization of the hard_resource_limits launchd key from "HardreSourceLimits" to "HardResourceLimits"

## Description
Seems to have been a typo.
You can check e.g. https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html or https://www.launchd.info/ for the proper capitalization.

Signed-off-by: Marc Seeger <mseeger@fb.com>

## Related Issue
https://github.com/chef/chef/issues/9238

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
