### PR TITLE
Soft fail spellchecker in ci

### DIFF
--- a/.expeditor/verify_public.pipeline.yml
+++ b/.expeditor/verify_public.pipeline.yml
@@ -577,6 +577,7 @@ steps:
     - ruby -rjson -e "JSON.parse(File.read('cspell.json'))" 2>/dev/null || (echo "Failed to parse config file 'cspell.json', skipping spellcheck" && exit 1)
     - npm install -g cspell
     - cspell "**/*"
+  soft_fail: true
   expeditor:
     executor:
       docker:


### PR DESCRIPTION
To prevent developer annoyance, run the spellchecker in CI but don't let it fail builds.