### PR TITLE
Add distro constants to the bootstrap templates to support non-Chef distros

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -75,20 +75,20 @@ module ChefConfig
     end
 
     # On *nix, /etc/chef
-    def self.etc_chef_dir
-      path = ChefUtils.windows? ? c_chef_dir : PathHelper.join("/etc", ChefConfig::Dist::DIR_SUFFIX)
+    def self.etc_chef_dir(is_windows = ChefUtils.windows?)
+      path = is_windows? ? c_chef_dir : PathHelper.join("/etc", ChefConfig::Dist::DIR_SUFFIX)
       PathHelper.cleanpath(path)
     end
 
     # On *nix, /var/chef
-    def self.var_chef_dir
-      path = ChefUtils.windows? ? c_chef_dir : PathHelper.join("/var", ChefConfig::Dist::DIR_SUFFIX)
+    def self.var_chef_dir(is_windows = ChefUtils.windows?)
+      path = is_windows? ? c_chef_dir : PathHelper.join("/var", ChefConfig::Dist::DIR_SUFFIX)
       PathHelper.cleanpath(path)
     end
 
     # On *nix, the root of /var/, used to test if we can create and write in /var/chef
-    def self.var_root_dir
-      path = ChefUtils.windows? ? c_chef_dir : "/var"
+    def self.var_root_dir(is_windows = ChefUtils.windows?)
+      path = is_windows? ? c_chef_dir : "/var"
       PathHelper.cleanpath(path)
     end
 
@@ -96,6 +96,12 @@ module ChefConfig
     def self.c_chef_dir
       drive = windows_installation_drive || "C:"
       path = PathHelper.join(drive, ChefConfig::Dist::DIR_SUFFIX)
+      PathHelper.cleanpath(path)
+    end
+
+    def self.c_opscode_dir
+      drive = windows_installation_drive || "C:"
+      path = PathHelper.join(drive, ChefConfig::Dist::LEGACY_CONF_DIR, ChefConfig::Dist::DIR_SUFFIX)
       PathHelper.cleanpath(path)
     end
 

--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -76,19 +76,19 @@ module ChefConfig
 
     # On *nix, /etc/chef
     def self.etc_chef_dir(is_windows = ChefUtils.windows?)
-      path = is_windows? ? c_chef_dir : PathHelper.join("/etc", ChefConfig::Dist::DIR_SUFFIX)
+      path = is_windows ? c_chef_dir : PathHelper.join("/etc", ChefConfig::Dist::DIR_SUFFIX)
       PathHelper.cleanpath(path)
     end
 
     # On *nix, /var/chef
     def self.var_chef_dir(is_windows = ChefUtils.windows?)
-      path = is_windows? ? c_chef_dir : PathHelper.join("/var", ChefConfig::Dist::DIR_SUFFIX)
+      path = is_windows ? c_chef_dir : PathHelper.join("/var", ChefConfig::Dist::DIR_SUFFIX)
       PathHelper.cleanpath(path)
     end
 
     # On *nix, the root of /var/, used to test if we can create and write in /var/chef
     def self.var_root_dir(is_windows = ChefUtils.windows?)
-      path = is_windows? ? c_chef_dir : "/var"
+      path = is_windows ? c_chef_dir : "/var"
       PathHelper.cleanpath(path)
     end
 

--- a/chef-config/lib/chef-config/dist.rb
+++ b/chef-config/lib/chef-config/dist.rb
@@ -15,5 +15,9 @@ module ChefConfig
 
     # The user's configuration directory
     USER_CONF_DIR = ".chef".freeze
+
+    # The legacy conf folder: C:/opscode/chef. Specifically the "opscode" part
+    # DIR_SUFFIX is appended to it in code where relevant
+    LEGACY_CONF_DIR = "opscode".freeze
   end
 end

--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -185,50 +185,50 @@ if test "x$tmp_dir" != "x"; then
   rm -r "$tmp_dir"
 fi
 
-mkdir -p /etc/chef
+mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>
 
 <% if client_pem -%>
