### PR TITLE
Fix dnf_package version and arch property support and idempotency

### DIFF
--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -434,6 +434,8 @@ class Chef
               case action
               when :upgrade
                 if current_version.nil?
+                  # with installed_version_satisfies_version_constraints there may be a package installed, but it fails the user's
+                  # requested new_resource.version constraints
                   logger.trace("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
                   target_version_array.push(candidate_version)
                 elsif version_equals?(current_version, new_version)
@@ -467,6 +469,8 @@ class Chef
                     target_version_array.push(new_version)
                   end
                 elsif current_version.nil?
+                  # with installed_version_satisfies_version_constraints there may be a package installed, but it fails the user's
+                  # requested new_resource.version constraints
                   logger.trace("#{new_resource} #{package_name} not installed, installing #{candidate_version}")
                   target_version_array.push(candidate_version)
                 else

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -53,6 +53,11 @@ class Chef
       # [ this may arguably be useful for all package providers and it greatly simplifies the logic
       #   in the superclass that gets executed, so maybe this should always be used now? ]
       #
+      # note that when using this feature that the current_resource.version must be loaded with the
+      # correct currently installed version, without doing the filtering -- for reporting and for
+      # correctly displaying version upgrades.  that means there are 3 different arrays which must be
+      # loaded by the subclass:  candidate_version, magic_version and current_resource.version.
+      #
       subclass_directive :use_magic_version
 
       #

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -58,6 +58,9 @@ class Chef
       # correctly displaying version upgrades.  that means there are 3 different arrays which must be
       # loaded by the subclass:  candidate_version, magic_version and current_resource.version.
       #
+      # NOTE: magic_version is a terrible name, but I couldn't think of anything better, at least this
+      #       way it stands out clearly.
+      #
       subclass_directive :use_magic_version
 
       #

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -28,13 +28,32 @@ class Chef
     class Package < Chef::Provider
       extend Chef::Mixin::SubclassDirective
 
-      # subclasses declare this if they want all their arguments as arrays of packages and names
+      # subclasses declare this if they want all their arguments as arrays of packages and names.
+      # any new packages using this should also use allow_nils below.
+      #
       subclass_directive :use_multipackage_api
-      # subclasses declare this if they want sources (filenames) pulled from their package names
+
+      # subclasses declare this if they want sources (filenames) pulled from their package names.
+      # this is for package providers that take a path into the filesystem (rpm, dpkg).
+      #
       subclass_directive :use_package_name_for_source
+
       # keeps package_names_for_targets and versions_for_targets indexed the same as package_name at
-      # the cost of having the subclass needing to deal with nils
+      # the cost of having the subclass needing to deal with nils.  all providers are encouraged to
+      # migrate to using this as it simplifies dealing with package aliases in subclasses.
+      #
       subclass_directive :allow_nils
+
+      # subclasses that implement complex pattern matching using constraints, particularly the yum and
+      # dnf classes, should filter the installed version against the desired version constraint and
+      # return nil if it does not match.  this means that 'nil' does not mean that no version of the
+      # package is installed, but that the installed version does not satisfy the desired constraints.
+      # (the package plus the constraints are not installed)
+      #
+      # [ this may arguably be useful for all package providers and it greatly simplifies the logic
+      #   in the superclass that gets executed, so maybe this should always be used now? ]
+      #
+      subclass_directive :installed_version_satisfies_version_constraints
 
       #
       # Hook that subclasses use to populate the candidate_version(s)
@@ -414,19 +433,19 @@ class Chef
             each_package do |package_name, new_version, current_version, candidate_version|
               case action
               when :upgrade
-                if version_equals?(current_version, new_version)
-                  # this is an odd use case
-                  logger.trace("#{new_resource} #{package_name} #{new_version} is already installed -- you are equality pinning with an :upgrade action, this may be deprecated in the future")
-                  target_version_array.push(nil)
-                elsif version_equals?(current_version, candidate_version)
-                  logger.trace("#{new_resource} #{package_name} #{candidate_version} is already installed")
+                if current_version.nil?
+                  logger.trace("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
+                  target_version_array.push(candidate_version)
+                elsif version_equals?(current_version, new_version)
+                  # this is a short-circuit to avoid needing to (expensively) query the candidate_version which must come later
+                  logger.trace("#{new_resource} #{package_name} #{new_version} is already installed")
                   target_version_array.push(nil)
                 elsif candidate_version.nil?
                   logger.trace("#{new_resource} #{package_name} has no candidate_version to upgrade to")
                   target_version_array.push(nil)
-                elsif current_version.nil?
-                  logger.trace("#{new_resource} has no existing installed version. Installing install #{candidate_version}")
-                  target_version_array.push(candidate_version)
+                elsif version_equals?(current_version, candidate_version)
+                  logger.trace("#{new_resource} #{package_name} #{candidate_version} is already installed")
+                  target_version_array.push(nil)
                 elsif !allow_downgrade && version_compare(current_version, candidate_version) == 1
                   logger.trace("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{candidate_version}. Skipping...)")
                   target_version_array.push(nil)
@@ -436,15 +455,12 @@ class Chef
                 end
 
               when :install
-                if new_version
+                if new_version && !installed_version_satisfies_version_constraints?
                   if version_requirement_satisfied?(current_version, new_version)
                     logger.trace("#{new_resource} #{package_name} #{current_version} satisfies #{new_version} requirement")
                     target_version_array.push(nil)
                   elsif current_version && !allow_downgrade && version_compare(current_version, new_version) == 1
                     logger.warn("#{new_resource} #{package_name} has installed version #{current_version}, which is newer than available version #{new_version}. Skipping...)")
-                    target_version_array.push(nil)
-                  elsif version_equals?(current_version, candidate_version)
-                    logger.trace("#{new_resource} #{package_name} #{candidate_version} is already installed")
                     target_version_array.push(nil)
                   else
                     logger.trace("#{new_resource} #{package_name} #{current_version} needs updating to #{new_version}")
@@ -511,8 +527,14 @@ class Chef
             each_package do |package_name, new_version, current_version, candidate_version|
               next if new_version.nil? || current_version.nil?
 
-              if !version_requirement_satisfied?(current_version, new_version) && candidate_version.nil?
-                missing.push(package_name)
+              if installed_version_satisfies_version_constraints?
+                if !current_version && candidate_version.nil?
+                  missing.push(package_name)
+                end
+              else
+                if !version_requirement_satisfied?(current_version, new_version) && candidate_version.nil?
+                  missing.push(package_name)
+                end
               end
             end
             missing

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -225,22 +225,22 @@ class Chef
         def magical_version(index)
           @magical_version ||= []
           @magical_version[index] ||= if new_resource.source
-                                          python_helper.package_query(:whatinstalled, available_version(index).name, version: safe_version_array[index], arch: safe_arch_array[index], options: options)
-                                        else
-                                          python_helper.package_query(:whatinstalled, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index], options: options)
-                                        end
+                                        python_helper.package_query(:whatinstalled, available_version(index).name, version: safe_version_array[index], arch: safe_arch_array[index], options: options)
+                                      else
+                                        python_helper.package_query(:whatinstalled, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index], options: options)
+                                      end
           @magical_version[index]
         end
 
