### PR TITLE
Implement eager_load_libraries metadata option

### DIFF
--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -229,7 +229,7 @@ class Chef
         raise
       end
 
-      def load_libraries_from_cookbook(cookbook_name, globs = "*/*.rb")
+      def load_libraries_from_cookbook(cookbook_name, globs = "**/*.rb")
         each_file_in_cookbook_by_segment(cookbook_name, :libraries, globs) do |filename|
           begin
             logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Daniel DeLeo (<dan@chef.io>)
-# Copyright:: Copyright 2012-2019, Chef Software Inc.
+# Copyright:: Copyright 2012-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,7 +100,15 @@ class Chef
       def compile_libraries
         @events.library_load_start(count_files_by_segment(:libraries))
         cookbook_order.each do |cookbook|
-          load_libraries_from_cookbook(cookbook)
+          eager_load_libraries = cookbook_collection[cookbook].metadata.eager_load_libraries
+          if eager_load_libraries == true # actully true, not truthy
+            load_libraries_from_cookbook(cookbook, "**/*.rb")
+          else
+            $LOAD_PATH.unshift File.expand_path("libraries", cookbook_collection[cookbook].root_dir)
+            if eager_load_libraries # we have a String or Array<String> and not false
+              load_libraries_from_cookbook(cookbook, eager_load_libraries)
+            end
+          end
         end
         @events.library_load_complete
       end
@@ -221,10 +229,8 @@ class Chef
         raise
       end
 
-      def load_libraries_from_cookbook(cookbook_name)
-        files_in_cookbook_by_segment(cookbook_name, :libraries).each do |filename|
-          next unless File.extname(filename) == ".rb"
-
+      def load_libraries_from_cookbook(cookbook_name, globs)
+        each_file_in_cookbook_by_segment(cookbook_name, :libraries, globs) do |filename|
           begin
             logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")
             Kernel.require(filename)
@@ -325,6 +331,22 @@ class Chef
       # (attribute, recipe, etc.), sorted lexically.
       def files_in_cookbook_by_segment(cookbook, segment)
         cookbook_collection[cookbook].files_for(segment).map { |record| record[:full_path] }.sort
+      end
+
+      # Iterates through all files in given cookbook segment, yielding the full path to the file
+      # if it matches one of the given globs.  Returns matching files in lexical sort order.  Supports
+      # extended globbing.  The segment should not be included in the glob.
+      #
+      def each_file_in_cookbook_by_segment(cookbook, segment, globs)
+        cookbook_collection[cookbook].files_for(segment).sort_by { |record| record[:path] }.each do |record|
+          Array(globs).each do |glob|
+            target = record[:path].delete_prefix("#{segment}/")
+            if File.fnmatch(glob, target, File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH)
+              yield record[:full_path]
+              break
+            end
+          end
+        end
       end
 
       # Yields the name, as a symbol, of each cookbook depended on by

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -102,7 +102,7 @@ class Chef
         cookbook_order.each do |cookbook|
           eager_load_libraries = cookbook_collection[cookbook].metadata.eager_load_libraries
           if eager_load_libraries == true # actully true, not truthy
-            load_libraries_from_cookbook(cookbook, "**/*.rb")
+            load_libraries_from_cookbook(cookbook)
           else
             $LOAD_PATH.unshift File.expand_path("libraries", cookbook_collection[cookbook].root_dir)
             if eager_load_libraries # we have a String or Array<String> and not false
@@ -229,7 +229,7 @@ class Chef
         raise
       end
 
-      def load_libraries_from_cookbook(cookbook_name, globs)
+      def load_libraries_from_cookbook(cookbook_name, globs = "*/*.rb")
         each_file_in_cookbook_by_segment(cookbook_name, :libraries, globs) do |filename|
           begin
             logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")

--- a/spec/integration/knife/cookbook_show_spec.rb
+++ b/spec/integration/knife/cookbook_show_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2013-2016, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,25 +43,26 @@ describe "knife cookbook show", :workstation do
         metadata:
           chef_versions:
           dependencies:
-          description:      
+          description:
+          eager_load_libraries: true
           gems:
-          issues_url:       
-          license:          All rights reserved
-          long_description: 
-          maintainer:       
-          maintainer_email: 
-          name:             x
+          issues_url:
+          license:              All rights reserved
+          long_description:
+          maintainer:
+          maintainer_email:
+          name:                 x
           ohai_versions:
           platforms:
-          privacy:          false
+          privacy:              false
           providing:
             x:    >= 0.0.0
             x::x: >= 0.0.0
           recipes:
-            x:    
-            x::x: 
-          source_url:       
-          version:          1.0.0
+            x:
+            x::x:
+          source_url:
+          version:              1.0.0
         name:          x-1.0.0
         recipes:
           checksum:    4631b34cf58de10c5ef1304889941b2e
