### PR TITLE
Add :swap action to yum_package resource

### DIFF
--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -78,6 +78,18 @@ class Chef
             a.whyrun "assuming #{new_resource.source} would have previously been created"
           end
 
+          requirements.assert(:swap) do |a|
+            a.assertion { !new_resource.swap_from.nil? }
+            a.failure_message Chef::Exceptions::Package, ":swap action requires the swap_from property"
+            a.whyrun "assuming #{new_resource.source} would have previously been created"
+          end
+
+          requirements.assert(:swap) do |a|
+            a.assertion { new_resource.package_name.length == 1 }
+            a.failure_message Chef::Exceptions::Package, ":swap action only supports a single package_name"
+            a.whyrun "assuming #{new_resource.source} would have previously been created"
+          end
+
           super
         end
 

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -94,9 +94,12 @@ class Chef
         end
 
         def get_swap_from_current_version
-          # TODO: Figure out what to do given that when git is queried it returns results for git216... How Will
-          # that effect things downstream. Don't forget this.
-          python_helper.package_query(:whatinstalled, swap_from_current_resource.package_name).version_with_arch
+          pkg = python_helper.package_query(:whatinstalled, swap_from_current_resource.package_name)
+
+          # This seems weird, but the reason it's here is that the RPM database Returns
+          # drop in replacement packages when queried. For example if git216 is installed and you query
+          # if git is installed, it will return git216. This guardrails against that from happening.
+          pkg.version_with_arch if pkg.name == swap_from_current_resource.package_name
         end
 
         def available_version_for(package_name)
@@ -162,7 +165,7 @@ class Chef
         action :swap do
           # If package is already installed, don't do anything.
           return if new_resource.package_name == current_resource.package_name &&
-            new_resource.package_version == current_resource.package_version
+            !current_resource.package_version.nil?
 
           if swap_from_is_installed?
             # TODO: raise exception if the package_name contains more than a single package

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -81,13 +81,11 @@ class Chef
           requirements.assert(:swap) do |a|
             a.assertion { !new_resource.swap_from.nil? }
             a.failure_message Chef::Exceptions::Package, ":swap action requires the swap_from property"
-            a.whyrun "assuming #{new_resource.source} would have previously been created"
           end
 
           requirements.assert(:swap) do |a|
             a.assertion { new_resource.package_name.length == 1 }
             a.failure_message Chef::Exceptions::Package, ":swap action only supports a single package_name"
-            a.whyrun "assuming #{new_resource.source} would have previously been created"
           end
 
           super

--- a/lib/chef/provider/package/yum.rb
+++ b/lib/chef/provider/package/yum.rb
@@ -138,6 +138,14 @@ class Chef
           flushcache
         end
 
+        action :swap do
+          if node["packages"].keys.include?(new_resource.swap_from)
+            execute "yum swap #{new_resource.swap_from} #{new_resource.package_name}"
+          else
+            new_resource.run_action(:install)
+          end
+        end
+
         # NB: the yum_package provider manages individual single packages, please do not submit issues or PRs to try to add wildcard
         # support to lock / unlock.  The best solution is to write an execute resource which does a not_if `yum versionlock | grep '^pattern`` kind of approach
         def lock_package(names, versions)

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -53,6 +53,10 @@ class Chef
         description: "The architecture of the package to be installed or upgraded. This value can also be passed as part of the package name.",
         coerce: proc { |x| x.is_a?(Array) ? x.to_a : x }
 
+      property :swap_from, [ String ],
+        description: "The name of the package you want to swap out in favor of package_name.",
+        introduced: "15.9"
+
       property :flush_cache, Hash,
         description: "Flush the in-memory cache before or after a Yum operation that installs, upgrades, or removes a package. Accepts a Hash in the form: { :before => true/false, :after => true/false } or an Array in the form [ :before, :after ].\nYum automatically synchronizes remote metadata to a local cache. The #{Chef::Dist::CLIENT} creates a copy of the local cache, and then stores it in-memory during the #{Chef::Dist::CLIENT} run. The in-memory cache allows packages to be installed during the #{Chef::Dist::CLIENT} run without the need to continue synchronizing the remote metadata to the local cache while the #{Chef::Dist::CLIENT} run is in-progress.",
         default: { before: false, after: false },

--- a/lib/chef/resource/yum_package.rb
+++ b/lib/chef/resource/yum_package.rb
@@ -55,7 +55,7 @@ class Chef
 
       property :swap_from, [ String ],
         description: "The name of the package you want to swap out in favor of package_name.",
-        introduced: "15.9"
+        introduced: "16.0"
 
       property :flush_cache, Hash,
         description: "Flush the in-memory cache before or after a Yum operation that installs, upgrades, or removes a package. Accepts a Hash in the form: { :before => true/false, :after => true/false } or an Array in the form [ :before, :after ].\nYum automatically synchronizes remote metadata to a local cache. The #{Chef::Dist::CLIENT} creates a copy of the local cache, and then stores it in-memory during the #{Chef::Dist::CLIENT} run. The in-memory cache allows packages to be installed during the #{Chef::Dist::CLIENT} run without the need to continue synchronizing the remote metadata to the local cache while the #{Chef::Dist::CLIENT} run is in-progress.",


### PR DESCRIPTION
## Description

For folks who are running RHEL distros and need to swap in different packages from the [IUS repository](https://ius.io/usage), this would give them the ability to do so natively in Chef Infra Client.

### Example

```ruby
yum_package 'git222' do
  swap_from 'git'
  action :swap
end
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
