### PR TITLE
Set env vars in the container setup script

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -26,10 +26,6 @@ steps:
       docker:
         image: rubydistros/ubuntu-18.04
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - BUNDLE_GEMFILE=/workdir/Gemfile
 
 - label: "Functional Specs Ubuntu :ruby: 2.6"
   commands:
@@ -43,9 +39,6 @@ steps:
       docker:
         image: rubydistros/ubuntu-18.04
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Unit Specs Ubuntu :ruby: 2.6"
   commands:
@@ -57,9 +50,6 @@ steps:
     executor:
       docker:
         image: rubydistros/ubuntu-18.04
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Integration Specs CentOS :ruby: 2.6"
   commands:
@@ -71,10 +61,6 @@ steps:
       docker:
         image: rubydistros/centos-7
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - BUNDLE_GEMFILE=/workdir/Gemfile
 
 - label: "Functional Specs CentOS :ruby: 2.6"
   commands:
@@ -87,9 +73,6 @@ steps:
       docker:
         image: rubydistros/centos-7
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Unit Specs CentOS :ruby: 2.6"
   commands:
@@ -101,9 +84,6 @@ steps:
     executor:
       docker:
         image: rubydistros/centos-7
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Integration Specs openSUSE :ruby: 2.6"
   commands:
@@ -115,10 +95,6 @@ steps:
       docker:
         image: rubydistros/opensuse-15
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - BUNDLE_GEMFILE=/workdir/Gemfile
 
 - label: "Functional Specs openSUSE :ruby: 2.6"
   commands:
@@ -131,9 +107,6 @@ steps:
       docker:
         image: rubydistros/opensuse-15
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Unit Specs openSUSE :ruby: 2.6"
   commands:
@@ -145,9 +118,6 @@ steps:
     executor:
       docker:
         image: rubydistros/opensuse-15
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Integration Specs Fedora :ruby: 2.6"
   commands:
@@ -159,10 +129,6 @@ steps:
       docker:
         image: rubydistros/fedora-latest
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - BUNDLE_GEMFILE=/workdir/Gemfile
 
 - label: "Functional Specs Fedora :ruby: 2.6"
   commands:
@@ -189,9 +155,6 @@ steps:
     executor:
       docker:
         image: rubydistros/fedora-latest
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
 
 - label: "Integration Specs Windows :ruby: 2.6"
   commands:
@@ -259,10 +222,6 @@ steps:
       docker:
         image: ruby:2.7-buster
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - INTEGRATION_SPECS_27=1
 
 - label: "Functional Specs :ruby: 2.7"
   commands:
@@ -276,10 +235,6 @@ steps:
       docker:
         image: ruby:2.7-buster
         privileged: true
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - FUNCTIONAL_SPECS_27=1
 
 - label: "Unit Specs :ruby: 2.7"
   commands:
@@ -291,10 +246,6 @@ steps:
     executor:
       docker:
         image: ruby:2.7-buster
-        environment:
-          - FORCE_FFI_YAJL=ext
-          - CHEF_LICENSE=accept-no-persist
-          - UNIT_SPECS_27=1
 
 #########################################################################
   # EXTERNAL GEM TESTING

--- a/scripts/bk_tests/bk_container_prep.sh
+++ b/scripts/bk_tests/bk_container_prep.sh
@@ -1,5 +1,9 @@
 # This script gets a container ready to run our various tests in BuildKite
 
+export FORCE_FFI_YAJL="ext"
+export CHEF_LICENSE="accept-no-persist"
+export BUNDLE_GEMFILE="/workdir/Gemfile"
+
 # make sure we have the network tools in place for various network specs
 if [ -f /etc/debian_version ]; then
   touch /etc/network/interfaces


### PR DESCRIPTION
We're setting the same env vars in each job. Seems entirely pointless.

Signed-off-by: Tim Smith <tsmith@chef.io>