### PR TITLE
Add Amazon Linux 2 Testers

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -21,6 +21,7 @@ builder-to-testers-map:
   el-7-aarch64:
     - el-7-aarch64
     - el-8-aarch64
+    - amzn-2-aarch64
   el-7-ppc64:
     - el-7-ppc64
   el-7-ppc64le:
@@ -28,6 +29,7 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
+    - amzn-2-x86_64
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64


### PR DESCRIPTION
This PR adds the new Amazon Linux 2 Testers (x86_64 + aarch64) to the Omnibus pipeline.

An adhoc build is available here:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/237

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>