### PR TITLE
Add windows_nt_version and powershell_version helpers to chef-utils

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/windows.rb
+++ b/chef-utils/lib/chef-utils/dsl/windows.rb
@@ -20,6 +20,8 @@ require_relative "../internal"
 module ChefUtils
   module DSL
     module Windows
+      require "chef-utils/version_string"
+
       include Internal
 
       # Determine if the current node is Windows Server Core.
@@ -50,6 +52,26 @@ module ChefUtils
       #
       def windows_server?(node = __getnode)
         node["kernel"]["product_type"] == "Server"
+      end
+
+      # Determine the current Windows NT version. The NT version often differs from the marketing version, but offers a good way to find desktop and server releases that are based on the same codebase. IE: NT 6.3 is Windows 8.1 and Windows 2012 R2.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [ChefUtils::VersionString]
+      #
+      def windows_nt_version(node = __getnode)
+        ChefUtils::VersionString.new(node["os_version"])
+      end
+
+      # Determine the installed version of PowerShell
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [ChefUtils::VersionString]
+      #
+      def powershell_version(node = __getnode)
+        ChefUtils::VersionString.new(node["languages"]["powershell"]["version"])
       end
 
       extend self


### PR DESCRIPTION
Backport #9297 

These both return version objects which means they can be compared without creating version objects first or .to_i / .to_f messes. Much simpler for users.

Signed-off-by: Tim Smith <tsmith@chef.io>