### PR TITLE
Deprecate Chef::Platform.supports_msi?

### DIFF
--- a/lib/chef/platform/query_helpers.rb
+++ b/lib/chef/platform/query_helpers.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,21 +31,11 @@ class Chef
         false
       end
 
+      # @deprecated we added this method due to Windows Server Nano, which is no longer a platform
       def supports_msi?
         return false unless windows?
 
-        require "win32/registry" unless defined?(Win32::Registry)
-
-        key = "System\\CurrentControlSet\\Services\\msiserver"
-        access = ::Win32::Registry::KEY_QUERY_VALUE
-
-        begin
-          ::Win32::Registry::HKEY_LOCAL_MACHINE.open(key, access) do |reg|
-            true
-          end
-        rescue ::Win32::Registry::Error
-          false
-        end
+        true
       end
 
       # @deprecated we don't support any release of Windows that isn't PS 3+

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2017, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@
 
 # TODO: Allow new_resource.source to be a Product Code as a GUID for uninstall / network install
 
-require_relative "../../../win32/api/installer" if (RUBY_PLATFORM =~ /mswin|mingw32|windows/) && Chef::Platform.supports_msi?
+require_relative "../../../win32/api/installer" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
 require_relative "../../../mixin/shell_out"
 
 class Chef
@@ -26,7 +26,7 @@ class Chef
     class Package
       class Windows
         class MSI
-          include Chef::ReservedNames::Win32::API::Installer if (RUBY_PLATFORM =~ /mswin|mingw32|windows/) && Chef::Platform.supports_msi?
+          include Chef::ReservedNames::Win32::API::Installer if RUBY_PLATFORM =~ /mswin|mingw32|windows/
           include Chef::Mixin::ShellOut
 
           def initialize(resource, uninstall_entries)

--- a/spec/unit/platform/query_helpers_spec.rb
+++ b/spec/unit/platform/query_helpers_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2018, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,78 +17,6 @@
 #
 
 require "spec_helper"
-
-describe "Chef::Platform#supports_msi?" do
-  include_context "Win32" # clear and restore Win32:: namespace
-
-  let(:key) { "System\\CurrentControlSet\\Services\\msiserver" }
-  let(:key_query_value) { 0x0001 }
-  let(:access) { key_query_value }
-  let(:hive) { double("Win32::Registry::HKEY_LOCAL_MACHINE") }
-  let(:registry) { double("Win32::Registry") }
-
-  before(:all) do
-    Win32::Registry = Class.new
-    Win32::Registry::Error = Class.new(RuntimeError)
-  end
-
-  before do
-    Win32::Registry::HKEY_LOCAL_MACHINE = hive
-    Win32::Registry::KEY_QUERY_VALUE = key_query_value
-  end
-
-  after do
-    Win32::Registry.send(:remove_const, "HKEY_LOCAL_MACHINE") if defined?(Win32::Registry::HKEY_LOCAL_MACHINE)
-    Win32::Registry.send(:remove_const, "KEY_QUERY_VALUE") if defined?(Win32::Registry::KEY_QUERY_VALUE)
-  end
-
-  it "returns false early when not on windows" do
-    allow(ChefUtils).to receive(:windows?).and_return(false)
-    expect(Chef::Platform).to_not receive(:require)
-    expect(Chef::Platform.supports_msi?).to be false
-  end
-
-  it "returns true when the registry key exists" do
-    allow(ChefUtils).to receive(:windows?).and_return(true)
-    allow(Chef::Platform).to receive(:require).with("win32/registry")
-    expect(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open)
-      .with(key, access)
-      .and_yield(registry)
-    expect(Chef::Platform.supports_msi?).to be true
-  end
-
-  it "returns false when the registry key does not exist" do
-    allow(ChefUtils).to receive(:windows?).and_return(true)
-    allow(Chef::Platform).to receive(:require).with("win32/registry")
-    expect(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open)
-      .with(key, access)
-      .and_raise(Win32::Registry::Error, "The system cannot find the file specified.")
-    expect(Chef::Platform.supports_msi?).to be false
-  end
-end
-
-describe "Chef::Platform#supports_dsc?" do
-  it "returns false if PowerShell is not present" do
-    node = Chef::Node.new
-    expect(Chef::Platform.supports_dsc?(node)).to be_falsey
-  end
-
-  ["1.0", "2.0", "3.0"].each do |version|
-    it "returns false for PowerShell #{version}" do
-      node = Chef::Node.new
-      node.automatic[:languages][:powershell][:version] = version
-      expect(Chef::Platform.supports_dsc?(node)).to be_falsey
-    end
-  end
-
-  ["4.0", "5.0"].each do |version|
-    it "returns true for PowerShell #{version}" do
-      node = Chef::Node.new
-      node.automatic[:languages][:powershell][:version] = version
-      expect(Chef::Platform.supports_dsc?(node)).to be_truthy
-    end
-  end
-end
 
 describe "Chef::Platform#supports_dsc_invoke_resource?" do
   it "returns false if powershell is not present" do


### PR DESCRIPTION
This was put in place for Windows Server Nano which didn't support MSIs. That's not a platform anymore so it can go. Here's the original PR: https://github.com/chef/chef/pull/3939

Signed-off-by: Tim Smith <tsmith@chef.io>