### PR TITLE
Add always_dump_stacktrace config option & workaround to fix the encoding bugs

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -4,7 +4,7 @@
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Mark Mzyk (<mmzyk@chef.io>)
 # Author:: Kyle Goodwin (<kgoodwin@primerevenue.com>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -399,6 +399,9 @@ module ChefConfig
 
     # Using `force_logger` causes chef to default to logger output when STDOUT is a tty
     default :force_logger, false
+
+    # When set to true always print the stacktrace even if we haven't done -l debug
+    default :always_dump_stacktrace, false
 
     # Using 'stream_execute_output' will have Chef always stream the execute output
     default :stream_execute_output, false

--- a/kitchen-tests/kitchen.yml
+++ b/kitchen-tests/kitchen.yml
@@ -12,21 +12,22 @@ provisioner:
   name: dokken
   client_rb:
     diff_disabled: true
+    always_dump_stacktrace: true
   chef_license: "accept-no-persist"
 
 lifecycle:
   pre_converge:
     - remote: echo "Chef container's Chef / Ohai release:"
-    - remote: /opt/chef/embedded/bin/chef-client -v
-    - remote: /opt/chef/embedded/bin/ohai -v
+    - remote: /opt/chef/bin/chef-client -v
+    - remote: /opt/chef/bin/ohai -v
     - remote: /opt/chef/embedded/bin/rake --version
     - remote: /opt/chef/embedded/bin/bundle -v
     - remote: /opt/chef/embedded/bin/gem install appbundler appbundle-updater --no-doc
     - remote: /opt/chef/embedded/bin/appbundle-updater chef ohai <%= File.readlines('../Gemfile.lock', File.expand_path(File.dirname(__FILE__))).find { |l| l =~ /^\s+ohai \((\d+\.\d+\.\d+)\)/ }; 'v' + $1 %> --tarball --github chef/ohai
     - remote: /opt/chef/embedded/bin/appbundle-updater chef chef <%= ENV['BUILDKITE_COMMIT']  || %x(git rev-parse HEAD).chomp %> --tarball --github chef/chef
     - remote: echo "Installed Chef / Ohai release:"
-    - remote: /opt/chef/embedded/bin/chef-client -v
-    - remote: /opt/chef/embedded/bin/ohai -v
+    - remote: /opt/chef/bin/chef-client -v
+    - remote: /opt/chef/bin/ohai -v
 
 verifier:
   name: inspec

--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -1,7 +1,7 @@
 #
 # Author:: AJ Christensen (<aj@chef.io>)
 # Author:: Mark Mzyk (mmzyk@chef.io)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -392,7 +392,11 @@ class Chef
         Chef::FileCache.store("#{Chef::Dist::SHORT}-stacktrace.out", chef_stacktrace_out)
         logger.fatal("Stacktrace dumped to #{Chef::FileCache.load("#{Chef::Dist::SHORT}-stacktrace.out", false)}")
         logger.fatal("Please provide the contents of the stacktrace.out file if you file a bug report")
-        logger.debug(message)
+        if Chef::Config[:always_dump_stacktrace]
+          logger.fatal(message)
+        else
+          logger.debug(message)
+        end
         true
       end
 

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -76,6 +76,12 @@ class Chef::Application::Apply < Chef::Application
     description: "Set the log level (trace, debug, info, warn, error, fatal).",
     proc: lambda { |l| l.to_sym }
 
+  option :always_dump_stacktrace,
+    long: "--[no-]always-dump-stacktrace",
+    boolean: true,
+    default: false,
+    description: "Always dump the stacktrace regardless of the log_level setting."
+
   option :help,
     short: "-h",
     long: "--help",

--- a/lib/chef/application/base.rb
+++ b/lib/chef/application/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,6 +99,12 @@ class Chef::Application::Base < Chef::Application
     long: "--logfile LOGLOCATION",
     description: "Set the log file location, defaults to STDOUT - recommended for daemonizing.",
     proc: nil
+
+  option :always_dump_stacktrace,
+    long: "--[no-]always-dump-stacktrace",
+    boolean: true,
+    default: false,
+    description: "Always dump the stacktrace regardless of the log_level setting."
 
   option :help,
     short: "-h",

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Lamont Granquist (<lamont@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -381,7 +381,7 @@ class Chef
 
       def update_file_contents
         do_backup unless needs_creating?
-        deployment_strategy.deploy(tempfile.path, ::File.realpath(new_resource.path))
+        deployment_strategy.deploy(tempfile.path, ::File.realpath(new_resource.path).force_encoding(Chef::Config[:ruby_encoding]))
         logger.info("#{new_resource} updated file contents #{new_resource.path}")
         if managing_content?
           # save final checksum for reporting.


### PR DESCRIPTION
This should be backwards compatible with ruby 2.6.5 behavior but
is most likely brittle.

The PR adds an --always-dump-stacktrace option and turns it on so that we can see where things blow up.