### PR TITLE
Refactor verify pipeline to use Ruby 2.7 on Windows docker image

### DIFF
--- a/.expeditor/verify_public.pipeline.yml
+++ b/.expeditor/verify_public.pipeline.yml
@@ -201,42 +201,45 @@ steps:
         privileged: true
         shell: ["powershell", "-Command"]
 
-#########################################################################
-# Tests Ruby 2.6
-#########################################################################
-
-- label: "Integration Windows :ruby: 2.6"
+- label: "Integration Windows :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_win_integration.ps1
   expeditor:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.7
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
         shell: ["powershell", "-Command"]
 
-- label: "Chocolatey Windows :ruby: 2.6"
+- label: "Chocolatey Windows :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_run_choco.ps1
   expeditor:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.7
         shell: ["powershell", "-Command"]
 
-- label: "Unit Windows :ruby: 2.6"
+- label: "Unit Windows :ruby: 2.7"
   commands:
     - /workdir/scripts/bk_tests/bk_win_unit.ps1
   expeditor:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.7
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
         shell: ["powershell", "-Command"]
+
+#########################################################################
+# Tests Ruby 2.6
+#########################################################################
 
 - label: "Chefstyle :ruby: 2.6"
   commands:

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -1,112 +1,43 @@
-# The filename of the Ruby installer
-$RubyFilename = "rubyinstaller-devkit-2.7.1-1-x64.exe"
-
-# The sha256 of the Ruby installer (capitalized?)
-$RubySHA256 = "B22C5C1C819A53A1676CCA3410E3FF1BB39A9510C0CFD1E7BA19A728AE4FE86F"
-
-# Where on disk to download Ruby to
-$RubyPath = "$env:temp\$RubyFilename"
-
-# Where to download Ruby from:
-$RubyS3Path = "s3://public-cd-buildkite-cache/$RubyFilename"
-
-Function DownloadRuby
-{
-  $RandDigits = Get-Random
-  echo "Downloading Ruby + DevKit"
-
-  aws s3 cp "$RubyS3Path" "$RubyPath.$RandDigits" | Out-Null # Out-Null is a hack to wait for the process to complete
-
-  if ($LASTEXITCODE -ne 0) {
-    echo "aws s3 download failed: $LASTEXITCODE"
-    exit $LASTEXITCODE
-  }
-
-  $FileHash = (Get-FileHash "$RubyPath.$RandDigits" -Algorithm SHA256).Hash
-  If ($FileHash -eq $RubySHA256) {
-    echo "Downloaded SHA256 matches: $FileHash"
-  } Else {
-    echo "Downloaded file hash $FileHash does not match desired $RubySHA256"
-    exit 1
-  }
-
-  # On a shared filesystem, sometimes a good file appears while we are downloading
-  If (Test-Path $RubyPath) {
-    $FileHash = (Get-FileHash "$RubyPath" -Algorithm SHA256).Hash
-    If ($FileHash -eq $RubySHA256) {
-      echo "A matching file appeared while downloading, using it."
-      Remove-Item "$RubyPath.$RandDigits" -Force
-      Return
-    } Else {
-      echo "Existing file does not match, bad hash: $FileHash"
-      Remove-Item $RubyPath -Force
-    }
-  }
-
-  echo "Moving file installer into place"
-  Rename-Item -Path "$RubyPath.$RandDigits" -NewName $RubyFilename
-}
-
-Function InstallRuby
-{
-  If (Test-Path $RubyPath) {
-    echo "$RubyPath already exists"
-
-    $FileHash = (Get-FileHash "$RubyPath" -Algorithm SHA256).Hash
-    If ($FileHash -eq $RubySHA256) {
-      echo "Found matching Ruby + DevKit on disk"
-    } Else {
-      echo "SHA256 hash mismatch, re-downloading"
-      DownloadRuby
-    }
-  } Else {
-    echo "No Ruby found at $RubyPath, downloading"
-    DownloadRuby
-  }
-
-  echo "Installing Ruby + DevKit"
-  Start-Process $RubyPath -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
-
-  echo "Cleaning up installation"
-  Remove-Item $RubyPath -Force -ErrorAction SilentlyContinue
-}
-
-echo "--- system details"
+Write-Output "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
 # chocolatey functional tests fail so delete the chocolatey binary to avoid triggering them
 Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyContinue
 