-(umask 077 && (cat > /etc/chef/client.pem <<'EOP'
+(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/client.pem <<'EOP'
 <%= ::File.read(::File.expand_path(client_pem)) %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if validation_key -%>
-(umask 077 && (cat > /etc/chef/validation.pem <<'EOP'
+(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if encrypted_data_bag_secret -%>
-(umask 077 && (cat > /etc/chef/encrypted_data_bag_secret <<'EOP'
+(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% unless trusted_certs.empty? -%>
-mkdir -p /etc/chef/trusted_certs
+mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>/trusted_certs
 <%= trusted_certs %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>
 <% unless @chef_config[:knife][:hints].nil? || @chef_config[:knife][:hints].empty? -%>
-mkdir -p /etc/chef/ohai/hints
+mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>/ohai/hints
 
 <% @chef_config[:knife][:hints].each do |name, hash| -%>
-cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
+cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/ohai/hints/<%= name %>.json <<'EOP'
 <%= Chef::JSONCompat.to_json(hash) %>
 EOP
 <% end -%>
 <% end -%>
 
-cat > /etc/chef/client.rb <<'EOP'
+cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/client.rb <<'EOP'
 <%= config_content %>
 EOP
 
-cat > /etc/chef/first-boot.json <<'EOP'
+cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/first-boot.json <<'EOP'
 <%= Chef::JSONCompat.to_json(first_boot) %>
 EOP
 

--- a/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
@@ -120,11 +120,11 @@ If !ERRORLEVEL!==0 (
 )
 
 :install
-@rem If user has provided the custom installation command for <%= Chef::Dist::CLIENT %> then execute it
+@rem If user has provided the custom installation command, execute it
 <% if @chef_config[:knife][:bootstrap_install_command] %>
   <%= @chef_config[:knife][:bootstrap_install_command] %>
 <% else %>
-  @rem Install Chef using <%= Chef::Dist::CLIENT %> MSI installer
+  @rem Install Chef using the MSI installer
 
   @set "LOCAL_DESTINATION_MSI_PATH=<%= local_download_path %>"
   @set "CHEF_CLIENT_MSI_LOG_PATH=%TEMP%\<%= Chef::Dist::CLIENT %>-msi%RANDOM%.log"

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -59,9 +59,9 @@ class Chef
           client_rb = <<~CONFIG
             chef_server_url  "#{@chef_config[:chef_server_url]}"
             validation_client_name "#{@chef_config[:validation_client_name]}"
-            file_cache_path   "c:/chef/cache"
-            file_backup_path  "c:/chef/backup"
-            cache_options     ({:path => "c:/chef/cache/checksums", :skip_expires => true})
+            file_cache_path   "#{ChefConfig::Config.var_chef_dir(true)}/cache"
+            file_backup_path  "#{ChefConfig::Config.var_chef_dir(true)}/backup"
+            cache_options     ({:path => "#{ChefConfig::Config.etc_chef_dir(true)}/cache/checksums", :skip_expires => true})
           CONFIG
 
           unless @chef_config[:chef_license].nil?
@@ -124,11 +124,11 @@ class Chef
           end
 
           if @config[:secret]
-            client_rb << %Q{encrypted_data_bag_secret "c:/chef/encrypted_data_bag_secret"\n}
+            client_rb << %Q{encrypted_data_bag_secret "#{ChefConfig::Config.etc_chef_dir(true)}/encrypted_data_bag_secret"\n}
           end
 
           unless trusted_certs_script.empty?
-            client_rb << %Q{trusted_certs_dir "c:/chef/trusted_certs"\n}
+            client_rb << %Q{trusted_certs_dir "#{ChefConfig::Config.etc_chef_dir(true)}/trusted_certs"\n}
           end
 
           if Chef::Config[:fips]
@@ -158,8 +158,8 @@ class Chef
 
         def start_chef
           bootstrap_environment_option = bootstrap_environment.nil? ? "" : " -E #{bootstrap_environment}"
-          start_chef = "SET \"PATH=%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\;%PATH%\"\n"
-          start_chef << "chef-client -c c:/chef/client.rb -j c:/chef/first-boot.json#{bootstrap_environment_option}\n"
+          start_chef = "SET \"PATH=%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\;C:\\ruby\\bin;#{ChefConfig::Config.c_opscode_dir}\\#{ChefConfig::Dist::DIR_SUFFIX}\\bin;#{ChefConfig::Config.c_opscode_dir}\\#{ChefConfig::Dist::DIR_SUFFIX}\\embedded\\bin\;%PATH%\"\n"
+          start_chef << "chef-client -c #{ChefConfig::Config.etc_chef_dir(true)}/client.rb -j #{ChefConfig::Config.etc_chef_dir(true)}/first-boot.json#{bootstrap_environment_option}\n"
         end
 
         def win_wget
@@ -260,7 +260,7 @@ class Chef
         end
 
         def bootstrap_directory
-          "C:\\chef"
+          ChefConfig::Config.etc_chef_dir(true)
         end
 
         def local_download_path

--- a/spec/unit/knife/core/windows_bootstrap_context_spec.rb
+++ b/spec/unit/knife/core/windows_bootstrap_context_spec.rb
@@ -164,9 +164,9 @@ describe Chef::Knife::Core::WindowsBootstrapContext do
       expected = <<~EXPECTED
         echo.chef_server_url  "http://chef.example.com:4444"
         echo.validation_client_name "chef-validator-testing"
-        echo.file_cache_path   "c:/chef/cache"
-        echo.file_backup_path  "c:/chef/backup"
-        echo.cache_options     ^({:path =^> "c:/chef/cache/checksums", :skip_expires =^> true}^)
+        echo.file_cache_path   "C:/chef/cache"
+        echo.file_backup_path  "C:/chef/backup"
+        echo.cache_options     ^({:path =^> "C:/chef/cache/checksums", :skip_expires =^> true}^)
         echo.# Using default node name ^(fqdn^)
         echo.log_level :info
         echo.log_location       STDOUT


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Add distro constants to bootstrap templates, this time using the OS at the far end of the train  connection to evaluate paths as opposed to the workstation's OS

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes. # See my kitchen-tf monstrosity https://github.com/bobchaos/bootstrap_integration_test
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
