### PR TITLE
Update the rhsm_erata* and rhsm_register resources for RHEL 8

### DIFF
--- a/lib/chef/resource/rhsm_errata.rb
+++ b/lib/chef/resource/rhsm_errata.rb
@@ -37,9 +37,15 @@ class Chef
         description "Installs a package for a specific errata ID."
 
         execute "Install errata packages for #{new_resource.errata_id}" do
-          command "{rhel8? ? 'dnf' : 'yum'} update --advisory #{new_resource.errata_id} -y"
+          command "#{package_manager_command} update --advisory #{new_resource.errata_id} -y"
           default_env true
           action :run
+        end
+      end
+
+      action_class do
+        def package_manager_command
+          node["platform_version"].to_i >= 8 ? "dnf" : "yum"
         end
       end
     end

--- a/lib/chef/resource/rhsm_errata.rb
+++ b/lib/chef/resource/rhsm_errata.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2018 Chef Software, Inc.
+# Copyright:: 2015-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmErrata < Chef::Resource
+      unified_mode true
       resource_name :rhsm_errata
       provides(:rhsm_errata) { true }
 
@@ -36,7 +37,7 @@ class Chef
         description "Installs a package for a specific errata ID."
 
         execute "Install errata packages for #{new_resource.errata_id}" do
-          command "yum update --advisory #{new_resource.errata_id} -y"
+          command "{rhel8? ? 'dnf' : 'yum'} update --advisory #{new_resource.errata_id} -y"
           default_env true
           action :run
         end

--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2018 Chef Software, Inc.
+# Copyright:: 2015-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmErrataLevel < Chef::Resource
+      unified_mode true
       resource_name :rhsm_errata_level
       provides(:rhsm_errata_level) { true }
 
@@ -35,13 +36,12 @@ class Chef
       action :install do
         description "Install all packages of the specified errata level."
 
-        yum_package "yum-plugin-security" do
-          action :install
-          only_if { node["platform_version"].to_i == 6 }
+        if rhel6?
+          yum_package "yum-plugin-security"
         end
 
         execute "Install any #{new_resource.errata_level} errata" do
-          command "yum update --sec-severity=#{new_resource.errata_level.capitalize} -y"
+          command "{rhel8? ? 'dnf' : 'yum'} update --sec-severity=#{new_resource.errata_level.capitalize} -y"
           default_env true
           action :run
         end

--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -41,9 +41,15 @@ class Chef
         end
 
         execute "Install any #{new_resource.errata_level} errata" do
-          command "{rhel8? ? 'dnf' : 'yum'} update --sec-severity=#{new_resource.errata_level.capitalize} -y"
+          command "#{package_manager_command} update --sec-severity=#{new_resource.errata_level.capitalize} -y"
           default_env true
           action :run
+        end
+      end
+
+      action_class do
+        def package_manager_command
+          node["platform_version"].to_i >= 8 ? "dnf" : "yum"
         end
       end
     end


### PR DESCRIPTION
These need to use dnf instead of yum_package where they can. I also
enabled these for unified_mode and moved some only_if logic outside the
resources for cleaner logging. These should really all just get
converted to use shell_out and a nice converge_by

Signed-off-by: Tim Smith <tsmith@chef.io>