### PR TITLE
More aggressively deprecate config_value

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -705,7 +705,7 @@ class Chef
 
       # FIXME: someone needs to clean this up properly:  https://github.com/chef/chef/issues/9645
       # This code is deliberately left without an abstraction around deprecating the config options to avoid knife plugins from
-      # using those methods (which will need to be deprecated and break them) via inheretance (ruby does not have a true `private`
+      # using those methods (which will need to be deprecated and break them) via inheritance (ruby does not have a true `private`
       # so the lack of any inheritable implementation is because of that).
       #
       def winrm_auth_method

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -703,8 +703,17 @@ class Chef
         true
       end
 
+      # FIXME: someone needs to clean this up properly:  https://github.com/chef/chef/issues/9645
+      # This code is deliberately left without an abstraction around deprecating the config options to avoid knife plugins from
+      # using those methods (which will need to be deprecated and break them) via inheretance (ruby does not have a true `private`
+      # so the lack of any inheritable implementation is because of that).
+      #
       def winrm_auth_method
-        config_value(:winrm_auth_method, :winrm_authentication_protocol, "negotiate")
+        config.key?(:winrm_auth_method) ? config[:winrm_auth_method] : config.key?(:winrm_authentications_protocol) ? config[:winrm_authentication_protocol] : "negotiate" # rubocop:disable Style/NestedTernaryOperator
+      end
+
+      def ssh_verify_host_key
+        config.key?(:ssh_verify_host_key) ? config[:ssh_verify_host_key] : config.key?(:host_key_verify) ? config[:host_key_verify] : "always" # rubocop:disable Style/NestedTernaryOperator
       end
 
       # Fail if using plaintext auth without ssl because
@@ -905,7 +914,7 @@ class Chef
           { self_signed: config[:winrm_no_verify_cert] === true }
         elsif ssh?
           # Fall back to the old knife config key name for back compat.
-          { verify_host_key: config_value(:ssh_verify_host_key, :host_key_verify, "always") }
+          { verify_host_key: ssh_verify_host_key }
         else
           {}
         end
@@ -1051,7 +1060,7 @@ class Chef
       # @api deprecated
       #
       def config_value(key, fallback_key = nil, default = nil)
-        Chef.deprecated(:knife_bootstrap_apis, "Use of config_value without a fallback_key is deprecated.  Knife plugin authors should access the config hash directly, which does correct merging of cli and config options.") if fallback_key.nil?
+        Chef.deprecated(:knife_bootstrap_apis, "Use of config_value is deprecated.  Knife plugin authors should access the config hash directly, which does correct merging of cli and config options.")
         if config.key?(key)
           # the first key is the primary key so we check the merged hash first
           config[key]

--- a/spec/unit/knife/bootstrap_spec.rb
+++ b/spec/unit/knife/bootstrap_spec.rb
@@ -1927,6 +1927,7 @@ describe Chef::Knife::Bootstrap do
       Chef::Config[:knife][:test_key_c] = "c from Chef::Config"
       Chef::Config[:knife][:alt_test_key_c] = "alt c from Chef::Config"
       knife.merge_configs
+      Chef::Config[:treat_deprecation_warnings_as_errors] = false
     end
 
     it "returns the Chef::Config value from the cli when the CLI key is set" do


### PR DESCRIPTION
Force subclasses to use the `config` hash directly.

This should not affect any knife plugins shipping in chef-workstation
since the calls to config_value have already been removed from all of
those plugins.  The multiple-argument version of config_value was not
actually used anywhere in those plugins and the single value version
was removed and replaced with accessing the config hash.  Since that
was introduced sometime in 15.x when the bootstrap changes went in,
it is not expected that many external knife plugins have picked up
the usage of config_value.
