### PR TITLE
Fix how enforce_license is set in run method for chef-apply

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -216,7 +216,7 @@ class Chef::Application::Apply < Chef::Application
   end
 
   # Get this party started
-  def run(enforce_license = false)
+  def run(enforce_license: false)
     reconfigure
     check_license_acceptance if enforce_license
     run_application

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -94,6 +94,13 @@ describe Chef::Application do
           end
         end
 
+        describe "when enforce_license is set to false" do
+          it "should not check the license acceptance" do
+            expect(@app).to_not receive(:check_license_acceptance)
+            @app.run(enforce_license: false)
+          end
+        end
+
         it "should run the actual application" do
           expect(@app).to receive(:run_application).and_return(true)
           @app.run


### PR DESCRIPTION
I recently discovered that when using
``Chef::Application::Apply.new.run(enforce_license: false)``, chef-apply will still
run the license verification when I expected it to be disabled. It seems this
feature works if you install this as a gem, however if you build chef using
omnibus with this set, it refuses to work. I suspect this might be something
with appbundler.

I noticed that other binaries (i.e. solo) were using "run(enforce_license:
false)" instead of "run(enforce_license = false)" which chef-apply uses. If I
changed this to "run(enforce_license: false)", this worked as expected.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This backports #9963 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
