### PR TITLE
Don't require / include mixins that are built in

### DIFF
--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -18,7 +18,6 @@
 
 require_relative "../package"
 require_relative "../../resource/cab_package"
-require_relative "../../mixin/shell_out"
 require_relative "../../mixin/uris"
 require_relative "../../mixin/checksum"
 require "cgi" unless defined?(CGI)
@@ -27,7 +26,6 @@ class Chef
   class Provider
     class Package
       class Cab < Chef::Provider::Package
-        include Chef::Mixin::ShellOut
         include Chef::Mixin::Uris
         include Chef::Mixin::Checksum
 

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -17,8 +17,6 @@
 
 require_relative "../package"
 require_relative "../../resource/dnf_package"
-require_relative "../../mixin/which"
-require_relative "../../mixin/shell_out"
 require_relative "../../mixin/get_source_from_package"
 require_relative "dnf/python_helper"
 require_relative "dnf/version"
@@ -27,8 +25,6 @@ class Chef
   class Provider
     class Package
       class Dnf < Chef::Provider::Package
-        extend Chef::Mixin::Which
-        extend Chef::Mixin::ShellOut
         include Chef::Mixin::GetSourceFromPackage
 
         allow_nils

--- a/lib/chef/provider/package/msu.rb
+++ b/lib/chef/provider/package/msu.rb
@@ -22,7 +22,6 @@
 # Reference: https://support.microsoft.com/en-in/kb/934307
 require_relative "../package"
 require_relative "../../resource/msu_package"
-require_relative "../../mixin/shell_out"
 require_relative "cab"
 require_relative "../../util/path_helper"
 require_relative "../../mixin/uris"
@@ -33,7 +32,6 @@ class Chef
   class Provider
     class Package
       class Msu < Chef::Provider::Package
-        include Chef::Mixin::ShellOut
         include Chef::Mixin::Uris
         include Chef::Mixin::Checksum
 

--- a/lib/chef/provider/package/openbsd.rb
+++ b/lib/chef/provider/package/openbsd.rb
@@ -33,7 +33,6 @@ class Chef
         provides :package, os: "openbsd"
         provides :openbsd_package
 
-        include Chef::Mixin::ShellOut
         include Chef::Mixin::GetSourceFromPackage
 
         def initialize(*args)

--- a/lib/chef/provider/package/windows/exe.rb
+++ b/lib/chef/provider/package/windows/exe.rb
@@ -17,15 +17,11 @@
 # limitations under the License.
 #
 
-require_relative "../../../mixin/shell_out"
-
 class Chef
   class Provider
     class Package
       class Windows
         class Exe
-          include Chef::Mixin::ShellOut
-
           def initialize(resource, installer_type, uninstall_entries)
             @new_resource = resource
             @logger = new_resource.logger

--- a/lib/chef/provider/package/windows/msi.rb
+++ b/lib/chef/provider/package/windows/msi.rb
@@ -19,7 +19,6 @@
 # TODO: Allow new_resource.source to be a Product Code as a GUID for uninstall / network install
 
 require_relative "../../../win32/api/installer" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-require_relative "../../../mixin/shell_out"
 
 class Chef
   class Provider
@@ -27,7 +26,6 @@ class Chef
       class Windows
         class MSI
           include Chef::ReservedNames::Win32::API::Installer if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-          include Chef::Mixin::ShellOut
 
           def initialize(resource, uninstall_entries)
             @new_resource = resource


### PR DESCRIPTION
which and shell_out come for free in universal.

Signed-off-by: Tim Smith <tsmith@chef.io>