-echo "--- install ruby + devkit"
 $ErrorActionPreference = 'Stop'
 
-InstallRuby
+Write-Output "--- Enable Ruby 2.7"
+Write-Output "Add Uru to Environment PATH"
+$env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
+[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-# Set-Item -Path Env:Path -Value to include ruby26
-$Env:Path+=";C:\ruby26\bin"
+Write-Output "Register Installed Ruby Version 2.7 With Uru"
+Start-Process "C:\Program Files (x86)\Uru\uru_rt.exe" -ArgumentList 'admin add C:\ruby27\bin' -Wait
+uru 271
+if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
 
-echo "--- configure winrm"
+Write-Output "--- configure winrm"
 
 winrm quickconfig -q
 
-echo "--- update bundler"
+Write-Output "--- update bundler"
 
 ruby -v
 if (-not $?) { throw "Can't run Ruby. Is it installed?" }
 
 $env:BUNDLER_VERSION=$(findstr bundler omnibus_overrides.rb | %{ $_.split(" ")[3] })
 $env:BUNDLER_VERSION=($env:BUNDLER_VERSION -replace '"', "")
-echo $env:BUNDLER_VERSION
+Write-Output $env:BUNDLER_VERSION
 
 gem install bundler -v $env:BUNDLER_VERSION --force --no-document --quiet
 if (-not $?) { throw "Unable to update Bundler" }
 bundle --version
 
-echo "--- bundle install"
+Write-Output "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
 if (-not $?) { throw "Unable to install gem dependencies" }
 
-echo "+++ bundle exec rake spec:functional"
+Write-Output "+++ bundle exec rake spec:functional"
 bundle exec rake spec:functional
 if (-not $?) { throw "Chef functional specs failing." }

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -35,7 +35,7 @@ if (-not $?) { throw "Unable to update Bundler" }
 bundle --version
 
 Write-Output "--- bundle install"
-bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+bundle install --jobs=3 --retry=3 --without omnibus_package
 if (-not $?) { throw "Unable to install gem dependencies" }
 
 Write-Output "+++ bundle exec rake spec:functional"

--- a/scripts/bk_tests/bk_win_integration.ps1
+++ b/scripts/bk_tests/bk_win_integration.ps1
@@ -3,7 +3,7 @@ $PrepScript = Join-Path $CurrentDirectory "bk_win_prep.ps1"
 Invoke-Expression $PrepScript
 
 # Set-Item -Path Env:Path -Value ($Env:Path + ";C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin")
-$Env:Path="C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ruby26\bin;C:\ci-studio-common\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\Go\bin;C:\Users\ContainerAdministrator\go\bin"
+$Env:Path="C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\ruby27\bin;C:\ci-studio-common\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\Go\bin;C:\Users\ContainerAdministrator\go\bin"
 
 winrm quickconfig -q
 

--- a/scripts/bk_tests/bk_win_prep.ps1
+++ b/scripts/bk_tests/bk_win_prep.ps1
@@ -16,5 +16,5 @@ if (-not $?) { throw "Unable to update Bundler" }
 bundle --version
 
 echo "--- bundle install"
-bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+bundle install --jobs=3 --retry=3 --without omnibus_package
 if (-not $?) { throw "Unable to install gem dependencies" }


### PR DESCRIPTION
## Description

This PR modifies the verify pipeline to use Ruby 2.7 on a Windows 2019 docker image.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Related Issue

https://github.com/chef/chef/issues/9853

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
