### PR TITLE
option to show policy name/group on status output

### DIFF
--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -72,6 +72,8 @@ class Chef
             result["ip"] = ip if ip
             result["fqdn"] = fqdn if fqdn
             result["run_list"] = node.run_list if config["run_list"]
+            result["policy_name"] = node.policy_name if config["policy"]
+            result["policy_group"] = node.policy_group if config["policy"]
             result["ohai_time"] = node["ohai_time"]
             result["platform"] = node["platform"] if node["platform"]
             result["platform_version"] = node["platform_version"] if node["platform_version"]
@@ -106,6 +108,11 @@ class Chef
               else
                 run_list = node["run_list"]
               end
+            end
+
+            if config[:policy]
+              policy_name = node["policy_name"]
+              policy_group = node["policy_group"]
             end
 
             line_parts = []
@@ -144,6 +151,9 @@ class Chef
               end
               line_parts << platform
             end
+
+            line_parts << policy_name if policy_name
+            line_parts << policy_group if policy_group
 
             summarized = summarized + line_parts.join(", ") + ".\n"
           end

--- a/lib/chef/knife/status.rb
+++ b/lib/chef/knife/status.rb
@@ -37,6 +37,11 @@ class Chef
         long: "--run-list",
         description: "Show the run list"
 
+      option :policy,
+        short: "-p",
+        long: "--policy",
+        description: "Show the policy name and group"
+
       option :sort_reverse,
         short: "-s",
         long: "--sort-reverse",
@@ -60,6 +65,7 @@ class Chef
           opts = { filter_result:
                  { name: ["name"], ipaddress: ["ipaddress"], ohai_time: ["ohai_time"],
                    ec2: ["ec2"], run_list: ["run_list"], platform: ["platform"],
+                   policy_name: ["policy_name"], policy_group: ["policy_group"],
                    platform_version: ["platform_version"], chef_environment: ["chef_environment"] } }
         end
 

--- a/spec/unit/knife/status_spec.rb
+++ b/spec/unit/knife/status_spec.rb
@@ -40,6 +40,7 @@ describe Chef::Knife::Status do
       { filter_result:
                  { name: ["name"], ipaddress: ["ipaddress"], ohai_time: ["ohai_time"],
                    ec2: ["ec2"], run_list: ["run_list"], platform: ["platform"],
+                   policy_name: ["policy_name"], policy_group: ["policy_group"]
                    platform_version: ["platform_version"], chef_environment: ["chef_environment"] } }
     end
 


### PR DESCRIPTION
## Description

The `knife status` command can optionally show the run list and the environment for a node, but for users that have adopted Policyfiles, this doesn't show anything particularly relevant or useful. This change will add a `-p` option to show the Policy name and group to the output of the status command.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Joshua Timberman <joshua@chef.io>
