### PR TITLE
msu_package: Fix cumulative updates installation and provide a 3600s default timeout

### DIFF
--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -74,7 +74,7 @@ class Chef
 
         def dism_command(command)
           with_os_architecture(nil) do
-            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout })
+            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout || 3600 })
             if result.exitstatus == -2146498530
               raise Chef::Exceptions::Package, "The specified package is not applicable to this image." if result.stdout.include?("0x800f081e")
 
@@ -93,7 +93,7 @@ class Chef
             split_package_identity(p["package_identity"])
           end
           found_packages = existing_package_identities.select do |existing_package_ident|
-            existing_package_ident["name"] == package["name"]
+            existing_package_ident["version"] == package["version"].chomp && existing_package_ident["name"] == package["name"]
           end
           if found_packages.empty?
             nil

--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -74,7 +74,7 @@ class Chef
 
         def dism_command(command)
           with_os_architecture(nil) do
-            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout || 3600 })
+            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout })
             if result.exitstatus == -2146498530
               raise Chef::Exceptions::Package, "The specified package is not applicable to this image." if result.stdout.include?("0x800f081e")
 

--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -110,6 +110,7 @@ class Chef
           @cab_files.each do |cab_file|
             declare_resource(:cab_package, new_resource.name) do
               source cab_file
+              timeout new_resource.timeout
               action :install
             end
           end

--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -44,6 +44,11 @@ class Chef
 
       property :checksum, String, desired_state: false,
                description: "SHA-256 digest used to verify the checksum of the downloaded MSU package."
+
+      property :timeout, [String, Integer],
+        default: 3600,
+        description: "The amount of time (in seconds) to wait before timing out.",
+        desired_state: false
     end
   end
 end

--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -24,6 +24,7 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
   let(:package_name) { "Package_for_KB2959977" }
   let(:package_source) { "https://download.microsoft.com/download/3/B/3/3B320C07-B7B1-41E5-81F4-79EBC02DF7D3/Windows8.1-KB2959977-x64.msu" }
   let(:package_identity) { "Package_for_KB2959977~31bf3856ad364e35~amd64~~6.3.1.1" }
+  let(:timeout) { 3600 }
 
   let(:new_resource) { Chef::Resource::CabPackage.new("windows_test_pkg") }
   let(:cab_provider) do
@@ -37,6 +38,7 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
     new_resource = Chef::Resource::MsuPackage.new("test msu package", run_context)
     new_resource.package_name package_name
     new_resource.source package_source
+    new_resource.timeout timeout
     new_resource
   end
 

--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -23,6 +23,7 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
 
   let(:package_name) { "Package_for_KB2959977" }
   let(:package_source) { "https://download.microsoft.com/download/3/B/3/3B320C07-B7B1-41E5-81F4-79EBC02DF7D3/Windows8.1-KB2959977-x64.msu" }
+  let(:package_identity) { "Package_for_KB2959977~31bf3856ad364e35~amd64~~6.3.1.1" }
 
   let(:new_resource) { Chef::Resource::CabPackage.new("windows_test_pkg") }
   let(:cab_provider) do
@@ -44,7 +45,7 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
 
     it "installs the package successfully" do
       subject.run_action(:install)
-      found_packages = cab_provider.installed_packages.select { |p| p["package_identity"] =~ /^#{package_name}~/ }
+      found_packages = cab_provider.installed_packages.select { |p| p["package_identity"] == package_identity }
       expect(found_packages.length).to be == 1
     end
   end
@@ -53,7 +54,7 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
     it "removes an installed package" do
       subject.run_action(:install)
       remove_package
-      found_packages = cab_provider.installed_packages.select { |p| p["package_identity"] =~ /^#{package_name}~/ }
+      found_packages = cab_provider.installed_packages.select { |p| p["package_identity"] == package_identity }
       expect(found_packages.length).to be == 0
     end
   end

--- a/spec/unit/resource/msu_package_spec.rb
+++ b/spec/unit/resource/msu_package_spec.rb
@@ -60,4 +60,8 @@ describe Chef::Resource::MsuPackage do
     resource.source("package.msu")
     expect(resource.source).not_to eq("package.msu")
   end
+
+  it "sets timeout property to 3600 by default" do
+    expect(resource.timeout).to eql(3600)
+  end
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
-- Updated to match with version as well along with package name.
-- Identifies correct match for cumulative updates.
-- Added `timeout` property for setting new default 3600 because some packages which are larger in sizes gets time nearly 45mins to 60mins to complete.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes: https://github.com/chef/chef/issues/9383
Fixes: #9245 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
