### PR TITLE
powershell_package: Use ohai data to get the powershell release instead of shelling out

### DIFF
--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -36,7 +36,7 @@ class Chef
 
         def define_resource_requirements
           super
-          if ChefUtils.powershell_version(node).strip.to_i < 5
+          if node["languages"] && node["languages"]["powershell"] && node["languages"]["powershell"]["version"].strip.to_i < 5
             raise "Minimum installed PowerShell Version required is 5"
           end
 

--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -36,7 +36,7 @@ class Chef
 
         def define_resource_requirements
           super
-          if powershell_out("$PSVersionTable.PSVersion.Major").stdout.strip.to_i < 5
+          if ChefUtils.powershell_version(node).strip.to_i < 5
             raise "Minimum installed PowerShell Version required is 5"
           end
 

--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -36,7 +36,7 @@ class Chef
 
         def define_resource_requirements
           super
-          if powershell_version.to_i < 5
+          if powershell_version < 5
             raise "Minimum installed PowerShell Version required is 5"
           end
 

--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -36,7 +36,7 @@ class Chef
 
         def define_resource_requirements
           super
-          if node["languages"] && node["languages"]["powershell"] && node["languages"]["powershell"]["version"].strip.to_i < 5
+          if powershell_version.to_i < 5
             raise "Minimum installed PowerShell Version required is 5"
           end
 

--- a/spec/unit/provider/package/powershell_spec.rb
+++ b/spec/unit/provider/package/powershell_spec.rb
@@ -28,6 +28,7 @@ describe Chef::Provider::Package::Powershell do
 
   let(:provider) do
     node = Chef::Node.new
+    node.consume_external_attrs(OHAI_SYSTEM.data.dup, {})
     events = Chef::EventDispatch::Dispatcher.new
     run_context = Chef::RunContext.new(node, {}, events)
     Chef::Provider::Package::Powershell.new(new_resource, run_context)

--- a/spec/unit/provider/package/powershell_spec.rb
+++ b/spec/unit/provider/package/powershell_spec.rb
@@ -19,7 +19,7 @@
 require "spec_helper"
 require "chef/mixin/powershell_out"
 
-describe Chef::Provider::Package::Powershell do
+describe Chef::Provider::Package::Powershell, :windows_only do
   include Chef::Mixin::PowershellOut
   let(:timeout) { 900 }
   let(:source) { nil }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Use Ohai data to determine if we have PowerShell installed

## Related Issue
Fixed: https://github.com/chef/chef/issues/9398

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