@@ -69,7 +70,7 @@ describe "knife cookbook show", :workstation do
           path:        recipes/default.rb
           specificity: default
           url:         http://127.0.0.1:8900/file_store/checksums/4631b34cf58de10c5ef1304889941b2e
-          
+
           checksum:    d41d8cd98f00b204e9800998ecf8427e
           name:        recipes/x.rb
           path:        recipes/x.rb
@@ -89,25 +90,26 @@ describe "knife cookbook show", :workstation do
       knife("cookbook show x 1.0.0 metadata").should_succeed <<~EOM
         chef_versions:
         dependencies:
-        description:      
+        description:
+        eager_load_libraries: true
         gems:
-        issues_url:       
-        license:          All rights reserved
-        long_description: 
-        maintainer:       
-        maintainer_email: 
-        name:             x
+        issues_url:
+        license:              All rights reserved
+        long_description:
+        maintainer:
+        maintainer_email:
+        name:                 x
         ohai_versions:
         platforms:
-        privacy:          false
+        privacy:              false
         providing:
           x:    >= 0.0.0
           x::x: >= 0.0.0
         recipes:
-          x:    
-          x::x: 
-        source_url:       
-        version:          1.0.0
+          x:
+          x::x:
+        source_url:
+        version:              1.0.0
       EOM
     end
 
@@ -118,7 +120,7 @@ describe "knife cookbook show", :workstation do
         path:        recipes/default.rb
         specificity: default
         url:         http://127.0.0.1:8900/file_store/checksums/4631b34cf58de10c5ef1304889941b2e
-        
+
         checksum:    d41d8cd98f00b204e9800998ecf8427e
         name:        recipes/x.rb
         path:        recipes/x.rb

--- a/spec/support/shared/integration/knife_support.rb
+++ b/spec/support/shared/integration/knife_support.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@chef.io>)
-# Copyright:: Copyright 2013-2017, Chef Software Inc.
+# Copyright:: Copyright 2013-2020, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -170,20 +170,23 @@ module KnifeSupport
 
     def should_result_in(expected)
       expected[:stdout] = "" unless expected[:stdout]
+      expected[:stdout] = expected[:stdout].is_a?(String) ? expected[:stdout].gsub(/[ \t\f\v]+$/, "") : expected[:stdout]
       expected[:stderr] = "" unless expected[:stderr]
+      expected[:stderr] = expected[:stderr].is_a?(String) ? expected[:stderr].gsub(/[ \t\f\v]+$/, "") : expected[:stderr]
       expected[:exit_code] = 0 unless expected[:exit_code]
       # TODO make this go away
       stderr_actual = @stderr.sub(/^WARNING: No knife configuration file found\n/, "")
-
+      stderr_actual = stderr_actual.gsub(/[ \t\f\v]+$/, "")
+      stdout_actual = @stdout
+      stdout_actual = stdout_actual.gsub(/[ \t\f\v]+$/, "")
+      if ChefUtils.windows?
+        stderr_actual = stderr_actual.gsub("\r\n", "\n")
+        stdout_actual = stdout_actual.gsub("\r\n", "\n")
+      end
       if expected[:stderr].is_a?(Regexp)
         expect(stderr_actual).to match(expected[:stderr])
       else
         expect(stderr_actual).to eq(expected[:stderr])
-      end
-      stdout_actual = @stdout
-      if ChefUtils.windows?
-        stderr_actual = stderr_actual.gsub("\r\n", "\n")
-        stdout_actual = stdout_actual.gsub("\r\n", "\n")
       end
       expect(@exit_code).to eq(expected[:exit_code])
       if expected[:stdout].is_a?(Regexp)

--- a/spec/unit/knife/cookbook_show_spec.rb
+++ b/spec/unit/knife/cookbook_show_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
-# Copyright:: Copyright 2008-2017, Chef Software Inc.
+# Copyright:: Copyright 2008-2020, Chef Software Inc.
 # License:: Apache License, version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,6 +109,7 @@ describe Chef::Knife::CookbookShow do
           "metadata" => {
             "name" => nil,
             "description" => "",
+            "eager_load_libraries" => true,
             "long_description" => "",
             "maintainer" => "",
             "maintainer_email" => "",


### PR DESCRIPTION
This implements RFC-40 from the old chef rfc repo:

https://github.com/chef-boneyard/chef-rfc/blob/master/rfc040-on-demand-cookbook-libraries.md

Closes #3494

As far as I can see we have recursively loaded libraries for some time, this offers some better options to not load any library files but to push them into the LOAD_PATH or to push them into the LOAD_PATH and load a single "bootstrapping" hook.

This should also help with vendoring gems, although vendoring multiple gems with this mechanism isn't super straight forwards and we might want to have a top level first class "gems" segment for a cookbook that ships a pile of gems, along with their gemspecs in order to handle getting the gems activated correctly.