### PR TITLE
Fix windows_package not allowing version to be an array

### DIFF
--- a/lib/chef/resource/msu_package.rb
+++ b/lib/chef/resource/msu_package.rb
@@ -39,7 +39,7 @@ class Chef
 
       # This is the same property as the main package resource except it has the skip docs set to true
       # This resource abuses the package resource by storing the versions of all the cabs in the MSU file
-      # in the version attribute from load current value even though those aren't technically the versio of the
+      # in the version attribute from load current value even though those aren't technically the version of the
       # msu. Since the user wouldn't actually set this we don't want it on the docs site.
       property :version, [String, Array],
         skip_docs: true,

--- a/lib/chef/resource/windows_package.rb
+++ b/lib/chef/resource/windows_package.rb
@@ -104,8 +104,8 @@ class Chef
         description: "An optional property to set the package name if it differs from the resource block's name.",
         identity: true
 
-      property :version, String,
-        description: "The version of a package to be installed or upgraded."
+      # we don't redefine the version property as a string here since we store the current value
+      # of version and that may be an array if multiple versions of a package are present on the system
 
       # windows can't take array options yet
       property :options, String,

--- a/spec/unit/resource/windows_package_spec.rb
+++ b/spec/unit/resource/windows_package_spec.rb
@@ -93,6 +93,16 @@ describe Chef::Resource::WindowsPackage, "initialize" do
     expect(resource.returns).to eq([0, 3010])
   end
 
+  it "does not accept a string for the package_name property" do
+    expect { resource.package_name(%w{this should break}) }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  # even though we don't do anything with arrays of versions we need them for current_value
+  it "accepts both Strings and Arrays for the version property" do
+    expect { resource.version "1.2.3" }.not_to raise_error
+    expect { resource.version ["1.2.3", "1.2.3.4"] }.not_to raise_error
+  end
+
   it "defaults source to the resource name" do
     # it's a little late to stub out File.absolute_path
     expect(resource.source).to include("solitaire.msi")


### PR DESCRIPTION
Due to the way the resource is built we need to be able to store an
array of current versions. I added some tests and comments so we don't
refactor this away later.

Signed-off-by: Tim Smith <tsmith@chef.io>