### PR TITLE
Pull the windows Ruby installer from S3 for tests

### DIFF
--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 
 echo "Downloading Ruby + DevKit"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-(New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-devkit-2.6.5-1-x64.exe', 'c:\\rubyinstaller-devkit-2.6.5-1-x64.exe')
+(New-Object System.Net.WebClient).DownloadFile('https://public-cd-buildkite-cache.s3-us-west-2.amazonaws.com/rubyinstaller-devkit-2.6.5-1-x64.exe', 'c:\\rubyinstaller-devkit-2.6.5-1-x64.exe')
 
 echo "Installing Ruby + DevKit"
 Start-Process c:\rubyinstaller-devkit-2.6.5-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait


### PR DESCRIPTION
This should prevent failures when we get throttled pulling it from
Github

Signed-off-by: Tim Smith <tsmith@chef.io>