### PR TITLE
Remove reference to travis.org and pin ruby-prof

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,8 @@ end
 
 # Everything except AIX
 group(:ruby_prof) do
-  gem "ruby-prof"
+  # ruby-prof 1.3.0 does not compile on our centos6 builders/kitchen testers
+  gem "ruby-prof", "< 1.3.0"
 end
 
 # Everything except AIX and Windows

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,8 +336,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-prof (1.3.0)
-    ruby-prof (1.3.0-x64-mingw32)
+    ruby-prof (1.2.0)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
@@ -479,7 +478,7 @@ DEPENDENCIES
   rspec-expectations (~> 3.5)
   rspec-mocks (~> 3.5)
   rspec_junit_formatter (~> 0.2.0)
-  ruby-prof
+  ruby-prof (< 1.3.0)
   ruby-shadow
   simplecov
   webmock

--- a/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
@@ -52,7 +52,7 @@ users_manage "sysadmin" do
 end
 
 ssh_known_hosts_entry "github.com"
-ssh_known_hosts_entry "travis.org"
+ssh_known_hosts_entry "localhost"
 
 sudo "sysadmins" do
   group ["sysadmin", "%superadmin"]

--- a/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/default.rb
@@ -52,7 +52,6 @@ users_manage "sysadmin" do
 end
 
 ssh_known_hosts_entry "github.com"
-ssh_known_hosts_entry "localhost"
 
 sudo "sysadmins" do
   group ["sysadmin", "%superadmin"]


### PR DESCRIPTION
we're probably getting packetfiltered or something now that we're
no longer using travis.

