### PR TITLE
Swap Ubuntu 20.04 for 18.04 aarch64

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -45,10 +45,11 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
+  ubuntu-18.04-aarch64:
+    - ubuntu-18.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
-    - ubuntu-20.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,9 +36,9 @@ Resolved failures in the `windows_share` resource when setting the `path` proper
 
 ## Platform Support
 
-### Ubuntu 20.04
+### Ubuntu 18.04 aarch64
 
-Chef Infra Client is now tested on Ubuntu 20.04 with packages available on the [Chef Downloads Page](https://downloads.chef.io/chef).
+Chef Infra Client is now tested on Ubuntu 18.04 aarch64 with packages available on the [Chef Downloads Page](https://downloads.chef.io/chef).
 
 ### Windows 10
 


### PR DESCRIPTION
20.04 has testing issues right now.

Signed-off-by: Tim Smith <tsmith@chef.io>