### PR TITLE
Pin chef-telementry to 1.0.3 to avoid ffi build breakage 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ end
 
 gem "cheffish", ">= 14"
 
+# avoid bringing in the new http 4 gem that comes with other ffi baggage which breaks builds
+gem "chef-telemetry", "=1.0.3"
+
 group(:omnibus_package) do
   gem "appbundler"
   gem "rb-readline"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 2a1f66849aae33b05a519be99ae4a475ff07260f
+  revision: 45dff3307b8509dd52e1432c4ff1c2a6c43f316b
   branch: master
   specs:
     ohai (16.0.20)
@@ -177,7 +177,7 @@ GEM
     erubis (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    fauxhai-ng (8.0.0)
+    fauxhai-ng (8.1.0)
       net-ssh
     ffi (1.12.2)
     ffi (1.12.2-x64-mingw32)
@@ -193,7 +193,7 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hana (1.3.5)
+    hana (1.3.6)
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
@@ -284,7 +284,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     nori (2.6.0)
     parallel (1.19.1)
-    parser (2.7.1.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.3)
@@ -315,8 +315,8 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
     rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -326,7 +326,7 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+    rspec-support (3.9.3)
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -445,7 +445,7 @@ GEM
       winrm (~> 2.0)
     wisper (2.0.1)
     wmi-lite (1.0.5)
-    yard (0.9.24)
+    yard (0.9.25)
 
 PLATFORMS
   ruby
@@ -458,6 +458,7 @@ DEPENDENCIES
   chef!
   chef-bin!
   chef-config!
+  chef-telemetry (= 1.0.3)
   chef-utils!
   chef-vault
   cheffish (>= 14)

--- a/docs/dev/how_to/updating_dependencies.md
+++ b/docs/dev/how_to/updating_dependencies.md
@@ -9,7 +9,5 @@ If you want to change our constraints (change which packages and versions we acc
 In order to update everything, run `rake dependencies`.  Note that the [Gemfile.lock](Gemfile.lock) pins Windows platform gems, and to fully regenerate the lockfile, you must use the following commands, or run `rake dependencies:update_gemfile_lock`:
 
 ```bash
-bundle lock --update --add-platform ruby
-bundle lock --update --add-platform x64-mingw32
-bundle lock --update --add-platform x86-mingw32
+bundle lock --update --add-platform ruby x64-mingw32 x86-mingw32
 ```

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -33,9 +33,7 @@ namespace :dependencies do
       Dir.chdir(dir) do
         Bundler.with_unbundled_env do
           rm_f "#{dir}/Gemfile.lock"
-          sh "bundle lock --update --add-platform ruby"
-          sh "bundle lock --update --add-platform x64-mingw32"
-          sh "bundle lock --update --add-platform x86-mingw32"
+          sh "bundle lock --update --add-platform ruby x64-mingw32 x86-mingw32"
         end
       end
     end


### PR DESCRIPTION
Avoid builds exploding