### PR TITLE
Fix for knife config use-profile doesn't validate that the profile exist

### DIFF
--- a/lib/chef/knife/config_use_profile.rb
+++ b/lib/chef/knife/config_use_profile.rb
@@ -33,17 +33,27 @@ class Chef
       end
 
       def run
+        credentials_data = self.class.config_loader.parse_credentials_file
         context_file = ChefConfig::PathHelper.home(".chef", "context").freeze
         profile = @name_args[0]&.strip
-        if profile && !profile.empty?
+        if profile.nil? || profile.empty?
+          show_usage
+          ui.fatal("You must specify a profile")
+          exit 1
+        end
+
+        if credentials_data.nil? || credentials_data.empty?
+          ui.fatal("No profiles found, #{self.class.config_loader.credentials_file_path} does not exist or is empty")
+          exit 1
+        end
+
+        if credentials_data[profile].nil?
+          raise ChefConfig::ConfigurationError, "Profile #{profile} doesn't exist. Please add it to #{self.class.config_loader.credentials_file_path} and if it is profile with DNS name check that you are not missing single quotes around it as per docs https://docs.chef.io/workstation/knife_setup/#knife-profiles."
+        else
           # Ensure the .chef/ folder exists.
           FileUtils.mkdir_p(File.dirname(context_file))
           IO.write(context_file, "#{profile}\n")
           ui.msg("Set default profile to #{profile}")
-        else
-          show_usage
-          ui.fatal("You must specify a profile")
-          exit 1
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
After fix output:  "when user provides profile which does not exist in credentials file"
```
bundle exec knife config use-profile test -c ~/workspace/hosted-chef-repo/chef-repo/.chef/knife.rb 
ERROR: ChefConfig::ConfigurationError: Profile test doesn't exist. Please add it to /home/msys/.chef/credentials and if it is profile with DNS name check that you are not missing single quotes around it as per docs https://docs.chef.io/workstation/knife_setup/#knife-profiles.
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#9686 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
