### PR TITLE
Remove S390x EL6 tester

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -16,8 +16,6 @@ builder-to-testers-map:
     - debian-10-x86_64
   el-6-i686:
     - el-6-i686
-  el-6-s390x:
-    - el-6-s390x
   el-6-x86_64:
     - el-6-x86_64
   el-7-aarch64:


### PR DESCRIPTION
We no longer support EL6 on S390x

Signed-off-by: Tim Smith <tsmith@chef.io>