### PR TITLE
Fix cloud? helper to only report true on cloud instances

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/cloud.rb
+++ b/chef-utils/lib/chef-utils/dsl/cloud.rb
@@ -30,7 +30,8 @@ module ChefUtils
       # @return [Boolean]
       #
       def cloud?(node = __getnode)
-        node.key?("cloud")
+        # cloud is always present, but nil if not on a cloud
+        !node["cloud"].nil?
       end
 
       # Return true if the current current node is in EC2.

--- a/chef-utils/spec/unit/dsl/cloud_spec.rb
+++ b/chef-utils/spec/unit/dsl/cloud_spec.rb
@@ -79,4 +79,10 @@ RSpec.describe ChefUtils::DSL::Cloud do
   context "on softlayer" do
     cloud_reports_true_for(:cloud?, :softlayer?, node: { "softlayer" => {}, "cloud" => {} })
   end
+
+  context "on virtualbox" do
+    it "does not return true for cloud?" do
+      expect(described_class.cloud?({ "virtualbox" => {}, "cloud" => nil })).to be false
+    end
+  end
 end


### PR DESCRIPTION
Ohai always returns the cloud key so checking for the key isn't valid for cloud. We need to make sure it's not nil instead.

Backport https://github.com/chef/chef/pull/9553

Signed-off-by: Tim Smith <tsmith@chef.io>