### PR TITLE
Replace highline.color with pastel.decorate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ PATH
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 16.0)
+      pastel
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
@@ -87,6 +88,7 @@ PATH
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
       ohai (~> 16.0)
+      pastel
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
   s.add_dependency "highline", ">= 1.6.9", "< 2"
   s.add_dependency "tty-screen", "~> 0.6" # knife list
+  s.add_dependency "pastel" # knife ui.color
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
   s.add_dependency "ffi-libarchive"

--- a/lib/chef/formatters/indentable_output_stream.rb
+++ b/lib/chef/formatters/indentable_output_stream.rb
@@ -17,21 +17,12 @@ class Chef
         @semaphore = Mutex.new
       end
 
-      def highline
-        @highline ||= begin
-          require "highline"
-          HighLine.new
+      # pastel.decorate is a lightweight replacement for highline.color
+      def pastel
+        @pastel ||= begin
+          require "pastel"
+          Pastel.new
         end
-      end
-
-      # Print text. This will start a new line and indent if necessary
-      # but will not terminate the line (future print and puts statements
-      # will start off where this print left off).
-      #
-      # @param string [String]
-      # @param args [Array<Hash,Symbol>]
-      def color(string, *args)
-        print(string, from_args(args))
       end
 
       # Print the start of a new line.  This will terminate any existing lines and
@@ -83,7 +74,7 @@ class Chef
       #
       # == Alternative
       #
-      # You may also call print('string', :red) (a list of colors a la Highline.color)
+      # You may also call print('string', :red) (https://github.com/piotrmurach/pastel#3-supported-colors)
       def print(string, *args)
         options = from_args(args)
 
@@ -140,7 +131,7 @@ class Chef
         end
 
         if Chef::Config[:color] && options[:colors]
-          @out.print highline.color(line, *options[:colors])
+          @out.print pastel.decorate(line, *options[:colors])
         else
           @out.print line
         end

--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -61,6 +61,14 @@ class Chef
         end
       end
 
+      # pastel.decorate is a lightweight replacement for highline.color
+      def pastel
+        @pastel ||= begin
+          require "pastel"
+          Pastel.new
+        end
+      end
+
       # Prints a message to stdout. Aliased as +info+ for compatibility with
       # the logger API.
       #
@@ -134,7 +142,7 @@ class Chef
 
       def color(string, *colors)
         if color?
-          highline.color(string, *colors)
+          pastel.decorate(string, *colors)
         else
           string
         end

--- a/spec/unit/knife/core/ui_spec.rb
+++ b/spec/unit/knife/core/ui_spec.rb
@@ -507,6 +507,22 @@ describe Chef::Knife::UI do
     end
   end
 
+  describe "color" do
+    context "when ui.color? => true" do
+      it "returns colored output" do
+        expect(@ui).to receive(:color?).and_return(true)
+        expect(@ui.color("a_bus_is", :yellow)).to eql("\e[33ma_bus_is\e[0m")
+      end
+    end
+
+    context "when ui.color? => false" do
+      it "returns plain output" do
+        expect(@ui).to receive(:color?).and_return(false)
+        expect(@ui.color("a_bus_is", :yellow)).to eql("a_bus_is")
+      end
+    end
+  end
+
   describe "confirm" do
     let(:stdout) { StringIO.new }
     let(:output) { stdout.string }


### PR DESCRIPTION
Contributes to the removal of the 'heavy' highline dependency (#9359) by
switching from highline.color to pastel.decorate, which is a drop-in
replacement. Pastel is part of the tty[1] family of libraries.

[1] https://github.com/piotrmurach/tty#3-components

Signed-off-by: Bryan McLellan <btm@loftninjas.org>
