### PR TITLE
Update Chefstyle to 1.0.5, Ohai to 16.1.1, and cheffish to 15.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,19 @@
 GIT
   remote: https://github.com/chef/chefstyle.git
-  revision: 274a01b0e3fc9a350962c3ea73005e2a0d3215f2
+  revision: d8b485c06560bffe507ba519137a5aceb8ee0ac8
   branch: master
   specs:
-    chefstyle (1.0.3)
-      rubocop (= 0.82.0)
+    chefstyle (1.0.5)
+      rubocop (= 0.83.0)
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 1d3b0b74a8a7c5244878c8b8f46946a1d2205641
+  revision: 0154d81e4caa42634b416e11cc34f4abf7ae2729
   branch: master
   specs:
-    ohai (16.1.0)
+    ohai (16.1.1)
       chef-config (>= 12.8, < 17)
+      chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -158,7 +159,7 @@ GEM
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
-    cheffish (15.0.0)
+    cheffish (15.0.3)
       chef-zero (>= 14.0)
       net-ssh
     coderay (1.1.2)
@@ -238,7 +239,6 @@ GEM
       inspec-core (= 4.18.111)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
-    jaro_winkler (1.5.4)
     json (2.3.0)
     json_schemer (0.2.11)
       ecma-re-validator (~> 0.2)
@@ -287,7 +287,7 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     parslet (1.8.2)
-    pastel (0.7.3)
+    pastel (0.7.4)
       equatable (~> 0.6)
       tty-color (~> 0.5)
     plist (3.5.0)
@@ -304,7 +304,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -317,7 +317,7 @@ GEM
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.1)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-its (1.3.0)
@@ -330,8 +330,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.82.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -359,7 +358,7 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.0.1)
-    tins (1.24.1)
+    tins (1.25.0)
       sync
     tomlrb (1.3.0)
     train-core (3.2.28)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: aa7a7eb9f199cfa80e0bcc64ec1fdfeede11ba4b
+  revision: 74e9d02cf7f9b164d67789a0a0a7e167143db6fb
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,16 +32,16 @@ GEM
     artifactory (3.0.12)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.310.0)
-    aws-sdk-core (3.94.1)
+    aws-partitions (1.314.0)
+    aws-sdk-core (3.95.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.30.0)
+    aws-sdk-kms (1.31.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.63.1)
+    aws-sdk-s3 (1.64.0)
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.0.275)
+    chef (16.0.287)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.0.275)
-      chef-utils (= 16.0.275)
+      chef-config (= 16.0.287)
+      chef-utils (= 16.0.287)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -98,12 +98,12 @@ GEM
       train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (16.0.275-universal-mingw32)
+    chef (16.0.287-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.0.275)
-      chef-utils (= 16.0.275)
+      chef-config (= 16.0.287)
+      chef-utils (= 16.0.287)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -145,15 +145,15 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.0.275)
+    chef-config (16.0.287)
       addressable
-      chef-utils (= 16.0.275)
+      chef-utils (= 16.0.287)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
-    chef-utils (16.0.275)
+    chef-utils (16.0.287)
     chef-vault (4.0.1)
     chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
@@ -259,7 +259,7 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    pastel (0.7.3)
+    pastel (0.7.4)
       equatable (~> 0.6)
       tty-color (~> 0.5)
     pedump (0.5.4)
@@ -272,7 +272,7 @@ GEM
     plist (3.5.0)
     progressbar (1.10.1)
     proxifier (1.0.3)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     rack (2.2.2)
     rainbow (3.0.0)
     retryable (3.0.5)


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>