### PR TITLE
Add after_resource to pair with current_resource

### DIFF
--- a/lib/chef/event_dispatch/base.rb
+++ b/lib/chef/event_dispatch/base.rb
@@ -266,6 +266,9 @@ class Chef
       # Called after #load_current_resource has run.
       def resource_current_state_loaded(resource, action, current_resource); end
 
+      # Called after #load_after_resource has run.
+      def resource_after_state_loaded(resource, action, after_resource); end
+
       # Called when resource current state load is skipped due to the provider
       # not supporting whyrun mode.
       def resource_current_state_load_bypassed(resource, action, current_resource); end

--- a/lib/chef/resource/action_class.rb
+++ b/lib/chef/resource/action_class.rb
@@ -29,71 +29,42 @@ class Chef
         "#{new_resource || "<no resource>"} action #{action ? action.inspect : "<no action>"}"
       end
 
-      #
-      # If load_current_value! is defined on the resource, use that.
-      #
-      def load_current_resource
+      def return_load_current_value
+        resource = nil
         if new_resource.respond_to?(:load_current_value!)
-          # dup the resource and then reset desired-state properties.
-          current_resource = new_resource.dup
+          resource = new_resource.class.new(new_resource.name, new_resource.run_context)
 
-          # We clear desired state in the copy, because it is supposed to be actual state.
-          # We keep identity properties and non-desired-state, which are assumed to be
-          # "control" values like `recurse: true`
-          current_resource.class.properties.each_value do |property|
-            if property.desired_state? && !property.identity? && !property.name_property?
-              property.reset(current_resource)
+          # copy the non-desired state, the identity properties and name property to the new resource
+          # (the desired state values must be loaded by load_current_value)
+          resource.class.properties.each_value do |property|
+            if !property.desired_state? || property.identity? || property.name_property?
+              property.set(resource, new_resource.send(property.name)) if new_resource.class.properties[property.name].is_set?(new_resource)
             end
           end
 
-          # Call the actual load_current_value! method. If it raises
-          # CurrentValueDoesNotExist, set current_resource to `nil`.
+          # we support optionally passing the new_resource as an arg to load_current_value and
+          # load_current_value can raise in order to clear the current_resource to nil
           begin
-            # If the user specifies load_current_value do |desired_resource|, we
-            # pass in the desired resource as well as the current one.
-            if current_resource.method(:load_current_value!).arity > 0
-              current_resource.load_current_value!(new_resource)
+            if resource.method(:load_current_value!).arity > 0
+              resource.load_current_value!(new_resource)
             else
-              current_resource.load_current_value!
+              resource.load_current_value!
             end
           rescue Chef::Exceptions::CurrentValueDoesNotExist
-            current_resource = nil
+            resource = nil
           end
         end
-
-        @current_resource = current_resource
+        resource
       end
 
+      # build the before state (current_resource)
+      def load_current_resource
+        @current_resource = return_load_current_value
+      end
+
+      # build the after state (after_resource)
       def load_after_resource
-        if new_resource.respond_to?(:load_current_value!)
-          # dup the resource and then reset desired-state properties.
-          after_resource = new_resource.dup
-
-          # We clear desired state in the copy, because it is supposed to be actual state.
-          # We keep identity properties and non-desired-state, which are assumed to be
-          # "control" values like `recurse: true`
-          after_resource.class.properties.each_value do |property|
-            if property.desired_state? && !property.identity? && !property.name_property?
-              property.reset(after_resource)
-            end
-          end
-
-          # Call the actual load_current_value! method. If it raises
-          # CurrentValueDoesNotExist, set after_resource to `nil`.
-          begin
-            # If the user specifies load_current_value do |desired_resource|, we
-            # pass in the desired resource as well as the current one.
-            if after_resource.method(:load_current_value!).arity > 0
-              after_resource.load_current_value!(new_resource)
-            else
-              after_resource.load_current_value!
-            end
-          rescue Chef::Exceptions::CurrentValueDoesNotExist
-            after_resource = nil
-          end
-        end
-
-        @after_resource = after_resource
+        @after_resource = return_load_current_value
       end
 
       def self.include_resource_dsl?

