### PR TITLE
Remove outdated comment about shell args on different platforms.

### DIFF
--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -26,10 +26,6 @@ class Chef
       #
       # all consumers should now call shell_out!/shell_out.
       #
-      # on unix the shell_out API supports the clean_array() kind of syntax (below) so that
-      # array args are flat/compact/to_s'd.  on windows, array args aren't supported to its
-      # up to the caller to join(" ") on arrays of strings.
-      #
       # the shell_out_compacted/shell_out_compacted! APIs are private but are intended for use
       # in rspec tests, and should ideally always be used to make code refactorings that do not
       # change behavior easier:


### PR DESCRIPTION
## Description

I made a reference to this comment in #9509 and @lamont-granquist said it was outdated and should be removed.

## Related Issue
https://github.com/chef/chef/pull/9509#issuecomment-600949638

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
