### PR TITLE
Remove the canonical DSL

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -952,6 +952,11 @@ class Chef
       if name != NOT_PASSED
         if name
           @resource_name = name.to_sym
+          name = name.to_sym
+          # FIXME: determine a way to deprecate this magic behavior
+          unless Chef::ResourceResolver.includes_handler?(name, self)
+            provides name
+          end
         else
           @resource_name = nil
         end
@@ -1338,7 +1343,8 @@ class Chef
     def self.provides(name, **options, &block)
       name = name.to_sym
 
-      resource_name name if resource_name.nil?
+      # deliberately do not go through the accessor here
+      @resource_name = name if resource_name.nil?
 
       if @chef_version_for_provides && !options.include?(:chef_version)
         options[:chef_version] = @chef_version_for_provides

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1320,9 +1320,7 @@ class Chef
     #
     # Since resource_name calls provides the generally correct way of doing this is
     # to do `chef_version_for_provides` first, then `resource_name` and then
-    # any additional options `provides` lines.  Calling `resource_name` is somewhat
-    # important to have the canonical_dsl removed or else that'll stick around
-    # and chef_version won't get applied to it.
+    # any additional options `provides` lines.
     #
     # Once we no longer care about supporting chef < 14.4 then we can deprecate
     # this API.

--- a/lib/chef/resource/apt_package.rb
+++ b/lib/chef/resource/apt_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class AptPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :apt_package
       provides :apt_package, target_mode: true
       provides :package, platform_family: "debian", target_mode: true
 

--- a/lib/chef/resource/apt_preference.rb
+++ b/lib/chef/resource/apt_preference.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: 2016-2019, Chef Software Inc.
+# Copyright:: 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ class Chef
     class AptPreference < Chef::Resource
       unified_mode true
 
-      resource_name :apt_preference
       provides(:apt_preference) { true }
 
       description "The apt_preference resource allows for the creation of APT preference files. Preference files are used to control which package versions and sources are prioritized during installation."

--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -26,7 +26,6 @@ class Chef
     class AptRepository < Chef::Resource
       unified_mode true
 
-      resource_name :apt_repository
       provides(:apt_repository) { true }
 
       description "Use the apt_repository resource to specify additional APT repositories. Adding a new repository will update the APT package cache immediately."

--- a/lib/chef/resource/apt_update.rb
+++ b/lib/chef/resource/apt_update.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016-2019, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class AptUpdate < Chef::Resource
       unified_mode true
 
-      resource_name :apt_update
       provides(:apt_update) { true }
 
       description "Use the apt_update resource to manage APT repository updates on Debian and Ubuntu platforms."

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2017-2019, Chef Software Inc.
+# Copyright:: Copyright 2017-2020, Chef Software Inc.
 # Author:: Jamie Winsor (<jamie@vialstudios.com>)
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
@@ -25,7 +25,6 @@ class Chef
     class ArchiveFile < Chef::Resource
       unified_mode true
 
-      resource_name :archive_file
       provides :archive_file
       provides :libarchive_file # legacy cookbook name
 

--- a/lib/chef/resource/bash.rb
+++ b/lib/chef/resource/bash.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
   class Resource
     class Bash < Chef::Resource::Script
       unified_mode true
+
+      provides :bash
 
       description "Use the bash resource to execute scripts using the Bash interpreter. This resource may also use any of the actions and properties that are available to the execute resource. Commands that are executed with this resource are (by their nature) not idempotent, as they are typically unique to the environment in which they are run. Use not_if and only_if to guard this resource for idempotence."
 

--- a/lib/chef/resource/bff_package.rb
+++ b/lib/chef/resource/bff_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Deepali Jagtap (<deepali.jagtap@clogeny.com>)
-# Copyright:: Copyright 2013-2019, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class BffPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :bff_package
       provides :bff_package
 
       description "Use the bff_package resource to manage packages for the AIX platform using the installp utility. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."

--- a/lib/chef/resource/breakpoint.rb
+++ b/lib/chef/resource/breakpoint.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ class Chef
       unified_mode true
 
       provides :breakpoint, target_mode: true
-      resource_name :breakpoint
 
       description "Use the breakpoint resource to add breakpoints to recipes. Run the #{Chef::Dist::SHELL} in #{Chef::Dist::PRODUCT} mode, and then use those breakpoints to debug recipes. Breakpoints are ignored by the #{Chef::Dist::CLIENT} during an actual #{Chef::Dist::CLIENT} run. That said, breakpoints are typically used to debug recipes only when running them in a non-production environment, after which they are removed from those recipes before the parent cookbook is uploaded to the Chef server."
       introduced "12.0"

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -21,7 +21,6 @@ class Chef
     class BuildEssential < Chef::Resource
       unified_mode true
 
-      resource_name :build_essential
       provides(:build_essential) { true }
 
       description "Use the build_essential resource to install the packages required for compiling C software from source."

