### PR TITLE
Resolve deprecations in chef-utils specs

### DIFF
--- a/chef-utils/spec/unit/dsl/platform_family_spec.rb
+++ b/chef-utils/spec/unit/dsl/platform_family_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ChefUtils::DSL::PlatformFamily do
   end
 
   context "on redhat6" do
-    let(:options) { { platform: "redhat", version: "6.9" } }
+    let(:options) { { platform: "redhat", version: "6.10" } }
 
     pf_reports_true_for(:rhel?, :rpm_based?, :fedora_derived?, :redhat_based?, :el?, :rhel6?)
   end


### PR DESCRIPTION
Use the latest fauxhai data to avoid a giant pile of spec warnings

Signed-off-by: Tim Smith <tsmith@chef.io>