### PR TITLE
Add a umask property for resources.

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -459,6 +459,7 @@ class Chef
     #
     property :umask, String,
       desired_state: false,
+      introduced: "16.2",
       description: "Set a umask to be used for the duration of converging the resource. Defaults to `nil`, which means to use the system umask."
 
     # The time it took (in seconds) to run the most recently-run action.  Not

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -457,7 +457,9 @@ class Chef
     # @param arg [String] The umask to apply while converging the resource.
     # @return [Boolean] The umask to apply while converging the resource.
     #
-    property :umask, String, desired_state: false
+    property :umask, String,
+      desired_state: false,
+      description: "Set a umask to be used for the duration of converging the resource. Defaults to `nil`, which means to use the system umask."
 
     # The time it took (in seconds) to run the most recently-run action.  Not
     # cumulative across actions.  This is set to 0 as soon as a new action starts

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -451,7 +451,12 @@ class Chef
       description: "Determines whether or not the resource is executed during the compile time phase.",
       default: false, desired_state: false
 
-    # TODO: fill in doc info
+    # Set a umask to be used for the duration of converging the resource.
+    # Defaults to `nil`, which means to use the system umask.
+    #
+    # @param arg [String] The umask to apply while converging the resource.
+    # @return [Boolean] The umask to apply while converging the resource.
+    #
     property :umask, String, desired_state: false
 
     # The time it took (in seconds) to run the most recently-run action.  Not

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -452,7 +452,7 @@ class Chef
       default: false, desired_state: false
 
     # TODO: fill in doc info
-    property :umask, String
+    property :umask, String, desired_state: false
 
     # The time it took (in seconds) to run the most recently-run action.  Not
     # cumulative across actions.  This is set to 0 as soon as a new action starts

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -618,17 +618,10 @@ class Chef
     end
 
     def with_umask
-      if umask.nil?
-        yield
-        return
-      end
-
-      old_value = ::File.umask(umask.oct)
-      begin
-        yield
-      ensure
-        ::File.umask(old_value)
-      end
+      old_value = ::File.umask(umask.oct) if umask
+      yield
+    ensure
+      ::File.umask(old_value) if umask
     end
 
     #

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1239,21 +1239,26 @@ describe Chef::Resource do
 
   describe "#with_umask" do
     let(:resource) { Chef::Resource.new("testy testerson") }
+    let!(:original_umask) { ::File.umask }
+
+    after do
+      ::File.umask(original_umask)
+    end
+
     it "does not affect the umask by default" do
-      original_value = ::File.umask
       block_value = nil
 
       resource.with_umask do
         block_value = ::File.umask
       end
 
-      expect(block_value).to eq(original_value)
+      expect(block_value).to eq(original_umask)
     end
 
     it "changes the umask in the block to the set value" do
-      block_value = nil
-
       resource.umask = "0123"
+
+      block_value = nil
 
       resource.with_umask do
         block_value = ::File.umask
@@ -1266,25 +1271,21 @@ describe Chef::Resource do
     end
 
     it "resets the umask afterwards" do
-      original_value = ::File.umask
-
       resource.umask = "0123"
 
       resource.with_umask do
         "noop"
       end
 
-      expect(::File.umask).to eq(original_value)
+      expect(::File.umask).to eq(original_umask)
     end
 
     it "resets the umask if the block raises an error" do
-      original_value = ::File.umask
-
       resource.umask = "0123"
 
       expect { resource.with_umask { 1 / 0 } }.to raise_error(ZeroDivisionError)
 
-      expect(::File.umask).to eq(original_value)
+      expect(::File.umask).to eq(original_umask)
     end
   end
 end

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1282,7 +1282,7 @@ describe Chef::Resource do
 
       resource.umask = "0123"
 
-      expect { resource.with_umask { 1/0 } }.to raise_error(ZeroDivisionError)
+      expect { resource.with_umask { 1 / 0 } }.to raise_error(ZeroDivisionError)
 
       expect(::File.umask).to eq(original_value)
     end


### PR DESCRIPTION
Adds a umask property for all resources. Implements #3741.

Given a file resource like this:
```
Petes-MBP:chef pete$ cat ../test_file_resource.rb
file '/tmp/index.php' do
  content '<html>This is a placeholder for the home page.</html>'
  umask '111'
end
```

Running this with `chef-apply` creates the file with mode `0666`:
```
Petes-MBP:chef pete$ rm /tmp/index.php && chef-apply ../test_file_resource.rb && ls -l /tmp/index.php
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * file[/tmp/index.php] action create
    - create new file /tmp/index.php
    - update content in file /tmp/index.php from none to 3d079e
    --- /tmp/index.php  2020-06-15 18:33:40.877388343 -0700
    +++ /tmp/.chef-index20200615-78177-e907h5.php       2020-06-15 18:33:40.877069714 -0700
    @@ -1 +1,2 @@
    +<html>This is a placeholder for the home page.</html>
-rw-rw-rw-  1 pete  wheel  53 Jun 15 18:33 /tmp/index.php
```

If I comment out the `umask` line, the file is created with the default umask of `022` for a mode of `0755`:

```
Petes-MBP:chef pete$ rm /tmp/index.php && chef-apply ../test_file_resource.rb && ls -l /tmp/index.php
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * file[/tmp/index.php] action create
    - create new file /tmp/index.php
    - update content in file /tmp/index.php from none to 3d079e
    --- /tmp/index.php  2020-06-15 18:37:12.727712477 -0700
    +++ /tmp/.chef-index20200615-78808-1qunzal.php      2020-06-15 18:37:12.727396881 -0700
    @@ -1 +1,2 @@
    +<html>This is a placeholder for the home page.</html>
-rw-r--r--  1 pete  wheel  53 Jun 15 18:37 /tmp/index.php
```

Another example is using `gem_package`: 
```
Petes-MBP:chef pete$ cat ../test_gem_package_resource.rb
gem_package 'syntax' do
  umask '0077'
  action :install
end
```

If I run this with sudo, my regular user account can't read the gem's source after installing:

```
Petes-MBP:chef pete$ sudo gem uninstall syntax && sudo chef-apply ../test_gem_package_resource.rb && ls -l ~/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/syntax-1.2.2/
Successfully uninstalled syntax-1.2.2
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * gem_package[syntax] action install
    - install version 1.2.2 of package syntax
ls: : Permission denied
```

If I comment out the umask line I can read the source without any special permissions:

```
Petes-MBP:chef pete$ sudo gem uninstall syntax && sudo chef-apply ../test_gem_package_resource.rb && ls -l ~/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/syntax-1.2.2/
Successfully uninstalled syntax-1.2.2
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * gem_package[syntax] action install
    - install version 1.2.2 of package syntax
total 24
-rw-r--r--  1 root  staff   801 Jun 15 18:43 CHANGELOG
-rw-r--r--  1 root  staff  1499 Jun 15 18:43 LICENSE
-rw-r--r--  1 root  staff  2143 Jun 15 18:43 README.rdoc
drwxr-xr-x  4 root  staff   128 Jun 15 18:43 lib
```