### PR TITLE
Update HTTPServerException to be HTTPClientException

### DIFF
--- a/lib/chef/monkey_patches/net_http.rb
+++ b/lib/chef/monkey_patches/net_http.rb
@@ -5,10 +5,6 @@ module ChefNetHTTPExceptionExtensions
   attr_accessor :chef_rest_request
 end
 
-unless defined?(Net::HTTPClientException)
-  Net::HTTPClientException = Net::HTTPServerException
-end
-
 require "net/http" unless defined?(Net::HTTP)
 module Net
   class HTTPError

--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -80,7 +80,7 @@ class Chef
           search item.search
         rescue ChefVault::Exceptions::KeysNotFound
           current_value_does_not_exist!
-        rescue Net::HTTPServerException => e
+        rescue Net::HTTPClientException => e
           current_value_does_not_exist! if e.response_code == "404"
         end
       end

--- a/spec/integration/knife/data_bag_show_spec.rb
+++ b/spec/integration/knife/data_bag_show_spec.rb
@@ -26,7 +26,7 @@ describe "knife data bag show", :workstation do
 
   when_the_chef_server "is empty" do
     it "raises error if try to retrieve it" do
-      expect { knife("data bag show bag") }.to raise_error(Net::HTTPServerException)
+      expect { knife("data bag show bag") }.to raise_error(Net::HTTPClientException)
     end
   end
 


### PR DESCRIPTION
Avoid deprecation warnings. Also remove the monkeypatch that provided
HTTPClientException on older Ruby releases since we're 2.6+ now and we
don't need this.

Signed-off-by: Tim Smith <tsmith@chef.io>