### PR TITLE
Fix rspec warning about `not_to raise_error` with a specific exception.

### DIFF
--- a/spec/functional/resource/windows_task_spec.rb
+++ b/spec/functional/resource/windows_task_spec.rb
@@ -513,13 +513,13 @@ describe Chef::Resource::WindowsTask, :windows_only do
         it "not raises any Argument error if frequency_modifier set as 'first, second, third' and day is provided" do
           subject.frequency_modifier "first, second, third"
           subject.day "Mon, Fri"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
         end
 
         it "not raises any Argument error if frequency_modifier 2 " do
           subject.frequency_modifier 2
           subject.day "Mon, Sun"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
         end
 
         it "raises argument error if frequency_modifier > 12" do
@@ -535,7 +535,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
         it "creates scheduled task to run task monthly on Monday and Friday of first, second and third week of month" do
           subject.frequency_modifier "first, second, third"
           subject.day "Mon, Fri"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
@@ -558,7 +558,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
         it "creates scheduled task to run task monthly on every 6 months when frequency_modifier is 6 and to run on 1st and 2nd day of month" do
           subject.frequency_modifier 6
           subject.day "1, 2"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
@@ -590,7 +590,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
 
         it "creates scheduled task to run monthly to run last day of the month" do
           subject.day "last"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
@@ -611,7 +611,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
 
         it "day property set as 'lastday' creates scheduled task to run monthly to run last day of the month" do
           subject.day "lastday"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
@@ -635,7 +635,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
         it "creates scheduled task to run monthly on last week of the month" do
           subject.frequency_modifier "last"
           subject.day "Mon, Fri"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)
@@ -659,7 +659,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
       context "when wild card (*) set as months" do
         it "creates the scheduled task to run on 1st day of the all months" do
           subject.months "*"
-          expect { subject.after_created }.not_to raise_error(ArgumentError)
+          expect { subject.after_created }.not_to raise_error
           call_for_create_action
           current_resource = call_for_load_current_resource
           expect(current_resource.exists).to eq(true)

--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -82,12 +82,12 @@ describe "a class that mixes in user_context" do
         let(:block_parameter) { Proc.new { raise UserContextTextException } }
 
         it "raises the exception raised by the block" do
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error(UserContextTestException)
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error
         end
 
         it "closes the logon session so resources are not leaked" do
           expect(logon_session).to receive(:close)
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error(UserContextTestException)
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error
         end
       end
     end

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -121,7 +121,7 @@ describe "Chef::Resource.property" do
 
   context "deprecated properties" do
     it "does not create a deprecation warning on definition" do
-      expect { resource_class.class_eval { property :x, String, deprecated: 10 } }.not_to raise_error Chef::Exceptions::DeprecatedFeatureError
+      expect { resource_class.class_eval { property :x, String, deprecated: 10 } }.not_to raise_error
     end
 
     with_property ":x, deprecated: 'a deprecated property'" do

--- a/spec/unit/resource/chef_client_scheduled_task_spec.rb
+++ b/spec/unit/resource/chef_client_scheduled_task_spec.rb
@@ -46,13 +46,13 @@ describe Chef::Resource::ChefClientScheduledTask do
   it "validates the start_time property input" do
     expect { resource.start_time("8:00 am") }.to raise_error(Chef::Exceptions::ValidationFailed)
     expect { resource.start_time("8:00") }.to raise_error(Chef::Exceptions::ValidationFailed)
-    expect { resource.start_time("08:00") }.not_to raise_error(Chef::Exceptions::ValidationFailed)
+    expect { resource.start_time("08:00") }.not_to raise_error
   end
 
   it "validates the start_date property input" do
     expect { resource.start_date("2/1/20") }.to raise_error(Chef::Exceptions::ValidationFailed)
     expect { resource.start_date("02/01/20") }.to raise_error(Chef::Exceptions::ValidationFailed)
-    expect { resource.start_date("02/01/2020") }.not_to raise_error(Chef::Exceptions::ValidationFailed)
+    expect { resource.start_date("02/01/2020") }.not_to raise_error
   end
 
   it "raises an error if frequency_modifier is not a positive number" do

