### PR TITLE
Avoid setting package to macports and then overriding to homebrew

### DIFF
--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -27,7 +27,7 @@ class Chef
         allow_nils
         use_multipackage_api
 
-        provides :package, os: "darwin", override: true
+        provides :package, os: "darwin"
         provides :homebrew_package
 
         include Chef::Mixin::HomebrewUser

--- a/lib/chef/provider/package/macports.rb
+++ b/lib/chef/provider/package/macports.rb
@@ -2,8 +2,6 @@ class Chef
   class Provider
     class Package
       class Macports < Chef::Provider::Package
-
-        provides :package, os: "darwin"
         provides :macports_package
 
         def load_current_resource


### PR DESCRIPTION
This seems entirely unnecessary

Signed-off-by: Tim Smith <tsmith@chef.io>