### PR TITLE
Support non-Linux hosts in chef_client_cron

### DIFF
--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -49,6 +49,10 @@ class Chef
 
       resource_name :chef_client_scheduled_task
 
+      property :task_name, String,
+        description: "The name of the scheduled task to create.",
+        default: Chef::Dist::CLIENT
+
       property :user, String,
         description: "The name of the user that #{Chef::Dist::PRODUCT} runs as.",
         default: "System", sensitive: true
@@ -108,10 +112,6 @@ class Chef
       property :daemon_options, Array,
         description: "An array of options to pass to the #{Chef::Dist::CLIENT} command.",
         default: lazy { [] }
-
-      property :task_name, String,
-        description: "The name of the scheduled task to create.",
-        default: Chef::Dist::CLIENT
 
       action :add do
         # TODO: Replace this with a :create_if_missing action on directory when that exists


### PR DESCRIPTION
The cron_d resource only works on systems that support and /etc/cron.d directory, which is Linux as far as I can tell. We want this resource to work on all the other *nix platforms so we need to fall back to the legacy cron resource for those hosts.

I also reordered all the properties so we can diff the 3 resources easier

Signed-off-by: Tim Smith <tsmith@chef.io>