### PR TITLE
Stop upgrading rubygems in tests

### DIFF
--- a/scripts/bk_tests/bk_container_prep.sh
+++ b/scripts/bk_tests/bk_container_prep.sh
@@ -12,9 +12,7 @@ if [ -f /etc/debian_version ]; then
 fi
 
 # make sure we have the omnibus_overrides specified version of rubygems / bundler
-echo "--- Install proper rubygems / bundler"
-gem update --system $(grep rubygems omnibus_overrides.rb | cut -d'"' -f2)
-gem --version
+echo "--- Install proper bundler"
 gem uninstall bundler -a -x || true
 gem install bundler -v $(grep :bundler omnibus_overrides.rb | cut -d'"' -f2)
 bundle --version

--- a/scripts/bk_tests/bk_run_choco.ps1
+++ b/scripts/bk_tests/bk_run_choco.ps1
@@ -4,23 +4,15 @@ Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table
 
 choco --version
 
-echo "--- update bundler and rubygems"
+echo "--- update bundler"
 
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
-$env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-
-$env:RUBYGEMS_VERSION=($env:RUBYGEMS_VERSION -replace '"', "")
 $env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-
-echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
-gem update --system $env:RUBYGEMS_VERSION
-if (-not $?) { throw "Unable to update system Rubygems" }
-gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
 if (-not $?) { throw "Unable to update Bundler" }
 bundle --version

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -1,5 +1,5 @@
 # The filename of the Ruby installer
-$RubyFilename = "rubyinstaller-devkit-2.6.5-1-x64.exe"
+$RubyFilename = "rubyinstaller-devkit-2.6.6-1-x64.exe"
 
 # The sha256 of the Ruby installer (capitalized?)
 $RubySHA256 = "BD2050496A149C7258ED4E2E44103756CA3A05C7328A939F0FDC97AE9616A96D"

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -90,26 +90,18 @@ echo "--- configure winrm"
 
 winrm quickconfig -q
 
-echo "--- update bundler and rubygems"
+echo "--- update bundler"
 
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
-$env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-
-$env:RUBYGEMS_VERSION=($env:RUBYGEMS_VERSION -replace '"', "")
 $env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-
-echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
-gem update --system $env:RUBYGEMS_VERSION
-if (-not $?) { throw "Unable to update system Rubygems" }
-gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
 if (-not $?) { throw "Unable to update Bundler" }
-bundle --versio
+bundle --version
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle

--- a/scripts/bk_tests/bk_win_integration.ps1
+++ b/scripts/bk_tests/bk_win_integration.ps1
@@ -7,26 +7,18 @@ $Env:Path="C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ruby
 
 winrm quickconfig -q
 
-echo "--- update bundler and rubygems"
+echo "--- update bundler"
 
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
-$env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-
-$env:RUBYGEMS_VERSION=($env:RUBYGEMS_VERSION -replace '"', "")
 $env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-
-echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
-gem update --system $env:RUBYGEMS_VERSION
-if (-not $?) { throw "Unable to update system Rubygems" }
-gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
 if (-not $?) { throw "Unable to update Bundler" }
-bundle --versio
+bundle --version
 
 echo "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle

--- a/scripts/bk_tests/bk_win_unit.ps1
+++ b/scripts/bk_tests/bk_win_unit.ps1
@@ -2,23 +2,15 @@ echo "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
-echo "--- update bundler and rubygems"
+echo "--- update bundler"
 
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
-$env:RUBYGEMS_VERSION=$(findstr rubygems omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
-
-$env:RUBYGEMS_VERSION=($env:RUBYGEMS_VERSION -replace '"', "")
 $env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-
-echo $env:RUBYGEMS_VERSION
 echo $env:BUNDLER_VERSION
 
-gem update --system $env:RUBYGEMS_VERSION
-if (-not $?) { throw "Unable to update system Rubygems" }
-gem --version
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
 if (-not $?) { throw "Unable to update Bundler" }
 bundle --version


### PR DESCRIPTION
Rubygems is built into ruby and we're not updating it anymore in our
builds. We get the version that ships in Ruby

Signed-off-by: Tim Smith <tsmith@chef.io>