### PR TITLE
Fix typo in the cron_access docs

### DIFF
--- a/lib/chef/resource/cron_access.rb
+++ b/lib/chef/resource/cron_access.rb
@@ -44,7 +44,7 @@ class Chef
 
         Specify the username with the user property
         ```ruby
-        cron_access 'Deny the tomcat access to cron for security purposes' do
+        cron_access 'Deny the jenkins user access to cron for security purposes' do
           user 'jenkins'
           action :deny
         end


### PR DESCRIPTION
This made no sense

Signed-off-by: Tim Smith <tsmith@chef.io>