### PR TITLE
RFC: fixing systemd_services

### DIFF
--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -94,6 +94,9 @@ class Chef
       # if the service is masked or not
       property :masked, [ TrueClass, FalseClass ], skip_docs: true
 
+      # if the service is static or not
+      property :static, [ TrueClass, FalseClass ], skip_docs: true
+
       # if the service is indirect or not
       property :indirect, [ TrueClass, FalseClass ], skip_docs: true
 


### PR DESCRIPTION
In #9063 I thought I had fixed a bug in the systemd service provider,
to handle indirect services. Here I'm adding the same "fix" for static
services. But it turns out, I had not. You get fun stuff like:

```
[2020-06-02T16:56:33-07:00] TRACE: service[gdm] cannot be disabled: it is static
[2020-06-02T16:56:33-07:00] INFO: service[gdm] disabled
```

womp womp.

This is because the actual `action :disable` in `providers/service.rb`
(the superclass) is what decides:

```
      action :disable do
        if current_resource.enabled
          converge_by("disable service #{new_resource}") do
            disable_service
            logger.info("#{new_resource} disabled")
          end
        else
          logger.trace("#{new_resource} already disabled - nothing to do")
        end
        load_new_resource_state
        new_resource.enabled(false)
      end
```

There are a few ways around this:

1. We could define our own action :disable and not use the superclass.
2. We could instead push the idea of static/indirect up to the parent
class, it's already in the resource, and have them default to `false`
which would make it a no-op for other subclasses
3. ?? Something i haven't thougt of?

Also I changed this not to run `is-enabled` 4 times for every service
(sigh).