-         def current_version(index)
-           @current_version ||= []
-           @current_version[index] ||= if new_resource.source
-                                          python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index], options: options)
-                                         else
-                                          python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index], options: options)
-                                         end
-           @current_version[index]
-         end
+        def current_version(index)
+          @current_version ||= []
+          @current_version[index] ||= if new_resource.source
+                                        python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index], options: options)
+                                      else
+                                        python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index], options: options)
+                                      end
+          @current_version[index]
+        end
 
         # cache flushing is accomplished by simply restarting the python helper.  this produces a roughly
         # 15% hit to the runtime of installing/removing/upgrading packages.  correctly using multipackage

--- a/lib/chef/provider/package/dnf.rb
+++ b/lib/chef/provider/package/dnf.rb
@@ -34,7 +34,7 @@ class Chef
         allow_nils
         use_multipackage_api
         use_package_name_for_source
-        installed_version_satisfies_version_constraints
+        use_magic_version
 
         # all rhel variants >= 8 will use DNF
         provides :package, platform_family: "rhel", platform_version: ">= 8"
@@ -74,7 +74,7 @@ class Chef
 
         def load_after_resource
           # force the installed version array to repopulate
-          @installed_version = []
+          @current_version = []
           @after_resource = Chef::Resource::DnfPackage.new(new_resource.name)
           after_resource.package_name(new_resource.package_name)
           after_resource.version(get_current_versions)
