### PR TITLE
Cleanup a bunch more files and pull in the smaller license-acceptance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       regexp_parser (~> 1.5)
       uri_template (~> 0.7)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.13)
+    license-acceptance (1.0.18)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     kitchen-vagrant (1.6.1)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
-    license-acceptance (1.0.13)
+    license-acceptance (1.0.18)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -68,6 +68,9 @@ build do
       features
       *Upgrade.md
       vendor
+      *.blurb
+      autotest
+      VERSION
     }
 
     Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|
@@ -86,7 +89,7 @@ build do
       *.gemspec
       Gemfile
       Rakefile
-      tasks/*.rake
+      tasks
     }
 
     Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -78,4 +78,33 @@ build do
       FileUtils.rm_rf(f)
     end
   end
+
+  block "Removing Gemspec / Rakefile / Gemfile unless there's a bin dir / not a chef gem" do
+    # find the embedded ruby gems dir and clean it up for globbing
+    target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
+    files = %w{
+      *.gemspec
+      Gemfile
+      Rakefile
+      tasks/*.rake
+    }
+
+    Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|
+      # don't delete these files if there's a bin dir in the same dir or we're in a chef owned gem
+      next if Dir.exist?(File.join(File.dirname(f), "bin")) || File.basename(File.expand_path("..", f)).start_with?("chef-")
+
+      puts "Deleting #{f}"
+      FileUtils.rm_rf(f)
+    end
+  end
+
+  block "Removing spec dirs from non-Chef gems" do
+    Dir.glob(Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/*/spec".tr('\\', "/"))).each do |f|
+      # if we're in a chef- gem then don't remove the specs
+      next if File.basename(File.expand_path("..", f)).start_with?("chef-")
+
+      puts "Deleting #{f}"
+      FileUtils.rm_rf(f)
+    end
+  end
 end


### PR DESCRIPTION
With this change we now have 25% fewer files than 15.8 and ~24% less space used on disk.

Signed-off-by: Tim Smith <tsmith@chef.io>