### PR TITLE
Only require the driver_name property when creating printer ports

### DIFF
--- a/lib/chef/resource/windows_printer.rb
+++ b/lib/chef/resource/windows_printer.rb
@@ -62,7 +62,7 @@ class Chef
 
       property :driver_name, String,
         description: "The exact name of printer driver installed on the system.",
-        required: true
+        required: [:create]
 
       property :location, String,
         description: "Printer location, such as `Fifth floor copy room`."


### PR DESCRIPTION
This restores the previous behavior

Signed-off-by: Tim Smith <tsmith@chef.io>