### PR TITLE
Add support for parsing YAML recipes with chef-apply

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -154,10 +154,6 @@ class Chef::Application::Apply < Chef::Application
     if file_name.nil?
       Chef::Application.fatal!("No recipe file was provided", Chef::Exceptions::RecipeNotFound.new)
     else
-      if file_name =~ /\.yml$/
-        logger.info "Recipe file name ends with .yml, parsing as YAML"
-        config[:yaml] = true
-      end
       recipe_path = File.expand_path(file_name)
       unless File.exist?(recipe_path)
         Chef::Application.fatal!("No file exists at #{recipe_path}", Chef::Exceptions::RecipeNotFound.new)
@@ -208,7 +204,8 @@ class Chef::Application::Apply < Chef::Application
       @recipe_text, @recipe_fh = read_recipe_file @recipe_filename
     end
     recipe, run_context = get_recipe_and_run_context
-    if config[:yaml]
+    if config[:yaml] || File.extname(@recipe_filename) == ".yml"
+      logger.info "Parsing recipe as YAML"
       recipe.from_yaml(@recipe_text)
     else
       recipe.instance_eval(@recipe_text, @recipe_filename, 1)

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -1,7 +1,7 @@
 #--
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2018, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,26 +88,24 @@ class Chef
     def from_yaml_file(filename)
       self.source_file = filename
       if File.file?(filename) && File.readable?(filename)
-        from_yaml(IO.read(filename))
+        yaml_contents = IO.read(filename)
+        if YAML.load_stream(yaml_contents).length > 1
+          raise ArgumentError, "YAML recipe '#{filename}' contains multiple documents, only one is supported"
+        end
+
+        from_yaml(yaml_contents)
       else
-        raise IOError, "Cannot open or read #{filename}!"
+        raise IOError, "Cannot open or read file '#{filename}'!"
       end
     end
 
     def from_yaml(string)
       res = ::YAML.safe_load(string)
-      if res.is_a?(Hash)
-        from_hash(res)
-      elsif res.is_a?(Array)
-        from_array(res)
-      else
-        raise "boom"
+      unless res.is_a?(Hash) && res.key?("resources")
+        raise ArgumentError, "YAML recipe '#{source_file}' must contain a top-level 'resources' hash (YAML sequence), i.e. 'resources:'"
       end
-    end
 
-    def from_array(array)
-      Chef::Log.warn "array yaml files are super duper experimental behavior"
-      array.each { |e| from_hash(e) }
+      from_hash(res)
     end
 
     def from_hash(hash)

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+require "yaml"
 require_relative "dsl/recipe"
 require_relative "mixin/from_file"
 require_relative "mixin/deprecation"
@@ -89,7 +90,7 @@ class Chef
       self.source_file = filename
       if File.file?(filename) && File.readable?(filename)
         yaml_contents = IO.read(filename)
-        if YAML.load_stream(yaml_contents).length > 1
+        if ::YAML.load_stream(yaml_contents).length > 1
           raise ArgumentError, "YAML recipe '#{filename}' contains multiple documents, only one is supported"
         end
 

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -46,6 +46,7 @@ describe Chef::Application::Apply do
     it "should read text properly" do
       expect(@app.read_recipe_file(@recipe_file_name)[0]).to eq(@recipe_text)
     end
+
     it "should return a file_handle" do
       expect(@app.read_recipe_file(@recipe_file_name)[1]).to be_instance_of(RSpec::Mocks::Double)
     end
@@ -57,6 +58,7 @@ describe Chef::Application::Apply do
         @app.read_recipe_file(nil)
       end
     end
+
     describe "when recipe doesn't exist" do
       before do
         allow(File).to receive(:exist?).with(@recipe_path).and_return(false)
@@ -67,7 +69,22 @@ describe Chef::Application::Apply do
         @app.read_recipe_file(@recipe_file_name)
       end
     end
+
+    describe "when the recipe filename ends in .yml" do
+      it "configures for parsing the recipe as YAML" do
+        @recipe_file_name = "foo.yml"
+        @recipe_path = File.expand_path(@recipe_file_name)
+        @recipe_file = double("Tempfile (mock)", read: @recipe_text)
+        allow(@app).to receive(:open).with(@recipe_path).and_return(@recipe_file)
+        allow(File).to receive(:exist?).with(@recipe_path).and_return(true)
+        allow(Chef::Application).to receive(:fatal!).and_return(true)
+
+        @app.read_recipe_file(@recipe_file_name)
+        expect(@app.config[:yaml]).to eq(true)
+      end
+    end
   end
+
   describe "temp_recipe_file" do
     before do
       @app.instance_variable_set(:@recipe_text, @recipe_text)

--- a/spec/unit/application/apply_spec.rb
+++ b/spec/unit/application/apply_spec.rb
@@ -69,20 +69,6 @@ describe Chef::Application::Apply do
         @app.read_recipe_file(@recipe_file_name)
       end
     end
-
-    describe "when the recipe filename ends in .yml" do
-      it "configures for parsing the recipe as YAML" do
-        @recipe_file_name = "foo.yml"
-        @recipe_path = File.expand_path(@recipe_file_name)
-        @recipe_file = double("Tempfile (mock)", read: @recipe_text)
-        allow(@app).to receive(:open).with(@recipe_path).and_return(@recipe_file)
-        allow(File).to receive(:exist?).with(@recipe_path).and_return(true)
-        allow(Chef::Application).to receive(:fatal!).and_return(true)
-
-        @app.read_recipe_file(@recipe_file_name)
-        expect(@app.config[:yaml]).to eq(true)
-      end
-    end
   end
 
   describe "temp_recipe_file" do


### PR DESCRIPTION
Enables `chef-apply foo.yml` and `chef-apply foo.whatever --yaml`.

Improves error messages around incorrectly formatted YAML.

 **Also changes/enforces the YAML file format** 
This removes an unnecessary array that we had been using.

New format:
```
---
resources:
  - name: "do something"
    type: "execute"
```

```
{ "resources" => [ { "name" => "do something", "type" => "execute" } ] }
```
Old format:
```
---
- resources:
  - name: "do something"
     type: "execute"
```

```
[ { "resources" => [ { "name" => "do something", "type" => "execute" } ] } ]
```
