### PR TITLE
Add a default_description in windows_task

### DIFF
--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -77,7 +77,8 @@ class Chef
                description: "The frequency with which to run the task."
 
       property :start_day, String,
-        description: "Specifies the first date on which the task runs in MM/DD/YYYY format."
+        description: "Specifies the first date on which the task runs in MM/DD/YYYY format.",
+        default_description: "The current date."
 
       property :start_time, String,
         description: "Specifies the start time to run the task, in HH:mm format."


### PR DESCRIPTION
This came up in https://github.com/chef/chef-web-docs/pull/2256 and we
should really be documenting that behavior here so we can generate the
docs with it.

Signed-off-by: Tim Smith <tsmith@chef.io>