### PR TITLE
clean up chef_client_cron

### DIFF
--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2020, Chef Software Inc.
+# Copyright:: 2020-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ class Chef
       ```
       DOC
 
+      extend Chef::ResourceHelpers::CronValidations
+
       property :user, String,
         description: "The name of the user that #{Chef::Dist::PRODUCT} runs as.",
         default: "root"
@@ -57,31 +59,31 @@ class Chef
       property :minute, [Integer, String],
         description: "The minute at which #{Chef::Dist::PRODUCT} is to run (0 - 59) or a cron pattern such as '0,30'.",
         default: "0,30", callbacks: {
-          "should be a valid minute spec" => ->(spec) { Chef::ResourceHelpers::CronValidations.validate_numeric(spec, 0, 59) },
+          "should be a valid minute spec" => method(:validate_minute),
         }
 
       property :hour, [Integer, String],
         description: "The hour at which #{Chef::Dist::PRODUCT} is to run (0 - 23) or a cron pattern such as '0,12'.",
         default: "*", callbacks: {
-          "should be a valid hour spec" => ->(spec) { Chef::ResourceHelpers::CronValidations.validate_numeric(spec, 0, 23) },
+          "should be a valid hour spec" => method(:validate_hour),
         }
 
       property :day, [Integer, String],
         description: "The day of month at which #{Chef::Dist::PRODUCT} is to run (1 - 31) or a cron pattern such as '1,7,14,21,28'.",
         default: "*", callbacks: {
-          "should be a valid day spec" => ->(spec) { Chef::ResourceHelpers::CronValidations.validate_numeric(spec, 1, 31) },
+          "should be a valid day spec" => method(:validate_day),
         }
 
       property :month, [Integer, String],
         description: "The month in the year on which #{Chef::Dist::PRODUCT} is to run (1 - 12, jan-dec, or *).",
         default: "*", callbacks: {
-          "should be a valid month spec" => ->(spec) { Chef::ResourceHelpers::CronValidations.validate_month(spec) },
+          "should be a valid month spec" => method(:validate_month),
         }
 
       property :weekday, [Integer, String],
         description: "The day of the week on which #{Chef::Dist::PRODUCT} is to run (0-7, mon-sun, or *), where Sunday is both 0 and 7.",
         default: "*", callbacks: {
-          "should be a valid weekday spec" => ->(spec) { Chef::ResourceHelpers::CronValidations.validate_dow(spec) },
+          "should be a valid weekday spec" => method(:validate_dow),
         }
 
       property :mailto, String,

--- a/lib/chef/resource/helpers/cron_validations.rb
+++ b/lib/chef/resource/helpers/cron_validations.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2020, Chef Software Inc.
+# Copyright:: Copyright 2020-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ class Chef
       # @param min the lowest value allowed
       # @param max the highest value allowed
       # @return [Boolean] valid or not?
-      def self.validate_numeric(spec, min, max)
+      def validate_numeric(spec, min, max)
         return true if spec == "*"
 
         if spec.respond_to? :to_int
@@ -46,7 +46,7 @@ class Chef
       # validate the provided month value to be jan - dec, 1 - 12, or *
       # @param spec the value to validate
       # @return [Boolean] valid or not?
-      def self.validate_month(spec)
+      def validate_month(spec)
         return true if spec == "*"
 
         if spec.respond_to? :to_int
@@ -65,11 +65,34 @@ class Chef
       # validate the provided day of the week is sun-sat, 0-7, or *
       # @param spec the value to validate
       # @return [Boolean] valid or not?
-      def self.validate_dow(spec)
+      def validate_dow(spec)
         spec == "*" ||
           validate_numeric(spec, 0, 7) ||
           %w{sun mon tue wed thu fri sat}.include?(String(spec).downcase)
       end
+
+      # validate the day of the month is 1-31
+      # @param spec the value to validate
+      # @return [Boolean] valid or not?
+      def validate_day(spec)
+        validate_numeric(spec, 1, 31)
+      end
+
+      # validate the hour is 0-23
+      # @param spec the value to validate
+      # @return [Boolean] valid or not?
+      def validate_hour(spec)
+        validate_numeric(spec, 0, 23)
+      end
+
+      # validate the minute is 0-59
+      # @param spec the value to validate
+      # @return [Boolean] valid or not?
+      def validate_minute(spec)
+        validate_numeric(spec, 0, 59)
+      end
+
+      extend self
     end
   end
 end


### PR DESCRIPTION
- add instance methods to the module so it can be mixed in
- extend the module into the resource class
- use explicit methods for "currying" arguments to avoid the cognitive
  overhead of the lambda syntax and allow using method()
- use method() to keep the callbacks readable
