### PR TITLE
Fix wrong unit test exposed by cleaning up rspec deprecations.

### DIFF
--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -79,7 +79,7 @@ describe "a class that mixes in user_context" do
       context "when the block raises an exception" do
         it "closes the logon session so resources are not leaked" do
           expect(logon_session).to receive(:close)
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1/0 } }.to raise_error(ZeroDivisionError)
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1 / 0 } }.to raise_error(ZeroDivisionError)
         end
       end
     end

--- a/spec/unit/mixin/user_context_spec.rb
+++ b/spec/unit/mixin/user_context_spec.rb
@@ -77,17 +77,9 @@ describe "a class that mixes in user_context" do
       end
 
       context "when the block raises an exception" do
-        class UserContextTestException < RuntimeError
-        end
-        let(:block_parameter) { Proc.new { raise UserContextTextException } }
-
-        it "raises the exception raised by the block" do
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error(UserContextTestException)
-        end
-
         it "closes the logon session so resources are not leaked" do
           expect(logon_session).to receive(:close)
-          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life", &block_parameter) }.not_to raise_error(UserContextTestException)
+          expect { instance_with_user_context.with_context("kamilah", nil, "chef4life") { 1/0 } }.to raise_error(ZeroDivisionError)
         end
       end
     end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>