### PR TITLE
Add examples to windows_security_policy

### DIFF
--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -43,6 +43,35 @@ class Chef
       description "Use the **windows_security_policy** resource to set a security policy on the Microsoft Windows platform."
       introduced "16.0"
 
+      examples <<~DOC
+      **Set Administrator Account to Enabled**:
+
+      ```ruby
+      windows_security_policy 'EnableAdminAccount' do
+        secvalue       '1'
+        action         :set
+      end
+      ```
+
+      **Rename Administrator Account**:
+
+      ```ruby
+      windows_security_policy 'NewAdministratorName' do
+        secvalue       'AwesomeChefGuy'
+        action         :set
+      end
+      ```
+
+      **Set Guest Account to Disabled**:
+
+      ```ruby
+      windows_security_policy 'EnableGuestAccount' do
+        secvalue       '0'
+        action         :set
+      end
+      ```
+      DOC
+
       property :secoption, String, name_property: true, required: true, equal_to: policy_names,
       description: "The name of the policy to be set on windows platform to maintain its security."
 

--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -72,6 +72,48 @@ class Chef
 
       introduced "16.0"
 
+      examples <<~DOC
+      **Set the SeNetworkLogonRight Privilege for the Builtin Administrators Group and Authenticated Users**:
+
+      ```ruby
+      windows_user_privilege 'Netowrk Logon Rights' do
+        privilege      'SeNetworkLogonRight'
+        users          ['BUILTIN\Administrators', 'NT AUTHORITY\Authenticated Users']
+        action         :set
+      end
+      ```
+
+      **Add the SeDenyRemoteInteractiveLogonRight Privilege to the Builtin Guests and Local Accounts User Groups**:
+
+      ```ruby
+      windows_user_privilege 'Remote interactive logon' do
+        privilege      'SeDenyRemoteInteractiveLogonRight'
+        users          ['Builtin\Guests', 'NT AUTHORITY\Local Account']
+        action         :add
+      end
+      ```
+
+      **Provide only the Builtin Guests and Administrator Groups with the SeCreatePageFile Privilege**:
+
+      ```ruby
+      windows_user_privilege 'Create Pagefile' do
+        privilege      'SeCreatePagefilePrivilege'
+        users          ['BUILTIN\Guests', 'BUILTIN\Administrators']
+        action         :set
+      end
+      ```
+
+      **Remove the SeCreatePageFile Privilege from the Builtin Guests Group**:
+
+      ```ruby
+      windows_user_privilege 'Create Pagefile' do
+        privilege      'SeCreatePagefilePrivilege'
+        users          ['BUILTIN\Guests']
+        action         :remove
+      end
+      ```
+      DOC
+
       property :principal, String,
         description: "An optional property to add the user to the given privilege. Use only with add and remove action.",
         name_property: true


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Updates examples in windows_security_policy and windows_user_privilege resources.

## Description
Resource examples were updated in chef/chef-web-docs#2488
This adds those examples to chef/chef

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