--- a/lib/chef/resource/cab_package.rb
+++ b/lib/chef/resource/cab_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Vasundhara Jagdale (<vasundhara.jagdale@msystechnologies.com>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ class Chef
       include Chef::Mixin::Uris
       unified_mode true
 
-      resource_name :cab_package
       provides :cab_package
 
       description "Use the cab_package resource to install or remove Microsoft Windows cabinet (.cab) packages."

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -36,7 +36,7 @@ class Chef
     #    immediately after it is installed
     class ChefGem < Chef::Resource::Package::GemPackage
       unified_mode true
-      resource_name :chef_gem
+      provides :chef_gem
 
       property :gem_binary, default: "#{RbConfig::CONFIG["bindir"]}/gem", default_description: "Chef's built-in gem binary.",
                             description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the #{Chef::Dist::CLIENT} will be installed.",

--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Seth Chisamore <schisamo@chef.io>
-# Copyright:: 2011-2019, Chef Software Inc.<legal@chef.io>
+# Copyright:: 2011-2020, Chef Software Inc.<legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ class Chef
     class ChefHandler < Chef::Resource
       unified_mode true
 
-      resource_name :chef_handler
       provides(:chef_handler) { true }
 
       description "Use the chef_handler resource to install or uninstall reporting/exception handlers."

--- a/lib/chef/resource/chef_sleep.rb
+++ b/lib/chef/resource/chef_sleep.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019-2019, Chef Software Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ require_relative "../dist"
 class Chef
   class Resource
     class ChefSleep < Chef::Resource
-      resource_name :chef_sleep
       provides :chef_sleep
 
       unified_mode true

--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -21,7 +21,6 @@ require "chef-vault"
 class Chef
   class Resource
     class ChefVaultSecret < Chef::Resource
-      resource_name :chef_vault_secret
       provides :chef_vault_secret
 
       introduced "16.0"

--- a/lib/chef/resource/chocolatey_config.rb
+++ b/lib/chef/resource/chocolatey_config.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2018-2019, Chef Software Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 class Chef
   class Resource
     class ChocolateyConfig < Chef::Resource
-      resource_name :chocolatey_config
       unified_mode true
+
+      provides :chocolatey_config
 
       description "Use the chocolatey_config resource to add or remove Chocolatey configuration keys."
       introduced "14.3"

--- a/lib/chef/resource/chocolatey_feature.rb
+++ b/lib/chef/resource/chocolatey_feature.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019-2019, Chef Software Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ class Chef
   class Resource
     class ChocolateyFeature < Chef::Resource
       unified_mode true
-      resource_name :chocolatey_feature
+      provides :chocolatey_feature
 
       description "Use the chocolatey_feature resource to enable and disable Chocolatey features."
       introduced "15.1"

--- a/lib/chef/resource/chocolatey_package.rb
+++ b/lib/chef/resource/chocolatey_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class ChocolateyPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :chocolatey_package
       provides :chocolatey_package
 
       description "Use the chocolatey_package resource to manage packages using Chocolatey on the Microsoft Windows platform."

--- a/lib/chef/resource/chocolatey_source.rb
+++ b/lib/chef/resource/chocolatey_source.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2018-2019, Chef Software Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ class Chef
   class Resource
     class ChocolateySource < Chef::Resource
       unified_mode true
-      resource_name :chocolatey_source
+      provides :chocolatey_source
 
       description "Use the chocolatey_source resource to add, remove, enable, or disable Chocolatey sources."
       introduced "14.3"

--- a/lib/chef/resource/cookbook_file.rb
+++ b/lib/chef/resource/cookbook_file.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ class Chef
       include Chef::Mixin::Securable
       unified_mode true
 
-      resource_name :cookbook_file
+      provides :cookbook_file
 
       description "Use the cookbook_file resource to transfer files from a sub-directory of COOKBOOK_NAME/files/ to a specified path located on a host that is running the #{Chef::Dist::PRODUCT}. The file is selected according to file specificity, which allows different source files to be used based on the hostname, host platform (operating system, distro, or as appropriate), or platform version. Files that are located in the COOKBOOK_NAME/files/default sub-directory may be used on any platform.\n\nDuring a #{Chef::Dist::PRODUCT} run, the checksum for each local file is calculated and then compared against the checksum for the same file as it currently exists in the cookbook on the #{Chef::Dist::SERVER_PRODUCT}. A file is not transferred when the checksums match. Only files that require an update are transferred from the #{Chef::Dist::SERVER_PRODUCT} to a node."
 

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -24,7 +24,6 @@ class Chef
   class Resource
     class Cron < Chef::Resource
       unified_mode true
-      resource_name :cron
       provides :cron
 
       description "Use the cron resource to manage cron entries for time-based job scheduling. Properties for a schedule will default to * if not provided. The cron resource requires access to a crontab program, typically cron."

--- a/lib/chef/resource/cron_access.rb
+++ b/lib/chef/resource/cron_access.rb
@@ -3,7 +3,7 @@
 # Author:: Tim Smith <tsmith@chef.io>
 #
 # Copyright:: 2014-2018, Sander Botman
-# Copyright:: 2018-2019, Chef Software Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class Chef
   class Resource
     class CronAccess < Chef::Resource
       unified_mode true
-      resource_name :cron_access
+      provides :cron_access
       provides(:cron_manage) # legacy name @todo in Chef 15 we should { true } this so it wins over the cookbook
 
       introduced "14.4"

--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2008-2019, Chef Software Inc.
+# Copyright:: 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class CronD < Chef::Resource
       unified_mode true
-      resource_name :cron_d
+      provides :cron_d
 
       introduced "14.4"
       description "Use the cron_d resource to manage cron definitions in /etc/cron.d. This is similar to the 'cron' resource, but it does not use the monolithic /etc/crontab file."

--- a/lib/chef/resource/csh.rb
+++ b/lib/chef/resource/csh.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
   class Resource
     class Csh < Chef::Resource::Script
       unified_mode true
+
+      provides :csh
 
       description "Use the csh resource to execute scripts using the csh interpreter."\
                   " This resource may also use any of the actions and properties that are"\

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ class Chef
     class Directory < Chef::Resource
       unified_mode true
 
-      resource_name :directory
+      provides :directory
 
       description "Use the directory resource to manage a directory, which is a hierarchy"\
                   " of folders that comprises all of the information stored on a computer."\

--- a/lib/chef/resource/dmg_package.rb
+++ b/lib/chef/resource/dmg_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Joshua Timberman (<jtimberman@chef.io>)
-# Copyright:: 2011-2019, Chef Software Inc.
+# Copyright:: 2011-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ class Chef
   class Resource
     class DmgPackage < Chef::Resource
       unified_mode true
-      resource_name :dmg_package
+
       provides(:dmg_package) { true }
 
       description "Use the dmg_package resource to install a package from a .dmg file. The resource will retrieve the dmg file from a remote URL, mount it using OS X's hdidutil, copy the application (.app directory) to the specified destination (/Applications), and detach the image using hdiutil. The dmg file will be stored in the Chef::Config[:file_cache_path]."

--- a/lib/chef/resource/dnf_package.rb
+++ b/lib/chef/resource/dnf_package.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016-2019, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,7 @@ class Chef
       extend Chef::Mixin::ShellOut
 
       unified_mode true
-      resource_name :dnf_package
+      provides :dnf_package
 
       # all rhel variants >= 8 will use DNF
       provides :package, platform_family: "rhel", platform_version: ">= 8"
@@ -39,8 +39,6 @@ class Chef
       provides :package, platform: "amazon" do
         which("dnf")
       end
-
-      provides :dnf_package
 
       description "Use the dnf_package resource to install, upgrade, and remove packages with DNF for Fedora and RHEL 8+. The dnf_package resource is able to resolve provides data for packages much like DNF can do when it is run from the command line. This allows a variety of options for installing packages, like minimum versions, virtual provides and library names."
       introduced "12.18"

--- a/lib/chef/resource/dpkg_package.rb
+++ b/lib/chef/resource/dpkg_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class DpkgPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :dpkg_package
       provides :dpkg_package
 
       description "Use the dpkg_package resource to manage packages for the dpkg platform. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -23,7 +23,6 @@ class Chef
     class DscResource < Chef::Resource
       unified_mode true
 
-      resource_name :dsc_resource
       provides :dsc_resource
 
       description "The dsc_resource resource allows any DSC resource to be used in a recipe, as well as any custom resources that have been added to your Windows PowerShell environment. Microsoft frequently adds new resources to the DSC resource collection."

--- a/lib/chef/resource/dsc_script.rb
+++ b/lib/chef/resource/dsc_script.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014-2019, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,6 @@ class Chef
       include Chef::DSL::Powershell
 
       unified_mode true
-      resource_name :dsc_script
       provides :dsc_script
 
       description "Many DSC resources are comparable to built-in #{Chef::Dist::PRODUCT} resources. For example, both DSC and #{Chef::Dist::PRODUCT} have file, package, and service resources. The dsc_script resource is most useful for those DSC resources that do not have a direct comparison to a resource in #{Chef::Dist::PRODUCT}, such as the Archive resource, a custom DSC resource, an existing DSC script that performs an important task, and so on. Use the dsc_script resource to embed the code that defines a DSC configuration directly within a #{Chef::Dist::PRODUCT} recipe."

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ class Chef
     class Execute < Chef::Resource
       unified_mode true
 
-      resource_name :execute
       provides :execute, target_mode: true
 
       description "Use the execute resource to execute a single command. Commands that"\

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,8 @@ class Chef
     class File < Chef::Resource
       include Chef::Mixin::Securable
       unified_mode true
+
+      provides :file
 
       description "Use the file resource to manage files directly on a node."
 

--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -26,7 +26,7 @@ class Chef
   class Resource
     class FreebsdPackage < Chef::Resource::Package
       unified_mode true
-      resource_name :freebsd_package
+      provides :freebsd_package
       provides :package, platform: "freebsd"
 
       description "Use the freebsd_package resource to manage packages for the FreeBSD platform."

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ class Chef
   class Resource
     class GemPackage < Chef::Resource::Package
       unified_mode true
-      resource_name :gem_package
+      provides :gem_package
 
       description "Use the gem_package resource to manage gem packages that are only included in recipes. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."
 

--- a/lib/chef/resource/git.rb
+++ b/lib/chef/resource/git.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@ class Chef
   class Resource
     class Git < Chef::Resource::Scm
       unified_mode true
+
+      provides :git
 
       description "Use the git resource to manage source control resources that exist in a git repository. git version 1.6.5 (or higher) is required to use all of the functionality in the git resource."
 

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
       state_attrs :members
 
       description "Use the group resource to manage a local group."
+
+      provides :group
 
       allowed_actions :create, :remove, :modify, :manage
       default_action :create

--- a/lib/chef/resource/homebrew_cask.rb
+++ b/lib/chef/resource/homebrew_cask.rb
@@ -25,7 +25,6 @@ class Chef
     class HomebrewCask < Chef::Resource
       unified_mode true
 
-      resource_name :homebrew_cask
       provides(:homebrew_cask) { true }
 
       description "Use the homebrew_cask resource to install binaries distributed via the Homebrew package manager."

--- a/lib/chef/resource/homebrew_package.rb
+++ b/lib/chef/resource/homebrew_package.rb
@@ -26,7 +26,7 @@ class Chef
     class HomebrewPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :homebrew_package
+      provides :homebrew_package
       provides :package, os: "darwin"
 
       description "Use the homebrew_package resource to manage packages for the macOS platform."

--- a/lib/chef/resource/homebrew_tap.rb
+++ b/lib/chef/resource/homebrew_tap.rb
@@ -25,7 +25,6 @@ class Chef
     class HomebrewTap < Chef::Resource
       unified_mode true
 
-      resource_name :homebrew_tap
       provides(:homebrew_tap) { true }
 
       description "Use the homebrew_tap resource to add additional formula repositories to the Homebrew package manager."

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -21,7 +21,6 @@ class Chef
     class Hostname < Chef::Resource
       unified_mode true
 
-      resource_name :hostname
       provides :hostname
 
       description "Use the hostname resource to set the system's hostname, configure hostname and hosts config file, and re-run the Ohai hostname plugin so the hostname will be available in subsequent cookbooks."

--- a/lib/chef/resource/http_request.rb
+++ b/lib/chef/resource/http_request.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ class Chef
     class HttpRequest < Chef::Resource
       unified_mode true
 
-      resource_name :http_request
       provides :http_request
 
       description "Use the http_request resource to send an HTTP request (GET, PUT, POST, DELETE, HEAD, or OPTIONS) with an arbitrary message. This resource is often useful when custom callbacks are necessary."

--- a/lib/chef/resource/ifconfig.rb
+++ b/lib/chef/resource/ifconfig.rb
@@ -28,7 +28,7 @@ class Chef
     class Ifconfig < Chef::Resource
       unified_mode true
 
-      resource_name :ifconfig
+      provides :ifconfig
 
       description "Use the ifconfig resource to manage interfaces on Unix and Linux systems."
 

--- a/lib/chef/resource/ips_package.rb
+++ b/lib/chef/resource/ips_package.rb
@@ -24,9 +24,8 @@ class Chef
     class IpsPackage < ::Chef::Resource::Package
       unified_mode true
 
-      resource_name :ips_package
-      provides :package, os: "solaris2"
       provides :ips_package
+      provides :package, os: "solaris2"
 
       description "Use the ips_package resource to manage packages (using Image Packaging System (IPS)) on the Solaris 11 platform."
 

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -13,7 +13,7 @@ class Chef
     class KernelModule < Chef::Resource
       unified_mode true
 
-      resource_name :kernel_module
+      provides :kernel_module
 
       description "Use the kernel_module resource to manage kernel modules on Linux systems. This resource can load, unload, blacklist, disable, install, and uninstall modules."
       introduced "14.3"

--- a/lib/chef/resource/ksh.rb
+++ b/lib/chef/resource/ksh.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nolan Davidson (<nolan.davidson@gmail.com>)
-# Copyright:: Copyright 2015-2016, Chef Software, Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@ class Chef
   class Resource
     class Ksh < Chef::Resource::Script
       unified_mode true
+
+      provides :ksh
 
       description "Use the ksh resource to execute scripts using the Korn shell (ksh)"\
                   " interpreter. This resource may also use any of the actions and properties"\

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class Launchd < Chef::Resource
-      resource_name :launchd
       provides :launchd
 
       description "Use the launchd resource to manage system-wide services (daemons) and per-user services (agents) on the macOS platform."

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,6 @@ class Chef
       include Chef::Mixin::Securable
       unified_mode true
 
-      resource_name :link
       provides :link
 
       description "Use the link resource to create symbolic or hard links.\n\n"\

--- a/lib/chef/resource/locale.rb
+++ b/lib/chef/resource/locale.rb
@@ -22,7 +22,7 @@ class Chef
   class Resource
     class Locale < Chef::Resource
       unified_mode true
-      resource_name :locale
+      provides :locale
 
       description "Use the locale resource to set the system's locale."
       introduced "14.5"

--- a/lib/chef/resource/log.rb
+++ b/lib/chef/resource/log.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Cary Penniman (<cary@rightscale.com>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,6 @@ class Chef
     class Log < Chef::Resource
       unified_mode true
 
-      resource_name :log
       provides :log, target_mode: true
 
       description "Use the log resource to create log entries. The log resource behaves"\

--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,6 +51,7 @@ class Chef
 
           resource_class = Class.new(self)
           resource_class.run_context = run_context
+          resource_class.provides resource_name.to_sym
           resource_class.class_from_file(filename)
 
           # Make a useful string for the class (rather than <Class:312894723894>)
@@ -64,10 +65,6 @@ class Chef
           Chef::Log.trace("Loaded contents of #{filename} into resource #{resource_name} (#{resource_class})")
 
           LWRPBase.loaded_lwrps[filename] = true
-
-          # wire up the default resource name after the class is parsed only if we haven't declared one.
-          # (this ordering is important for MapCollision deprecation warnings)
-          resource_class.resource_name resource_name.to_sym if resource_class.resource_name.nil?
 
           resource_class
         end

--- a/lib/chef/resource/macos_userdefaults.rb
+++ b/lib/chef/resource/macos_userdefaults.rb
@@ -23,9 +23,8 @@ class Chef
       unified_mode true
 
       # align with apple's marketing department
-      resource_name :macos_userdefaults
-      provides(:mac_os_x_userdefaults) { true }
       provides(:macos_userdefaults) { true }
+      provides(:mac_os_x_userdefaults) { true }
 
       description "Use the macos_userdefaults resource to manage the macOS user defaults system. The properties of this resource are passed to the defaults command, and the parameters follow the convention of that command. See the defaults(1) man page for details on how the tool works."
       introduced "14.0"

--- a/lib/chef/resource/macosx_service.rb
+++ b/lib/chef/resource/macosx_service.rb
@@ -23,7 +23,6 @@ class Chef
     class MacosxService < Chef::Resource::Service
       unified_mode true
 
-      resource_name :macosx_service
       provides :macosx_service
       provides :service, os: "darwin"
 

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: David Balatero (<dbalatero@gmail.com>)
-# Copyright:: Copyright 2009-2016, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@ require_relative "package"
 class Chef
   class Resource
     class MacportsPackage < Chef::Resource::Package
-      resource_name :macports_package
+      provides :macports_package
 
       description "Use the macports_package resource to manage packages for the macOS platform."
     end

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -24,7 +24,7 @@ class Chef
     class Mdadm < Chef::Resource
       unified_mode true
 
-      resource_name :mdadm
+      provides :mdadm
 
       description "Use the mdadm resource to manage RAID devices in a Linux environment using the mdadm utility. The mdadm resource"\
                   " will create and assemble an array, but it will not create the config file that is used to persist the array upon"\

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Joshua Timberman (<joshua@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
   class Resource
     class Mount < Chef::Resource
       description "Use the mount resource to manage a mounted file system."
+
+      provides :mount
 
       default_action :mount
       allowed_actions :mount, :umount, :unmount, :remount, :enable, :disable

--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ class Chef
     class MsuPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
 
-      resource_name :msu_package
       provides :msu_package
 
       description "Use the msu_package resource to install Microsoft Update(MSU) packages on Microsoft Windows machines."

--- a/lib/chef/resource/notify_group.rb
+++ b/lib/chef/resource/notify_group.rb
@@ -20,7 +20,6 @@ require_relative "../dist"
 class Chef
   class Resource
     class NotifyGroup < Chef::Resource
-      resource_name :notify_group
       provides :notify_group
 
       unified_mode true

--- a/lib/chef/resource/ohai.rb
+++ b/lib/chef/resource/ohai.rb
@@ -25,7 +25,6 @@ class Chef
     class Ohai < Chef::Resource
       unified_mode true
 
-      resource_name :ohai
       provides :ohai
 
       description "Use the ohai resource to reload the Ohai configuration on a node. This allows recipes that change system attributes (like a recipe that adds a user) to refer to those attributes later on during the #{Chef::Dist::CLIENT} run."

--- a/lib/chef/resource/ohai_hint.rb
+++ b/lib/chef/resource/ohai_hint.rb
@@ -22,7 +22,6 @@ class Chef
     class OhaiHint < Chef::Resource
       unified_mode true
 
-      resource_name :ohai_hint
       provides(:ohai_hint) { true }
 
       description "Use the ohai_hint resource to aid in configuration detection by passing hint data to Ohai."

--- a/lib/chef/resource/openbsd_package.rb
+++ b/lib/chef/resource/openbsd_package.rb
@@ -2,7 +2,7 @@
 # Authors:: AJ Christensen (<aj@chef.io>)
 #           Richard Manyanza (<liseki@nyikacraftsmen.com>)
 #           Scott Bonds (<scott@ggr.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # Copyright:: Copyright 2014-2016, Richard Manyanza, Scott Bonds
 # License:: Apache License, Version 2.0
 #
@@ -25,7 +25,7 @@ require_relative "../provider/package/openbsd"
 class Chef
   class Resource
     class OpenbsdPackage < Chef::Resource::Package
-      resource_name :openbsd_package
+      provides :openbsd_package
       provides :package, os: "openbsd"
 
       description "Use the openbsd_package resource to manage packages for the OpenBSD platform."

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_dhparam
       provides(:openssl_dhparam) { true }
 
       description "Use the openssl_dhparam resource to generate dhparam.pem files. If a valid dhparam.pem file is found at the specified location, no new file will be created. If a file is found at the specified location but it is not a valid dhparam file, it will be overwritten."

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # Author:: Julien Huon
 # License:: Apache License, Version 2.0
 #
@@ -24,7 +24,7 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_ec_private_key
+      provides :openssl_ec_private_key
 
       description "Use the openssl_ec_private_key resource to generate an elliptic curve (EC) private key file. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, then it will be overwritten."
       introduced "14.4"

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # Author:: Julien Huon
 # License:: Apache License, Version 2.0
 #
@@ -24,7 +24,7 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_ec_public_key
+      provides :openssl_ec_public_key
 
       description "Use the openssl_ec_public_key resource to generate elliptic curve (EC) public key files from a given EC private key."
       introduced "14.4"

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_rsa_private_key
       provides(:openssl_rsa_private_key) { true }
       provides(:openssl_rsa_key) { true } # legacy cookbook resource name
 

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_rsa_public_key
       provides(:openssl_rsa_public_key) { true }
 
       examples <<~DOC

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -1,7 +1,7 @@
 #
 # License:: Apache License, Version 2.0
 # Author:: Julien Huon
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_x509_certificate
+      provides :openssl_x509_certificate
       provides(:openssl_x509) { true } # legacy cookbook name.
 
       description "Use the openssl_x509_certificate resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. Note: This resource was renamed from openssl_x509 to openssl_x509_certificate. The legacy name will continue to function, but cookbook code should be updated for the new resource name."

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -1,7 +1,7 @@
 #
 # License:: Apache License, Version 2.0
 # Author:: Julien Huon
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_x509_crl
+      provides :openssl_x509_crl
 
       description "Use the openssl_x509_crl resource to generate PEM-formatted x509 certificate revocation list (CRL) files."
       introduced "14.4"

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -1,7 +1,7 @@
 #
 # License:: Apache License, Version 2.0
 # Author:: Julien Huon
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
-      resource_name :openssl_x509_request
+      provides :openssl_x509_request
 
       description "Use the openssl_x509_request resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate."
       introduced "14.4"

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class OsxProfile < Chef::Resource
-      resource_name :osx_profile
       provides :osx_profile
       provides :osx_config_profile
 

--- a/lib/chef/resource/package.rb
+++ b/lib/chef/resource/package.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ require_relative "../resource"
 class Chef
   class Resource
     class Package < Chef::Resource
-      resource_name :package
+      provides :package
 
       description "Use the package resource to manage packages. When the package is"\
                   " installed from a local file (such as with RubyGems, dpkg, or RPM"\

--- a/lib/chef/resource/pacman_package.rb
+++ b/lib/chef/resource/pacman_package.rb
@@ -23,7 +23,6 @@ class Chef
     class PacmanPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :pacman_package
       provides :pacman_package
 
       description "Use the pacman_package resource to manage packages (using pacman) on the Arch Linux platform."

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -24,7 +24,6 @@ class Chef
     class PaludisPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :paludis_package
       provides :paludis_package
 
       description "Use the paludis_package resource to manage packages for the Paludis platform."

--- a/lib/chef/resource/perl.rb
+++ b/lib/chef/resource/perl.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
   class Resource
     class Perl < Chef::Resource::Script
       unified_mode true
+
+      provides :perl
 
       def initialize(name, run_context = nil)
         super

--- a/lib/chef/resource/portage_package.rb
+++ b/lib/chef/resource/portage_package.rb
@@ -23,7 +23,6 @@ class Chef
     class PortagePackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :portage_package
       provides :portage_package
 
       description "Use the portage_package resource to manage packages for the Gentoo platform."

--- a/lib/chef/resource/powershell_package.rb
+++ b/lib/chef/resource/powershell_package.rb
@@ -1,5 +1,5 @@
 # Author:: Dheeraj Dubey(dheeraj.dubey@msystechnologies.com)
-# Copyright:: Copyright 2008-2016, Chef Software, Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Chef
     class PowershellPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
 
-      resource_name :powershell_package
       provides :powershell_package
 
       description "Use the powershell_package resource to install and manage packages via the PowerShell Package Manager for the Microsoft Windows platform. The powershell_package resource requires administrative access, and a source must be configured in the PowerShell Package Manager via the powershell_package_source resource."

--- a/lib/chef/resource/powershell_package_source.rb
+++ b/lib/chef/resource/powershell_package_source.rb
@@ -21,7 +21,7 @@ require_relative "../json_compat"
 class Chef
   class Resource
     class PowershellPackageSource < Chef::Resource
-      resource_name "powershell_package_source"
+      provides :powershell_package_source
 
       description "Use the powershell_package_source resource to register a PowerShell package repository."
       introduced "14.3"

--- a/lib/chef/resource/python.rb
+++ b/lib/chef/resource/python.rb
@@ -1,5 +1,5 @@
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@ class Chef
   class Resource
     class Python < Chef::Resource::Script
       unified_mode true
+
+      provides :python
 
       def initialize(name, run_context = nil)
         super

--- a/lib/chef/resource/reboot.rb
+++ b/lib/chef/resource/reboot.rb
@@ -24,7 +24,6 @@ class Chef
     class Reboot < Chef::Resource
       unified_mode true
 
-      resource_name :reboot
       provides :reboot
 
       description "Use the reboot resource to reboot a node, a necessary step with some"\

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -1,7 +1,7 @@
 # Author:: Prajakta Purohit (<prajakta@chef.io>)
 # Author:: Lamont Granquist (<lamont@chef.io>)
 #
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ class Chef
     class RegistryKey < Chef::Resource
       unified_mode true
 
-      resource_name :registry_key
       provides(:registry_key) { true }
 
       description "Use the registry_key resource to create and delete registry keys in Microsoft Windows."

--- a/lib/chef/resource/remote_directory.rb
+++ b/lib/chef/resource/remote_directory.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,8 @@ class Chef
     class RemoteDirectory < Chef::Resource::Directory
       include Chef::Mixin::Securable
       unified_mode true
+
+      provides :remote_directory
 
       description "Use the remote_directory resource to incrementally transfer a directory from a cookbook to a node. The director that is copied from the cookbook should be located under COOKBOOK_NAME/files/default/REMOTE_DIRECTORY. The remote_directory resource will obey file specificity."
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,8 @@ class Chef
     class RemoteFile < Chef::Resource::File
       include Chef::Mixin::Securable
       unified_mode true
+
+      provides :remote_file
 
       description "Use the remote_file resource to transfer a file from a remote location"\
                   " using file specificity. This resource is similar to the file resource."

--- a/lib/chef/resource/rhsm_errata.rb
+++ b/lib/chef/resource/rhsm_errata.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2020 Chef Software, Inc.
+# Copyright:: 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class RhsmErrata < Chef::Resource
       unified_mode true
-      resource_name :rhsm_errata
       provides(:rhsm_errata) { true }
 
       description "Use the rhsm_errata resource to install packages associated with a given Red"\

--- a/lib/chef/resource/rhsm_errata_level.rb
+++ b/lib/chef/resource/rhsm_errata_level.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2020 Chef Software, Inc.
+# Copyright:: 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ class Chef
   class Resource
     class RhsmErrataLevel < Chef::Resource
       unified_mode true
-      resource_name :rhsm_errata_level
       provides(:rhsm_errata_level) { true }
 
       description "Use the rhsm_errata_level resource to install all packages of a specified errata level from the Red Hat Subscription Manager. For example, you can ensure that all packages associated with errata marked at a 'Critical' security level are installed."

--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2020 Chef Software, Inc.
+# Copyright:: 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@ class Chef
   class Resource
     class RhsmRegister < Chef::Resource
       unified_mode true
-      resource_name :rhsm_register
       provides(:rhsm_register) { true }
 
       description "Use the rhsm_register resource to register a node with the Red Hat Subscription Manager"\

--- a/lib/chef/resource/rhsm_repo.rb
+++ b/lib/chef/resource/rhsm_repo.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2018 Chef Software, Inc.
+# Copyright:: 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmRepo < Chef::Resource
-      resource_name :rhsm_repo
       provides(:rhsm_repo) { true }
 
       description "Use the rhsm_repo resource to enable or disable Red Hat Subscription Manager"\

--- a/lib/chef/resource/rhsm_subscription.rb
+++ b/lib/chef/resource/rhsm_subscription.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2015-2018 Chef Software, Inc.
+# Copyright:: 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class RhsmSubscription < Chef::Resource
-      resource_name :rhsm_subscription
       provides(:rhsm_subscription) { true }
 
       description "Use the rhsm_subscription resource to add or remove Red Hat Subscription Manager"\

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -24,6 +24,8 @@ class Chef
     class Route < Chef::Resource
       unified_mode true
 
+      provides :route
+
       default_action :add
       allowed_actions :add, :delete
 

--- a/lib/chef/resource/rpm_package.rb
+++ b/lib/chef/resource/rpm_package.rb
@@ -23,7 +23,6 @@ class Chef
     class RpmPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :rpm_package
       provides :rpm_package
 
       description "Use the rpm_package resource to manage packages for the RPM Package Manager platform."

--- a/lib/chef/resource/ruby.rb
+++ b/lib/chef/resource/ruby.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ class Chef
   class Resource
     class Ruby < Chef::Resource::Script
       unified_mode true
+
+      provides :ruby
 
       description "Use the ruby resource to execute scripts using the Ruby interpreter. This"\
                   " resource may also use any of the actions and properties that are available"\

--- a/lib/chef/resource/script.rb
+++ b/lib/chef/resource/script.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ class Chef
     class Script < Chef::Resource::Execute
       unified_mode true
 
-      resource_name :script
+      provides :script
 
       identity_attr :name
 

--- a/lib/chef/resource/smartos_package.rb
+++ b/lib/chef/resource/smartos_package.rb
@@ -23,7 +23,6 @@ class Chef
     class SmartosPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :smartos_package
       provides :smartos_package
       provides :package, platform_family: "smartos"
 

--- a/lib/chef/resource/snap_package.rb
+++ b/lib/chef/resource/snap_package.rb
@@ -23,7 +23,7 @@ class Chef
     class SnapPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :snap_package
+      provides :snap_package
 
       description "Use the snap_package resource to manage snap packages on Debian and Ubuntu platforms."
       introduced "15.0"

--- a/lib/chef/resource/solaris_package.rb
+++ b/lib/chef/resource/solaris_package.rb
@@ -24,7 +24,6 @@ class Chef
     class SolarisPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :solaris_package
       provides :solaris_package
       provides :package, os: "solaris2", platform_family: "nexentacore"
       provides :package, os: "solaris2", platform_family: "solaris2", platform_version: "<= 5.10"

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -2,7 +2,7 @@
 # Author:: Seth Vargo (<sethvargo@gmail.com>)
 #
 # Copyright:: 2013-2018, Seth Vargo
-# Copyright:: 2017-2018, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ require_relative "../dist"
 class Chef
   class Resource
     class SshKnownHostsEntry < Chef::Resource
-      resource_name :ssh_known_hosts_entry
+      provides :ssh_known_hosts_entry
 
       description "Use the ssh_known_hosts_entry resource to add an entry for the specified host in /etc/ssh/ssh_known_hosts or a user's known hosts file if specified."
       introduced "14.3"

--- a/lib/chef/resource/subversion.rb
+++ b/lib/chef/resource/subversion.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,8 @@ class Chef
   class Resource
     class Subversion < Chef::Resource::Scm
       unified_mode true
+
+      provides :subversion
 
       description "Use the subversion resource to manage source control resources that exist in a Subversion repository."
 

--- a/lib/chef/resource/sudo.rb
+++ b/lib/chef/resource/sudo.rb
@@ -26,7 +26,6 @@ class Chef
     class Sudo < Chef::Resource
       unified_mode true
 
-      resource_name :sudo
       provides(:sudo) { true }
 
       description "Use the sudo resource to add or remove individual sudo entries using sudoers.d files."\

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -1,6 +1,6 @@
 #
 # Copyright:: 2012-2018, Seth Vargo
-# Copyright:: 2017-2020, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ class Chef
     class SwapFile < Chef::Resource
       unified_mode true
 
-      resource_name :swap_file
       provides(:swap_file) { true }
 
       description "Use the swap_file resource to create or delete swap files on Linux systems, and optionally to manage the swappiness configuration for a host."

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -22,7 +22,6 @@ class Chef
     class Sysctl < Chef::Resource
       unified_mode true
 
-      resource_name :sysctl
       provides(:sysctl) { true }
       provides(:sysctl_param) { true }
 

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -23,7 +23,7 @@ require "iniparse"
 class Chef
   class Resource
     class SystemdUnit < Chef::Resource
-      resource_name(:systemd_unit) { true }
+      provides(:systemd_unit) { true }
 
       description "Use the systemd_unit resource to create, manage, and run systemd units."
       introduced "12.11"

--- a/lib/chef/resource/template.rb
+++ b/lib/chef/resource/template.rb
@@ -2,7 +2,7 @@
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,6 @@ class Chef
     class Template < Chef::Resource::File
       unified_mode true
 
-      resource_name :template
       provides :template
 
       include Chef::Mixin::Securable

--- a/lib/chef/resource/timezone.rb
+++ b/lib/chef/resource/timezone.rb
@@ -24,7 +24,7 @@ class Chef
     class Timezone < Chef::Resource
       unified_mode true
 
-      resource_name :timezone
+      provides :timezone
 
       description "Use the timezone resource to change the system timezone on Windows, Linux, and macOS hosts. Timezones are specified in tz database format, with a complete list of available TZ values for Linux and macOS here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones and for Windows here: https://ss64.com/nt/timezones.html."
       introduced "14.6"

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,6 @@ class Chef
   class Resource
     class User < Chef::Resource
       unified_mode true
-
-      resource_name :user_resource_abstract_base_class # this prevents magickal class name DSL wiring
 
       description "Use the user resource to add users, update existing users, remove users, and to lock/unlock user passwords."
 

--- a/lib/chef/resource/user/aix_user.rb
+++ b/lib/chef/resource/user/aix_user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,6 @@ class Chef
     class User
       class AixUser < Chef::Resource::User
         unified_mode true
-
-        resource_name :aix_user
 
         provides :aix_user
         provides :user, os: "aix"

--- a/lib/chef/resource/user/dscl_user.rb
+++ b/lib/chef/resource/user/dscl_user.rb
@@ -23,8 +23,6 @@ class Chef
       class DsclUser < Chef::Resource::User
         unified_mode true
 
-        resource_name :dscl_user
-
         provides :dscl_user
         provides :user, platform: "mac_os_x", platform_version: "< 10.14"
 

--- a/lib/chef/resource/user/linux_user.rb
+++ b/lib/chef/resource/user/linux_user.rb
@@ -23,8 +23,6 @@ class Chef
       class LinuxUser < Chef::Resource::User
         unified_mode true
 
-        resource_name :linux_user
-
         provides :linux_user
         provides :user, os: "linux"
 

--- a/lib/chef/resource/user/mac_user.rb
+++ b/lib/chef/resource/user/mac_user.rb
@@ -60,8 +60,6 @@ class Chef
       class MacUser < Chef::Resource::User
         unified_mode true
 
-        resource_name :mac_user
-
         provides :mac_user
         provides :user, platform: "mac_os_x", platform_version: ">= 10.14"
 

--- a/lib/chef/resource/user/pw_user.rb
+++ b/lib/chef/resource/user/pw_user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,6 @@ class Chef
     class User
       class PwUser < Chef::Resource::User
         unified_mode true
-
-        resource_name :pw_user
 
         provides :pw_user
         provides :user, os: "freebsd"

--- a/lib/chef/resource/user/solaris_user.rb
+++ b/lib/chef/resource/user/solaris_user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,6 @@ class Chef
     class User
       class SolarisUser < Chef::Resource::User
         unified_mode true
-
-        resource_name :solaris_user
 
         provides :solaris_user
         provides :user, os: %w{omnios solaris2}

--- a/lib/chef/resource/user/windows_user.rb
+++ b/lib/chef/resource/user/windows_user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016-2017, Chef Software Inc.
+# Copyright:: Copyright 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,6 @@ class Chef
     class User
       class WindowsUser < Chef::Resource::User
         unified_mode true
-
-        resource_name :windows_user
 
         provides :windows_user
         provides :user, os: "windows"

--- a/lib/chef/resource/whyrun_safe_ruby_block.rb
+++ b/lib/chef/resource/whyrun_safe_ruby_block.rb
@@ -19,6 +19,7 @@
 class Chef
   class Resource
     class WhyrunSafeRubyBlock < Chef::Resource::RubyBlock
+      provides :whyrun_safe_ruby_block
       unified_mode true
     end
   end

--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -21,7 +21,6 @@ require_relative "../dist"
 class Chef
   class Resource
     class WindowsAdJoin < Chef::Resource
-      resource_name :windows_ad_join
       provides :windows_ad_join
 
       description "Use the windows_ad_join resource to join a Windows Active Directory domain."

--- a/lib/chef/resource/windows_auto_run.rb
+++ b/lib/chef/resource/windows_auto_run.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Paul Morton (<pmorton@biaprotect.com>)
 # Copyright:: 2011-2018, Business Intelligence Associates, Inc.
-# Copyright:: 2017-2018, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsAutorun < Chef::Resource
-      resource_name :windows_auto_run
       provides(:windows_auto_run) { true }
 
       description "Use the windows_auto_run resource to set applications to run at login."

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -2,7 +2,7 @@
 # Author:: Richard Lavey (richard.lavey@calastone.com)
 #
 # Copyright:: 2015-2017, Calastone Ltd.
-# Copyright:: 2018-2019, Chef Software Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ require_relative "../dist"
 class Chef
   class Resource
     class WindowsCertificate < Chef::Resource
-      resource_name :windows_certificate
+      provides :windows_certificate
 
       description "Use the windows_certificate resource to install a certificate into the Windows certificate store from a file. The resource grants read-only access to the private key for designated accounts. Due to current limitations in WinRM, installing certificates remotely may not work if the operation requires a user profile. Operations on the local machine store should still work."
       introduced "14.7"

--- a/lib/chef/resource/windows_dfs_folder.rb
+++ b/lib/chef/resource/windows_dfs_folder.rb
@@ -2,7 +2,7 @@
 # Author:: Jason Field
 #
 # Copyright:: 2018, Calastone Ltd.
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsFolder < Chef::Resource
-      resource_name :windows_dfs_folder
       provides :windows_dfs_folder
 
       description "The windows_dfs_folder resources creates a folder within dfs as many levels deep as required."

--- a/lib/chef/resource/windows_dfs_namespace.rb
+++ b/lib/chef/resource/windows_dfs_namespace.rb
@@ -2,7 +2,7 @@
 # Author:: Jason Field
 #
 # Copyright:: 2018, Calastone Ltd.
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsNamespace < Chef::Resource
-      resource_name :windows_dfs_namespace
       provides :windows_dfs_namespace
 
       description "Creates a share and DFS namespace on the local server."

--- a/lib/chef/resource/windows_dfs_server.rb
+++ b/lib/chef/resource/windows_dfs_server.rb
@@ -2,7 +2,7 @@
 # Author:: Jason Field
 #
 # Copyright:: 2018, Calastone Ltd.
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDfsServer < Chef::Resource
-      resource_name :windows_dfs_server
       provides :windows_dfs_server
 
       description "The windows_dfs_server resource sets system-wide DFS settings."

--- a/lib/chef/resource/windows_dns_record.rb
+++ b/lib/chef/resource/windows_dns_record.rb
@@ -2,7 +2,7 @@
 # Author:: Jason Field
 #
 # Copyright:: 2018, Calastone Ltd.
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDnsRecord < Chef::Resource
-      resource_name :windows_dns_record
       provides :windows_dns_record
 
       description "The windows_dns_record resource creates a DNS record for the given domain."

--- a/lib/chef/resource/windows_dns_zone.rb
+++ b/lib/chef/resource/windows_dns_zone.rb
@@ -2,7 +2,7 @@
 # Author:: Jason Field
 #
 # Copyright:: 2018, Calastone Ltd.
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsDnsZone < Chef::Resource
-      resource_name :windows_dns_zone
       provides :windows_dns_zone
 
       description "The windows_dns_zone resource creates an Active Directory Integrated DNS Zone on the local server."

--- a/lib/chef/resource/windows_env.rb
+++ b/lib/chef/resource/windows_env.rb
@@ -22,7 +22,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsEnv < Chef::Resource
-      resource_name :windows_env
       provides :windows_env
       provides :env # backwards compat with the pre-Chef 14 resource name
 

--- a/lib/chef/resource/windows_feature.rb
+++ b/lib/chef/resource/windows_feature.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 #
-# Copyright:: 2011-2018, Chef Software, Inc.
+# Copyright:: 2011-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsFeature < Chef::Resource
-      resource_name :windows_feature
       provides(:windows_feature) { true }
 
       description "Use the windows_feature resource to add, remove or entirely delete Windows features and roles. This resource calls the 'windows_feature_dism' or 'windows_feature_powershell' resources depending on the specified installation method, and defaults to DISM, which is available on both Workstation and Server editions of Windows."

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
 #
-# Copyright:: 2011-2020, Chef Software, Inc.
+# Copyright:: 2011-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ require_relative "../platform/query_helpers"
 class Chef
   class Resource
     class WindowsFeatureDism < Chef::Resource
-      resource_name :windows_feature_dism
       provides(:windows_feature_dism) { true }
 
       description "Use the windows_feature_dism resource to add, remove, or entirely delete Windows features and roles using DISM."

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -23,7 +23,6 @@ require_relative "../platform/query_helpers"
 class Chef
   class Resource
     class WindowsFeaturePowershell < Chef::Resource
-      resource_name :windows_feature_powershell
       provides(:windows_feature_powershell) { true }
 
       description "Use the windows_feature_powershell resource to add, remove, or entirely delete Windows features and roles using PowerShell. This resource offers significant speed benefits over the windows_feature_dism resource, but requires installation of the Remote Server Administration Tools on non-server releases of Windows."

--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -3,7 +3,7 @@
 # Author:: Tor Magnus Rakvåg (tor.magnus@outlook.com)
 # Author:: Tim Smith (tsmith@chef.io)
 # Copyright:: 2013-2015 Matt Clifton
-# Copyright:: 2018, Chef Software, Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 # Copyright:: 2018, Intility AS
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ require_relative "../json_compat"
 class Chef
   class Resource
     class WindowsFirewallRule < Chef::Resource
-      resource_name :windows_firewall_rule
+      provides :windows_firewall_rule
 
       description "Use the windows_firewall_rule resource to create, change or remove windows firewall rules."
       introduced "14.7"

--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -1,6 +1,6 @@
 #
 # Copyright:: 2014-2018, Schuberg Philis BV.
-# Copyright:: 2017-2018, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ class Chef
     class WindowsFont < Chef::Resource
       require_relative "../util/path_helper"
 
-      resource_name :windows_font
       provides(:windows_font) { true }
 
       description "Use the windows_font resource to install font files on Windows. By default, the font is sourced from the cookbook using the resource, but a URI source can be specified as well."

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Bryan McLellan <btm@loftninjas.org>
-# Copyright:: Copyright 2014-2019, Chef Software Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,6 @@ class Chef
     class WindowsPackage < Chef::Resource::Package
       include Chef::Mixin::Uris
 
-      resource_name :windows_package
       provides(:windows_package) { true }
       provides :package, os: "windows"
 

--- a/lib/chef/resource/windows_pagefile.rb
+++ b/lib/chef/resource/windows_pagefile.rb
@@ -1,6 +1,6 @@
 #
 # Copyright:: 2012-2018, Nordstrom, Inc.
-# Copyright:: 2017-2018, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsPagefile < Chef::Resource
-      resource_name :windows_pagefile
       provides(:windows_pagefile) { true }
 
       description "Use the windows_pagefile resource to configure pagefile settings on Windows."

--- a/lib/chef/resource/windows_path.rb
+++ b/lib/chef/resource/windows_path.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsPath < Chef::Resource
-      resource_name :windows_path
       provides(:windows_path) { true }
 
       description "Use the windows_path resource to manage the path environment variable on Microsoft Windows."

--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -24,7 +24,6 @@ class Chef
     class WindowsPrinter < Chef::Resource
       require "resolv"
 
-      resource_name :windows_printer
       provides(:windows_printer) { true }
 
       description "Use the windows_printer resource to setup Windows printers. Note that this doesn't currently install a printer driver. You must already have the driver installed on the system."

--- a/lib/chef/resource/windows_printer_port.rb
+++ b/lib/chef/resource/windows_printer_port.rb
@@ -24,7 +24,6 @@ class Chef
     class WindowsPrinterPort < Chef::Resource
       require "resolv"
 
-      resource_name :windows_printer_port
       provides(:windows_printer_port) { true }
 
       description "Use the windows_printer_port resource to create and delete TCP/IPv4 printer ports on Windows."

--- a/lib/chef/resource/windows_script.rb
+++ b/lib/chef/resource/windows_script.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2013-2019, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,8 @@ class Chef
   class Resource
     class WindowsScript < Chef::Resource::Script
       unified_mode true
+
+      provides :windows_script
 
       # This is an abstract resource meant to be subclasses; thus no 'provides'
 

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -4,7 +4,7 @@
 # Author:: Tim Smith (tsmith@chef.io)
 #
 # Copyright:: 2014-2017, Sölvi Páll Ásgeirsson.
-# Copyright:: 2018, Chef Software, Inc.
+# Copyright:: 2018-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ require_relative "../util/path_helper"
 class Chef
   class Resource
     class WindowsShare < Chef::Resource
-      resource_name :windows_share
+      provides :windows_share
 
       description "Use the windows_share resource to create, modify and remove Windows shares."
       introduced "14.7"

--- a/lib/chef/resource/windows_shortcut.rb
+++ b/lib/chef/resource/windows_shortcut.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Doug MacEachern <dougm@vmware.com>
 # Copyright:: 2010-2018, VMware, Inc.
-# Copyright:: 2017-2018, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsShortcut < Chef::Resource
-      resource_name :windows_shortcut
       provides(:windows_shortcut) { true }
 
       description "Use the windows_shortcut resource to create shortcut files on Windows."

--- a/lib/chef/resource/windows_task.rb
+++ b/lib/chef/resource/windows_task.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@ require_relative "../win32/security" if Chef::Platform.windows?
 class Chef
   class Resource
     class WindowsTask < Chef::Resource
-      resource_name :windows_task
       provides(:windows_task) { true }
 
       description "Use the windows_task resource to create, delete or run a Windows scheduled task. Requires Windows Server 2008 or later due to API usage."

--- a/lib/chef/resource/windows_uac.rb
+++ b/lib/chef/resource/windows_uac.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsUac < Chef::Resource
-      resource_name :windows_uac
       provides :windows_uac
 
       description 'The windows_uac resource configures UAC on Windows hosts by setting registry keys at \'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\''

--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Jared Kauppila (<jared@kauppi.la>)
 # Author:: Vasundhara Jagdale(<vasundhara.jagdale@chef.io>)
-# Copyright 2008-2020, Chef Software, Inc.
+# Copyright 2008-2020, Chef Software Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class Chef
                           SeTakeOwnershipPrivilege
                         }
 
-      resource_name :windows_user_privilege
+      provides :windows_user_privilege
       description "The windows_user_privilege resource allows to add and set principal (User/Group) to the specified privilege. \n Ref: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment"
 
       introduced "16.0"

--- a/lib/chef/resource/windows_workgroup.rb
+++ b/lib/chef/resource/windows_workgroup.rb
@@ -22,7 +22,6 @@ require_relative "../dist"
 class Chef
   class Resource
     class WindowsWorkgroup < Chef::Resource
-      resource_name :windows_workgroup
       provides :windows_workgroup
 
       include Chef::Mixin::PowershellOut

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -24,7 +24,7 @@ class Chef
     class YumPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :yum_package
+      provides :yum_package
       provides :package, platform_family: "fedora_derived"
 
       description "Use the yum_package resource to install, upgrade, and remove packages with Yum"\

--- a/lib/chef/resource/yum_repository.rb
+++ b/lib/chef/resource/yum_repository.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2016-2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class YumRepository < Chef::Resource
-      resource_name :yum_repository
       provides(:yum_repository) { true }
 
       description "Use the yum_repository resource to manage a Yum repository configuration"\

--- a/lib/chef/resource/zypper_package.rb
+++ b/lib/chef/resource/zypper_package.rb
@@ -23,7 +23,7 @@ class Chef
     class ZypperPackage < Chef::Resource::Package
       unified_mode true
 
-      resource_name :zypper_package
+      provides :zypper_package
       provides :package, platform_family: "suse"
 
       description "Use the zypper_package resource to install, upgrade, and remove packages with Zypper for the SUSE Enterprise and OpenSUSE platforms."

--- a/lib/chef/resource/zypper_repository.rb
+++ b/lib/chef/resource/zypper_repository.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Tim Smith (<tsmith@chef.io>)
-# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ require_relative "../resource"
 class Chef
   class Resource
     class ZypperRepository < Chef::Resource
-      resource_name :zypper_repository
       provides(:zypper_repository) { true }
       provides(:zypper_repo) { true }
 

--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -92,7 +92,7 @@ module ResourceInspector
                  if File.directory?(arg)
                    extract_cookbook(arg, complete).each { |k, v| acc[k] = v }
                  else
-                   r = Chef::ResourceResolver.resolve(arg.to_sym, canonical: nil)
+                   r = Chef::ResourceResolver.resolve(arg.to_sym)
                    acc[r.resource_name] = extract_resource(r, complete)
                  end
                end

--- a/lib/chef/resource_resolver.rb
+++ b/lib/chef/resource_resolver.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2015-2017, Chef Software Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +29,8 @@ class Chef
     # @param node [Chef::Node] The node against which to resolve. `nil` causes
     #   platform filters to be ignored.
     #
-    def self.resolve(resource_name, node: nil, canonical: nil)
-      new(node, resource_name, canonical: canonical).resolve
+    def self.resolve(resource_name, node: nil)
+      new(node, resource_name).resolve
     end
 
     #
@@ -40,11 +40,9 @@ class Chef
     # @param resource_name [Symbol] The resource DSL name (e.g. `:file`).
     # @param node [Chef::Node] The node against which to resolve. `nil` causes
     #   platform filters to be ignored.
-    # @param canonical [Boolean] `true` or `false` to match canonical or
-    #   non-canonical values only. `nil` to ignore canonicality.
     #
-    def self.list(resource_name, node: nil, canonical: nil)
-      new(node, resource_name, canonical: canonical).list
+    def self.list(resource_name, node: nil)
+      new(node, resource_name).list
     end
 
     include Chef::Mixin::ConvertToClassName
@@ -55,8 +53,6 @@ class Chef
     attr_reader :resource_name
     # @api private
     attr_reader :action
-    # @api private
-    attr_reader :canonical
 
     #
     # Create a resolver.
@@ -64,14 +60,11 @@ class Chef
     # @param node [Chef::Node] The node against which to resolve. `nil` causes
     #   platform filters to be ignored.
     # @param resource_name [Symbol] The resource DSL name (e.g. `:file`).
-    # @param canonical [Boolean] `true` or `false` to match canonical or
-    #   non-canonical values only. `nil` to ignore canonicality.  Default: `nil`
     #
     # @api private use Chef::ResourceResolver.resolve or .list instead.
-    def initialize(node, resource_name, canonical: nil)
+    def initialize(node, resource_name)
       @node = node
       @resource_name = resource_name.to_sym
-      @canonical = canonical
     end
 
     # @api private use Chef::ResourceResolver.resolve instead.
@@ -135,7 +128,7 @@ class Chef
 
     # @api private
     def potential_handlers
-      handler_map.list(node, resource_name, canonical: canonical).uniq
+      handler_map.list(node, resource_name).uniq
     end
 
     def enabled_handlers
@@ -146,7 +139,7 @@ class Chef
       @prioritized_handlers ||= begin
         enabled_handlers = self.enabled_handlers
 
-        prioritized = priority_map.list(node, resource_name, canonical: canonical).flatten(1)
+        prioritized = priority_map.list(node, resource_name).flatten(1)
         prioritized &= enabled_handlers # Filter the priority map by the actual enabled handlers
         prioritized |= enabled_handlers # Bring back any handlers that aren't in the priority map, at the *end* (ordered set)
         prioritized

--- a/spec/integration/recipes/lwrp_inline_resources_spec.rb
+++ b/spec/integration/recipes/lwrp_inline_resources_spec.rb
@@ -20,7 +20,7 @@ describe "LWRPs with inline resources" do
 
   context "with a use_inline_resources provider with 'def action_a' instead of action :a" do
     class LwrpInlineResourcesTest < Chef::Resource
-      resource_name :lwrp_inline_resources_test
+      provides :lwrp_inline_resources_test
       allowed_actions :a, :nothing
       default_action :a
       property :ran_a
@@ -46,8 +46,8 @@ describe "LWRPs with inline resources" do
 
   context "with an inline resource with a property that shadows the enclosing provider's property" do
     class LwrpShadowedPropertyTest < Chef::Resource
+      provides :lwrp_shadowed_property_test
       PATH = ::File.join(Dir.tmpdir, "shadow-property.txt")
-      use_automatic_resource_name
       allowed_actions :fiddle
       property :content
       action :fiddle do
@@ -73,7 +73,7 @@ describe "LWRPs with inline resources" do
 
   context "with an inline_resources provider with two actions, one calling the other" do
     class LwrpInlineResourcesTest2 < Chef::Resource
-      resource_name :lwrp_inline_resources_test2
+      provides :lwrp_inline_resources_test2
       allowed_actions :a, :b, :nothing
       default_action :b
       property :ran_a

--- a/spec/integration/recipes/noop_resource_spec.rb
+++ b/spec/integration/recipes/noop_resource_spec.rb
@@ -6,7 +6,7 @@ describe "Resources with a no-op provider" do
   context "with noop provider providing foo" do
     before(:each) do
       class NoOpFoo < Chef::Resource
-        resource_name "hi_there"
+        provides "hi_there"
         default_action :update
       end
       Chef::Provider::Noop.provides :hi_there

--- a/spec/integration/recipes/provider_choice.rb
+++ b/spec/integration/recipes/provider_choice.rb
@@ -16,6 +16,8 @@ describe "Recipe DSL methods" do
     context "And class Chef::Provider::ProviderThingy with no provides" do
       before :context do
         class Chef::Provider::ProviderThingy < Chef::Provider
+          provides :provider_thingy
+
           def load_current_resource; end
 
           def action_create

--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -15,7 +15,7 @@ describe "Recipe DSL methods" do
     before(:each) do
 
       class BaseThingy < Chef::Resource
-        resource_name "base_thingy"
+        provides :base_thingy
         default_action :create
 
         class<<self
@@ -67,7 +67,6 @@ describe "Recipe DSL methods" do
     context "nameless resources" do
       before(:each) do
         class NamelessThingy < BaseThingy
-          resource_name :nameless_thingy
           provides :nameless_thingy
 
           property :name, String, default: ""
@@ -124,7 +123,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class AnotherNoNameThingy < BaseThingy
-            resource_name :another_thingy_name
+            provides :another_thingy_name
           end
 
         end
@@ -148,8 +147,8 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class AnotherNoNameThingy2 < BaseThingy
-            resource_name :another_thingy_name2
-            resource_name :another_thingy_name3
+            provides :another_thingy_name2
+            provides :another_thingy_name3
           end
 
         end
@@ -160,10 +159,12 @@ describe "Recipe DSL methods" do
           end.to raise_error(NoMethodError)
         end
 
-        it "another_thingy_name2 does not work" do
-          expect_converge do
+        it "another_thingy_name2 works" do
+          recipe = converge do
             another_thingy_name2("blah") {}
-          end.to raise_error(NoMethodError)
+          end
+          expect(recipe.logged_warnings).to eq ""
+          expect(BaseThingy.created_resource).to eq(AnotherNoNameThingy2)
         end
 
         it "yet_another_thingy_name3 works" do
@@ -180,7 +181,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class AnotherNoNameThingy3 < BaseThingy
-              resource_name :another_no_name_thingy_3
+              provides :another_no_name_thingy_3
               provides :another_no_name_thingy3, os: "blarghle"
             end
 
@@ -209,7 +210,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class AnotherNoNameThingy4 < BaseThingy
-              resource_name :another_no_name_thingy_4
+              provides :another_no_name_thingy_4
               provides :another_no_name_thingy4, os: "blarghle"
               provides :another_no_name_thingy4, platform_family: "foo"
             end
@@ -249,7 +250,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class AnotherNoNameThingy5 < BaseThingy
-              resource_name :another_thingy_name_for_another_no_name_thingy5
+              provides :another_thingy_name_for_another_no_name_thingy5
               provides :another_no_name_thingy5, os: "blarghle"
             end
 
@@ -287,7 +288,7 @@ describe "Recipe DSL methods" do
 
             class AnotherNoNameThingy6 < BaseThingy
               provides :another_no_name_thingy6, os: "blarghle"
-              resource_name :another_thingy_name_for_another_no_name_thingy6
+              provides :another_thingy_name_for_another_no_name_thingy6
             end
 
           end
@@ -323,18 +324,20 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class AnotherNoNameThingy7 < BaseThingy
-              resource_name :another_thingy_name_for_another_no_name_thingy7
+              provides :another_thingy_name_for_another_no_name_thingy7
               provides :another_thingy_name_for_another_no_name_thingy7, os: "blarghle"
             end
 
           end
 
-          it "and os = linux, another_thingy_name_for_another_no_name_thingy7 does not work" do
-            expect_converge do
+          it "and os = linux, another_thingy_name_for_another_no_name_thingy7 works" do
+            recipe = converge do
               # this is an ugly way to test, make Cheffish expose node attrs
               run_context.node.automatic[:os] = "linux"
               another_thingy_name_for_another_no_name_thingy7("blah") {}
-            end.to raise_error(Chef::Exceptions::NoSuchResourceType)
+            end
+            expect(recipe.logged_warnings).to eq ""
+            expect(BaseThingy.created_resource).to eq (AnotherNoNameThingy7)
           end
 
           it "and os = blarghle, another_thingy_name_for_another_no_name_thingy7 works" do
@@ -356,43 +359,6 @@ describe "Recipe DSL methods" do
           end
         end
 
-        # opposite order from the previous test (provides, then resource_name)
-        context "with a resource named AnotherNoNameThingy8, a provides with a new resource name, and resource_name with that new resource name" do
-          before(:each) do
-
-            class AnotherNoNameThingy8 < BaseThingy
-              provides :another_thingy_name_for_another_no_name_thingy8, os: "blarghle"
-              resource_name :another_thingy_name_for_another_no_name_thingy8
-            end
-
-          end
-
-          it "and os = linux, another_thingy_name_for_another_no_name_thingy8 does not work" do
-            expect_converge do
-              # this is an ugly way to test, make Cheffish expose node attrs
-              run_context.node.automatic[:os] = "linux"
-              another_thingy_name_for_another_no_name_thingy8("blah") {}
-            end.to raise_error(Chef::Exceptions::NoSuchResourceType)
-          end
-
-          it "and os = blarghle, another_thingy_name_for_another_no_name_thingy8 works" do
-            recipe = converge do
-              # this is an ugly way to test, make Cheffish expose node attrs
-              run_context.node.automatic[:os] = "blarghle"
-              another_thingy_name_for_another_no_name_thingy8("blah") {}
-            end
-            expect(recipe.logged_warnings).to eq ""
-            expect(BaseThingy.created_resource).to eq (AnotherNoNameThingy8)
-          end
-
-          it "the old resource name does not work" do
-            expect_converge do
-              # this is an ugly way to test, make Cheffish expose node attrs
-              run_context.node.automatic[:os] = "linux"
-              another_thingy_name8("blah") {}
-            end.to raise_error(NoMethodError)
-          end
-        end
       end
     end
 
@@ -401,7 +367,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class RecipeDSLSpecNamespace::MySupplier < BaseThingy
-            resource_name :hemlock
+            provides :hemlock
           end
 
         end
@@ -424,7 +390,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class RecipeDSLSpecNamespace::Thingy3 < BaseThingy
-            resource_name :thingy3
+            provides :thingy3
           end
 
         end
@@ -440,7 +406,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class RecipeDSLSpecNamespace::Thingy4 < BaseThingy
-              resource_name :thingy3
+              provides :thingy3
             end
 
           end
@@ -468,7 +434,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class RecipeDSLSpecNamespace::Thingy5 < BaseThingy
-            resource_name :thingy5
+            provides :thingy5
             provides :thingy5reverse
             provides :thingy5_2
             provides :thingy5_2reverse
@@ -487,7 +453,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class RecipeDSLSpecNamespace::Thingy6 < BaseThingy
-              resource_name :thingy6
+              provides :thingy6
               provides :thingy5
             end
 
@@ -508,14 +474,14 @@ describe "Recipe DSL methods" do
           end
 
           it "resource_matching_short_name returns Thingy6" do
-            expect(Chef::Resource.resource_matching_short_name(:thingy5)).to eq RecipeDSLSpecNamespace::Thingy5
+            expect(Chef::Resource.resource_matching_short_name(:thingy5)).to eq RecipeDSLSpecNamespace::Thingy6
           end
 
           context "and AThingy5 provides :thingy5reverse" do
             before(:each) do
 
               class RecipeDSLSpecNamespace::AThingy5 < BaseThingy
-                resource_name :thingy5reverse
+                provides :thingy5reverse
               end
 
             end
@@ -533,7 +499,7 @@ describe "Recipe DSL methods" do
 
               module ZRecipeDSLSpecNamespace
                 class Thingy5 < BaseThingy
-                  resource_name :thingy5_2
+                  provides :thingy5_2
                 end
               end
 
@@ -552,7 +518,7 @@ describe "Recipe DSL methods" do
 
               module ARecipeDSLSpecNamespace
                 class Thingy5 < BaseThingy
-                  resource_name :thingy5_2reverse
+                  provides :thingy5_2reverse
                 end
               end
 
@@ -571,7 +537,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class RecipeDSLSpecNamespace::Thingy3 < BaseThingy
-              resource_name :thingy3
+              provides :thingy3
             end
 
           end
@@ -587,7 +553,7 @@ describe "Recipe DSL methods" do
             before(:each) do
 
               class RecipeDSLSpecNamespace::Thingy4 < BaseThingy
-                resource_name :thingy3
+                provides :thingy3
               end
 
             end
@@ -614,7 +580,7 @@ describe "Recipe DSL methods" do
             before(:each) do
 
               class RecipeDSLSpecNamespace::Thingy4 < BaseThingy
-                resource_name :thingy3
+                provides :thingy3
               end
 
             end
@@ -644,7 +610,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class RecipeDSLSpecNamespace::Thingy7 < BaseThingy
-            resource_name :thingy7
+            provides :thingy7
             provides :thingy8
           end
 
@@ -654,7 +620,7 @@ describe "Recipe DSL methods" do
           before(:each) do
 
             class RecipeDSLSpecNamespace::Thingy8 < BaseThingy
-              resource_name :thingy8
+              provides :thingy8
             end
 
           end
@@ -683,7 +649,7 @@ describe "Recipe DSL methods" do
         before(:each) do
 
           class RecipeDSLSpecNamespace::Thingy12 < BaseThingy
-            resource_name :thingy12
+            provides :thingy12
             provides :twizzle
             provides :twizzle2
           end
@@ -715,12 +681,12 @@ describe "Recipe DSL methods" do
       context "with platform-specific resources 'my_super_thingy_foo' and 'my_super_thingy_bar'" do
         before(:each) do
           class MySuperThingyFoo < BaseThingy
-            resource_name :my_super_thingy_foo
+            provides :my_super_thingy_foo
             provides :my_super_thingy, platform: "foo"
           end
 
           class MySuperThingyBar < BaseThingy
-            resource_name :my_super_thingy_bar
+            provides :my_super_thingy_bar
             provides :my_super_thingy, platform: "bar"
           end
         end
@@ -761,7 +727,7 @@ describe "Recipe DSL methods" do
       context "when Thingy10 provides :thingy10" do
         before(:each) do
           class RecipeDSLSpecNamespace::Thingy10 < BaseThingy
-            resource_name :thingy10
+            provides :thingy10
           end
         end
 
@@ -776,7 +742,7 @@ describe "Recipe DSL methods" do
       context "when Thingy11 provides :thingy11" do
         before(:each) do
           class RecipeDSLSpecNamespace::Thingy11 < BaseThingy
-            resource_name :thingy10
+            provides :thingy10
           end
         end
 
@@ -801,7 +767,7 @@ describe "Recipe DSL methods" do
 
           def self.inspect; name.inspect; end
         end
-        result.resource_name two_classes_one_dsl
+        result.provides two_classes_one_dsl
         result
       end
       before { resource_class } # pull on it so it gets defined before the recipe runs
@@ -817,7 +783,7 @@ describe "Recipe DSL methods" do
 
             def self.inspect; name.inspect; end
           end
-          result.resource_name two_classes_one_dsl
+          result.provides two_classes_one_dsl
           result
         end
         before { resource_class_a } # pull on it so it gets defined before the recipe runs
@@ -847,7 +813,7 @@ describe "Recipe DSL methods" do
 
             def self.inspect; name.inspect; end
           end
-          result.resource_name two_classes_one_dsl
+          result.provides two_classes_one_dsl
           result
         end
         before { resource_class_z } # pull on it so it gets defined before the recipe runs
@@ -882,25 +848,6 @@ describe "Recipe DSL methods" do
           it "resource_matching_short_name returns Z" do
             expect(Chef::Resource.resource_matching_short_name(two_classes_one_dsl)).to eq resource_class_z
           end
-
-          context "when Z provides(:two_classes_one_dsl) { false }" do
-            before do
-              resource_class_z.provides(two_classes_one_dsl) { false }
-            end
-
-            it "two_classes_one_dsl resolves to B (picks the next thing in the priority array)" do
-              temp_two_classes_one_dsl = two_classes_one_dsl
-              recipe = converge do
-                instance_eval("#{temp_two_classes_one_dsl} 'blah'")
-              end
-              expect(recipe.logged_warnings).to eq ""
-              expect(BaseThingy.created_resource).to eq resource_class
-            end
-
-            it "resource_matching_short_name returns B" do
-              expect(Chef::Resource.resource_matching_short_name(two_classes_one_dsl)).to eq resource_class
-            end
-          end
         end
 
         context "and priority arrays [ B ] and [ Z ]" do
@@ -921,52 +868,7 @@ describe "Recipe DSL methods" do
           it "resource_matching_short_name returns Z" do
             expect(Chef::Resource.resource_matching_short_name(two_classes_one_dsl)).to eq resource_class_z
           end
-
-          context "when Z provides(:two_classes_one_dsl) { false }" do
-            before do
-              resource_class_z.provides(two_classes_one_dsl) { false }
-            end
-
-            it "two_classes_one_dsl resolves to B (picks the first match from the other priority array)" do
-              temp_two_classes_one_dsl = two_classes_one_dsl
-              recipe = converge do
-                instance_eval("#{temp_two_classes_one_dsl} 'blah'")
-              end
-              expect(recipe.logged_warnings).to eq ""
-              expect(BaseThingy.created_resource).to eq resource_class
-            end
-
-            it "resource_matching_short_name returns B" do
-              expect(Chef::Resource.resource_matching_short_name(two_classes_one_dsl)).to eq resource_class
-            end
-          end
         end
-
-        context "and a priority array [ Z ]" do
-          before do
-            Chef.set_resource_priority_array(two_classes_one_dsl, [ resource_class_z ])
-          end
-
-          context "when Z provides(:two_classes_one_dsl) { false }" do
-            before do
-              resource_class_z.provides(two_classes_one_dsl) { false }
-            end
-
-            it "two_classes_one_dsl resolves to B (picks the first match outside the priority array)" do
-              temp_two_classes_one_dsl = two_classes_one_dsl
-              recipe = converge do
-                instance_eval("#{temp_two_classes_one_dsl} 'blah'")
-              end
-              expect(recipe.logged_warnings).to eq ""
-              expect(BaseThingy.created_resource).to eq resource_class
-            end
-
-            it "resource_matching_short_name returns B" do
-              expect(Chef::Resource.resource_matching_short_name(two_classes_one_dsl)).to eq resource_class
-            end
-          end
-        end
-
       end
 
       context "and a provider named 'B' which provides :two_classes_one_dsl" do
@@ -1113,7 +1015,7 @@ describe "Recipe DSL methods" do
 
             def self.inspect; name.inspect; end
           end
-          result.resource_name two_classes_one_dsl
+          result.provides two_classes_one_dsl
           result.provides two_classes_one_dsl, os: "blarghle"
           result
         end
@@ -1138,7 +1040,7 @@ describe "Recipe DSL methods" do
             instance_eval("#{temp_two_classes_one_dsl} 'blah' do; end")
           end
           expect(recipe.logged_warnings).to eq ""
-          expect(BaseThingy.created_resource).to eq resource_class
+          expect(BaseThingy.created_resource).to eq resource_class_blarghle
         end
       end
     end
@@ -1160,7 +1062,7 @@ describe "Recipe DSL methods" do
 
       context "with resource_name :my_resource" do
         before do
-          resource_class.resource_name my_resource
+          resource_class.provides my_resource
         end
 
         context "with provides? returning true to my_resource" do
@@ -1311,7 +1213,7 @@ describe "Recipe DSL methods" do
     context "with UTF-8 provides" do
       before(:each) do
         class UTF8Thingy < BaseThingy
-          resource_name :Straße
+          provides :Straße
           provides :Straße
         end
       end

--- a/spec/integration/recipes/resource_action_spec.rb
+++ b/spec/integration/recipes/resource_action_spec.rb
@@ -1,7 +1,7 @@
 require "support/shared/integration/integration_helper"
 
 class NoActionJackson < Chef::Resource
-  use_automatic_resource_name
+  provides :no_action_jackson
 
   def foo(value = nil)
     @foo = value if value
@@ -14,7 +14,7 @@ class NoActionJackson < Chef::Resource
 end
 
 class WeirdActionJackson < Chef::Resource
-  use_automatic_resource_name
+  provides :weird_action_jackson
 
   class <<self
     attr_accessor :action_was
@@ -163,7 +163,8 @@ module ResourceActionSpec
 
     context "With resource 'action_jackson'" do
       class ActionJackson < Chef::Resource
-        use_automatic_resource_name
+        provides :action_jackson
+
         def foo(value = nil)
           @foo = value if value
           @foo
@@ -256,7 +257,7 @@ module ResourceActionSpec
       context "And 'action_jackgrandson' inheriting from ActionJackson and changing nothing" do
         before(:each) do
           class ActionJackgrandson < ActionJackson
-            use_automatic_resource_name
+            provides :action_jackgrandson
           end
         end
 
@@ -267,7 +268,7 @@ module ResourceActionSpec
 
       context "And 'action_jackalope' inheriting from ActionJackson with an extra attribute, action and custom method" do
         class ActionJackalope < ActionJackson
-          use_automatic_resource_name
+          provides :action_jackalope
 
           def foo(value = nil)
             @foo = "#{value}alope" if value
@@ -380,7 +381,7 @@ module ResourceActionSpec
 
     context "With a resource with a set_or_return property named group (same name as a resource)" do
       class ResourceActionSpecWithGroupAction < Chef::Resource
-        resource_name :resource_action_spec_set_group_to_nil
+        provides :resource_action_spec_set_group_to_nil
         action :set_group_to_nil do
           # Access x during converge to ensure that we emit no warnings there
           resource_action_spec_with_group "hi" do
@@ -391,7 +392,7 @@ module ResourceActionSpec
       end
 
       class ResourceActionSpecWithGroup < Chef::Resource
-        resource_name :resource_action_spec_with_group
+        provides :resource_action_spec_with_group
         def group(value = nil)
           set_or_return(:group, value, {})
         end
@@ -408,7 +409,8 @@ module ResourceActionSpec
 
     context "When a resource has a property with the same name as another resource" do
       class HasPropertyNamedTemplate < Chef::Resource
-        use_automatic_resource_name
+        provides :has_property_named_template
+
         property :template
         action :create do
           template "x" do
@@ -420,7 +422,8 @@ module ResourceActionSpec
 
     context "When a resource declares methods in action_class" do
       class DeclaresActionClassMethods < Chef::Resource
-        use_automatic_resource_name
+        provides :declares_action_class_methods
+
         property :x
         action_class do
           def a
@@ -452,7 +455,8 @@ module ResourceActionSpec
 
       context "And a subclass overrides a method with an action_class block" do
         class DeclaresActionClassMethodsToo < DeclaresActionClassMethods
-          use_automatic_resource_name
+          provides :declares_action_class_methods_too
+
           action_class do
             def a
               5
@@ -477,7 +481,8 @@ module ResourceActionSpec
       context "And a subclass overrides a method with class_eval" do
         # this tests inheritance with *only* an action_class accessor that does not declare a block
         class DeclaresActionClassMethodsToo < DeclaresActionClassMethods
-          use_automatic_resource_name
+          provides :declares_action_class_methods_too
+
           action_class.class_eval <<-EOM
             def a
               5

--- a/spec/integration/recipes/resource_converge_if_changed_spec.rb
+++ b/spec/integration/recipes/resource_converge_if_changed_spec.rb
@@ -35,7 +35,7 @@ describe "Resource::ActionClass#converge_if_changed" do
           @converged = 0
         end
       end
-      result.resource_name resource_name
+      result.provides resource_name
       result
     end
     let(:converged_recipe) { converge(converge_recipe) }

--- a/spec/integration/recipes/resource_load_spec.rb
+++ b/spec/integration/recipes/resource_load_spec.rb
@@ -35,7 +35,7 @@ describe "Resource.load_current_value" do
         new_resource.class.created_x = new_resource.x
       end
     end
-    result.resource_name resource_name
+    result.provides resource_name
     result
   end
 
@@ -126,7 +126,7 @@ describe "Resource.load_current_value" do
       r = Class.new(resource_class) do
         property :y, default: lazy { "default_y #{Namer.incrementing_value}" }
       end
-      r.resource_name subresource_name
+      r.provides subresource_name
       r
     end
 

--- a/spec/support/lib/chef/resource/zen_follower.rb
+++ b/spec/support/lib/chef/resource/zen_follower.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2014-2016, Chef Software, Inc.
+# Copyright:: Copyright 2014-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,8 @@ require "chef/json_compat"
 class Chef
   class Resource
     class ZenFollower < Chef::Resource
+
+      provides :zen_follower
 
       provides :follower, platform: "zen"
 

--- a/spec/unit/lwrp_spec.rb
+++ b/spec/unit/lwrp_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# Copyright:: Copyright 2009-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/recipe_spec.rb
+++ b/spec/unit/recipe_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Christopher Walters (<cw@chef.io>)
 # Author:: Tim Hinderliter (<tim@chef.io>)
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/resource/user_spec.rb
+++ b/spec/unit/resource/user_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,8 @@ require "spec_helper"
 describe Chef::Resource::User, "initialize" do
   let(:resource) { Chef::Resource::User.new("notarealuser") }
 
-  it "sets the resource_name to :user_resource_abstract_base_class" do
-    expect(resource.resource_name).to eql(:user_resource_abstract_base_class)
+  it "sets the resource_name to nil" do
+    expect(resource.resource_name).to eql(nil)
   end
 
   it "username property is the name property" do

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1195,8 +1195,8 @@ describe Chef::Resource do
     end
 
     it "does not affect provides by default" do
-      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass, { canonical: true })
-      klass.resource_name(:test_resource)
+      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass)
+      klass.provides(:test_resource)
     end
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1195,7 +1195,7 @@ describe Chef::Resource do
     end
 
     it "does not affect provides by default" do
