### PR TITLE
Fix wrong unit test exposed by cleaning up rspec deprecations.

### DIFF
--- a/lib/chef/resource/chef_client_scheduled_task.rb
+++ b/lib/chef/resource/chef_client_scheduled_task.rb
@@ -82,7 +82,7 @@ class Chef
         coerce: proc { |x| Integer(x) },
         callbacks: { "should be a positive number" => proc { |v| v > 0 } },
         description: "Numeric value to go with the scheduled task frequency",
-        default: lazy { frequency == "minute" ? 30 : 1 }, 
+        default: lazy { frequency == "minute" ? 30 : 1 },
         default_description: "30 if frequency is 'minute', 1 otherwise"
 
       property :accept_chef_license, [true, false],

--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -77,17 +77,9 @@ describe "a class that mixes in user_context" do
       end
 
       context "when the block raises an exception" do
-        class UserContextTestException < RuntimeError
-        end
-        let(:block_parameter) { Proc.new { raise UserContextTextException } }
-
-        it "raises the exception raised by the block" do
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error
-        end
-
         it "closes the logon session so resources are not leaked" do
           expect(logon_session).to receive(:close)
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1/0 } }.to raise_error(ZeroDivisionError)
         end
       end
     end

--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -79,7 +79,7 @@ describe "a class that mixes in user_context" do
       context "when the block raises an exception" do
         it "closes the logon session so resources are not leaked" do
           expect(logon_session).to receive(:close)
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1/0 } }.to raise_error(ZeroDivisionError)
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1 / 0 } }.to raise_error(ZeroDivisionError)
         end
       end
     end


### PR DESCRIPTION
These tests were broken in #9937 because they are doing exactly what that warning was about: hiding a real exception. It also turns out that the test was wrong because that code is supposed to raise an exception in this case.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>