### PR TITLE
windows_ad_join: Fix joining specific domains when domain trusts are involved

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -70,7 +70,7 @@ class Chef
 
         unless on_desired_domain?
           cmd = "$pswd = ConvertTo-SecureString \'#{new_resource.domain_password}\' -AsPlainText -Force;"
-          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}@#{new_resource.domain_name}\",$pswd);"
+          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{sanitize_usename}\",$pswd);"
           cmd << "Add-Computer -DomainName #{new_resource.domain_name} -Credential $credential"
           cmd << " -OUPath \"#{new_resource.ou_path}\"" if new_resource.ou_path
           cmd << " -NewName \"#{new_resource.new_hostname}\"" if new_resource.new_hostname

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -174,9 +174,12 @@ class Chef
         #   if the domain_user property contains an @ symbol followed by any number of non white space characheters
         #   then we assume it is a user from another domain than the one specifed in the resource domain_name property.
         #   if this is the case we do not append the domain_name property to the domain_user property
-        #   regex: https://rubular.com/r/VzupyBWemC8MMM
+        #   the domain_user and domain_name form the UPN (userPrincipalName)
+        #   The specification for the UPN format is RFC 822
+        #   links: https://docs.microsoft.com/en-us/windows/win32/ad/naming-properties#userprincipalname https://tools.ietf.org/html/rfc822
+        #   regex: https://rubular.com/r/isAWojpTMKzlnp
         def sanitize_usename
-          if new_resource.domain_user =~ /^\S*@\S*$/
+          if new_resource.domain_user =~ /@/
             new_resource.domain_user
           else
             "#{new_resource.domain_user}@#{new_resource.domain_name}"

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -102,7 +102,7 @@ class Chef
         if joined_to_domain?
           cmd = ""
           cmd << "$pswd = ConvertTo-SecureString \'#{new_resource.domain_password}\' -AsPlainText -Force;"
-          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{new_resource.domain_user}@#{new_resource.domain_name}\",$pswd);"
+          cmd << "$credential = New-Object System.Management.Automation.PSCredential (\"#{sanitize_usename}\",$pswd);"
           cmd << "Remove-Computer"
           cmd << " -UnjoinDomainCredential $credential"
           cmd << " -NewName \"#{new_resource.new_hostname}\"" if new_resource.new_hostname
@@ -167,6 +167,20 @@ class Chef
         #
         def on_desired_domain?
           node_domain == new_resource.domain_name.downcase
+        end
+
+        #
+        # @return [String] the correct user and domain to use.
+        #   if the domain_user property contains an @ symbol followed by any number of non white space characheters
+        #   then we assume it is a user from another domain than the one specifed in the resource domain_name property.
+        #   if this is the case we do not append the domain_name property to the domain_user property
+        #   regex: https://rubular.com/r/VzupyBWemC8MMM
+        def sanitize_usename
+          if new_resource.domain_user =~ /^\S*@\S*$/
+            new_resource.domain_user
+          else
+            "#{new_resource.domain_user}@#{new_resource.domain_name}"
+          end
         end
 
         # This resource historically took `:immediate` and `:delayed` as arguments to the reboot property but then


### PR DESCRIPTION
Signed-off-by: srb3 <sbrown@chef.io>


## Description
A customer has an issue where they want the user who initiates the domain to join to be in a different domain to the one that is being joined to.

```
you cannot use the windows_ad_join resource to join a computer in for example domain-b, by a user in domain-a that has a trust between them
```

customer would like to do the following

```
windows_ad_join domain-b do
  domain_user     username + "@domain-a"
  domain_password domain_creds['password']
  action          :join
  notifies        :reboot_now, 'reboot[post-domain-join]', :immediately
end
```
however it ends up with something like this:

 ```username@domain-a@domain-b```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ ]x All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).