### PR TITLE
Fix windows_firewall_rule resource for rules with multiple profiles

### DIFF
--- a/lib/chef/resource/windows_firewall_rule.rb
+++ b/lib/chef/resource/windows_firewall_rule.rb
@@ -76,7 +76,7 @@ class Chef
         description: "The profile the firewall rule applies to.",
         coerce: proc { |p| Array(p).map(&:downcase).map(&:to_sym).sort },
         callbacks: {
-          "contains values not in :public, :private :domain, :any or :notapplicable" => lambda { |p|
+          "contains values not in :public, :private, :domain, :any or :notapplicable" => lambda { |p|
             p.all? { |e| %i{public private domain any notapplicable}.include?(e) }
           },
         }
@@ -110,6 +110,10 @@ class Chef
         else
           state = Chef::JSONCompat.from_json(output.stdout)
         end
+
+        # Need to reverse `$rule.Profile.ToString()` in powershell command
+        current_profiles = state["profile"].split(", ").map(&:to_sym)
+
         group state["group"]
         local_address state["local_address"]
         local_port Array(state["local_port"]).sort
@@ -118,7 +122,7 @@ class Chef
         direction state["direction"]
         protocol state["protocol"]
         firewall_action state["firewall_action"]
-        profile state["profile"]
+        profile current_profiles
         program state["program"]
         service state["service"]
         interface_type state["interface_type"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
So far, changing Windows firewall rules with more than one associated profile will fail validation on loading the current state.

The reason is a `.ToString` conversion of an array in the Powershell helper, which is not reversed into individual symbols on loading state.

Also fixing a minor typo.

## Related Issue
Related to issue #8808 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
