### PR TITLE
Modify verify pipeline to use rubydistros windows-2019 docker image

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -163,6 +163,7 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.6
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist
@@ -184,6 +185,7 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.6
         shell: ["powershell", "-Command"]
 
 - label: "Unit Specs Windows :ruby: 2.6"
@@ -193,6 +195,7 @@ steps:
     executor:
       docker:
         host_os: windows
+        image: rubydistros/windows-2019:2.6
         environment:
           - FORCE_FFI_YAJL=ext
           - CHEF_LICENSE=accept-no-persist

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -1,101 +1,32 @@
-# The filename of the Ruby installer
-$RubyFilename = "rubyinstaller-devkit-2.6.5-1-x64.exe"
-
-# The sha256 of the Ruby installer (capitalized?)
-$RubySHA256 = "BD2050496A149C7258ED4E2E44103756CA3A05C7328A939F0FDC97AE9616A96D"
-
-# Where on disk to download Ruby to
-$RubyPath = "$env:temp\$RubyFilename"
-
-# Where to download Ruby from:
-$RubyS3Path = "s3://public-cd-buildkite-cache/$RubyFilename"
-
-Function DownloadRuby
-{
-  $RandDigits = Get-Random
-  echo "Downloading Ruby + DevKit"
-
-  aws s3 cp "$RubyS3Path" "$RubyPath.$RandDigits" | Out-Null # Out-Null is a hack to wait for the process to complete
-
-  if ($LASTEXITCODE -ne 0) {
-    echo "aws s3 download failed: $LASTEXITCODE"
-    exit $LASTEXITCODE
-  }
-
-  $FileHash = (Get-FileHash "$RubyPath.$RandDigits" -Algorithm SHA256).Hash
-  If ($FileHash -eq $RubySHA256) {
-    echo "Downloaded SHA256 matches: $FileHash"
-  } Else {
-    echo "Downloaded file hash $FileHash does not match desired $RubySHA256"
-    exit 1
-  }
-
-  # On a shared filesystem, sometimes a good file appears while we are downloading
-  If (Test-Path $RubyPath) {
-    $FileHash = (Get-FileHash "$RubyPath" -Algorithm SHA256).Hash
-    If ($FileHash -eq $RubySHA256) {
-      echo "A matching file appeared while downloading, using it."
-      Remove-Item "$RubyPath.$RandDigits" -Force
-      Return
-    } Else {
-      echo "Existing file does not match, bad hash: $FileHash"
-      Remove-Item $RubyPath -Force
-    }
-  }
-
-  echo "Moving file installer into place"
-  Rename-Item -Path "$RubyPath.$RandDigits" -NewName $RubyFilename
-}
-
-Function InstallRuby
-{
-  If (Test-Path $RubyPath) {
-    echo "$RubyPath already exists"
-
-    $FileHash = (Get-FileHash "$RubyPath" -Algorithm SHA256).Hash
-    If ($FileHash -eq $RubySHA256) {
-      echo "Found matching Ruby + DevKit on disk"
-    } Else {
-      echo "SHA256 hash mismatch, re-downloading"
-      DownloadRuby
-    }
-  } Else {
-    echo "No Ruby found at $RubyPath, downloading"
-    DownloadRuby
-  }
-
-  echo "Installing Ruby + DevKit"
-  Start-Process $RubyPath -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait
-
-  echo "Cleaning up installation"
-  Remove-Item $RubyPath -Force -ErrorAction SilentlyContinue
-}
-
-echo "--- system details"
+Write-Output "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
 Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
 
 # chocolatey functional tests fail so delete the chocolatey binary to avoid triggering them
 Remove-Item -Path C:\ProgramData\chocolatey\bin\choco.exe -ErrorAction SilentlyContinue
 
-echo "--- install ruby + devkit"
 $ErrorActionPreference = 'Stop'
 
-InstallRuby
+Write-Output "--- Enable Ruby 2.6"
+Write-Output "Add Uru to Environment PATH"
+$env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
+[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-# Set-Item -Path Env:Path -Value to include ruby26
-$Env:Path+=";C:\ruby26\bin"
+Write-Output "Register Installed Ruby Version 2.6 With Uru"
+Start-Process "C:\Program Files (x86)\Uru\uru_rt.exe" -ArgumentList 'admin add C:\ruby26\bin' -Wait
+uru 266
+if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
 
-echo "--- configure winrm"
+Write-Output "--- configure winrm"
 
 winrm quickconfig -q
 ruby -v
 bundle --version
 
-echo "--- bundle install"
+Write-Output "--- bundle install"
 bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
 
-echo "+++ bundle exec rake spec:functional"
+Write-Output "+++ bundle exec rake spec:functional"
 bundle exec rake spec:functional
 
 exit $LASTEXITCODE

--- a/scripts/bk_tests/bk_win_functional.ps1
+++ b/scripts/bk_tests/bk_win_functional.ps1
@@ -24,7 +24,7 @@ ruby -v
 bundle --version
 
 Write-Output "--- bundle install"
-bundle install --jobs=3 --retry=3 --without omnibus_package docgen chefstyle
+bundle install --jobs=3 --retry=3 --without omnibus_package
 
 Write-Output "+++ bundle exec rake spec:functional"
 bundle exec rake spec:functional


### PR DESCRIPTION
## Description
This PR modifies the verify pipeline to use the rubydistros project's windows-2019 ruby 2.6 image.

## Related Issue
https://github.com/chef/chef/issues/9853

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
