### PR TITLE
Improve chef_client_* resources

### DIFF
--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -89,6 +89,10 @@ class Chef
       property :mailto, String,
         description: "The e-mail address to e-mail any cron task failures to."
 
+      property :accept_chef_license, [true, false],
+        description: "Accept the Chef Online Master License and Services Agreement. See https://www.chef.io/online-master-agreement/",
+        default: false
+
       property :job_name, String,
         default: Chef::Dist::CLIENT,
         description: "The name of the cron job to create."
@@ -184,6 +188,8 @@ class Chef
           cmd << "/bin/sleep #{splay_sleep_time(new_resource.splay)}; "
           cmd << "#{new_resource.chef_binary_path} "
           cmd << "#{new_resource.daemon_options.join(" ")} " unless new_resource.daemon_options.empty?
+          cmd << "-c #{::File.join(new_resource.config_directory, "client.rb")} "
+          cmd << "--chef-license accept " if new_resource.accept_chef_license
           cmd << log_command
           cmd << " || echo \"#{Chef::Dist::PRODUCT} execution failed\"" if new_resource.mailto
           cmd

--- a/spec/unit/resource/chef_client_cron_spec.rb
+++ b/spec/unit/resource/chef_client_cron_spec.rb
@@ -77,33 +77,43 @@ describe Chef::Resource::ChefClientCron do
     end
 
     it "creates a valid command if using all default properties" do
-      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -L /var/log/chef/client.log")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/chef/client.rb -L /var/log/chef/client.log")
     end
 
     it "uses daemon_options if set" do
       resource.daemon_options ["--foo 1", "--bar 2"]
-      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client --foo 1 --bar 2 -L /var/log/chef/client.log")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client --foo 1 --bar 2 -c /etc/chef/client.rb -L /var/log/chef/client.log")
+    end
+
+    it "uses custom config dir if set" do
+      resource.config_directory "/etc/some_other_dir"
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/some_other_dir/client.rb -L /var/log/chef/client.log")
     end
 
     it "uses custom log files / paths if set" do
       resource.log_file_name "my-client.log"
       resource.log_directory "/var/log/my-chef/"
-      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -L /var/log/my-chef/my-client.log")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/chef/client.rb -L /var/log/my-chef/my-client.log")
     end
 
     it "uses mailto if set" do
       resource.mailto "bob@example.com"
-      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -L /var/log/chef/client.log || echo \"Chef Infra Client execution failed\"")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/chef/client.rb -L /var/log/chef/client.log || echo \"Chef Infra Client execution failed\"")
     end
 
     it "uses custom chef-client binary if set" do
       resource.chef_binary_path "/usr/local/bin/chef-client"
-      expect(provider.cron_command).to eql("/bin/sleep 123; /usr/local/bin/chef-client -L /var/log/chef/client.log")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /usr/local/bin/chef-client -c /etc/chef/client.rb -L /var/log/chef/client.log")
     end
 
     it "appends to the log file appending if set to false" do
       resource.append_log_file false
-      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client > /var/log/chef/client.log 2>&1")
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/chef/client.rb > /var/log/chef/client.log 2>&1")
+    end
+
+    it "sets the license acceptance flag if set" do
+      resource.accept_chef_license true
+      expect(provider.cron_command).to eql("/bin/sleep 123; /opt/chef/bin/chef-client -c /etc/chef/client.rb --chef-license accept -L /var/log/chef/client.log")
     end
   end
 end

--- a/spec/unit/resource/chef_client_scheduled_task_spec.rb
+++ b/spec/unit/resource/chef_client_scheduled_task_spec.rb
@@ -67,4 +67,36 @@ describe Chef::Resource::ChefClientScheduledTask do
     expect { resource.action :add }.not_to raise_error
     expect { resource.action :remove }.not_to raise_error
   end
+
+  describe "#client_cmd" do
+    it "creates a valid command if using all default properties" do
+      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb")
+    end
+
+    it "uses daemon_options if set" do
+      resource.daemon_options ["--foo 1", "--bar 2"]
+      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --foo 1 --bar 2")
+    end
+
+    it "uses custom config dir if set" do
+      resource.config_directory "C:/foo/bar"
+      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L C:/foo/bar/log/client.log -c C:/foo/bar/client.rb")
+    end
+
+    it "uses custom log files / paths if set" do
+      resource.log_file_name "my-client.log"
+      resource.log_directory "C:/foo/bar"
+      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L C:/foo/bar/my-client.log -c /etc/chef/client.rb")
+    end
+
+    it "uses custom chef-client binary if set" do
+      resource.chef_binary_path "C:/foo/bar/chef-client"
+      expect(provider.client_cmd).to eql("C:/foo/bar/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb")
+    end
+
+    it "sets the license acceptance flag if set" do
+      resource.accept_chef_license true
+      expect(provider.client_cmd).to eql("C:/opscode/chef/bin/chef-client -L /etc/chef/log/client.log -c /etc/chef/client.rb --chef-license accept")
+    end
+  end
 end


### PR DESCRIPTION
- Add new accept_chef_license property
- Wire up config_directory property in chef_client_cron to match the chef_client_scheduled_task behavior
- Add run_on_battery property to chef_client_scheduled_task
- Move logic into helpers in chef_client_schedule_task
- Add more testing to chef_client_scheduled_task

Signed-off-by: Tim Smith <tsmith@chef.io>