### PR TITLE
Change the name_property to be the identity property by default, and to have desired_state: false by default

### DIFF
--- a/lib/chef/mixin/properties.rb
+++ b/lib/chef/mixin/properties.rb
@@ -264,8 +264,20 @@ class Chef
           end
 
           result = properties.values.select(&:identity?)
-          result = [ properties[:name] ] if result.empty?
+          # if there are no other identity properites set, then the name_property becomes the identity, or
+          # failing that we use the actual name.
+          if result.empty?
+            result = name_property ? [ properties[name_property] ] : [ properties[:name] ]
+          end
           result
+        end
+
+        # Returns the name of the name property.  Returns nil if there is no name property.
+        #
+        # @return [Symbol] the name property for this resource
+        def name_property
+          p = properties.find { |n, p| p.name_property? }
+          p ? p.first : nil
         end
 
         def included(other)

--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -1,7 +1,7 @@
 #
 # Author:: John Keiser <jkeiser@chef.io>
 # Copyright:: Copyright 2015-2016, John Keiser
-# Copyright:: Copyright 2015-2020, Chef Software, Inc.
+# Copyright:: Copyright 2015-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,6 +139,10 @@ class Chef
 
       if options.key?(:default) && options.key?(:name_property)
         raise ArgumentError, "A property cannot be both a name_property/name_attribute and have a default value. Use one or the other on property #{self}"
+      end
+
+      if options[:name_property]
+        options[:desired_state] = false unless options.key?(:desired_state)
       end
 
       # Recursively freeze the default if it isn't a lazy value.

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -497,22 +497,11 @@ class Chef
     def state_for_resource_reporter
       state = {}
       state_properties = self.class.state_properties
-#      p = state_properties.find { |p| p.name_property? }
-#      if p
-#        pp p
-#        raise "boom"
-#      end
-
       state_properties.each do |property|
         if property.is_set?(self)
           state[property.name] = property.sensitive? ? "*sensitive value suppressed*" : send(property.name)
         end
       end
-#      identity_properties = self.class.identity_properties
-#      pp identity_properties
-#      identity_properties.each do |property|
-#        state[property.name] = property.sensitive? ? "*sensitive value suppressed*" : send(property.name)
-#      end
       state
     end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -497,11 +497,22 @@ class Chef
     def state_for_resource_reporter
       state = {}
       state_properties = self.class.state_properties
+#      p = state_properties.find { |p| p.name_property? }
+#      if p
+#        pp p
+#        raise "boom"
+#      end
+
       state_properties.each do |property|
-        if property.identity? || property.is_set?(self)
+        if property.is_set?(self)
           state[property.name] = property.sensitive? ? "*sensitive value suppressed*" : send(property.name)
         end
       end
+#      identity_properties = self.class.identity_properties
+#      pp identity_properties
+#      identity_properties.each do |property|
+#        state[property.name] = property.sensitive? ? "*sensitive value suppressed*" : send(property.name)
+#      end
       state
     end
 

--- a/lib/chef/resource/directory.rb
+++ b/lib/chef/resource/directory.rb
@@ -42,7 +42,7 @@ class Chef
       default_action :create
       allowed_actions :create, :delete
 
-      property :path, String, name_property: true, identity: true,
+      property :path, String, name_property: true,
                description: "The path to the directory. Using a fully qualified path is recommended, but is not always required."
 
       property :recursive, [ TrueClass, FalseClass ],

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -49,7 +49,7 @@ class Chef
       end
 
       property :command, [ String, Array ],
-        name_property: true, identity: true,
+        name_property: true,
         description: "An optional property to set the command to be executed if it differs from the resource block's name."
 
       property :umask, [ String, Integer ],

--- a/lib/chef/resource/file.rb
+++ b/lib/chef/resource/file.rb
@@ -55,7 +55,7 @@ class Chef
       default_action :create
       allowed_actions :create, :delete, :touch, :create_if_missing
 
-      property :path, String, name_property: true, identity: true,
+      property :path, String, name_property: true,
                description: "The full path to the file, including the file name and its extension. For example: /files/file.txt. Default value: the name of the resource block. Microsoft Windows: A path that begins with a forward slash (/) will point to the root of the current working directory of the #{Chef::Dist::CLIENT} process. This path can vary from system to system. Therefore, using a path that begins with a forward slash (/) is not recommended."
 
       property :atomic_update, [ TrueClass, FalseClass ], desired_state: false, default: lazy { docker? && special_docker_files?(path) ? false : Chef::Config[:file_atomic_update] },

--- a/lib/chef/resource/group.rb
+++ b/lib/chef/resource/group.rb
@@ -31,7 +31,7 @@ class Chef
       default_action :create
 
       property :group_name, String,
