### PR TITLE
Updates to timeout properties in various resources

### DIFF
--- a/lib/chef/provider/execute.rb
+++ b/lib/chef/provider/execute.rb
@@ -27,7 +27,7 @@ class Chef
 
       provides :execute, target_mode: true
 
-      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env
+      def_delegators :new_resource, :command, :returns, :environment, :user, :domain, :password, :group, :cwd, :umask, :creates, :elevated, :default_env, :timeout
 
       def load_current_resource
         current_resource = Chef::Resource::Execute.new(new_resource.name)
@@ -39,12 +39,6 @@ class Chef
           # FIXME? move this onto the resource?
           raise Chef::Exceptions::Execute, "Please either specify a full path for the creates property, or specify a cwd property to the #{new_resource} resource"
         end
-      end
-
-      def timeout
-        # original implementation did not specify a timeout, but ShellOut
-        # *always* times out. So, set a very long default timeout
-        new_resource.timeout || 3600
       end
 
       action :run do

--- a/lib/chef/resource/dsc_resource.rb
+++ b/lib/chef/resource/dsc_resource.rb
@@ -101,12 +101,13 @@ class Chef
       # is necessary, reboot_action provides the mechanism for a reboot to
       # be requested.
       property :reboot_action, Symbol, default: :nothing, equal_to: %i{nothing reboot_now request_reboot},
-                introduced: "12.6",
-                description: "Use to request an immediate reboot or to queue a reboot using the :reboot_now (immediate reboot) or :request_reboot (queued reboot) actions built into the reboot resource."
+        introduced: "12.6",
+        description: "Use to request an immediate reboot or to queue a reboot using the :reboot_now (immediate reboot) or :request_reboot (queued reboot) actions built into the reboot resource."
 
       property :timeout, Integer,
         introduced: "12.6",
-        description: "The amount of time (in seconds) a command is to wait before timing out."
+        description: "The amount of time (in seconds) a command is to wait before timing out.",
+        desired_state: false
 
       private
 

--- a/lib/chef/resource/dsc_script.rb
+++ b/lib/chef/resource/dsc_script.rb
@@ -124,7 +124,8 @@ class Chef
         description: "A Hash of environment variables in the form of ({'ENV_VARIABLE' => 'VALUE'}). (These variables must exist for a command to be run successfully)."
 
       property :timeout, Integer,
-        description: "The amount of time (in seconds) a command is to wait before timing out."
+        description: "The amount of time (in seconds) a command is to wait before timing out.",
+        desired_state: false
     end
   end
 end

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -68,18 +68,19 @@ class Chef
         description: "The group name or group ID that must be changed before running a command."
 
       property :live_stream, [ TrueClass, FalseClass ], default: false,
-               description: "Send the output of the command run by this execute resource block to the #{Chef::Dist::CLIENT} event stream."
+        description: "Send the output of the command run by this execute resource block to the #{Chef::Dist::CLIENT} event stream."
 
       # default_env defaults to `false` so that the command execution more exactly matches what the user gets on the command line without magic
       property :default_env, [ TrueClass, FalseClass ], desired_state: false, default: false,
-               introduced: "14.2",
-               description: "When true this enables ENV magic to add path_sanity to the PATH and force the locale to English+UTF-8 for parsing output"
+        introduced: "14.2",
+        description: "When true this enables ENV magic to add path_sanity to the PATH and force the locale to English+UTF-8 for parsing output"
 
       property :returns, [ Integer, Array ], default: 0,
-               description: "The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match."
+        description: "The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match."
 
       property :timeout, [ Integer, Float ],
-        description: "The amount of time (in seconds) a command is to wait before timing out."
+        description: "The amount of time (in seconds) a command is to wait before timing out.",
+        desired_state: false
 
       property :user, [ String, Integer ],
         description: "The user name of the user identity with which to launch the new process. The user name may optionally be specifed with a domain, i.e. domainuser or user@my.dns.domain.com via Universal Principal Name (UPN)format. It can also be specified without a domain simply as user if the domain is instead specified using the domain property. On Windows only, if this property is specified, the password property must be specified."
@@ -89,8 +90,8 @@ class Chef
         description: "Windows only: The domain of the user user specified by the user property. If not specified, the user name and password specified by the user and password properties will be used to resolve that user against the domain in which the system running #{Chef::Dist::PRODUCT} is joined, or if that system is not joined to a domain it will resolve the user as a local account on that system. An alternative way to specify the domain is to leave this property unspecified and specify the domain as part of the user property."
 
       property :password, String, sensitive: true,
-               introduced: "12.21",
-               description: "Windows only: The password of the user specified by the user property. This property is mandatory if user is specified on Windows and may only be specified if user is specified. The sensitive property for this resource will automatically be set to true if password is specified."
+        introduced: "12.21",
+        description: "Windows only: The password of the user specified by the user property. This property is mandatory if user is specified on Windows and may only be specified if user is specified. The sensitive property for this resource will automatically be set to true if password is specified."
 
       # lazy used to set default value of sensitive to true if password is set
       property :sensitive, [ TrueClass, FalseClass ],
@@ -98,8 +99,8 @@ class Chef
         default: lazy { password ? true : false }, default_description: "True if the password property is set. False otherwise."
 
       property :elevated, [ TrueClass, FalseClass ], default: false,
