### PR TITLE
Add nightly cleanup of orphaned test resources

### DIFF
--- a/.expeditor/cleanup_orphaned_test_resources.sh
+++ b/.expeditor/cleanup_orphaned_test_resources.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- Setting up Azure credentials"
+export VAULT_UTIL_SECRETS="{\"ARM_TENANT_ID\":{\"account\":\"azure/engineering-dev-test\",\"field\":\"tenant_id\"},\"ARM_CLIENT_ID\":{\"account\":\"azure/engineering-dev-test\",\"field\":\"client_id\"},\"ARM_CLIENT_SECRET\":{\"account\":\"azure/engineering-dev-test\",\"field\":\"client_secret\"}}"
+. <(vault-util fetch-secret-env)
+
+# this allows time for the new service-principal to become available
+sleep 10
+
+az login --service-principal --tenant "$ARM_TENANT_ID" --username "$ARM_CLIENT_ID" --password "$ARM_CLIENT_SECRET"
+
+echo "--- Deleting Azure kitchen-end-to-end-windows-10 resource groups"
+az group list --query "[?starts_with(name, 'kitchen-end-to-end-windows-10-')].name" --output tsv | xargs -n1 -t -I% az group delete -y --no-wait --name "%"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -69,6 +69,11 @@ github:
     - chef-14:
         version_constraint: 14*
 
+schedules:
+  - name: cleanup_orphaned_test_resources
+    description: Cleanup orphaned test resources
+    cronline: "0 1 * * *" # every day at 1am
+
 changelog:
   rollup_header: Changes not yet released to stable
 
@@ -96,6 +101,10 @@ merge_actions:
       only_if: built_in:bump_version
 
 subscriptions:
+  - workload: schedule_triggered:{{agent_id}}:cleanup_orphaned_test_resources:*
+    actions:
+      - bash:.expeditor/cleanup_orphaned_test_resources.sh
+
   # the omnibus/docker/gem chain
   - workload: artifact_published:unstable:chef:{{version_constraint}}
     actions:


### PR DESCRIPTION
## Description

The private verify pipeline currently uses Test Kitchen Azure to test against Windows 10.

Unfortunately this approach does not clean up after itself and orphaned resource groups are typically left behind.  If this is not taken care of we'll exhaust our resource pool (esp. public ips).

This commit simply adds a nightly (1am) script to delete the Azure resource groups associated with the private verify pipeline.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