@@ -98,9 +98,15 @@ class Chef
           end
         end
 
+        def magic_version
+          package_name_array.each_with_index.map do |pkg, i|
+            magical_version(i).version_with_arch
+          end
+        end
+
         def get_current_versions
           package_name_array.each_with_index.map do |pkg, i|
-            installed_version(i).version_with_arch
+            current_version(i).version_with_arch
           end
         end
 
@@ -118,7 +124,7 @@ class Chef
         alias upgrade_package install_package
 
         def remove_package(names, versions)
-          resolved_names = names.each_with_index.map { |name, i| installed_version(i).to_s unless name.nil? }
+          resolved_names = names.each_with_index.map { |name, i| magical_version(i).to_s unless name.nil? }
           dnf(options, "-y", "remove", resolved_names)
           flushcache
         end
@@ -148,10 +154,10 @@ class Chef
         def resolved_package_lock_names(names)
           names.each_with_index.map do |name, i|
             unless name.nil?
-              if installed_version(i).version.nil?
+              if magical_version(i).version.nil?
                 available_version(i).name
               else
-                installed_version(i).name
+                magical_version(i).name
               end
             end
           end
@@ -216,15 +222,25 @@ class Chef
         end
 
         # @return [Array<Version>]
-        def installed_version(index)
-          @installed_version ||= []
-          @installed_version[index] ||= if new_resource.source
+        def magical_version(index)
+          @magical_version ||= []
+          @magical_version[index] ||= if new_resource.source
                                           python_helper.package_query(:whatinstalled, available_version(index).name, version: safe_version_array[index], arch: safe_arch_array[index], options: options)
                                         else
                                           python_helper.package_query(:whatinstalled, package_name_array[index], version: safe_version_array[index], arch: safe_arch_array[index], options: options)
                                         end
-          @installed_version[index]
+          @magical_version[index]
         end
+
+         def current_version(index)
+           @current_version ||= []
+           @current_version[index] ||= if new_resource.source
+                                          python_helper.package_query(:whatinstalled, available_version(index).name, arch: safe_arch_array[index], options: options)
+                                         else
+                                          python_helper.package_query(:whatinstalled, package_name_array[index], arch: safe_arch_array[index], options: options)
+                                         end
+           @current_version[index]
+         end
 
         # cache flushing is accomplished by simply restarting the python helper.  this produces a roughly
         # 15% hit to the runtime of installing/removing/upgrading packages.  correctly using multipackage

--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -98,14 +98,24 @@ def query(command):
         q = q.available()
 
     if 'epoch' in command:
-        q = q.filterm(epoch=int(command['epoch']))
+        if not dnf.util.is_glob_pattern(command['epoch']):
+            q = q.filterm(epoch=int(command['epoch']))
     if 'version' in command:
-        q = q.filterm(version__glob=command['version'])
+        if dnf.util.is_glob_pattern(command['version']):
+            q = q.filterm(version__glob=command['version'])
+        else:
+            q = q.filterm(version=command['version'])
     if 'release' in command:
-        q = q.filterm(release__glob=command['release'])
+        if dnf.util.is_glob_pattern(command['release']):
+            q = q.filterm(release__glob=command['release'])
+        else:
+            q = q.filterm(release=command['release'])
 
     if 'arch' in command:
