### PR TITLE
CentOS 6.9 Fauxhai deprecation

### DIFF
--- a/chef-utils/spec/unit/dsl/platform_family_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_family_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
   end
 
   context "on centos6" do
-    let(:options) { { platform: "centos", version: "6.9" } }
+    let(:options) { { platform: "centos", version: "6.10" } }
 
     pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel6?)
   end


### PR DESCRIPTION
Fix `WARNING: Fauxhai platform data for redhat 6.9 is deprecated and will be removed in the 9.0 release 3/2021`