### PR TITLE
Update Ohai to 16.0.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: d8ab39bbf318bf9ceb25e188fff795a827097564
+  revision: 2a1f66849aae33b05a519be99ae4a475ff07260f
   branch: master
   specs:
-    ohai (16.0.19)
+    ohai (16.0.20)
       chef-config (>= 12.8, < 17)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -145,7 +145,7 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
-    byebug (11.1.2)
+    byebug (11.1.3)
     chef-telemetry (1.0.3)
       chef-config
       concurrent-ruby (~> 1.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 9b8f0d93b99395d91be29dea3f33f94cfa5a8633
+  revision: 5f57d0a9243cc4c476d2acafc9aaafd61ceb1b03
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.301.0)
+    aws-partitions (1.303.0)
     aws-sdk-core (3.94.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
This fixes constant warnings when reloading Ohai plugins

Signed-off-by: Tim Smith <tsmith@chef.io>