### PR TITLE
Add "most recent call first" to traceback message

### DIFF
--- a/lib/chef/formatters/error_inspectors/compile_error_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/compile_error_inspector.rb
@@ -41,7 +41,7 @@ class Chef
 
           if found_error_in_cookbooks?
             traceback = filtered_bt.map { |line| "  #{line}" }.join("\n")
-            error_description.section("Cookbook Trace:", traceback)
+            error_description.section("Cookbook Trace: (most recent call first)", traceback)
             error_description.section("Relevant File Content:", context)
           end
 

--- a/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
+++ b/lib/chef/formatters/error_inspectors/resource_failure_inspector.rb
@@ -37,7 +37,7 @@ class Chef
           error_description.section(exception.class.name, exception.message)
 
           unless filtered_bt.empty?
-            error_description.section("Cookbook Trace:", filtered_bt.join("\n"))
+            error_description.section("Cookbook Trace: (most recent call first)", filtered_bt.join("\n"))
           end
 
           unless dynamic_resource?


### PR DESCRIPTION
Signed-off-by: Zeal Wierslee <zeal@wierslee.me>

Add "most recent call first" to traceback message

## Description

Chef's tracebacks are formatted so that the most recent call is first, and older calls are below it.

Many developers use programming languages (like ruby and python) which use the opposite style, which formats it's stack traces with the most recent line at the bottom, and older calls above that.

For this reason, developers more comfortable working in other environments might have difficultly parsing the stack traces at a glance, since the calls will be in the opposite order.

This PR simply adds a "most recent call first" message to the traceback message, so the traceback ordering is explicit.

## Related Issue

#9966 

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

(Calling this a "bug" is probably generous, but I think that category fits best).

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
