### PR TITLE
Fix load path in test runs.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,17 +24,15 @@ module Shell
   IRB = nil unless defined? IRB
 end
 
-# Ruby 1.9 Compat
-$:.unshift File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../..", __FILE__)
+
+$LOAD_PATH.unshift File.expand_path("../../chef-config/lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../chef-utils/lib", __FILE__)
 
 require "rubygems"
 require "rspec/mocks"
 
 require "webmock/rspec"
-
-$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-$:.unshift(File.expand_path("../lib", __FILE__))
-$:.unshift(File.dirname(__FILE__))
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
Fixes the load path in rspec runs to always load the local version of sub-gems.

## Description

* Add the local versions of `chef-config` and `chef-utils` to the load path so that rspec will always load the local versions when called without bundler.
* Use `$LOAD_PATH` instead of the cryptic `$:`.
* Remove some unnecessary additions to the load path that are automatically done by rspec.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
