### PR TITLE
Pin habitat bundler to 1.17.3

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -17,7 +17,7 @@ pkg_deps=(
   core/libiconv
   core/xz
   core/zlib
-  core/bundler
+  core/bundler/1.17.3
   core/openssl
   core/cacerts
   core/libffi


### PR DESCRIPTION
This should fix our builds

Signed-off-by: Tim Smith <tsmith@chef.io>