### PR TITLE
chef_client_cron: cleanup the appropriate cron job

### DIFF
--- a/lib/chef/resource/chef_client_cron.rb
+++ b/lib/chef/resource/chef_client_cron.rb
@@ -163,7 +163,7 @@ class Chef
       end
 
       action :remove do
-        cron_d new_resource.job_name do
+        declare_resource(cron_resource_type, new_resource.job_name) do
           action :delete
         end
       end


### PR DESCRIPTION
This makes it so we cleanup the right cron job on Solaris / AIX systems
that don't support cron_d

Fixes #9781

Signed-off-by: Tim Smith <tsmith@chef.io>