### PR TITLE
Update our usage of OpenSSL::Digest to avoid Ruby 3 breaking change

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -69,7 +69,7 @@ class Chef
           private
 
           def calc_checksum(value)
-            OpenSSL::Digest::MD5.hexdigest(value)
+            OpenSSL::Digest.hexdigest("MD5", value)
           end
         end
       end

--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -39,9 +39,9 @@ class Chef
 
     def generate_checksum(file)
       if file.is_a?(StringIO)
-        checksum_io(file, OpenSSL::Digest::SHA256.new)
+        checksum_io(file, OpenSSL::Digest.new("SHA256"))
       else
-        checksum_file(file, OpenSSL::Digest::SHA256.new)
+        checksum_file(file, OpenSSL::Digest.new("SHA256"))
       end
     end
 
@@ -50,11 +50,11 @@ class Chef
     end
 
     def generate_md5_checksum_for_file(file)
-      checksum_file(file, OpenSSL::Digest::MD5.new)
+      checksum_file(file, OpenSSL::Digest.new("MD5"))
     end
 
     def generate_md5_checksum(io)
-      checksum_io(io, OpenSSL::Digest::MD5.new)
+      checksum_io(io, OpenSSL::Digest.new("MD5"))
     end
 
     private

--- a/lib/chef/encrypted_data_bag_item/decryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/decryptor.rb
@@ -158,7 +158,7 @@ class Chef::EncryptedDataBagItem
             d = OpenSSL::Cipher.new(algorithm)
             d.decrypt
             # We must set key before iv: https://bugs.ruby-lang.org/issues/8221
-            d.key = OpenSSL::Digest::SHA256.digest(key)
+            d.key = OpenSSL::Digest.digest("SHA256", key)
             d.iv = iv
             d
           end

--- a/lib/chef/encrypted_data_bag_item/encryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/encryptor.rb
@@ -102,7 +102,7 @@ class Chef::EncryptedDataBagItem
           encryptor = OpenSSL::Cipher.new(algorithm)
           encryptor.encrypt
           # We must set key before iv: https://bugs.ruby-lang.org/issues/8221
-          encryptor.key = OpenSSL::Digest::SHA256.digest(key)
+          encryptor.key = OpenSSL::Digest.digest("SHA256", key)
           @iv ||= encryptor.random_iv
           encryptor.iv = @iv
           encryptor

--- a/lib/chef/key.rb
+++ b/lib/chef/key.rb
@@ -252,7 +252,7 @@ class Chef
           OpenSSL::ASN1::Integer.new(openssl_key_object.public_key.n),
           OpenSSL::ASN1::Integer.new(openssl_key_object.public_key.e),
         ])
-        OpenSSL::Digest::SHA1.hexdigest(data_string.to_der).scan(/../).join(":")
+        OpenSSL::Digest.hexdigest("SHA1", data_string.to_der).scan(/../).join(":")
       end
 
       def list(keys, actor, load_method_symbol, inflate)

--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -218,7 +218,7 @@ class Chef
         # Chef 12 backward compatibility
         ::OpenSSL::PKey::EC.send(:alias_method, :private?, :private_key?)
 
-        request.sign(key, ::OpenSSL::Digest::SHA256.new)
+        request.sign(key, ::OpenSSL::Digest.new("SHA256"))
         request
       end
 
@@ -289,7 +289,7 @@ class Chef
         cert.add_extension ef.create_extension("authorityKeyIdentifier",
           "keyid:always,issuer:always")
 
-        cert.sign(key, ::OpenSSL::Digest::SHA256.new)
+        cert.sign(key, ::OpenSSL::Digest.new("SHA256"))
         cert
       end
 
@@ -319,7 +319,7 @@ class Chef
         crl.add_extension ::OpenSSL::X509::Extension.new("crlNumber", ::OpenSSL::ASN1::Integer(1))
         crl.add_extension ef.create_extension("authorityKeyIdentifier",
           "keyid:always,issuer:always")
-        crl.sign(ca_private_key, ::OpenSSL::Digest::SHA256.new)
+        crl.sign(ca_private_key, ::OpenSSL::Digest.new("SHA256"))
         crl
       end
 
@@ -398,7 +398,7 @@ class Chef
           ::OpenSSL::ASN1::Integer(get_next_crl_number(crl)))]
         crl.add_extension ef.create_extension("authorityKeyIdentifier",
           "keyid:always,issuer:always")
