### PR TITLE
Expand the path in knife cookbook upload errors

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -108,7 +108,7 @@ class Chef
 
         if cookbooks.empty?
           cookbook_path = config[:cookbook_path].respond_to?(:join) ? config[:cookbook_path].join(", ") : config[:cookbook_path]
-          ui.warn("Could not find any cookbooks in your cookbook path: #{cookbook_path}. Use --cookbook-path to specify the desired path.")
+          ui.warn("Could not find any cookbooks in your cookbook path: '#{File.expand_path(cookbook_path)}'. Use --cookbook-path to specify the desired path.")
         else
           begin
             tmp_cl = Chef::CookbookLoader.copy_to_tmp_dir_from_array(cookbooks)

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -325,7 +325,7 @@ describe Chef::Knife::CookbookUpload do
           it "should warn users that no cookbooks exist" do
             knife.config[:cookbook_path] = ["/chef-repo/cookbooks", "/home/user/cookbooks"]
             expect(knife.ui).to receive(:warn).with(
-              /Could not find any cookbooks in your cookbook path: #{knife.config[:cookbook_path].join(', ')}\. Use --cookbook-path to specify the desired path\./
+              /Could not find any cookbooks in your cookbook path: '#{knife.config[:cookbook_path].join(', ')}'\. Use --cookbook-path to specify the desired path\./
             )
             knife.run
           end
@@ -335,7 +335,7 @@ describe Chef::Knife::CookbookUpload do
           it "should warn users that no cookbooks exist" do
             knife.config[:cookbook_path] = "/chef-repo/cookbooks"
             expect(knife.ui).to receive(:warn).with(
-              /Could not find any cookbooks in your cookbook path: #{knife.config[:cookbook_path]}\. Use --cookbook-path to specify the desired path\./
+              /Could not find any cookbooks in your cookbook path: '#{knife.config[:cookbook_path]}'\. Use --cookbook-path to specify the desired path\./
             )
             knife.run
           end


### PR DESCRIPTION
```
WARNING: Could not find any cookbooks in your cookbook path: '/Users/tsmith/dev/work/chef'. Use --cookbook-path to specify the desired path.
```

instead of:

```
WARNING: Could not find any cookbooks in your cookbook path: .. Use --cookbook-path to specify the desired path.
```

Signed-off-by: Tim Smith <tsmith@chef.io>