### PR TITLE
Add compile_time property to all resources

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -415,7 +415,6 @@ class Chef
       @not_if
     end
 
-    #
     # The number of times to retry this resource if it fails by throwing an
     # exception while running an action.  Default: 0
     #
@@ -427,7 +426,6 @@ class Chef
     #
     property :retries, Integer, default: 0, desired_state: false
 
-    #
     # The number of seconds to wait between retries.  Default: 2.
     #
     # @param arg [Integer] The number of seconds to wait between retries.
@@ -435,7 +433,6 @@ class Chef
     #
     property :retry_delay, Integer, default: 2, desired_state: false
 
-    #
     # Whether to treat this resource's data as sensitive.  If set, no resource
     # data will be displayed in log output.
     #
@@ -444,7 +441,16 @@ class Chef
     #
     property :sensitive, [ TrueClass, FalseClass ], default: false, desired_state: false
 
+    # If this is set the resource will be set to run at compile time and the converge time
+    # action will be set to :nothing.
     #
+    # @param arg [Boolean] Whether or not to force this resource to run at compile time.
+    # @return [Boolean] Whether or not to force this resource to run at compile time.
+    #
+    property :compile_time, [TrueClass, FalseClass],
+      description: "Determines whether or not the resource is executed during the compile time phase.",
+      default: false, desired_state: false
+
     # The time it took (in seconds) to run the most recently-run action.  Not
     # cumulative across actions.  This is set to 0 as soon as a new action starts
     # running, and set to the elapsed time at the end of the action.
@@ -458,7 +464,6 @@ class Chef
     #
     attr_accessor :executed_by_runner
 
-    #
     # The guard interpreter that will be used to process `only_if` and `not_if`
     # statements.  If left unset, the #default_guard_interpreter will be used.
     #

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2008-2019, Chef Software Inc.
+# Copyright:: 2008-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,10 +42,6 @@ class Chef
 
       # this allows us to use build_essential without setting a name
       property :name, String, default: ""
-
-      property :compile_time, [TrueClass, FalseClass],
-        description: "Install the build essential packages at compile time.",
-        default: false, desired_state: false
 
       property :raise_if_unsupported, [TrueClass, FalseClass],
         description: "Raise a hard error on platforms where this resource is unsupported.",
@@ -147,17 +143,6 @@ class Chef
           cmd.run_command
           # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
-        end
-      end
-
-      # this resource forces itself to run at compile_time
-      #
-      # @return [void]
-      def after_created
-        return unless compile_time
-
-        Array(action).each do |action|
-          run_action(action)
         end
       end
     end

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2012-2019, Chef Software Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,21 +43,6 @@ class Chef
                             callbacks: {
                  "The chef_gem resource is restricted to the current gem environment, use gem_package to install to other environments." => proc { |v| v == "#{RbConfig::CONFIG["bindir"]}/gem" },
                }
-      property :compile_time, [TrueClass, FalseClass],
-        description: "Controls the phase during which a gem is installed on a node. Set to 'true' to install a gem while the resource collection is being built (the 'compile phase'). Set to 'false' to install a gem while the #{Chef::Dist::CLIENT} is configuring the node (the 'converge phase').",
-        default: false, desired_state: false
-
-      # force the resource to compile time if the compile time property has been set
-      #
-      # @return [void]
-      def after_created
-        if compile_time
-          Array(action).each do |action|
-            run_action(action)
-          end
-          Gem.clear_paths
-        end
-      end
     end
   end
 end

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -1,7 +1,7 @@
 #
 # Authors:: AJ Christensen (<aj@chef.io>)
 #           Richard Manyanza (<liseki@nyikacraftsmen.com>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # Copyright:: Copyright 2014-2016, Richard Manyanza.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -30,10 +30,6 @@ class Chef
         description: "An optional property to set the hostname if it differs from the resource block's name.",
         name_property: true
 
-      property :compile_time, [ TrueClass, FalseClass ],
-        description: "Determines whether or not the resource should be run at compile time.",
-        default: true, desired_state: false
-
       property :ipaddress, String,
         description: "The IP address to use when configuring the hosts file.",
         default: lazy { node["ipaddress"] }, default_description: "The node's IP address as determined by Ohai."
@@ -41,6 +37,11 @@ class Chef
       property :aliases, [ Array, nil ],
         description: "An array of hostname aliases to use when configuring the hosts file.",
         default: nil
+
+      # override compile_time property to be true by default
+      property :compile_time, [ TrueClass, FalseClass ],
+        description: "Determines whether or not the resource should be run at compile time.",
+        default: true, desired_state: false
 
       property :windows_reboot, [ TrueClass, FalseClass ],
         description: "Determines whether or not Windows should be reboot after changing the hostname, as this is required for the change to take effect.",
@@ -248,17 +249,6 @@ class Chef
             reason "chef setting hostname"
             action :nothing
             only_if { new_resource.windows_reboot }
-          end
-        end
-      end
-
-      # this resource forces itself to run at compile_time
-      #
-      # @return [void]
-      def after_created
-        if compile_time
-          Array(action).each do |action|
-            run_action(action)
           end
         end
       end

--- a/lib/chef/resource/ohai_hint.rb
+++ b/lib/chef/resource/ohai_hint.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2011-2018, Chef Software, Inc.
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@ class Chef
       property :content, Hash,
         description: "Values to include in the hint file."
 
+      # override compile_time property to default to true
       property :compile_time, [TrueClass, FalseClass],
         description: "Determines whether or not the resource is executed during the compile time phase.",
         default: true, desired_state: false
@@ -81,17 +82,6 @@ class Chef
           return "" if content.nil? || content.empty?
 
           JSON.pretty_generate(content)
-        end
-      end
-
-      # this resource forces itself to run at compile_time
-      #
-      # @return [void]
-      def after_created
-        return unless compile_time
-
-        Array(action).each do |action|
-          run_action(action)
         end
       end
     end

--- a/lib/chef/resource_builder.rb
+++ b/lib/chef/resource_builder.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2015-2017, Chef Software Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,6 +72,14 @@ class Chef
 
       # Run optional resource hook
       resource.after_created
+
+      # Force to compile_time execution if the flag is set
+      if resource.compile_time
+        Array(resource.action).each do |action|
+          resource.run_action(action)
+        end
+        resource.action :nothing
+      end
 
       resource
     end


### PR DESCRIPTION
This eliminates one thing that people need to memorize

The ohai_hint and hostname resources still default to true

This also forces the resource to `action :nothing` in the
converge phase automatically, which is a behavior which has
been missed up until now.
