### PR TITLE
hostname: Remove support for Solaris 5.10

### DIFF
--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -1,4 +1,7 @@
 #
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -199,24 +199,7 @@ class Chef
               group node["root_group"]
               mode "0644"
             end
-          when ::File.exist?("/etc/nodename")
-            # Solaris <= 5.10 systems prior to svccfg taking over this functionality (must come before svccfg handling)
-            declare_resource(:file, "/etc/nodename") do
-              content "#{new_resource.hostname}\n"
-              owner "root"
-              group node["root_group"]
-              mode "0644"
-            end
-            # Solaris also has /etc/inet/hosts (copypasta alert)
-            unless new_resource.ipaddress.nil?
-              newline = "#{new_resource.ipaddress} #{new_resource.hostname}"
-              newline << " #{new_resource.aliases.join(" ")}" if new_resource.aliases && !new_resource.aliases.empty?
-              newline << " #{new_resource.hostname[/[^\.]*/]}"
-              r = append_replacing_matching_lines("/etc/inet/hosts", /^#{new_resource.ipaddress}\s+|\s+#{new_resource.hostname}\s+/, newline)
-              r.notifies :reload, "ohai[reload hostname]"
-            end
-          when ::File.exist?("/usr/sbin/svccfg")
-            # Solaris >= 5.11 systems using svccfg (must come after /etc/nodename handling)
+          when ::File.exist?("/usr/sbin/svccfg") # solaris 5.11
             declare_resource(:execute, "svccfg -s system/identity:node setprop config/nodename=\'#{new_resource.hostname}\'") do
               notifies :run, "execute[svcadm refresh]", :immediately
               notifies :run, "execute[svcadm restart]", :immediately


### PR DESCRIPTION
We don't support Solaris 5.10 in Chef anymore so there's no reason to make this check every time the resource runs on Solaris 5.11

Signed-off-by: Tim Smith <tsmith@chef.io>