### PR TITLE
Revert openssl digest update that broke FIPS

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbook_file.rb
@@ -18,7 +18,7 @@
 
 require_relative "../base_fs_object"
 require_relative "../../../http/simple"
-require "openssl" unless defined?(OpenSSL)
+require "digest" unless defined?(Digest)
 
 class Chef
   module ChefFS
@@ -69,7 +69,7 @@ class Chef
           private
 
           def calc_checksum(value)
-            OpenSSL::Digest.hexdigest("MD5", value)
+            ::Digest::MD5.hexdigest(value)
           end
         end
       end

--- a/lib/chef/digester.rb
+++ b/lib/chef/digester.rb
@@ -19,6 +19,7 @@
 #
 
 require "openssl" unless defined?(OpenSSL)
+require "digest" unless defined?(Digest)
 require "singleton" unless defined?(Singleton)
 
 class Chef
@@ -50,11 +51,11 @@ class Chef
     end
 
     def generate_md5_checksum_for_file(file)
-      checksum_file(file, OpenSSL::Digest.new("MD5"))
+      checksum_file(file, ::Digest::MD5.new)
     end
 
     def generate_md5_checksum(io)
-      checksum_io(io, OpenSSL::Digest.new("MD5"))
+      checksum_io(io, ::Digest::MD5.new)
     end
 
     private


### PR DESCRIPTION
We're going to have to figure out how to work around this before Ruby 3.0 this the constants go away.