### PR TITLE
Avoid double pry by pinning to the exact version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ group(:omnibus_package) do
 end
 
 group(:omnibus_package, :pry) do
-  gem "pry"
-  gem "pry-byebug"
+  gem "pry", "=0.12.2" # we ended up with double pry before. Confirm that doesn't come back when bumping ruby & adjust
+  gem "pry-byebug", "=3.8.0" # we ended up with double pry-byebug before. Confirm that doesn't come back when bumping ruby & adjust
   gem "pry-remote"
   gem "pry-stack_explorer"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,8 +472,8 @@ DEPENDENCIES
   inspec-core (~> 4.18)
   inspec-core-bin (~> 4.18)
   ohai!
-  pry
-  pry-byebug
+  pry (= 0.12.2)
+  pry-byebug (= 3.8.0)
   pry-remote
   pry-stack_explorer
   rake (<= 13.0.1)


### PR DESCRIPTION
It's in the gemfile.lock once, but we're ending up with 0.12.2 and 0.13
which is super odd.

Signed-off-by: Tim Smith <tsmith@chef.io>