### PR TITLE
Fix gsub so only file endings of .rb and .json are removed.

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -775,7 +775,7 @@ class Chef
           end
 
         elsif path.length == 2 && path[0] != "cookbooks"
-          path[1] = path[1].gsub(/\.(rb|json)/, "")
+          path[1] = path[1].gsub(/\.(rb|json)$/, "")
         end
 
         path


### PR DESCRIPTION
Fix gsub so only file endings of .rb and .json are removed. Any file paths, like FQDNs with them in between will not be handeled.

Signed-off-by: Jörg Herzinger <joerg.herzinger@gmail.com>

## Description

Finding this gave us a really hard time. In Kitchen we started testing with fake nodes, but we had a new FQDN which contained a ".rb" in-between (like our.fqdn.rbsomething.com). Chef Zero gave us nasty 404 errors when we tried searching for node attributes so we started tracking it down and eventually found that this regex removes any .rb and .json even if they are not at the and of the path.
I also tried finding a test that I could duplicate to check this, but I did not find anything. If you want a test please point me to where such a test should be added.
Essentially this is a quite obvious fix in my eyes.

## Related Issue

Here we already reported this, but since we changed the node_name the error can not be reproduced by these infos: 
https://discourse.chef.io/t/kitchen-search-on-aws-fails-with-net-httpserverexception-404-not-found/16734

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
