### PR TITLE
Remove the mixin powershell includes from resources

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -17,13 +17,11 @@
 
 require_relative "../package"
 require_relative "../../resource/chocolatey_package"
-require_relative "../../mixin/powershell_out"
 
 class Chef
   class Provider
     class Package
       class Chocolatey < Chef::Provider::Package
-        include Chef::Mixin::PowershellOut
 
         provides :chocolatey_package
 

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -19,7 +19,6 @@
 require_relative "../mixin/shell_out"
 require "rexml/document" unless defined?(REXML::Document)
 require "iso8601" if ChefUtils.windows?
-require_relative "../mixin/powershell_out"
 require_relative "../provider"
 require_relative "../util/path_helper"
 require "win32/taskscheduler" if ChefUtils.windows?
@@ -28,7 +27,6 @@ class Chef
   class Provider
     class WindowsTask < Chef::Provider
       include Chef::Mixin::ShellOut
-      include Chef::Mixin::PowershellOut
 
       if ChefUtils.windows?
         include Win32

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -16,7 +16,6 @@
 #
 
 require_relative "../resource"
-require_relative "../mixin/powershell_out"
 require_relative "../dist"
 
 class Chef
@@ -24,8 +23,6 @@ class Chef
     class WindowsAdJoin < Chef::Resource
       resource_name :windows_ad_join
       provides :windows_ad_join
-
-      include Chef::Mixin::PowershellOut
 
       description "Use the windows_ad_join resource to join a Windows Active Directory domain."
       introduced "14.0"

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require_relative "../mixin/powershell_out"
 require_relative "../json_compat"
 require_relative "../resource"
 require_relative "../platform/query_helpers"
@@ -58,8 +57,6 @@ class Chef
         # features aren't case sensitive so let's compare in lowercase
         x.map(&:downcase)
       end
-
-      include Chef::Mixin::PowershellOut
 
       action :install do
         reload_cached_powershell_data unless node["powershell_features_cache"]


### PR DESCRIPTION
This is in universal so we don't need to do it in these resources / providers. We had it in some, but not in others.

Signed-off-by: Tim Smith <tsmith@chef.io>