-        crl.sign(ca_private_key, ::OpenSSL::Digest::SHA256.new)
+        crl.sign(ca_private_key, ::OpenSSL::Digest.new("SHA256"))
         crl
       end
 

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -382,7 +382,7 @@ in 'password', with the associated 'salt' and 'iterations'.")
               salt,
               iterations,
               128,
-              OpenSSL::Digest::SHA512.new
+              OpenSSL::Digest.new("SHA512")
             )
           end
 
@@ -627,7 +627,7 @@ in 'password', with the associated 'salt' and 'iterations'.")
             salt,
             current_resource.iterations,
             128,
-            OpenSSL::Digest::SHA512.new
+            OpenSSL::Digest.new("SHA512")
           ).unpack("H*").first == current_resource.password
         end
 

--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -495,7 +495,7 @@ class Chef
             convert_to_binary(current_resource.salt),
             current_resource.iterations.to_i,
             128,
-            OpenSSL::Digest::SHA512.new
+            OpenSSL::Digest.new("SHA512")
           ).unpack("H*")[0] != current_resource.password
         end
 
@@ -521,7 +521,7 @@ class Chef
                 salt.string,
                 new_resource.iterations,
                 128,
-                OpenSSL::Digest::SHA512.new
+                OpenSSL::Digest.new("SHA512")
               )
             )
           end

--- a/lib/chef/resource/windows_certificate.rb
+++ b/lib/chef/resource/windows_certificate.rb
@@ -308,7 +308,7 @@ class Chef
         #
         def import_certificates(cert_objs, is_pfx)
           [cert_objs].flatten.each do |cert_obj|
-            thumbprint = OpenSSL::Digest::SHA1.new(cert_obj.to_der).to_s # Fetch its thumbprint
+            thumbprint = OpenSSL::Digest.new("SHA1", cert_obj.to_der).to_s # Fetch its thumbprint
             # Need to check if return value is Boolean:true
             # If not then the given certificate should be added in certstore
             if verify_cert(thumbprint) == true

--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -126,8 +126,8 @@ class Chef
         required: true,
         coerce: proc { |v| v.is_a?(String) ? Array[v] : v },
         callbacks: {
-           "Option privilege must include any of the: #{privilege_opts}" => lambda {
-             |v| (privilege_opts & v).size == v.size
+           "Option privilege must include any of the: #{privilege_opts}" => lambda { |v|
+             (privilege_opts & v).size == v.size
            },
          }
 

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -27,7 +27,7 @@ Chef::Log.level(Chef::Config.log_level)
 Chef::Config.solo(false)
 
 def sha256_checksum(path)
-  OpenSSL::Digest::SHA256.hexdigest(File.read(path))
+  OpenSSL::Digest.hexdigest("SHA256", File.read(path))
 end
 
 # extracted from Ruby < 2.5 to return a unique temp file name without creating it

--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -488,7 +488,7 @@ describe Chef::Mixin::OpenSSLHelper do
       @ca_cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
       @ca_cert.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
       @ca_cert.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
-      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+      @ca_cert.sign(@ca_key, OpenSSL::Digest.new("SHA256"))
 
       @info_with_issuer = { "validity" => 365, "issuer" => @ca_cert }
       @info_without_issuer = { "validity" => 365 }
@@ -614,7 +614,7 @@ describe Chef::Mixin::OpenSSLHelper do
       @ca_cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
       @ca_cert.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
       @ca_cert.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
-      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+      @ca_cert.sign(@ca_key, OpenSSL::Digest.new("SHA256"))
 
       @info = { "validity" => 8, "issuer" => @ca_cert }
     end
@@ -684,7 +684,7 @@ describe Chef::Mixin::OpenSSLHelper do
       @ca_cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
       @ca_cert.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
       @ca_cert.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
-      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+      @ca_cert.sign(@ca_key, OpenSSL::Digest.new("SHA256"))
 
       @info = { "validity" => 8, "issuer" => @ca_cert }
 
@@ -765,7 +765,7 @@ describe Chef::Mixin::OpenSSLHelper do
       @ca_cert.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
       @ca_cert.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
       @ca_cert.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
-      @ca_cert.sign(@ca_key, OpenSSL::Digest::SHA256.new)
+      @ca_cert.sign(@ca_key, OpenSSL::Digest.new("SHA256"))
 
       @info = { "validity" => 8, "issuer" => @ca_cert }
 


### PR DESCRIPTION
There's a RuboCop cop to fix these before Ruby 3 breaks it.

Signed-off-by: Tim Smith <tsmith@chef.io>