### PR TITLE
Silence exception output in threaded test.

### DIFF
--- a/spec/unit/util/threaded_job_queue_spec.rb
+++ b/spec/unit/util/threaded_job_queue_spec.rb
@@ -21,6 +21,15 @@ end
 describe Chef::Util::ThreadedJobQueue do
   let(:queue) { Chef::Util::ThreadedJobQueue.new }
 
+  around(:example) do |example|
+    old_value = Thread.report_on_exception
+    Thread.report_on_exception = false
+
+    example.run
+
+    Thread.report_on_exception = old_value
+  end
+
   it "should pass mutex to jobs with an arity of 1" do
     job = double
     expect(job).to receive(:arity).at_least(:once).and_return(1)


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Before this, you'd see this confusing output:

```
Petes-MBP:chef pete$ rspec spec/unit/util/threaded_job_queue_spec.rb
WARNING: Shared example group 'with a chef repo' has been previously defined at:
  /Users/pete/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/cheffish-16.0.2/lib/cheffish/rspec/repository_support.rb:12
...and you are now defining it at:
  /Users/pete/work/chef/spec/support/shared/integration/integration_helper.rb:109
The new definition will overwrite the original one.
Run options:
  include {:focus=>true}
  exclude {:provider=>#<Proc:./spec/spec_helper.rb:210>, :arch=>#<Proc:./spec/spec_helper.rb:204>, :choco_installed=>true, :ruby=>"2.6.6", :chef=>"16.2.38", :not_intel_64bit=>true, :rhel_gte_8=>true, :rhel8=>true, :rhel7=>true, :rhel6=>true, :rhel=>true, :not_wpar=>true, :broken=>true, :openssl_lt_101=>true, :requires_root_or_running_windows=>true, :requires_root=>true, :selinux_only=>true, :debian_family_only=>true, :opensuse=>true, :suse_only=>true, :aix_only=>true, :linux_only=>true, :system_windows_service_gem_only=>true, :solaris_only=>true, :windows_service_requires_assign_token=>true, :windows_domain_joined_only=>true, :windows_powershell_dsc_only=>true, :ruby32_only=>true, :windows_gte_10=>true, :windows32_only=>true, :windows64_only=>true, :win2012r2_only=>true, :macos_1014=>true, :not_supported_on_macos=>true, :windows_only=>true, :volatile_from_verify=>false, :volatile=>true, :external=>true}

All examples were filtered out; ignoring {:focus=>true}
...#<Thread:0x00007f84761e9658@/Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:49 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        3: from /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:50:in `block (2 levels) in process'
        2: from /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:50:in `loop'
        1: from /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:52:in `block (3 levels) in process'
/Users/pete/work/chef/spec/unit/util/threaded_job_queue_spec.rb:48:in `block (3 levels) in <top (required)>': WorkerThreadError (WorkerThreadError)
.

Finished in 0.01914 seconds (files took 13.1 seconds to load)
4 examples, 0 failures
```