### PR TITLE
directory resource: Remove support for macOS < 10.11

### DIFF
--- a/chef-config/lib/chef-config/path_helper.rb
+++ b/chef-config/lib/chef-config/path_helper.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2019, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -265,15 +265,15 @@ module ChefConfig
       end
     end
 
-    # Determine if the given path is protected by OS X System Integrity Protection.
+    # Determine if the given path is protected by macOS System Integrity Protection.
     def self.is_sip_path?(path, node)
-      if node["platform"] == "mac_os_x" && Gem::Version.new(node["platform_version"]) >= Gem::Version.new("10.11")
+      if ChefUtils.macos?
           # @todo: parse rootless.conf for this?
         sip_paths = [
           "/System", "/bin", "/sbin", "/usr"
         ]
         sip_paths.each do |sip_path|
-          ChefConfig.logger.info("This is a SIP path, checking if it in exceptions list.")
+          ChefConfig.logger.info("#{sip_path} is a SIP path, checking if it is in the exceptions list.")
           return true if path.start_with?(sip_path)
         end
         false
@@ -293,7 +293,7 @@ module ChefConfig
       sip_exceptions.each do |exception_path|
         return true if path.start_with?(exception_path)
       end
-      ChefConfig.logger.error("Cannot write to a SIP Path on OS X 10.11+")
+      ChefConfig.logger.error("Cannot write to a SIP path #{path} on macOS!")
       false
     end
 

--- a/spec/unit/provider/directory_spec.rb
+++ b/spec/unit/provider/directory_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -201,33 +201,22 @@ describe Chef::Provider::Directory do
       end
     end
 
-    describe "on OS X" do
+    describe "on macOS" do
       before do
-        allow(node).to receive(:[]).with("platform").and_return("mac_os_x")
+        allow(ChefUtils).to receive(:macos?).and_return(true)
         new_resource.path "/usr/bin/chef_test"
         new_resource.recursive false
         allow_any_instance_of(Chef::Provider::File).to receive(:do_selinux)
       end
 
-      it "os x 10.10 can write to sip locations" do
-        allow(node).to receive(:[]).with("platform_version").and_return("10.10")
-        allow(Dir).to receive(:mkdir).and_return([true], [])
-        allow(::File).to receive(:directory?).and_return(true)
-        allow(Chef::FileAccessControl).to receive(:writable?).and_return(true)
-        directory.run_action(:create)
-        expect(new_resource).to be_updated
-      end
-
-      it "os x 10.11 cannot write to sip locations" do
-        allow(node).to receive(:[]).with("platform_version").and_return("10.11")
+      it "macOS cannot write to sip locations" do
         allow(::File).to receive(:directory?).and_return(true)
         allow(Chef::FileAccessControl).to receive(:writable?).and_return(false)
         expect { directory.run_action(:create) }.to raise_error(Chef::Exceptions::InsufficientPermissions)
       end
 
-      it "os x 10.11 can write to sip exlcusions" do
+      it "macOS can write to sip exclusions" do
         new_resource.path "/usr/local/chef_test"
-        allow(node).to receive(:[]).with("platform_version").and_return("10.11")
         allow(::File).to receive(:directory?).and_return(true)
         allow(Dir).to receive(:mkdir).and_return([true], [])
         allow(Chef::FileAccessControl).to receive(:writable?).and_return(false)


### PR DESCRIPTION
There's no reason to test this behavior anymore since we don't support macOS < 10.13

Signed-off-by: Tim Smith <tsmith@chef.io>