### PR TITLE
Bump highline to 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive
       ffi-yajl (~> 2.2)
-      highline (>= 1.6.9, < 2)
+      highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
@@ -75,7 +75,7 @@ PATH
       ffi (~> 1.9, >= 1.9.25)
       ffi-libarchive
       ffi-yajl (~> 2.2)
-      highline (>= 1.6.9, < 2)
+      highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
       iso8601 (~> 0.12.1)
       license-acceptance (~> 1.0, >= 1.0.5)
@@ -197,7 +197,7 @@ GEM
     hana (1.3.5)
     hashdiff (1.0.1)
     hashie (3.6.0)
-    highline (1.7.10)
+    highline (2.0.3)
     htmlentities (4.3.4)
     http (2.2.2)
       addressable (~> 2.3)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-sftp", "~> 2.1", ">= 2.1.2"
   s.add_dependency "ed25519", "~> 1.2" # ed25519 ssh key support
   s.add_dependency "bcrypt_pbkdf", "~> 1.0" # ed25519 ssh key support
-  s.add_dependency "highline", ">= 1.6.9", "< 2"
+  s.add_dependency "highline", ">= 1.6.9", "< 3"
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "pastel" # knife ui.color
   s.add_dependency "erubis", "~> 2.7"


### PR DESCRIPTION
We need 2.x for ruby 2.7 compat and warning suppresion
