### PR TITLE
Pin omnibus-software before the change that breaks Ruby < 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "chef-config", path: File.expand_path("../chef-config", __FILE__) if File.ex
 gem "cheffish", "~> 14"
 
 group(:omnibus_package) do
-  gem "appbundler"
+  gem "appbundler", "< 1.0"
   gem "rb-readline"
   gem "inspec-core", "~> 3"
   gem "chef-vault"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     parallel (1.19.1)
-    parser (2.7.0.5)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.3)
@@ -354,7 +354,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  appbundler
+  appbundler (< 1.0)
   chef!
   chef-config!
   chef-vault

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "master"
+
+# omnibus-software 52823134ba902daac1f18b1a75de0386558cc0a5 and later requires Ruby 2.6 with built in bundler
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "91c3649a7dc1196fec7d872b731705dcf80b7c23"
 gem "artifactory"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     ed25519 (1.2.4)
@@ -313,7 +313,7 @@ GEM
     solve (4.0.3)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
-    specinfra (2.82.12)
+    specinfra (2.82.13)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,8 +18,8 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 1b490aa4e6a5b224d98d07d72cdf90cb2f132576
-  branch: master
+  revision: 91c3649a7dc1196fec7d872b731705dcf80b7c23
+  branch: 91c3649a7dc1196fec7d872b731705dcf80b7c23
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.293.0)
+    aws-partitions (1.294.0)
     aws-sdk-core (3.92.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.30.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.61.1)
+    aws-sdk-s3 (1.61.2)
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -165,9 +165,9 @@ GEM
     erubis (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
-    ffi (1.12.1-x64-mingw32)
-    ffi (1.12.1-x86-mingw32)
+    ffi (1.12.2)
+    ffi (1.12.2-x64-mingw32)
+    ffi (1.12.2-x86-mingw32)
     ffi-win32-extensions (1.0.3)
       ffi
     ffi-yajl (2.3.3)


### PR DESCRIPTION
https://github.com/chef/omnibus-software/pull/1175 removed bundler from
a number of software definitions because Ruby 2.6+ includes bundler. But
Chef 14 still uses Ruby 2.5 so we need the bundler dependencies to get
bundle in the build.
