### PR TITLE
Fix macos signing key

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -84,7 +84,7 @@ end
 proj_to_work_around_cleanroom = self
 package :pkg do
   identifier "com.getchef.pkg.#{proj_to_work_around_cleanroom.name}"
-  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
+  signing_identity "Chef Software, Inc. (EU3VF8YLX2)"
 end
 compress :dmg
 


### PR DESCRIPTION
Per 120c01a414db79a7111b3c89eba5999031718f96
