### PR TITLE
Add Ubuntu 20.04 + SLES 15 aarch64 Testers

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -40,6 +40,8 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
+  sles-15-aarch64:
+    - sles-15-aarch64
 #  solaris2-5.11-i386:
 #    - solaris2-5.11-i386
 #  solaris2-5.11-sparc:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -48,6 +48,7 @@ builder-to-testers-map:
 #    - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
+    - ubuntu-20.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64


### PR DESCRIPTION
This PR adds the Ubuntu 20.04 and SLES 15 aarch64 support

An adhoc build can be found here:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/246

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>