### PR TITLE
Fixed Powershell_Package does not throw error when it cannot connect to powershell gallery

### DIFF
--- a/lib/chef/provider/package/powershell.rb
+++ b/lib/chef/provider/package/powershell.rb
@@ -53,6 +53,9 @@ class Chef
 
         # Installs the package specified with the version passed else latest version will be installed
         def install_package(names, versions)
+          # To enable tls 1.2, which is disabled by default in some OS
+          powershell_out("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+
           names.each_with_index do |name, index|
             cmd = powershell_out(build_powershell_package_command("Install-Package '#{name}'", versions[index]), timeout: new_resource.timeout)
             next if cmd.nil?
@@ -115,7 +118,8 @@ class Chef
           command = [command] unless command.is_a?(Array)
           cmdlet_name = command.first
           command.unshift("(")
-          %w{-Force -ForceBootstrap}.each do |arg|
+          # -WarningAction SilentlyContinue is used to suppress the warnings from stdout
+          %w{-Force -ForceBootstrap -WarningAction SilentlyContinue}.each do |arg|
             command.push(arg)
           end
           command.push("-RequiredVersion #{version}") if version

--- a/spec/unit/provider/package/powershell_spec.rb
+++ b/spec/unit/provider/package/powershell_spec.rb
@@ -131,7 +131,7 @@ describe Chef::Provider::Package::Powershell do
     end
 
     it "should set the candidate_version to the latest version when not pinning and package name is space seperated" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_available)
       new_resource.package_name(["7-Zip 16.02 (x64)"])
       new_resource.version(nil)
       expect(provider.candidate_version).to eql(["16.02"])

--- a/spec/unit/provider/package/powershell_spec.rb
+++ b/spec/unit/provider/package/powershell_spec.rb
@@ -93,19 +93,19 @@ describe Chef::Provider::Package::Powershell do
     double("powershell_out", stdout: "5")
   end
 
-  let(:generated_command) { "( Get-Package posh-git -Force -ForceBootstrap ).Version" }
-  let(:generated_get_cmdlet) { "( Get-Package xNetworking -Force -ForceBootstrap ).Version" }
-  let(:generated_get_cmdlet_with_version) { "( Get-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 ).Version" }
-  let(:generated_find_cmdlet) { "( Find-Package xNetworking -Force -ForceBootstrap ).Version" }
-  let(:generated_find_cmdlet_with_version) { "( Find-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 ).Version" }
-  let(:generated_find_cmdlet_with_source) { "( Find-Package xNetworking -Force -ForceBootstrap -Source MyGallery ).Version" }
-  let(:generated_find_cmdlet_with_source_and_version) { "( Find-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 -Source MyGallery ).Version" }
-  let(:generated_install_cmdlet) { "( Install-Package xNetworking -Force -ForceBootstrap ).Version" }
-  let(:generated_install_cmdlet_with_version) { "( Install-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 ).Version" }
-  let(:generated_install_cmdlet_with_source) { "( Install-Package xNetworking -Force -ForceBootstrap -Source MyGallery ).Version" }
-  let(:generated_install_cmdlet_with_source_and_version) { "( Install-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 -Source MyGallery ).Version" }
-  let(:generated_uninstall_cmdlet) { "( Uninstall-Package xNetworking -Force -ForceBootstrap ).Version" }
-  let(:generated_uninstall_cmdlet_with_version) { "( Uninstall-Package xNetworking -Force -ForceBootstrap -RequiredVersion 1.0.0.0 ).Version" }
+  let(:generated_command) { "( Get-Package posh-git -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version" }
+  let(:generated_get_cmdlet) { "( Get-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version" }
+  let(:generated_get_cmdlet_with_version) { "( Get-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 ).Version" }
+  let(:generated_find_cmdlet) { "( Find-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version" }
+  let(:generated_find_cmdlet_with_version) { "( Find-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 ).Version" }
+  let(:generated_find_cmdlet_with_source) { "( Find-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version" }
+  let(:generated_find_cmdlet_with_source_and_version) { "( Find-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 -Source MyGallery ).Version" }
+  let(:generated_install_cmdlet) { "( Install-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version" }
+  let(:generated_install_cmdlet_with_version) { "( Install-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 ).Version" }
+  let(:generated_install_cmdlet_with_source) { "( Install-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version" }
+  let(:generated_install_cmdlet_with_source_and_version) { "( Install-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 -Source MyGallery ).Version" }
+  let(:generated_uninstall_cmdlet) { "( Uninstall-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version" }
+  let(:generated_uninstall_cmdlet_with_version) { "( Uninstall-Package xNetworking -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 1.0.0.0 ).Version" }
 
   describe "#initialize" do
     it "should return the correct class" do
