### PR TITLE
Update bcrypt_pbkdf to 1.1.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group(:omnibus_package) do
   gem "inspec-core-bin", "~> 4.18" # need to provide the binaries for inspec
   gem "chef-vault"
   gem "ed25519" # ed25519 ssh key support done here as it's a native gem we can't put in train
-  gem "bcrypt_pbkdf" # ed25519 ssh key support done here as it's a native gem we can't put in train
+  gem "bcrypt_pbkdf", ">= 1.1.0.rc1" # ed25519 ssh key support done here as it's a native gem we can't put in train
 end
 
 group(:omnibus_package, :pry) do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,9 +139,9 @@ GEM
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
-    bcrypt_pbkdf (1.0.1)
-    bcrypt_pbkdf (1.0.1-x64-mingw32)
-    bcrypt_pbkdf (1.0.1-x86-mingw32)
+    bcrypt_pbkdf (1.1.0.rc1)
+    bcrypt_pbkdf (1.1.0.rc1-x64-mingw32)
+    bcrypt_pbkdf (1.1.0.rc1-x86-mingw32)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -454,7 +454,7 @@ PLATFORMS
 
 DEPENDENCIES
   appbundler
-  bcrypt_pbkdf
+  bcrypt_pbkdf (>= 1.1.0.rc1)
   chef!
   chef-bin!
   chef-config!


### PR DESCRIPTION
This provides working ed25519 ssh support for Windows under
Rubies 2.4-2.7.

I'm submitting this with the RC gem instead of waiting for
final release because because we don't have a timeline from the
maintainer when the RC will be finalized.

Part of this is because no decision as been made as to whether
to do a major version bump for the gem.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>


Before: 


![capture_087](https://user-images.githubusercontent.com/1130204/80404161-c29ca200-888e-11ea-9e15-50f655dffbbe.png)

After:

![capture_089](https://user-images.githubusercontent.com/1130204/80404182-c8928300-888e-11ea-90c5-286a990a34d8.png)

After:


## Related Issue

Fixes #9639

