### PR TITLE
Switch from ASDF to a Amazon Linux extras collection for Ruby

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -322,11 +322,11 @@ steps:
   # START TEST KITCHEN ONLY
 #########################################################################
 
-- label: ":test-kitchen: Tests :aws-logo: 2"
+- label: ":test-kitchen: Tests :aws-logo: 201X"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-amazonlinux-2
+    - bundle exec kitchen test end-to-end-amazonlinux-2
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -337,11 +337,11 @@ steps:
         privileged: true
         single-use: true
 
-- label: ":test-kitchen: Tests :aws-logo: 201X"
+- label: ":test-kitchen: Tests :aws-logo: 2"
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-amazonlinux-2
+    - bundle exec kitchen test end-to-end-amazonlinux-2
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -356,7 +356,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-ubuntu-1604
+    - bundle exec kitchen test end-to-end-ubuntu-1604
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -372,7 +372,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-ubuntu-1804
+    - bundle exec kitchen test end-to-end-ubuntu-1804
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -387,7 +387,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-ubuntu-2004
+    - bundle exec kitchen test end-to-end-ubuntu-2004
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -402,7 +402,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-debian-8
+    - bundle exec kitchen test end-to-end-debian-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -417,7 +417,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-debian-9
+    - bundle exec kitchen test end-to-end-debian-9
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -432,7 +432,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-debian-10
+    - bundle exec kitchen test end-to-end-debian-10
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -447,7 +447,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-centos-6
+    - bundle exec kitchen test end-to-end-centos-6
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -462,7 +462,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-centos-7
+    - bundle exec kitchen test end-to-end-centos-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -477,7 +477,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-centos-8
+    - bundle exec kitchen test end-to-end-centos-8
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -492,7 +492,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-oraclelinux-7
+    - bundle exec kitchen test end-to-end-oraclelinux-7
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -507,7 +507,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-fedora-latest
+    - bundle exec kitchen test end-to-end-fedora-latest
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
@@ -522,7 +522,7 @@ steps:
   commands:
     - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - ~/.asdf/shims/bundle exec kitchen test end-to-end-opensuse-leap-15
+    - bundle exec kitchen test end-to-end-opensuse-leap-15
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -27,8 +27,6 @@ sudo amazon-linux-extras install ruby2.6 -y
 # Update Gems
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc
-gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2) --force
 sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
 bundle install --jobs=3 --retry=3 --path=vendor/bundle
 

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -19,18 +19,10 @@ curl -fsSL https://chef.io/chef/install.sh | sudo bash -s -- -P omnibus-toolchai
 export BUNDLE_GEMFILE=$PWD/kitchen-tests/Gemfile
 export FORCE_FFI_YAJL=ext
 export CHEF_LICENSE="accept-silent"
-export PATH=$PATH:~/.asdf/shims:/opt/asdf/bin:/opt/asdf/shims:/opt/omnibus-toolchain/embedded/bin
+export PATH=$PATH:/opt/omnibus-toolchain/embedded/bin
 
-# Install ASDF software manager
-echo "--- Installing ASDF software version manager from master"
-sudo git clone https://github.com/asdf-vm/asdf.git /opt/asdf
-. /opt/asdf/asdf.sh
-. /opt/asdf/completions/asdf.bash
-
-echo "--- Installing Ruby 2.7.1"
-/opt/asdf/bin/asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
-/opt/asdf/bin/asdf install ruby 2.7.1
-/opt/asdf/bin/asdf global ruby 2.7.1
+echo "--- Installing Ruby 2.6"
+sudo amazon-linux-extras install ruby2.6 -y
 
 # Update Gems
 echo "--- Installing Gems"

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -21,15 +21,11 @@ export FORCE_FFI_YAJL=ext
 export CHEF_LICENSE="accept-silent"
 export PATH=$PATH:/opt/omnibus-toolchain/embedded/bin
 
-echo "--- Installing Ruby 2.6"
-sudo amazon-linux-extras install ruby2.6 -y
-sudo yum install rubygem-bundler -y
-
 # Update Gems
 echo "--- Installing Gems"
 echo 'gem: --no-document' >> ~/.gemrc
 sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-bundle install --jobs=3 --retry=3 --path=vendor/bundle
+bundle install --jobs=3 --retry=3 --path=../vendor/bundle
 
 echo "--- Config information"
 

--- a/scripts/bk_tests/bk_linux_exec.sh
+++ b/scripts/bk_tests/bk_linux_exec.sh
@@ -23,6 +23,7 @@ export PATH=$PATH:/opt/omnibus-toolchain/embedded/bin
 
 echo "--- Installing Ruby 2.6"
 sudo amazon-linux-extras install ruby2.6 -y
+sudo yum install rubygem-bundler -y
 
 # Update Gems
 echo "--- Installing Gems"


### PR DESCRIPTION
Fingers crossed this speeds up our tests. We won't get the latest and greatest ruby, but we don't need that. We need a version of ruby we can install our kit in, which gives them a year to update.

Signed-off-by: Tim Smith <tsmith@chef.io>