### PR TITLE
Use our fork of docker-api in the kitchen tests

### DIFF
--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -8,3 +8,6 @@ gem "kitchen-dokken", "~> 2.0"
 gem "kitchen-inspec", git: "https://github.com/chef/kitchen-inspec.git", branch: "master"
 gem "inspec"
 gem "test-kitchen", git: "https://github.com/test-kitchen/test-kitchen.git", branch: "master"
+
+# avoid Ruby 2.7 warnings
+gem "docker-api", git: "https://github.com/chef/docker-api.git", branch: "master"


### PR DESCRIPTION
This avoids a giant pile of deprecation warnings

Signed-off-by: Tim Smith <tsmith@chef.io>