### PR TITLE
Require compatible cheffish and chef-zero releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ else
   gem "chef-bin" # rubocop:disable Bundler/DuplicatedGem
 end
 
-gem "cheffish", ">= 14"
+gem "cheffish", ">= 15"
 
 group(:omnibus_package) do
   gem "appbundler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: d86c8139e35e8bb92405d56e4b75d0c89d5472b3
+  revision: 1100200f616fe080048fa49fa5942754904c32ca
   branch: master
   specs:
-    chefstyle (0.14.1)
+    chefstyle (0.14.2)
       rubocop (= 0.75.1)
 
 GIT
@@ -34,7 +34,7 @@ PATH
       chef-config (= 16.0.69)
       chef-utils (= 16.0.69)
       chef-vault
-      chef-zero (>= 14.0.11)
+      chef-zero (>= 15.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
@@ -67,7 +67,7 @@ PATH
       chef-config (= 16.0.69)
       chef-utils (= 16.0.69)
       chef-vault
-      chef-zero (>= 14.0.11)
+      chef-zero (>= 15.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
@@ -144,20 +144,20 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
     byebug (11.1.1)
-    chef-telemetry (1.0.2)
+    chef-telemetry (1.0.3)
       chef-config
       concurrent-ruby (~> 1.0)
       ffi-yajl (~> 2.2)
       http (~> 2.2)
     chef-vault (4.0.1)
-    chef-zero (14.0.17)
+    chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 4.0)
+      hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
-    cheffish (14.0.13)
-      chef-zero (~> 14.0)
+    cheffish (15.0.0)
+      chef-zero (>= 14.0)
       net-ssh
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -357,7 +357,7 @@ GEM
     tins (1.24.1)
       sync
     tomlrb (1.2.9)
-    train-core (3.2.20)
+    train-core (3.2.22)
       addressable (~> 2.5)
       inifile (~> 3.0)
       json (>= 1.8, < 3.0)
@@ -453,7 +453,7 @@ DEPENDENCIES
   chef-config!
   chef-utils!
   chef-vault
-  cheffish (>= 14)
+  cheffish (>= 15)
   chefstyle!
   ed25519
   fauxhai-ng

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
   s.add_dependency "ffi-libarchive"
-  s.add_dependency "chef-zero", ">= 14.0.11"
+  s.add_dependency "chef-zero", ">= 15.0"
   s.add_dependency "chef-vault"
 
   s.add_dependency "plist", "~> 3.2"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -18,7 +18,7 @@ group :development do
   gem "ohai"
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem "test-kitchen", ">= 1.23"
+  gem "test-kitchen", ">= 2"
   gem "kitchen-vagrant", ">= 1.3.1"
   gem "winrm-fs", "~> 1.0"
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: 6b0f3401c34e8b346476fb2aad202705b30a1db4
+  revision: e06e607ca1a962cb01b40a687409f74811b83823
   branch: master
   specs:
-    omnibus (7.0.3)
+    omnibus (7.0.4)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: e8312ad1f93bb3b88a232d0921ded4a0e82936b3
+  revision: 7b2486c33e8553bd70cb75aa5a5a853cc61659b1
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -150,9 +150,9 @@ GEM
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
     chef-utils (15.8.23)
-    chef-zero (14.0.17)
+    chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 4.0)
+      hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
@@ -180,7 +180,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.6.0)
+    hashie (4.1.0)
     highline (1.7.10)
     httpclient (2.8.3)
     inifile (3.0.0)
@@ -394,7 +394,7 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   pedump
-  test-kitchen (>= 1.23)
+  test-kitchen (>= 2)
   winrm-fs (~> 1.0)
 
 BUNDLED WITH


### PR DESCRIPTION
We should require releases that work with Ruby 2.6/2.7.

Signed-off-by: Tim Smith <tsmith@chef.io>