### PR TITLE
fix ruby 2.7 URI.unescape deprecation

### DIFF
--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -176,8 +176,8 @@ class Chef
         @http_request.body = request_body if request_body && @http_request.request_body_permitted?
         # Optionally handle HTTP Basic Authentication
         if url.user
-          user = URI.unescape(url.user)
-          password = URI.unescape(url.password) if url.password
+          user = CGI.unescape(url.user)
+          password = CGI.unescape(url.password) if url.password
           @http_request.basic_auth(user, password)
         end
 

--- a/lib/chef/http/http_request.rb
+++ b/lib/chef/http/http_request.rb
@@ -5,7 +5,7 @@
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2009-2016, 2010-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2016, 2010-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
 # limitations under the License.
 #
 require "uri" unless defined?(URI)
+require "cgi" unless defined?(CGI)
 require "net/http" unless defined?(Net::HTTP)
 require_relative "../dist"
 

--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -58,7 +58,7 @@ class Chef
 
         def default_download_cache_path
           uri = ::URI.parse(new_resource.source)
-          filename = ::File.basename(::URI.unescape(uri.path))
+          filename = ::File.basename(::CGI.unescape(uri.path))
           file_cache_dir = Chef::FileCache.create_cache_path("package/")
           Chef::Util::PathHelper.cleanpath("#{file_cache_dir}/#{filename}")
         end

--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@msystechnologies.com>)
-# Copyright:: Copyright 2015-2019, Chef Software Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ require_relative "../../resource/cab_package"
 require_relative "../../mixin/shell_out"
 require_relative "../../mixin/uris"
 require_relative "../../mixin/checksum"
+require "cgi" unless defined?(CGI)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -99,7 +99,7 @@ class Chef
 
         def default_download_cache_path
           uri = ::URI.parse(new_resource.source)
-          filename = ::File.basename(::URI.unescape(uri.path))
+          filename = ::File.basename(::CGI.unescape(uri.path))
           file_cache_dir = Chef::FileCache.create_cache_path("package/")
           Chef::Util::PathHelper.cleanpath("#{file_cache_dir}/#{filename}")
         end

--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright 2015-2016, Chef Software, Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ require_relative "cab"
 require_relative "../../util/path_helper"
 require_relative "../../mixin/uris"
 require_relative "../../mixin/checksum"
+require "cgi" unless defined?(CGI)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -277,7 +277,7 @@ class Chef
 
         def default_download_cache_path
           uri = ::URI.parse(new_resource.source)
-          filename = ::File.basename(::URI.unescape(uri.path))
+          filename = ::File.basename(::CGI.unescape(uri.path))
           file_cache_dir = Chef::FileCache.create_cache_path("package/")
           Chef::Util::PathHelper.cleanpath("#{file_cache_dir}/#{filename}")
         end

--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2018, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ require_relative "../../resource/windows_package"
 require_relative "../package"
 require_relative "../../util/path_helper"
 require_relative "../../mixin/checksum"
+require "cgi" unless defined?(CGI)
 
 class Chef
   class Provider

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -17,6 +17,7 @@
 #
 
 require "uri" unless defined?(URI)
+require "cgi" unless defined?(CGI)
 require "tempfile" unless defined?(Tempfile)
 require "net/ftp"
 require_relative "../remote_file"

--- a/lib/chef/provider/remote_file/ftp.rb
+++ b/lib/chef/provider/remote_file/ftp.rb
@@ -57,7 +57,7 @@ class Chef
 
         def user
           if uri.userinfo
-            URI.unescape(uri.user)
+            CGI.unescape(uri.user)
           else
             "anonymous"
           end
@@ -65,7 +65,7 @@ class Chef
 
         def pass
           if uri.userinfo
-            URI.unescape(uri.password)
+            CGI.unescape(uri.password)
           else
             nil
           end

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -17,6 +17,7 @@
 #
 
 require "uri" unless defined?(URI)
+require "cgi" unless defined?(CGI)
 require "tempfile" unless defined?(Tempfile)
 require_relative "../remote_file"
 

--- a/lib/chef/provider/remote_file/local_file.rb
+++ b/lib/chef/provider/remote_file/local_file.rb
@@ -40,7 +40,7 @@ class Chef
 
         def source_path
           @source_path ||= begin
-            path = URI.unescape(uri.path)
+            path = CGI.unescape(uri.path)
             ChefUtils.windows? ? fix_windows_path(path) : path
           end
         end

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -47,7 +47,7 @@ class Chef
         end
 
         def user
-          URI.unescape(uri.user)
+          CGI.unescape(uri.user)
         end
 
         def fetch
@@ -62,7 +62,7 @@ class Chef
         end
 
         def pass
-          URI.unescape(uri.password)
+          CGI.unescape(uri.password)
         end
 
         def validate_path!

--- a/lib/chef/provider/remote_file/sftp.rb
+++ b/lib/chef/provider/remote_file/sftp.rb
@@ -17,6 +17,7 @@
 #
 
 require "uri" unless defined?(URI)
+require "cgi" unless defined?(CGI)
 require "tempfile" unless defined?(Tempfile)
 require "net/sftp"
 require_relative "../remote_file"

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -19,7 +19,7 @@
 require_relative "../resource"
 require_relative "../http/simple"
 require "tmpdir" unless defined?(Dir.mktmpdir)
-require "cgi" unless defined?(CGI)
+require "addressable" unless defined?(Addressable)
 
 class Chef
   class Resource
@@ -379,7 +379,7 @@ class Chef
         def build_repo(uri, distribution, components, trusted, arch, add_src = false)
           uri = make_ppa_url(uri) if is_ppa_url?(uri)
 
-          uri = CGI.escape(uri)
+          uri = Addressable::URI.parse(uri)
           components = Array(components).join(" ")
           options = []
           options << "arch=#{arch}" if arch
@@ -387,7 +387,7 @@ class Chef
           optstr = unless options.empty?
                      "[" + options.join(" ") + "]"
                    end
-          info = [ optstr, uri, distribution, components ].compact.join(" ")
+          info = [ optstr, uri.normalize.to_s, distribution, components ].compact.join(" ")
           repo =  "deb      #{info}\n"
           repo << "deb-src  #{info}\n" if add_src
           repo

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: 2016-2019, Chef Software Inc.
+# Copyright:: 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 require_relative "../resource"
 require_relative "../http/simple"
 require "tmpdir" unless defined?(Dir.mktmpdir)
+require "cgi" unless defined?(CGI)
 
 class Chef
   class Resource

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -378,7 +378,7 @@ class Chef
         def build_repo(uri, distribution, components, trusted, arch, add_src = false)
           uri = make_ppa_url(uri) if is_ppa_url?(uri)
 
-          uri = URI.escape(uri)
+          uri = CGI.escape(uri)
           components = Array(components).join(" ")
           options = []
           options << "arch=#{arch}" if arch


### PR DESCRIPTION
Necessary for ruby 2.7 support