### PR TITLE
Use /etc/chef for bootstrapping instead of ChefConfig

### DIFF
--- a/lib/chef/knife/bootstrap/templates/chef-full.erb
+++ b/lib/chef/knife/bootstrap/templates/chef-full.erb
@@ -185,50 +185,50 @@ if test "x$tmp_dir" != "x"; then
   rm -r "$tmp_dir"
 fi
 
-mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>
+mkdir -p /etc/chef
 
 <% if client_pem -%>
-(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/client.pem <<'EOP'
+(umask 077 && (cat > /etc/chef/client.pem <<'EOP'
 <%= ::File.read(::File.expand_path(client_pem)) %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if validation_key -%>
-(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/validation.pem <<'EOP'
+(umask 077 && (cat > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% if encrypted_data_bag_secret -%>
-(umask 077 && (cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/encrypted_data_bag_secret <<'EOP'
+(umask 077 && (cat > /etc/chef/encrypted_data_bag_secret <<'EOP'
 <%= encrypted_data_bag_secret %>
 EOP
 )) || exit 1
 <% end -%>
 
 <% unless trusted_certs.empty? -%>
-mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>/trusted_certs
+mkdir -p /etc/chef/trusted_certs
 <%= trusted_certs %>
 <% end -%>
 
 <%# Generate Ohai Hints -%>
 <% unless @config[:hints].nil? || @config[:hints].empty? -%>
-mkdir -p <%= ChefConfig::Config.etc_chef_dir(false) %>/ohai/hints
+mkdir -p /etc/chef/ohai/hints
 
 <% @config[:hints].each do |name, hash| -%>
-cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/ohai/hints/<%= name %>.json <<'EOP'
+cat > /etc/chef/ohai/hints/<%= name %>.json <<'EOP'
 <%= Chef::JSONCompat.to_json(hash) %>
 EOP
 <% end -%>
 <% end -%>
 
-cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/client.rb <<'EOP'
+cat > /etc/chef/client.rb <<'EOP'
 <%= config_content %>
 EOP
 
-cat > <%= ChefConfig::Config.etc_chef_dir(false) %>/first-boot.json <<'EOP'
+cat > /etc/chef/first-boot.json <<'EOP'
 <%= Chef::JSONCompat.to_json(first_boot) %>
 EOP
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Use `/etc/chef` for bootstrapping instead of ChefConfig because `is_windows` from https://github.com/chef/chef/blob/master/chef-config/lib/chef-config/config.rb#L79 run on native windows and returns true always which evaluates to `C:\chef` and causes failure to bootstrap from windows---->linux
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/9914
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
