### PR TITLE
Add note about origins of resource yaml/md files

### DIFF
--- a/tasks/docs.rb
+++ b/tasks/docs.rb
@@ -256,6 +256,11 @@ namespace :docs_site do
 
       r = {}
 
+      # Add a comment at the top stating that the resource yaml/md files are generated from chef/chef
+      r["generate_comment_1"] = "This file is generated from code in https://github.com/chef/chef/"
+      r["generate_comment_2"] = "To recommend changes to this file, make a pull request against"
+      r["generate_comment_3"] = "https://github.com/chef/chef/blob/master/lib/chef/resource/#{name}.rb"
+
       # We want all our resources to show up in the main resource reference page
       r["resource_reference"] = true
 
@@ -306,7 +311,7 @@ namespace :docs_site do
         FileUtils.mkdir_p "docs_site/#{resource}"
         # write out the yaml contents of the hash and append a --- since this is actually a yaml
         # block in the middle of a markdown page and the block needs an ending
-        File.open("docs_site/#{resource}/_index.md", "w") { |f| f.write(resource_data.to_yaml + "---") }
+        File.open("docs_site/#{resource}/_index.md", "w") { |f| f.write((resource_data.to_yaml + "---").gsub(/generate_comment_\d:/, '#')) }
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

This will add a comment to the top of each resource md/yaml file stating that the file is generated in chef/chef so make PRs there.

## Description
This adds a comment `generate_comment_x: <comment_text>`to the top of the yaml/array and then after the array is converted to yaml, the `generate_comment_x:` is replaced with `#` leaving `# <comment_text>`.

Unfortunately we can't add a comment before the yaml, Hugo won't build the page, so it has to be added to the yaml or it could go after the yaml. 

## Related Issue
People are making PRs against the resource files in chef-web-docs but they originate from chef/chef. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
