### PR TITLE
windows_security_policy was using resource_name instead of provides

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -27,6 +27,11 @@ timezone "UTC"
 
 include_recipe "ntp"
 
+windows_security_policy "EnableGuestAccount" do
+  secoption "EnableGuestAccount"
+  secvalue "1"
+end
+
 users_manage "remove sysadmin" do
   group_name "sysadmin"
   group_id 2300

--- a/lib/chef/resource/windows_security_policy.rb
+++ b/lib/chef/resource/windows_security_policy.rb
@@ -21,7 +21,7 @@ require_relative "../resource"
 class Chef
   class Resource
     class WindowsSecurityPolicy < Chef::Resource
-      resource_name :windows_security_policy
+      provides :windows_security_policy
 
       # The valid policy_names options found here
       # https://github.com/ChrisAWalker/cSecurityOptions under 'AccountSettings'


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
windows_security_policy broke with the 16.2 rollout of chef-client because it hadn't been udpated from using `resource_name` to using `provides`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
