### PR TITLE
Cleanup more resource examples

### DIFF
--- a/lib/chef/resource/cron/_cron_shared.rb
+++ b/lib/chef/resource/cron/_cron_shared.rb
@@ -60,16 +60,15 @@ property :user, String,
   default: "root"
 
 property :environment, Hash,
-  description: "A Hash containing additional arbitrary environment variables under which the cron job will be run in the form of `({'ENV_VARIABLE' => 'VALUE'})`.",
+  description: "A Hash containing additional arbitrary environment variables under which the cron job will be run in the form of `({'ENV_VARIABLE' => 'VALUE'})`. **Note**: These variables must exist for a command to be run successfully.",
   default: lazy { {} }
 
 property :time_out, Hash,
-  description: "A Hash of timeouts in the form of `({'OPTION' => 'VALUE'})`.
-  Accepted valid options are:
-  `preserve-status` (BOOL, default: 'false'),
-  `foreground` (BOOL, default: 'false'),
-  `kill-after` (in seconds),
-  `signal` (a name like 'HUP' or a number)",
+  description: "A Hash of timeouts in the form of `({'OPTION' => 'VALUE'})`. Accepted valid options are:
+  - `preserve-status` (BOOL, default: 'false'),
+  - `foreground` (BOOL, default: 'false'),
+  - `kill-after` (in seconds),
+  - `signal` (a name like 'HUP' or a number)",
   default: lazy { {} },
   introduced: "15.7",
   coerce: proc { |h|


### PR DESCRIPTION
In execute remove some complex examples that weren't adding much.  Also cleanup some of the ruby code so that it would pass cookstyle. Also improve the dist values we use, random formatting, and how we specify notes so they get parsed out correctly.

Signed-off-by: Tim Smith <tsmith@chef.io>