### PR TITLE
Convert the node[:platform_version] to a Chef::VersionString

### DIFF
--- a/chef-utils/lib/chef-utils/version_string.rb
+++ b/chef-utils/lib/chef-utils/version_string.rb
@@ -27,8 +27,13 @@ module ChefUtils
     #
     # @param val [String] Version string to parse.
     def initialize(val)
-      super
-      @parsed_version = ::Gem::Version.create(self)
+      val = "" unless val
+      super(val)
+      begin
+        @parsed_version = ::Gem::Version.create(self)
+      rescue ArgumentError
+        @parsed_version = nil
+      end
     end
 
     # @!group Compat wrappers for String
@@ -135,7 +140,12 @@ module ChefUtils
       when Regexp
         super
       else
-        Gem::Requirement.create(other) =~ parsed_version
+        begin
+          Gem::Requirement.create(other) =~ parsed_version
+        rescue ArgumentError
+          # one side of the comparison wasn't parseable
+          super
+        end
       end
     end
 

--- a/lib/chef/node.rb
+++ b/lib/chef/node.rb
@@ -2,7 +2,7 @@
 # Author:: Christopher Brown (<cb@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -363,7 +363,7 @@ class Chef
       # FIXME(log): should be trace
       logger.debug("Platform is #{platform} version #{version}")
       automatic[:platform] = platform
-      automatic[:platform_version] = version
+      automatic[:platform_version] = Chef::VersionString.new(version)
       automatic[:chef_guid] = Chef::Config[:chef_guid] || ( Chef::Config[:chef_guid] = node_uuid )
       automatic[:name] = name
       automatic[:chef_environment] = chef_environment

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -964,6 +964,13 @@ describe Chef::Node do
       node.consume_external_attrs(@ohai_data, { "foo" => "bar" })
       node.expand!
       expect(node.normal_attrs).to eq({ "foo" => "bar", "tags" => [] })
+    end
+
+    it "converts the platform_version to a Chef::VersionString" do
+      node.consume_external_attrs(@ohai_data, {})
+      expect(node.automatic_attrs[:platform_version]).to be_a_kind_of(Chef::VersionString)
+      expect(node[:platform_version]).to be_a_kind_of(Chef::VersionString)
+      expect(node[:platform_version] =~ "~> 23.6").to be true
     end
 
   end


### PR DESCRIPTION
`node[:platform_version] =~ "~> 1.2"` will now just work.

This might conceivably be breaking if people are doing really weird
things by the class changing (Chef::VersionString still inherits from
String though, so it'll have to be weirdness on par with the bad
`thing.class.to_s == "Mash"` kind of comparisons that were in ohai).

closes #9154 
