### PR TITLE
Pinning ohai branch to get tests building

### DIFF
--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -21,7 +21,7 @@ build_dir = Dir.pwd
 
 env = {
   "GEMFILE_MOD" => "gem 'chef', path: '#{build_dir}'; " \
-    "gem 'ohai', git: 'https://github.com/chef/ohai.git'",
+    "gem 'ohai', git: 'https://github.com/chef/ohai.git', branch: '15-stable'",
   "CHEF_LICENSE" => "accept-no-persist",
 }
 


### PR DESCRIPTION
## Description
Our external gem tests need to be pinned to the same branch of Ohai that
the Chef Client source code is. Otherwise we get a Bundler error.

## Related Issue
https://buildkite.com/chef-oss/chef-chef-chef-15-verify/builds/77#29dfd399-1019-4707-8f3f-a19ea10cfac4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