--- a/spec/integration/recipes/resource_load_spec.rb
+++ b/spec/integration/recipes/resource_load_spec.rb
@@ -65,17 +65,17 @@ describe "Resource.load_current_value" do
       end
 
       it "current_resource is passed name but not x" do
-        expect(resource.current_value.x).to eq "loaded 2 (name=blah)"
+        expect(resource.current_value.x).to eq "loaded 3 (name=blah)"
       end
 
       it "resource.current_value returns a different resource" do
-        expect(resource.current_value.x).to eq "loaded 2 (name=blah)"
+        expect(resource.current_value.x).to eq "loaded 3 (name=blah)"
         expect(resource.x).to eq "desired"
       end
 
       it "resource.current_value constructs the resource anew each time" do
-        expect(resource.current_value.x).to eq "loaded 2 (name=blah)"
         expect(resource.current_value.x).to eq "loaded 3 (name=blah)"
+        expect(resource.current_value.x).to eq "loaded 4 (name=blah)"
       end
 
       it "the provider accesses the current value of x" do
@@ -96,7 +96,7 @@ describe "Resource.load_current_value" do
         end
 
         it "i, name and d are passed to load_current_value, but not x" do
-          expect(resource.current_value.x).to eq "loaded 2 (d=desired_d, i=desired_i, name=blah)"
+          expect(resource.current_value.x).to eq "loaded 3 (d=desired_d, i=desired_i, name=blah)"
         end
       end
 
@@ -114,7 +114,7 @@ describe "Resource.load_current_value" do
         end
 
         it "i, name and d are passed to load_current_value, but not x" do
-          expect(resource.current_value.x).to eq "loaded 2 (d=desired_d, i=desired_i, name=blah)"
+          expect(resource.current_value.x).to eq "loaded 3 (d=desired_d, i=desired_i, name=blah)"
         end
       end
     end
@@ -146,7 +146,7 @@ describe "Resource.load_current_value" do
 
     context "and a child resource class with no load_current_value" do
       it "the parent load_current_value is used" do
-        expect(subresource.current_value.x).to eq "loaded 2 (name=blah)"
+        expect(subresource.current_value.x).to eq "loaded 3 (name=blah)"
       end
       it "load_current_value yields a copy of the child class" do
         expect(subresource.current_value).to be_kind_of(subresource_class)
@@ -165,8 +165,8 @@ describe "Resource.load_current_value" do
 
       it "the overridden load_current_value is used" do
         current_resource = subresource.current_value
-        expect(current_resource.x).to eq "default 3"
-        expect(current_resource.y).to eq "loaded_y 2 (name=blah)"
+        expect(current_resource.x).to eq "default 4"
+        expect(current_resource.y).to eq "loaded_y 3 (name=blah)"
       end
     end
 
@@ -183,10 +183,131 @@ describe "Resource.load_current_value" do
 
       it "the original load_current_value is called as well as the child one" do
         current_resource = subresource.current_value
