### PR TITLE
apt_repository: add a description for components when using a PPA

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -120,7 +120,7 @@ class Chef
 
       property :components, Array,
         description: "Package groupings, such as 'main' and 'stable'.",
-        default: lazy { [] }
+        default: lazy { [] }, default_description: "'main' if using a PPA repository."
 
       property :arch, [String, nil, FalseClass],
         description: "Constrain packages to a particular CPU architecture such as 'i386' or 'amd64'."


### PR DESCRIPTION
When you're using a PPA there's a default here that doesn't apply to non-PPA repos.

Signed-off-by: Tim Smith <tsmith@chef.io>