### PR TITLE
Make the hab version check a full version check not just minor release

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -16,8 +16,7 @@ $pkg_deps=@(
 )
 
 function Invoke-Begin {
-    $hab_version = (hab --version).split(" ")
-    [Version]$hab_version = $hab_version[1].split("/")[0]
+    [Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
     if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
         Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -16,9 +16,9 @@ $pkg_deps=@(
 )
 
 function Invoke-Begin {
-    $hab_version = (hab --version)
-    $hab_minor_version = $hab_version.split('.')[1]
-    if ( -not $? -Or $hab_minor_version -lt 85 ) {
+    $hab_version = (hab --version).split(" ")
+    [Version]$hab_version = $hab_version[1].split("/")[0]
+    if ($hab_version -lt [Version]"0.85.0" ) {
         Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
         Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
         throw "unable to build: required minimum version of Habitat not installed"


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

With the latest version of Habitat only checking the minor release will not work at 5 is less than 85. This fixes this by checking the full version for Habitat.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
