### PR TITLE
consume powershell shim DLLs from hab package

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -13,6 +13,7 @@ $pkg_bin_dirs=@(
 $pkg_deps=@(
   "core/cacerts"
   "chef/ruby27-plus-devkit"
+  "chef/chef-powershell-shim"
 )
 
 function Invoke-Begin {
@@ -28,7 +29,6 @@ function Invoke-Begin {
 
 function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
-    Push-RuntimeEnv -IsPath RUBY_DLL_PATH "$pkg_prefix/lib"
 
     Set-RuntimeEnv APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
     Set-RuntimeEnv FORCE_FFI_YAJL "ext" # Always use the C-extensions because we use MRI on all the things and C is fast.
@@ -77,9 +77,6 @@ function Invoke-Build {
     try {
         Push-Location "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"
 
-        Write-BuildLine " ** Copying Chef DLLs"
-        New-Item -ItemType Directory -Force -Path "$pkg_prefix/lib"
-        Get-ChildItem ./distro/ruby_bin_folder -Filter "*.dll" | Copy-Item -Destination "$pkg_prefix/lib"
         $env:_BUNDER_WINDOWS_DLLS_COPIED = "1"
 
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"


### PR DESCRIPTION
fixes #9754

This requires https://github.com/chef/chef-powershell-shim/pull/11 and for that chef-powershell-shim package to be build, uploaded and promoted.

This consumes that package which sets the `RUBY_DLL_PATH` and also `CHEF_POWERSHELL_BIN` which with the changes to the shim wrapper code will be where the .Net clr will look for the shim .net assemblies (Chef.Powershell.dll and Newtonsoft.Json.dll).

To test I built and uploaded to my mwrock origin and then built this in my mwrock origin and then ran:

```
hab pkg exec mwrock/chef-infra-client chef-apply.bat -e "puts (powershell_exec('write-output
`$PSVersionTable')).result"
```
This produced the expected powershell json result.
