### PR TITLE
Fixes to support unbundled rake use

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# we need this to resolve files required by lib/chef/dist
+$LOAD_PATH.unshift(File.expand_path("../chef-config/lib", __FILE__))
+
 begin
   require_relative "tasks/rspec"
   require_relative "tasks/dependencies"
@@ -26,6 +29,8 @@ begin
 rescue LoadError => e
   puts "Skipping missing rake dep: #{e}"
 end
+
+require "bundler/gem_helper"
 
 ENV["CHEF_LICENSE"] = "accept-no-persist"
 

--- a/chef-bin/Rakefile
+++ b/chef-bin/Rakefile
@@ -1,6 +1,8 @@
 # we need to force the install in order to overwrite the binstubs from
 # old chef gems.
 
+require "bundler/gem_helper"
+
 Bundler::GemHelper.install_tasks
 
 # this is necessary to use to overwrite any chef-14 or earlier era gem which has the bin files in


### PR DESCRIPTION
We're using Bundler::GemHelper without requiring it

We're requiring `lib/chef/dist.rb` which requires files out
of `chef-config/lib/chef-config` which will escape into the
main fileset if we don't push that libdir on there.

(Also:  all of `lib/chef/dist.rb` and
`chef-config/lib/chef-config/dist.rb` needs to be pushed into
chef-utils and reading values into `lib/chef/dist.rb` from
the Chef::Config itself seems like the wrong flow of information)
