### PR TITLE
restore magic resource name ordering

### DIFF
--- a/lib/chef/resource/lwrp_base.rb
+++ b/lib/chef/resource/lwrp_base.rb
@@ -51,7 +51,6 @@ class Chef
 
           resource_class = Class.new(self)
           resource_class.run_context = run_context
-          resource_class.provides resource_name.to_sym
           resource_class.class_from_file(filename)
 
           # Make a useful string for the class (rather than <Class:312894723894>)
@@ -65,6 +64,10 @@ class Chef
           Chef::Log.trace("Loaded contents of #{filename} into resource #{resource_name} (#{resource_class})")
 
           LWRPBase.loaded_lwrps[filename] = true
+
+          # wire up the default resource name after the class is parsed only if we haven't declared one.
+          # (this ordering is important for MapCollision deprecation warnings)
+          resource_class.provides resource_name.to_sym unless Chef::ResourceResolver.includes_handler?(resource_name.to_sym, self)
 
           resource_class
         end


### PR DESCRIPTION
this restores the order that the magic wiring of LWRP / custom resources
to the cookbook_name + resource filename comes after the parsing of the
file that it is defined in.

i had moved this because i was running into issues with recursive calls
between provides and the resource_name method, which i later solved.

this restores the prior behavior, but calls provides instead of
resource_name, but relies on the implicit call to resource_name from
the first provides to be functionally identical to the prior behavior
anyway.

no idea if this actually fixes any bugs, but it was not really
intentional to change it.  stuff like chef_version_for_provides
needs to be called before calling provides, so it seems like the
behavior this fixes should have been buggy with respect to that
but it is obviously...  complicated.


this probably fixes issues where if the provides is called before the parsing of the resource file
itself the stuff like `chef_version_for_provides` will not work correctly since that needs to come
first (along with just restoring the prior order of parsing and probably fixing other edge conditions
that depend on that ordering).
