### PR TITLE
Fix ruby 2.7 keyword argument warning.

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -149,7 +149,7 @@ class Chef
               # this must come before other methods like /etc/hostname and /etc/sysconfig/network
               declare_resource(:execute, "hostnamectl set-hostname #{new_resource.hostname}") do
                 notifies :reload, "ohai[reload hostname]"
-                not_if { shell_out!("hostnamectl status", { returns: [0, 1] }).stdout =~ /Static hostname:\s*#{new_resource.hostname}\s*$/ }
+                not_if { shell_out!("hostnamectl status", returns: [0, 1]).stdout =~ /Static hostname:\s*#{new_resource.hostname}\s*$/ }
               end
             when ::File.exist?("/etc/hostname")
               # debian family uses /etc/hostname

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -146,7 +146,7 @@ shared_context Chef::Resource::WindowsScript do
       shared_examples_for "a script whose file system location cannot be accessed by other non-admin users" do
         let(:ruby_access_command) { file_access_command }
         it "generates a script in the local file system that prevents read access to other non-admin users" do
-          shell_out!(access_command, { user: windows_nonadmin_user, password: windows_nonadmin_user_password, returns: [access_denied_sentinel] })
+          shell_out!(access_command, user: windows_nonadmin_user, password: windows_nonadmin_user_password, returns: [access_denied_sentinel])
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Fix for #9879.