### PR TITLE
Fix failures to install windows packages with Ruby 2.7

### DIFF
--- a/lib/chef/provider/package/windows.rb
+++ b/lib/chef/provider/package/windows.rb
@@ -147,7 +147,7 @@ class Chef
             validate_content!
           end
 
-          super
+          super()
         end
 
         # Chef::Provider::Package action_install + action_remove call install_package + remove_package


### PR DESCRIPTION
This super needs to be changed to super() to resolve failures here.

Test recipe:
```ruby
windows_package '7zip' do
  source 'http://www.7-zip.org/a/7z938-x64.msi'
  action :install
end
```

Output:

```
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * windows_package[7zip] action install
  Recipe: <Dynamically Defined Resource>
    * remote_file[C:\chef\cache\package\7z938-x64.msi] action create
      - create new file C:\chef\cache\package\7z938-x64.msi
      - update content in file C:\chef\cache\package\7z938-x64.msi from none to 7c8e87
      (new content is binary, diff output suppressed)
    - install version 9.38.00.0 of package 7zip
```

Signed-off-by: Tim Smith <tsmith@chef.io>