### PR TITLE
Fix most Ruby 2.7 test failures / systemd service provider splat args conversion

### DIFF
--- a/lib/chef/node/mixin/immutablize_array.rb
+++ b/lib/chef/node/mixin/immutablize_array.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016-2019, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,7 @@ class Chef
           compact
           count
           cycle
+          deconstruct
           detect
           difference
           dig
@@ -59,6 +60,7 @@ class Chef
           entries
           fetch
           filter
+          filter_map
           find
           find_all
           find_index
@@ -71,6 +73,7 @@ class Chef
           include?
           index
           inject
+          intersection
           join
           last
           lazy
@@ -113,6 +116,7 @@ class Chef
           sum
           take
           take_while
+          tally
           to_a
           to_ary
           to_csv

--- a/lib/chef/node/mixin/immutablize_hash.rb
+++ b/lib/chef/node/mixin/immutablize_hash.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016-2019, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,7 @@ class Chef
           compare_by_identity?
           count
           cycle
+          deconstruct_keys
           default
           default_proc
           detect
@@ -60,6 +61,7 @@ class Chef
           fetch
           fetch_values
           filter
+          filter_map
           find
           find_all
           find_index
@@ -109,6 +111,7 @@ class Chef
           sum
           take
           take_while
+          tally
           to_a
           to_h
           to_hash

--- a/lib/chef/platform/priority_map.rb
+++ b/lib/chef/platform/priority_map.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2015-2016, Chef Software Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,8 @@ require_relative "../node_map"
 class Chef
   class Platform
     class PriorityMap < Chef::NodeMap
-      def priority(resource_name, priority_array, *filter)
-        set_priority_array(resource_name.to_sym, priority_array, *filter)
+      def priority(resource_name, priority_array, **filter)
+        set_priority_array(resource_name.to_sym, priority_array, **filter)
       end
 
       # @api private
@@ -31,9 +31,9 @@ class Chef
       end
 
       # @api private
-      def set_priority_array(key, priority_array, *filter, &block)
+      def set_priority_array(key, priority_array, **filter, &block)
         priority_array = Array(priority_array)
-        set(key, priority_array, *filter, &block)
+        set(key, priority_array, **filter, &block)
         priority_array
       end
     end

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -543,7 +543,7 @@ class Chef
           modified_options.key?(:default)
         options = options.reject { |k, v| k == :name_attribute || k == :name_property || k == :default }
       end
-      self.class.new(options.merge(modified_options))
+      self.class.new(**options.merge(modified_options))
     end
 
     #

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2016, 2009-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2016, 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -334,7 +334,7 @@ class Chef
     end
 
     def self.provides(short_name, opts = {}, &block)
-      Chef.provider_handler_map.set(short_name, self, opts, &block)
+      Chef.provider_handler_map.set(short_name, self, **opts, &block)
     end
 
     def self.provides?(node, resource)

--- a/lib/chef/provider/service/systemd.rb
+++ b/lib/chef/provider/service/systemd.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Stephen Haynes (<sh@nomitor.com>)
 # Author:: Davide Cavalca (<dcavalca@fb.com>)
-# Copyright:: Copyright 2011-2019, Chef Software Inc.
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,7 +104,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out!("#{systemctl_path} #{args} start #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
+        shell_out!(systemctl_path, args, "start", new_resource.service_name, default_env: false, **options)
       end
     end
   end
@@ -117,7 +117,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
         super
       else
         options, args = get_systemctl_options_args
-        shell_out!("#{systemctl_path} #{args} stop #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
+        shell_out!(systemctl_path, args, "stop", new_resource.service_name, default_env: false, **options)
       end
     end
   end
@@ -127,7 +127,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       super
     else
       options, args = get_systemctl_options_args
-      shell_out!("#{systemctl_path} #{args} restart #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
+      shell_out!(systemctl_path, args, "restart", new_resource.service_name, default_env: false, **options)
     end
   end
 
@@ -137,7 +137,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
     else
       if current_resource.running
         options, args = get_systemctl_options_args
-        shell_out!("#{systemctl_path} #{args} reload #{Shellwords.escape(new_resource.service_name)}", default_env: false, **options)
+        shell_out!(systemctl_path, args, "reload", new_resource.service_name, default_env: false, **options)
       else
         start_service
       end
@@ -150,7 +150,7 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       return
     end
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} enable #{Shellwords.escape(new_resource.service_name)}", **options)
+    shell_out!(systemctl_path, args, "enable", new_resource.service_name, **options)
   end
 
   def disable_service
@@ -159,38 +159,38 @@ class Chef::Provider::Service::Systemd < Chef::Provider::Service::Simple
       return
     end
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} disable #{Shellwords.escape(new_resource.service_name)}", **options)
+    shell_out!(systemctl_path, args, "disable", new_resource.service_name, **options)
   end
 
   def mask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} mask #{Shellwords.escape(new_resource.service_name)}", **options)
