### PR TITLE
Pull in updated omnibus-software for rubygems perf patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 0154d81e4caa42634b416e11cc34f4abf7ae2729
+  revision: c01c03fba0834bcebb7f90c9c27dd720ab8b4a58
   branch: master
   specs:
     ohai (16.1.1)
@@ -284,7 +284,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     nori (2.6.0)
     parallel (1.19.1)
-    parser (2.7.1.2)
+    parser (2.7.1.3)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.4)
@@ -301,9 +301,9 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
-    pry-stack_explorer (0.4.9.3)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
+    pry-stack_explorer (0.5.1)
+      binding_of_caller (~> 0.7)
+      pry (~> 0.13)
     public_suffix (4.0.5)
     rack (2.2.2)
     rainbow (3.0.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 74e9d02cf7f9b164d67789a0a0a7e167143db6fb
+  revision: 86a1c7ebb859161385676e3bfe537e13ba680f59
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -29,11 +29,11 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    artifactory (3.0.12)
+    artifactory (3.0.13)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.314.0)
-    aws-sdk-core (3.95.0)
+    aws-partitions (1.321.0)
+    aws-sdk-core (3.96.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -41,8 +41,8 @@ GEM
     aws-sdk-kms (1.31.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.64.0)
-      aws-sdk-core (~> 3, >= 3.83.0)
+    aws-sdk-s3 (1.66.0)
+      aws-sdk-core (~> 3, >= 3.96.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.3)
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.0.287)
+    chef (16.1.0)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.0.287)
-      chef-utils (= 16.0.287)
+      chef-config (= 16.1.0)
+      chef-utils (= 16.1.0)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -98,12 +98,12 @@ GEM
       train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (16.0.287-universal-mingw32)
+    chef (16.1.0-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.0.287)
-      chef-utils (= 16.0.287)
+      chef-config (= 16.1.0)
+      chef-utils (= 16.1.0)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -145,15 +145,15 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.0.287)
+    chef-config (16.1.0)
       addressable
-      chef-utils (= 16.0.287)
+      chef-utils (= 16.1.0)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
-    chef-utils (16.0.287)
+    chef-utils (16.1.0)
     chef-vault (4.0.1)
     chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
@@ -247,8 +247,9 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (16.0.20)
+    ohai (16.1.1)
       chef-config (>= 12.8, < 17)
+      chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -294,7 +295,7 @@ GEM
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.5.0)
+    test-kitchen (2.5.1)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       license-acceptance (~> 1.0, >= 1.0.11)


### PR DESCRIPTION
This resolves the rubygems perf regression in the release that shipped in Ruby 2.7.x

Signed-off-by: Tim Smith <tsmith@chef.io>