-               description: "Determines whether the script will run with elevated permissions to circumvent User Access Control (UAC) interactively blocking the process.\nThis will cause the process to be run under a batch login instead of an interactive login. The user running #{Chef::Dist::CLIENT} needs the “Replace a process level token” and “Adjust Memory Quotas for a process” permissions. The user that is running the command needs the “Log on as a batch job” permission.\nBecause this requires a login, the user and password properties are required.",
-               introduced: "13.3"
+        description: "Determines whether the script will run with elevated permissions to circumvent User Access Control (UAC) interactively blocking the process.\nThis will cause the process to be run under a batch login instead of an interactive login. The user running #{Chef::Dist::CLIENT} needs the “Replace a process level token” and “Adjust Memory Quotas for a process” permissions. The user that is running the command needs the “Log on as a batch job” permission.\nBecause this requires a login, the user and password properties are required.",
+        introduced: "13.3"
 
       alias :env :environment
 

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -78,7 +78,8 @@ class Chef
       property :returns, [ Integer, Array ], default: 0,
         description: "The return value for a command. This may be an array of accepted values. An exception is raised when the return value(s) do not match."
 
-      property :timeout, [ Integer, Float ],
+      property :timeout, [ Integer, String, Float ],
+        default: 3600,
         description: "The amount of time (in seconds) a command is to wait before timing out.",
         desired_state: false
 

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -31,9 +31,10 @@ class Chef
 
       allowed_actions :install, :remove, :upgrade
 
-      property :timeout, Integer,
+      property :timeout, [String, Integer],
         description: "The amount of time (in seconds) to wait before timing out.",
-        default: 3600
+        default: 3600,
+        desired_state: false
     end
   end
 end

--- a/lib/chef/resource/portage_package.rb
+++ b/lib/chef/resource/portage_package.rb
@@ -27,8 +27,10 @@ class Chef
 
       description "Use the portage_package resource to manage packages for the Gentoo platform."
 
-      property :timeout, default: 3600,
-               description: "The amount of time (in seconds) to wait before timing out."
+      property :timeout, [String, Integer],
+        default: 3600,
+        description: "The amount of time (in seconds) to wait before timing out.",
+        desired_state: false
     end
   end
 end

--- a/lib/chef/resource/scm.rb
+++ b/lib/chef/resource/scm.rb
@@ -61,6 +61,7 @@ class Chef
         desired_state: false
 
       property :timeout, Integer,
+        description: "The amount of time (in seconds) to wait before timing out.",
         desired_state: false
 
       property :checkout_branch, String,

--- a/lib/chef/resource/ssh_known_hosts_entry.rb
+++ b/lib/chef/resource/ssh_known_hosts_entry.rb
@@ -47,7 +47,8 @@ class Chef
 
       property :timeout, Integer,
         description: "The timeout in seconds for ssh-keyscan.",
-        default: 30
+        default: 30,
+        desired_state: false
 
       property :mode, String,
         description: "The file mode for the ssh_known_hosts file.",

--- a/lib/chef/resource/swap_file.rb
+++ b/lib/chef/resource/swap_file.rb
@@ -40,7 +40,8 @@ class Chef
 
       property :timeout, Integer,
         description: "Timeout for 'dd' / 'fallocate' commands.",
-        default: 600
+        default: 600,
+        desired_state: false
 
       property :swappiness, Integer,
         description: "The swappiness value to set on the system."

--- a/lib/chef/resource/windows_feature.rb
+++ b/lib/chef/resource/windows_feature.rb
@@ -48,7 +48,8 @@ class Chef
 
       property :timeout, Integer,
         description: "Specifies a timeout (in seconds) for the feature installation.",
-        default: 600
+        default: 600,
+        desired_state: false
 
       action :install do
         description "Install a Windows role/feature"

--- a/lib/chef/resource/windows_feature_dism.rb
+++ b/lib/chef/resource/windows_feature_dism.rb
@@ -41,7 +41,8 @@ class Chef
 
       property :timeout, Integer,
         description: "Specifies a timeout (in seconds) for the feature installation.",
-        default: 600
+        default: 600,
+        desired_state: false
 
       # @return [Array] lowercase the array
       def to_formatted_array(x)

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -42,7 +42,8 @@ class Chef
 
       property :timeout, Integer,
         description: "Specifies a timeout (in seconds) for the feature installation.",
-        default: 600
+        default: 600,
+        desired_state: false
 
       property :management_tools, [TrueClass, FalseClass],
         description: "Install all applicable management tools for the roles, role services, or features.",

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -51,7 +51,8 @@ class Chef
 
       property :timeout, [ String, Integer ], default: 600,
         default_description: "600 (seconds)",
-        description: "The amount of time (in seconds) to wait before timing out."
+        description: "The amount of time (in seconds) to wait before timing out.",
+        desired_state: false
 
       # In the past we accepted return code 127 for an unknown reason and 42 because of a bug
       # we accept 3010 which means success, but a reboot is necessary


### PR DESCRIPTION
1) make sure they all have desired state false
2) Fix some indentation
3) Fix portage_package to have a type of String/Integer to match package
4) Add the String type to paludis_package to match the package default
5) Set the default timeout in the execute resource instead of overriding it in the provider

Signed-off-by: Tim Smith <tsmith@chef.io>