### PR TITLE
[CI] add exitstatus checks after bare commands in PowerShell scripts

### DIFF
--- a/scripts/bk_tests/bk_run_choco.ps1
+++ b/scripts/bk_tests/bk_run_choco.ps1
@@ -7,6 +7,7 @@ choco --version
 echo "--- update bundler and rubygems"
 
 ruby -v
+if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 $env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
@@ -18,14 +19,16 @@ echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
 gem update --system $env:RUBYGEMS_VERSION
+if (-not $?) { throw "Unable to update system Rubygems" }
 gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
+if (-not $?) { throw "Unable to update Bundler" }
 bundle --version
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+if (-not $?) { throw "Unable to install gem dependencies" }
 
 echo "+++ bundle exec rspec chocolatey_package_spec"
 bundle exec rspec spec/functional/resource/chocolatey_package_spec.rb
-
-exit $LASTEXITCODE
+if (-not $?) { throw "Chef chocolatey functional tests failing." }

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -93,6 +93,7 @@ winrm quickconfig -q
 echo "--- update bundler and rubygems"
 
 ruby -v
+if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 $env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
@@ -104,14 +105,16 @@ echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
 gem update --system $env:RUBYGEMS_VERSION
+if (-not $?) { throw "Unable to update system Rubygems" }
 gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
-bundle --version
+if (-not $?) { throw "Unable to update Bundler" }
+bundle --versio
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+if (-not $?) { throw "Unable to install gem dependencies" }
 
 echo "+++ bundle exec rake spec:functional"
 bundle exec rake spec:functional
-
-exit $LASTEXITCODE
+if (-not $?) { throw "Chef functional specs failing." }

--- a/scripts/bk_tests/bk_win_integration.ps1
+++ b/scripts/bk_tests/bk_win_integration.ps1
@@ -2,7 +2,7 @@ echo "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
-# Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin") 
+# Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin")
 $Env:Path="C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ruby26\bin;C:\ci-studio-common\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\Go\bin;C:\Users\ContainerAdministrator\go\bin"
 
 winrm quickconfig -q
@@ -10,6 +10,7 @@ winrm quickconfig -q
 echo "--- update bundler and rubygems"
 
 ruby -v
+if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 $env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
@@ -21,14 +22,16 @@ echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
 gem update --system $env:RUBYGEMS_VERSION
+if (-not $?) { throw "Unable to update system Rubygems" }
 gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
-bundle --version
+if (-not $?) { throw "Unable to update Bundler" }
+bundle --versio
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+if (-not $?) { throw "Unable to install gem dependencies" }
 
 echo "+++ bundle exec rake spec:integration"
 bundle exec rake spec:integration
-
-exit $LASTEXITCODE
+if (-not $?) { throw "Chef integration specs failing." }


### PR DESCRIPTION
## Description

Need these so the PowerShell scripts will exit when bare commands fail.
Otherwise the build just keeps truckin' and the errors just pile up.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
