### PR TITLE
Update to Ruby 2.5.8 + nokogiri 1.10.9

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -58,4 +58,3 @@ builder-to-testers-map:
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
-    - windows-10-x86_64

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "omnibus", git: "https://github.com/chef/omnibus", branch: "master"
 
 # omnibus-software 52823134ba902daac1f18b1a75de0386558cc0a5 and later requires Ruby 2.6 with built in bundler
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "91c3649a7dc1196fec7d872b731705dcf80b7c23"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software", branch: "legacy_ruby"
 gem "artifactory"
 
 gem "pedump"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,8 +18,8 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 91c3649a7dc1196fec7d872b731705dcf80b7c23
-  branch: 91c3649a7dc1196fec7d872b731705dcf80b7c23
+  revision: 013d8762f22dfe3050ca02f30221f92e4fc2ecbf
+  branch: legacy_ruby
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)
@@ -32,8 +32,8 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.294.0)
-    aws-sdk-core (3.92.0)
+    aws-partitions (1.295.0)
+    aws-sdk-core (3.93.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -208,7 +208,7 @@ GEM
     mixlib-archive (1.0.5-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
-    mixlib-cli (2.1.5)
+    mixlib-cli (2.1.6)
     mixlib-config (3.0.6)
       tomlrb
     mixlib-install (3.12.1)
@@ -274,7 +274,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (4.0.3)
+    public_suffix (4.0.4)
     rack (2.2.2)
     rainbow (3.0.0)
     retryable (3.0.5)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "2.7.9"
 override :bundler, version: "1.16.6"
-override "nokogiri", version: "1.10.5"
+override "nokogiri", version: "1.10.9"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.4"
@@ -17,13 +17,13 @@ override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "openssl", version: "1.0.2u"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.5.7"
+override "ruby", version: "2.5.8"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 
-# we build both a chef and ohai omnibus-software defintion which create the
+# We build both chef and ohai omnibus-software definitions which creates the
 # chef-client and ohai binstubs. Out of the box the ohai definition uses whatever
 # is in master, which won't match what's in the Gemfile.lock and used by the chef
 # definition. This pin will ensure that ohai and chef-client commands use the


### PR DESCRIPTION
Pull in from a new legacy_ruby branch in omnibus-software that is 52823134ba902daac1f18b1a75de0386558cc0a5 + the new CVE fixes to ruby.

The nokogiri bump brings us to the latest, which should be a no-op for how we use nokogiri, but matches our 15 release.

Signed-off-by: Tim Smith <tsmith@chef.io>