### PR TITLE
Stop producing packages for EOL Debian 8

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -10,8 +10,7 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   debian-10-aarch64:


### PR DESCRIPTION
Debian 8 went EOL June 6th: https://endoflife.software/operating-systems/linux/debian

Signed-off-by: Tim Smith <tsmith@chef.io>