### PR TITLE
Remove the last bits of Appveyor from the specs

### DIFF
--- a/spec/functional/resource/windows_certificate_spec.rb
+++ b/spec/functional/resource/windows_certificate_spec.rb
@@ -47,7 +47,7 @@ module WindowsCertificateHelper
   end
 end
 
-describe Chef::Resource::WindowsCertificate, :windows_only, :appveyor_only do
+describe Chef::Resource::WindowsCertificate, :windows_only do
   include WindowsCertificateHelper
 
   let(:stdout) { StringIO.new }

--- a/spec/functional/resource/windows_service_spec.rb
+++ b/spec/functional/resource/windows_service_spec.rb
@@ -18,8 +18,7 @@
 
 require "spec_helper"
 
-describe Chef::Resource::WindowsService, :windows_only, :system_windows_service_gem_only, :appveyor_only, broken: true do
-  # Marking as broken. This test is causing appveyor tests to exit with 116.
+describe Chef::Resource::WindowsService, :windows_only, :system_windows_service_gem_only do
 
   include_context "using Win32::Service"
 

--- a/spec/functional/win32/service_manager_spec.rb
+++ b/spec/functional/win32/service_manager_spec.rb
@@ -33,7 +33,7 @@ end
 # directories.
 #
 
-describe "Chef::Application::WindowsServiceManager", :windows_only, :system_windows_service_gem_only, :appveyor_only do
+describe "Chef::Application::WindowsServiceManager", :windows_only, :system_windows_service_gem_only do
 
   include_context "using Win32::Service"
 

--- a/spec/integration/client/client_spec.rb
+++ b/spec/integration/client/client_spec.rb
@@ -540,8 +540,7 @@ describe "chef-client" do
     end
   end
 
-  # Fails on appveyor, but works locally on windows and on windows hosts in Ci.
-  context "when using recipe-url", :skip_appveyor do
+  context "when using recipe-url" do
     before(:each) do
       start_tiny_server
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,9 +140,6 @@ RSpec.configure do |config|
   config.filter_run_excluding volatile_on_solaris: true if solaris?
   config.filter_run_excluding volatile_from_verify: false
 
-  config.filter_run_excluding skip_appveyor: true if ENV["APPVEYOR"]
-  config.filter_run_excluding appveyor_only: true unless ENV["APPVEYOR"]
-
   config.filter_run_excluding skip_buildkite: true if ENV["BUILDKITE"]
 
   config.filter_run_excluding windows_only: true unless windows?


### PR DESCRIPTION
We don't have Appveyor anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>