### PR TITLE
Avoid load method deprecation warnings in knife

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_artifacts_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_artifacts_dir.rb
@@ -66,7 +66,7 @@ class Chef
 
               # Instantiate a proxy loader using the temporary symlink
               proxy_loader = Chef::Cookbook::CookbookVersionLoader.new(proxy_cookbook_path, other.chefignore)
-              proxy_loader.load_cookbooks
+              proxy_loader.load!
 
               cookbook_to_upload = proxy_loader.cookbook_version
               cookbook_to_upload.identifier = identifier

--- a/lib/chef/chef_fs/file_system/chef_server/versioned_cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/versioned_cookbooks_dir.rb
@@ -72,7 +72,7 @@ class Chef
 
               # Instantiate a proxy loader using the temporary symlink
               proxy_loader = Chef::Cookbook::CookbookVersionLoader.new(proxy_cookbook_path, other.chefignore)
-              proxy_loader.load_cookbooks
+              proxy_loader.load!
 
               cookbook_to_upload = proxy_loader.cookbook_version
               cookbook_to_upload.freeze_version if options[:freeze]

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_artifact_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_artifact_dir.rb
@@ -29,7 +29,7 @@ class Chef
             cookbook_name, _dash, identifier = name.rpartition("-")
             # KLUDGE: We shouldn't have to use instance_variable_set
             loader.instance_variable_set(:@cookbook_name, cookbook_name)
-            loader.load_cookbooks
+            loader.load!
             cookbook_version = loader.cookbook_version
             cookbook_version.identifier = identifier
             cookbook_version

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_cookbook_dir.rb
@@ -143,7 +143,7 @@ class Chef
 
           def cookbook_version
             loader = Chef::Cookbook::CookbookVersionLoader.new(file_path, chefignore)
-            loader.load_cookbooks
+            loader.load!
             loader.cookbook_version
           end
         end

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_versioned_cookbook_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_versioned_cookbook_dir.rb
@@ -33,7 +33,7 @@ class Chef
 
             # KLUDGE: We shouldn't have to use instance_variable_set
             loader.instance_variable_set(:@cookbook_name, canonical_name)
-            loader.load_cookbooks
+            loader.load!
             loader.cookbook_version
           end
         end

--- a/lib/chef/cookbook/cookbook_version_loader.rb
+++ b/lib/chef/cookbook/cookbook_version_loader.rb
@@ -82,7 +82,7 @@ class Chef
       end
 
       def load
-        Chef::Log.warn "load method is deprecated. Use load! instead"
+        Chef::Log.warn "Chef::Cookbook::CookbookVersionLoader's load method is deprecated. Please use load! instead."
         metadata # force lazy evaluation to occur
 
         # re-raise any exception that occurred when reading the metadata

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -54,7 +54,6 @@ describe "ChefFSDataStore tests", :workstation do
 
       context "GET /TYPE" do
         it "knife list -z -R returns everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
           knife("list -z -Rfp /").should_succeed <<~EOM
             /acls/
             /acls/clients/
@@ -119,7 +118,6 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife delete -z -r /cookbooks/x works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("delete -z -r /cookbooks/x").should_succeed "Deleted /cookbooks/x\n"
           knife("list -z -Rfp /cookbooks").should_succeed ""
         end
@@ -157,7 +155,6 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife show -z /cookbooks/x/metadata.rb works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("show -z /cookbooks/x/metadata.rb").should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
         end
 
@@ -193,7 +190,6 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife cookbook upload works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("cookbook upload -z --cookbook-path #{path_to("cookbooks_to_upload")} x").should_succeed stderr: <<~EOM
             Uploading x              [1.0.0]
             Uploaded 1 cookbook.
@@ -446,7 +442,6 @@ describe "ChefFSDataStore tests", :workstation do
 
       context "GET /TYPE" do
         it "knife list -z -R returns everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("list -z -Rfp /").should_succeed <<~EOM
             /clients/
             /clients/x.json

