### PR TITLE
Move some of the ruby-cleanup logic into omnibus-software

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: a2df4abd292052dfc822da3d34ff737c0c3d87b0
+  revision: b37087b3d0d1f27b9429de401c51e1f7ea41b8f0
   branch: master
   specs:
-    chefstyle (1.0.1)
+    chefstyle (1.0.2)
       rubocop (= 0.82.0)
 
 GIT

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 1b490aa4e6a5b224d98d07d72cdf90cb2f132576
+  revision: eb8812bd870f3f268a7bef0448f84151eb0ccde9
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.297.0)
+    aws-partitions (1.299.0)
     aws-sdk-core (3.94.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,11 +41,11 @@ GEM
     aws-sdk-kms (1.30.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.61.2)
+    aws-sdk-s3 (1.62.0)
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.1)
+    aws-sigv4 (1.1.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt_pbkdf (1.0.1)
     bcrypt_pbkdf (1.0.1-x64-mingw32)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -31,26 +31,15 @@ build do
     files = %w{
       *.blurb
       *Upgrade.md
-      .appveyor.yml
-      .autotest
-      .circleci
-      .github
-      .kokoro
-      .simplecov
-      .tool-versions
-      Appraisals
       autotest
       autotest/*
       bench
       benchmark
       benchmarks
-      bundle_install_all_ruby_versions.sh
-      concourse
       design_rationale.rb
       doc
       doc-api
       docs
-      donate.png
       ed25519.png
       example
       examples
@@ -59,28 +48,18 @@ build do
       frozen_old_spec
       Gemfile.devtools
       Gemfile.lock
-      Gemfile.travis
       INSTALL.txt
-      logo.png
       man
       minitest
-      NEWS.md
       on_what.rb
       rakelib
-      README.euc
-      release-script.txt
-      run_specs_all_ruby_versions.sh
       sample
       samples
-      SECURITY.md
       site
-      SPEC.rdoc
       test
       tests
-      travis_build_script.sh
       vendor
       VERSION
-      warning.txt
       website
       yard-template
     }


### PR DESCRIPTION
Bump the deps to current to bring in the latest omnibus that includes some of this cleanup natively

Signed-off-by: Tim Smith <tsmith@chef.io>