### PR TITLE
Update the list of allowed policies for the windows_security_policy resource

### DIFF
--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -25,21 +25,23 @@ class Chef
 
       # The valid policy_names options found here
       # https://github.com/ChrisAWalker/cSecurityOptions under 'AccountSettings'
-      policy_names = %w{MinimumPasswordAge
-                MaximumPasswordAge
-                MinimumPasswordLength
-                PasswordComplexity
-                PasswordHistorySize
-                LockoutBadCount
-                RequireLogonToChangePassword
-                ForceLogoffWhenHourExpire
-                NewAdministratorName
-                NewGuestName
-                ClearTextPassword
-                LSAAnonymousNameLookup
-                EnableAdminAccount
-                EnableGuestAccount
-                }
+      policy_names = %w{LockoutDuration
+                        MaximumPasswordAge
+                        MinimumPasswordAge
+                        MinimumPasswordLength
+                        PasswordComplexity
+                        PasswordHistorySize
+                        LockoutBadCount
+                        ResetLockoutCount
+                        RequireLogonToChangePassword
+                        ForceLogoffWhenHourExpire
+                        NewAdministratorName
+                        NewGuestName
+                        ClearTextPassword
+                        LSAAnonymousNameLookup
+                        EnableAdminAccount
+                        EnableGuestAccount
+                       }
       description "Use the **windows_security_policy** resource to set a security policy on the Microsoft Windows platform."
       introduced "16.0"
 


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
adds a couple of policies to the list of allowed security policies for the windows_security_policy resource.

Added policies are `LockoutDuration` and `ResetLockoutCount` 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
