### PR TITLE
chef_fs: Fix gsub so only file endings of .rb and .json are removed. 

### DIFF
--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -775,7 +775,7 @@ class Chef
           end
 
         elsif path.length == 2 && path[0] != "cookbooks"
-          path[1] = path[1].gsub(/\.(rb|json)/, "")
+          path[1] = path[1].gsub(/\.(rb|json)$/, "")
         end
 
         path


### PR DESCRIPTION
Backport https://github.com/chef/chef/pull/9429

Any file paths, like FQDNs with them in between, will not be handled.

Signed-off-by: Jörg Herzinger <joerg.herzinger@gmail.com>