-        expect(current_resource.x).to eq "loaded 3 (name=blah)"
-        expect(current_resource.y).to eq "loaded_y 4 (name=blah, x=loaded 3 (name=blah))"
+        expect(current_resource.x).to eq "loaded 5 (name=blah)"
+        expect(current_resource.y).to eq "loaded_y 6 (name=blah, x=loaded 5 (name=blah))"
+      end
+    end
+  end
+end
+
+describe "simple load_current_value tests" do
+  let(:resource_class) do
+    Class.new(Chef::Resource) do
+      attr_writer :index # this is our hacky global state
+      def index; @index ||= 1; end
+
+      property :myindex, Integer
+
+      load_current_value do |new_resource|
+        myindex new_resource.index
+      end
+
+      action :run do
+        new_resource.index += 1
       end
     end
   end
 
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:new_resource) { resource_class.new("test", run_context) }
+  let(:provider) { new_resource.provider_for_action(:run) }
+
+  it "calling the action on the provider sets the current_resource" do
+    expect(events).to receive(:resource_current_state_loaded).with(new_resource, :run, anything)
+    provider.run_action(:run)
+    expect(provider.current_resource.myindex).to eql(1)
+  end
+
+  it "calling the action on the provider sets the after_resource" do
+    expect(events).to receive(:resource_after_state_loaded).with(new_resource, :run, anything)
+    provider.run_action(:run)
+    expect(provider.after_resource.myindex).to eql(2)
+  end
+end
+
+describe "simple load_current_resource tests" do
+  let(:provider_class) do
+    Class.new(Chef::Provider) do
+      provides :no_load_current_value
+      def load_current_resource
+        @current_resource = new_resource.dup
+        @current_resource.myindex = 1
+      end
+      action :run do
+      end
+    end
+  end
+
+  let(:resource_class) do
+    provider_class # vivify the provider_class
+    Class.new(Chef::Resource) do
+      provides :no_load_current_value
+      property :myindex, Integer
+    end
+  end
+
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:new_resource) { resource_class.new("test", run_context) }
+  let(:provider) { new_resource.provider_for_action(:run) }
+
+  it "calling the action on the provider sets the current_resource" do
+    expect(events).to receive(:resource_current_state_loaded).with(new_resource, :run, anything)
+    provider.run_action(:run)
+    expect(provider.current_resource.myindex).to eql(1)
+  end
+
+  it "calling the action on the provider sets the after_resource" do
+    expect(events).to receive(:resource_after_state_loaded).with(new_resource, :run, new_resource)
+    provider.run_action(:run)
+    expect(provider.after_resource.myindex).to eql(nil)
+  end
+end
+
+describe "simple load_current_resource and load_after_resource tests" do
+  let(:provider_class) do
+    Class.new(Chef::Provider) do
+      provides :load_after
+      def load_current_resource
+        @current_resource = new_resource.dup
+        @current_resource.myindex = 1
+      end
+
+      def load_after_resource
+        @after_resource = new_resource.dup
+        @after_resource.myindex = 2
+      end
+      action :run do
+      end
+    end
+  end
+
+  let(:resource_class) do
+    provider_class # autovivify provider class
+    Class.new(Chef::Resource) do
+      provides :load_after
+      property :myindex, Integer
+    end
+  end
+
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:new_resource) { resource_class.new("test", run_context) }
+  let(:provider) { new_resource.provider_for_action(:run) }
+
+  it "calling the action on the provider sets the current_resource" do
+    expect(events).to receive(:resource_current_state_loaded).with(new_resource, :run, anything)
+    provider.run_action(:run)
+    expect(provider.current_resource.myindex).to eql(1)
+  end
+
+  it "calling the action on the provider sets the after_resource" do
+    expect(events).to receive(:resource_after_state_loaded).with(new_resource, :run, anything)
+    provider.run_action(:run)
+    expect(provider.after_resource.myindex).to eql(2)
+  end
 end

--- a/spec/unit/resource/chocolatey_source_spec.rb
+++ b/spec/unit/resource/chocolatey_source_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software, Inc.
+# Copyright:: Copyright 2018-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,9 +49,10 @@ describe Chef::Resource::ChocolateySource do
   before(:each) do
     disable_provider # vivify before mocking
     enable_provider
+    current_resource
     allow(resource).to receive(:provider_for_action).and_return(disable_provider)
     allow(resource).to receive(:provider_for_action).and_return(enable_provider)
-    allow(resource).to receive(:dup).and_return(current_resource)
+    allow(resource.class).to receive(:new).and_return(current_resource)
     @original_env = ENV.to_hash
     ENV["ALLUSERSPROFILE"] = 'C:\ProgramData'
   end


### PR DESCRIPTION
For custom resources which correctly implement load_current_value the
new after_resource comes for "free" and load_current_value will be
called twice to load the current_resource (should be renamed the
"before_resource" but that ship sailed) and then the after_resource.

Appropriate wiring is added for a new event and capturing that into
the action_collection and then the data_collector.  The resource_reporter
has not and will not be updated.

For old style resources which are difficult to convert to custom
resources (thinking here particularly of the 1:N model of the service
resource in core chef, or stuff that just may be a lot of work like the
file resource) then they can override the load_after_resource to
manually wire up their own after_resource.

closes #6036