### PR TITLE
Cookstyle fixes for our resources

### DIFF
--- a/lib/chef/provider/group/usermod.rb
+++ b/lib/chef/provider/group/usermod.rb
@@ -1,6 +1,6 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,10 +76,7 @@ class Chef
         end
 
         def append_flags
-          case node[:platform]
-          when "openbsd", "netbsd", "aix", "smartos", "omnios"
-            "-G"
-          end
+          "-G" if platform?("openbsd", "netbsd", "aix", "smartos", "omnios")
         end
 
       end

--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -2,8 +2,7 @@
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Graeme Mathieson (<mathie@woss.name>)
 #
-# Copyright 2011-2016, Chef Software Inc.
-# Copyright 2014-2016, Chef Software, Inc <legal@chef.io>
+# Copyright:: 2011-2016, Chef Software, Inc <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -3,7 +3,7 @@
 # Authors:: Adam Jacob (<adam@chef.io>)
 #           Ionuț Arțăriși (<iartarisi@suse.cz>)
 # Copyright:: Copyright 2008-2017, Chef Software Inc.
-#             Copyright 2013-2016, SUSE Linux GmbH
+# Copyright:: 2013-2016, SUSE Linux GmbH
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -1,6 +1,7 @@
 #
 # Author:: Bryan McLellan (btm@loftninjas.org), Jesse Nelson (spheromak@gmail.com)
 # Copyright:: Copyright 2009-2016, Bryan McLellan
+# Copyright:: Copyright 2020, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -159,8 +160,7 @@ class Chef
       end
 
       def generate_config
-        case node[:platform_family]
-        when "rhel", "amazon", "fedora"
+        if platform_family?("rhel", "amazon", "fedora")
           conf = {}
           # walk the collection
           run_context.resource_collection.each do |resource|

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -2,8 +2,7 @@
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Graeme Mathieson (<mathie@woss.name>)
 #
-# Copyright 2011-2020, Chef Software Inc.
-# Copyright 2014-2020, Chef Software Inc.<legal@chef.io>
+# Copyright:: 2011-2020, Chef Software Inc.<legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -3,8 +3,8 @@
 #
 # The MIT License (MIT)
 #
-# Copyright 2016-2018, Shopify Inc.
-# Copyright 2018-2020, Chef Software Inc.
+# Copyright:: 2016-2018, Shopify Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 
 require_relative "../resource"
 

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -1,6 +1,6 @@
 #
-# Copyright 2012-2018, Seth Vargo
-# Copyright 2017-2020, Chef Software Inc.
+# Copyright:: 2012-2018, Seth Vargo
+# Copyright:: 2017-2020, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Kirill Kouznetsov <agon.smith@gmail.com>
 #
-# Copyright 2018, Kirill Kouznetsov.
-# Copyright 2018-2020, Chef Software Inc.
+# Copyright:: 2018, Kirill Kouznetsov.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -85,7 +85,6 @@ class Chef
         guard_script << cert_exists_script(hash)
 
         powershell_script "setting the acls on #{new_resource.source} in #{cert_location}\\#{new_resource.store_name}" do
-          guard_interpreter :powershell_script
           convert_boolean_return true
           code code_script
           only_if guard_script


### PR DESCRIPTION
I ran cookstyle against the resources and fixes a few minor issues:

- Remove the now default guard interpreter from a powershell_script
- Use our rdoc like header format everywhere
- Remove some duplicate copyrights
- Simplify a few platform case statements

Signed-off-by: Tim Smith <tsmith@chef.io>