### PR TITLE
Fix bootstrapping windows from linux

### DIFF
--- a/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
+++ b/lib/chef/knife/bootstrap/templates/windows-chef-client-msi.erb
@@ -202,10 +202,12 @@ If !ERRORLEVEL!==0 (
   ) else (
       @echo Installation completed successfully
       del /f /q "%CHEF_CLIENT_MSI_LOG_PATH%"
-    )
+  )
 
 <% end %>
 
+@rem This line is required to separate the key_create label from the "block boundary"
+@rem Removing these lines will cause the error "The system cannot find the batch label specified - key_create"
 :key_create
 @endlocal
 

--- a/lib/chef/knife/core/windows_bootstrap_context.rb
+++ b/lib/chef/knife/core/windows_bootstrap_context.rb
@@ -41,6 +41,21 @@ class Chef
           super(config, run_list, chef_config, secret)
         end
 
+        # This is a duplicate of ChefConfig::PathHelper.cleanpath, however
+        # this presumes Windows so we can avoid changing the method definitions
+        # across Chef, ChefConfig, and ChefUtils for the circumstance where
+        # the methods are being run for a system other than the one Ruby is
+        # executing on.
+        #
+        # We only need to cleanpath the paths that we are passing to cmd.exe,
+        # anything written to a configuration file or passed as an argument
+        # will be interpreted by ruby later and do the right thing.
+        def cleanpath(path)
+          path = Pathname.new(path).cleanpath.to_s
+          path = path.gsub(File::SEPARATOR, '\\')
+          path
+        end
+
         def validation_key
           if File.exist?(File.expand_path(chef_config[:validation_key]))
             IO.read(File.expand_path(chef_config[:validation_key]))
@@ -262,7 +277,7 @@ class Chef
         end
 
         def bootstrap_directory
-          ChefConfig::Config.etc_chef_dir(true)
+          cleanpath(ChefConfig::Config.etc_chef_dir(true))
         end
 
         def local_download_path


### PR DESCRIPTION
Similar to the changes in #9371, we need c_chef_dir and c_opscode_dir in Chef::Knife::Core::WindowsBootstrapContext to be able to be hinted to act as if on Windows for the purposes of bootstrapping a windows system from a linux system. This also means that hint getting all the way to PathHelper.cleanpath.

Also fixes #9844 by putting some black magic worksforme in the windows bootstrap batch script.