### PR TITLE
Avoid constant warnings in specs

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -23,8 +23,8 @@ require_relative "../knife"
 class Chef
   class Knife
     class CookbookUpload < Knife
-      CHECKSUM = "checksum".freeze
-      MATCH_CHECKSUM = /[0-9a-f]{32,}/.freeze
+      CHECKSUM ||= "checksum".freeze
+      MATCH_CHECKSUM ||= /[0-9a-f]{32,}/.freeze
 
       deps do
         require_relative "../mixin/file_class"


### PR DESCRIPTION
We get a bunch of constant warnings when running the specs.

Signed-off-by: Tim Smith <tsmith@chef.io>