### PR TITLE
Revert the change to the load paths in the specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,17 +24,16 @@ module Shell
   IRB = nil unless defined? IRB
 end
 
-# Ruby 1.9 Compat
-$:.unshift File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../..", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../chef-config/lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../chef-utils/lib", __FILE__)
+$LOAD_PATH.unshift File.dirname(__FILE__)
 
 require "rubygems"
 require "rspec/mocks"
 
 require "webmock/rspec"
-
-$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
-$:.unshift(File.expand_path("../lib", __FILE__))
-$:.unshift(File.dirname(__FILE__))
 
 require "chef"
 require "chef/knife"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,15 +24,17 @@ module Shell
   IRB = nil unless defined? IRB
 end
 
-$LOAD_PATH.unshift File.expand_path("../..", __FILE__)
-
-$LOAD_PATH.unshift File.expand_path("../../chef-config/lib", __FILE__)
-$LOAD_PATH.unshift File.expand_path("../../chef-utils/lib", __FILE__)
+# Ruby 1.9 Compat
+$:.unshift File.expand_path("../..", __FILE__)
 
 require "rubygems"
 require "rspec/mocks"
 
 require "webmock/rspec"
+
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$:.unshift(File.expand_path("../lib", __FILE__))
+$:.unshift(File.dirname(__FILE__))
 
 require "chef"
 require "chef/knife"


### PR DESCRIPTION
This reverts commit de8d3a3299a18d4bfd2b419cb1303258441a862a.

This code works fine within Workstation, but it fails hard with DK. We
need to keep the DK verify checks running with Chef 15 until both of
these codebases go away. For now just revert this and roll forward with
life in master where we have the new paths