### PR TITLE
mac_user: fixing gid and system properties, and adding hidden property

### DIFF
--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -51,7 +51,10 @@ class Chef
             current_resource.home(user_plist[:home][0])
             current_resource.shell(user_plist[:shell][0])
             current_resource.comment(user_plist[:comment][0])
-            current_resource.hidden(user_plist[:is_hidden][0] == "1" ? true : false)
+
+            if user_plist[:is_hidden]
+              current_resource.hidden(user_plist[:is_hidden][0] == "1" ? true : false)
+            end
 
             shadow_hash = user_plist[:shadow_hash]
             if shadow_hash

--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -428,9 +428,7 @@ class Chef
           return false unless prop_is_set?(:gid)
 
           group_name, group_id = user_group_info
-
           current_resource.gid != group_id.to_i
-          end
         end
 
         def password_diverged?

--- a/lib/chef/resource/user/mac_user.rb
+++ b/lib/chef/resource/user/mac_user.rb
@@ -101,7 +101,7 @@ class Chef
         property :admin, [TrueClass, FalseClass], description: "Create the user as an admin", default: false
 
         # Hide a user account in the macOS login window
-        property :hidden, [TrueClass, FalseClass], description: "Hide account from loginwindow and system preferences", default: false
+        property :hidden, [TrueClass, FalseClass, nil], description: "Hide account from loginwindow and system preferences", default: nil
 
         # TCC on macOS >= 10.14 requires admin credentials of an Admin user that
         # has SecureToken enabled in order to toggle SecureToken.

--- a/lib/chef/resource/user/mac_user.rb
+++ b/lib/chef/resource/user/mac_user.rb
@@ -100,6 +100,9 @@ class Chef
 
         property :admin, [TrueClass, FalseClass], description: "Create the user as an admin", default: false
 
+        # Hide a user account in the macOS login window
+        property :hidden, [TrueClass, FalseClass], description: "Hide account from loginwindow and system preferences", default: false
+
         # TCC on macOS >= 10.14 requires admin credentials of an Admin user that
         # has SecureToken enabled in order to toggle SecureToken.
         property :admin_username, String, description: "Admin username for superuser actions"


### PR DESCRIPTION
Goals:
- `mac_user` provider will now use the numeric GID when creating a user, instead of passing what was literally in the resource (e.g. it will use 80 instead of "admin")
- brings back support for `system true` from the old `dscl` provider.
- adds support for new property `hidden` which will set the `IsHidden` value in the user plist.

## Description
The GID will fix issues where the system does not recognize the user (for `chown` operations, or `id`, etc)

The `system: true` works, but there are still macOS quirks. For instance, if you run chef manually in terminal, you'll be prompted to give Terminal.app privacy protection rights to be able to set the UID.  When run via launchd, which is how most orgs would use chef, macOS just ignores the UID you pass and pulls its own (usually starting at 502 and going up to the next available one). This seems to be a limitation in the `sysadminctl` tool itself, in conjunction with the added privacy protections around updating a UID for a user. The fix for this behavior would involve signing chef (or chef's ruby) and whitelisting it for `SystemPolicySysAdminFiles` via MDM.

Since what most of us are interested in is not specifically assigning a UID under 500 (which Apple doesn't even support), I'm also adding in support to this resource for the `IsHidden` dscl attribute. Setting this to `1` (which, apple terms, means "true"), the account will not show up in System Prefs or at the Login Window. 

## Related Issue
#9171

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
