### PR TITLE
Modify pre-command hook to only run in verify pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,6 +2,9 @@
 
 set -eu
 
+# Only execute in the verify pipeline
+[[ "$BUILDKITE_PIPELINE_NAME" =~ verify$ ]] || exit 0
+
 docker ps || true
 free -m || true
 


### PR DESCRIPTION
## Description
The `.buildkite/hooks/pre-command` script should only be executed within the `verify` pipeline.  This PR just adds a conditional to allow the script to exit successfully if the pipeline name doesn't end with "verify"

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
