### PR TITLE
Make sure all the non-multipackage packge resources can't take arrays

### DIFF
--- a/lib/chef/resource/bff_package.rb
+++ b/lib/chef/resource/bff_package.rb
@@ -27,6 +27,13 @@ class Chef
 
       description "Use the bff_package resource to manage packages for the AIX platform using the installp utility. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."
       introduced "12.0"
+
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/cab_package.rb
+++ b/lib/chef/resource/cab_package.rb
@@ -32,6 +32,13 @@ class Chef
 
       allowed_actions :install, :remove
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :source, String,
         description: "The local file path or URL for the CAB package.",
         coerce: (proc do |s|

--- a/lib/chef/resource/chef_gem.rb
+++ b/lib/chef/resource/chef_gem.rb
@@ -38,6 +38,13 @@ class Chef
       unified_mode true
       provides :chef_gem
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :gem_binary, default: "#{RbConfig::CONFIG["bindir"]}/gem", default_description: "Chef's built-in gem binary.",
                             description: "The path of a gem binary to use for the installation. By default, the same version of Ruby that is used by the #{Chef::Dist::CLIENT} will be installed.",
                             callbacks: {

--- a/lib/chef/resource/gem_package.rb
+++ b/lib/chef/resource/gem_package.rb
@@ -27,6 +27,13 @@ class Chef
 
       description "Use the gem_package resource to manage gem packages that are only included in recipes. When a package is installed from a local file, it must be added to the node using the remote_file or cookbook_file resources."
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       # the source can either be a path to a package source like:
       #   source /var/tmp/mygem-1.2.3.4.gem
       # or it can be a url rubygems source like:

--- a/lib/chef/resource/ips_package.rb
+++ b/lib/chef/resource/ips_package.rb
@@ -31,6 +31,13 @@ class Chef
 
       allowed_actions :install, :remove, :upgrade
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :accept_license, [TrueClass, FalseClass],
         default: false, desired_state: false,
         description: "Accept an end-user license agreement, automatically."

--- a/lib/chef/resource/macports_package.rb
+++ b/lib/chef/resource/macports_package.rb
@@ -24,7 +24,14 @@ class Chef
       unified_mode true
       provides :macports_package
 
-      description "Use the macports_package resource to manage packages for the macOS platform."
+      description "Use the macports_package resource to manage packages for the macOS platform using the MacPorts package management system."
+
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -33,6 +33,13 @@ class Chef
       allowed_actions :install, :remove
       default_action :install
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :source, String,
         description: "The local file path or URL for the MSU package.",
         coerce: (proc do |s|

--- a/lib/chef/resource/openbsd_package.rb
+++ b/lib/chef/resource/openbsd_package.rb
@@ -31,6 +31,13 @@ class Chef
 
       description "Use the openbsd_package resource to manage packages for the OpenBSD platform."
       introduced "12.1"
+
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/paludis_package.rb
+++ b/lib/chef/resource/paludis_package.rb
@@ -31,6 +31,13 @@ class Chef
 
       allowed_actions :install, :remove, :upgrade
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :timeout, [String, Integer],
         description: "The amount of time (in seconds) to wait before timing out.",
         default: 3600,

--- a/lib/chef/resource/portage_package.rb
+++ b/lib/chef/resource/portage_package.rb
@@ -27,6 +27,13 @@ class Chef
 
       description "Use the portage_package resource to manage packages for the Gentoo platform."
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       property :timeout, [String, Integer],
         default: 3600,
         description: "The amount of time (in seconds) to wait before timing out.",

--- a/lib/chef/resource/rpm_package.rb
+++ b/lib/chef/resource/rpm_package.rb
@@ -29,6 +29,12 @@ class Chef
 
       property :allow_downgrade, [ true, false ], default: true, desired_state: false
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/smartos_package.rb
+++ b/lib/chef/resource/smartos_package.rb
@@ -27,6 +27,13 @@ class Chef
       provides :package, platform_family: "smartos"
 
       description "Use the smartos_package resource to manage packages for the SmartOS platform."
+
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/solaris_package.rb
+++ b/lib/chef/resource/solaris_package.rb
@@ -29,6 +29,13 @@ class Chef
       provides :package, os: "solaris2", platform_family: "solaris2", platform_version: "<= 5.10"
 
       description "The solaris_package resource is used to manage packages for the Solaris platform."
+
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
     end
   end
 end

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -40,6 +40,13 @@ class Chef
         @source ||= source(@package_name) if @package_name.downcase.end_with?(".msi")
       end
 
+      property :package_name, String,
+        description: "An optional property to set the package name if it differs from the resource block's name.",
+        identity: true
+
+      property :version, String,
+        description: "The version of a package to be installed or upgraded."
+
       # windows can't take array options yet
       property :options, String,
         description: "One (or more) additional options that are passed to the command."


### PR DESCRIPTION
Right now these resources inherit package_name, versions, and options from the package resource which allows arrays. The problem is the actual providers for these package resources don't know what to do with arrays and they explode. They explode in ways that are really unfriendly to users. With this change they'll get a nice input validation error and they'll have a lot more of an idea of how to go about resolving the problem. This also means that our automatically generated documentation for the package resources will be correct since right now it documents everything as accepting an array.

Signed-off-by: Tim Smith <tsmith@chef.io>