### PR TITLE
Add a Windows 10 tester to the pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -55,3 +55,4 @@ builder-to-testers-map:
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
+    - windows-10-x86_64

--- a/spec/functional/win32/version_info_spec.rb
+++ b/spec/functional/win32/version_info_spec.rb
@@ -32,12 +32,12 @@ describe "Chef::ReservedNames::Win32::File::VersionInfo", :windows_only do
 
   subject { Chef::ReservedNames::Win32::File::VersionInfo.new(file_path) }
 
-  it "file version has the same version as windows" do
-    expect(subject.FileVersion).to start_with(os_version)
+  it "file version has the same major.minor version as windows" do
+    expect(subject.FileVersion).to start_with(os_version.rpartition(".").first)
   end
 
-  it "product version has the same version as windows" do
-    expect(subject.ProductVersion).to start_with(os_version)
+  it "product version has the same major.minor version as windows" do
+    expect(subject.ProductVersion).to start_with(os_version.rpartition(".").first)
   end
 
   it "company is microsoft" do


### PR DESCRIPTION
Add a dedicated tester for Windows 10 instead of relying on WIndows 2019