### PR TITLE
Let the user know what protocol we're using in knife bootstrap

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -602,7 +602,7 @@ class Chef
       end
 
       def connect!
-        ui.info("Connecting to #{ui.color(server_name, :bold)}")
+        ui.info("Connecting to #{ui.color(server_name, :bold)} using #{connection_protocol}")
         opts ||= connection_opts.dup
         do_connect(opts)
       rescue Train::Error => e


### PR DESCRIPTION
This makes it really clear that you're not using the right protocol when you're bootstrapping a Windows node:

```
❰tsmith❙~/dev/work/chef(git✱knife_password)❱✘≻ bundle exec knife bootstrap 172.16.1.233 -U ubuntu
Connecting to 172.16.1.233
```

becomes

```
❰tsmith❙~/dev/work/chef(git✱knife_password)❱✘≻ bundle exec knife bootstrap 172.16.1.233 -U ubuntu
Connecting to 172.16.1.233 using ssh
```

Signed-off-by: Tim Smith <tsmith@chef.io>