### PR TITLE
launchd: Fix capitalization of HardResourceLimits

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -194,7 +194,7 @@ class Chef
           "environment_variables" => "EnvironmentVariables",
           "exit_timeout" => "ExitTimeout",
           "ld_group" => "GroupName",
-          "hard_resource_limits" => "HardreSourceLimits",
+          "hard_resource_limits" => "HardResourceLimits",
           "inetd_compatibility" => "inetdCompatibility",
           "init_groups" => "InitGroups",
           "keep_alive" => "KeepAlive",


### PR DESCRIPTION
Seems to have been a typo.
You can check e.g. https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html or https://www.launchd.info/ for the proper capitalization.

Signed-off-by: Marc Seeger <mseeger@fb.com>