### PR TITLE
Fix install windows features when install state is removed

### DIFF
--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -142,10 +142,10 @@ class Chef
         # @return [Array] features the user has requested to install which need installation
         def features_to_install
           # the intersection of the features to install & disabled/removed features are what needs installing
-          if new_resource.source && node["powershell_features_cache"]["removed"]
-            @install ||= new_resource.feature_name & ( node["powershell_features_cache"]["disabled"] | node["powershell_features_cache"]["removed"] )
-          else
-            @install ||= new_resource.feature_name & node["powershell_features_cache"]["disabled"]
+          @features_to_install ||= begin
+            features = node["powershell_features_cache"]["disabled"]
+            features |= node["powershell_features_cache"]["removed"] if new_resource.source
+            new_resource.feature_name & features
           end
         end
 

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -141,8 +141,8 @@ class Chef
       action_class do
         # @return [Array] features the user has requested to install which need installation
         def features_to_install
-          # the intersection of the features to install & disabled features are what needs installing
-          @install ||= new_resource.feature_name & node["powershell_features_cache"]["disabled"]
+          # the intersection of the features to install & disabled/removed features are what needs installing
+          @install ||= new_resource.feature_name & ( node["powershell_features_cache"]["disabled"] | node["powershell_features_cache"]["removed"] )
         end
 
         # @return [Array] features the user has requested to remove which need removing

--- a/lib/chef/resource/windows_feature_powershell.rb
+++ b/lib/chef/resource/windows_feature_powershell.rb
@@ -142,7 +142,11 @@ class Chef
         # @return [Array] features the user has requested to install which need installation
         def features_to_install
           # the intersection of the features to install & disabled/removed features are what needs installing
-          @install ||= new_resource.feature_name & ( node["powershell_features_cache"]["disabled"] | node["powershell_features_cache"]["removed"] )
+          if new_resource.source && node["powershell_features_cache"]["removed"]
+            @install ||= new_resource.feature_name & ( node["powershell_features_cache"]["disabled"] | node["powershell_features_cache"]["removed"] )
+          else
+            @install ||= new_resource.feature_name & node["powershell_features_cache"]["disabled"]
+          end
         end
 
         # @return [Array] features the user has requested to remove which need removing

--- a/spec/unit/resource/windows_feature_powershell_spec.rb
+++ b/spec/unit/resource/windows_feature_powershell_spec.rb
@@ -35,10 +35,6 @@ describe Chef::Resource::WindowsFeaturePowershell do
     expect(resource.feature_name).to eql(%w{snmp dhcp})
   end
 
-  it "sets the default action as :install" do
-    expect(resource.action).to eql([:install])
-  end
-
   it "supports :delete, :install, :remove actions" do
     expect { resource.action :delete }.not_to raise_error
     expect { resource.action :install }.not_to raise_error

--- a/spec/unit/resource/windows_feature_powershell_spec.rb
+++ b/spec/unit/resource/windows_feature_powershell_spec.rb
@@ -50,4 +50,14 @@ describe Chef::Resource::WindowsFeaturePowershell do
     resource.feature_name "SNMP"
     expect(resource.feature_name).to eql(["snmp"])
   end
+
+  it "install a single feature" do
+    resource.feature_name "snmp"
+    expect { resource.action :install }.not_to raise_error
+  end
+
+  it "install multi feature" do
+    resource.feature_name "SNMP, DHCP"
+    expect { resource.action :install }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
windows features were not getting installed when it's InstallState was `Removed`
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- This change handles installing features when state is removed or disabled(available)
- Works for single as well as multi-feature installation
- Earlier intersection of the features returned nil when state was `Removed` so feature was not getting installed.
- Ensured `Idempotent`  for the `windows_feature_powershell`
- Redundant test removed
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/9536
## O/P Postfix
```
PS C:\Users\Administrator\chef> Get-WindowsFeature -Name NET-Framework-Core

Display Name                                            Name                       Install State
------------                                            ----                       -------------
    [ ] .NET Framework 3.5 (includes .NET 2.0 and 3.0)  NET-Framework-Core               Removed


PS C:\Users\Administrator\chef> bundle exec chef-apply \\tsclient\Downloads\recipe-windows-feature.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * windows_feature[NET-Framework-Core] action install
    * windows_feature_powershell[NET-Framework-Core] action install
      - install Windows feature net-framework-core

PS C:\Users\Administrator\chef> Get-WindowsFeature -Name NET-Framework-Core

Display Name                                            Name                       Install State
------------                                            ----                       -------------
    [X] .NET Framework 3.5 (includes .NET 2.0 and 3.0)  NET-Framework-Core             Installed


PS C:\Users\Administrator\chef>
PS C:\Users\Administrator\chef> Get-WindowsFeature -Name Web-Net-Ext45

Display Name                                            Name                       Install State
------------                                            ----                       -------------
            [ ] .NET Extensibility 4.6                  Web-Net-Ext45                  Available


PS C:\Users\Administrator\chef> Get-WindowsFeature -Name Web-Net-Ext45

Display Name                                            Name                       Install State
------------                                            ----                       -------------
            [ ] .NET Extensibility 4.6                  Web-Net-Ext45                  Available


PS C:\Users\Administrator\chef> bundle exec chef-apply C:\Users\Administrator\Downloads\recipe-windows-feature.rb
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * windows_feature[Web-Asp-Net45, Web-Net-Ext45] action install
    * windows_feature_powershell[Web-Asp-Net45, Web-Net-Ext45] action install
      - install Windows features web-asp-net45,web-net-ext45

PS C:\Users\Administrator\chef> Get-WindowsFeature -Name Web-Net-Ext45

Display Name                                            Name                       Install State
------------                                            ----                       -------------
            [X] .NET Extensibility 4.6                  Web-Net-Ext45                  Installed


```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