-        q = q.filterm(arch__glob=command['arch'])
+        if dnf.util.is_glob_pattern(command['arch']):
+            q = q.filterm(arch__glob=command['arch'])
+        else:
+            q = q.filterm(arch=command['arch'])
 
     # only apply the default arch query filter if it returns something
     archq = q.filter(arch=[ 'noarch', hawkey.detect_arch() ])
@@ -170,4 +180,4 @@ try:
             raise RuntimeError("bad command")
 finally:
     if base is not None:
-        base.closeRpmDB()
+        base.close()

--- a/lib/chef/provider/package/dnf/dnf_helper.py
+++ b/lib/chef/provider/package/dnf/dnf_helper.py
@@ -98,6 +98,9 @@ def query(command):
         q = q.available()
 
     if 'epoch' in command:
+        # We assume that any glob is "*" so just omit the filter since the dnf libraries have no
+        # epoch__glob filter.  That means "?" wildcards in epochs will fail.  The workaround is to
+        # not use the version filter here but to put the version with all the globs in the package name.
         if not dnf.util.is_glob_pattern(command['epoch']):
             q = q.filterm(epoch=int(command['epoch']))
     if 'version' in command:

--- a/lib/chef/provider/package/dnf/python_helper.rb
+++ b/lib/chef/provider/package/dnf/python_helper.rb
@@ -42,13 +42,13 @@ class Chef
           def dnf_command
             # platform-python is used for system tools on RHEL 8 and is installed under /usr/libexec
             @dnf_command ||= begin
-              cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
-                shell_out("#{f} -c 'import dnf'").exitstatus == 0
-              end
-              raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd
+                               cmd = which("platform-python", "python", "python3", "python2", "python2.7", extra_path: "/usr/libexec") do |f|
+                                 shell_out("#{f} -c 'import dnf'").exitstatus == 0
+                               end
+                               raise Chef::Exceptions::Package, "cannot find dnf libraries, you may need to use yum_package" unless cmd
 
-              "#{cmd} #{DNF_HELPER}"
-            end
+                               "#{cmd} #{DNF_HELPER}"
+                             end
           end
 
           def start

--- a/spec/functional/resource/dnf_package_spec.rb
+++ b/spec/functional/resource/dnf_package_spec.rb
@@ -931,7 +931,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be false
       end
 
-      it "with a full version pin in the name it downgrdes the package" do
+      it "with a full version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.package_name("chef_rpm")
         dnf_package.version("1.2-1")
@@ -953,7 +953,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be false
       end
 
-      it "with a partial (no release) version pin in the name it downgrdes the package" do
+      it "with a partial (no release) version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.package_name("chef_rpm")
         dnf_package.version("1.2")
@@ -974,7 +974,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be false
       end
 
-      it "with a full version pin in the name it downgrdes the package" do
+      it "with a full version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.package_name("chef_rpm-1.2-1")
         dnf_package.run_action(:upgrade)
@@ -994,7 +994,7 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be false
       end
 
-      it "with a partial (no release) version pin in the name it downgrdes the package" do
+      it "with a partial (no release) version pin in the name it downgrades the package" do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.package_name("chef_rpm-1.2")
         dnf_package.run_action(:upgrade)

--- a/spec/functional/resource/dnf_package_spec.rb
+++ b/spec/functional/resource/dnf_package_spec.rb
@@ -91,7 +91,6 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be false
-        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
       end
 
       it "does not install twice" do
@@ -128,6 +127,105 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       end
     end
 
