### PR TITLE
Use require_relative within the specs

### DIFF
--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/client"
 
 describe Chef::RunLock do

--- a/spec/functional/util/powershell/cmdlet_spec.rb
+++ b/spec/functional/util/powershell/cmdlet_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef/json_compat"
-require File.expand_path("../../../../spec_helper", __FILE__)
+require_relative "../../../spec_helper"
 
 describe Chef::Util::Powershell::Cmdlet, :windows_powershell_dsc_only do
   before(:all) do

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/mixin/shell_out"
 require "chef/version"
 require "ohai/version"

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/data_collector"
 require "socket"
 

--- a/spec/unit/json_compat_spec.rb
+++ b/spec/unit/json_compat_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/json_compat"
 
 describe Chef::JSONCompat do

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/resource_reporter"
 require "socket"
 

--- a/spec/unit/run_lock_spec.rb
+++ b/spec/unit/run_lock_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/client"
 
 describe Chef::RunLock do

--- a/spec/unit/scan_access_control_spec.rb
+++ b/spec/unit/scan_access_control_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require File.expand_path("../../spec_helper", __FILE__)
+require_relative "../spec_helper"
 require "chef/scan_access_control"
 
 describe Chef::ScanAccessControl do


### PR DESCRIPTION
Simplify how we include the spec_helper via the new cookstyle rule.

Signed-off-by: Tim Smith <tsmith@chef.io>