### PR TITLE
fix Habitat Windows package build

### DIFF
--- a/scripts/ci/ensure-minimum-viable-hab.ps1
+++ b/scripts/ci/ensure-minimum-viable-hab.ps1
@@ -1,6 +1,5 @@
-$hab_version = (hab --version)
-$hab_minor_version = $hab_version.split('.')[1]
-if ( -not $? -Or $hab_minor_version -lt 85 ) {
+[Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
+if ($hab_version -lt [Version]"0.85.0" ) {
     Write-Host "--- :habicat: Installing the version of Habitat required"
     install-habitat --version 0.85.0.20190916
     if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }


### PR DESCRIPTION
## Description
Needed to install the gems-from-git-repos first. Those are the least likely to have missing dependencies. Then we move on to installing the gems that live in subdirectories of this repo. Sometimes that fails for non-obvious reasons, but a retry seems to succeed.

Added some checks for previous status code after bare commands to exit the PowerShell script with failure when those bare commands fail.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
