### PR TITLE
Add ssl_verify option for remote_file

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -304,7 +304,8 @@ class Chef
 
         SocketlessChefZeroClient.new(base_url)
       else
-        BasicClient.new(base_url, ssl_policy: Chef::HTTP::APISSLPolicy, keepalives: keepalives)
+        ssl_policy = @options[:ssl_verify_mode] || Chef::HTTP::APISSLPolicy
+        BasicClient.new(base_url, ssl_policy: ssl_policy, keepalives: keepalives)
       end
     end
 

--- a/lib/chef/http/ssl_policies.rb
+++ b/lib/chef/http/ssl_policies.rb
@@ -129,5 +129,23 @@ class Chef
       end
     end
 
+    # This policy is used when we want to explicitly turn on verification
+    # for a specific request regardless of the API Policy. For example, when
+    # doing a `remote_file` where the user specified `verify_mode :verify_peer`
+    class VerifyPeerSSLPolicy < DefaultSSLPolicy
+      def set_verify_mode
+        http_client.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
+    end
+
+    # This policy is used when we want to explicitly turn off verification
+    # for a specific request regardless of the API Policy. For example, when
+    # doing a `remote_file` where the user specified `verify_mode :verify_none`
+    class VerifyNoneSSLPolicy < DefaultSSLPolicy
+      def set_verify_mode
+        http_client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
+    end
+
   end
 end

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -134,6 +134,14 @@ class Chef
             logger.trace("Turning gzip compression off due to filename ending in gz")
             opts[:disable_gzip] = true
           end
+          if new_resource.ssl_verify_mode
+            opts[:ssl_verify_mode] = case new_resource.ssl_verify_mode
+                                     when :verify_none
+                                       Chef::HTTP::VerifyNoneSSLPolicy
+                                     else :verify_peer
+                                       Chef::HTTP::VerifyPeerSSLPolicy
+                                     end
+          end
           opts
         end
 

--- a/lib/chef/resource/remote_file.rb
+++ b/lib/chef/resource/remote_file.rb
@@ -94,6 +94,9 @@ class Chef
 
       property :show_progress, [ TrueClass, FalseClass ], default: false
 
+      property :ssl_verify_mode, equal_to: %i{verify_none verify_peer}, default: nil,
+        description: "Optional property to override SSL policy. If not specified, uses the SSL polify from config.rb."
+
       property :remote_user, String
 
       property :remote_domain, String

--- a/spec/unit/http/ssl_policies_spec.rb
+++ b/spec/unit/http/ssl_policies_spec.rb
@@ -166,4 +166,24 @@ describe "HTTP SSL Policy" do
     end
 
   end
+
+  describe Chef::HTTP::VerifyPeerSSLPolicy do
+
+    let(:ssl_policy) { Chef::HTTP::VerifyPeerSSLPolicy.new(unconfigured_http_client) }
+
+    it "sets the OpenSSL verify mode to verify_peer" do
+      expect(http_client.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
+
+  end
+
+  describe Chef::HTTP::VerifyNoneSSLPolicy do
+
+    let(:ssl_policy) { Chef::HTTP::VerifyNoneSSLPolicy.new(unconfigured_http_client) }
+
+    it "sets the OpenSSL verify mode to verify_peer" do
+      expect(http_client.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+    end
+
+  end
 end


### PR DESCRIPTION
## Description

Different servers have different https requirements and enforcing
the API policy on all `remote_file` resources isn't reasonable.

The logic around the HTTP clients and policies in Chef is... complex.
This approach seemed like the best one, but I'm open to others.

By default here if the user specifies nothing, `remote_file`'s http
clients will fall back to the API policy, otherwise, it'll use whatever
the specify.

And yes, Tim, I can add tests, but first I want to make sure this
approach is palatable. :)

## Related Issue

This fixes #8897

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
