### PR TITLE
msu_package: Removal also requires passing timeout property

### DIFF
--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -121,6 +121,7 @@ class Chef
           @cab_files.each do |cab_file|
             declare_resource(:cab_package, new_resource.name) do
               source cab_file
+              timeout new_resource.timeout
               action :remove
             end
           end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- We found that removal of msu_package also requires timeout for packages larger in size.
- So added the timeout to fix this behaviour.

