### PR TITLE
Switch end-to-end-windows-10 back to use the Linux scripts

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,7 +24,7 @@ docker_images:
   - chef
 
 pipelines:
-  - verify/public:
+  - verify:
       definition: .expeditor/verify_public.pipeline.yml
       public: true
   - verify/private:

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -17,14 +17,18 @@ steps:
 
 - label: "Kitchen Tests Windows 10"
   commands:
-    - scripts/bk_tests/bk_win_prep.ps1
+    - scripts/bk_tests/bk_linux_exec.sh
     - cd kitchen-tests
-    - kitchen test end-to-end-windows-10
+    - /opt/omnibus-toolchain/bin/bundle exec kitchen test end-to-end-windows-10
   artifact_paths:
     - $PWD/.kitchen/logs/kitchen.log
   env:
       KITCHEN_YAML: kitchen.azure.yml
   expeditor:
+    executor:
+      linux:
+        privileged: true
+        single-use: true
     secrets:
       AZURE_TENANT_ID:
         account: azure/engineering-dev-test

--- a/kitchen-tests/Gemfile
+++ b/kitchen-tests/Gemfile
@@ -8,6 +8,7 @@ gem "kitchen-dokken", "~> 2.0"
 gem "kitchen-inspec", git: "https://github.com/chef/kitchen-inspec.git", branch: "master"
 gem "inspec"
 gem "test-kitchen", git: "https://github.com/test-kitchen/test-kitchen.git", branch: "master"
+gem "kitchen-azurerm", git: "https://github.com/test-kitchen/kitchen-azurerm.git", branch: "master"
 
 # avoid Ruby 2.7 warnings
 gem "docker-api", git: "https://github.com/chef/docker-api.git", branch: "master"


### PR DESCRIPTION
kitchen is run on a linux container

Also rename the verify/public pipeline back to verify. This keeps the
history and is otherwise really just a bikeshed because they show up in
different buildkite sites.