### PR TITLE
Warn during bootstrapping when using validation keys

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -580,11 +580,8 @@ class Chef
 
           bootstrap_context.client_pem = client_builder.client_path
         else
-          ui.info <<~EOM
-            Performing legacy client registration with the validation key at #{Chef::Config[:validation_key]}...
-            Delete your validation key in order to use your user credentials for client registration instead.
-          EOM
-
+          ui.warn "Performing legacy client registration with the validation key at #{Chef::Config[:validation_key]}..."
+          ui.warn "Remove the key file or remove the 'validation_key' configuration option from your config.rb (knife.rb) to use more secure user credentials for client registration."
         end
       end
 

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1729,8 +1729,8 @@ describe Chef::Knife::Bootstrap do
         allow(vault_handler_mock).to receive(:doing_chef_vault?).and_return false
       end
 
-      it "shows a message" do
-        expect(knife.ui).to receive(:info)
+      it "shows a warning message" do
+        expect(knife.ui).to receive(:warn).twice
         knife.register_client
       end
     end


### PR DESCRIPTION
We should highly encourage users to move to validatorless bootstrapping
 1) It's more secure
 2) It requires less admin work since there no validation key to pass
    around or rotate

This also provides an improved message helping the user to move off the
old keys and fixes some bad formatting where the 2nd line was indented
about 40 columns.

Signed-off-by: Tim Smith <tsmith@chef.io>