### PR TITLE
Update all our links to use the new docs site format / cleanup descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For Chef Infra usage, please refer to our [Learn Chef Rally](https://learn.chef.
 
 Other useful resources for Chef Infra users:
 
-- Documentation: <https://docs.chef.io>
+- Documentation: <https://docs.chef.io/>
 - Source: <https://github.com/chef/chef/tree/master>
 - Tickets/Issues: <https://github.com/chef/chef/issues>
 - Slack: [Chef Community Slack](https://community-slack.chef.io/)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes.html> for the official Chef release notes.
+This file holds "in progress" release notes for the current release under development and is intended for consumption by the Chef Documentation team. Please see <https://docs.chef.io/release_notes/> for the official Chef release notes.
 
 # Chef Infra Client 15.8
 
@@ -504,11 +504,11 @@ end
 
 ### macOS 10.15 Support
 
-Chef Infra Client is now validated against macOS 10.15 (Catalina) with packages now available at [downloads.chef.io](https://downloads.chef.io/) and via the [Omnitruck API](https://docs.chef.io/api_omnitruck.html). Additionally, Chef Infra Client will no longer be validated against macOS 10.12.
+Chef Infra Client is now validated against macOS 10.15 (Catalina) with packages now available at [downloads.chef.io](https://downloads.chef.io/) and via the [Omnitruck API](https://docs.chef.io/api_omnitruck/). Additionally, Chef Infra Client will no longer be validated against macOS 10.12.
 
 ### AIX 7.2
 
-Chef Infra Client is now validated against AIX 7.2 with packages now available at [downloads.chef.io](https://downloads.chef.io/) and via the [Omnitruck API](https://docs.chef.io/api_omnitruck.html).
+Chef Infra Client is now validated against AIX 7.2 with packages now available at [downloads.chef.io](https://downloads.chef.io/) and via the [Omnitruck API](https://docs.chef.io/api_omnitruck/).
 
 ## Chef InSpec 4.16
 
@@ -565,11 +565,11 @@ Chef Infra Client 15.2 now includes native packages for RHEL 8 with all builds n
 
 ### SLES 11 EOL
 
-Packages will no longer be built for SUSE Linux Enterprise Server (SLES) 11 as SLES 11 exited the 'General Support' phase on March 31, 2019. See Chef's [Platform End-of-Life Policy](https://docs.chef.io/platforms.html#platform-end-of-life-policy) for more information on when Chef ends support for an OS release.
+Packages will no longer be built for SUSE Linux Enterprise Server (SLES) 11 as SLES 11 exited the 'General Support' phase on March 31, 2019. See Chef's [Platform End-of-Life Policy](https://docs.chef.io/platforms/#platform-end-of-life-policy) for more information on when Chef ends support for an OS release.
 
 ### Ubuntu 14.04 EOL
 
-Packages will no longer be built for Ubuntu 14.04 as Canonical ended maintenance updates on April 30, 2019. See Chef's [Platform End-of-Life Policy](https://docs.chef.io/platforms.html#platform-end-of-life-policy) for more information on when Chef ends support for an OS release.
+Packages will no longer be built for Ubuntu 14.04 as Canonical ended maintenance updates on April 30, 2019. See Chef's [Platform End-of-Life Policy](https://docs.chef.io/platforms/#platform-end-of-life-policy) for more information on when Chef ends support for an OS release.
 
 ## Ohai 15.2
 
@@ -601,7 +601,7 @@ bzip2 has been updated from 1.0.6 to 1.0.8 to resolve [CVE-2016-3189](https://cv
 
 ### chocolatey_feature
 
-The `chocolatey_feature` resource allows you to enable and disable Chocolatey features. See the [chocolatey_feature documentation](https://docs.chef.io/resource_chocolatey_feauture.html) for full usage information. Thanks [@gep13](https://github.com/gep13) for this new resource.
+The `chocolatey_feature` resource allows you to enable and disable Chocolatey features. See the [chocolatey_feature documentation](https://docs.chef.io/resources/chocolatey_feature/) for full usage information. Thanks [@gep13](https://github.com/gep13) for this new resource.
 
 ## Updated Resources
 
@@ -737,49 +737,49 @@ Chef Solo's `--delete-entire-chef-repo` option has been extended to work in Loca
 
 Use the `archive_file` resource to decompress multiple archive formats without the need for compression tools on the host.
 
-See the [archive_file](https://docs.chef.io/resource_archive_file.html) documentation for more information.
+See the [archive_file](https://docs.chef.io/resources/archive_file/) documentation for more information.
 
 ### windows_uac resource
 
 Use the `windows_uac` resource to configure UAC settings on Windows hosts.
 
-See the [windows_uac](https://docs.chef.io/resource_windows_uac.html) documentation for more information.
+See the [windows_uac](https://docs.chef.io/resources/windows_uac) documentation for more information.
 
 ### windows_dfs_folder resource
 
 Use the `windows_dfs_folder` resource to create and delete Windows DFS folders.
 
-See the [windows_dfs_folder](https://docs.chef.io/resource_windows_dfs_folder.html) documentation for more information.
+See the [windows_dfs_folder](https://docs.chef.io/resources/windows_dfs_folder) documentation for more information.
 
 ### windows_dfs_namespace resources
 
 Use the `windows_dfs_namespace` resource to create and delete Windows DFS namespaces.
 
-See the [windows_dfs_namespace](https://docs.chef.io/resource_windows_dfs_namespace.html) documentation for more information.
+See the [windows_dfs_namespace](https://docs.chef.io/resources/windows_dfs_namespace) documentation for more information.
 
 ### windows_dfs_server resources
 
 Use the `windows_dfs_server` resource to configure Windows DFS server settings.
 
-See the [windows_dfs_server](https://docs.chef.io/resource_windows_dfs_server.html) documentation for more information.
+See the [windows_dfs_server](https://docs.chef.io/resources/windows_dfs_server) documentation for more information.
 
 ### windows_dns_record resource
 
 Use the `windows_dns_record` resource to create or delete DNS records.
 
-See the [windows_dns_record](https://docs.chef.io/resource_windows_dns_record.html) documentation for more information.
+See the [windows_dns_record](https://docs.chef.io/resources/windows_dns_record) documentation for more information.
 
 ### windows_dns_zone resource
 
 Use the `windows_dns_zone` resource to create or delete DNS zones.
 
-See the [windows_dns_zone](https://docs.chef.io/resource_windows_dns_zone.html) documentation for more information.
+See the [windows_dns_zone](https://docs.chef.io/resources/windows_dns_zone) documentation for more information.
 
 ### snap_package resource
 
 Use the `snap_package` resource to install snap packages on Ubuntu hosts.
 
-See the [snap_package](https://docs.chef.io/resource_snap_package.html) documentation for more information.
+See the [snap_package](https://docs.chef.io/resources/snap_package) documentation for more information.
 
 ## Resource Improvements
 
@@ -1369,7 +1369,7 @@ OpenSSL has been updated to 1.0.2q in order to resolve:
 
 Use the `windows_firewall_rule` resource create or delete Windows Firewall rules.
 
-See the [windows_firewall_rule](https://docs.chef.io/resource_windows_firewall_rule.html) documentation for more information.
+See the [windows_firewall_rule](https://docs.chef.io/resources/windows_firewall_rule) documentation for more information.
 
 Thank you [Schuberg Philis](https://schubergphilis.com/) for transferring us the [windows_firewall cookbook](https://supermarket.chef.io/cookbooks/windows_firewall) and to [@Happycoil](https://github.com/Happycoil) for porting it to chef-client with a significant refactoring.
 
@@ -1377,13 +1377,13 @@ Thank you [Schuberg Philis](https://schubergphilis.com/) for transferring us the
 
 Use the `windows_share` resource create or delete Windows file shares.
 
-See the [windows_share](https://docs.chef.io/resource_windows_share.html) documentation for more information.
+See the [windows_share](https://docs.chef.io/resources/windows_share) documentation for more information.
 
 ### windows_certificate
 
 Use the `windows_certificate` resource add, remove, or verify certificates in the system or user certificate stores.
 
-See the [windows_certificate](https://docs.chef.io/resource_windows_certificate.html) documentation for more information.
+See the [windows_certificate](https://docs.chef.io/resources/windows_certificate) documentation for more information.
 
 ## Updated Resources
 
@@ -1519,7 +1519,7 @@ We've added new resources to Chef 14.5. Cookbooks using these resources will con
 
 Use the `windows_workgroup` resource to join or change a Windows host workgroup.
 
-See the [windows_workgroup](https://docs.chef.io/resource_windows_workgroup.html) documentation for more information.
+See the [windows_workgroup](https://docs.chef.io/resources/windows_workgroup) documentation for more information.
 
 Thanks [@derekgroh](https://github.com/derekgroh) for contributing this new resource.
 
@@ -1527,7 +1527,7 @@ Thanks [@derekgroh](https://github.com/derekgroh) for contributing this new reso
 
 Use the `locale` resource to set the system's locale.
 
-See the [locale](https://docs.chef.io/resource_locale.html) documentation for more information.
+See the [locale](https://docs.chef.io/resources/locale) documentation for more information.
 
 Thanks [@vincentaubert](https://github.com/vincentaubert) for contributing this new resource.
 
@@ -1604,39 +1604,39 @@ The following new previous resources were added to Chef 14.4. Cookbooks with the
 
 ### Cron_d
 
-Use the [cron_d](https://docs.chef.io/resource_cron_d.html) resource to manage cron definitions in /etc/cron.d. This is similar to the `cron` resource, but it does not use the monolithic `/etc/crontab`. file.
+Use the [cron_d](https://docs.chef.io/resources/cron_d) resource to manage cron definitions in /etc/cron.d. This is similar to the `cron` resource, but it does not use the monolithic `/etc/crontab`. file.
 
 ### Cron_access
 
-Use the [cron_access](https://docs.chef.io/resource_cron_access.html) resource to manage the `/etc/cron.allow` and `/etc/cron.deny` files. This resource previously shipped in the `cron` community cookbook and has fully backwards compatibility with the previous `cron_manage` definition in that cookbook.
+Use the [cron_access](https://docs.chef.io/resources/cron_access) resource to manage the `/etc/cron.allow` and `/etc/cron.deny` files. This resource previously shipped in the `cron` community cookbook and has fully backwards compatibility with the previous `cron_manage` definition in that cookbook.
 
 ### openssl_x509_certificate
 
-Use the [openssl_x509_certificate](https://docs.chef.io/resource_openssl_x509_certificate.html) resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource automatically generates a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. This resource previously shipped in the `openssl` cookbook as `openssl_x509` and is fully backwards compatible with the legacy resource name.
+Use the [openssl_x509_certificate](https://docs.chef.io/resources/openssl_x509_certificate) resource to generate signed or self-signed, PEM-formatted x509 certificates. If no existing key is specified, the resource automatically generates a passwordless key with the certificate. If a CA private key and certificate are provided, the certificate will be signed with them. This resource previously shipped in the `openssl` cookbook as `openssl_x509` and is fully backwards compatible with the legacy resource name.
 
 Thank you [@juju482](https://github.com/juju482) for updating this resource!
 
 ### openssl_x509_request
 
-Use the [openssl_x509_request](https://docs.chef.io/resource_openssl_x509_request.html) resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource automatically generates a passwordless key with the certificate.
+Use the [openssl_x509_request](https://docs.chef.io/resources/openssl_x509_request) resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource automatically generates a passwordless key with the certificate.
 
 Thank you [@juju482](https://github.com/juju482) for contributing this resource.
 
 ### openssl_x509_crl
 
-Use the [openssl_x509_crl](https://docs.chef.io/resource_openssl_x509_crl.html)l resource to generate PEM-formatted x509 certificate revocation list (CRL) files.
+Use the [openssl_x509_crl](https://docs.chef.io/resources/openssl_x509_crl)l resource to generate PEM-formatted x509 certificate revocation list (CRL) files.
 
 Thank you [@juju482](https://github.com/juju482) for contributing this resource.
 
 ### openssl_ec_private_key
 
-Use the [openssl_ec_private_key](https://docs.chef.io/resource_openssl_ec_private_key.html) resource to generate ec private key files. If a valid ec key file can be opened at the specified location, no new file will be created.
+Use the [openssl_ec_private_key](https://docs.chef.io/resources/openssl_ec_private_key) resource to generate ec private key files. If a valid ec key file can be opened at the specified location, no new file will be created.
 
 Thank you [@juju482](https://github.com/juju482) for contributing this resource.
 
 ### openssl_ec_public_key
 
-Use the [openssl_ec_public_key](https://docs.chef.io/resource_openssl_ec_public_key.html) resource to generate ec public key files given a private key.
+Use the [openssl_ec_public_key](https://docs.chef.io/resources/openssl_ec_public_key) resource to generate ec public key files given a private key.
 
 Thank you [@juju482](https://github.com/juju482) for contributing this resource.
 
@@ -1666,7 +1666,7 @@ The route resource now supports additional RHEL platform_family systems as well 
 
 ### systemd_unit
 
-The [systemd_unit](https://docs.chef.io/resource_systemd_unit.html) resource now supports specifying options multiple times in the content hash. Instead of setting the value to a string you can now set it to an array of strings.
+The [systemd_unit](https://docs.chef.io/resources/systemd_unit) resource now supports specifying options multiple times in the content hash. Instead of setting the value to a string you can now set it to an array of strings.
 
 Thank you [@dbresson](https://github.com/dbresson) for this contribution.
 
@@ -1868,7 +1868,7 @@ We advise caution in the use of this feature, as excessive or prolonged silencin
 
 As noted above, this release of Chef unifies our shell_out helpers into just shell_out and shell_out!. Previous helpers are now deprecated and will be removed in Chef Infra Client 15.
 
-See [CHEF-26 Deprecation Page](https://docs.chef.io/deprecations_shell_out.html) for details.
+See [CHEF-26 Deprecation Page](https://docs.chef.io/deprecations_shell_out) for details.
 
 ### Legacy FreeBSD pkg provider
 
@@ -2349,7 +2349,7 @@ The Chef Solor `-r` flag has been removed as it was deprecated and replaced with
 
 ### node.set and node.set_unless attribute levels removal
 
-`node.set` and `node.set_unless` were deprecated in Chef 12 and have been removed in Chef 14\. To replicate this same functionality users should use `node.normal` and `node.normal_unless`, although we highly recommend reading our [attribute documentation](https://docs.chef.io/attributes.html) to make sure `normal` is in fact the your desired attribute level.
+`node.set` and `node.set_unless` were deprecated in Chef 12 and have been removed in Chef 14\. To replicate this same functionality users should use `node.normal` and `node.normal_unless`, although we highly recommend reading our [attribute documentation](https://docs.chef.io/attributes) to make sure `normal` is in fact the your desired attribute level.
 
 ### chocolatey_package :uninstall Action
 
@@ -2741,7 +2741,7 @@ The mdadm plugin has been updated to properly handle arrays with more than 10 di
 
 ## `deploy` Resource Is Deprecated
 
-The `deploy` resource (and its alter ego `deploy_revision`) have been deprecated, to be removed in Chef 14\. This is being done because this resource is considered overcomplicated and error-prone in the modern Chef ecosystem. A compatibility cookbook will be available to help users migrate during the Chef 14 release cycle. See [the deprecation documentation](https://docs.chef.io/deprecations_deploy_resource.html) for more information.
+The `deploy` resource (and its alter ego `deploy_revision`) have been deprecated, to be removed in Chef 14\. This is being done because this resource is considered overcomplicated and error-prone in the modern Chef ecosystem. A compatibility cookbook will be available to help users migrate during the Chef 14 release cycle. See [the deprecation documentation](https://docs.chef.io/deprecations_deploy_resource) for more information.
 
 ## zypper_package supports package downgrades
 
@@ -3160,7 +3160,7 @@ Additionally, Chef now always performs a reconfigure after every run when daemon
 
 ### Explicit property methods
 
-<https://docs.chef.io/deprecations_namespace_collisions.html>
+<https://docs.chef.io/deprecations_namespace_collisions>
 
 In Chef 14, custom resources will no longer assume property methods are being called on `new_resource`, and instead require the resource author to be explicit.
 
@@ -3204,7 +3204,7 @@ Ohai now properly detects the [Clear](https://clearlinux.org/) and [ClearOS](htt
 
 ### Removal of IpScopes plugin. (OHAI-13)
 
-<https://docs.chef.io/deprecations_ohai_ipscopes.html>
+<https://docs.chef.io/deprecations_ohai_ipscopes>
 
 In Chef/Ohai 14 (April 2018) we will remove the IpScopes plugin. The data returned by this plugin is nearly identical to information already returned by individual network plugins and this plugin required the installation of an additional gem into the Chef installation. We believe that few users were installing the gem and users would be better served by the data returned from the network plugins.
 
@@ -3220,7 +3220,7 @@ If you use Chef Provisioning with Local Mode, you may need to pass `--listen` to
 
 ### Removal of support for Ohai version 6 plugins (OHAI-10)
 
-<https://docs.chef.io/deprecations_ohai_v6_plugins.html>
+<https://docs.chef.io/deprecations_ohai_v6_plugins>
 
 In Chef/Ohai 14 (April 2018) we will remove support for loading Ohai v6 plugins, which we deprecated in Ohai 7/Chef 11.12.
 
@@ -3296,7 +3296,7 @@ Chef now properly supports managing sys-v services on hosts running systemd. Pre
 
 ### Resource Cloning has been removed
 
-When Chef compiles resources, it will no longer attempt to merge the properties of previously compiled resources with the same name and type in to the new resource. See [the deprecation page](https://docs.chef.io/deprecations_resource_cloning.html) for further information.
+When Chef compiles resources, it will no longer attempt to merge the properties of previously compiled resources with the same name and type in to the new resource. See [the deprecation page](https://docs.chef.io/deprecations_resource_cloning) for further information.
 
 ### It is an error to specify both `default` and `name_property` on a property
 
@@ -3723,35 +3723,35 @@ GCC detection has been improved to collect additional information, and to not pr
 ### Ohai::Config removed
 
 - **Deprecation ID**: OHAI-1
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_legacy_config.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_legacy_config>
 - **Expected Removal**: Ohai 13 (April 2017)
 
 ### sigar gem based plugins removed
 
 - **Deprecation ID**: OHAI-2
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_sigar_plugins.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_sigar_plugins>
 - **Expected Removal**: Ohai 13 (April 2017)
 
 ### run_command and popen4 helper methods removed
 
 - **Deprecation ID**: OHAI-3
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_run_command_helpers.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_run_command_helpers>
 - **Expected Removal**: Ohai 13 (April 2017)
 
 ### libvirt plugin attributes moved
 
 - **Deprecation ID**: OHAI-4
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_libvirt_plugin.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_libvirt_plugin>
 - **Expected Removal**: Ohai 13 (April 2017)
 
 ### Windows CPU plugin attribute changes
 
 - **Deprecation ID**: OHAI-5
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_windows_cpu.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_windows_cpu>
 - **Expected Removal**: Ohai 13 (April 2017)
 
 ### DigitalOcean plugin attribute changes
 
 - **Deprecation ID**: OHAI-6
-- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_digitalocean.html>
+- **Remediation Docs**: <https://docs.chef.io/deprecations_ohai_digitalocean/>
 - **Expected Removal**: Ohai 13 (April 2017)

--- a/docs/dev/design_documents/resource_guard_interpreters.md
+++ b/docs/dev/design_documents/resource_guard_interpreters.md
@@ -45,8 +45,9 @@ the following use cases:
   processes
 
 ## Definitions
+
 This document assumes familiarity with the Chef resource DSL, which is
-documented at <http://docs.chef.io/chef/resources.html>.
+documented at <https://docs.chef.io/dsl_recipe/>.
 
 These definitions are used throughout the discussion:
 
@@ -217,7 +218,7 @@ end
 ## Guard interpreter formal specification
 
 The documented behavior for guards can be found at
-<http://docs.chef.io/resource_common.html>. Guards are expressed via the optional
+<https://docs.chef.io/resource_common/>. Guards are expressed via the optional
 `not_if` and `only_if` attributes. The expression following the attribute
 may be either a block or a string.
 

--- a/docs/dev/how_to/upgrading_from_chef_12.md
+++ b/docs/dev/how_to/upgrading_from_chef_12.md
@@ -6,9 +6,9 @@ title: Upgrading From Chef 12
 
 This is not a general guide on how to upgrade from Chef Infra 12.  There already exists documentation on:
 
-* [How to upgrade from the command line](https://docs.chef.io/upgrade_client)
+* [How to upgrade from the command line](https://docs.chef.io/upgrade_client/)
 * [How to use the `chef_client_updater` cookbook](https://supermarket.chef.io/cookbooks/chef_client_updater)
-* [All of the possible Deprecations and remediation steps](https://docs.chef.io/chef_deprecations_client)
+* [All of the possible Deprecations and remediation steps](https://docs.chef.io/chef_deprecations_client/)
 
 This is strictly expert-level documentation on what the large scale focus should be and what kind of otherwise
 undocumented gotchas can occur.

--- a/docs/dev/how_to/upgrading_from_chef_12.md
+++ b/docs/dev/how_to/upgrading_from_chef_12.md
@@ -6,9 +6,9 @@ title: Upgrading From Chef 12
 
 This is not a general guide on how to upgrade from Chef Infra 12.  There already exists documentation on:
 
-* [How to upgrade from the command line](https://docs.chef.io/upgrade_client.html)
+* [How to upgrade from the command line](https://docs.chef.io/upgrade_client)
 * [How to use the `chef_client_updater` cookbook](https://supermarket.chef.io/cookbooks/chef_client_updater)
-* [All of the possible Deprecations and remediation steps](https://docs.chef.io/chef_deprecations_client.html)
+* [All of the possible Deprecations and remediation steps](https://docs.chef.io/chef_deprecations_client)
 
 This is strictly expert-level documentation on what the large scale focus should be and what kind of otherwise
 undocumented gotchas can occur.
@@ -237,4 +237,3 @@ to retroactively change behavior or add any warnings. It is not a common issue. 
 preferable since it asserts that the once the configuration for the service is updated that the service is restarted
 by the delayed action which occurs at the end of the custom resource's action and then future recipes can rely on
 the service being in a correctly running state.
-

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -3,7 +3,7 @@ run_list = ""
 
 local_mode = true
 
-# Positive License Acceptance. See https://docs.chef.io/chef_license_accept
+# Positive License Acceptance. See https://docs.chef.io/chef_license_accept/
 chef_license = "donotaccept"
 
 # Path to the chef client config on disk.  If blank, will default to the one built by habitat.

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -3,7 +3,7 @@ run_list = ""
 
 local_mode = true
 
-# Positive License Acceptance.  See https://docs.chef.io/chef_license_accept.html
+# Positive License Acceptance. See https://docs.chef.io/chef_license_accept
 chef_license = "donotaccept"
 
 # Path to the chef client config on disk.  If blank, will default to the one built by habitat.
@@ -27,7 +27,7 @@ minimal_ohai = false
 # The name of the node. Determines which configuration should be applied and sets the client_name,
 # which is the name used when authenticating to a Chef server. The default value is the FQDN of the chef-client,
 # as detected by Ohai. In general, Chef recommends that you leave this setting blank and let Ohai
-# assign the FQDN of the node as the node_name during each chef-clientrun.
+# assign the FQDN of the node as the node_name during each chef-client run.
 node_name = ""
 
 # The name of the environment

--- a/lib/chef/cookbook/metadata.rb
+++ b/lib/chef/cookbook/metadata.rb
@@ -604,7 +604,7 @@ class Chef
           msg = <<~OBSOLETED
             The dependency specification syntax you are using is no longer valid. You may not
             specify more than one version constraint for a particular cookbook.
-            Consult https://docs.chef.io/config_rb_metadata.html for the updated syntax.
+            Consult https://docs.chef.io/config_rb_metadata/ for the updated syntax.
 
             Called by: #{caller_name} '#{dep_name}', #{version_constraints.map(&:inspect).join(", ")}
             Called from:
@@ -621,9 +621,10 @@ class Chef
 
         msg = <<~INVALID
           The version constraint syntax you are using is not valid. If you recently
-          upgraded to Chef 0.10.0, be aware that you no may longer use "<<" and ">>" for
-          'less than' and 'greater than'; use '<' and '>' instead.
-          Consult https://docs.chef.io/config_rb_metadata.html for more information.
+          upgraded from Chef Infra releases before 0.10, be aware that you no may
+          longer use "<<" and ">>" for 'less than' and 'greater than'; use '<' and
+          '>' instead. Consult https://docs.chef.io/config_rb_metadata/ for more
+          information.
 
           Called by: #{caller_name} '#{dep_name}', '#{constraint_str}'
           Called from:

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -88,7 +88,7 @@ class Chef
     # @return [Chef::CookbookVersion]
     def load_cookbook(cookbook_name)
       unless cookbook_version_loaders.key?(cookbook_name)
-        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook_name}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata.html)"
+        raise Exceptions::CookbookNotFoundInRepo, "Cannot find a cookbook named #{cookbook_name}; did you forget to add metadata to a cookbook? (https://docs.chef.io/config_rb_metadata/)"
       end
 
       return cookbooks_by_name[cookbook_name] if cookbooks_by_name.key?(cookbook_name)

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -104,7 +104,7 @@ class Chef
         #
         # @example
         #   class MyDeprecation < Base
-        #     target 123, "my_deprecation.html"
+        #     target 123, "my_deprecation"
         #   end
         # @param id [Integer] Deprecation ID number. This must be unique among
         #   all deprecations.
@@ -113,7 +113,7 @@ class Chef
         # @return [void]
         def target(id, page = nil)
           @deprecation_id = id
-          @doc_page = page || "#{deprecation_key}.html"
+          @doc_page = page || "#{deprecation_key}"
         end
       end
     end
@@ -137,7 +137,7 @@ class Chef
     end
 
     class CustomResource < Base
-      target 5, "custom_resource_cleanups.html"
+      target 5, "custom_resource_cleanups"
     end
 
     class EasyInstall < Base
@@ -235,7 +235,7 @@ class Chef
 
     class Generic < Base
       def url
-        "https://docs.chef.io/chef_deprecations_client.html"
+        "https://docs.chef.io/chef_deprecations_client"
       end
 
       def to_s

--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -47,7 +47,7 @@ class Chef
       #
       # @return [String]
       def url
-        "#{BASE_URL}#{self.class.doc_page}"
+        "#{BASE_URL}#{self.class.doc_page}/"
       end
 
       # Render the user-visible message for this deprecation.
@@ -235,7 +235,7 @@ class Chef
 
     class Generic < Base
       def url
-        "https://docs.chef.io/chef_deprecations_client"
+        "https://docs.chef.io/chef_deprecations_client/"
       end
 
       def to_s

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -252,7 +252,7 @@ class Chef
       # @deprecated Windows releases before Windows 2012 and 8 are no longer supported
       # @return [Boolean] Is the system older than Windows 8 / 2012
       def older_than_win_2012_or_8?(node = run_context.nil? ? nil : run_context.node)
-        node["platform_version"].to_f < 6.2
+        false # we don't support platforms that would be true
       end
 
       # ^^^^^^ NOTE: PLEASE DO NOT CONTINUE TO ADD THESE KINDS OF PLATFORM_VERSION APIS WITHOUT ^^^^^^^

--- a/lib/chef/dsl/reboot_pending.rb
+++ b/lib/chef/dsl/reboot_pending.rb
@@ -39,11 +39,11 @@ class Chef
           # http://technet.microsoft.com/en-us/library/cc960241.aspx
           registry_value_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', { name: "PendingFileRenameOperations" }) ||
 
-          # RebootRequired key contains Update IDs with a value of 1 if they require a reboot.
-          # The existence of RebootRequired alone is sufficient on my Windows 8.1 workstation in Windows Update
+            # RebootRequired key contains Update IDs with a value of 1 if they require a reboot.
+            # The existence of RebootRequired alone is sufficient on my Windows 8.1 workstation in Windows Update
             registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') ||
 
-          # Vista + Server 2008 and newer may have reboots pending from CBS
+            # Vista + Server 2008 and newer may have reboots pending from CBS
             registry_key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending')
         elsif platform?("ubuntu")
           # This should work for Debian as well if update-notifier-common happens to be installed. We need an API for that.

--- a/lib/chef/knife.rb
+++ b/lib/chef/knife.rb
@@ -191,7 +191,7 @@ class Chef
       config_loader.profile = profile
       config_loader.load
 
-      ui.warn("No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.") if config_loader.no_config_found?
+      ui.warn("No knife configuration file found. See https://docs.chef.io/config_rb/ for details.") if config_loader.no_config_found?
 
       config_loader
     rescue Exceptions::ConfigurationError => e

--- a/lib/chef/knife/bootstrap/templates/README.md
+++ b/lib/chef/knife/bootstrap/templates/README.md
@@ -5,7 +5,7 @@ standardized on the [Omnibus](https://github.com/chef/omnibus) built installatio
 packages.
 
 The 'chef-full' template downloads a script which is used to determine the correct
-Omnibus package for this system from the [Omnitruck](https://docs.chef.io/api_omnitruck.html) API.
+Omnibus package for this system from the [Omnitruck](https://docs.chef.io/api_omnitruck/) API.
 
 You can still utilize custom bootstrap templates on your system if your installation
-needs are unique. Additional information can be found on the [docs site](https://docs.chef.io/knife_bootstrap.html#custom-templates).
+needs are unique. Additional information can be found on the [docs site](https://docs.chef.io/knife_bootstrap/#custom-templates).

--- a/lib/chef/knife/core/ui.rb
+++ b/lib/chef/knife/core/ui.rb
@@ -216,7 +216,7 @@ class Chef
             tf.sync = true
             tf.puts output
             tf.close
-            raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup.html for details." unless system("#{config[:editor]} #{tf.path}")
+            raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details." unless system("#{config[:editor]} #{tf.path}")
 
             output = IO.read(tf.path)
           end

--- a/lib/chef/knife/edit.rb
+++ b/lib/chef/knife/edit.rb
@@ -74,7 +74,7 @@ class Chef
 
             # Let the user edit the temporary file
             unless system("#{config[:editor]} #{file.path}")
-              raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup.html for details."
+              raise "Please set EDITOR environment variable. See https://docs.chef.io/knife_setup/ for details."
             end
 
             result_text = IO.read(file.path)

--- a/lib/chef/mixin/api_version_request_handling.rb
+++ b/lib/chef/mixin/api_version_request_handling.rb
@@ -55,7 +55,7 @@ class Chef
           The server that received the request supports a min version of #{min_version} and a max version of #{max_version}.
           User keys are now managed via the key rotation commmands.
           Please refer to the documentation on how to manage your keys via the key rotation commands:
-          https://docs.chef.io/server_security.html#key-rotation
+          https://docs.chef.io/ctl_chef_server/#key-rotation
         EOH
       end
 

--- a/lib/chef/provider/package/rubygems.rb
+++ b/lib/chef/provider/package/rubygems.rb
@@ -403,7 +403,7 @@ class Chef
                 "Gem options must be passed to gem_package as a string instead of a hash when",
                 "using this installation of #{Chef::Dist::PRODUCT} because it runs with its own packaged Ruby. A hash",
                 "may only be used when installing a gem to the same Ruby installation that #{Chef::Dist::PRODUCT} is",
-                "running under.  See https://docs.chef.io/resource_gem_package.html for more information.",
+                "running under. See https://docs.chef.io/resources/gem_package/ for more information.",
                 "Error raised at #{new_resource} from #{new_resource.source_line}",
               ].join("\n")
               raise ArgumentError, msg

--- a/lib/chef/resource/cron.rb
+++ b/lib/chef/resource/cron.rb
@@ -136,7 +136,7 @@ class Chef
       end
 
       property :time, Symbol,
-        description: "A time interval. Possible values: :annually, :daily, :hourly, :midnight, :monthly, :reboot, :weekly, or :yearly.",
+        description: "A time interval.",
         equal_to: Chef::Provider::Cron::SPECIAL_TIME_VALUES
 
       property :mailto, String,

--- a/lib/chef/resource/cron_d.rb
+++ b/lib/chef/resource/cron_d.rb
@@ -147,7 +147,7 @@ class Chef
       property :cookbook, String, desired_state: false
 
       property :predefined_value, String,
-        description: 'Schedule your cron job with one of the special predefined value instead of ** * pattern. This correspond to "@reboot", "@yearly", "@annually", "@monthly", "@weekly", "@daily", "@midnight" or "@hourly".',
+        description: "Schedule your cron job with one of the special predefined value instead of ** * pattern.",
         equal_to: %w{ @reboot @yearly @annually @monthly @weekly @daily @midnight @hourly }
 
       property :minute, [Integer, String],

--- a/lib/chef/shell/ext.rb
+++ b/lib/chef/shell/ext.rb
@@ -211,7 +211,7 @@ module Shell
       desc "prints information about #{Chef::Dist::PRODUCT}"
       def version
         puts "Welcome to the #{Chef::Dist::SHELL} #{::Chef::VERSION}\n" +
-          "For usage see https://docs.chef.io/chef_shell.html"
+          "For usage see https://docs.chef.io/chef_shell/"
         :ucanhaz_automation
       end
       alias :shell :version

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -58,7 +58,7 @@ $ bundle exec omnibus help
 
 ## Kitchen-based Build Environment
 
-Every Omnibus project ships will a project-specific [Berksfile](https://docs.chef.io/berkshelf.html) that will allow you to build your omnibus projects on all of the projects listed in the `kitchen.yml`. You can add/remove additional platforms as needed by changing the list found in the `kitchen.yml` `platforms` YAML stanza.
+Every Omnibus project ships will a project-specific [Berksfile](https://docs.chef.io/berkshelf/) that will allow you to build your omnibus projects on all of the projects listed in the `kitchen.yml`. You can add/remove additional platforms as needed by changing the list found in the `kitchen.yml` `platforms` YAML stanza.
 
 This build environment is designed to get you up-and-running quickly. However, there is nothing that restricts you to building on other platforms. Simply use the [omnibus cookbook](https://github.com/chef-cookbooks/omnibus) to setup your desired platform and execute the build steps listed above.
 

--- a/omnibus/resources/chef/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chef/msi/localization-en-us.wxl.erb
@@ -38,5 +38,5 @@
   <String Id="CustomizeDlgSecondRadioButtonText">Chef Infra Client Service</String>
   <String Id="CustomizeDlgThirdRadioButtonText">None</String>
 
-  <String Id="CustomizeDlgOptionsMsg">The installer can configure the Chef Infra Client to run periodically as either a scheduled task or a service. Using a scheduled task is recommended. For more information, see https://docs.chef.io/windows.html.</String>
+  <String Id="CustomizeDlgOptionsMsg">The installer can configure the Chef Infra Client to run periodically as either a scheduled task or a service. Using a scheduled task is recommended. For more information, see https://docs.chef.io/windows/.</String>
 </WixLocalization>

--- a/spec/data/cookbooks/starter/recipes/default.rb
+++ b/spec/data/cookbooks/starter/recipes/default.rb
@@ -1,4 +1,4 @@
 # This is a Chef recipe file. It can be used to specify resources which will
 # apply configuration to a server.
 
-# For more information, see the documentation: https://docs.chef.io/essentials_cookbook_recipes.html
+# For more information, see the documentation: https://docs.chef.io/recipes/

--- a/spec/integration/knife/deps_spec.rb
+++ b/spec/integration/knife/deps_spec.rb
@@ -242,7 +242,7 @@ depends "foo"'
         it "knife deps --tree prints each once" do
           knife("deps --tree /roles/foo.json /roles/self.json") do
             expect(stdout).to eq("/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n")
-            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.\n")
+            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb/ for details.\n")
           end
         end
       end
@@ -580,7 +580,7 @@ depends "self"' }
         it "knife deps --tree prints each once" do
           knife("deps --remote --tree /roles/foo.json /roles/self.json") do
             expect(stdout).to eq("/roles/foo.json\n  /roles/bar.json\n    /roles/baz.json\n      /roles/foo.json\n/roles/self.json\n  /roles/self.json\n")
-            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb_knife.html for details.\n")
+            expect(stderr).to eq("WARNING: No knife configuration file found. See https://docs.chef.io/config_rb/ for details.\n")
           end
         end
       end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -626,7 +626,7 @@ describe Chef::DataCollector do
         it "collects deprecation messages" do
           location = Chef::Log.caller_location
           events.deprecation(Chef::Deprecated.create(:internal_api, "deprecation warning", location))
-          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api.html" }])
+          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api" }])
           send_run_failed_or_completed_event
         end
       end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -626,7 +626,7 @@ describe Chef::DataCollector do
         it "collects deprecation messages" do
           location = Chef::Log.caller_location
           events.deprecation(Chef::Deprecated.create(:internal_api, "deprecation warning", location))
-          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api" }])
+          expect_converge_message("deprecations" => [{ location: location, message: "deprecation warning", url: "https://docs.chef.io/deprecations_internal_api/" }])
           send_run_failed_or_completed_event
         end
       end

--- a/spec/unit/deprecated_spec.rb
+++ b/spec/unit/deprecated_spec.rb
@@ -20,7 +20,7 @@ require "chef/deprecated"
 
 describe Chef::Deprecated do
   class TestDeprecation < Chef::Deprecated::Base
-    target 999, "test.html"
+    target 999, "test"
   end
 
   context "loading a deprecation class" do
@@ -44,11 +44,11 @@ describe Chef::Deprecated do
     let(:location) { "the location" }
 
     it "displays the full URL" do
-      expect(TestDeprecation.new.url).to eql("https://docs.chef.io/deprecations_test.html")
+      expect(TestDeprecation.new.url).to eql("https://docs.chef.io/deprecations_test")
     end
 
     it "formats a complete deprecation message" do
-      expect(TestDeprecation.new(message, location).to_s).to eql("Deprecation CHEF-999 from the location\n\n  A test message\n\nPlease see https://docs.chef.io/deprecations_test.html for further details and information on how to correct this problem.")
+      expect(TestDeprecation.new(message, location).to_s).to eql("Deprecation CHEF-999 from the location\n\n  A test message\n\nPlease see https://docs.chef.io/deprecations_test for further details and information on how to correct this problem.")
     end
   end
 

--- a/spec/unit/deprecated_spec.rb
+++ b/spec/unit/deprecated_spec.rb
@@ -44,11 +44,11 @@ describe Chef::Deprecated do
     let(:location) { "the location" }
 
     it "displays the full URL" do
-      expect(TestDeprecation.new.url).to eql("https://docs.chef.io/deprecations_test")
+      expect(TestDeprecation.new.url).to eql("https://docs.chef.io/deprecations_test/")
     end
 
     it "formats a complete deprecation message" do
-      expect(TestDeprecation.new(message, location).to_s).to eql("Deprecation CHEF-999 from the location\n\n  A test message\n\nPlease see https://docs.chef.io/deprecations_test for further details and information on how to correct this problem.")
+      expect(TestDeprecation.new(message, location).to_s).to eql("Deprecation CHEF-999 from the location\n\n  A test message\n\nPlease see https://docs.chef.io/deprecations_test/ for further details and information on how to correct this problem.")
     end
   end
 


### PR DESCRIPTION
When we migrated to hugo the URLs changed a bit. Nothing ends in .html and we moved all the resources into their own dir.

Signed-off-by: Tim Smith <tsmith@chef.io>