### PR TITLE
Switch to RUBY_PLATFORM for the windows check

### DIFF
--- a/spec/support/platforms/win32/spec_service.rb
+++ b/spec/support/platforms/win32/spec_service.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-if ChefUtils.windows?
+if RUBY_PLATFORM =~ /mswin|mingw|windows/
   require "win32/daemon"
 
   class SpecService < ::Win32::Daemon


### PR DESCRIPTION
Merging in this check broke the build tests on Windows hosts.

Signed-off-by: Tim Smith <tsmith@chef.io>