### PR TITLE
Add powershell_exec! helper to make conversion from powershell_out! easier

### DIFF
--- a/lib/chef/mixin/powershell_exec.rb
+++ b/lib/chef/mixin/powershell_exec.rb
@@ -20,7 +20,7 @@ require_relative "../powershell"
 # The powershell_exec mixin provides in-process access to PowerShell engine via
 # a COM interop (installed by the Chef Client installer).
 #
-# powershell_exec returns a Chef::PowerShell object that provides 3 methods:
+# powershell_exec returns a Chef::PowerShell object that provides 4 methods:
 #
 # .result - returns a hash representing the results returned by executing the
 #           PowerShell script block
@@ -28,6 +28,7 @@ require_relative "../powershell"
 #           PowerShell error stream during execution
 # .error? - returns true if there were error messages written to the PowerShell
 #           error stream during execution
+# .error! - raise Chef::PowerShell::CommandFailed if there was an error
 #
 # Some examples of usage:
 #
@@ -99,6 +100,14 @@ class Chef
       # @return [Chef::PowerShell] output
       def powershell_exec(script)
         Chef::PowerShell.new(script)
+      end
+
+      # The same as the #powershell_exec method except this will raise
+      # Chef::PowerShell::CommandFailed if the command fails
+      def powershell_exec!(script)
+        cmd = Chef::PowerShell.new(script)
+        cmd.error!
+        cmd
       end
     end
   end

--- a/lib/chef/powershell.rb
+++ b/lib/chef/powershell.rb
@@ -39,10 +39,24 @@ class Chef
       exec(script)
     end
 
+    #
+    # Was there an error running the command
+    #
+    # @return [Boolean]
+    #
     def error?
       return true if errors.count > 0
 
       false
+    end
+
+    class CommandFailed < RuntimeError; end
+
+    #
+    # @raise [Chef::PowerShell::CommandFailed] raise if the command failed
+    #
+    def error!
+      raise Chef::PowerShell::CommandFailed, "Unexpected exit in PowerShell command: #{@errors}" if error?
     end
 
     private

--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -43,7 +43,7 @@ describe Chef::Mixin::PowershellExec, :windows_only do
 
   describe "#powershell_exec!" do
     it "runs a basic command and returns a Chef::PowerShell object" do
-      expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(Chef::PowerShell::CommandFailed
+      expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(Chef::PowerShell::CommandFailed)
     end
 
     it "raises an error if the command fails" do

--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -40,4 +40,14 @@ describe Chef::Mixin::PowershellExec, :windows_only do
       expect(execution.errors[0]).to include("Runtime exception: this-should-error")
     end
   end
+
+  describe "#powershell_exec!" do
+    it "runs a basic command and returns a Chef::PowerShell object" do
+      expect(object.powershell_exec("$PSVersionTable")).to be_kind_of(Chef::PowerShell::CommandFailed
+    end
+
+    it "raises an error if the command fails" do
+      expect { object.powershell_exec("$PSVersionTable") }.to raise_error(Chef::Exceptions::Script)
+    end
+  end
 end


### PR DESCRIPTION
This is something we have in powershell_out! and shell_out! already and we use it a lot. This will make updating resources much easier.