+    context "expanded idempotency checks with version variants" do
+      %w{1.10 1* 1.10-1 1*-1 1.10-* 1*-* 0:1.10 0:1* 0:1.10-1 0:1*-1 *:1.10-* *:1*-*}.each do |vstring|
+        it "installs the rpm when #{vstring} is in the package_name" do
+          flush_cache
+          dnf_package.package_name("chef_rpm-#{vstring}")
+          dnf_package.run_action(:install)
+          expect(dnf_package.updated_by_last_action?).to be true
+        end
+
+        it "is idempotent when #{vstring} is in the package_name" do
+          preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm-#{vstring}")
+          dnf_package.run_action(:install)
+          expect(dnf_package.updated_by_last_action?).to be false
+        end
+
+        it "installs the rpm when #{vstring} is in the version property" do
+          flush_cache
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:install)
+          expect(dnf_package.updated_by_last_action?).to be true
+        end
+
+        it "is idempotent when #{vstring} is in the version property" do
+          preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:install)
+          expect(dnf_package.updated_by_last_action?).to be false
+        end
+
+        it "upgrades the rpm when #{vstring} is in the package_name" do
+          flush_cache
+          dnf_package.package_name("chef_rpm-#{vstring}")
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be true
+        end
+
+        it "is idempotent when #{vstring} is in the package_name" do
+          preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm-#{vstring}")
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be false
+        end
+
+        it "upgrades the rpm when #{vstring} is in the version property" do
+          flush_cache
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be true
+        end
+
+        it "is idempotent when #{vstring} is in the version property" do
+          preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be false
+        end
+      end
+
+      %w{1.2 1* 1.2-1 1*-1 1.2-* 1*-* 0:1.2 0:1* 0:1.2-1 0:1*-1 *:1.2-* *:1*-*}.each do |vstring|
+        it "is idempotent when #{vstring} is in the version property and there is a candidate version" do
+          preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:install)
+          expect(dnf_package.updated_by_last_action?).to be false
+          expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        end
+      end
+
+      %w{1.2 1.2-1 1.2-* 0:1.2 0:1.2-1 *:1.2-*}.each do |vstring|
+        it "is idempotent when #{vstring} is in the version property on upgrade and it doesn't match the candidate version" do
+          preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be false
+          expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        end
+      end
+
+      %w{1* 1*-1 1*-* 0:1* 0:1*-1 *:1*-*}.each do |vstring|
+        it "upgrades when #{vstring} is in the version property on upgrade and it matches the candidate version" do
+          preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+          dnf_package.package_name("chef_rpm")
+          dnf_package.version(vstring)
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be true
+          expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+          dnf_package.run_action(:upgrade)
+          expect(dnf_package.updated_by_last_action?).to be false
+        end
+      end
+    end
+
     context "with versions or globs in the name" do
       it "works with a version" do
         flush_cache
@@ -135,6 +233,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "works with an older version" do
@@ -143,6 +243,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "works with an evra" do
@@ -151,6 +253,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "works with version and release" do
@@ -159,6 +263,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "works with a version glob" do
@@ -167,6 +273,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "works with a name glob + version glob" do
@@ -175,6 +283,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "upgrades when the installed version does not match the version string" do
@@ -183,6 +293,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "downgrades when the installed version is higher than the package_name version" do
@@ -191,6 +303,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -203,6 +317,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "matches with a glob" do
@@ -212,6 +328,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "matches the vr" do
@@ -221,6 +339,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "matches the evr" do
@@ -230,6 +350,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "matches with a vr glob", :rhel_gte_8 do
@@ -239,6 +361,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "matches with an evr glob", :rhel_gte_8 do
@@ -248,6 +372,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -260,6 +386,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -270,6 +398,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs with 32-bit arch in the name" do
@@ -278,6 +408,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs with 64-bit arch in the property" do
@@ -287,6 +419,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs with 32-bit arch in the property" do
@@ -296,6 +430,30 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "installs when the 32-bit arch is in the name and the version is in the property" do
+        flush_cache
+        dnf_package.package_name("chef_rpm.i686")
+        dnf_package.version("1.10-1")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.i686$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "installs when the 64-bit arch is in the name and the version is in the property" do
+        flush_cache
+        dnf_package.package_name("chef_rpm.#{pkg_arch}")
+        dnf_package.version("1.10-1")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -306,6 +464,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "when it is met, it does nothing" do
@@ -330,6 +490,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "when it is not met by an installed rpm, it upgrades" do
@@ -338,6 +500,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with an equality constraint, when it is not met by an installed rpm, it upgrades" do
@@ -346,6 +510,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with an equality constraint, when it is met by an installed rpm, it does nothing" do
@@ -382,6 +548,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a less than constraint, when the install version matches, it does nothing" do
@@ -398,6 +566,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -424,6 +594,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs the package when the name is a path to a file" do
@@ -432,6 +604,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "downgrade on a local file with allow_downgrade true works" do
@@ -441,6 +615,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "does not downgrade the package with :install" do
@@ -475,15 +651,6 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be false
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
       end