--- a/spec/integration/knife/chef_fs_data_store_spec.rb
+++ b/spec/integration/knife/chef_fs_data_store_spec.rb
@@ -54,7 +54,7 @@ describe "ChefFSDataStore tests", :workstation do
 
       context "GET /TYPE" do
         it "knife list -z -R returns everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
           knife("list -z -Rfp /").should_succeed <<~EOM
             /acls/
             /acls/clients/
@@ -119,7 +119,7 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife delete -z -r /cookbooks/x works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(3).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("delete -z -r /cookbooks/x").should_succeed "Deleted /cookbooks/x\n"
           knife("list -z -Rfp /cookbooks").should_succeed ""
         end
@@ -157,7 +157,7 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife show -z /cookbooks/x/metadata.rb works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("show -z /cookbooks/x/metadata.rb").should_succeed "/cookbooks/x/metadata.rb:\n#{cookbook_x_100_metadata_rb}\n"
         end
 
@@ -193,7 +193,7 @@ describe "ChefFSDataStore tests", :workstation do
         end
 
         it "knife cookbook upload works" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("cookbook upload -z --cookbook-path #{path_to("cookbooks_to_upload")} x").should_succeed stderr: <<~EOM
             Uploading x              [1.0.0]
             Uploaded 1 cookbook.
@@ -446,7 +446,7 @@ describe "ChefFSDataStore tests", :workstation do
 
       context "GET /TYPE" do
         it "knife list -z -R returns everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("list -z -Rfp /").should_succeed <<~EOM
             /clients/
             /clients/x.json

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -41,7 +41,7 @@ describe "knife deps", :workstation do
         file "cookbooks/soup/recipes/chicken.rb", ""
       end
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /roles/starring.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -61,7 +61,7 @@ describe "knife deps", :workstation do
         file "cookbooks/soup/recipes/chicken.rb", ""
       end
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /roles/starring.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -96,7 +96,7 @@ describe "knife deps", :workstation do
         file "nodes/mort.json", { "run_list" => %w{role[minor] recipe[quiche] recipe[soup::chicken]} }
       end
       it "knife deps reports just the node" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/mort.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -111,7 +111,7 @@ describe "knife deps", :workstation do
         file "cookbooks/quiche/recipes/default.rb", ""
       end
       it "knife deps reports just the cookbook" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
         knife("deps /cookbooks/quiche").should_succeed "/cookbooks/quiche\n"
       end
     end
@@ -123,7 +123,7 @@ depends "kettle"'
         file "cookbooks/quiche/recipes/default.rb", ""
       end
       it "knife deps reports just the cookbook" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /cookbooks/quiche").should_succeed "/cookbooks/kettle\n/cookbooks/quiche\n"
       end
     end
@@ -153,7 +153,7 @@ depends "kettle"'
       end
 
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/mort.json").should_succeed <<~EOM
           /environments/desert.json
           /roles/minor.json
