### PR TITLE
build_essential resource: fix macOS 10.15 and improve installation support with a new :upgrade action for macOS

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -118,8 +118,8 @@ class Chef
         if macos?
           pkg_label = xcode_cli_package_label
 
-          # with upgrade action we should install if it's not install or if there's an available update to install
-          # xcode_cli_package_label will be nil if there's not update
+          # With upgrade action we should install if it's not installed or if there's an available update.
+          # `xcode_cli_package_label` will be nil if there's no update.
           install_xcode_cli_tools(pkg_label) if !xcode_cli_installed? || xcode_cli_package_label
         else
           Chef::Log.info "The build_essential resource :upgrade action is only supported on macOS systems. Skipping..."

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -173,7 +173,7 @@ class Chef
           label_match = available_updates.stdout.match(/^\s*\* (?:Label: )?(Command Line Tools.*)/)
 
           # this will return the match or nil
-          label_match&.first
+          label_match[1] unless label_match.nil?
         end
       end
     end

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -61,8 +61,8 @@ class Chef
           package "devel/m4"
           package "devel/gettext"
         when macos?
-          update_label = xcode_cli_package
-          unless xcode_cli_installed? && update_label.empty?
+          update_pkg_label = xcode_cli_package_label
+          unless xcode_cli_installed? && update_pkg_label.nil?
             # This script was graciously borrowed and modified from Tim Sutton's
             # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
             execute "install XCode Command Line tools" do
@@ -71,7 +71,7 @@ class Chef
                 # in Apple's SUS catalog
                 touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
                 # find the CLI Tools update. We tail here because sometimes there's 2 and newest is last
-                PROD=#{update_label}
+                PROD=#{update_pkg_label}
                 # install it
                 softwareupdate -i "$PROD" --verbose
                 # Remove the placeholder to prevent perpetual appearance in the update utility
@@ -140,16 +140,20 @@ class Chef
         end
 
         #
-        # Return to package label of the latest XCode Command Line Tools update, if available
+        # Return to package label of the latest Xcode Command Line Tools update, if available
         #
-        # @return [String]
-        def xcode_cli_package
-          cmd = <<-EOH.gsub(/^ {14}/, "")
-          softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n' | sed 's/Label: //g'
-          EOH
-          cmd.run_command
-          cmd.error!
-          cmd.stdout
+        # @return [String, NilClass]
+        def xcode_cli_package_label
+          available_updates = shell_out("softwareupdate", "--list")
+
+          # raise if we fail to check
+          available_updates.error!
+
+          # https://rubular.com/r/UPEE5P7mZLvXNs
+          label_match = available_updates.stdout.match(/^\s*\* (?:Label: )?(Command Line Tools.*)/)
+
+          # this will return the match or nil
+          label_match&.first
         end
       end
     end

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -66,14 +66,12 @@ class Chef
             # This script was graciously borrowed and modified from Tim Sutton's
             # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
             execute "install XCode Command Line tools" do
-              command <<-EOH.gsub(/^ {14}/, "")
+              command <<-EOH
                 # create the placeholder file that's checked by CLI updates' .dist code
                 # in Apple's SUS catalog
                 touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-                # find the CLI Tools update. We tail here because sometimes there's 2 and newest is last
-                PROD=#{update_pkg_label}
                 # install it
-                softwareupdate -i "$PROD" --verbose
+                softwareupdate -i "#{update_pkg_label}" --verbose
                 # Remove the placeholder to prevent perpetual appearance in the update utility
                 rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
               EOH

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -134,8 +134,7 @@ class Chef
         #
         # @return [true, false]
         def xcode_cli_installed?
