### PR TITLE
Update registry helper behavior

### DIFF
--- a/lib/chef/win32/registry.rb
+++ b/lib/chef/win32/registry.rb
@@ -201,7 +201,7 @@ class Chef
       end
 
       def value_exists?(key_path, value)
-        key_exists!(key_path)
+        return false unless key_exists?(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
           return true if reg.any? { |val| safely_downcase(val) == safely_downcase(value[:name]) }
@@ -210,7 +210,7 @@ class Chef
       end
 
       def data_exists?(key_path, value)
-        key_exists!(key_path)
+        return false unless key_exists?(key_path)
         hive, key = get_hive_and_key(key_path)
         hive.open(key, ::Win32::Registry::KEY_READ | registry_system_architecture) do |reg|
           reg.each do |val_name, val_type, val_data|

--- a/spec/functional/win32/registry_spec.rb
+++ b/spec/functional/win32/registry_spec.rb
@@ -96,10 +96,10 @@ describe "Chef::Win32::Registry", :windows_only do
 
   describe "value_exists?" do
     it "throws an exception if the hive does not exist" do
-      expect { @registry.value_exists?("JKLM\\Software\\Branch\\Flower", { name: "Petals" }) }.to raise_error(Chef::Exceptions::Win32RegHiveMissing)
+      expect { @registry.value_exists?("JKLM\\Software\\Branch\\Flower", { name: "Petals" }) }.to eq(false)
     end
     it "throws an exception if the key does not exist" do
-      expect { @registry.value_exists?("HKCU\\Software\\Branch\\Flower", { name: "Petals" }) }.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect { @registry.value_exists?("HKCU\\Software\\Branch\\Flower", { name: "Petals" }) }.to eq(false)
     end
     it "returns true if the value exists" do
       expect(@registry.value_exists?("HKCU\\Software\\Root\\Branch\\Flower", { name: "Petals" })).to eq(true)
@@ -132,10 +132,10 @@ describe "Chef::Win32::Registry", :windows_only do
 
   describe "data_exists?" do
     it "throws an exception if the hive does not exist" do
-      expect { @registry.data_exists?("JKLM\\Software\\Branch\\Flower", { name: "Petals", type: :multi_string, data: %w{Pink Delicate} }) }.to raise_error(Chef::Exceptions::Win32RegHiveMissing)
+      expect { @registry.data_exists?("JKLM\\Software\\Branch\\Flower", { name: "Petals", type: :multi_string, data: %w{Pink Delicate} }) }.to eq(false)
     end
     it "throws an exception if the key does not exist" do
-      expect { @registry.data_exists?("HKCU\\Software\\Branch\\Flower", { name: "Petals", type: :multi_string, data: %w{Pink Delicate} }) }.to raise_error(Chef::Exceptions::Win32RegKeyMissing)
+      expect { @registry.data_exists?("HKCU\\Software\\Branch\\Flower", { name: "Petals", type: :multi_string, data: %w{Pink Delicate} }) }.to eq(false)
     end
     it "returns true if all the data matches" do
       expect(@registry.data_exists?("HKCU\\Software\\Root\\Branch\\Flower", { name: "Petals", type: :multi_string, data: %w{Pink Delicate} })).to eq(true)


### PR DESCRIPTION
Signed-off-by: James Massardo <jmassardo@chef.io>

## Description
This change updates the behavior of the `registry_value_exists?` and `registry_data_exists?` helpers so they return `false` instead of an exception if the value or data does not exist.

There are several use cases where a one would use a registry key guard on resources that install and/or update certain applications where the data may or may not exist or may or may not contain the desired value. This change allows one to use a single guard to on their resource instead of needing to perform several checks beforehand.

## Related Issue
Here are a couple examples of users that struggle with this issue.
* https://chef-success.slack.com/archives/C0E8C3K97/p1587758901048000
* https://discourse.chef.io/t/windows-registry-key-only-if-not-if-registry-value-exists-help/8075/2

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have run the pre-merge tests locally and they pass.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
