### PR TITLE
Add deprecation warnings at the end of the run after the end of April 2021

### DIFF
--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -327,14 +327,8 @@ class Chef
 
     # @api private
     def warn_if_eol
-      require_relative "version"
-
-      # We make a release every year so take the version you're on + 2006 and you get
-      # the year it goes EOL
-      eol_year = 2006 + Gem::Version.new(Chef::VERSION).segments.first
-
-      if Time.now > Time.new(eol_year, 5, 01)
-        logger.warn("This release of #{Chef::Dist::PRODUCT} became end of life (EOL) on May 1st #{eol_year}. Please update to a supported release to receive new features, bug fixes, and security updates.")
+      if Time.now > Time.new(2021, 5, 01)
+        logger.warn("This release of #{Chef::Dist::PRODUCT} became end of life (EOL) on May 1st 2021. Please update to a supported release to receive new features, bug fixes, and security updates.")
       end
     end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -329,15 +329,12 @@ class Chef
     def warn_if_eol
       require_relative "version"
 
-      # we have a yearly release and we know 15 goes EOL in 2021 so calculate off that
-      # this way we don't have to update anything or maintain a hash of EOL dates
-      base_eol_year = 2022
-      base_release = Gem::Version.new(15)
+      # We make a release every year so take the version you're on + 2006 and you get
+      # the year it goes EOL
+      eol_year = 2006 + Gem::Version.new(Chef::VERSION).segments.first
 
-      diff_from_base_release = Gem::Version.new(Chef::VERSION).segments.first - base_release.segments.first
-
-      if Time.now > Time.new(base_eol_year + diff_from_base_release, 5, 1)
-        logger.warn("This release of #{Chef::Dist::PRODUCT} became end of life (EOL) on May 1st #{base_eol_year + diff_from_base_release}. Please update to a supported release to receive new features, bug fixes, and security updates.")
+      if Time.now > Time.new(eol_year, 5, 01)
+        logger.warn("This release of #{Chef::Dist::PRODUCT} became end of life (EOL) on May 1st #{eol_year}. Please update to a supported release to receive new features, bug fixes, and security updates.")
       end
     end
 

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -295,6 +295,8 @@ class Chef
         # keep this inside the main loop to get exception backtraces
         end_profiling
 
+        warn_if_eol
+
         # rebooting has to be the last thing we do, no exceptions.
         Chef::Platform::Rebooter.reboot_if_needed!(node)
       rescue Exception => run_error
@@ -322,6 +324,22 @@ class Chef
     # Private API
     # @todo make this stuff protected or private
     #
+
+    # @api private
+    def warn_if_eol
+      require_relative "version"
+
+      # we have a yearly release and we know 15 goes EOL in 2021 so calculate off that
+      # this way we don't have to update anything or maintain a hash of EOL dates
+      base_eol_year = 2022
+      base_release = Gem::Version.new(15)
+
+      diff_from_base_release = Gem::Version.new(Chef::VERSION).segments.first - base_release.segments.first
+
+      if Time.now > Time.new(base_eol_year + diff_from_base_release, 5, 1)
+        logger.warn("This release of #{Chef::Dist::PRODUCT} became end of life (EOL) on May 1st #{base_eol_year + diff_from_base_release}. Please update to a supported release to receive new features, bug fixes, and security updates.")
+      end
+    end
 
     # @api private
     def configure_formatters

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -308,15 +308,13 @@ describe Chef::Client do
   end
 
   describe "eol release warning" do
-    it "warns when running an EOL release" do
-      stub_const("Chef::VERSION", 15)
+    it "warns when the date is after April 30, 2021" do
       allow(Time).to receive(:now).and_return(Time.new(2021, 5, 1, 5))
       expect(logger).to receive(:warn).with(/This release of.*became end of life \(EOL\) on May 1st 2021/)
       client.warn_if_eol
     end
 
-    it "does not warn when running an non-EOL release" do
-      stub_const("Chef::VERSION", 15)
+    it "does not warn when date is before May 1st 2021" do
       allow(Time).to receive(:now).and_return(Time.new(2021, 4, 31))
       expect(logger).to_not receive(:warn).with(/became end of life/)
       client.warn_if_eol

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -307,6 +307,22 @@ describe Chef::Client do
     end
   end
 
+  describe "eol release warning" do
+    it "warns when running an EOL release" do
+      stub_const("Chef::VERSION", 15)
+      allow(Time).to receive(:now).and_return(Time.new("2030-01-01"))
+      expect(logger).to receive(:warn).with(/This release of.*became end of life \(EOL\) on May 1st 2022/)
+      client.warn_if_eol
+    end
+
+    it "does not warn when running an non-EOL release" do
+      stub_const("Chef::VERSION", 15)
+      allow(Time).to receive(:now).and_return(Time.new("2020-01-01"))
+      expect(logger).to_not receive(:warn).with(/became end of life/)
+      client.warn_if_eol
+    end
+  end
+
   describe "authentication protocol selection" do
     context "when FIPS is disabled" do
       before do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -310,14 +310,14 @@ describe Chef::Client do
   describe "eol release warning" do
     it "warns when running an EOL release" do
       stub_const("Chef::VERSION", 15)
-      allow(Time).to receive(:now).and_return(Time.new("2030-01-01"))
-      expect(logger).to receive(:warn).with(/This release of.*became end of life \(EOL\) on May 1st 2022/)
+      allow(Time).to receive(:now).and_return(Time.new(2021, 5, 1, 5))
+      expect(logger).to receive(:warn).with(/This release of.*became end of life \(EOL\) on May 1st 2021/)
       client.warn_if_eol
     end
 
     it "does not warn when running an non-EOL release" do
       stub_const("Chef::VERSION", 15)
-      allow(Time).to receive(:now).and_return(Time.new("2020-01-01"))
+      allow(Time).to receive(:now).and_return(Time.new(2021, 4, 31))
       expect(logger).to_not receive(:warn).with(/became end of life/)
       client.warn_if_eol
     end


### PR DESCRIPTION
Warn at the end of the chef-client run after the end April 2021. Let people know when it's EOL.