### PR TITLE
Deprecate supports_powershell_execution_bypass? check

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -48,9 +48,9 @@ class Chef
         end
       end
 
+      # @deprecated we don't support any release of Windows that isn't PS 3+
       def supports_powershell_execution_bypass?(node)
-        node[:languages] && node[:languages][:powershell] &&
-          node[:languages][:powershell][:version].to_i >= 3
+        true
       end
 
       def supports_dsc?(node)

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,22 +71,12 @@ class Chef
       end
 
       # Options that will be passed to Windows PowerShell command
+      #
+      # @returns [String]
       def default_flags
-        # Execution policy 'Bypass' is preferable since it doesn't require
-        # user input confirmation for files such as PowerShell modules
-        # downloaded from the Internet. However, 'Bypass' is not supported
-        # prior to PowerShell 3.0, so the fallback is 'Unrestricted'
-        execution_policy = Chef::Platform.supports_powershell_execution_bypass?(run_context.node) ? "Bypass" : "Unrestricted"
-
-        [
-          "-NoLogo",
-          "-NonInteractive",
-          "-NoProfile",
-          "-ExecutionPolicy #{execution_policy}",
-          # PowerShell will hang if STDIN is redirected
-          # http://connect.microsoft.com/PowerShell/feedback/details/572313/powershell-exe-can-hang-if-stdin-is-redirected
-          "-InputFormat None",
-        ].join(" ")
+        # Set InputFormat to None as PowerShell will hang if STDIN is redirected
+        # http://connect.microsoft.com/PowerShell/feedback/details/572313/powershell-exe-can-hang-if-stdin-is-redirected
+        "-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None"
       end
     end
   end

--- a/spec/unit/provider/powershell_script_spec.rb
+++ b/spec/unit/provider/powershell_script_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2013-2017, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,35 +73,13 @@ describe Chef::Provider::PowershellScript, "action_run" do
       execution_policy_index ? provider_flags[execution_policy_index + 1] : nil
     end
 
-    context "when running with an unspecified PowerShell version" do
-      let(:powershell_version) { nil }
-      it "sets default -ExecutionPolicy flag to 'Unrestricted'" do
-        expect(execution_policy_flag.downcase).to eq("unrestricted".downcase)
-      end
-      it "sets user defined -ExecutionPolicy flag to 'RemoteSigned'" do
-        set_user_defined_flag
-        expect(execution_policy_flag.downcase).to eq("RemoteSigned".downcase)
-      end
+    it "sets default -ExecutionPolicy flag to 'Bypass'" do
+      expect(execution_policy_flag).to eq("Bypass")
     end
 
-    { "2.0" => "Unrestricted",
-      "2.5" => "Unrestricted",
-      "3.0" => "Bypass",
-      "3.6" => "Bypass",
-      "4.0" => "Bypass",
-      "5.0" => "Bypass" }.each do |version_policy|
-        let(:powershell_version) { version_policy[0].to_f }
-        context "when running PowerShell version #{version_policy[0]}" do
-          let(:powershell_version) { version_policy[0].to_f }
-
-          it "sets default -ExecutionPolicy flag to '#{version_policy[1]}'" do
-            expect(execution_policy_flag.downcase).to eq(version_policy[1].downcase)
-          end
-          it "sets user defined -ExecutionPolicy flag to 'RemoteSigned'" do
-            set_user_defined_flag
-            expect(execution_policy_flag.downcase).to eq("RemoteSigned".downcase)
-          end
-        end
-      end
+    it "sets user defined -ExecutionPolicy flag to 'RemoteSigned'" do
+      set_user_defined_flag
+      expect(execution_policy_flag).to eq("RemoteSigned")
+    end
   end
 end


### PR DESCRIPTION
All the platforms we support have PowerShell 3.0+ now so this is always true.

Signed-off-by: Tim Smith <tsmith@chef.io>