### PR TITLE
Fix symbols and arrays in yaml conversion tool

### DIFF
--- a/lib/chef/knife/yaml_convert.rb
+++ b/lib/chef/knife/yaml_convert.rb
@@ -56,7 +56,7 @@ class Chef::Knife::YamlConvert < Chef::Knife
     end
 
     # Unfortunately, per the YAML spec, comments are stripped when we load, so we lose them on conversion
-    yaml_hash = ::YAML.safe_load(yaml_contents)
+    yaml_hash = ::YAML.safe_load(yaml_contents, permitted_classes: [Symbol])
     unless yaml_hash.is_a?(Hash) && yaml_hash.key?("resources")
       ui.fatal!("YAML recipe '#{source_file}' must contain a top-level 'resources' hash (YAML sequence), i.e. 'resources:'")
     end

--- a/lib/chef/knife/yaml_convert.rb
+++ b/lib/chef/knife/yaml_convert.rb
@@ -81,7 +81,13 @@ class Chef::Knife::YamlConvert < Chef::Knife
 
       ruby_contents << "#{type} \"#{name}\" do"
       r.each do |k, v|
-        ruby_contents << "  #{k} \"#{v}\""
+        ruby_contents <<
+          case v
+          when Array
+            "  #{k} #{v}"
+          else
+            "  #{k} \"#{v}\""
+          end
       end
       ruby_contents << "end\n"
     end

--- a/lib/chef/knife/yaml_convert.rb
+++ b/lib/chef/knife/yaml_convert.rb
@@ -81,13 +81,7 @@ class Chef::Knife::YamlConvert < Chef::Knife
 
       ruby_contents << "#{type} \"#{name}\" do"
       r.each do |k, v|
-        ruby_contents <<
-          case v
-          when Array
-            "  #{k} #{v}"
-          else
-            "  #{k} \"#{v}\""
-          end
+        ruby_contents << "  #{k} #{v.inspect}"
       end
       ruby_contents << "end\n"
     end


### PR DESCRIPTION
Potential fix for #9766.

A quick and dirty fix for the problems @chefrycar found:

* First off, unquoted strings in yaml are just strings, so there's not much to be done there.
* Symbols were not allowed previously, so now they are.
* Arrays are no longer quoted.
* Hashes are another thing that are probably not handled properly, but I did not make an attempt to do anything there.

With this input file:

```
Petes-MBP:chef pete$ cat temp.yml
---
resources:
  - type: "package"
    name: "httpd"
    action: install
  - type: "service"
    name: "httpd"
    action:
      - "enable"
      - "start"
  - type: "nachos"
    name: "httpd"
    action:
      - :enable
      - :start
```

I now get this output:

```
Petes-MBP:chef pete$ ./bin/knife yaml convert temp.yml
WARNING: No knife configuration file found. See https://docs.chef.io/config_rb/ for details.
Converted 'temp.yml' to 'temp.rb'
Petes-MBP:chef pete$ cat temp.rb
# Autoconverted recipe from temp.yml

package "httpd" do
  action "install"
end

service "httpd" do
  action ["enable", "start"]
end

nachos "httpd" do
  action [:enable, :start]
end
```

closes #9766 