@@ -116,14 +116,14 @@ describe Chef::Provider::Package::Powershell do
   describe "#candidate_version" do
 
     it "should set the candidate_version to the latest version when not pinning" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
       new_resource.package_name(["xNetworking"])
       new_resource.version(nil)
       expect(provider.candidate_version).to eql(["2.12.0.0"])
     end
 
     it "should use the candidate_version from the correct source" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
       new_resource.package_name(["xNetworking"])
       new_resource.version(nil)
       new_resource.source("MyGallery")
@@ -138,53 +138,53 @@ describe Chef::Provider::Package::Powershell do
     end
 
     it "should set the candidate_version to pinned version if available" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.0.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available_2_0_0_0)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.0.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available_2_0_0_0)
       new_resource.package_name(["xCertificate"])
       new_resource.version(["2.0.0.0"])
       expect(provider.candidate_version).to eql(["2.0.0.0"])
     end
 
     it "should set the candidate_version to nil if there is no candidate" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       new_resource.package_name(["xCertificate"])
       expect(provider.candidate_version).to eql([nil])
     end
 
     it "should set the candidate_version correctly when there are two packages to install" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
       expect(provider.candidate_version).to eql(["2.1.0.0", "2.12.0.0"])
     end
 
     it "should set the candidate_version correctly when only the first is installable" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
       expect(provider.candidate_version).to eql(["2.1.0.0", nil])
     end
 
     it "should set the candidate_version correctly when only the last is installable" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
       expect(provider.candidate_version).to eql([nil, "2.12.0.0"])
     end
 
     it "should set the candidate_version correctly when neither are is installable and version is passed as nil array" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       new_resource.package_name(%w{xNetworking xCertificate})
       new_resource.version([nil, nil])
       expect(provider.candidate_version).to eql([nil, nil])
     end
 
     it "should set the candidate_version correctly when neither are is installable and version is not passed" do
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       new_resource.package_name(%w{xNetworking xCertificate})
       new_resource.version(nil)
       expect(provider.candidate_version).to eql([nil, nil])
@@ -283,10 +283,11 @@ describe Chef::Provider::Package::Powershell do
       provider.load_current_resource
       new_resource.package_name(["xCertificate"])
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -296,10 +297,11 @@ describe Chef::Provider::Package::Powershell do
       new_resource.package_name(["xCertificate"])
       new_resource.version(nil)
       new_resource.source("MyGallery")
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -309,10 +311,11 @@ describe Chef::Provider::Package::Powershell do
       new_resource.package_name(["xCertificate"])
       new_resource.version(nil)
       new_resource.skip_publisher_check(true)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -SkipPublisherCheck ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -SkipPublisherCheck ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 -SkipPublisherCheck ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 -SkipPublisherCheck ).Version", { timeout: new_resource.timeout })
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -321,10 +324,11 @@ describe Chef::Provider::Package::Powershell do
       provider.load_current_resource
       new_resource.package_name(["7-Zip 16.02 (x64)"])
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_not_installed)
+      allow(provider).to receive(:powershell_out).with("( Find-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_7zip_not_installed)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap -RequiredVersion 16.02 ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package '7-Zip 16.02 (x64)' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 16.02 ).Version", { timeout: new_resource.timeout })
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -336,10 +340,11 @@ describe Chef::Provider::Package::Powershell do
         provider.load_current_resource
         new_resource.package_name(["xCertificate"])
         new_resource.version(nil)
-        allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-        allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+        allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+        allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
         allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-        expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+        allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+        expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
         provider.run_action(:install)
         expect(new_resource).to be_updated_by_last_action
       end