--- a/spec/unit/resource/windows_dns_record_spec.rb
+++ b/spec/unit/resource/windows_dns_record_spec.rb
@@ -29,15 +29,15 @@ describe Chef::Resource::WindowsDnsRecord do
   end
 
   it "the record_type property accepts 'CNAME'" do
-    expect { resource.record_type "CNAME" }.not_to raise_error(ArgumentError)
+    expect { resource.record_type "CNAME" }.not_to raise_error
   end
 
   it "the record_type property accepts 'ARecord'" do
-    expect { resource.record_type "ARecord" }.not_to raise_error(ArgumentError)
+    expect { resource.record_type "ARecord" }.not_to raise_error
   end
 
   it "the record_type property accepts 'PTR'" do
-    expect { resource.record_type "PTR" }.not_to raise_error(ArgumentError)
+    expect { resource.record_type "PTR" }.not_to raise_error
   end
 
   it "the resource raises an ArgumentError if invalid record_type is set" do

--- a/spec/unit/resource/windows_dns_zone_spec.rb
+++ b/spec/unit/resource/windows_dns_zone_spec.rb
@@ -29,11 +29,11 @@ describe Chef::Resource::WindowsDnsZone do
   end
 
   it "the server_type property accepts 'Standalone'" do
-    expect { resource.server_type "Standalone" }.not_to raise_error(ArgumentError)
+    expect { resource.server_type "Standalone" }.not_to raise_error
   end
 
   it "the server_type property accepts 'Domain'" do
-    expect { resource.server_type "Domain" }.not_to raise_error(ArgumentError)
+    expect { resource.server_type "Domain" }.not_to raise_error
   end
 
   it "the resource raises an ArgumentError if invalid server_type is set" do

--- a/spec/unit/resource/windows_task_spec.rb
+++ b/spec/unit/resource/windows_task_spec.rb
@@ -144,7 +144,7 @@ describe Chef::Resource::WindowsTask, :windows_only do
       resource.frequency :once
       resource.random_delay "20"
       resource.start_time "15:00"
-      expect { resource.after_created }.to_not raise_error(ArgumentError, "`random_delay` property is supported only for frequency :once, :minute, :hourly, :daily, :weekly and :monthly")
+      expect { resource.after_created }.to_not raise_error
     end
 
     it "raises error for invalid random_delay" do

--- a/spec/unit/resource/windows_uac_spec.rb
+++ b/spec/unit/resource/windows_uac_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::WindowsUac do
 
   %i{no_prompt secure_prompt_for_creds secure_prompt_for_consent prompt_for_creds prompt_for_consent prompt_for_consent_non_windows_binaries}.each do |val|
     it "the consent_behavior_admins property accepts :#{val}" do
-      expect { resource.consent_behavior_admins val }.not_to raise_error(ArgumentError)
+      expect { resource.consent_behavior_admins val }.not_to raise_error
     end
   end
 
@@ -36,7 +36,7 @@ describe Chef::Resource::WindowsUac do
 
   %i{auto_deny secure_prompt_for_creds prompt_for_creds}.each do |val|
     it "the consent_behavior_users property accepts :#{val}" do
-      expect { resource.consent_behavior_users val }.not_to raise_error(ArgumentError)
+      expect { resource.consent_behavior_users val }.not_to raise_error
     end
   end
 

--- a/spec/unit/resource/yum_repository_spec.rb
+++ b/spec/unit/resource/yum_repository_spec.rb
@@ -73,52 +73,52 @@ describe Chef::Resource::YumRepository do
   end
 
   it "the timeout property expects numeric Strings" do
-    expect { resource.timeout "123" }.not_to raise_error(ArgumentError)
+    expect { resource.timeout "123" }.not_to raise_error
     expect { resource.timeout "123foo" }.to raise_error(ArgumentError)
   end
 
   it "the priority property expects numeric Strings from '1' to '99'" do
-    expect { resource.priority "99" }.not_to raise_error(ArgumentError)
-    expect { resource.priority "1" }.not_to raise_error(ArgumentError)
+    expect { resource.priority "99" }.not_to raise_error
+    expect { resource.priority "1" }.not_to raise_error
     expect { resource.priority "100" }.to raise_error(ArgumentError)
     expect { resource.priority "0" }.to raise_error(ArgumentError)
   end
 
   it "the failovermethod property accepts 'priority' or 'roundrobin'" do
