### PR TITLE
Accept exit code 3010 as valid in windows_package

### DIFF
--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -55,9 +55,11 @@ class Chef
         description: "The amount of time (in seconds) to wait before timing out."
 
       # In the past we accepted return code 127 for an unknown reason and 42 because of a bug
-      property :returns, [ String, Integer, Array ], default: [ 0 ],
+      # we accept 3010 which means success, but a reboot is necessary
+      property :returns, [ String, Integer, Array ], default: [ 0, 3010 ],
         desired_state: false,
-        description: "A comma-delimited list of return codes that indicate the success or failure of the package command that was run."
+        description: "A comma-delimited list of return codes that indicate the success or failure of the package command that was run.",
+        default_description: "0 (success) and 3010 (success where a reboot is necessary)"
 
       property :source, String,
         coerce: (proc do |s|

--- a/spec/unit/provider/package/windows/exe_spec.rb
+++ b/spec/unit/provider/package/windows/exe_spec.rb
@@ -126,7 +126,7 @@ describe Chef::Provider::Package::Windows::Exe do
       it "removes installed package and quotes uninstall string" do
         new_resource.timeout = 300
         allow(::File).to receive(:exist?).with("uninst_dir/uninst_file").and_return(true)
-        expect(provider).to receive(:shell_out!).with(%r{start \"\" /wait \"uninst_dir/uninst_file\" /S /NCRC & exit %%%%ERRORLEVEL%%%%}, default_env: false, timeout: 300, returns: [0])
+        expect(provider).to receive(:shell_out!).with(%r{start \"\" /wait \"uninst_dir/uninst_file\" /S /NCRC & exit %%%%ERRORLEVEL%%%%}, default_env: false, timeout: 300, returns: [0, 3010])
         provider.remove_package
       end
     end

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2019, Chef Software, Inc.
+# Copyright:: Copyright 2014-2020, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,6 +87,10 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     allow(::File).to receive(:absolute_path).and_return("c:\\frost.msi")
     resource.source("c:/frost.msi")
     expect(resource.source).to eql "c:\\frost.msi"
+  end
+
+  it "defaults returns to [0, 3010]" do
+    expect(resource.returns).to eq([0, 3010])
   end
 
   it "defaults source to the resource name" do


### PR DESCRIPTION
This just means a reboot is necessary. A lot of people struggle with this and then eventually set the return code. We should just do that by default like we do in windows_feature already.

Fixes #9079 

Signed-off-by: Tim Smith <tsmith@chef.io>