+    shell_out!(systemctl_path, args, "mask", new_resource.service_name, **options)
   end
 
   def unmask_service
     options, args = get_systemctl_options_args
-    shell_out!("#{systemctl_path} #{args} unmask #{Shellwords.escape(new_resource.service_name)}", **options)
+    shell_out!(systemctl_path, args, "unmask", new_resource.service_name, **options)
   end
 
   def is_active?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-active #{Shellwords.escape(new_resource.service_name)} --quiet", **options).exitstatus == 0
+    shell_out(systemctl_path, args, "is-active", new_resource.service_name, "--quiet", **options).exitstatus == 0
   end
 
   def is_enabled?
     options, args = get_systemctl_options_args
-    shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)} --quiet", **options).exitstatus == 0
+    shell_out(systemctl_path, args, "is-enabled", new_resource.service_name, "--quiet", **options).exitstatus == 0
   end
 
   def is_indirect?
     options, args = get_systemctl_options_args
-    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", **options)
+    s = shell_out(systemctl_path, args, "is-enabled", new_resource.service_name, **options)
     s.stdout.include?("indirect")
   end
 
   def is_masked?
     options, args = get_systemctl_options_args
-    s = shell_out("#{systemctl_path} #{args} is-enabled #{Shellwords.escape(new_resource.service_name)}", **options)
+    s = shell_out(systemctl_path, args, "is-enabled", new_resource.service_name, **options)
     s.exitstatus != 0 && s.stdout.include?("masked")
   end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1376,7 +1376,7 @@ class Chef
         options[:chef_version] = @chef_version_for_provides
       end
 
