### PR TITLE
Add chef-sugar virtualization helpers

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -148,8 +148,8 @@ Architecture Helpers allow you to determine the processor architecture of your n
 * `openvz?` - if the node is an openvz guest
 * `openvz_host?` - if the node is an openvz host
 * `guest?` - if the node is detected as any kind of guest
-* `virtual_host?` - if the node is detected as being any kind of virtual host
-* `physical?` - strictly the logical opposite of `guest?`
+* `hypervisor?` - if the node is detected as being any kind of hypervisor
+* `physical?` - the node is not running as a guest (may be a hypervisor or may be plain metal)
 * `vagrant?` - attempts to identify the node as a vagrant guest (this check may be error prone)
 
 ### Train Helpers

--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -135,14 +135,15 @@ Architecture Helpers allow you to determine the processor architecture of your n
 
 ### Virtualization Helpers
 
-* `kvm?` - if the node is a kvm guest
-* `lxc?` - if the node is an lxc guest
-* `parallels?`- if the node is a parallels guest
-* `vbox?` - if the node is a virtualbox guest
-* `vmware?` - if the node is a vmware guest
-* `openvz?` - if the node is an openvz guest
-* `virtual?` - if any of the above are true (guest of any detected virtualization system)
-* `physical?` - strictly the logical opposite of `virtual?`
+* `kvm?` - if the node is a kvm (guest or host)
+* `lxc?` - if the node is an lxc (guest or host)
+* `parallels?`- if the node is a parallels (guest or host)
+* `vbox?` - if the node is a virtualbox (guest or host)
+* `vmware?` - if the node is a vmware (guest or host)
+* `openvz?` - if the node is an openvz (guest or host)
+* `guest?` - if the node is detected as any kind of guest
+* `virtual_host?` - if the node is detected as being any kind of virtual host
+* `physical?` - strictly the logical opposite of `guest?`
 * `vagrant?` - attempts to identify the node as a vagrant guest (this check may be error prone)
 
 ### Train Helpers

--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -133,6 +133,18 @@ Architecture Helpers allow you to determine the processor architecture of your n
 * `digital_ocean?` - if the node is running in digital ocean
 * `softlayer?` - if the node is running in softlayer
 
+### Virtualization Helpers
+
+* `kvm?` - if the node is a kvm guest
+* `lxc?` - if the node is an lxc guest
+* `parallels?`- if the node is a parallels guest
+* `vbox?` - if the node is a virtualbox guest
+* `vmware?` - if the node is a vmware guest
+* `openvz?` - if the node is an openvz guest
+* `virtual?` - if any of the above are true (guest of any detected virtualization system)
+* `physical?` - strictly the logical opposite of `virtual?`
+* `vagrant?` - attempts to identify the node as a vagrant guest (this check may be error prone)
+
 ### Train Helpers
 
 **EXPERIMENTAL**: APIs may have breaking changes any time without warning

--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -135,12 +135,18 @@ Architecture Helpers allow you to determine the processor architecture of your n
 
 ### Virtualization Helpers
 
-* `kvm?` - if the node is a kvm (guest or host)
-* `lxc?` - if the node is an lxc (guest or host)
-* `parallels?`- if the node is a parallels (guest or host)
-* `vbox?` - if the node is a virtualbox (guest or host)
-* `vmware?` - if the node is a vmware (guest or host)
-* `openvz?` - if the node is an openvz (guest or host)
+* `kvm?` - if the node is a kvm guest
+* `kvm_host?` - if the node is a kvm host
+* `lxc?` - if the node is an lxc guest
+* `lxc_host?` - if the node is an lxc host
+* `parallels?`- if the node is a parallels guest
+* `parallels_host?`- if the node is a parallels host
+* `vbox?` - if the node is a virtualbox guest
+* `vbox_host?` - if the node is a virtualbox host
+* `vmware?` - if the node is a vmware guest
+* `vmware_host?` - if the node is a vmware host
+* `openvz?` - if the node is an openvz guest
+* `openvz_host?` - if the node is an openvz host
 * `guest?` - if the node is detected as any kind of guest
 * `virtual_host?` - if the node is detected as being any kind of virtual host
 * `physical?` - strictly the logical opposite of `guest?`

