### PR TITLE
Revert windows server manager spec helper

### DIFF
--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -63,7 +63,7 @@ end
 # win32/service gem. windows_service_manager tests create a windows
 # service that starts with the system ruby and requires this gem.
 def system_windows_service_gem?
-  windows_service_gem_check_command = %{ruby -r "win32/daemon" -e ":noop" > #{DEV_NULL} 2>&1}
+  windows_service_gem_check_command = %q{ruby -r "win32/daemon" -e ":noop"}
   if defined?(Bundler)
     Bundler.with_unbundled_env do
       # This returns true if the gem can be loaded


### PR DESCRIPTION
This was causing our specs to fail

Signed-off-by: Tim Smith <tsmith@chef.io>