### PR TITLE
Fix file descriptor leak in our tests

### DIFF
--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2012-2016, Chef Software, Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -404,6 +404,10 @@ describe Chef::RunLock do
           example.log_event("#{name}.stop finished (pid #{pid} wasn't running)")
         end
       end
+      @read_from_process.close rescue nil
+      @write_to_tests.close rescue nil
+      @read_from_tests.close rescue nil
+      @write_to_process.close rescue nil
     end
 
     def fire_event(event)


### PR DESCRIPTION
Mac has a default max fd of 256 which this can pretty much blow out by
leaking PIPE objects which last until the garbage collector destroys
the instances, this forces the pipes to be closed when the stop function
is called here.  Cuts down on over 200 leaking file descriptors from
this test which leak into the subsequent tests.

