### PR TITLE
Chef-16.1 breaking change

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -950,16 +950,7 @@ class Chef
     def self.resource_name(name = NOT_PASSED)
       # Setter
       if name != NOT_PASSED
-        if name
-          @resource_name = name.to_sym
-          name = name.to_sym
-          # FIXME: determine a way to deprecate this magic behavior
-          unless Chef::ResourceResolver.includes_handler?(name, self)
-            provides name
-          end
-        else
-          @resource_name = nil
-        end
+        @resource_name = name.to_sym rescue nil
       end
 
       @resource_name = nil unless defined?(@resource_name)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -492,6 +492,20 @@ describe Chef::Resource do
       expect(r.resource_name).to eq :blah
       expect(r.declared_type).to eq :d
     end
+
+    # This tests some somewhat confusing behavior that used to occur due to the resource_name call
+    # automatically wiring up the old canonical provides line.
+    it "setting resoure_name does not override provides in prior resource" do
+      c1 = Class.new(Chef::Resource) do
+        resource_name :self_resource_name_test_4
+        provides :self_resource_name_test_4
+      end
+      c2 = Class.new(Chef::Resource) do
+        resource_name :self_resource_name_test_4
+        provides(:self_resource_name_test_4) { false } # simulates any filter that does not match
+      end
+      expect(Chef::Resource.resource_for_node(:self_resource_name_test_4, node)).to eql(c1)
+    end
   end
 
   describe "to_json" do


### PR DESCRIPTION
This is a breaking change to fix an intentionally breaking change in Chef 16.0 to remove the canonical DSL #9206 with unintended side effects #9885.  Breaking behavior differently, but correctly, without the side effects.

The new behavior is that a resource which relies upon the resource_name
statement to wire the resource up to the DSL will fail (although the
very old wiring of the "<cookbook_name>_<resource_filename>" continues
to work).

So for a resource which does not get its DSL wiring from the filename,
only declaring a resource_name will fail:

```
resource_name :foo
```

This can be fixed by adding an explicit `provides` line (which is
backwards compatible):

```
resource_name :foo
provides :foo
```

If backwards compatibility is not a concern, then post-16.0 the
resource_name call can be completely dropped:

```
provides :foo
```

This is a vastly simpler backwards compatibility break than the
unintentional break in #9885, which is difficult to describe and
to detect.

The rules going forward are fairly simple to explain:

1.  The resource_name now only sets the resource_name.
2.  The old behavior of the fallback resource_name and DSL wiring
    based on the filename is preserved (unless the values are set).
3.  In Chef 16, The first provides line will set the resource_name if
    it has not already been set, allowing the resource_name to be
    omitted.

It is recommended that all resources only set provides lines, the
use of the fallback filename-based wiring is discouraged and
explicitly setting the resource_name is discouraged.