-      result = Chef.resource_handler_map.set(name, self, options, &block)
+      result = Chef.resource_handler_map.set(name, self, **options, &block)
       Chef::DSL::Resources.add_resource_dsl(name)
       result
     end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Falcon (<seth@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -457,10 +457,10 @@ describe Chef::Cookbook::Metadata do
       metadata.version "1.2.3"
       metadata.gem "foo", "~> 1.2"
       metadata.gem "bar", ">= 2.2", "< 4.0"
-      metadata.chef_version ">= 11.14.2", "< 11.18.10"
-      metadata.chef_version ">= 12.2.1", "< 12.5.1"
-      metadata.ohai_version ">= 7.1.0", "< 7.5.0"
-      metadata.ohai_version ">= 8.0.1", "< 8.6.0"
+      metadata.chef_version "< 11.18.10", ">= 11.14.2"
+      metadata.chef_version "< 12.5.1", ">= 12.2.1"
+      metadata.ohai_version "< 7.5.0", ">= 7.1.0"
+      metadata.ohai_version "< 8.6.0", ">= 8.0.1"
     end
 
     it "should produce the same output from to_json and Chef::JSONCompat" do

--- a/spec/unit/node/attribute_spec.rb
+++ b/spec/unit/node/attribute_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1259,12 +1259,12 @@ describe Chef::Node::Attribute do
   describe "frozen immutable strings" do
     it "strings in hashes should be frozen" do
       @attributes.default["foo"]["bar"]["baz"] = "fizz"
-      expect { @attributes["foo"]["bar"]["baz"] << "buzz" }.to raise_error(RuntimeError, "can't modify frozen String")
+      expect { @attributes["foo"]["bar"]["baz"] << "buzz" }.to raise_error(FrozenError, /can't modify frozen String/)
     end
 
     it "strings in arrays should be frozen" do
       @attributes.default["foo"]["bar"] = [ "fizz" ]
-      expect { @attributes["foo"]["bar"][0] << "buzz" }.to raise_error(RuntimeError, "can't modify frozen String")
+      expect { @attributes["foo"]["bar"][0] << "buzz" }.to raise_error(FrozenError, /can't modify frozen String/)
     end
   end
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -542,7 +542,7 @@ describe "Chef::Resource.property" do
           expect(resource.x).to eq ""
         end
         it "x is immutable" do
-          expect { resource.x << "foo" }.to raise_error(RuntimeError, "can't modify frozen String")
+          expect { resource.x << "foo" }.to raise_error(FrozenError, /can't modify frozen String/)
         end
       end
 
@@ -562,7 +562,7 @@ describe "Chef::Resource.property" do
           expect(resource.x).to eq({})
         end
         it "x is immutable" do
-          expect { resource.x["foo"] = "bar" }.to raise_error(RuntimeError, "can't modify frozen Hash")
+          expect { resource.x["foo"] = "bar" }.to raise_error(FrozenError, /can't modify frozen Hash/)
         end
         it "The same exact value is returned multiple times in a row" do
           value = resource.x
@@ -595,13 +595,13 @@ describe "Chef::Resource.property" do
           expect(resource.x).to eq([{ foo: "bar" }])
         end
         it "x is immutable" do
-          expect { resource.x << :other }.to raise_error(RuntimeError, "can't modify frozen Array")
+          expect { resource.x << :other }.to raise_error(FrozenError, /can't modify frozen Array/)
         end
         it "x.first is immutable" do
-          expect { resource.x.first[:foo] = "other" }.to raise_error(RuntimeError, "can't modify frozen Hash")
+          expect { resource.x.first[:foo] = "other" }.to raise_error(FrozenError, /can't modify frozen Hash/)
         end
         it "x.first[:foo] is immutable" do
-          expect { resource.x.first[:foo] << "other" }.to raise_error(RuntimeError, "can't modify frozen String")
+          expect { resource.x.first[:foo] << "other" }.to raise_error(FrozenError, /can't modify frozen String/)
         end
       end
     end
@@ -1072,13 +1072,13 @@ describe "Chef::Resource.property" do
 
   it "raises an error if both name_property and name_attribute are specified" do
     expect { resource_class.property :x, name_property: false, name_attribute: 1 }.to raise_error ArgumentError,
-      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)./
+      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)/
     expect { resource_class.property :x, name_property: false, name_attribute: nil }.to raise_error ArgumentError,
-      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)./
+      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)/
     expect { resource_class.property :x, name_property: false, name_attribute: false }.to raise_error ArgumentError,
-      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)./
+      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)/
     expect { resource_class.property :x, name_property: true, name_attribute: true }.to raise_error ArgumentError,
-      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)./
+      /name_attribute and name_property are functionally identical and both cannot be specified on a property at once. Use just one on property x of resource chef_resource_property_spec_(\d+)/
   end
 
   context "property_type" do

--- a/spec/unit/provider/service/systemd_service_spec.rb
+++ b/spec/unit/provider/service/systemd_service_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Stephen Haynes (<sh@nomitor.com>)
 # Author:: Davide Cavalca (<dcavalca@fb.com>)
-# Copyright:: Copyright 2011-2018, Chef Software Inc.
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -177,13 +177,13 @@ describe Chef::Provider::Service::Systemd do
 
         context "when a user is not specified" do
           it "should call '#{systemctl_path} --system start service_name' if no start command is specified" do
-            expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system start #{service_name_escaped}", default_env: false).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "start", service_name, default_env: false, timeout: 900).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --system start service_name' if it is already running" do
             current_resource.running(true)
-            expect(provider).not_to receive(:shell_out!).with("#{systemctl_path} --system start #{service_name_escaped}", {})
+            expect(provider).not_to receive(:shell_out_compacted!).with(systemctl_path, "--system", "start", service_name, timeout: 900)
             provider.start_service
           end
         end
@@ -191,14 +191,14 @@ describe Chef::Provider::Service::Systemd do
         context "when a user is specified" do
           it "should call '#{systemctl_path} --user start service_name' if no start command is specified" do
             current_resource.user("joe")
-            expect(provider).to receive(:shell_out!).with("#{systemctl_path} --user start #{service_name_escaped}", { environment: { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, user: "joe", default_env: false }).and_return(shell_out_success)
+            expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--user", "start", service_name, environment: { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, user: "joe", default_env: false, timeout: 900).and_return(shell_out_success)
             provider.start_service
           end
 
           it "should not call '#{systemctl_path} --user start service_name' if it is already running" do
             current_resource.running(true)
             current_resource.user("joe")
-            expect(provider).not_to receive(:shell_out!).with("#{systemctl_path} --user start #{service_name_escaped}", { environment: { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, user: "joe" })
+            expect(provider).not_to receive(:shell_out_compacted!).with(systemctl_path, "--user", "start", service_name, environment: { "DBUS_SESSION_BUS_ADDRESS" => "unix:path=/run/user/10000/bus" }, user: "joe", timeout: 900)
             provider.start_service
           end
         end
@@ -212,7 +212,7 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} --system restart service_name' if no restart command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system restart #{service_name_escaped}", default_env: false).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "restart", service_name, default_env: false, timeout: 900).and_return(shell_out_success)
           provider.restart_service
         end
 
@@ -229,7 +229,7 @@ describe Chef::Provider::Service::Systemd do
           context "when a reload command is not specified" do
             it "should call '#{systemctl_path} --system reload service_name' if the service is running" do
               current_resource.running(true)
-              expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system reload #{service_name_escaped}", default_env: false).and_return(shell_out_success)
+              expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "reload", service_name, default_env: false, timeout: 900).and_return(shell_out_success)
               provider.reload_service
             end
 
@@ -250,13 +250,13 @@ describe Chef::Provider::Service::Systemd do
 
         it "should call '#{systemctl_path} --system stop service_name' if no stop command is specified" do
           current_resource.running(true)
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system stop #{service_name_escaped}", default_env: false).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "stop", service_name, timeout: 900, default_env: false).and_return(shell_out_success)
           provider.stop_service
         end
 
         it "should not call '#{systemctl_path} --system stop service_name' if it is already stopped" do
           current_resource.running(false)
-          expect(provider).not_to receive(:shell_out!).with("#{systemctl_path} --system stop #{service_name_escaped}", {})
+          expect(provider).not_to receive(:shell_out_compacted!).with(systemctl_path, "--system", "stop", service_name, timeout: 900)
           provider.stop_service
         end
       end
@@ -269,12 +269,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} --system enable service_name' to enable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system enable #{service_name_escaped}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "enable", service_name, timeout: 900).and_return(shell_out_success)
           provider.enable_service
         end
 
         it "should call '#{systemctl_path} --system disable service_name' to disable the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system disable #{service_name_escaped}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "disable", service_name, timeout: 900).and_return(shell_out_success)
           provider.disable_service
         end
       end
