### PR TITLE
Pin chef-zero < 15

### DIFF
--- a/chef.gemspec
+++ b/chef.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubis", "~> 2.7"
   s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
 
-  s.add_dependency "chef-zero", ">= 13.0"
+  s.add_dependency "chef-zero", ">= 13.0", "< 15.0"
 
   s.add_dependency "plist", "~> 3.2"
   s.add_dependency "iniparse", "~> 1.4"


### PR DESCRIPTION
chef-zero 15.0 bumped the required Ruby from 2.4 to 2.6

Chef 14 only requires/uses 2.4.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>