--- a/chef-utils/lib/chef-utils.rb
+++ b/chef-utils/lib/chef-utils.rb
@@ -24,11 +24,12 @@ require_relative "chef-utils/dsl/platform"
 require_relative "chef-utils/dsl/platform_family"
 require_relative "chef-utils/dsl/service"
 require_relative "chef-utils/dsl/train_helpers"
+require_relative "chef-utils/dsl/virtualization"
 require_relative "chef-utils/dsl/which"
 require_relative "chef-utils/dsl/windows"
 require_relative "chef-utils/mash"
 
-# This is the Chef Infra Client DSL, not everytihng needs to go in here
+# This is the Chef Infra Client DSL, not everything needs to go in here
 module ChefUtils
   include ChefUtils::DSL::Architecture
   include ChefUtils::DSL::Cloud
@@ -38,6 +39,7 @@ module ChefUtils
   include ChefUtils::DSL::Platform
   include ChefUtils::DSL::PlatformFamily
   include ChefUtils::DSL::TrainHelpers
+  include ChefUtils::DSL::Virtualization
   include ChefUtils::DSL::Which
   include ChefUtils::DSL::Windows
   # ChefUtils::DSL::Service is deliberately excluded

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -94,11 +94,23 @@ module ChefUtils
       #
       # @return [Boolean]
       #
-      def virtual?(node = __getnode)
-        openvz?(node) || vmware?(node) || virtualbox?(node) || parallels?(node) || lxc?(node) || kvm?(node)
+      def guest?(node = __getnode)
+        node.dig("virtualization", "role") == "guest"
       end
 
-      # Determine if the current node is NOT running under any virutalization environment
+      alias_method :virtual?, :guest?
+
+      # Determine if the current node is running under any virutalization environment
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def virtual_host?(node = __getnode)
+        node.dig("virtualization", "role") == "host"
+      end
+
+      # Determine if the current node is NOT running under any virutalization environment (virtual hosts or just plain on metal)
       #
       # @param [Chef::Node] node
       #

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -1,0 +1,159 @@
+#
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../internal"
+
+module ChefUtils
+  module DSL
+    module Virtualization
+      include Internal
+
+      # Determine if the current node is running under KVM.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def kvm?(node = __getnode)
+        node.dig("virtualization", "system") == "kvm"
+      end
+
+      # Determine if the current node is running in a linux container.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def lxc?(node = __getnode)
+        node.dig("virtualization", "system") == "lxc"
+      end
+
+      #
+      # Determine if the current node is running under Parallels Desktop.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #   true if the machine is currently running under Parallels Desktop, false
+      #   otherwise
+      #
+      def parallels?(node = __getnode)
+        node.dig("virtualization", "system") == "parallels"
+      end
+
+      # Determine if the current node is running under VirtualBox.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vbox?(node = __getnode)
+        node.dig("virtualization", "system") == "vbox"
+      end
+
+      alias_method :virtualbox?, :vbox?
+
+      #
+      # Determine if the current node is running under VMware.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vmware?(node = __getnode)
+        node.dig("virtualization", "system") == "vmware"
+      end
+
+      # Determine if the current node is running under openvz.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def openvz?(node = __getnode)
+        node.dig("virtualization", "system") == "openvz"
+      end
+
+      # Determine if the current node is running under any virutalization environment
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def virtual?(node = __getnode)
+        openvz?(node) || vmware?(node) || virtualbox?(node) || parallels?(node) || lxc?(node) || kvm?(node)
+      end
+
+      # Determine if the current node is NOT running under any virutalization environment
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def physical?(node = __getnode)
+        !virtual?(node)
+      end
+
+      # Determine if the current node is running in vagrant mode.
+      #
+      # Note that this API is equivalent to just looking for the vagrant user or the
+      # vagrantup.com domain in the hostname, which is the best API we have.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #   true if the machine is currently running vagrant, false
+      #   otherwise
+      #
+      def vagrant?(node = __getnode)
+        vagrant_key?(node) || vagrant_domain?(node) || vagrant_user?(node)
+      end
+
+      private
+
+      # Check if the +vagrant+ key exists on the +node+ object. This key is no
+      # longer populated by vagrant, but it is kept around for legacy purposes.
+      #
+      # @param (see vagrant?)
+      # @return (see vagrant?)
+      #
+      def vagrant_key?(node = __getnode)
+        node.key?("vagrant")
+      end
+
+      # Check if "vagrantup.com" is included in the node's domain.
+      #
+      # @param (see vagrant?)
+      # @return (see vagrant?)
+      #
+      def vagrant_domain?(node = __getnode)
+        node.key?("domain") && !node["domain"].nil? && node["domain"].include?("vagrantup.com")
+      end
+
+      # Check if the system contains a +vagrant+ user.
+      #
+      # @param (see vagrant?)
+      # @return (see vagrant?)
+      #
+      def vagrant_user?(node = __getnode)
+        !!(Etc.getpwnam("vagrant") rescue nil)
+      end
+
+      extend self
+    end
+  end
+end

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -160,17 +160,17 @@ module ChefUtils
 
       alias_method :virtual?, :guest?
 
