### PR TITLE
Use the correct plist class in the mac user provider

### DIFF
--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -80,7 +80,7 @@ class Chef
           admin_group_xml = run_dscl("read", "/Groups/admin")
           return nil unless admin_group_xml && admin_group_xml != ""
 
-          @admin_group_plist = ::Plist.new(::Plist.parse_xml(admin_group_xml))
+          @admin_group_plist = Plist.new(::Plist.parse_xml(admin_group_xml))
         end
 
         def reload_user_plist
@@ -95,7 +95,7 @@ class Chef
 
           return nil if user_xml.nil? || user_xml == ""
 
-          @user_plist = ::Plist.new(::Plist.parse_xml(user_xml))
+          @user_plist = Plist.new(::Plist.parse_xml(user_xml))
 
           return unless user_plist[:shadow_hash]
 


### PR DESCRIPTION
This is actually a subclass of the mac user provider and not the Plist gem. This is a super confusing name btw. Plist passed Plist, but it's a different Plist.

Signed-off-by: Tim Smith <tsmith@chef.io>