### PR TITLE
Add resource partials

### DIFF
--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Adam Jacob (<adam@chef.io>)
 # Author:: Christopher Walters (<cw@chef.io>)
-# Copyright:: Copyright 2008-2016, 2009-2020, Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ class Chef
     def self.use(partial)
       dirname = ::File.dirname(partial)
       basename = ::File.basename(partial, ".rb")
-      basename = basename[1..-1] if basename[0] == "_"
+      basename = basename[1..-1] if basename.start_with?("_")
       class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
     end
 

--- a/lib/chef/provider.rb
+++ b/lib/chef/provider.rb
@@ -81,6 +81,20 @@ class Chef
       # Chef.deprecated(:use_inline_resources, "The use_inline_resources mode is no longer optional and the line enabling it can be removed")
     end
 
+    # Use a partial code fragment.  This can be used for code sharing between multiple resources.
+    #
+    # Do not wrap the code fragment in a class or module.  It also does not support the use of super
+    # to subclass any methods defined in the fragment, the methods will just be overwritten.
+    #
+    # @param partial [String] the code fragment to eval against the class
+    #
+    def self.use(partial)
+      dirname = ::File.dirname(partial)
+      basename = ::File.basename(partial, ".rb")
+      basename = basename[1..-1] if basename[0] == "_"
+      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
+    end
+
     # delegate to the resource
     #
     def_delegators :@new_resource, :property_is_set?

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1461,6 +1461,20 @@ class Chef
       @default_description
     end
 
+    # Use a partial code fragment.  This can be used for code sharing between multiple resources.
+    #
+    # Do not wrap the code fragment in a class or module.  It also does not support the use of super
+    # to subclass any methods defined in the fragment, the methods will just be overwritten.
+    #
+    # @param partial [String] the code fragment to eval against the class
+    #
+    def self.use(partial)
+      dirname = ::File.dirname(partial)
+      basename = ::File.basename(partial, ".rb")
+      basename = basename[1..-1] if basename[0] == "_"
+      class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
+    end
+
     # The cookbook in which this Resource was defined (if any).
     #
     # @return Chef::CookbookVersion The cookbook in which this Resource was defined.

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -1471,7 +1471,7 @@ class Chef
     def self.use(partial)
       dirname = ::File.dirname(partial)
       basename = ::File.basename(partial, ".rb")
-      basename = basename[1..-1] if basename[0] == "_"
+      basename = basename[1..-1] if basename.start_with?("_")
       class_eval IO.read(::File.expand_path("#{dirname}/_#{basename}.rb", ::File.dirname(caller_locations.first.absolute_path)))
     end
 

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -245,11 +245,13 @@ class Chef
       def load_lwrps_from_cookbook(cookbook_name)
         files_in_cookbook_by_segment(cookbook_name, :providers).each do |filename|
           next unless File.extname(filename) == ".rb"
+          next if File.basename(filename).match?(/^_/)
 
           load_lwrp_provider(cookbook_name, filename)
         end
         files_in_cookbook_by_segment(cookbook_name, :resources).each do |filename|
           next unless File.extname(filename) == ".rb"
+          next if File.basename(filename).match?(/^_/)
 
           load_lwrp_resource(cookbook_name, filename)
         end

--- a/spec/integration/recipes/notifies_spec.rb
+++ b/spec/integration/recipes/notifies_spec.rb
@@ -1,3 +1,19 @@
+#
+# Copyright:: Copyright Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "spec_helper"
 require "support/shared/integration/integration_helper"
 require "chef/mixin/shell_out"

--- a/spec/integration/recipes/use_partial_spec.rb
+++ b/spec/integration/recipes/use_partial_spec.rb
@@ -1,0 +1,112 @@
+#
+# Copyright:: Copyright Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+require "support/shared/integration/integration_helper"
+require "chef/mixin/shell_out"
+
+describe "notifying_block" do
+  include IntegrationSupport
+  include Chef::Mixin::ShellOut
+
+  let(:chef_dir) { File.expand_path("../../../../bin", __FILE__) }
+  let(:chef_client) { "bundle exec chef-client --minimal-ohai" }
+
+  when_the_repository "has a cookbook with partial resources" do
+    before do
+      directory "cookbooks/x" do
+        file "resources/_shared_properties.rb", <<-EOM
+          property :content, String
+        EOM
+        file "resources/_action_helpers.rb", <<-EOM
+          def printit(string)
+            puts "DIDIT: \#{string}"
+          end
+        EOM
+        file "resources/thing.rb", <<-EOM
+          provides :thing
+          use "shared_properties"
+          action_class do
+            use "action_helpers"
+          end
+          action :run do
+            printit(new_resource.content)
+          end
+        EOM
+        file "recipes/default.rb", <<~EOM
+          thing "whatever" do
+            content "stuff"
+          end
+        EOM
+      end
+      file "config/client.rb", <<-EOM
+        local_mode true
+        cookbook_path "#{path_to("cookbooks")}"
+        log_level :warn
+        always_dump_stacktrace true
+      EOM
+    end
+
+    it "should run cleanly and print the output" do
+      result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
+      expect(result.stdout).to match(/DIDIT: stuff/)
+      result.error!
+    end
+  end
+
+  when_the_repository "has a cookbook with partial resources done differently" do
+    before do
+      directory "cookbooks/x" do
+        file "partials/_shared_properties.rb", <<-EOM
+          property :content, String
+        EOM
+        file "partials/_action_partials.rb", <<-EOM
+          def printit(string)
+            puts "DIDIT: \#{string}"
+          end
+        EOM
+        # this tests relative pathing, including the underscore and including the trailing .rb all work
+        file "resources/thing.rb", <<-EOM
+          provides :thing
+          use "../partials/_shared_properties.rb"
+          action_class do
+            use "../partials/_action_partials.rb"
+          end
+          action :run do
+            printit(new_resource.content)
+          end
+        EOM
+        file "recipes/default.rb", <<~EOM
+          thing "whatever" do
+            content "stuff"
+          end
+        EOM
+      end
+      file "config/client.rb", <<-EOM
+        local_mode true
+        cookbook_path "#{path_to("cookbooks")}"
+        log_level :warn
+        always_dump_stacktrace true
+      EOM
+    end
+
+    it "should run cleanly and print the output" do
+      result = shell_out("#{chef_client} -c \"#{path_to("config/client.rb")}\" --no-color -F doc -o 'x::default'", cwd: chef_dir)
+      expect(result.stdout).to match(/DIDIT: stuff/)
+      result.error!
+    end
+  end
+end


