### PR TITLE
[chef-16] Remove the data bag secret short option

### DIFF
--- a/lib/chef/knife/data_bag_secret_options.rb
+++ b/lib/chef/knife/data_bag_secret_options.rb
@@ -35,7 +35,6 @@ class Chef
 
       def self.included(base)
         base.option :secret,
-          short: "-s SECRET",
           long: "--secret SECRET",
           description: "The secret key to use to encrypt data bag item values. Can also be defaulted in your config with the key 'secret'.",
           # Need to store value from command line in separate variable - knife#merge_configs populates same keys
@@ -80,16 +79,9 @@ class Chef
       end
 
       def validate_secrets
-        if has_cl_secret?
-          if opt_parser.default_argv.include?("-s")
-            ui.warn("Secret short option -s is deprecated and will remove in the future. Please use --secret instead.
-")
-          end
-
-          if has_cl_secret_file?
-            ui.fatal("Please specify only one of --secret, --secret-file")
-            exit(1)
-          end
+        if has_cl_secret? && has_cl_secret_file?
+          ui.fatal("Please specify only one of --secret, --secret-file")
+          exit(1)
         end
 
         if knife_config[:secret] && knife_config[:secret_file]

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -382,7 +382,7 @@ describe Chef::Knife::Bootstrap do
       k
     end
 
-    let(:options) { ["--bootstrap-no-proxy", setting, "-s", "foo"] }
+    let(:options) { ["--bootstrap-no-proxy", setting] }
 
     let(:template_file) { File.expand_path(File.join(CHEF_SPEC_DATA, "bootstrap", "no_proxy.erb")) }
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
As we have planned to remove the data  bags `secret` short option in chef-16. earlier added deprecation warning in #8909 if someone uses -s for data bag.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Closes https://github.com/chef/chef/issues/4647

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>