### PR TITLE
Fix fuzzy node search to work when the search type is a string rather than a symbol

### DIFF
--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if type == :node
+          if [:node, 'node'].include?(type)
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if [:node, 'node'].include?(type)
+          if [:node, "node"].include?(type)
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/lib/chef/search/query.rb
+++ b/lib/chef/search/query.rb
@@ -63,7 +63,7 @@ class Chef
 
         args_h = hashify_args(*args)
         if args_h[:fuzz]
-          if [:node, "node"].include?(type)
+          if type.to_sym == :node
             query = fuzzify_node_query(query)
           end
           # FIXME: can i haz proper ruby-2.x named parameters someday plz?

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -244,7 +244,7 @@ describe Chef::Search::Query do
       expect(rest).to receive(:get).with(
         "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
       ).and_return(response)
-      query.search('node', "free.messi", fuzz: true)
+      query.search("node", "free.messi", fuzz: true)
     end
 
     it "does not fuzzify node searches when fuzz is not set" do

--- a/spec/unit/search/query_spec.rb
+++ b/spec/unit/search/query_spec.rb
@@ -233,11 +233,18 @@ describe Chef::Search::Query do
       end
     end
 
-    it "fuzzifies node searches when fuzz is set" do
+    it "fuzzifies node searches when fuzz is set and type is a symbol" do
       expect(rest).to receive(:get).with(
         "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
       ).and_return(response)
       query.search(:node, "free.messi", fuzz: true)
+    end
+
+    it "fuzzifies node searches when fuzz is set and type is a string" do
+      expect(rest).to receive(:get).with(
+        "search/node?q=tags:*free.messi*%20OR%20roles:*free.messi*%20OR%20fqdn:*free.messi*%20OR%20addresses:*free.messi*%20OR%20policy_name:*free.messi*%20OR%20policy_group:*free.messi*&start=0&rows=#{default_rows}"
+      ).and_return(response)
+      query.search('node', "free.messi", fuzz: true)
     end
 
     it "does not fuzzify node searches when fuzz is not set" do


### PR DESCRIPTION
Backport https://github.com/chef/chef/pull/9287