### PR TITLE
Skip the ifconfig functional tests if we don't have ifconfig

### DIFF
--- a/spec/functional/resource/ifconfig_spec.rb
+++ b/spec/functional/resource/ifconfig_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Kaustubh Deorukhkar (<kaustubh@clogeny.com>)
-# Copyright:: Copyright 2013-2018, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ require "chef/mixin/shell_out"
 # run this test only for following platforms.
 include_flag = !(%w{amazon debian aix}.include?(ohai[:platform_family]) || (ohai[:platform_family] == "rhel" && ohai[:platform_version].to_i < 7))
 
-describe Chef::Resource::Ifconfig, :requires_root, external: include_flag do
+describe Chef::Resource::Ifconfig, :requires_root, :requires_ifconfig, external: include_flag do
   include Chef::Mixin::ShellOut
 
   let(:new_resource) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2019, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -198,7 +198,9 @@ RSpec.configure do |config|
   config.filter_run_excluding chef: DependencyProc.with(Chef::VERSION)
   config.filter_run_excluding ruby: DependencyProc.with(RUBY_VERSION)
 
+  # check for particular binaries we need
   config.filter_run_excluding choco_installed: true unless choco_installed?
+  config.filter_run_excluding requires_ifconfig: true unless ifconfig?
 
   running_platform_arch = `uname -m`.strip unless windows?
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -270,6 +270,10 @@ rescue SocketError
   false
 end
 
+def ifconfig?
+  which("ifconfig")
+end
+
 def choco_installed?
   result = ShellHelpers.powershell_out("choco --version")
   result.stderr.empty? ? true : false


### PR DESCRIPTION
I'm looking at you Ubuntu 20.04

Signed-off-by: Tim Smith <tsmith@chef.io>