@@ -287,12 +287,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should call '#{systemctl_path} --system mask service_name' to mask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system mask #{service_name_escaped}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "mask", service_name, timeout: 900).and_return(shell_out_success)
           provider.mask_service
         end
 
         it "should call '#{systemctl_path} --system unmask service_name' to unmask the service" do
-          expect(provider).to receive(:shell_out!).with("#{systemctl_path} --system unmask #{service_name_escaped}", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted!).with(systemctl_path, "--system", "unmask", service_name, timeout: 900).and_return(shell_out_success)
           provider.unmask_service
         end
       end
@@ -305,12 +305,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-active service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name_escaped} --quiet", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-active", service_name, "--quiet", timeout: 900).and_return(shell_out_success)
           expect(provider.is_active?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-active service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-active #{service_name_escaped} --quiet", {}).and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-active", service_name, "--quiet", timeout: 900).and_return(shell_out_failure)
           expect(provider.is_active?).to be false
         end
       end
@@ -323,12 +323,12 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped} --quiet", {}).and_return(shell_out_success)
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, "--quiet", timeout: 900).and_return(shell_out_success)
           expect(provider.is_enabled?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped} --quiet", {}).and_return(shell_out_failure)
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, "--quiet", timeout: 900).and_return(shell_out_failure)
           expect(provider.is_enabled?).to be false
         end
       end
@@ -341,22 +341,22 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 'masked' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "masked", exitstatus: shell_out_failure))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "masked", exitstatus: shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' outputs 'masked-runtime' and returns anything except 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "masked-runtime", exitstatus: shell_out_failure))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "masked-runtime", exitstatus: shell_out_failure))
           expect(provider.is_masked?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns 0" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "enabled", exitstatus: shell_out_success))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "enabled", exitstatus: shell_out_success))
           expect(provider.is_masked?).to be false
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0 and outputs an error'" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "Failed to get unit file state for #{service_name}: No such file or directory", exitstatus: shell_out_failure))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "Failed to get unit file state for #{service_name}: No such file or directory", exitstatus: shell_out_failure))
           expect(provider.is_masked?).to be false
         end
       end
@@ -369,17 +369,17 @@ describe Chef::Provider::Service::Systemd do
         end
 
         it "should return true if '#{systemctl_path} --system is-enabled service_name' returns 'indirect'" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "indirect", exitstatus: shell_out_success))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "indirect", exitstatus: shell_out_success))
           expect(provider.is_indirect?).to be true
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns 0 and outputs something other than 'indirect'" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "enabled", exitstatus: shell_out_success))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "enabled", exitstatus: shell_out_success))
           expect(provider.is_indirect?).to be false
         end
 
         it "should return false if '#{systemctl_path} --system is-enabled service_name' returns anything except 0 and outputs somethign other than 'indirect''" do
-          expect(provider).to receive(:shell_out).with("#{systemctl_path} --system is-enabled #{service_name_escaped}", {}).and_return(double(stdout: "enabled", exitstatus: shell_out_failure))
+          expect(provider).to receive(:shell_out_compacted).with(systemctl_path, "--system", "is-enabled", service_name, timeout: 900).and_return(double(stdout: "enabled", exitstatus: shell_out_failure))
           expect(provider.is_indirect?).to be false
         end
       end


### PR DESCRIPTION
Fixes most of the spec failures for ruby 2.7

Also in the process converts the systemd service provider to using shell_out splat-args array style arg parsing (easiest way to fix it for 2.7 was to just do it right).