### PR TITLE
Add SLES 15 / Ubuntu 20.04 aarch64 builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -43,12 +43,15 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
+  sles-15-aarch64:
+    - sles-15-aarch64
   solaris2-5.11-i386:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
   ubuntu-18.04-aarch64:
     - ubuntu-18.04-aarch64
+    - ubuntu-20.04-aarch64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64


### PR DESCRIPTION
These work now. We should ship them for 15 as well.

Signed-off-by: Tim Smith <tsmith@chef.io>