### PR TITLE
revert to "chef"

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -471,7 +471,7 @@ module ChefConfig
       # When set to a String, Chef Zero disables multitenant support.  This is
       # what you want when using Chef Zero to serve a single Chef Repo. Setting
       # this to `false` enables multi-tenant.
-      default :single_org, ChefConfig::Dist::SHORT
+      default :single_org, "chef"
 
       # Whether Chef Zero should operate in a mode analogous to OSS Chef Server
       # 11 (true) or Chef Server 12 (false). Chef Zero can still serve


### PR DESCRIPTION
Signed-off-by: Marc Chamberland <chamberland.marc@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Distros like Cinc are unable to use chef-zero as it hardcodes the `single_org` parameter to be "chef". While we currently patch it, this PR would bring the change upstream so everyone can benefit from it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [NA] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
