### PR TITLE
Force requiring properties

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -303,8 +303,12 @@ class Chef
     #
     # @return [Boolean]
     #
-    def required?
-      options[:required]
+    def required?(action = nil)
+      if !action.nil? && options[:required].is_a?(Array)
+        options[:required].include?(action)
+      else
+        !!options[:required]
+      end
     end
 
     #

--- a/lib/chef/resource/windows_env.rb
+++ b/lib/chef/resource/windows_env.rb
@@ -36,7 +36,7 @@ class Chef
 
       property :value, String,
         description: "The value of the environmental variable to set.",
-        required: true
+        required: %i{create modify}
 
       property :delim, [ String, nil, false ],
         description: "The delimiter that is used to separate multiple values for a single key.",


### PR DESCRIPTION
All required properties are now required for all actions by default
even if the action does not reference the property.

In order to only make the property required for a subset of the
actions, specify them as an array of symbols to the required
options on the property.

```
property :whatever, String, required: %i{start stop}

action :start do
end

action :stop do
end

action :enable do
end

action :disable do
end
```

That property will be required for start+stop but not for
enable+disable.

There's an unaddressed edge case here where if you reference the
property in an action which was not specified that it will also
fail validation.  That is correct behavior.  We should probably
dig into how to warn the user that they must either remove the
reference to the property from that action or else to add the
action to the list of required actions on the property.

Closes #4596