### PR TITLE
Fix for Chocolate_resource options causing extra quotes

### DIFF
--- a/lib/chef/provider/package/chocolatey.rb
+++ b/lib/chef/provider/package/chocolatey.rb
@@ -17,14 +17,15 @@
 
 require_relative "../package"
 require_relative "../../resource/chocolatey_package"
+require_relative "../../win32/api/command_line_helper" if ChefUtils.windows?
 
 class Chef
   class Provider
     class Package
       class Chocolatey < Chef::Provider::Package
+        include Chef::ReservedNames::Win32::API::CommandLineHelper if ChefUtils.windows?
 
         provides :chocolatey_package
-
         # Declare that our arguments should be arrays
         use_multipackage_api
 
@@ -207,7 +208,7 @@ class Chef
         # @param include_source [Boolean] should the source parameter be added
         # @return [String] options from new_resource or empty string
         def cmd_args(include_source: true)
-          cmd_args = [ new_resource.options ]
+          cmd_args = new_resource.options.is_a?(String) ? command_line_to_argv_w_helper(new_resource.options) : Array(new_resource.options)
           cmd_args += common_options(include_source: include_source)
           cmd_args
         end

--- a/lib/chef/win32/api/command_line_helper.rb
+++ b/lib/chef/win32/api/command_line_helper.rb
@@ -1,0 +1,89 @@
+#
+# Author:: Kapil Chouhan <kapil.chouhan@msystechnologies.com>
+# Copyright:: Copyright 2013-2020, Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../api"
+
+class Chef
+  module ReservedNames::Win32
+    module API
+      module CommandLineHelper
+        # extend Chef::ReservedNames::Win32
+        extend Chef::ReservedNames::Win32::API
+
+        ###############################################
+        # Win32 API Bindings
+        ###############################################
+
+        ffi_lib "Shell32"
+
+=begin
+LPWSTR * CommandLineToArgvW(
+  LPCWSTR lpCmdLine,
+  int     *pNumArgs
+);
+=end
+
+        safe_attach_function :command_line_to_argv_w, :CommandLineToArgvW, %i{pointer pointer}, :pointer
+
+        ffi_lib "Kernel32"
+
+=begin
+LPSTR GetCommandLineA();
+=end
+
+        safe_attach_function :get_command_line, :GetCommandLineA, [], :pointer
+
+=begin
+HLOCAL LocalFree(
+  _Frees_ptr_opt_ HLOCAL hMem
+);
+=end
+
+        safe_attach_function :local_free, :LocalFree, [:pointer], :pointer
+
+        ###############################################
+        # Helpers
+        ###############################################
+
+        # It takes the supplied string and splits it into an array.
+        def command_line_to_argv_w_helper(args)
+          arguments_list = []
+          argv = args.to_wstring
+          result = get_command_line
+          argc = FFI::MemoryPointer.new(:int)
+
+          # Parses a Unicode command line string
+          # It is return an array of pointers to the command line arguments.
+          # Along with a count of such arguments
+          result = command_line_to_argv_w(argv, argc)
+          str_ptr = result.read_pointer
+          offset = 0
+          number_of_agrs = argc.read_int
+          number_of_agrs.times do
+            new_str_pointer = str_ptr.+(offset)
+            argument = new_str_pointer.read_wstring
+            arguments_list << argument
+            offset = offset + argument.length * 2 + 2
+          end
+          local_free(result)
+          arguments_list
+        end
+      end
+    end
+  end
+end

--- a/spec/functional/resource/chocolatey_package_spec.rb
+++ b/spec/functional/resource/chocolatey_package_spec.rb
@@ -32,6 +32,11 @@ describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
     new_resource
   end
 
+  let(:provider) do
+    provider = subject.provider_for_action(subject.action)
+    provider
+  end
+
   context "installing a package" do
     after { remove_package }
 
@@ -86,6 +91,30 @@ describe Chef::Resource::ChocolateyPackage, :windows_only, :choco_installed do
       subject.options "--force --confirm"
       subject.run_action(:install)
       expect(package_list.call).to eq("#{package_name}|2.0")
+    end
+
+    context "when multiple options passed as string" do
+      before do
+        subject.options "--force --confirm"
+        subject.source nil
+      end
+
+      it "splits a string into an array of options" do
+        expect(provider.send(:cmd_args)).to eq(["--force", "--confirm"])
+      end
+
+      it "calls command_line_to_argv_w_helper method" do
+        expect(provider).to receive(:command_line_to_argv_w_helper).with(subject.options).and_return(["--force", "--confirm"])
+        provider.send(:cmd_args)
+      end
+    end
+
+    context "when multiple options passed as array" do
+      it "Does not call command_line_to_argv_w_helper method" do
+        subject.options [ "--force", "--confirm" ]
+        expect(provider).not_to receive(:command_line_to_argv_w_helper)
+        provider.send(:cmd_args)
+      end
     end
 
     it "installs with multiple options as an array" do

--- a/spec/unit/provider/package/chocolatey_spec.rb
+++ b/spec/unit/provider/package/chocolatey_spec.rb
@@ -18,7 +18,7 @@
 
 require "spec_helper"
 
-describe Chef::Provider::Package::Chocolatey do
+describe Chef::Provider::Package::Chocolatey, :windows_only do
   let(:timeout) { 900 }
 
   let(:new_resource) { Chef::Resource::ChocolateyPackage.new("git") }


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

## Description
- Whenever user was passing the installer arguments `--% -ia \"INSTALLDIR=\"#{path}\"\"` in `options` property of chocolatey_package, it wasn't installed where the user wanted, rather it is installed at the default location. so we have fixed it.
- Added `CommandLineToArgvW` function for split a string options into an array.
- Added test cases
- Ensured chef-style on the code changes made.

## Related Issue
Fixes: #9413 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
