### PR TITLE
Update license scout to fix broken windows builds

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
-    license_scout (1.1.7)
+    license_scout (1.1.8)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)


### PR DESCRIPTION
This knows about the new location of the readme file for win32-api gem.

Signed-off-by: Tim Smith <tsmith@chef.io>