### PR TITLE
Remove the unused simplecov depedency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ group(:development, :test) do
   gem "rspec-mocks", "~> 3.5"
   gem "rspec-expectations", "~> 3.5"
   gem "rspec_junit_formatter", "~> 0.2.0"
-  gem "simplecov"
   gem "webmock"
   gem "fauxhai-ng" # for chef-utils gem
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
-    docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ecma-re-validator (0.2.1)
@@ -346,10 +345,6 @@ GEM
     rubyzip (1.3.0)
     safe_yaml (1.0.5)
     semverse (3.0.0)
-    simplecov (0.18.5)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
     slop (3.6.0)
     sslshake (1.3.0)
     strings (0.1.8)
@@ -484,7 +479,6 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.2.0)
   ruby-prof (< 1.3.0)
   ruby-shadow
-  simplecov
   webmock
   yard
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,17 +34,6 @@ require "rspec/mocks"
 
 require "webmock/rspec"
 
-if ENV["COVERAGE"]
-  require "simplecov"
-  SimpleCov.start do
-    add_filter "/spec/"
-    add_group "Remote File", "remote_file"
-    add_group "Resources", "/resource/"
-    add_group "Providers", "/provider/"
-    add_group "Knife", "knife"
-  end
-end
-
 require "chef"
 require "chef/knife"
 


### PR DESCRIPTION
We're not actually running these coverage tests and even if we did they don't have high value since you can game the numbers without writing quality tests.

Signed-off-by: Tim Smith <tsmith@chef.io>