-      # Determine if the current node is running under any virutalization environment
+      # Determine if the current node supports running guests under any virtualization environment
       #
       # @param [Chef::Node] node
       #
       # @return [Boolean]
       #
-      def virtual_host?(node = __getnode)
+      def hypervisor?(node = __getnode)
         node.dig("virtualization", "role") == "host"
       end
 
-      # Determine if the current node is NOT running under any virutalization environment (virtual hosts or just plain on metal)
+      # Determine if the current node is NOT running under any virtualization environment (plain metal or hypervisor on metal)
       #
       # @param [Chef::Node] node
       #

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -22,14 +22,24 @@ module ChefUtils
     module Virtualization
       include Internal
 
-      # Determine if the current node is running under KVM.
+      # Determine if the current node is a KVM guest.
       #
       # @param [Chef::Node] node
       #
       # @return [Boolean]
       #
       def kvm?(node = __getnode)
-        node.dig("virtualization", "system") == "kvm"
+        node.dig("virtualization", "system") == "kvm" && node.dig("virtualization", "role") == "guest"
+      end
+
+      # Determine if the current node is a KVM host.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def kvm_host?(node = __getnode)
+        node.dig("virtualization", "system") == "kvm" && node.dig("virtualization", "role") == "host"
       end
 
       # Determine if the current node is running in a linux container.
@@ -39,10 +49,19 @@ module ChefUtils
       # @return [Boolean]
       #
       def lxc?(node = __getnode)
-        node.dig("virtualization", "system") == "lxc"
+        node.dig("virtualization", "system") == "lxc" && node.dig("virtualization", "role") == "guest"
       end
 
+      # Determine if the current node is a linux container host.
       #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def lxc_host?(node = __getnode)
+        node.dig("virtualization", "system") == "lxc" && node.dig("virtualization", "role") == "host"
+      end
+
       # Determine if the current node is running under Parallels Desktop.
       #
       # @param [Chef::Node] node
@@ -52,40 +71,81 @@ module ChefUtils
       #   otherwise
       #
       def parallels?(node = __getnode)
-        node.dig("virtualization", "system") == "parallels"
+        node.dig("virtualization", "system") == "parallels" && node.dig("virtualization", "role") == "guest"
       end
 
-      # Determine if the current node is running under VirtualBox.
+      # Determine if the current node is a Parallels Desktop host.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #   true if the machine is currently running under Parallels Desktop, false
+      #   otherwise
+      #
+      def parallels_host?(node = __getnode)
+        node.dig("virtualization", "system") == "parallels" && node.dig("virtualization", "role") == "host"
+      end
+
+      # Determine if the current node is a VirtualBox guest.
       #
       # @param [Chef::Node] node
       #
       # @return [Boolean]
       #
       def vbox?(node = __getnode)
-        node.dig("virtualization", "system") == "vbox"
+        node.dig("virtualization", "system") == "vbox" && node.dig("virtualization", "role") == "guest"
+      end
+
+      # Determine if the current node is a VirtualBox host.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vbox_host?(node = __getnode)
+        node.dig("virtualization", "system") == "vbox" && node.dig("virtualization", "role") == "host"
       end
 
       alias_method :virtualbox?, :vbox?
 
-      #
-      # Determine if the current node is running under VMware.
+      # Determine if the current node is a VMWare guest.
       #
       # @param [Chef::Node] node
       #
       # @return [Boolean]
       #
       def vmware?(node = __getnode)