-        name_property: true, identity: true,
+        name_property: true,
         description: "The name of the group."
 
       property :gid, [ String, Integer ],

--- a/lib/chef/resource/kernel_module.rb
+++ b/lib/chef/resource/kernel_module.rb
@@ -66,7 +66,7 @@ class Chef
 
       property :modname, String,
         description: "An optional property to set the kernel module name if it differs from the resource block's name.",
-        name_property: true, identity: true
+        name_property: true
 
       property :options, Array,
         description: "An optional property to set options for the kernel module.",

--- a/lib/chef/resource/launchd.rb
+++ b/lib/chef/resource/launchd.rb
@@ -31,7 +31,7 @@ class Chef
       allowed_actions :create, :create_if_missing, :delete, :enable, :disable, :restart
 
       property :label, String,
-        identity: true, name_property: true,
+        name_property: true,
         description: "The unique identifier for the job."
 
       property :backup, [Integer, FalseClass],

--- a/lib/chef/resource/link.rb
+++ b/lib/chef/resource/link.rb
@@ -45,7 +45,7 @@ class Chef
 
       property :target_file, String,
         description: "An optional property to set the target file if it differs from the resource block's name.",
-        name_property: true, identity: true
+        name_property: true
 
       property :to, String,
         description: "The actual file to which the link is to be created."

--- a/lib/chef/resource/mdadm.rb
+++ b/lib/chef/resource/mdadm.rb
@@ -59,7 +59,7 @@ class Chef
         description: "The path to a file in which a write-intent bitmap is stored."
 
       property :raid_device, String,
-        identity: true, name_property: true,
+        name_property: true,
         description: "An optional property to specify the name of the RAID device if it differs from the resource block's name."
 
       property :layout, String,

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -40,7 +40,7 @@ class Chef
         description: "Windows only:. Use to specify the password for username.",
         sensitive: true
 
-      property :mount_point, String, name_property: true, identity: false,
+      property :mount_point, String, name_property: true,
                description: "The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided."
 
       property :device, String, identity: true,

--- a/lib/chef/resource/mount.rb
+++ b/lib/chef/resource/mount.rb
@@ -40,7 +40,7 @@ class Chef
         description: "Windows only:. Use to specify the password for username.",
         sensitive: true
 
-      property :mount_point, String, name_property: true,
+      property :mount_point, String, name_property: true, identity: false,
                description: "The directory (or path) in which the device is to be mounted. Defaults to the name of the resource block if not provided."
 
       property :device, String, identity: true,

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -34,7 +34,7 @@ class Chef
 
       property :profile_name, String,
         description: "Use to specify the name of the profile, if different from the name of the resource block.",
-        name_property: true, identity: true
+        name_property: true
 
       property :profile, [ String, Hash ],
         description: "Use to specify a profile. This may be the name of a profile contained in a cookbook or a Hash that contains the contents of the profile."

--- a/lib/chef/resource/registry_key.rb
+++ b/lib/chef/resource/registry_key.rb
@@ -70,7 +70,7 @@ class Chef
         @values, @unscrubbed_values = [], []
       end
 
-      property :key, String, name_property: true, identity: true
+      property :key, String, name_property: true
 
       def values(arg = nil)
         if not arg.nil?

--- a/lib/chef/resource/route.rb
+++ b/lib/chef/resource/route.rb
@@ -33,7 +33,7 @@ class Chef
 
       property :target, String,
         description: "The IP address of the target route.",
-        identity: true, name_property: true
+        name_property: true
 
       property :comment, [String, nil],
         description: "Add a comment for the route.",

