### PR TITLE
Allow Arrays in msu_package version again

### DIFF
--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -37,7 +37,12 @@ class Chef
         description: "An optional property to set the package name if it differs from the resource block's name.",
         identity: true
 
-      property :version, String,
+      # This is the same property as the main package resource except it has the skip docs set to true
+      # This resource abuses the package resource by storing the versions of all the cabs in the MSU file
+      # in the version attribute from load current value even though those aren't technically the versio of the
+      # msu. Since the user wouldn't actually set this we don't want it on the docs site.
+      property :version, [String, Array],
+        skip_docs: true,
         description: "The version of a package to be installed or upgraded."
 
       property :source, String,


### PR DESCRIPTION
This is a bug, but we're going to need to live with it for now.

Signed-off-by: Tim Smith <tsmith@chef.io>