### PR TITLE
Use Ohai's cloud attributes in knife node / status presenters

### DIFF
--- a/lib/chef/knife/core/node_presenter.rb
+++ b/lib/chef/knife/core/node_presenter.rb
@@ -94,8 +94,8 @@ class Chef
         def summarize(data)
           if data.is_a?(Chef::Node)
             node = data
-            # special case ec2 with their split horizon whatsis.
-            ip = (node[:ec2] && node[:ec2][:public_ipv4]) || node[:ipaddress]
+            # special case clouds with their split horizon whatsis.
+            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
 
             summarized = <<~SUMMARY
               #{ui.color("Node Name:", :bold)}   #{ui.color(node.name, :bold)}

--- a/lib/chef/knife/core/node_presenter.rb
+++ b/lib/chef/knife/core/node_presenter.rb
@@ -95,7 +95,7 @@ class Chef
           if data.is_a?(Chef::Node)
             node = data
             # special case clouds with their split horizon whatsis.
-            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
+            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
 
             summarized = <<~SUMMARY
               #{ui.color("Node Name:", :bold)}   #{ui.color(node.name, :bold)}

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -95,9 +95,9 @@ class Chef
           summarized = ""
           list.each do |data|
             node = data
-            # special case ec2 with their split horizon whatsis.
-            ip = (node[:ec2] && node[:ec2][:public_ipv4]) || node[:ipaddress]
-            fqdn = (node[:ec2] && node[:ec2][:public_hostname]) || node[:fqdn]
+            # special case clouds with their split horizon whatsis.
+            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
+            fqdn = (node[:cloud] && node[:cloud][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 
             if config[:run_list]

--- a/lib/chef/knife/core/status_presenter.rb
+++ b/lib/chef/knife/core/status_presenter.rb
@@ -96,7 +96,7 @@ class Chef
           list.each do |data|
             node = data
             # special case clouds with their split horizon whatsis.
-            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
+            ip = (node[:cloud] && node[:cloud][:public_ipv4_addrs] && node[:cloud][:public_ipv4_addrs].first) || node[:ipaddress]
             fqdn = (node[:cloud] && node[:cloud][:public_hostname]) || node[:fqdn]
             name = node["name"] || node.name
 


### PR DESCRIPTION
Right now we have a specific case for EC2. This extends the same logic
to all clouds by using the node['cloud'] data. This really only changes
things if you run knife status with the --long flag.

The output doesn't change for EC2 nodes:

bundle exec knife status --long
36666 hours ago, smith-0, smith-0, 172.16.1.13, ubuntu 14.04.
7411 hours ago, myhost, ec2-13-59-123-123.us-east-2.compute.amazonaws.com, 13.59.123.123, ubuntu 18.04.
7298 hours ago, tim_test, ec2-34-123-123-2.us-west-2.compute.amazonaws.com, 34.221.123.123, ubuntu 16.04.
7298 hours ago, tim_test2, ec2-52-88-123-123.us-west-2.compute.amazonaws.com, 52.88.123.123, redhat 7.6.

Signed-off-by: Tim Smith <tsmith@chef.io>