### PR TITLE
Add build verification on Amazon Linux 2

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -29,6 +29,7 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
+    - amazon-2-x86_64
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64


### PR DESCRIPTION
This way we get Amazon 2 packages on the downloads site

Signed-off-by: Tim Smith <tsmith@chef.io>