### PR TITLE
Make sure a password is passed with knife bootstrap -P

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -42,7 +42,7 @@ class Chef
         long: "--connection-password PASSWORD",
         description: "Authenticate to the target host with this password.",
         proc: Proc.new { |v|
-          # If a user passes -P and leaves out the password the knife interprets the next flag as the password
+          # If a user passes -P and leaves out the password knife interprets the next flag as the password
           # which is incredibly hard to troubleshoot. Let's help the user out here by seeing if a short or long
           # flag is in the password field.
           # regular expression explaination: https://rubular.com/r/gcknBouOOHokhT

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -40,7 +40,16 @@ class Chef
       option :connection_password,
         short: "-P PASSWORD",
         long: "--connection-password PASSWORD",
-        description: "Authenticate to the target host with this password."
+        description: "Authenticate to the target host with this password.",
+        proc: Proc.new { |v|
+          # If a user passes -P and leaves out the password the knife interprets the next flag as the password
+          # which is incredibly hard to troubleshoot. Let's help the user out here by seeing if a short or long
+          # flag is in the password field.
+          # regular expression explaination: https://rubular.com/r/gcknBouOOHokhT
+          if v.match?(/^(-([a-zA-Z])$)|(--([a-z]|_)*)$/)
+            raise ArgumentError, "It looks as though you haven't passed a value with the '--connection-password' / '-P' values. Leave off this flag to be prompted for the password or provide a valid password."
+          end
+        }
 
       option :connection_port,
         short: "-p PORT",

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -50,6 +50,29 @@ describe Chef::Knife::Bootstrap do
     k
   end
 
+  context "--connection-password validation" do
+    context "when passed with a password value" do
+      let(:bootstrap_cli_options) { [ "-P", "some_password" ] }
+      it "does not raise an error" do
+        expect { knife.merge_configs }.not_to raise_error
+      end
+    end
+
+    context "with no value and the next flag is a short flag" do
+      let(:bootstrap_cli_options) { [ "-P", "-U", "ubuntu" ] }
+      it "raises an error" do
+        expect { knife.merge_configs }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with no value and the next flag is a long flag" do
+      let(:bootstrap_cli_options) { [ "-P", "--sudo" ] }
+      it "raises an error" do
+        expect { knife.merge_configs }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   context "#check_license" do
     let(:acceptor) { instance_double(LicenseAcceptance::Acceptor) }
 


### PR DESCRIPTION
It's common with a lot of applications that the password flag w/o an option means prompt for password. That's not how it works with Knife and it's very hard to troubleshoot. Instead we eat the next flag and make that the password. Then we throw a very cryptic auth error since the password is not "--sudo". This validates the password field doesn't start with - and a single letter or -- and then letters or an underscore. The chances of a false positive seem incredibly low here and it should help folks with a day 1 problem that is quite awful.

Signed-off-by: Tim Smith <tsmith@chef.io>