### PR TITLE
fix Habitat Windows package build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,24 +29,32 @@ end
 
 ENV["CHEF_LICENSE"] = "accept-no-persist"
 
-# hack the chef-config install to run before the traditional install task
-task :super_install do
-  %w{chef-utils chef-config}.each do |gem|
-    path = ::File.join(::File.dirname(__FILE__), gem)
-    Dir.chdir(path)
-    sh("rake install")
+namespace :pre_install do
+  desc "Runs 'rake install' for the gems that live in subdirectories in this repo"
+  task :install_gems_from_dirs do
+    %w{chef-utils chef-config}.each do |gem|
+      path = ::File.join(::File.dirname(__FILE__), gem)
+      Dir.chdir(path) do
+        sh("rake install")
+      end
+    end
   end
 
-# Templating the powershell extensions so we can inject distro constants
-  template_file = ::File.join(::File.dirname(__FILE__), "distro", "templates", "powershell", "chef", "chef.psm1.erb")
-  psm1_path = ::File.join(::File.dirname(__FILE__), "distro", "powershell", "chef")
-  FileUtils.mkdir_p psm1_path
-  template = ERB.new(IO.read(template_file))
-  chef_psm1 = template.result
-  File.open(::File.join(psm1_path, "chef.psm1"), "w") { |f| f.write(chef_psm1) }
+  desc "Renders the powershell extensions with distro flavoring"
+  task :render_powershell_extension do
+    template_file = ::File.join(::File.dirname(__FILE__), "distro", "templates", "powershell", "chef", "chef.psm1.erb")
+    psm1_path = ::File.join(::File.dirname(__FILE__), "distro", "powershell", "chef")
+    FileUtils.mkdir_p psm1_path
+    template = ERB.new(IO.read(template_file))
+    chef_psm1 = template.result
+    File.open(::File.join(psm1_path, "chef.psm1"), "w") { |f| f.write(chef_psm1) }
+  end
+
+  task all: ["pre_install:install_gems_from_dirs", "pre_install:render_powershell_extension"]
 end
 
-task install: :super_install
+# hack in all the preinstall tasks to occur before the tradtional install task
+task install: "pre_install:all"
 
 # make sure we build the correct gemspec on windows
 gemspec = Gem.win_platform? ? "chef-universal-mingw32" : "chef"
@@ -55,8 +63,9 @@ Bundler::GemHelper.install_tasks name: gemspec
 # this gets appended to the normal bundler install helper
 task :install do
   chef_bin_path = ::File.join(::File.dirname(__FILE__), "chef-bin")
-  Dir.chdir(chef_bin_path)
-  sh("rake install:force")
+  Dir.chdir(chef_bin_path) do
+    sh("rake install:force")
+  end
 end
 
 task :pedant, :chef_zero_spec

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -28,6 +28,7 @@ function Invoke-Begin {
 
 function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
+    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$pkg_prefix/lib"
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
     Set-RuntimeEnv FORCE_FFI_YAJL "ext" # Always use the C-extensions because we use MRI on all the things and C is fast.
@@ -75,6 +76,11 @@ function Invoke-Prepare {
 function Invoke-Build {
     try {
         Push-Location "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
+
+        Write-BuildLine " ** Copying Chef DLLs"
+        New-Item -ItemType Directory -Force -Path "$pkg_prefix/lib"
+        Get-ChildItem ./distro/ruby_bin_folder -Filter "*.dll" | Copy-Item -Destination "$pkg_prefix/lib"
+        $env:_BUNDER_WINDOWS_DLLS_COPIED = "1"
 
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
         bundle install

--- a/scripts/ci/ensure-minimum-viable-hab.ps1
+++ b/scripts/ci/ensure-minimum-viable-hab.ps1
@@ -1,6 +1,5 @@
-$hab_version = (hab --version)
-$hab_minor_version = $hab_version.split('.')[1]
-if ( -not $? -Or $hab_minor_version -lt 85 ) {
+[Version]$hab_version = (hab --version).split(" ")[1].split("/")[0]
+if ($hab_version -lt [Version]"0.85.0" ) {
     Write-Host "--- :habicat: Installing the version of Habitat required"
     install-habitat --version 0.85.0.20190916
     if (-not $?) { throw "Hab version is older than 0.85 and could not update it." }


### PR DESCRIPTION
## Description
Needed to install the gems-from-git-repos first. Those are the least likely to have missing dependencies. Then we move on to installing the gems that live in subdirectories of this repo. Sometimes that fails for non-obvious reasons, but a retry seems to succeed.

Added some checks for previous status code after bare commands to exit the PowerShell script with failure when those bare commands fail.

## Related Issue

This is #9738 but on a branch within this repo instead of from a fork.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