@@ -348,8 +353,8 @@ describe Chef::Provider::Package::Powershell do
     it "should not install packages that are up-to-date" do
       new_resource.package_name(["xCertificate"])
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
       expect(provider).not_to receive(:install_package)
@@ -360,8 +365,8 @@ describe Chef::Provider::Package::Powershell do
     it "should not install packages that are up-to-date" do
       new_resource.package_name(["xNetworking"])
       new_resource.version(["2.11.0.0"])
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available_2_11_0_0)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available_2_11_0_0)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
       expect(provider).not_to receive(:install_package)
@@ -374,13 +379,14 @@ describe Chef::Provider::Package::Powershell do
       # new_version.resource[0]
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version([nil, "2.11.0.0"])
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available_2_11_0_0)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available_2_11_0_0)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.11.0.0 ).Version", { timeout: new_resource.timeout })
       provider.load_current_resource
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -389,13 +395,14 @@ describe Chef::Provider::Package::Powershell do
     it "should split up commands when given two packages, one with a version pin" do
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(["2.1.0.0", nil])
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.12.0.0 ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.12.0.0 ).Version", { timeout: new_resource.timeout })
 
       provider.load_current_resource
       provider.run_action(:install)
@@ -405,13 +412,14 @@ describe Chef::Provider::Package::Powershell do
     it "should do multipackage installs when given two packages without constraints" do
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.12.0.0 ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.12.0.0 ).Version", { timeout: new_resource.timeout })
       provider.load_current_resource
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -421,13 +429,14 @@ describe Chef::Provider::Package::Powershell do
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
       new_resource.source("MyGallery")
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -Source MyGallery ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
-      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -RequiredVersion 2.12.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
+      allow(provider).to receive(:powershell_out).with("[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12")
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Install-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.12.0.0 -Source MyGallery ).Version", { timeout: new_resource.timeout })
       provider.load_current_resource
       provider.run_action(:install)
       expect(new_resource).to be_updated_by_last_action
@@ -439,8 +448,8 @@ describe Chef::Provider::Package::Powershell do
       provider.load_current_resource
       new_resource.package_name(["xCertificate"])
       new_resource.version(["2.1.0.0"])
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       expect(provider).not_to receive(:remove_package)
       provider.run_action(:remove)
@@ -451,11 +460,11 @@ describe Chef::Provider::Package::Powershell do
       new_resource.package_name(["xCertificate"])
       new_resource.version(["2.1.0.0"])
       new_resource.source("MyGallery")
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 -Source MyGallery).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 -Source MyGallery).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
-      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -463,10 +472,10 @@ describe Chef::Provider::Package::Powershell do
     it "does nothing when all the packages are already removed" do
       new_resource.package_name(%w{xCertificate xNetworking})
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xNetworking' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xnetworking_not_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
       expect(provider).not_to receive(:remove_package)
@@ -477,11 +486,11 @@ describe Chef::Provider::Package::Powershell do
     it "removes a package when version is specified" do
       new_resource.package_name(["xCertificate"])
       new_resource.version(["2.1.0.0"])
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
-      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
+      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue -RequiredVersion 2.1.0.0 ).Version", { timeout: new_resource.timeout })
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end
@@ -489,11 +498,11 @@ describe Chef::Provider::Package::Powershell do
     it "removes a package when version is not specified" do
       new_resource.package_name(["xCertificate"])
       new_resource.version(nil)
-      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
-      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Find-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
+      allow(provider).to receive(:powershell_out).with("( Get-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_available)
       allow(provider).to receive(:powershell_out).with("$PSVersionTable.PSVersion.Major").and_return(powershell_installed_version)
       provider.load_current_resource
-      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
+      expect(provider).to receive(:powershell_out).with("( Uninstall-Package 'xCertificate' -Force -ForceBootstrap -WarningAction SilentlyContinue ).Version", { timeout: new_resource.timeout }).and_return(package_xcertificate_not_available)
       provider.run_action(:remove)
       expect(new_resource).to be_updated_by_last_action
     end


### PR DESCRIPTION
Fix Windows Server 2012 - 2016 to use TLS 1.2

Signed-off-by: sanga17 <sausekar@msystechnologies.com>