### PR TITLE
WIP: Provider::Package to use EVRAs for dnf rpm version comparisons

### DIFF
--- a/lib/chef/provider/package/dnf/version.rb
+++ b/lib/chef/provider/package/dnf/version.rb
@@ -37,7 +37,8 @@ class Chef
           end
 
           def version_with_arch
-            "#{version}.#{arch}" unless version.nil?
+            rvc = self.is_a?(EVRAVersion) ? EVRAString : String
+            rvc.new("#{version}.#{arch}") unless version.nil?
           end
 
           def name_with_arch
@@ -54,6 +55,21 @@ class Chef
 
           alias eql? ==
         end
+
+        #
+        # Helper classes to track if Version and String instances
+        # represent an rpm EVRA. This is important because it's
+        # impossible to differentiate between EVRs and EVRAs once they
+        # are in a string format, and we need to ensure we don't
+        # accidentally pass EVRs to functions that take EVRAs.
+        #
+
+        class EVRAVersion < Version
+        end
+
+        class EVRAString < String
+        end
+
       end
     end
   end


### PR DESCRIPTION
This is a potential bug fix for [Issue 9940](https://github.com/chef/chef/issues/9940).

Currently on dnf systems, Provider::Package does rpm version comparisons
between installed_version/candidate_version (EVRAs) and
new_resource.version / new_version_array (a VR or EVR). These
comparisons can fail in dnf_helper.py because versioncompare doesn't
know the type of version data it's comparing (and it's impossible to
deterministically parse an EVR[A] string without first knowing if it's
an EVR or EVRA).

To fix this problem, we first override new_version_array in
Chef::Provider::Package to just return nil values. This forces the
Package class to use candidate_version in place of new_version_array for
all version comparisons.

This doesn't fix rpm version comparisons in and of itself, but instead
it ensures that all version comparisons are done using EVRAs. This
allows us to update dnf_python.py versioncompare to properly parse and
compare EVRAs. This fixes rpm version comparisons for package resources
which contain a version specification and an :upgrade action.

To fix rpm version comparisons for package resources that have a version
specification and an :install action, we also need to update
target_version_array in Chef::Provider::Package to fallback to comparing
against candidate_version when new_version_array returns nil.

To test this fix I created four packages, each with two versions:
2.02-78.el8 and 2.02-78.el8_1.1.  I installed the 2.02-78.el8 version of
all the packages, and then executed a chef run with the following
resources configured:

---8<---
package 'empty-test-rpm-version-upgrade' do
  version '1:2.02-78.el8_1.1'
  action :upgrade
end

package 'empty-test-rpm-version-install' do
  version '1:2.02-78.el8_1.1'
  action :install
end

package 'empty-test-rpm-name-upgrade-1:2.02-78.el8_1.1' do
  action :upgrade
end

package 'empty-test-rpm-name-install-1:2.02-78.el8_1.1' do
  action :install
end
---8<---

and then I confirmed that all the packages were upgraded as expected.

I also regression tested that if an invalid new_version is requested
(ie, a version for which we can't find a candidate_version) that chef
fails (as expected).

Signed-off-by: Edward Pilatowicz <epilatow@fb.com>
