### PR TITLE
Fixed systemd_unit not respecting sensitive property

### DIFF
--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -237,6 +237,7 @@ class Chef
           f.owner "root"
           f.group "root"
           f.mode "0644"
+          f.sensitive new_resource.sensitive
           f.content new_resource.to_ini
           f.verify :systemd_unit if new_resource.verify
         end.run_action(action)

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -65,9 +65,6 @@ class Chef
                description: "The name of the unit file if it differs from the resource block's name.",
                introduced: "13.7"
 
-      property :sensitive, [ TrueClass, FalseClass ],
-        default: false, desired_state: false
-
       def to_ini
         case content
         when Hash

--- a/lib/chef/resource/systemd_unit.rb
+++ b/lib/chef/resource/systemd_unit.rb
@@ -65,6 +65,9 @@ class Chef
                description: "The name of the unit file if it differs from the resource block's name.",
                introduced: "13.7"
 
+      property :sensitive, [ TrueClass, FalseClass ],
+        default: false, desired_state: false
+
       def to_ini
         case content
         when Hash


### PR DESCRIPTION
Backport #9623, but change it to use the old format of this resource