### PR TITLE
Bump omnibus-software to avoid double pry

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: eb8812bd870f3f268a7bef0448f84151eb0ccde9
+  revision: 4b70980358e8b74c691682e9bd05e30b1f7e1c39
   branch: master
   specs:
     omnibus-software (4.0.0)


### PR DESCRIPTION
This exludes the debug group which prevents pulling in pry in ohai that
conflicts with the pry in the gemfile.lock

Signed-off-by: Tim Smith <tsmith@chef.io>