### PR TITLE
Update to ssl_verify_mode on remote_file

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -292,6 +292,21 @@ class Chef
     private
 
     # @api private
+    def ssl_policy
+      return Chef::HTTP::APISSLPolicy unless @options[:ssl_verify_mode]
+
+      case @options[:ssl_verify_mode]
+      when :verify_none
+        Chef::HTTP::VerifyNoneSSLPolicy
+      when :verify_peer
+        Chef::HTTP::VerifyPeerSSLPolicy
+      else
+        Chef::Log.error("Chef::HTTP was passed an ssl_verify_mode of #{@options[:ssl_verify_mode]} which is unsupported. Falling back to the API policy")
+        Chef::HTTP::APISSLPolicy
+      end
+    end
+
+    # @api private
     def build_http_client(base_url)
       if chef_zero_uri?(base_url)
         # PERFORMANCE CRITICAL: *MUST* lazy require here otherwise we load up webrick
@@ -304,7 +319,6 @@ class Chef
 
         SocketlessChefZeroClient.new(base_url)
       else
-        ssl_policy = @options[:ssl_verify_mode] || Chef::HTTP::APISSLPolicy
         BasicClient.new(base_url, ssl_policy: ssl_policy, keepalives: keepalives)
       end
     end

--- a/lib/chef/provider/remote_file/http.rb
+++ b/lib/chef/provider/remote_file/http.rb
@@ -135,12 +135,7 @@ class Chef
             opts[:disable_gzip] = true
           end
           if new_resource.ssl_verify_mode
-            opts[:ssl_verify_mode] = case new_resource.ssl_verify_mode
-                                     when :verify_none
-                                       Chef::HTTP::VerifyNoneSSLPolicy
-                                     when :verify_peer
-                                       Chef::HTTP::VerifyPeerSSLPolicy
-                                     end
+            opts[:ssl_verify_mode] = new_resource.ssl_verify_mode
           end
           opts
         end


### PR DESCRIPTION
So it turns out the `berkshelf` has been passing it's entire `options`
hash into `Chef::HTTP` this whole time, which, we should probably fix.

However, one of those options was `:ssl_verify_mode`. We ignore entries
in the `options` hash we don't recognize so this was fine, but suddenly
we recognize it. But we expected it to be class, and they're passing
in symbols. Whoops!

This makes that all work and puts the symbol->class conversion inside
of `Chef::HTTP`.