### PR TITLE
Don't require/include Mixin Shellout in freebsd_package and openbsd_package

### DIFF
--- a/lib/chef/resource/freebsd_package.rb
+++ b/lib/chef/resource/freebsd_package.rb
@@ -21,13 +21,10 @@
 require_relative "package"
 require_relative "../provider/package/freebsd/port"
 require_relative "../provider/package/freebsd/pkgng"
-require_relative "../mixin/shell_out"
 
 class Chef
   class Resource
     class FreebsdPackage < Chef::Resource::Package
-      include Chef::Mixin::ShellOut
-
       resource_name :freebsd_package
       provides :package, platform: "freebsd"
 

--- a/lib/chef/resource/openbsd_package.rb
+++ b/lib/chef/resource/openbsd_package.rb
@@ -21,13 +21,10 @@
 
 require_relative "package"
 require_relative "../provider/package/openbsd"
-require_relative "../mixin/shell_out"
 
 class Chef
   class Resource
     class OpenbsdPackage < Chef::Resource::Package
-      include Chef::Mixin::ShellOut
-
       resource_name :openbsd_package
       provides :package, os: "openbsd"
 


### PR DESCRIPTION
Backport https://github.com/chef/chef/pull/9423

This comes for free with Resource and these are the only two resources that were doing it.

Signed-off-by: Tim Smith <tsmith@chef.io>