### PR TITLE
Update docker? help comment to show it's since 12.11

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/introspection.rb
+++ b/chef-utils/lib/chef-utils/dsl/introspection.rb
@@ -31,7 +31,7 @@ module ChefUtils
       # Determine if the node is a docker container.
       #
       # @param [Chef::Node] node the node to check
-      # @since 15.5
+      # @since 12.11
       #
       # @return [Boolean]
       #


### PR DESCRIPTION
We've had this in chef/chef since 12.11. True it's only been in
chef-utils since 15.5. This led a community member to believe they
couldn't use it since they required Chef 13+. We should make sure folks
know they can use this helper.

Signed-off-by: Tim Smith <tsmith@chef.io>