-    expect { resource.failovermethod "priority" }.not_to raise_error(ArgumentError)
-    expect { resource.failovermethod "roundrobin" }.not_to raise_error(ArgumentError)
+    expect { resource.failovermethod "priority" }.not_to raise_error
+    expect { resource.failovermethod "roundrobin" }.not_to raise_error
     expect { resource.failovermethod "bob" }.to raise_error(ArgumentError)
   end
 
   it "the http_caching property accepts 'packages', 'all', or 'none'" do
-    expect { resource.http_caching "packages" }.not_to raise_error(ArgumentError)
-    expect { resource.http_caching "all" }.not_to raise_error(ArgumentError)
-    expect { resource.http_caching "none" }.not_to raise_error(ArgumentError)
+    expect { resource.http_caching "packages" }.not_to raise_error
+    expect { resource.http_caching "all" }.not_to raise_error
+    expect { resource.http_caching "none" }.not_to raise_error
     expect { resource.http_caching "bob" }.to raise_error(ArgumentError)
   end
 
   it "the metadata_expire property accepts a time value or 'never'" do
-    expect { resource.metadata_expire "100" }.not_to raise_error(ArgumentError)
-    expect { resource.metadata_expire "100d" }.not_to raise_error(ArgumentError)
-    expect { resource.metadata_expire "100h" }.not_to raise_error(ArgumentError)
-    expect { resource.metadata_expire "100m" }.not_to raise_error(ArgumentError)
-    expect { resource.metadata_expire "never" }.not_to raise_error(ArgumentError)
+    expect { resource.metadata_expire "100" }.not_to raise_error
+    expect { resource.metadata_expire "100d" }.not_to raise_error
+    expect { resource.metadata_expire "100h" }.not_to raise_error
+    expect { resource.metadata_expire "100m" }.not_to raise_error
+    expect { resource.metadata_expire "never" }.not_to raise_error
     expect { resource.metadata_expire "100s" }.to raise_error(ArgumentError)
   end
 
   it "the mirror_expire property accepts a time value" do
-    expect { resource.mirror_expire "100" }.not_to raise_error(ArgumentError)
-    expect { resource.mirror_expire "100d" }.not_to raise_error(ArgumentError)
-    expect { resource.mirror_expire "100h" }.not_to raise_error(ArgumentError)
-    expect { resource.mirror_expire "100m" }.not_to raise_error(ArgumentError)
+    expect { resource.mirror_expire "100" }.not_to raise_error
+    expect { resource.mirror_expire "100d" }.not_to raise_error
+    expect { resource.mirror_expire "100h" }.not_to raise_error
+    expect { resource.mirror_expire "100m" }.not_to raise_error
     expect { resource.mirror_expire "never" }.to raise_error(ArgumentError)
   end
 
   it "the mirrorlist_expire property accepts a time value" do
-    expect { resource.mirrorlist_expire "100" }.not_to raise_error(ArgumentError)
-    expect { resource.mirrorlist_expire "100d" }.not_to raise_error(ArgumentError)
-    expect { resource.mirrorlist_expire "100h" }.not_to raise_error(ArgumentError)
-    expect { resource.mirrorlist_expire "100m" }.not_to raise_error(ArgumentError)
+    expect { resource.mirrorlist_expire "100" }.not_to raise_error
+    expect { resource.mirrorlist_expire "100d" }.not_to raise_error
+    expect { resource.mirrorlist_expire "100h" }.not_to raise_error
+    expect { resource.mirrorlist_expire "100m" }.not_to raise_error
     expect { resource.mirrorlist_expire "never" }.to raise_error(ArgumentError)
   end
 

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -378,7 +378,7 @@ describe Chef::Resource do
       it "does not propagate validation errors" do
         resource_class = Class.new(Chef::Resource) { property :foo, String, required: true }
         resource = resource_class.new("required_property_tests")
-        expect { resource.to_text }.to_not raise_error Chef::Exceptions::ValidationFailed
+        expect { resource.to_text }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
I'm running a subset of the tests repeatedly and this is the majority of the output:

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/pete/work/chef/spec/unit/resource_spec.rb:381:in `block (4 levels) in <top (required)>'.
```

Signed-off-by: Pete Higgins <pete@peterhiggins.org>
