### PR TITLE
Update gcc pinning for solaris to 5.4.0

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -98,11 +98,7 @@ class Chef
           package "bison"
           package "gnu-coreutils"
           package "flex"
-          package "gcc" do
-            # lock because we don't use 5 yet
-            version "4.8.2"
-          end
-          package "gcc-3"
+          package "gcc"
           package "gnu-grep"
           package "gnu-make"
           package "gnu-patch"


### PR DESCRIPTION
closes #7245
