### PR TITLE
Update Ruby to 2.6.6, Rake to 12.3.3 and libarchive to 3.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group(:development, :test) do
   # we pin rake as a copy of rake is installed from the ruby source
   # if you bump the ruby version you should confirm we don't end up with
   # two rake gems installed again
-  gem "rake", "<= 12.3.2"
+  gem "rake", "<= 12.3.3"
 
   gem "rspec-core", "~> 3.5"
   gem "rspec-mocks", "~> 3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: ebbcec68f08a048406764ceae8d2ac33a33507af
+  revision: d0e353d4415834d58aa267f8bc6d5c4ce8d95652
   branch: master
   specs:
-    chefstyle (0.15.1)
-      rubocop (= 0.80.1)
+    chefstyle (1.0.0)
+      rubocop (= 0.81.0)
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 3481e16198505aa05f74a2a80e7070ba549491ce
+  revision: 1516a849f22c4248c8bccbf7b979e966d401d294
   branch: 15-stable
   specs:
     ohai (15.8.0)
@@ -172,7 +172,7 @@ GEM
     equatable (0.6.1)
     erubi (1.9.0)
     erubis (2.7.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     fauxhai-ng (8.0.0)
       net-ssh
@@ -205,7 +205,6 @@ GEM
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    inifile (3.0.0)
     iniparse (1.5.0)
     inspec-core (4.18.100)
       addressable (~> 2.4)
@@ -282,7 +281,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     nori (2.6.0)
     parallel (1.19.1)
-    parser (2.7.0.4)
+    parser (2.7.0.5)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.3)
@@ -305,7 +304,7 @@ GEM
     public_suffix (4.0.3)
     rack (2.2.2)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.3)
     rb-readline (0.5.5)
     regexp_parser (1.7.0)
     rexml (3.2.4)
@@ -328,14 +327,14 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-prof (1.2.0)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
@@ -363,10 +362,9 @@ GEM
     thor (1.0.1)
     tins (1.24.1)
       sync
-    tomlrb (1.2.9)
-    train-core (3.2.23)
+    tomlrb (1.3.0)
+    train-core (3.2.26)
       addressable (~> 2.5)
-      inifile (~> 3.0)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
@@ -397,8 +395,10 @@ GEM
       tty-screen (~> 0.7)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
-    unicode-display_width (1.6.1)
+    unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
+    unf_ext (0.0.7.7-x86-mingw32)
+    unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
     uri_template (0.7.0)
     uuidtools (2.1.5)
@@ -472,7 +472,7 @@ DEPENDENCIES
   pry-byebug
   pry-remote
   pry-stack_explorer
-  rake (<= 12.3.2)
+  rake (<= 12.3.3)
   rb-readline
   rspec-core (~> 3.5)
   rspec-expectations (~> 3.5)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: c086d8057ac9a15486fe2010009db0dee1cea682
+  revision: 18564cc92b5f7b6d3ada694a41adf3bf948918fb
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.281.0)
-    aws-sdk-core (3.91.0)
+    aws-partitions (1.293.0)
+    aws-sdk-core (3.92.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -164,7 +164,7 @@ GEM
     equatable (0.6.1)
     erubi (1.9.0)
     erubis (2.7.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     ffi (1.12.2-x64-mingw32)
@@ -183,7 +183,6 @@ GEM
     hashie (4.1.0)
     highline (1.7.10)
     httpclient (2.8.3)
-    inifile (3.0.0)
     iniparse (1.5.0)
     iostruct (0.0.4)
     ipaddress (0.8.3)
@@ -240,10 +239,10 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     nori (2.6.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.7.4)
+    ohai (15.8.0)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -306,10 +305,9 @@ GEM
     thor (0.20.3)
     toml-rb (2.0.1)
       citrus (~> 3.0, > 3.0)
-    tomlrb (1.2.9)
-    train-core (3.2.23)
+    tomlrb (1.3.0)
+    train-core (3.2.26)
       addressable (~> 2.5)
-      inifile (~> 3.0)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which results in performance issues / CLI warnings. Make sure these versions match before bumping either.
 override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
-override "libarchive", version: "3.4.0"
+override "libarchive", version: "3.4.2"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.4"
@@ -18,7 +18,7 @@ override "ncurses", version: "5.9"
 override "nokogiri", version: "1.10.5"
 override "openssl", version: "1.0.2u"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.6.5"
+override "ruby", version: "2.6.6"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"


### PR DESCRIPTION
Ruby resolves 2 CVEs: https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/
Rake is bundled in Ruby
libarchive updated to 3.4.2 for multiple security issues including CVE-2019-19221 and  CVE-2020-9308

Signed-off-by: Tim Smith <tsmith@chef.io>