### PR TITLE
fix launchd provider for chef-16

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -87,7 +87,6 @@ class Chef
       end
 
       def manage_plist(action)
-        path = path
         if source
           cookbook_file path do
             cookbook_name = new_resource.cookbook if new_resource.cookbook
@@ -106,10 +105,10 @@ class Chef
       end
 
       def manage_service(action)
-        path = path
+        plist_path = path
         macosx_service label do
           service_name(new_resource.label) if new_resource.label
-          plist(path) if path
+          plist(plist_path) if plist_path
           copy_properties_from(new_resource, :session_type)
           action(action)
           only_if { manage_agent?(action) }

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -87,7 +87,7 @@ class Chef
       end
 
       def manage_plist(action)
-        path = @path
+        path = path
         if source
           cookbook_file path do
             cookbook_name = new_resource.cookbook if new_resource.cookbook
@@ -108,7 +108,7 @@ class Chef
       end
 
       def manage_service(action)
-        path = @path
+        path = path
         macosx_service label do
           name(new_resource.label) if new_resource.label
           service_name(new_resource.label) if new_resource.label

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -100,7 +100,7 @@ class Chef
           file path do
             name(path) if path
             copy_properties_from(new_resource, :backup, :group, :mode, :owner)
-            content(content) if content?
+            content(file_content) if file_content?
             action(action)
             only_if { manage_agent?(action) }
           end
@@ -148,11 +148,11 @@ class Chef
         end
       end
 
-      def content?
-        !!content
+      def file_content?
+        !!file_content
       end
 
-      def content
+      def file_content
         plist_hash = new_resource.plist_hash || gen_hash
         ::Plist::Emit.dump(plist_hash) unless plist_hash.nil?
       end

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -91,14 +91,12 @@ class Chef
         if source
           cookbook_file path do
             cookbook_name = new_resource.cookbook if new_resource.cookbook
-            name(path) if path
             copy_properties_from(new_resource, :backup, :group, :mode, :owner, :source)
             action(action)
             only_if { manage_agent?(action) }
           end
         else
           file path do
-            name(path) if path
             copy_properties_from(new_resource, :backup, :group, :mode, :owner)
             content(file_content) if file_content?
             action(action)
@@ -110,7 +108,6 @@ class Chef
       def manage_service(action)
         path = path
         macosx_service label do
-          name(new_resource.label) if new_resource.label
           service_name(new_resource.label) if new_resource.label
           plist(path) if path
           copy_properties_from(new_resource, :session_type)

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -56,8 +56,10 @@ class Chef
           if @console_user
             @console_user = Etc.getpwuid(::File.stat("/dev/console").uid).name
             logger.trace("#{new_resource} console_user: '#{@console_user}'")
-            cmd = "su -l"
-            @base_user_cmd = cmd + "#{@console_user} -c"
+
+            @base_user_cmd = "su -l #{@console_user} -c"
+            logger.trace("#{new_resource} base_user_cmd: '#{@base_user_cmd}'")
+
             # Default LaunchAgent session should be Aqua
             @session_type = "Aqua" if @session_type.nil?
           end

--- a/spec/unit/provider/launchd_spec.rb
+++ b/spec/unit/provider/launchd_spec.rb
@@ -131,8 +131,8 @@ describe Chef::Provider::Launchd do
           new_resource.program "/Library/scripts/call_mom.sh"
           new_resource.time_out 300
           new_resource.start_calendar_interval "Hour" => 10, "Weekday" => 7
-          expect(provider.content?).to be_truthy
-          expect(provider.content).to eql(test_plist)
+          expect(provider.file_content?).to be_truthy
+          expect(provider.file_content).to eql(test_plist)
         end
       end
 
@@ -147,8 +147,8 @@ describe Chef::Provider::Launchd do
           new_resource.program "/Library/scripts/call_mom.sh"
           new_resource.time_out 300
           new_resource.start_calendar_interval allowed
-          expect(provider.content?).to be_truthy
-          expect(provider.content).to eql(test_plist_multiple_intervals)
+          expect(provider.file_content?).to be_truthy
+          expect(provider.file_content).to eql(test_plist_multiple_intervals)
         end
 
         it "should allow all StartCalendarInterval keys" do
@@ -162,9 +162,9 @@ describe Chef::Provider::Launchd do
           new_resource.program "/Library/scripts/call_mom.sh"
           new_resource.time_out 300
           new_resource.start_calendar_interval allowed
-          expect(provider.content?).to be_truthy
+          expect(provider.file_content?).to be_truthy
           %w{Minute Hour Day Weekday Month}.each do |key|
-            expect(provider.content).to include("<key>#{key}</key>")
+            expect(provider.file_content).to include("<key>#{key}</key>")
           end
         end
 
@@ -188,8 +188,8 @@ describe Chef::Provider::Launchd do
       describe "hash is passed" do
         it "should produce the test_plist content from the plist_hash property" do
           new_resource.plist_hash test_hash
-          expect(provider.content?).to be_truthy
-          expect(provider.content).to eql(test_plist)
+          expect(provider.file_content?).to be_truthy
+          expect(provider.file_content).to eql(test_plist)
         end
       end
     end


### PR DESCRIPTION
the refactoring to use the DSL (orthogonal to setting this up as
a unified_mode resource) meant we have to care about lexical scoping
now.
