### PR TITLE
Dist windows bootstrap template - fix msi_url

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -467,7 +467,7 @@ class Chef
       # @return [String] Default bootstrap template
       def default_bootstrap_template
         if connection.windows?
-          "windows-#{Chef::Dist::CLIENT}-msi"
+          "windows-chef-client-msi"
         else
           "chef-full"
         end

--- a/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
@@ -109,13 +109,13 @@ goto Version10.0
 goto chef_installed
 
 :chef_installed
-@echo Checking for existing chef installation
+@echo Checking for existing <%= Chef::Dist::PRODUCT %> installation
 WHERE <%= Chef::Dist::CLIENT %> >nul 2>nul
 If !ERRORLEVEL!==0 (
-  @echo Existing Chef installation detected, skipping download
+  @echo Existing <%= Chef::Dist::PRODUCT %> installation detected, skipping download
   goto key_create
 ) else (
-  @echo No existing installation of chef detected
+  @echo No existing installation of <%= Chef::Dist::PRODUCT %> detected
   goto install
 )
 
@@ -272,5 +272,5 @@ echo Validation key written.
   <%= client_d %>
 <% end -%>
 
-@echo Starting chef to bootstrap the node...
+@echo Starting <%= Chef::Dist::CLIENT %> to bootstrap the node...
 <%= start_chef %>

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -159,7 +159,7 @@ class Chef
         def start_chef
           bootstrap_environment_option = bootstrap_environment.nil? ? "" : " -E #{bootstrap_environment}"
           start_chef = "SET \"PATH=%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\;C:\\ruby\\bin;#{ChefConfig::Config.c_opscode_dir}\\#{ChefConfig::Dist::DIR_SUFFIX}\\bin;#{ChefConfig::Config.c_opscode_dir}\\#{ChefConfig::Dist::DIR_SUFFIX}\\embedded\\bin\;%PATH%\"\n"
-          start_chef << "chef-client -c #{ChefConfig::Config.etc_chef_dir(true)}/client.rb -j #{ChefConfig::Config.etc_chef_dir(true)}/first-boot.json#{bootstrap_environment_option}\n"
+          start_chef << "#{Chef::Dist::CLIENT} -c #{ChefConfig::Config.etc_chef_dir(true)}/client.rb -j #{ChefConfig::Config.etc_chef_dir(true)}/first-boot.json#{bootstrap_environment_option}\n"
         end
 
         def win_wget


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This will provide at least one way for third party distro to bootstrap windows node to their own product. Currently, you either end up with a Chef Infra MSI or an error on account of bad references to `chef-client`. This PR converts it to a distro constants. A few more cosmetic applications of the distro constants have been addressed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
