### PR TITLE
Avoid ruby deprecation warnings in cab_package and powershell_script

### DIFF
--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -74,7 +74,7 @@ class Chef
 
         def dism_command(command)
           with_os_architecture(nil) do
-            result = shell_out("dism.exe /Online /English #{command} /NoRestart", { timeout: new_resource.timeout })
+            result = shell_out("dism.exe /Online /English #{command} /NoRestart", timeout: new_resource.timeout)
             if result.exitstatus == -2146498530
               raise Chef::Exceptions::Package, "The specified package is not applicable to this image." if result.stdout.include?("0x800f081e")
 

--- a/lib/chef/provider/powershell_script.rb
+++ b/lib/chef/provider/powershell_script.rb
@@ -94,7 +94,7 @@ class Chef
           # means a non-zero return and thus a syntactically invalid script.
 
           with_os_architecture(node, architecture: new_resource.architecture) do
-            shell_out!(validation_command, { returns: [0] })
+            shell_out!(validation_command, returns: [0])
           end
         end
       end


### PR DESCRIPTION
Simple fix to avoid these with shell_out

Signed-off-by: Tim Smith <tsmith@chef.io>