-
-      it "is idempotent when the package is already installed and there is a version string with arch" do
-        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.version "1.2-1.#{pkg_arch}"
-        dnf_package.package_name("#{CHEF_SPEC_ASSETS}/yumrepo/chef_rpm-1.2-1.#{pkg_arch}.rpm")
-        dnf_package.run_action(:install)
-        expect(dnf_package.updated_by_last_action?).to be false
-        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
-      end
     end
 
     context "with no available version" do
@@ -502,6 +669,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -513,6 +682,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "does nothing if both are installed" do
@@ -530,6 +701,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs the first rpm if the second is installed" do
@@ -539,6 +712,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
@@ -550,6 +725,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
@@ -561,6 +738,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
@@ -572,6 +751,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.#{pkg_arch}$/)
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match(/^chef_rpm-1.10-1.i686$/)
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       # unlikely to work consistently correct, okay to deprecate the arch-array in favor of the arch in the name
@@ -597,6 +778,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "should work to enable a disabled repo" do
@@ -608,6 +791,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "when an idempotent install action is run, does not leave repos disabled" do
@@ -628,6 +813,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
   end
@@ -640,6 +827,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "throws a deprecation warning with allow_downgrade" do
@@ -647,10 +836,12 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         expect(Chef).to receive(:deprecated).with(:dnf_package_allow_downgrade, /^the allow_downgrade property on the dnf_package provider is not used/)
         preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
         dnf_package.version("1.2")
-        dnf_package.run_action(:install)
         dnf_package.allow_downgrade true
+        dnf_package.run_action(:install)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}")
+        dnf_package.run_action(:install)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -663,6 +854,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "installs the package when the name is a path to a file" do
@@ -671,6 +864,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "downgrades the package when allow_downgrade is true" do
@@ -679,6 +874,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "upgrades the package" do
@@ -687,6 +884,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "is idempotent when the package is already installed" do
@@ -715,16 +914,94 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
     context "version pinning" do
-      it "with an equality pin in the name it upgrades a prior package" do
+      it "with a full version pin it installs a later package" do
+        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm")
+        dnf_package.version("1.10-1")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a full version pin in the name it downgrdes the package" do
+        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm")
+        dnf_package.version("1.2-1")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a partial (no release) version pin it installs a later package" do
+        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm")
+        dnf_package.version("1.10")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a partial (no release) version pin in the name it downgrdes the package" do
+        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm")
+        dnf_package.version("1.2")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a full version pin it installs a later package" do
+        preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm-1.10-1")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a full version pin in the name it downgrdes the package" do
+        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm-1.2-1")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a partial (no release) version pin it installs a later package" do
         preinstall("chef_rpm-1.2-1.#{pkg_arch}.rpm")
         dnf_package.package_name("chef_rpm-1.10")
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
+      end
+
+      it "with a partial (no release) version pin in the name it downgrdes the package" do
+        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
+        dnf_package.package_name("chef_rpm-1.2")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be true
+        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a prco equality pin in the name it upgrades a prior package" do
@@ -733,14 +1010,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
-      end
-
-      it "with an equality pin in the name it downgrades a later package" do
-        preinstall("chef_rpm-1.10-1.#{pkg_arch}.rpm")
-        dnf_package.package_name("chef_rpm-1.2")
         dnf_package.run_action(:upgrade)
-        expect(dnf_package.updated_by_last_action?).to be true
-        expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a prco equality pin in the name it downgrades a later package" do
@@ -749,6 +1020,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a > pin in the name and no rpm installed it installs" do
@@ -757,6 +1030,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a < pin in the name and no rpm installed it installs" do
@@ -765,6 +1040,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a > pin in the name and matching rpm installed it does nothing" do
@@ -789,6 +1066,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "with a < pin in the name and non-matching rpm installed it downgrades" do
@@ -797,6 +1076,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:upgrade)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.2-1.#{pkg_arch}$")
+        dnf_package.run_action(:upgrade)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
   end