@@ -164,7 +164,7 @@ depends "kettle"'
         EOM
       end
       it "knife deps * reports all dependencies of all things" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/*").should_succeed <<~EOM
           /roles/minor.json
           /nodes/bart.json
@@ -176,7 +176,7 @@ depends "kettle"'
         EOM
       end
       it "knife deps a b reports all dependencies of a and b" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/bart.json /nodes/mort.json").should_succeed <<~EOM
           /roles/minor.json
           /nodes/bart.json
@@ -188,7 +188,7 @@ depends "kettle"'
         EOM
       end
       it "knife deps --tree /* shows dependencies in a tree" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).twice
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps --tree /nodes/*").should_succeed <<~EOM
           /nodes/bart.json
             /roles/minor.json
@@ -223,13 +223,13 @@ depends "foo"'
         end
 
         it "knife deps prints each once" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(3).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("deps /cookbooks/foo").should_succeed(
             stdout: "/cookbooks/baz\n/cookbooks/bar\n/cookbooks/foo\n"
           )
         end
         it "knife deps --tree prints each once" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(3).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("deps --tree /cookbooks/foo").should_succeed(
             stdout: "/cookbooks/foo\n  /cookbooks/bar\n    /cookbooks/baz\n      /cookbooks/foo\n"
           )

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -41,7 +41,6 @@ describe "knife deps", :workstation do
         file "cookbooks/soup/recipes/chicken.rb", ""
       end
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /roles/starring.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -61,7 +60,6 @@ describe "knife deps", :workstation do
         file "cookbooks/soup/recipes/chicken.rb", ""
       end
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /roles/starring.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -96,7 +94,6 @@ describe "knife deps", :workstation do
         file "nodes/mort.json", { "run_list" => %w{role[minor] recipe[quiche] recipe[soup::chicken]} }
       end
       it "knife deps reports just the node" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/mort.json").should_succeed <<~EOM
           /roles/minor.json
           /cookbooks/quiche
@@ -111,7 +108,6 @@ describe "knife deps", :workstation do
         file "cookbooks/quiche/recipes/default.rb", ""
       end
       it "knife deps reports just the cookbook" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
         knife("deps /cookbooks/quiche").should_succeed "/cookbooks/quiche\n"
       end
     end
@@ -123,7 +119,6 @@ depends "kettle"'
         file "cookbooks/quiche/recipes/default.rb", ""
       end
       it "knife deps reports just the cookbook" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /cookbooks/quiche").should_succeed "/cookbooks/kettle\n/cookbooks/quiche\n"
       end
     end
@@ -153,7 +148,6 @@ depends "kettle"'
       end
 
       it "knife deps reports all dependencies" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/mort.json").should_succeed <<~EOM
           /environments/desert.json
           /roles/minor.json
@@ -164,7 +158,6 @@ depends "kettle"'
         EOM
       end
       it "knife deps * reports all dependencies of all things" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/*").should_succeed <<~EOM
           /roles/minor.json
           /nodes/bart.json
@@ -176,7 +169,6 @@ depends "kettle"'
         EOM
       end
       it "knife deps a b reports all dependencies of a and b" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps /nodes/bart.json /nodes/mort.json").should_succeed <<~EOM
           /roles/minor.json
           /nodes/bart.json
@@ -188,7 +180,6 @@ depends "kettle"'
         EOM
       end
       it "knife deps --tree /* shows dependencies in a tree" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).twice
         knife("deps --tree /nodes/*").should_succeed <<~EOM
           /nodes/bart.json
             /roles/minor.json
@@ -223,13 +214,11 @@ depends "foo"'
         end
 
         it "knife deps prints each once" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("deps /cookbooks/foo").should_succeed(
             stdout: "/cookbooks/baz\n/cookbooks/bar\n/cookbooks/foo\n"
           )
         end
         it "knife deps --tree prints each once" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
           knife("deps --tree /cookbooks/foo").should_succeed(
             stdout: "/cookbooks/foo\n  /cookbooks/bar\n    /cookbooks/baz\n      /cookbooks/foo\n"
           )

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -197,7 +197,7 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x
@@ -217,7 +217,7 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload --no-diff adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload --no-diff /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x
@@ -494,7 +494,7 @@ describe "knife upload", :workstation do
         # technically we shouldn't have deleted missing files.  But ... cookbooks
         # are a special case.
         it "knife upload of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -504,7 +504,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --purge of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -520,7 +520,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -538,7 +538,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -554,7 +554,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --freeze freezes the cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --freeze /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -577,11 +577,11 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload fails to upload the frozen cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/frozencook").should_fail "ERROR: /cookbooks failed to write: Cookbook frozencook is frozen\n"
         end
         it "knife upload --force uploads the frozen cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --force /cookbooks/frozencook").should_succeed <<~EOM
             Updated /cookbooks/frozencook
           EOM
@@ -603,7 +603,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
@@ -641,7 +641,7 @@ describe "knife upload", :workstation do
             D\t/cookbooks/x/onlyin1.0.1.rb
             A\t/cookbooks/x/onlyin1.0.0.rb
           EOM
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -660,7 +660,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version generates metadata.json and uploads it." do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -676,7 +676,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version and generates metadata.json before upload and uploads it." do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
@@ -699,7 +699,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the new version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -802,7 +802,7 @@ describe "knife upload", :workstation do
           file "cookbooks/x/metadata.rb", cb_metadata("x", "1.0.0", "\nchef_version '~> 999.0'")
         end
         it "knife upload succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Created /cookbooks/x
           EOM
@@ -953,7 +953,7 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(3).times
+            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
             knife("upload /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x-1.0.0
@@ -1160,7 +1160,7 @@ describe "knife upload", :workstation do
         # technically we shouldn't have deleted missing files.  But ... cookbooks
         # are a special case.
         it "knife upload of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1168,7 +1168,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --purge of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1182,7 +1182,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1198,7 +1198,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1220,7 +1220,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x-1.0.0/onlyin1.0.0.rb
             D\t/cookbooks/x-1.0.1
@@ -1239,7 +1239,7 @@ describe "knife upload", :workstation do
           cookbook "x", "0.9.9", { "onlyin0.9.9.rb" => "hi" }
         end
         it "knife upload /cookbooks uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload --purge /cookbooks").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
             Deleted extra entry /cookbooks/x-0.9.9 (purge is on)
@@ -1254,7 +1254,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             D\t/cookbooks/x-1.0.1
             A\t/cookbooks/x-1.0.0
@@ -1273,7 +1273,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the new version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload --purge /cookbooks").should_succeed <<~EOM
             Created /cookbooks/x-1.0.0
             Deleted extra entry /cookbooks/x-0.9.9 (purge is on)
@@ -1348,7 +1348,7 @@ describe "knife upload", :workstation do
           file "cookbooks/x-1.0.0/metadata.rb", cb_metadata("x", "1.0.0", "\nchef_version '~> 999.0'")
         end
         it "knife upload succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).once
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Created /cookbooks/x-1.0.0
           EOM
@@ -1412,7 +1412,7 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload / uploads everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /").should_succeed <<~EOM
             Updated /acls/groups/blah.json
             Created /clients/x.json
@@ -1520,7 +1520,7 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload updates everything" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/).at_least(2).times
+            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload /").should_succeed <<~EOM
               Updated /acls/groups/blah.json
               Updated /clients/x.json

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -178,7 +178,7 @@ describe "knife upload", :workstation do
             file "cookbooks/x/metadata.rb", "name 'x'; version '1.0.0'; depends 'x'"
           end
 
-          it "should fail in Chef 13" do
+          it "fails with RuntimeError" do
             expect { knife("upload /cookbooks") }.to raise_error RuntimeError, /Cookbook depends on itself/
           end
         end
@@ -197,7 +197,6 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x
@@ -217,7 +216,6 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload --no-diff adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload --no-diff /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x
@@ -494,7 +492,6 @@ describe "knife upload", :workstation do
         # technically we shouldn't have deleted missing files.  But ... cookbooks
         # are a special case.
         it "knife upload of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -504,7 +501,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --purge of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -520,7 +516,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -538,7 +533,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -554,7 +548,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --freeze freezes the cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --freeze /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -577,11 +570,9 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload fails to upload the frozen cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/frozencook").should_fail "ERROR: /cookbooks failed to write: Cookbook frozencook is frozen\n"
         end
         it "knife upload --force uploads the frozen cookbook" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --force /cookbooks/frozencook").should_succeed <<~EOM
             Updated /cookbooks/frozencook
           EOM
@@ -603,7 +594,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
@@ -641,7 +631,6 @@ describe "knife upload", :workstation do
             D\t/cookbooks/x/onlyin1.0.1.rb
             A\t/cookbooks/x/onlyin1.0.0.rb
           EOM
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -660,7 +649,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version generates metadata.json and uploads it." do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -676,7 +664,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version and generates metadata.json before upload and uploads it." do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x/metadata.rb
             D\t/cookbooks/x/onlyin1.0.1.rb
@@ -699,7 +686,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the new version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload --purge /cookbooks/x").should_succeed <<~EOM
             Updated /cookbooks/x
           EOM
@@ -802,7 +788,6 @@ describe "knife upload", :workstation do
           file "cookbooks/x/metadata.rb", cb_metadata("x", "1.0.0", "\nchef_version '~> 999.0'")
         end
         it "knife upload succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /cookbooks/x").should_succeed <<~EOM
             Created /cookbooks/x
           EOM
@@ -953,7 +938,6 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload adds the new files" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(3).times
             knife("upload /").should_succeed <<~EOM
               Created /clients/y.json
               Updated /cookbooks/x-1.0.0
@@ -1160,7 +1144,6 @@ describe "knife upload", :workstation do
         # technically we shouldn't have deleted missing files.  But ... cookbooks
         # are a special case.
         it "knife upload of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1168,7 +1151,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload --purge of the cookbook itself succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1182,7 +1164,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1198,7 +1179,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload of the cookbook succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
           EOM
@@ -1220,7 +1200,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             M\t/cookbooks/x-1.0.0/onlyin1.0.0.rb
             D\t/cookbooks/x-1.0.1
@@ -1239,7 +1218,6 @@ describe "knife upload", :workstation do
           cookbook "x", "0.9.9", { "onlyin0.9.9.rb" => "hi" }
         end
         it "knife upload /cookbooks uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload --purge /cookbooks").should_succeed <<~EOM
             Updated /cookbooks/x-1.0.0
             Deleted extra entry /cookbooks/x-0.9.9 (purge is on)
@@ -1254,7 +1232,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the local version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("diff --name-status /cookbooks").should_succeed <<~EOM
             D\t/cookbooks/x-1.0.1
             A\t/cookbooks/x-1.0.0
@@ -1273,7 +1250,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload /cookbooks/x uploads the new version" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload --purge /cookbooks").should_succeed <<~EOM
             Created /cookbooks/x-1.0.0
             Deleted extra entry /cookbooks/x-0.9.9 (purge is on)
@@ -1348,7 +1324,6 @@ describe "knife upload", :workstation do
           file "cookbooks/x-1.0.0/metadata.rb", cb_metadata("x", "1.0.0", "\nchef_version '~> 999.0'")
         end
         it "knife upload succeeds" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).once
           knife("upload /cookbooks/x-1.0.0").should_succeed <<~EOM
             Created /cookbooks/x-1.0.0
           EOM
@@ -1412,7 +1387,6 @@ describe "knife upload", :workstation do
         end
 
         it "knife upload / uploads everything" do
-          expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
           knife("upload /").should_succeed <<~EOM
             Updated /acls/groups/blah.json
             Created /clients/x.json
@@ -1520,7 +1494,6 @@ describe "knife upload", :workstation do
           end
 
           it "knife upload updates everything" do
-            expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./).at_least(2).times
             knife("upload /").should_succeed <<~EOM
               Updated /acls/groups/blah.json
               Updated /clients/x.json

--- a/spec/unit/cookbook/cookbook_version_loader_spec.rb
+++ b/spec/unit/cookbook/cookbook_version_loader_spec.rb
@@ -125,7 +125,6 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning called with #load and raise error for Cookbook not found" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error(Chef::Exceptions::CookbookNotFoundInRepo)
       end
 
@@ -150,7 +149,6 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning to us load!  when called with #load and raises error" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error("THIS METADATA HAS A BUG")
       end
 
@@ -183,7 +181,6 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning to use load! method when called with #load and raises error for invalid metadata" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error(Chef::Exceptions::MetadataNotValid, error_message)
       end
 

--- a/spec/unit/cookbook/cookbook_version_loader_spec.rb
+++ b/spec/unit/cookbook/cookbook_version_loader_spec.rb
@@ -125,7 +125,7 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning called with #load and raise error for Cookbook not found" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/)
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error(Chef::Exceptions::CookbookNotFoundInRepo)
       end
 
@@ -150,7 +150,7 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning to us load!  when called with #load and raises error" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/)
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error("THIS METADATA HAS A BUG")
       end
 
@@ -183,7 +183,7 @@ describe Chef::Cookbook::CookbookVersionLoader do
       end
 
       it "gives deprecation warning to use load! method when called with #load and raises error for invalid metadata" do
-        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Use load! instead/)
+        expect(Chef::Log).to receive(:warn).with(/load method is deprecated. Please use load! instead./)
         expect { cookbook_loader.load }.to raise_error(Chef::Exceptions::MetadataNotValid, error_message)
       end
 


### PR DESCRIPTION
Avoid load method deprecation warnings in knife that were introduced with the release of 15.7.30. Backported from Chef 16