### PR TITLE
archive_file: better handle mode property and deprecate Integer values

### DIFF
--- a/lib/chef/deprecated.rb
+++ b/lib/chef/deprecated.rb
@@ -237,6 +237,10 @@ class Chef
       target 29
     end
 
+    class ArchiveFileIntegerFileMode < Base
+      target 30
+    end
+
     class Generic < Base
       def url
         "https://docs.chef.io/chef_deprecations_client/"

--- a/lib/chef/resource/archive_file.rb
+++ b/lib/chef/resource/archive_file.rb
@@ -53,7 +53,7 @@ class Chef
         description: "The group of the extracted files."
 
       property :mode, [String, Integer],
-        description: "The mode of the extracted files. Integer values are deprecated as octal strings (ex. 0755) would not be interpreted correctly.",
+        description: "The mode of the extracted files. Integer values are deprecated as octal values (ex. 0755) would not be interpreted correctly.",
         default: "755"
 
       property :destination, String,

--- a/spec/unit/resource/archive_file_spec.rb
+++ b/spec/unit/resource/archive_file_spec.rb
@@ -18,8 +18,11 @@
 require "spec_helper"
 
 describe Chef::Resource::ArchiveFile do
-
-  let(:resource) { Chef::Resource::ArchiveFile.new("foo") }
+  let(:node) { Chef::Node.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::ArchiveFile.new("foo", run_context) }
+  let(:provider) { resource.provider_for_action(:extract) }
 
   it "has a resource name of :archive_file" do
     expect(resource.resource_name).to eql(:archive_file)
@@ -39,6 +42,12 @@ describe Chef::Resource::ArchiveFile do
 
   it "mode property defaults to '755'" do
     expect(resource.mode).to eql("755")
+  end
+
+  it "mode property throws a deprecation warning if Integers are passed" do
+    expect(Chef::Log).to receive(:deprecation)
+    resource.mode 755
+    provider.define_resource_requirements
   end
 
   it "options property defaults to [:time]" do


### PR DESCRIPTION
FileUtils.mkdir_p expects the mode to be in octal form. We accept Integers, but Ruby doesn't have a way to tell if what the user passed was octal or not. The safest thing to do here is to only accept mode as a String and then convert it to octal form with .to_i(8). This adds a new deprecation and correctly sets the file mode value as octal. 

**Old behavior**

String mode: applies wrong permission
Base 10 mode: applies wrong permissions
Octal mode: Works

**New behavior**

String mode: Works
Base 10 mode: Works but throws a deprecation warning
Octal mode: applies the wrong permissions and throws a deprecation warning

Signed-off-by: Tim Smith <tsmith@chef.io>