### PR TITLE
Remove DK wording from knife warning

### DIFF
--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -284,7 +284,7 @@ class Chef
         elsif category_commands = guess_category(args)
           list_commands(category_commands)
         elsif OFFICIAL_PLUGINS.include?(args[0]) # command was an uninstalled official chef knife plugin
-          ui.info("Use `#{Chef::Dist::EXEC} gem install knife-#{args[0]}` to install the plugin into ChefDK / Chef Workstation")
+          ui.info("Use `#{Chef::Dist::EXEC} gem install knife-#{args[0]}` to install the plugin into Chef Workstation")
         else
           list_commands
         end


### PR DESCRIPTION
We won't have a DK when we have Chef 16 so this shouldn't be there.

Signed-off-by: Tim Smith <tsmith@chef.io>