### PR TITLE
Match platforms to chef-15

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -45,14 +45,17 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
+  ubuntu-18.04-aarch64:
+    - ubuntu-18.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+    - ubuntu-20.04-x86_64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:
-    - windows-2008r2-x86_64
     - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
+    - windows-10-x86_64


### PR DESCRIPTION
Drops 2008r2 (which we no longer have builders for)
Pulls in Windows 10, Ubuntu 20.04 x86_64, and Ubuntu 18.04 aarch64. Which are
very recently new.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>