### PR TITLE
Chefstyle fixes identified with Rubocop 0.80

### DIFF
--- a/lib/chef/chef_fs/command_line.rb
+++ b/lib/chef/chef_fs/command_line.rb
@@ -190,9 +190,9 @@ class Chef
           are_same, old_value, new_value = Chef::ChefFS::FileSystem.compare(old_entry, new_entry)
           if are_same
             if old_value == :none
-              return [ [ :both_nonexistent, old_entry, new_entry ] ]
+              [ [ :both_nonexistent, old_entry, new_entry ] ]
             else
-              return [ [ :same, old_entry, new_entry ] ]
+              [ [ :same, old_entry, new_entry ] ]
             end
           else
             if old_value == :none
@@ -235,11 +235,11 @@ class Chef
             end
 
             if old_value == :none || (old_value.nil? && !old_entry.exists?)
-              return [ [ :added, old_entry, new_entry, old_value, new_value ] ]
+              [ [ :added, old_entry, new_entry, old_value, new_value ] ]
             elsif new_value == :none
-              return [ [ :deleted, old_entry, new_entry, old_value, new_value ] ]
+              [ [ :deleted, old_entry, new_entry, old_value, new_value ] ]
             else
-              return [ [ :modified, old_entry, new_entry, old_value, new_value ] ]
+              [ [ :modified, old_entry, new_entry, old_value, new_value ] ]
             end
           end
         end

--- a/lib/chef/data_collector/config_validation.rb
+++ b/lib/chef/data_collector/config_validation.rb
@@ -77,27 +77,27 @@ class Chef
           case
           when Chef::Config[:why_run]
             Chef::Log.trace("data collector is disabled for why run mode")
-            return false
+            false
           when (want_mode != :both) && running_mode != want_mode
             Chef::Log.trace("data collector is configured to only run in #{Chef::Config[:data_collector][:mode]} modes, disabling it")
-            return false
+            false
           when !(Chef::Config[:data_collector][:server_url] || Chef::Config[:data_collector][:output_locations])
             Chef::Log.trace("Neither data collector URL or output locations have been configured, disabling data collector")
-            return false
+            false
           when running_mode == :client && Chef::Config[:data_collector][:token]
             Chef::Log.warn("Data collector token authentication is not recommended for client-server mode. " \
                            "Please upgrade #{Chef::Dist::SERVER_PRODUCT} to 12.11 or later and remove the token from your config file " \
                            "to use key based authentication instead")
-            return true
+            true
           when Chef::Config[:data_collector][:output_locations] && Chef::Config[:data_collector][:output_locations][:files] && !Chef::Config[:data_collector][:output_locations][:files].empty?
             # we can run fine to a file without a token, even in solo mode.
-            return true
+            true
           when running_mode == :solo && !Chef::Config[:data_collector][:token]
             # we are in solo mode and are not logging to a file, so must have a token
             Chef::Log.trace("Data collector token must be configured to use #{Chef::Dist::AUTOMATE} data collector with #{Chef::Dist::SOLO}")
-            return false
+            false
           else
-            return true
+            true
           end
         end
 

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -90,9 +90,9 @@ class Chef
 
           case key_matches.length
           when 0
-            return nil
+            nil
           when 1
-            return @values[platform][key_matches.first]
+            @values[platform][key_matches.first]
           else
             raise "Multiple matches detected for #{platform} with values #{@values}. The matches are: #{key_matches}"
           end

--- a/lib/chef/http/json_output.rb
+++ b/lib/chef/http/json_output.rb
@@ -65,7 +65,7 @@ class Chef
           if http_response.body
             Chef::Log.trace("Response body contains:\n#{http_response.body.length < 256 ? http_response.body : http_response.body[0..256] + " [...truncated...]"}")
           end
-          return [http_response, rest_request, http_response.body.to_s]
+          [http_response, rest_request, http_response.body.to_s]
         end
       end
 

--- a/lib/chef/knife/data_bag_edit.rb
+++ b/lib/chef/knife/data_bag_edit.rb
@@ -37,13 +37,13 @@ class Chef
         item = Chef::DataBagItem.load(bag, item_name)
         if encrypted?(item.raw_data)
           if encryption_secret_provided_ignore_encrypt_flag?
-            return Chef::EncryptedDataBagItem.new(item, read_secret).to_hash, true
+            [Chef::EncryptedDataBagItem.new(item, read_secret).to_hash, true]
           else
             ui.fatal("You cannot edit an encrypted data bag without providing the secret.")
             exit(1)
           end
         else
-          return item.raw_data, false
+          [item.raw_data, false]
         end
       end
 

