### PR TITLE
Improve welcome text in chef-shell

### DIFF
--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -295,7 +295,7 @@ module Shell
     option :chef_server_url,
       short: "-S CHEFSERVERURL",
       long: "--server CHEFSERVERURL",
-      description: "The #{Chef::Dist::PRODUCT} server URL",
+      description: "The #{Chef::Dist::SERVER_PRODUCT} URL",
       proc: nil
 
     option :version,

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -166,11 +166,10 @@ module Shell
 
     puts "run `help' for help, `exit' or ^D to quit."
     puts
-    puts "Ohai2u#{greeting}!"
   end
 
   def self.greeting
-    " #{Etc.getlogin}@#{Shell.session.node["fqdn"]}"
+    "#{Etc.getlogin}@#{Shell.session.node["fqdn"]}"
   rescue NameError, ArgumentError
     ""
   end

--- a/lib/chef/shell.rb
+++ b/lib/chef/shell.rb
@@ -263,7 +263,7 @@ module Shell
     option :standalone,
       short: "-a",
       long: "--standalone",
-      description: "standalone session",
+      description: "Standalone session",
       default: true,
       boolean: true
 
@@ -277,7 +277,7 @@ module Shell
     option :client,
       short: "-z",
       long: "--client",
-      description: "#{Chef::Dist::CLIENT} session",
+      description: "#{Chef::Dist::PRODUCT} session",
       boolean: true
 
     option :solo_legacy_shell,

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -204,7 +204,7 @@ module Shell
         else
           puts help_banner
         end
-        :ucanhaz_halp
+        :help
       end
       alias :halp :help
 

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -210,10 +210,8 @@ module Shell
 
       desc "prints information about #{Chef::Dist::PRODUCT}"
       def version
-        puts "This is the #{Chef::Dist::SHELL}.\n" +
-          " #{Chef::Dist::PRODUCT} Version: #{::Chef::VERSION}\n" +
-          " #{Chef::Dist::WEBSITE}\n" +
-          " https://docs.chef.io/"
+        puts "Welcome to the #{Chef::Dist::SHELL} #{::Chef::VERSION}\n" +
+          "For usage see https://docs.chef.io/chef_shell.html"
         :ucanhaz_automation
       end
       alias :shell :version


### PR DESCRIPTION
- Remove the decade-old meme references
- Link to the docs page that includes usage information
- Provide simpler version output
- Improve the dist constants we use

Old:

```
loading configuration: none (standalone session)
true
Session type: standalone
Loading.................done.

This is the chef-shell.
 Chef Infra Client Version: 16.0.52
 https://chef.io
 https://docs.chef.io/

run `help' for help, `exit' or ^D to quit.

Ohai2u tsmith@!
```

New:

```
loading configuration: none (standalone session)
true
Session type: standalone
Loading.........done.

Welcome to the chef-shell 16.0.51
For usage see https://docs.chef.io/chef_shell.html

run `help' for help, `exit' or ^D to quit.
```
