### PR TITLE
Add some version string backcompat APIs

### DIFF
--- a/chef-utils/lib/chef-utils.rb
+++ b/chef-utils/lib/chef-utils.rb
@@ -22,6 +22,7 @@ require_relative "chef-utils/dsl/os"
 require_relative "chef-utils/dsl/path_sanity"
 require_relative "chef-utils/dsl/platform"
 require_relative "chef-utils/dsl/platform_family"
+require_relative "chef-utils/dsl/platform_version"
 require_relative "chef-utils/dsl/service"
 require_relative "chef-utils/dsl/train_helpers"
 require_relative "chef-utils/dsl/virtualization"
@@ -38,6 +39,7 @@ module ChefUtils
   include ChefUtils::DSL::PathSanity
   include ChefUtils::DSL::Platform
   include ChefUtils::DSL::PlatformFamily
+  include ChefUtils::DSL::PlatformVersion
   include ChefUtils::DSL::TrainHelpers
   include ChefUtils::DSL::Virtualization
   include ChefUtils::DSL::Which

--- a/chef-utils/lib/chef-utils/dsl/platform.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018-2019, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/chef-utils/lib/chef-utils/dsl/platform_version.rb
+++ b/chef-utils/lib/chef-utils/dsl/platform_version.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../internal"
+
+module ChefUtils
+  module DSL
+    module PlatformVersion
+      include Internal
+
+      # Return the platform_version for the node. Acts like a String
+      # but also provides a mechanism for checking version constraints.
+      #
+      # @param [Chef::Node] node
+      #
+      # @return [ChefUtils::VersionString]
+      #
+      def platform_version(node = __getnode)
+        ChefUtils::VersionString.new(node["platform_version"])
+      end
+
+      extend self
+    end
+  end
+end

--- a/chef-utils/lib/chef-utils/version_string.rb
+++ b/chef-utils/lib/chef-utils/version_string.rb
@@ -139,5 +139,11 @@ module ChefUtils
       end
     end
 
+    # Back-compat API for chef-sugar.  The other APIs are preferable.
+    #
+    # @api private
+    def satisfies?(*constraints)
+      Gem::Requirement.new(*constraints).satisfied_by?(@parsed_version)
+    end
   end
 end


### PR DESCRIPTION
These are strictly necessary for backcompat with chef-sugar and
necessary for converting omnibus off of chef-sugar and onto
chef-utils.
