### PR TITLE
Fix typo in chef-utils comment

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -242,7 +242,7 @@ Those methods are marked API private for the purposes of end-users, but are publ
 
 ## Getting Involved
 
-We'd love to have your help developing Chef Infra. See our [Contributing Document](./CONTRIBUTING.md) for more information on getting started.
+We'd love to have your help developing Chef Infra. See our [Contributing Document](../CONTRIBUTING.md) for more information on getting started.
 
 ## License and Copyright
 

--- a/chef-utils/lib/chef-utils/dsl/virtualization.rb
+++ b/chef-utils/lib/chef-utils/dsl/virtualization.rb
@@ -161,7 +161,7 @@ module ChefUtils
         node.dig("virtualization", "system") == "openvz" && node.dig("virtualization", "role") == "host"
       end
 
-      # Determine if the current node is running under any virutalization environment
+      # Determine if the current node is running under any virtualization environment
       #
       # @param [Chef::Node] node
       # @since 15.8


### PR DESCRIPTION
These generate the vscode helpers so there was a typo in that snippet

Signed-off-by: Tim Smith <tsmith@chef.io>