-      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass)
+      expect(Chef.resource_handler_map).to receive(:set).with(:test_resource, klass, any_args)
       klass.provides(:test_resource)
     end
   end


### PR DESCRIPTION
Removes all the internal wiring of the "canonical DSL" in the ResourceResolver and the node_map.

The `resource_name` still has magical wiring to an automatic implicit `provides` of the given resource_name.  In auditing supermarket removing this magic would cause 22% of all otherwise correctly written custom resources to break because they only declare a resource_name with no provides.

The automatic wiring of the class name to the DSL and to the resource_name is removed.  This does not affect LWRPs or custom resources at all.  The default cookbook_name+file_name wiring of LWRPs+Custom Resources has been preserved.

The first provides line now wires up the resource_name if it has not been set yet.  I would highly encourage this to become the default way to write resources, because provides-with-automatic-resource_name still gets the any `os` or `platform_family` filters correct.   The alternative of resource_name-with-automatic-provides should IMO be discouraged since it leads to this kind of thing:

```
resource_name :windows_thingy
provides :windows_thingy, os: :windows
```

The provides line there is useless because due to the implicit provides this becomes:

```
resource_name :windows_thingy
provides :windows_thingy
provides :windows_thingy, os: :windows
```

Because of this I would argue that the correct thing to do would be to remove the implicit provides from the resource_name (but again this breaks 22% of resources on the supermarket today).

The alternative would be to embrace the `resource_name` as the thing to set everywhere and call that correct and establish that "yes the thing you call the resource should always be applied to the DSL` but that will mean that the correct way to write the above resource would simply be:

```
resource_name :windows_thingy  # implicitly calls provides :windows_thingy
```

Which then establishes that will commit to losing information about the os and platform_family applicability to most resources.  This is beneficial for cases like chefspec, which still does not handle dynamic resource resolution correctly, but will definitively break any hope of automatically generating per-OS self-documentation of which resources apply to which O/S.  I'd argue that is wrong and we should fix chefspec instead (I've waffled horribly about this idea in the past, I think I'm settling down to fixing chefspec as the correct direction).

At any rate -- we still support both bits of magic -- all the previous discussion is about the next step we should take.

closes #9206 