### PR TITLE
Fixed windows share cannot modify frozen string bug

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -39,7 +39,7 @@ class Chef
       # Specifies the path of the location of the folder to share. The path must be fully qualified. Relative paths or paths that contain wildcard characters are not permitted.
       property :path, String,
         description: "The path of the folder to share. Required when creating. If the share already exists on a different path then it is deleted and re-created.",
-        coerce: proc { |p| p.gsub!(%r{/}, "\\") || p }
+        coerce: proc { |p| p.gsub(%r{/}, "\\") || p }
 
       # Specifies an optional description of the SMB share. A description of the share is displayed by running the Get-SmbShare cmdlet. The description may not contain more than 256 characters.
       property :description, String,

--- a/spec/unit/resource/windows_share_spec.rb
+++ b/spec/unit/resource/windows_share_spec.rb
@@ -38,11 +38,9 @@ describe Chef::Resource::WindowsShare do
   end
 
   it "coerces path to a single path separator format" do
-    resource.path("C:/chef")
+    resource.path("C:/chef".freeze)
     expect(resource.path).to eql("C:\\chef")
     resource.path("C:\\chef")
-    expect(resource.path).to eql("C:\\chef")
-    resource.path("C:/chef".freeze)
     expect(resource.path).to eql("C:\\chef")
     resource.path("C:/chef".dup)
     expect(resource.path).to eql("C:\\chef")

--- a/spec/unit/resource/windows_share_spec.rb
+++ b/spec/unit/resource/windows_share_spec.rb
@@ -42,5 +42,9 @@ describe Chef::Resource::WindowsShare do
     expect(resource.path).to eql("C:\\chef")
     resource.path("C:\\chef")
     expect(resource.path).to eql("C:\\chef")
+    resource.path("C:/chef".freeze)
+    expect(resource.path).to eql("C:\\chef")
+    resource.path("C:/chef".dup)
+    expect(resource.path).to eql("C:\\chef")
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Compilation fails with error "can't modify frozen String". It shows error at path in the windows_share method.

## Related Issue
fixed: https://github.com/chef/chef/issues/9166

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
