### PR TITLE
link resource: Remove checks for symoblic link support on Windows

### DIFF
--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,11 +44,6 @@ class Chef
       default_action :create
       allowed_actions :create, :delete
 
-      def initialize(name, run_context = nil)
-        verify_links_supported!
-        super
-      end
-
       property :target_file, String,
         description: "An optional property to set the target file if it differs from the resource block's name.",
         name_property: true, identity: true
@@ -72,22 +67,6 @@ class Chef
       # make link quack like a file (XXX: not for public consumption)
       def path
         target_file
-      end
-
-      private
-
-      # On certain versions of windows links are not supported. Make
-      # sure we are not on such a platform.
-      def verify_links_supported!
-        if ChefUtils.windows?
-          require_relative "../win32/file"
-          begin
-            Chef::ReservedNames::Win32::File.verify_links_supported!
-          rescue Chef::Exceptions::Win32APIFunctionNotImplemented => e
-            Chef::Log.fatal("Link resource is not supported on this version of Windows")
-            raise e
-          end
-        end
       end
     end
   end

--- a/lib/chef/win32/file.rb
+++ b/lib/chef/win32/file.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Chisamore (<schisamo@chef.io>)
-# Author:: Mark Mzyk (<mmzyk@ospcode.com>)
-# Copyright:: Copyright 2011-2016, Chef Software Inc.
+# Author:: Mark Mzyk (<mmzyk@chef.io>)
+# Copyright:: Copyright 2011-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -164,14 +164,6 @@ class Chef
 
       def self.version_info(file_name)
         VersionInfo.new(file_name)
-      end
-
-      def self.verify_links_supported!
-        CreateSymbolicLinkW(nil)
-      rescue Chef::Exceptions::Win32APIFunctionNotImplemented => e
-        raise e
-      rescue Exception
-          # things are ok.
       end
 
       def self.file_access_check(path, desired_access)

--- a/spec/unit/provider/link_spec.rb
+++ b/spec/unit/provider/link_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@junglist.gen.nz>)
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -358,7 +358,6 @@ describe Chef::Resource::Link do
         allow(Chef::Resource::Link).to receive(:new).with(
           provider.new_resource.name
         ).and_return(resource_link)
-        allow(resource_link).to receive(:verify_links_supported!)
         allow(ChefUtils).to receive(:windows?).and_return(true)
       end
 

--- a/spec/unit/resource/link_spec.rb
+++ b/spec/unit/resource/link_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,10 +21,6 @@ require "spec_helper"
 
 describe Chef::Resource::Link do
   let(:resource) { Chef::Resource::Link.new("fakey_fakerton") }
-
-  before(:each) do
-    expect_any_instance_of(Chef::Resource::Link).to receive(:verify_links_supported!).and_return(true)
-  end
 
   it "the target_file property is the name_property" do
     expect(resource.target_file).to eql("fakey_fakerton")


### PR DESCRIPTION
Windows 2008+ has support for links. There's no reason to perform this check
every time on Windows. It's just wasting CPU cycles

Fixes #9416 

Signed-off-by: Tim Smith <tsmith@chef.io>