--- a/lib/chef/provider/package/yum/python_helper.rb
+++ b/lib/chef/provider/package/yum/python_helper.rb
@@ -88,9 +88,9 @@ class Chef
           def install_only_packages(name)
             query_output = query("installonlypkgs", { "package" => name })
             if query_output == "False"
-              return false
+              false
             elsif query_output == "True"
-              return true
+              true
             end
           end
 

--- a/lib/chef/provider/package/yum/rpm_utils.rb
+++ b/lib/chef/provider/package/yum/rpm_utils.rb
@@ -209,9 +209,9 @@ class Chef
 
               # the most unprocessed characters left wins
               if (x_pos_max - x_pos) > (y_pos_max - y_pos)
-                return 1
+                1
               else
-                return -1
+                -1
               end
             end
 
@@ -522,9 +522,9 @@ class Chef
           def lookup(package_name)
             pkgs = @rpms[package_name]
             if pkgs
-              return pkgs.sort.reverse
+              pkgs.sort.reverse
             else
-              return nil
+              nil
             end
           end
 

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -79,7 +79,7 @@ class Chef
           IPAddr.new(ip, Socket::AF_INET).to_s
         rescue ArgumentError
           logger.trace("Invalid IP address data: hex=#{hex_ip}, ip=#{ip}")
-          return nil
+          nil
         end
       end
 

--- a/lib/chef/provider/windows_env.rb
+++ b/lib/chef/provider/windows_env.rb
@@ -104,7 +104,7 @@ class Chef
         needs_delete = new_values.any? { |v| current_values.include?(v) }
         if !needs_delete
           logger.trace("#{new_resource} element '#{new_resource.value}' does not exist")
-          return true # do not delete the key
+          true # do not delete the key
         else
           new_value =
             current_values.select do |item|
@@ -112,13 +112,13 @@ class Chef
             end.join(new_resource.delim)
 
           if new_value.empty?
-            return false # nothing left here, delete the key
+            false # nothing left here, delete the key
           else
             old_value = new_resource.value(new_value)
             create_env
             logger.trace("#{new_resource} deleted #{old_value} element")
             new_resource.updated_by_last_action(true)
-            return true # we removed the element and updated; do not delete the key
+            true # we removed the element and updated; do not delete the key
           end
         end
       end

--- a/lib/chef/util/diff.rb
+++ b/lib/chef/util/diff.rb
@@ -152,14 +152,14 @@ class Chef
 
         if !diff_str.empty? && diff_str != "No differences encountered\n"
           if diff_str.length > diff_output_threshold
-            return "(long diff of over #{diff_output_threshold} characters, diff output suppressed)"
+            "(long diff of over #{diff_output_threshold} characters, diff output suppressed)"
           else
             diff_str = encode_diff_for_json(diff_str)
             @diff = diff_str.split("\n")
-            return "(diff available)"
+            "(diff available)"
           end
         else
-          return "(no diff)"
+          "(no diff)"
         end
       end
 

--- a/lib/chef/util/selinux.rb
+++ b/lib/chef/util/selinux.rb
@@ -75,9 +75,9 @@ class Chef
           cmd = shell_out!(selinuxenabled_path, returns: [0, 1])
           case cmd.exitstatus
           when 1
-            return false
+            false
           when 0
-            return true
+            true
           else
             raise "Unknown exit code from command #{selinuxenabled_path}: #{cmd.exitstatus}"
           end

--- a/lib/chef/win32/error.rb
+++ b/lib/chef/win32/error.rb
@@ -50,7 +50,7 @@ class Chef
 
         # Extract the string
         begin
-          return buffer.read_pointer.read_wstring(num_chars)
+          buffer.read_pointer.read_wstring(num_chars)
         ensure
           Chef::ReservedNames::Win32::Memory.local_free(buffer.read_pointer)
         end

--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -154,7 +154,7 @@ class Chef
             return true
           end
         rescue ::Win32::Registry::Error => e
-          return false
+          false
         end
       end
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -222,16 +222,16 @@ def selinux_enabled?
     cmd_result = cmd.run_command
     case cmd_result.exitstatus
     when 1
-      return false
+      false
     when 0
-      return true
+      true
     else
       raise "Unknown exit code from command #{selinuxenabled_path}: #{cmd.exitstatus}"
     end
   else
     # We assume selinux is not enabled if selinux utils are not
     # installed.
-    return false
+    false
   end
 end
 


### PR DESCRIPTION
The new Rubocop detects more unnecessary returns. This fixes these ahead of time so we can roll out the new Rubocop engine without breaking builds later.

Signed-off-by: Tim Smith <tsmith@chef.io>