### PR TITLE
Add : https_for_ca_consumer property to rhsm_register resource

### DIFF
--- a/lib/chef/resource/rhsm_register.rb
+++ b/lib/chef/resource/rhsm_register.rb
@@ -16,6 +16,7 @@
 #
 
 require_relative "../resource"
+require_relative "../dist"
 require "shellwords" unless defined?(Shellwords)
 
 class Chef
@@ -60,6 +61,10 @@ class Chef
         description: "If true, the system will be registered even if it is already registered. Normally, any register operations will fail if the machine has already been registered.",
         default: false, desired_state: false
 
+      property :https_for_ca_consumer, [TrueClass, FalseClass],
+        description: "If true, #{Chef::Dist::PRODUCT} will fetch the katello-ca-consumer-latest.noarch.rpm from the satellite_host using HTTPS.",
+        default: false, desired_state: false
+
       action :register do
         description "Register the node with RHSM."
 
@@ -73,7 +78,7 @@ class Chef
           end
 
           remote_file "#{Chef::Config[:file_cache_path]}/katello-package.rpm" do
-            source "http://#{new_resource.satellite_host}/pub/katello-ca-consumer-latest.noarch.rpm"
+            source ca_consumer_package_source
             action :create
             notifies :install, "#{package_resource}[katello-ca-consumer-latest]", :immediately
             not_if { katello_cert_rpm_installed? }
@@ -130,6 +135,11 @@ class Chef
           cmd = Mixlib::ShellOut.new("rpm -qa | grep katello-ca-consumer")
           cmd.run_command
           !cmd.stdout.match(/katello-ca-consumer/).nil?
+        end
+
+        def ca_consumer_package_source
+          protocol = new_resource.https_for_ca_consumer ? "https" : "http"
+          "#{protocol}://#{new_resource.satellite_host}/pub/katello-ca-consumer-latest.noarch.rpm"
         end
 
         def register_command

--- a/spec/unit/resource/rhsm_register_spec.rb
+++ b/spec/unit/resource/rhsm_register_spec.rb
@@ -179,6 +179,30 @@ describe Chef::Resource::RhsmRegister do
     end
   end
 
+  describe "#ca_consumer_package_source" do
+    let(:satellite_host) { "sat-host" }
+
+    before do
+      resource.satellite_host = satellite_host
+    end
+
+    context "when https_for_ca_consumer is true" do
+      before { resource.https_for_ca_consumer true }
+
+      it "returns url with https" do
+        expect(provider.ca_consumer_package_source).to eq("https://#{satellite_host}/pub/katello-ca-consumer-latest.noarch.rpm")
+      end
+    end
+
+    context "when https_for_ca_consumer is false" do
+      before { resource.https_for_ca_consumer false }
+
+      it "returns url with http" do
+        expect(provider.ca_consumer_package_source).to eq("http://#{satellite_host}/pub/katello-ca-consumer-latest.noarch.rpm")
+      end
+    end
+  end
+
   describe "#registered_with_rhsm?" do
     let(:cmd) { double("cmd") }
 


### PR DESCRIPTION
## Description

This will enable people to increase their security posture by verifying the remote satellite host SSL certificate.

## Related Issue

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
