### PR TITLE
Update rubyinstaller-devkit-2.6.6-1-x64.exe SHA

### DIFF
--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -2,7 +2,7 @@
 $RubyFilename = "rubyinstaller-devkit-2.6.6-1-x64.exe"
 
 # The sha256 of the Ruby installer (capitalized?)
-$RubySHA256 = "BD2050496A149C7258ED4E2E44103756CA3A05C7328A939F0FDC97AE9616A96D"
+$RubySHA256 = "6381FA0C683D4B9F8CEEDAA6B8B1191A0C4029588F11F8C77979F6E2CC00DD98"
 
 # Where on disk to download Ruby to
 $RubyPath = "$env:temp\$RubyFilename"


### PR DESCRIPTION
This just fixes the windows functional verify tests to use the correct sha for rubyinstaller-devkit-2.6.6-1-x64.exe`

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>