-        node.dig("virtualization", "system") == "vmware"
+        node.dig("virtualization", "system") == "vmware" && node.dig("virtualization", "role") == "guest"
       end
 
-      # Determine if the current node is running under openvz.
+      # Determine if the current node is VMware host.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def vmware_host?(node = __getnode)
+        node.dig("virtualization", "system") == "vmware" && node.dig("virtualization", "role") == "host"
+      end
+
+      # Determine if the current node is an openvz guest.
       #
       # @param [Chef::Node] node
       #
       # @return [Boolean]
       #
       def openvz?(node = __getnode)
-        node.dig("virtualization", "system") == "openvz"
+        node.dig("virtualization", "system") == "openvz" && node.dig("virtualization", "role") == "guest"
+      end
+
+      # Determine if the current node is an openvz host.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [Boolean]
+      #
+      def openvz_host?(node = __getnode)
+        node.dig("virtualization", "system") == "openvz" && node.dig("virtualization", "role") == "host"
       end
 
       # Determine if the current node is running under any virutalization environment
@@ -120,7 +180,7 @@ module ChefUtils
         !virtual?(node)
       end
 
-      # Determine if the current node is running in vagrant mode.
+      # Determine if the current node is running as a vagrant guest.
       #
       # Note that this API is equivalent to just looking for the vagrant user or the
       # vagrantup.com domain in the hostname, which is the best API we have.

--- a/chef-utils/spec/spec_helper.rb
+++ b/chef-utils/spec/spec_helper.rb
@@ -10,17 +10,19 @@ HELPER_MODULES = [
   ChefUtils::DSL::Platform,
   ChefUtils::DSL::PlatformFamily,
   ChefUtils::DSL::Service,
+  ChefUtils::DSL::Virtualization,
   ChefUtils::DSL::Which,
   ChefUtils::DSL::Windows,
 ].freeze
 
 ARCH_HELPERS = (ChefUtils::DSL::Architecture.methods - Module.methods).freeze
-OS_HELPERS = (ChefUtils::DSL::OS.methods - Module.methods).freeze
-PLATFORM_HELPERS = (ChefUtils::DSL::Platform.methods - Module.methods).freeze
-PLATFORM_FAMILY_HELPERS = (ChefUtils::DSL::PlatformFamily.methods - Module.methods).freeze
-INTROSPECTION_HELPERS = (ChefUtils::DSL::Introspection.methods - Module.methods).freeze
-WINDOWS_HELPERS = (ChefUtils::DSL::Windows.methods - Module.methods).freeze
 CLOUD_HELPERS = (ChefUtils::DSL::Cloud.methods - Module.methods).freeze
+INTROSPECTION_HELPERS = (ChefUtils::DSL::Introspection.methods - Module.methods).freeze
+OS_HELPERS = (ChefUtils::DSL::OS.methods - Module.methods).freeze
+PLATFORM_FAMILY_HELPERS = (ChefUtils::DSL::PlatformFamily.methods - Module.methods).freeze
+PLATFORM_HELPERS = (ChefUtils::DSL::Platform.methods - Module.methods).freeze
+VIRTUALIZATION_HELPERS = (ChefUtils::DSL::Virtualization.methods - Module.methods).freeze
+WINDOWS_HELPERS = (ChefUtils::DSL::Windows.methods - Module.methods).freeze
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/chef-utils/spec/unit/dsl/virtualization_spec.rb
+++ b/chef-utils/spec/unit/dsl/virtualization_spec.rb
@@ -45,24 +45,30 @@ RSpec.describe ChefUtils::DSL::Virtualization do
   end
 
   context "on kvm" do
-    virtualization_reports_true_for(:virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm",  "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :kvm?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })
   end
   context "on lxc" do
