### PR TITLE
Add Ubuntu 20.04 (x86_64) Tester

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -49,6 +49,7 @@ builder-to-testers-map:
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+    - ubuntu-20.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:


### PR DESCRIPTION
## Description

This PR just adds the new Ubuntu 20.04 x86_64 tester to the omnibus pipeline.

An adhoc build associated with this change can be found here:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/222

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Related Issue
#9456 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