--- a/lib/chef/resource/ruby_block.rb
+++ b/lib/chef/resource/ruby_block.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: AJ Christensen (<aj@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,7 @@ class Chef
         end
       end
 
-      property :block_name, String, name_property: true, identity: true
+      property :block_name, String, name_property: true
     end
   end
 end

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ class Chef
 
       property :destination, String,
         description: "The location path to which the source is to be cloned, checked out, or exported. Default value: the name of the resource block.",
-        name_property: true, identity: true
+        name_property: true
 
       property :repository, String
 

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -31,8 +31,6 @@ class Chef
 
       provides :service, target_mode: true
 
-      identity_attr :service_name
-
       description "Use the service resource to manage a service."
 
       default_action :nothing
@@ -46,7 +44,7 @@ class Chef
 
       property :service_name, String,
         description: "An optional property to set the service name if it differs from the resource block's name.",
-        name_property: true, identity: true
+        name_property: true
 
       # regex for match against ps -ef when !supports[:has_status] && status == nil
       property :pattern, String,

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -63,7 +63,7 @@ class Chef
         description: "Specifies if the unit will be verified before installation. Systemd can be overly strict when verifying units, so in certain cases it is preferable not to verify the unit."
 
       property :unit_name, String, desired_state: false,
-               identity: true, name_property: true,
+               name_property: true,
                description: "The name of the unit file if it differs from the resource block's name.",
                introduced: "13.7"
 

--- a/lib/chef/resource/user.rb
+++ b/lib/chef/resource/user.rb
@@ -30,7 +30,7 @@ class Chef
 
       property :username, String,
         description: "An optional property to set the username value if it differs from the resource block's name.",
-        name_property: true, identity: true
+        name_property: true
 
       property :comment, String,
         description: "The contents of the user comments field."

--- a/lib/chef/resource/windows_env.rb
+++ b/lib/chef/resource/windows_env.rb
@@ -32,7 +32,7 @@ class Chef
 
       property :key_name, String,
         description: "An optional property to set the name of the key that is to be created, deleted, or modified if it differs from the resource block's name.",
-        identity: true, name_property: true
+        name_property: true
 
       property :value, String,
         description: "The value of the environmental variable to set.",

--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -3,7 +3,7 @@
 # Author:: Prajakta Purohit (prajakta@chef.io>)
 # Auther:: Tyler Cloke (<tyler@opscode.com>)
 #
-# Copyright:: Copyright 2012-2019, Chef Software Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/property/state_spec.rb
+++ b/spec/unit/property/state_spec.rb
@@ -285,8 +285,8 @@ describe "Chef::Resource#identity and #state" do
       it "identity when x is not defined returns the value of x" do
         expect(resource.identity).to eq "blah"
       end
-      it "state when x is not defined returns the value of x" do
-        expect(resource.state_for_resource_reporter).to eq(x: "blah")
+      it "the name property is not included in the desired state" do
+        expect(resource.state_for_resource_reporter).to eq({})
       end
     end
   end
@@ -332,12 +332,17 @@ describe "Chef::Resource#identity and #state" do
     end
 
     with_property ":x, name_property: true" do
-      # it "Unset values with name_property are included in state" do
-      #   expect(resource.state_for_resource_reporter).to eq({ x: 'blah' })
-      # end
-      it "Set values with name_property are included in state" do
+      it "Is by default the identity property if no other identity property is included" do
+        expect(resource.identity).to eq("blah")
+      end
+
+      it "Unset values with name_property are not included in state" do
+        expect(resource.state_for_resource_reporter).to eq({})
+      end
+
+      it "Set values with name_property are not included in state" do
         resource.x 1
-        expect(resource.state_for_resource_reporter).to eq(x: 1)
+        expect(resource.state_for_resource_reporter).to eq({})
       end
     end
 

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -1022,6 +1022,9 @@ describe "Chef::Resource.property" do
         it "defaults x to resource.name" do
           expect(resource.x).to eq "blah"
         end
+        it "defaults to being part of the identity if there is no other identity" do
+          expect(resource.identity).to eq "blah"
+        end
         it "does not pick up resource.name if set" do
           expect(resource.x 10).to eq 10
           expect(resource.x).to eq 10

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -3,7 +3,7 @@
 # Author:: Prajakta Purohit (<prajakta@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
 #
-# Copyright:: Copyright 2012-2019, Chef Software Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -294,7 +294,7 @@ describe Chef::ResourceReporter do
       resource_reporter.run_started(run_status)
     end
 
-    context "when the new_resource is sensitive" do
+    context "when the new_resource is a sensitive execute resource" do
       before do
         @execute_resource = Chef::Resource::Execute.new("sensitive-resource")
         @execute_resource.name("sensitive-resource")
@@ -311,10 +311,6 @@ describe Chef::ResourceReporter do
 
       it "resource_name in prepared_run_data should be the same" do
         expect(@first_update_report["name"]).to eq("sensitive-resource")
-      end
-
-      it "resource_command in prepared_run_data should be blank" do
-        expect(@first_update_report["after"]).to eq({ command: "sensitive-resource" })
       end
     end
 


### PR DESCRIPTION
Setting `name_property: true` is now roughly equivalent to `name_property: true, identity: true, desired_state: false`.

If there is any other property which is marked as an identity though the name_property will no longer be considered an identity property.  A subtle detail of this is that the name_property itself is not marked as being `identity: true`, it is implemented via the `chef/mixin/properties.rb` mixin because the identity-ness of the name_property will be affected by other properties being marked as identity or not.  That means you have to inspect the whole property collection -- hence implemented in the properties mixin.  Consumers should check the identity_properties array on the resource class, and not inspect individual properties for being an identity themselves.

It makes no sense to have the name_property be set to being desired_state either since the name should not change before or after the resource converges.

closes #4282