### PR DESCRIPTION
Resource partials are code fragments that are class_eval'd into the Resource (or Provider/ActionClass) which is being built.

As such they don't look like normal helpers and lack any "module" or "class" statement or any name, and are not `include`'d or `extend`'d.

Their primary purpose is to address reducing code duplication of `property` declarations across resources (although they're not limited to that use case at all).

The `property` declarations cannot be deduplicated by using a module since properties rely on inheritance and a module cannot inherit from Chef::Resource (and mixing in properties into module which is then mixed into a resource does not work).  Therefore this solution does not use modules or inheritance, and is just a `class_eval` which is the simplest kind of deduplication via extracting what would have been typed -- there's no extra object being created.  This also implies, though, that there's no ability to do inheritance or subclassing or calling super in the Resource.

Since this is not a helper and is most closely related to a base class, it by default goes into the same directory as the resource.  Since it is not a resource there needs to be a mechanism to determine what is a partial and what is a resource, the convention is that if it begins with a `_` it is a partial, and the resource (or provider for old LWRPs) will skip loading it.  This ensures that it is *impossible* for a user to accidentally load a partial as a resource or vice-versa and ensures that we never see that particular helpdesk request.  The use of the `_` also instantly signals to the reader that the file does not contain a resource, class or module.

The API supports pathing and relative pathing though so that its possible to collect all partials in any arbitrary subdirectory.

There is no direct support for this feature in libraries directories.  While no cookbook use a resources file with a leading underscore, the leading underscore has been used in libraries directories to game the alpha sorting of the library load order.  It would be an actual known breaking change to community cookbooks to change that.  So, anyone that wants to use it in a libraries cookbook will need to manually wire things up with `eager_load_libraries` (or take the hint and convert to a custom resource because library resources are discouraged at this point to nearly being deprecated).

This is designed to be used in core chef libraries, since the loading of those files is manual there there's no need to skip loading the partials.  This avoids scattering "helper" subdirs around the codebase by including them in the same directory as the files.  This works well for e.g. the user resources which have been consolidated under their own directory.  The package resources should similarly be consolidated so that we can use this feature to create pseudo-base-classes.  In the mean time, because we throw all the resources in one big directory (which is wrong) we can avoid littering that up by manually creating a subdir to collect partials and referencing the files in there (but we should really stop dumping all the resources in the one big directory).

Having written that wall of text explaining it, usage is simple:


resources/_shared_properties.rb:

```
property :whatever, String
property :numberwang, Numeric
```

resources/mything.rb:

```
use "shared_properties"
```

Also supported is `use "_shared_properties.rb"` which is identical.  Or `use "whatever/shared_properties"` (`use "whatever/_shared_properties.rb"`) or `use "../whatever/shared_properties"`, etc.

Since this is just de-duplication of typing, anything can be extracted, including things which make no sense to extract like `action` blocks, `provides` lines and `resource_name`.  It also works both to include an `action_class` declaration inside of a partial, and to use a partial from within an `action_class`.

resources/_action_helpers1.rb

```
def the_helper1
  puts "the_helper"
end
```

resources/_action_helpers2.rb

```
action_class do
  def the_helper2
    puts "the_helper"
  end
end
```

resources/mything.rb:

```
action_class do
  use "action_helpers1"
end

use "action_helpers2"
```

Having shown that there are two methods of achieving the same thing, I'd would discourage using either of them for writing simple methods against an action class.  The proper way of including helpers is still to write a module, in a library file, and include it.  This feature is geared towards de-duplication of class method calls, like `property` declarations, where that cannot work.

closes #9077