### PR TITLE
Fix issue with unexpected nil in launchd provider

### DIFF
--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -64,7 +64,7 @@ class Chef
       action :delete do
         # If you delete a service you want to make sure its not loaded or
         # the service will be in memory and you wont be able to stop it.
-        if ::File.exists?(@path)
+        if ::File.exists?(path)
           manage_service(:disable)
         end
         manage_plist(:delete)
@@ -207,7 +207,7 @@ class Chef
 
       # @api private
       def path
-        @path = new_resource.path ? new_resource.path : gen_path_from_type
+        new_resource.path || gen_path_from_type
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fix for an issue in #9788

Given this test file:

```
launchd 'com.googlecode.munki.app_usage_monitor' do
  type 'daemon'
  action :delete
end
```

Running `chef-apply` would generate this error:
```
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * launchd[com.googlecode.munki.app_usage_monitor] action delete

    ================================================================================
    Error executing action `delete` on resource 'launchd[com.googlecode.munki.app_usage_monitor]'
    ================================================================================

    TypeError
    ---------
    no implicit conversion of nil into String

    Resource Declaration:
    ---------------------
    # In test_file

      2: launchd 'com.googlecode.munki.app_usage_monitor' do
      3:   type 'daemon'
      4:   action :delete
      5: end

    Compiled Resource:
    ------------------
    # Declared in test_file:2:in `run_chef_recipe'

    launchd("com.googlecode.munki.app_usage_monitor") do
      action [:delete]
      default_guard_interpreter :default
      declared_type :launchd
      cookbook_name "(chef-apply cookbook)"
      recipe_name "(chef-apply recipe)"
      type "daemon"
    end

    System Info:
    ------------
    chef_version=16.0.299
    platform=mac_os_x
    platform_version=10.15.4
    ruby=ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin19]
    program_name=./.git/safe/../../.bin/chef-apply
    executable=/Users/pete/work/chef/.bin/chef-apply

[2020-05-13T16:14:20-07:00] FATAL: Stacktrace dumped to /Users/pete/.chef/cache/chef-stacktrace.out
[2020-05-13T16:14:20-07:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2020-05-13T16:14:20-07:00] FATAL: TypeError: launchd[com.googlecode.munki.app_usage_monitor] ((chef-apply cookbook)::(chef-apply recipe) line 2) had an error: TypeError: no implicit conversion of nil into String
```

With this stacktrace:
```
Generated at 2020-05-13 16:01:01 -0700
TypeError: launchd[com.googlecode.munki.app_usage_monitor] ((chef-apply cookbook)::(chef-apply recipe) line 2) had an error: TypeError: no implicit conversion of nil into String
/Users/pete/work/chef/lib/chef/provider/launchd.rb:67:in `exists?'
/Users/pete/work/chef/lib/chef/provider/launchd.rb:67:in `block in <class:Launchd>'
(eval):2:in `block in action_delete'
/Users/pete/work/chef/lib/chef/provider.rb:279:in `instance_eval'
/Users/pete/work/chef/lib/chef/provider.rb:279:in `compile_and_converge_action'
(eval):2:in `action_delete'
/Users/pete/work/chef/lib/chef/provider.rb:220:in `run_action'
/Users/pete/work/chef/lib/chef/resource.rb:591:in `run_action'
/Users/pete/work/chef/lib/chef/runner.rb:74:in `run_action'
/Users/pete/work/chef/lib/chef/runner.rb:108:in `block in run_all_actions'
/Users/pete/work/chef/lib/chef/runner.rb:108:in `each'
/Users/pete/work/chef/lib/chef/runner.rb:108:in `run_all_actions'
/Users/pete/work/chef/lib/chef/runner.rb:132:in `block in converge'
/Users/pete/work/chef/lib/chef/resource_collection/resource_list.rb:96:in `block in execute_each_resource'
/Users/pete/work/chef/lib/chef/resource_collection/stepable_iterator.rb:115:in `call_iterator_block'
/Users/pete/work/chef/lib/chef/resource_collection/stepable_iterator.rb:86:in `step'
/Users/pete/work/chef/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/Users/pete/work/chef/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/Users/pete/work/chef/lib/chef/resource_collection/resource_list.rb:94:in `execute_each_resource'
/Users/pete/.asdf/installs/ruby/2.6.6/lib/ruby/2.6.0/forwardable.rb:230:in `execute_each_resource'
/Users/pete/work/chef/lib/chef/runner.rb:130:in `converge'
/Users/pete/work/chef/lib/chef/application/apply.rb:216:in `block in run_chef_recipe'
/Users/pete/work/chef/lib/chef/application/apply.rb:214:in `catch'
/Users/pete/work/chef/lib/chef/application/apply.rb:214:in `run_chef_recipe'
/Users/pete/work/chef/lib/chef/application/apply.rb:226:in `run_application'
/Users/pete/work/chef/lib/chef/application/apply.rb:239:in `run'
/Users/pete/work/chef/chef-bin/bin/chef-apply:24:in `<top (required)>'
./.git/safe/../../.bin/chef-apply:29:in `load'
./.git/safe/../../.bin/chef-apply:29:in `<main>'
```

After this PR it has this output:

```
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * launchd[com.googlecode.munki.app_usage_monitor] action delete
    * file[/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist] action delete (up to date)
     (up to date)
```