### PR TITLE
Add software def for bcrypt_pbkdf-ruby

### DIFF
--- a/omnibus/config/projects/chef.rb
+++ b/omnibus/config/projects/chef.rb
@@ -47,6 +47,10 @@ instance_eval(IO.read(overrides_path), overrides_path)
 
 dependency "preparation"
 
+dependency "bcrypt_pbkdf-ruby" # In order for the correct windows extension to build, this gem must be
+                               # built directly, before we build the chef gem.
+                               # see https://github.com/chef/chef/issues/9639 for details.
+
 dependency "chef"
 
 #

--- a/omnibus/config/software/bcrypt_pbkdf-ruby.rb
+++ b/omnibus/config/software/bcrypt_pbkdf-ruby.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: 2020 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "bcrypt_pbkdf-ruby"
+default_version "master"
+relative_path "bcrypt_pbkdf"
+
+source git: "https://github.com/mfazekas/bcrypt_pbkdf-ruby.git"
+
+license "MIT"
+license_file "COPYING"
+
+dependency "ruby"
+
+build do
+  env = with_embedded_path
+
+  bundle "install", env: env
+  bundle "exec rake gem", env: env
+
+  delete "pkg/*java*"
+
+  gem "install pkg/bcrypt_pbkdf-*.gem" \
+      " --no-document", env: env
+end


### PR DESCRIPTION
Fixes an issue where the named gem does not build a compatible
native extension  for Windows when it's installed indirectly via `bundle
install` of the `chef` gem

fixes: https://github.com/chef/chef/issues/9639


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
