### PR TITLE
Remove the sites-cookbooks dir from the cookbook_path default config

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -272,15 +272,8 @@ module ChefConfig
 
     # Location of cookbooks on disk. String or array of strings.
     # Defaults to <chef_repo_path>/cookbooks.  If chef_repo_path
-    # is not specified, this is set to [/var/chef/cookbooks, /var/chef/site-cookbooks]).
-    default(:cookbook_path) do
-      if configuration[:chef_repo_path]
-        derive_path_from_chef_repo_path("cookbooks")
-      else
-        Array(derive_path_from_chef_repo_path("cookbooks")).flatten +
-          Array(derive_path_from_chef_repo_path("site-cookbooks")).flatten
-      end
-    end
+    # is not specified, this is set to /var/chef/cookbooks.
+    default(:cookbook_path) { derive_path_from_chef_repo_path("cookbooks") }
 
     # Location of data bags on disk. String or array of strings.
     # Defaults to <chef_repo_path>/data_bags.


### PR DESCRIPTION
sites-cookbooks was the way to build out your Chef infrastructure circa
2010, but was long ago removed from documentation and we've slowly
killed off bits of the functionality like the merging.

Fixed #9123 

Signed-off-by: Tim Smith <tsmith@chef.io>