### PR TITLE
fix chef_vault_secret after_resource breakage

### DIFF
--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -79,6 +79,8 @@ class Chef
           clients item.get_clients
           admins item.get_admins
           search item.search
+        rescue ChefVault::Exceptions::SecretDecryption
+          current_value_does_not_exist!
         rescue ChefVault::Exceptions::KeysNotFound
           current_value_does_not_exist!
         rescue Net::HTTPClientException => e


### PR DESCRIPTION
fixes the idempotent behavior of chef_vault_secret to also not
error out, even if it isn't actually idempotent.
