### PR TITLE
Ruby 2.7 fix for powershell_out

### DIFF
--- a/lib/chef/mixin/powershell_out.rb
+++ b/lib/chef/mixin/powershell_out.rb
@@ -66,7 +66,7 @@ class Chef
         with_os_architecture(nil, architecture: arch) do
           shell_out(
             build_powershell_command(script),
-            options
+            **options
           )
         end
       end


### PR DESCRIPTION
Just makes a warning go away