### PR TITLE
Fix functional tests on Windows 10 by matching less

### DIFF
--- a/spec/functional/win32/version_info_spec.rb
+++ b/spec/functional/win32/version_info_spec.rb
@@ -32,12 +32,12 @@ describe "Chef::ReservedNames::Win32::File::VersionInfo", :windows_only do
 
   subject { Chef::ReservedNames::Win32::File::VersionInfo.new(file_path) }
 
-  it "file version has the same version as windows" do
-    expect(subject.FileVersion).to start_with(os_version)
+  it "file version has the same major.minor version as windows" do
+    expect(subject.FileVersion).to start_with(os_version.rpartition(".").first)
   end
 
-  it "product version has the same version as windows" do
-    expect(subject.ProductVersion).to start_with(os_version)
+  it "product version has the same major.minor version as windows" do
+    expect(subject.ProductVersion).to start_with(os_version.rpartition(".").first)
   end
 
   it "company is microsoft" do


### PR DESCRIPTION
Backport from master. This hit me testing the functional tests on a cloud instance. I'm not sure why it didn't hit us on chef-14. We don't really need it on chef-14 if we leave windows-10 out. But we can kick off another build with this at least.
---
Windows 10 1909 is a service pack, but without being called a service pack.

1909 is a very small update over 1903, and in fact most of the binaries are not rebuilt.

The version for 1909 is 10.0.18363, but the version in many files is still 10.0.18362, which was the version for 1903.

This caused this functional test to fail on 1909 because 10.0.18362 != 10.0.18363. Nowhere else are we concerned with the file versions matching the OS version, so the fix is to match less of the version. By matching only '10.0', we should not see this again.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>