### PR TITLE
Added armv6l and armv7l to arm? and armhf? helpers

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/architecture.rb
+++ b/chef-utils/lib/chef-utils/dsl/architecture.rb
@@ -110,17 +110,17 @@ module ChefUtils
       # @return [Boolean]
       #
       def arm?(node = __getnode)
-        %w{armhf aarch64 arm64 arch64}.include?(node["kernel"]["machine"])
+        %w{armv6l armv7l armhf aarch64 arm64 arch64}.include?(node["kernel"]["machine"])
       end
 
-      # Determine if the current architecture is 32-bit ARM.
+      # Determine if the current architecture is 32-bit ARM hard float.
       #
       # @since 15.5
       #
       # @return [Boolean]
       #
       def armhf?(node = __getnode)
-        %w{armhf}.include?(node["kernel"]["machine"])
+        %w{armv6l armv7l armhf}.include?(node["kernel"]["machine"])
       end
 
       # Determine if the current architecture is s390x.

--- a/chef-utils/spec/unit/dsl/architecture_spec.rb
+++ b/chef-utils/spec/unit/dsl/architecture_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe ChefUtils::DSL::Architecture do
 
     arch_reports_true_for(:armhf?, :_32_bit?, :arm?)
   end
+  context "on armv6l" do
+    let(:arch) { "armhf" }
+
+    arch_reports_true_for(:armhf?, :_32_bit?, :arm?)
+  end
+  context "on armv7l" do
+    let(:arch) { "armhf" }
+
+    arch_reports_true_for(:armhf?, :_32_bit?, :arm?)
+  end
+
   context "on s390" do
     let(:arch) { "s390" }
 


### PR DESCRIPTION
armv6l is Raspberry Pi 1/Zero
armv7l is Raspberry Pi 2,3,4 BeagleBone Black
Tested with Raspbian 10, Debian 10, Centos 7

This support was present in chef-sugar.

Signed-off-by: Matt Ray <github@mattray.dev>