-    virtualization_reports_true_for(:virtual?, :lxc?, node: { "virtualization" => { "system" => "lxc" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :lxc?, node: { "virtualization" => { "system" => "lxc", "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :lxc?, node: { "virtualization" => { "system" => "lxc", "role" => "host" } })
   end
   context "on parallels" do
-    virtualization_reports_true_for(:virtual?, :parallels?, node: { "virtualization" => { "system" => "parallels" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :parallels?, node: { "virtualization" => { "system" => "parallels", "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :parallels?, node: { "virtualization" => { "system" => "parallels", "role" => "host" } })
   end
   context "on virtualbox" do
-    virtualization_reports_true_for(:virtual?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox", "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox", "role" => "host" } })
   end
   context "on vmware" do
-    virtualization_reports_true_for(:virtual?, :vmware?, node: { "virtualization" => { "system" => "vmware" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :vmware?, node: { "virtualization" => { "system" => "vmware", "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :vmware?, node: { "virtualization" => { "system" => "vmware", "role" => "host" } })
   end
   context "on openvz" do
-    virtualization_reports_true_for(:virtual?, :openvz?, node: { "virtualization" => { "system" => "openvz" } })
+    virtualization_reports_true_for(:guest?, :virtual?, :openvz?, node: { "virtualization" => { "system" => "openvz", "role" => "guest" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :openvz?, node: { "virtualization" => { "system" => "openvz", "role" => "host" } })
   end
-  context "on anything else" do
+  context "on metal which is not a virt host" do
     virtualization_reports_true_for(:physical?, node: {} )
   end
 end

--- a/chef-utils/spec/unit/dsl/virtualization_spec.rb
+++ b/chef-utils/spec/unit/dsl/virtualization_spec.rb
@@ -1,0 +1,68 @@
+#
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "fauxhai"
+
+def virtualization_reports_true_for(*args, node:)
+  args.each do |method|
+    it "reports true for #{method}" do
+      expect(described_class.send(method, node)).to be true
+    end
+  end
+  (VIRTUALIZATION_HELPERS - args).each do |method|
+    it "reports false for #{method}" do
+      expect(described_class.send(method, node)).to be false
+    end
+  end
+end
+
+RSpec.describe ChefUtils::DSL::Virtualization do
+  ( HELPER_MODULES - [ described_class ] ).each do |klass|
+    it "does not have methods that collide with #{klass}" do
+      expect((klass.methods - Module.methods) & VIRTUALIZATION_HELPERS).to be_empty
+    end
+  end
+
+  VIRTUALIZATION_HELPERS.each do |helper|
+    it "has the #{helper} in the ChefUtils module" do
+      expect(ChefUtils).to respond_to(helper)
+    end
+  end
+
+  context "on kvm" do
+    virtualization_reports_true_for(:virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm" } })
+  end
+  context "on lxc" do
+    virtualization_reports_true_for(:virtual?, :lxc?, node: { "virtualization" => { "system" => "lxc" } })
+  end
+  context "on parallels" do
+    virtualization_reports_true_for(:virtual?, :parallels?, node: { "virtualization" => { "system" => "parallels" } })
+  end
+  context "on virtualbox" do
+    virtualization_reports_true_for(:virtual?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox" } })
+  end
+  context "on vmware" do
+    virtualization_reports_true_for(:virtual?, :vmware?, node: { "virtualization" => { "system" => "vmware" } })
+  end
+  context "on openvz" do
+    virtualization_reports_true_for(:virtual?, :openvz?, node: { "virtualization" => { "system" => "openvz" } })
+  end
+  context "on anything else" do
+    virtualization_reports_true_for(:physical?, node: {} )
+  end
+end

--- a/chef-utils/spec/unit/dsl/virtualization_spec.rb
+++ b/chef-utils/spec/unit/dsl/virtualization_spec.rb
@@ -46,27 +46,27 @@ RSpec.describe ChefUtils::DSL::Virtualization do
 
   context "on kvm" do
     virtualization_reports_true_for(:guest?, :virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm",  "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :kvm?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :kvm_host?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })
   end
   context "on lxc" do
     virtualization_reports_true_for(:guest?, :virtual?, :lxc?, node: { "virtualization" => { "system" => "lxc", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :lxc?, node: { "virtualization" => { "system" => "lxc", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :lxc_host?, node: { "virtualization" => { "system" => "lxc", "role" => "host" } })
   end
   context "on parallels" do
     virtualization_reports_true_for(:guest?, :virtual?, :parallels?, node: { "virtualization" => { "system" => "parallels", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :parallels?, node: { "virtualization" => { "system" => "parallels", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :parallels_host?, node: { "virtualization" => { "system" => "parallels", "role" => "host" } })
   end
   context "on virtualbox" do
     virtualization_reports_true_for(:guest?, :virtual?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :vbox_host?, node: { "virtualization" => { "system" => "vbox", "role" => "host" } })
   end
   context "on vmware" do
     virtualization_reports_true_for(:guest?, :virtual?, :vmware?, node: { "virtualization" => { "system" => "vmware", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :vmware?, node: { "virtualization" => { "system" => "vmware", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :vmware_host?, node: { "virtualization" => { "system" => "vmware", "role" => "host" } })
   end
   context "on openvz" do
     virtualization_reports_true_for(:guest?, :virtual?, :openvz?, node: { "virtualization" => { "system" => "openvz", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :openvz?, node: { "virtualization" => { "system" => "openvz", "role" => "host" } })
+    virtualization_reports_true_for(:virtual_host?, :physical?, :openvz_host?, node: { "virtualization" => { "system" => "openvz", "role" => "host" } })
   end
   context "on metal which is not a virt host" do
     virtualization_reports_true_for(:physical?, node: {} )

--- a/chef-utils/spec/unit/dsl/virtualization_spec.rb
+++ b/chef-utils/spec/unit/dsl/virtualization_spec.rb
@@ -46,27 +46,27 @@ RSpec.describe ChefUtils::DSL::Virtualization do
 
   context "on kvm" do
     virtualization_reports_true_for(:guest?, :virtual?, :kvm?, node: { "virtualization" => { "system" => "kvm",  "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :kvm_host?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :kvm_host?, node: { "virtualization" => { "system" => "kvm", "role" => "host" } })
   end
   context "on lxc" do
     virtualization_reports_true_for(:guest?, :virtual?, :lxc?, node: { "virtualization" => { "system" => "lxc", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :lxc_host?, node: { "virtualization" => { "system" => "lxc", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :lxc_host?, node: { "virtualization" => { "system" => "lxc", "role" => "host" } })
   end
   context "on parallels" do
     virtualization_reports_true_for(:guest?, :virtual?, :parallels?, node: { "virtualization" => { "system" => "parallels", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :parallels_host?, node: { "virtualization" => { "system" => "parallels", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :parallels_host?, node: { "virtualization" => { "system" => "parallels", "role" => "host" } })
   end
   context "on virtualbox" do
     virtualization_reports_true_for(:guest?, :virtual?, :virtualbox?, :vbox?, node: { "virtualization" => { "system" => "vbox", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :vbox_host?, node: { "virtualization" => { "system" => "vbox", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :vbox_host?, node: { "virtualization" => { "system" => "vbox", "role" => "host" } })
   end
   context "on vmware" do
     virtualization_reports_true_for(:guest?, :virtual?, :vmware?, node: { "virtualization" => { "system" => "vmware", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :vmware_host?, node: { "virtualization" => { "system" => "vmware", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :vmware_host?, node: { "virtualization" => { "system" => "vmware", "role" => "host" } })
   end
   context "on openvz" do
     virtualization_reports_true_for(:guest?, :virtual?, :openvz?, node: { "virtualization" => { "system" => "openvz", "role" => "guest" } })
-    virtualization_reports_true_for(:virtual_host?, :physical?, :openvz_host?, node: { "virtualization" => { "system" => "openvz", "role" => "host" } })
+    virtualization_reports_true_for(:hypervisor?, :physical?, :openvz_host?, node: { "virtualization" => { "system" => "openvz", "role" => "host" } })
   end
   context "on metal which is not a virt host" do
     virtualization_reports_true_for(:physical?, node: {} )

--- a/lib/chef/node/attribute.rb
+++ b/lib/chef/node/attribute.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -452,6 +452,8 @@ class Chef
       def read(*path)
         merged_attributes.read(*path)
       end
+
+      alias :dig :read
 
       def read!(*path)
         merged_attributes.read!(*path)

--- a/lib/chef/node/common_api.rb
+++ b/lib/chef/node/common_api.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright:: Copyright 2016, Chef Software, Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,6 +97,8 @@ class Chef
       rescue Chef::Exceptions::NoSuchAttribute
         nil
       end
+
+      alias :dig :read
 
       # non-autovivifying reader that throws an exception if the attribute does not exist
       def read!(*path)


### PR DESCRIPTION
this also adds `node.dig` as an alias for `node.read` so that Hashes can be used to mock Chef::Node because i don't want to break my own rule and take a dev time circular dep back on the chef gem (although VividMash probably needs to be moved into chef-utils eventually).