### PR TITLE
 Improved Ruby download/install for functional tests

### DIFF
--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -1,3 +1,57 @@
+# The filename of the Ruby installer
+$RubyFilename = "rubyinstaller-devkit-2.6.5-1-x64.exe"
+
+# The sha256 of the Ruby installer (capitalized?)
+$RubySHA256 = "BD2050496A149C7258ED4E2E44103756CA3A05C7328A939F0FDC97AE9616A96D"
+
+# Where on disk to download Ruby to
+$RubyPath = "$env:temp\$RubyFilename"
+
+# Where to download Ruby from:
+$RubyS3Path = "s3://public-cd-buildkite-cache/$RubyFilename"
+
+Function DownloadRuby
+{
+  echo "Downloading Ruby + DevKit"
+  aws s3 cp $RubyS3Path $RubyPath | Out-Null # Out-Null is a hack to wait for the process to complete
+
+  if ($LASTEXITCODE -ne 0)
+  {
+    echo "aws s3 download failed: $LASTEXITCODE"
+    exit $LASTEXITCODE
+  }
+  $DownloadedHash = (Get-FileHash $RubyPath -Algorithm SHA256).Hash
+  echo "Downloaded SHA256: $DownloadedHash"
+}
+
+Function InstallRuby
+{
+  If (Test-Path $RubyPath) {
+    echo "$RubyPath already exists"
+
+    $ExistingRubyHash = (Get-FileHash $RubyPath -Algorithm SHA256).Hash
+
+    echo "Verifying file SHA256 hash $ExistingRubyHash to desired hash $RubySHA256"
+
+    If ($ExistingRubyHash -ne $RubySHA256) {
+      echo "SHA256 hash mismatch, attempting to remove and re-download"
+      Remove-Item $RubyPath -Force
+      DownloadRuby
+    } Else {
+      echo "Found matching Ruby + DevKit on disk"
+    }
+  } Else {
+    echo "No Ruby found at $RubyPath, downloading"
+    DownloadRuby
+  }
+
+  echo "Installing Ruby + DevKit"
+  Start-Process $RubyPath -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
+
+  echo "Cleaning up installation"
+  Remove-Item $RubyPath -Force -ErrorAction SilentlyContinue
+}
+
 echo "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
@@ -8,15 +62,7 @@ Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyC
 echo "--- install ruby + devkit"
 $ErrorActionPreference = 'Stop'
 
-echo "Downloading Ruby + DevKit"
-aws s3 cp s3://public-cd-buildkite-cache/rubyinstaller-devkit-2.6.5-1-x64.exe $env:temp/rubyinstaller-devkit-2.6.5-1-x64.exe
-
-echo "Installing Ruby + DevKit"
-Start-Process $env:temp\rubyinstaller-devkit-2.6.5-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
-
-echo "Cleaning up installation"
-Remove-Item $env:temp\rubyinstaller-devkit-2.6.5-1-x64.exe -Force -ErrorAction SilentlyContinue
-echo "Closing out the layer (this can take awhile)"
+InstallRuby
 
 # Set-Item -Path Env:Path -Value to include ruby26
 $Env:Path+=";C:\ruby26\bin"


### PR DESCRIPTION
Adds more error checking and avoids trying to download Ruby if for some reason it already exists on disk and matches the SHA256 hash.

The primary issue discovered when troubleshooting this script was that aws.exe was running asynchronous. That was 'fixed' with '| Out-Null'.
