### PR TITLE
If we can't remove the Ruby installer in windows tests that's cool

### DIFF
--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -15,7 +15,7 @@ echo "Installing Ruby + DevKit"
 Start-Process c:\rubyinstaller-devkit-2.6.5-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
 
 echo "Cleaning up installation"
-Remove-Item c:\rubyinstaller-devkit-2.6.5-1-x64.exe -Force
+Remove-Item c:\rubyinstaller-devkit-2.6.5-1-x64.exe -Force -ErrorAction SilentlyContinue
 echo "Closing out the layer (this can take awhile)"
 
 # Set-Item -Path Env:Path -Value to include ruby26


### PR DESCRIPTION
We're failing a lot when we try to remove this file. Just move on with
life.

Signed-off-by: Tim Smith <tsmith@chef.io>