### PR TITLE
Require Ruby 2.6+

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -245,56 +245,6 @@ steps:
         image: rubydistros/ubuntu-18.04
 
 #########################################################################
-  # Tests Ruby 2.5
-#########################################################################
-
-- label: "Integration Specs :ruby: 2.5"
-  commands:
-    - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
-    - bundle exec rake spec:integration
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-        privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - INTEGRATION_SPECS_25=1
-#
-- label: "Functional Specs :ruby: 2.5"
-  commands:
-    - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - apt-get install -y cron locales # needed for functional tests to pass
-    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
-    - bundle exec rake spec:functional
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-        privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - FUNCTIONAL_SPECS_25=1
-
-- label: "Unit Specs :ruby: 2.5"
-  commands:
-    - /workdir/scripts/bk_tests/bk_container_prep.sh
-    - bundle install --jobs=3 --retry=3 --without omnibus_package docgen
-    - bundle exec rake spec:unit
-    - bundle exec rake component_specs
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - UNIT_SPECS_25=1
-
-#########################################################################
   # EXTERNAL GEM TESTING
 #########################################################################
 

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = "adam@chef.io"
   s.homepage = "https://www.chef.io"
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.6.0"
 
   s.add_dependency "chef-config", "= #{Chef::VERSION}"
   s.add_dependency "chef-utils", "= #{Chef::VERSION}"


### PR DESCRIPTION
We support the last 2 releases of Ruby on Chef. Ruby 2.7 is out so we
should remove Ruby 2.5 at this point. We'll add Ruby 2.7 testing in the
near future.

Signed-off-by: Tim Smith <tsmith@chef.io>