### PR TITLE
knife vault on windows 10 fails due to ERROR: Chef::Exceptions::InvalidDataBagPath

### DIFF
--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -94,7 +94,7 @@ class Chef
         names = []
         paths.each do |path|
           unless File.directory?(path)
-            raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' is invalid"
+            raise Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '#{path}'"
           end
 
           names += Dir.glob(File.join(
@@ -122,7 +122,7 @@ class Chef
         data_bag = {}
         paths.each do |path|
           unless File.directory?(path)
-            raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' is invalid"
+            raise Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '#{path}'"
           end
 
           Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path, name.to_s), "*.json")).inject({}) do |bag, f|

--- a/lib/chef/data_bag.rb
+++ b/lib/chef/data_bag.rb
@@ -94,7 +94,7 @@ class Chef
         names = []
         paths.each do |path|
           unless File.directory?(path)
-            raise Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '#{path}'"
+            raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' not found. Please create this directory."
           end
 
           names += Dir.glob(File.join(
@@ -122,7 +122,7 @@ class Chef
         data_bag = {}
         paths.each do |path|
           unless File.directory?(path)
-            raise Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '#{path}'"
+            raise Chef::Exceptions::InvalidDataBagPath, "Data bag path '#{path}' not found. Please create this directory."
           end
 
           Dir.glob(File.join(Chef::Util::PathHelper.escape_glob_dir(path, name.to_s), "*.json")).inject({}) do |bag, f|

--- a/spec/unit/data_bag_spec.rb
+++ b/spec/unit/data_bag_spec.rb
@@ -243,7 +243,7 @@ describe Chef::DataBag do
 
         expect do
           Chef::DataBag.load("foo")
-        end.to raise_error Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '/var/chef/data_bags'"
+        end.to raise_error Chef::Exceptions::InvalidDataBagPath, "Data bag path '/var/chef/data_bags' not found. Please create this directory."
       end
 
     end

--- a/spec/unit/data_bag_spec.rb
+++ b/spec/unit/data_bag_spec.rb
@@ -243,7 +243,7 @@ describe Chef::DataBag do
 
         expect do
           Chef::DataBag.load("foo")
-        end.to raise_error Chef::Exceptions::InvalidDataBagPath, "Data bag path '/var/chef/data_bags' is invalid"
+        end.to raise_error Chef::Exceptions::InvalidDataBagPath, "Please create databag folder at '/var/chef/data_bags'"
       end
 
     end


### PR DESCRIPTION
Signed-off-by: Snehal Dwivedi <sdwivedi@msystechnologies.com>

## Description
- updated exception `Chef::Exceptions::InvalidDataBagPath` message

## Related Issue
Fixes:  https://github.com/chef/chef-vault/issues/333
https://github.com/chef/chef-vault/issues/321