### PR TITLE
Remove the Windows version check in windows_share

### DIFF
--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -145,12 +145,8 @@ class Chef
         read_users r_users
       end
 
-      def after_created
-        raise "The windows_share resource relies on PowerShell cmdlets not present in Windows releases prior to 8/2012. Cannot continue!" if node["platform_version"].to_f < 6.3
-      end
-
-# given the string output of Get-SmbShareAccess parse out
-# arrays of full access users, change users, and read only users
+      # given the string output of Get-SmbShareAccess parse out
+      # arrays of full access users, change users, and read only users
       def parse_permissions(results_string)
         json_results = Chef::JSONCompat.from_json(results_string)
         json_results = [json_results] unless json_results.is_a?(Array) # single result is not an array


### PR DESCRIPTION
This was keeping this resource from working on Windows 8 / Windows
2012 which are 6.2. This works on all the versions of Windows we support
so there's no need to check this anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>