@@ -833,6 +1114,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "removes the package if the i686 package is installed", :intel_64bit do
@@ -841,6 +1124,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "removes the package if the prior version i686 package is installed", :intel_64bit do
@@ -849,6 +1134,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -866,6 +1153,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "removes the package if the prior version package is installed" do
@@ -873,6 +1162,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
 
       it "does nothing if the i686 package is installed" do
@@ -897,6 +1188,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^chef_rpm-1.10-1.#{pkg_arch}$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
 
@@ -907,6 +1200,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
         dnf_package.run_action(:remove)
         expect(dnf_package.updated_by_last_action?).to be true
         expect(shell_out("rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' chef_rpm").stdout.chomp).to match("^package chef_rpm is not installed$")
+        dnf_package.run_action(:remove)
+        expect(dnf_package.updated_by_last_action?).to be false
       end
     end
   end
@@ -926,6 +1221,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       dnf_package.run_action(:lock)
       expect(dnf_package.updated_by_last_action?).to be true
       expect(shell_out("dnf versionlock list").stdout.chomp).to match("^chef_rpm-0:")
+      dnf_package.run_action(:lock)
+      expect(dnf_package.updated_by_last_action?).to be false
     end
 
     it "does not lock if its already locked" do
@@ -944,6 +1241,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       dnf_package.run_action(:unlock)
       expect(dnf_package.updated_by_last_action?).to be true
       expect(shell_out("dnf versionlock list").stdout.chomp).not_to match("^chef_rpm-0:")
+      dnf_package.run_action(:unlock)
+      expect(dnf_package.updated_by_last_action?).to be false
     end
 
     it "does not unlock an already locked rpm" do
@@ -960,6 +1259,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       dnf_package.run_action(:lock)
       expect(dnf_package.updated_by_last_action?).to be true
       expect(shell_out("dnf versionlock list").stdout.chomp).to match("^chef_rpm-0:")
+      dnf_package.run_action(:lock)
+      expect(dnf_package.updated_by_last_action?).to be false
     end
 
     it "check that we can unlock based on provides" do
@@ -969,6 +1270,8 @@ describe Chef::Resource::DnfPackage, :requires_root, external: exclude_test do
       dnf_package.run_action(:unlock)
       expect(dnf_package.updated_by_last_action?).to be true
       expect(shell_out("dnf versionlock list").stdout.chomp).not_to match("^chef_rpm-0:")
+      dnf_package.run_action(:unlock)
+      expect(dnf_package.updated_by_last_action?).to be false
     end
   end
 end


### PR DESCRIPTION
This does two things:

1.  Fixes the filtering by name, version + arch.  This introduces one incompatibility which is that putting the arch in the version property was supported at one point in time with a test that I committed which doesn't seem to be used anywhere.  But we also now should correctly support mixing and matching the name with versions and arches in them combined with a version property and/or arch property.  Which is a bit crazy but it supports doing `package "openssl.i686"` with a version property.  It should now behave the same using either the property or putting the version and arch into the name.

2.  It changes the meaning of the "current_version" in the superclass (or confusingly the "installed_version" in the subclass) so that if a version of the package is installed, which does not match the requested version+arch filtering, the value is set to nil.  This is done so that the superclass can check current_version.nil? in order to check to see if a "good" package is installed or not.  This changes the semantics of that variable where previously it reported whatever version was installed.  The subclass_directive that is introduced switches between those behaviors.  The result is 2 fewer comparison operations that the superclass asks of the subclass which also speeds up execution.

This fixes many edge conditions around idempotency, along with differences in the supported APIs and idemopotency behavior between specifying the version constraints in the name and specifying the version constraints in the version property of the resource.

There's an unrelated fix to exception handling and crashes.

closes  #9763

Aha! Link: https://chef.aha.io/features/SH-120