-          cmd = Mixlib::ShellOut.new("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
-          cmd.run_command
+          cmd = shell_out("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
           # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
         end

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -145,7 +145,7 @@ class Chef
         #
         # @return [String]
         def xcode_cli_package
-          cmd = <<-EOH.gsub(/^ {14}/, '')
+          cmd = <<-EOH.gsub(/^ {14}/, "")
           softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n' | sed 's/Label: //g'
           EOH
           cmd.run_command

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -61,7 +61,8 @@ class Chef
           package "devel/m4"
           package "devel/gettext"
         when macos?
-          unless xcode_cli_installed?
+          update_label = xcode_cli_package
+          unless xcode_cli_installed? && update_label.empty?
             # This script was graciously borrowed and modified from Tim Sutton's
             # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
             execute "install XCode Command Line tools" do
@@ -70,7 +71,7 @@ class Chef
                 # in Apple's SUS catalog
                 touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
                 # find the CLI Tools update. We tail here because sometimes there's 2 and newest is last
-                PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+                PROD=#{update_label}
                 # install it
                 softwareupdate -i "$PROD" --verbose
                 # Remove the placeholder to prevent perpetual appearance in the update utility
@@ -137,6 +138,19 @@ class Chef
           cmd.run_command
           # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
+        end
+
+        #
+        # Return to package label of the latest XCode Command Line Tools update, if available
+        #
+        # @return [String]
+        def xcode_cli_package
+          cmd = <<-EOH.gsub(/^ {14}/, '')
+          softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n' | sed 's/Label: //g'
+          EOH
+          cmd.run_command
+          cmd.error!
+          cmd.stdout
         end
       end
     end

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -38,6 +38,13 @@ class Chef
           compile_time true
         end
         ```
+
+        Upgrade compilation packages on macOS systems
+        ```ruby
+        build_essential 'Install compilation tools' do
+          action :upgrade
+        end
+        ```
       DOC
 
       # this allows us to use build_essential without setting a name

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -134,7 +134,7 @@ class Chef
         #
         # @return [true, false]
         def xcode_cli_installed?
-          cmd = shell_out("pkgutil --pkgs=com.apple.pkg.CLTools_Executables")
+          cmd = shell_out("pkgutil", "--pkgs=com.apple.pkg.CLTools_Executables")
           # pkgutil returns an error if the package isn't found aka not installed
           cmd.error? ? false : true
         end

--- a/spec/unit/resource/build_essential_spec.rb
+++ b/spec/unit/resource/build_essential_spec.rb
@@ -59,12 +59,12 @@ describe Chef::Resource::BuildEssential do
 
   describe "#xcode_cli_installed?" do
     it "returns true if the CLI is in the InstallHistory plist" do
-      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return("spec/unit/resource/data/InstallHistory_with_CLT.plist")
+      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return(::File.join(::File.dirname(__FILE__), "data/InstallHistory_with_CLT.plist"))
       expect(provider.xcode_cli_installed?).to eql(true)
     end
 
     it "returns false if the pkgutil doesn't list the package" do
-      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return("spec/unit/resource/data/InstallHistory_without_CLT.plist")
+      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return(::File.join(::File.dirname(__FILE__), "data/InstallHistory_without_CLT.plist"))
       expect(provider.xcode_cli_installed?).to eql(false)
     end
   end

--- a/spec/unit/resource/build_essential_spec.rb
+++ b/spec/unit/resource/build_essential_spec.rb
@@ -25,14 +25,6 @@ describe Chef::Resource::BuildEssential do
   let(:resource) { Chef::Resource::BuildEssential.new("foo", run_context) }
   let(:provider) { resource.provider_for_action(:install) }
 
-  let(:pkgutil_cli_exists) do
-    double("shell_out", stdout: "com.apple.pkg.CLTools_Executables", exitstatus: 0, error?: false)
-  end
-
-  let(:pkgutil_cli_doesnt_exist) do
-    double("shell_out", exitstatus: 1, error?: true)
-  end
-
   it "has a resource name of :build_essential" do
     expect(resource.resource_name).to eql(:build_essential)
   end
@@ -54,13 +46,13 @@ describe Chef::Resource::BuildEssential do
   end
 
   describe "#xcode_cli_installed?" do
-    it "returns true if the pkgutil lists the package" do
-      allow(provider).to receive(:shell_out).with("pkgutil", "--pkgs=com.apple.pkg.CLTools_Executables").and_return(pkgutil_cli_exists)
+    it "returns true if the CLI is in the InstallHistory plist" do
+      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return("spec/unit/resource/data/InstallHistory_with_CLT.plist")
       expect(provider.xcode_cli_installed?).to eql(true)
     end
 
     it "returns false if the pkgutil doesn't list the package" do
-      allow(provider).to receive(:shell_out).with("pkgutil", "--pkgs=com.apple.pkg.CLTools_Executables").and_return(pkgutil_cli_doesnt_exist)
+      allow(::File).to receive(:open).with("/Library/Receipts/InstallHistory.plist", "r").and_return("spec/unit/resource/data/InstallHistory_without_CLT.plist")
       expect(provider.xcode_cli_installed?).to eql(false)
     end
   end

--- a/spec/unit/resource/data/InstallHistory_with_CLT.plist
+++ b/spec/unit/resource/data/InstallHistory_with_CLT.plist
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>contentType</key>
+		<string>config-data</string>
+		<key>date</key>
+		<date>2019-10-07T20:09:37Z</date>
+		<key>displayName</key>
+		<string>XProtectPlistConfigData</string>
+		<key>displayVersion</key>
+		<string>2106</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.XProtectPlistConfigData_10_15.16U4081</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+	<dict>
+		<key>contentType</key>
+		<string>config-data</string>
+		<key>date</key>
+		<date>2019-10-07T20:09:37Z</date>
+		<key>displayName</key>
+		<string>Gatekeeper Configuration Data</string>
+		<key>displayVersion</key>
+		<string>181</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.GatekeeperConfigData.16U1873</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+	<dict>
+		<key>contentType</key>
+		<string>config-data</string>
+		<key>date</key>
+		<date>2019-10-07T20:09:37Z</date>
+		<key>displayName</key>
+		<string>MRTConfigData</string>
+		<key>displayVersion</key>
+		<string>1.50</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.MRTConfigData_10_15.16U4082</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+	<dict>
+		<key>date</key>
+		<date>2019-10-09T02:37:33Z</date>
+		<key>displayName</key>
+		<string>Chef Infra Client</string>
+		<key>displayVersion</key>
+		<string></string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.getchef.pkg.chef</string>
+		</array>
+		<key>processName</key>
+		<string>installer</string>
+	</dict>
+	<dict>
+		<key>date</key>
+		<date>2019-10-09T02:47:02Z</date>
+		<key>displayName</key>
+		<string>Command Line Tools for Xcode</string>
+		<key>displayVersion</key>
+		<string>11.0</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.CLTools_Executables</string>
+			<string>com.apple.pkg.CLTools_SDK_macOS1015</string>
+			<string>com.apple.pkg.CLTools_SDK_macOS1014</string>
+			<string>com.apple.pkg.CLTools_macOS_SDK</string>
+			<string>com.apple.pkg.DevSDK</string>
+			<string>com.apple.pkg.DevSDK_OSX109</string>
+			<string>com.apple.pkg.DevSDK_OSX1010</string>
+			<string>com.apple.pkg.DevSDK_OSX1011</string>
+			<string>com.apple.pkg.DevSDK_OSX1012</string>
+			<string>com.apple.pkg.DevSDK_macOS1013_Public</string>
+			<string>com.apple.pkg.macOS_SDK_headers_for_macOS_10.14</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+</array>
+</plist>

--- a/spec/unit/resource/data/InstallHistory_without_CLT.plist
+++ b/spec/unit/resource/data/InstallHistory_without_CLT.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>contentType</key>
+		<string>config-data</string>
+		<key>date</key>
+		<date>2019-09-30T20:36:29Z</date>
+		<key>displayName</key>
+		<string>Gatekeeper Configuration Data</string>
+		<key>displayVersion</key>
+		<string>181</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.GatekeeperConfigData.16U1873</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+	<dict>
+		<key>contentType</key>
+		<string>config-data</string>
+		<key>date</key>
+		<date>2019-09-30T20:36:29Z</date>
+		<key>displayName</key>
+		<string>MRTConfigData</string>
+		<key>displayVersion</key>
+		<string>1.49</string>
+		<key>packageIdentifiers</key>
+		<array>
+			<string>com.apple.pkg.MRTConfigData_10_15.16U4080</string>
+		</array>
+		<key>processName</key>
+		<string>softwareupdated</string>
+	</dict>
+</array>
+</plist>


### PR DESCRIPTION
This picks off the last DCO signed off portion of #9178 so we can recreate the conversion to native Ruby without using the code we can't accept due to license concerns.