### PR TITLE
Allow setting file_cache_path and file_backup_path value in client.rb during bootstrap

### DIFF
--- a/lib/chef/knife/core/bootstrap_context.rb
+++ b/lib/chef/knife/core/bootstrap_context.rb
@@ -169,6 +169,14 @@ class Chef
             client_rb << "fips true\n"
           end
 
+          unless @chef_config[:file_cache_path].nil?
+            client_rb << "file_cache_path \"#{@chef_config[:file_cache_path]}\"\n"
+          end
+
+          unless @chef_config[:file_backup_path].nil?
+            client_rb << "file_backup_path \"#{@chef_config[:file_backup_path]}\"\n"
+          end
+
           client_rb
         end
 

--- a/spec/unit/knife/core/bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/bootstrap_context_spec.rb
@@ -86,6 +86,20 @@ describe Chef::Knife::Core::BootstrapContext do
     end
   end
 
+  describe "when file_cache_path is set" do
+    let(:chef_config) { { file_cache_path: "/home/opscode/cache" } }
+    it "sets file_cache_path in the generated config file" do
+      expect(bootstrap_context.config_content).to include("file_cache_path \"/home/opscode/cache\"")
+    end
+  end
+
+  describe "when file_backup_path is set" do
+    let(:chef_config) { { file_backup_path: "/home/opscode/backup" } }
+    it "sets file_backup_path in the generated config file" do
+      expect(bootstrap_context.config_content).to include("file_backup_path \"/home/opscode/backup\"")
+    end
+  end
+
   describe "alternate chef-client path" do
     let(:chef_config) { { chef_client_path: "/usr/local/bin/chef-client" } }
     it "runs chef-client from another path when specified" do


### PR DESCRIPTION
Signed-off-by: Kapil chouhan <kapil.chouhan@msystechnologies.com>
## Description
- Reflecting `file_cache_path` and `file_backup_path` value in `/etc/chef/client.rb`
- Added test cases
- Ensured chef-style on the code changes made

## Related Issue
Fixes: #9357 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
