### PR TITLE
Fix fuzzy node search to work when the search type is a string rather than a symbol

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if type == :node
+          if [:node, 'node'].include?(type)
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if [:node, 'node'].include?(type)
+          if [:node, "node"].include?(type)
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if [:node, "node"].include?(type)
+          if type.to_sym == :node
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -244,7 +244,7 @@ describe Chef::Search::Query do
       expect(rest).to receive(:get).with(
         "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
       ).and_return(response)
-      query.search('node', "free.messi", fuzz: true)
+      query.search("node", "free.messi", fuzz: true)
     end
 
     it "does not fuzzify node searches when fuzz is not set" do

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -233,11 +233,18 @@ describe Chef::Search::Query do
       end
     end
 
-    it "fuzzifies node searches when fuzz is set" do
+    it "fuzzifies node searches when fuzz is set and type is a symbol" do
       expect(rest).to receive(:get).with(
         "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
       ).and_return(response)
       query.search(:node, "free.messi", fuzz: true)
+    end
+
+    it "fuzzifies node searches when fuzz is set and type is a string" do
+      expect(rest).to receive(:get).with(
+        "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
+      ).and_return(response)
+      query.search('node', "free.messi", fuzz: true)
     end
 
     it "does not fuzzify node searches when fuzz is not set" do


### PR DESCRIPTION
## Description
The knife CLI calls search with a `type` of `'node'` (a string) for node searches (or searches where the index is unspecified). The `if` statement here only checks for the symbol `:node` which meant that fuzzy searches from the knife CLI did not work.

This fixes the issue by checking if the type is  `:node` or `'node'`. I'm not sure if there's a preference to check this way or to just coerce it to a symbol beforehand. 

## Related Issue
[#9285 - Knife cli fuzzy search does not work as documented](https://github.com/chef/chef/issues/9285)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
