### PR TITLE
Add chef-sugar include_recipe? helper

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -146,6 +146,7 @@ Architecture Helpers allow you to determine the processor architecture of your n
 * `systemd?` - if the init system is systemd
 * `kitchen?` - if ENV['TEST_KITCHEN'] is set
 * `ci?` - if ENV['CI'] is set
+* `include_recipe?(recipe_name)` - if the `recipe_name` is in the run list, the expanded run list, or has been `include_recipe`'d.
 
 ### Service Helpers
 

--- a/chef-utils/lib/chef-utils/dsl/introspection.rb
+++ b/chef-utils/lib/chef-utils/dsl/introspection.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018-2019, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,17 @@ module ChefUtils
           file_exist?("#{load_path}/systemd/system/#{svc_name}")
         end
       end
+
+      # Determine if the current node includes the given recipe name.
+      #
+      # @param [String] recipe_name
+      #
+      # @return [Boolean]
+      #
+      def includes_recipe?(recipe_name, node = __getnode)
+        node.recipe?(recipe_name)
+      end
+      alias_method :include_recipe?, :includes_recipe?
 
       extend self
     end

--- a/chef-utils/spec/unit/dsl/introspection_spec.rb
+++ b/chef-utils/spec/unit/dsl/introspection_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018-2019, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,6 +163,25 @@ RSpec.describe ChefUtils::DSL::Introspection do
         expect(File).to receive(:exist?).with("#{base}/systemd/system/example.mount").and_return(true)
         expect(ChefUtils.has_systemd_unit?("example.mount")).to be true
       end
+    end
+  end
+
+  context "#include_recipe?" do
+    it "is true when the recipe has been seen by the node" do
+      expect(node).to receive(:recipe?).with("myrecipe").and_return(true)
+      expect(ChefUtils.include_recipe?("myrecipe", node)).to be true
+    end
+    it "is false when the recipe has not been seen by the node" do
+      expect(node).to receive(:recipe?).with("myrecipe").and_return(false)
+      expect(ChefUtils.include_recipe?("myrecipe", node)).to be false
+    end
+    it "the alias is true when the recipe has been seen by the node" do
+      expect(node).to receive(:recipe?).with("myrecipe").and_return(true)
+      expect(ChefUtils.includes_recipe?("myrecipe", node)).to be true
+    end
+    it "the alias is false when the recipe has not been seen by the node" do
+      expect(node).to receive(:recipe?).with("myrecipe").and_return(false)
+      expect(ChefUtils.includes_recipe?("myrecipe", node)).to be false
     end
   end
 end


### PR DESCRIPTION
The two argument version of this needed to have its arguments reversed to make the node optional (this is hopefully incredibly unlikely to be used, but a necessary API break).