### PR TITLE
specs: Remove more methods defined on the top-level scope

### DIFF
--- a/spec/functional/knife/configure_spec.rb
+++ b/spec/functional/knife/configure_spec.rb
@@ -21,7 +21,7 @@ require "spec_helper"
 require "chef/knife/configure"
 
 describe "knife configure" do
-  let (:ohai) do
+  let(:ohai) do
     OHAI_SYSTEM
   end
 

--- a/spec/functional/resource/bash_spec.rb
+++ b/spec/functional/resource/bash_spec.rb
@@ -28,7 +28,7 @@ describe Chef::Resource::Bash, :unix_only do
   end
 
   describe "when setting the command property" do
-    let (:command) { "wizard racket" }
+    let(:command) { "wizard racket" }
 
     it "should raise an exception when trying to set the command" do
       expect { resource.command command }.to raise_error(Chef::Exceptions::Script)

--- a/spec/functional/resource/insserv_spec.rb
+++ b/spec/functional/resource/insserv_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Resource::Service, :requires_root, :opensuse do
     provider
   end
 
-  let (:service_name) { "Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)" }
+  let(:service_name) { "Chef::Util::PathHelper.escape_glob_dir(current_resource.service_name)" }
 
   let(:current_resource) do
     provider.load_current_resource

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -23,8 +23,8 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
 
   include_context Chef::Resource::WindowsScript
 
-  let (:architecture_command) { "echo $env:PROCESSOR_ARCHITECTURE" }
-  let (:output_command) { " | out-file -encoding ASCII " }
+  let(:architecture_command) { "echo $env:PROCESSOR_ARCHITECTURE" }
+  let(:output_command) { " | out-file -encoding ASCII " }
 
   it_behaves_like "a Windows script running on Windows"
 
@@ -68,8 +68,8 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
       end
     end
 
-    let (:negative_exit_status) { -27 }
-    let (:unsigned_exit_status) { (-negative_exit_status ^ 65535) + 1 }
+    let(:negative_exit_status) { -27 }
+    let(:unsigned_exit_status) { (-negative_exit_status ^ 65535) + 1 }
     it "returns the exit status -27 as a signed integer or an unsigned 16-bit 2's complement value of 65509 for a powershell script that exits with -27" do
 
       # Versions of PowerShell prior to 4.0 return a 16-bit unsigned value --

--- a/spec/functional/resource/remote_file_spec.rb
+++ b/spec/functional/resource/remote_file_spec.rb
@@ -229,8 +229,8 @@ describe Chef::Resource::RemoteFile do
           end
 
           context "when the resource is accessed using an alternate user's identity with no access to the file" do
-            let (:windows_nonadmin_user) { "chefremfile1" }
-            let (:windows_nonadmin_user_password) { "j82ajfxK3;2Xe1" }
+            let(:windows_nonadmin_user) { "chefremfile1" }
+            let(:windows_nonadmin_user_password) { "j82ajfxK3;2Xe1" }
             include_context "a non-admin Windows user"
 
             before do
@@ -246,8 +246,8 @@ describe Chef::Resource::RemoteFile do
         end
 
         context "when the the file is only accessible as a specific alternate identity" do
-          let (:windows_nonadmin_user) { "chefremfile2" }
-          let (:windows_nonadmin_user_password) { "j82ajfxK3;2Xe2" }
+          let(:windows_nonadmin_user) { "chefremfile2" }
+          let(:windows_nonadmin_user_password) { "j82ajfxK3;2Xe2" }
           include_context "a non-admin Windows user"
 
           before do
@@ -279,8 +279,8 @@ describe Chef::Resource::RemoteFile do
           end
 
           context "when the resource is accessed using an alternate user's identity with no access to the file" do
-            let (:windows_nonadmin_user) { "chefremfile3" }
-            let (:windows_nonadmin_user_password) { "j82ajfxK3;2Xe3" }
+            let(:windows_nonadmin_user) { "chefremfile3" }
+            let(:windows_nonadmin_user_password) { "j82ajfxK3;2Xe3" }
             include_context "a non-admin Windows user"
 
             let(:remote_user) { windows_nonadmin_user_qualified }

--- a/spec/functional/win32/crypto_spec.rb
+++ b/spec/functional/win32/crypto_spec.rb
@@ -32,7 +32,7 @@ describe "Chef::ReservedNames::Win32::Crypto", :windows_only do
       @run_context = Chef::RunContext.new(new_node, {}, events)
     end
 
-    let (:plaintext) { "p@assword" }
+    let(:plaintext) { "p@assword" }
 
     it "can be decrypted by powershell" do
       encrypted = Chef::ReservedNames::Win32::Crypto.encrypt(plaintext)

--- a/spec/integration/knife/cookbook_upload_spec.rb
+++ b/spec/integration/knife/cookbook_upload_spec.rb
@@ -25,7 +25,7 @@ describe "knife cookbook upload", :workstation do
 
   include_context "default config options"
 
-  let (:cb_dir) { "#{@repository_dir}/cookbooks" }
+  let(:cb_dir) { "#{@repository_dir}/cookbooks" }
 
   when_the_chef_server "is empty" do
     when_the_repository "has a cookbook" do

--- a/spec/integration/knife/data_bag_from_file_spec.rb
+++ b/spec/integration/knife/data_bag_from_file_spec.rb
@@ -24,7 +24,7 @@ describe "knife data bag from file", :workstation do
 
   include_context "default config options"
 
-  let (:db_dir) { "#{@repository_dir}/data_bags" }
+  let(:db_dir) { "#{@repository_dir}/data_bags" }
 
   when_the_chef_server "has an empty data bag" do
     before do

--- a/spec/integration/knife/environment_from_file_spec.rb
+++ b/spec/integration/knife/environment_from_file_spec.rb
@@ -24,7 +24,7 @@ describe "knife environment from file", :workstation do
 
   # include_context "default config options"
 
-  let (:env_dir) { "#{@repository_dir}/environments" }
+  let(:env_dir) { "#{@repository_dir}/environments" }
 
   when_the_chef_server "is empty" do
     when_the_repository "has some environments" do

--- a/spec/integration/knife/node_from_file_spec.rb
+++ b/spec/integration/knife/node_from_file_spec.rb
@@ -24,7 +24,7 @@ describe "knife node from file", :workstation do
 
   # include_context "default config options"
 
-  let (:node_dir) { "#{@repository_dir}/nodes" }
+  let(:node_dir) { "#{@repository_dir}/nodes" }
 
   when_the_chef_server "is empty" do
     when_the_repository "has some nodes" do

--- a/spec/integration/knife/role_from_file_spec.rb
+++ b/spec/integration/knife/role_from_file_spec.rb
@@ -24,7 +24,7 @@ describe "knife role from file", :workstation do
 
   # include_context "default config options"
 
-  let (:role_dir) { "#{@repository_dir}/roles" }
+  let(:role_dir) { "#{@repository_dir}/roles" }
 
   when_the_chef_server "is empty" do
     when_the_repository "has some roles" do

--- a/spec/integration/recipes/resource_load_spec.rb
+++ b/spec/integration/recipes/resource_load_spec.rb
@@ -119,10 +119,10 @@ describe "Resource.load_current_value" do
       end
     end
 
-    let (:subresource_name) do
+    let(:subresource_name) do
       :"load_current_value_subresource_dsl#{Namer.current_index}"
     end
-    let (:subresource_class) do
+    let(:subresource_class) do
       r = Class.new(resource_class) do
         property :y, default: lazy { "default_y #{Namer.incrementing_value}" }
       end

--- a/spec/support/shared/functional/securable_resource.rb
+++ b/spec/support/shared/functional/securable_resource.rb
@@ -135,7 +135,7 @@ shared_context "use Windows permissions", :windows_only do
     }
   end
 
-  let (:write_flag) { 3 }
+  let(:write_flag) { 3 }
 
   RSpec::Matchers.define :have_expected_properties do |mask, type, flags|
     match do |ace|

--- a/spec/support/shared/functional/windows_script.rb
+++ b/spec/support/shared/functional/windows_script.rb
@@ -91,7 +91,7 @@ shared_context Chef::Resource::WindowsScript do
       end
 
       context "when the guard's architecture is specified as 64-bit" do
-        let (:guard_architecture) { :x86_64 }
+        let(:guard_architecture) { :x86_64 }
         it "executes a 64-bit guard", :windows64_only do
           resource.only_if resource_guard_command, architecture: guard_architecture
           resource.run_action(:run)
@@ -100,7 +100,7 @@ shared_context Chef::Resource::WindowsScript do
       end
 
       context "when the guard's architecture is specified as 32-bit" do
-        let (:guard_architecture) { :i386 }
+        let(:guard_architecture) { :i386 }
         it "executes a 32-bit guard" do
           resource.only_if resource_guard_command, architecture: guard_architecture
           resource.run_action(:run)

--- a/spec/unit/chef_fs/config_spec.rb
+++ b/spec/unit/chef_fs/config_spec.rb
@@ -203,8 +203,8 @@ describe Chef::ChefFS::Config do
         })
       end
 
-      let (:path) { "/roles/foo.json" }
-      let (:entry) { Entry.new(path) }
+      let(:path) { "/roles/foo.json" }
+      let(:entry) { Entry.new(path) }
 
       it "returns the entry's path if the cwd isn't in the config" do
         cfg = Chef::ChefFS::Config.new(config, "/my_repo/cookbooks")

--- a/spec/unit/chef_fs/diff_spec.rb
+++ b/spec/unit/chef_fs/diff_spec.rb
@@ -20,17 +20,17 @@ require "spec_helper"
 require "chef/chef_fs/file_pattern"
 require "chef/chef_fs/command_line"
 
-# Removes the date stamp from the diff and replaces it with ' DATE'
-# example match: "/dev/null\t2012-10-16 16:15:54.000000000 +0000"
-# windows match: "--- /dev/null\tTue Oct 16 18:04:34 2012"
-# https://rubular.com/r/5JdtZDqWnZhB9J
-def remove_os_differences(diff)
-  diff = diff.gsub(/([+-]{3}.*)\t.*/, '\1 DATE')
-  diff.gsub(/^@@ -\d(,\d)? \+-?\d(,-?\d)? @@/, "CONTEXT_LINE_NUMBERS")
-end
-
 describe "diff", uses_diff: true do
   include FileSystemSupport
+
+  # Removes the date stamp from the diff and replaces it with ' DATE'
+  # example match: "/dev/null\t2012-10-16 16:15:54.000000000 +0000"
+  # windows match: "--- /dev/null\tTue Oct 16 18:04:34 2012"
+  # https://rubular.com/r/5JdtZDqWnZhB9J
+  def remove_os_differences(diff)
+    diff = diff.gsub(/([+-]{3}.*)\t.*/, '\1 DATE')
+    diff.gsub(/^@@ -\d(,\d)? \+-?\d(,-?\d)? @@/, "CONTEXT_LINE_NUMBERS")
+  end
 
   context "with two filesystems with all types of difference" do
     let(:a) do

--- a/spec/unit/decorator_spec.rb
+++ b/spec/unit/decorator_spec.rb
@@ -18,37 +18,37 @@
 
 require "spec_helper"
 
-def impersonates_a(klass)
-  it "#is_a?(#{klass}) is true" do
-    expect(decorator.is_a?(klass)).to be true
-  end
-
-  it "#is_a?(Chef::Decorator) is true" do
-    expect(decorator.is_a?(Chef::Decorator)).to be true
-  end
-
-  it "#kind_of?(#{klass}) is true" do
-    expect(decorator.is_a?(klass)).to be true
-  end
-
-  it "#kind_of?(Chef::Decorator) is true" do
-    expect(decorator.is_a?(Chef::Decorator)).to be true
-  end
-
-  it "#instance_of?(#{klass}) is false" do
-    expect(decorator.instance_of?(klass)).to be false
-  end
-
-  it "#instance_of?(Chef::Decorator) is true" do
-    expect(decorator.instance_of?(Chef::Decorator)).to be true
-  end
-
-  it "#class is Chef::Decorator" do
-    expect(decorator.class).to eql(Chef::Decorator)
-  end
-end
-
 describe Chef::Decorator do
+  def self.impersonates_a(klass)
+    it "#is_a?(#{klass}) is true" do
+      expect(decorator.is_a?(klass)).to be true
+    end
+
+    it "#is_a?(Chef::Decorator) is true" do
+      expect(decorator.is_a?(Chef::Decorator)).to be true
+    end
+
+    it "#kind_of?(#{klass}) is true" do
+      expect(decorator.is_a?(klass)).to be true
+    end
+
+    it "#kind_of?(Chef::Decorator) is true" do
+      expect(decorator.is_a?(Chef::Decorator)).to be true
+    end
+
+    it "#instance_of?(#{klass}) is false" do
+      expect(decorator.instance_of?(klass)).to be false
+    end
+
+    it "#instance_of?(Chef::Decorator) is true" do
+      expect(decorator.instance_of?(Chef::Decorator)).to be true
+    end
+
+    it "#class is Chef::Decorator" do
+      expect(decorator.class).to eql(Chef::Decorator)
+    end
+  end
+
   let(:obj) {}
   let(:decorator) { Chef::Decorator.new(obj) }
 

--- a/spec/unit/guard_interpreter_spec.rb
+++ b/spec/unit/guard_interpreter_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::GuardInterpreter do
   describe "#for_resource" do
-    let (:resource) { Chef::Resource.new("foo") }
+    let(:resource) { Chef::Resource.new("foo") }
 
     it "returns a DefaultGuardInterpreter if the resource has guard_interpreter set to :default" do
       resource.guard_interpreter :default

--- a/spec/unit/http/api_versions_spec.rb
+++ b/spec/unit/http/api_versions_spec.rb
@@ -72,7 +72,7 @@ describe Chef::HTTP::APIVersions do
   end
 
   context "with an unacceptable api version" do
-    let (:return_value) { "406" }
+    let(:return_value) { "406" }
     it "resets the list of supported versions" do
       Chef::ServerAPIVersions.instance.set_versions({ "min_version" => 1, "max_version" => 3 })
       run_api_version_handler

--- a/spec/unit/knife/cookbook_download_spec.rb
+++ b/spec/unit/knife/cookbook_download_spec.rb
@@ -83,7 +83,7 @@ describe Chef::Knife::CookbookDownload do
         }
       end
 
-      let (:cookbook) do
+      let(:cookbook) do
         cb = Chef::CookbookVersion.new("foobar")
         cb.version = "1.0.0"
         cb.manifest = manifest_data
@@ -91,7 +91,7 @@ describe Chef::Knife::CookbookDownload do
       end
 
       describe "and no version" do
-        let (:manifest_data) { { all_files: [] } }
+        let(:manifest_data) { { all_files: [] } }
         it "should determine which version to download" do
           expect(@knife).to receive(:determine_version).and_return("1.0.0")
           expect(File).to receive(:exists?).with("/var/tmp/chef/foobar-1.0.0").and_return(false)

--- a/spec/unit/knife/cookbook_show_spec.rb
+++ b/spec/unit/knife/cookbook_show_spec.rb
@@ -27,24 +27,24 @@ describe Chef::Knife::CookbookShow do
     allow(Chef::CookbookVersion).to receive(:load).and_return(cb)
   end
 
-  let (:knife) do
+  let(:knife) do
     knife = Chef::Knife::CookbookShow.new
     knife.config = {}
     knife.name_args = [ "cookbook_name" ]
     knife
   end
 
-  let (:cb) do
+  let(:cb) do
     cb = Chef::CookbookVersion.new("cookbook_name")
     cb.manifest = manifest
     cb
   end
 
-  let (:rest) { double(Chef::ServerAPI) }
+  let(:rest) { double(Chef::ServerAPI) }
 
-  let (:content) { "Example recipe text" }
+  let(:content) { "Example recipe text" }
 
-  let (:manifest) do
+  let(:manifest) do
     {
       "all_files" => [
         {
@@ -68,7 +68,7 @@ describe Chef::Knife::CookbookShow do
     end
 
     describe "with 1 argument: versions" do
-      let (:response) do
+      let(:response) do
         {
           "cookbook_name" => {
             "url" => "http://url/cookbooks/cookbook_name",

--- a/spec/unit/knife/data_bag_edit_spec.rb
+++ b/spec/unit/knife/data_bag_edit_spec.rb
@@ -95,7 +95,7 @@ describe Chef::Knife::DataBagEdit do
       let(:is_encrypted?) { true }
       let(:db) { Chef::DataBagItem.from_hash(enc_raw_hash) }
       # If the data bag is encrypted, it gets passed to `edit` as a hash.  Otherwise, it gets passed as a DataBag
-      let (:data_to_edit) { raw_hash }
+      let(:data_to_edit) { raw_hash }
 
       before(:each) do
         expect(knife).to receive(:encryption_secret_provided_ignore_encrypt_flag?).and_return(true)

--- a/spec/unit/mixin/powershell_type_coercions_spec.rb
+++ b/spec/unit/mixin/powershell_type_coercions_spec.rb
@@ -25,7 +25,7 @@ class Chef::PSTypeTester
 end
 
 describe Chef::Mixin::PowershellTypeCoercions do
-  let (:test_class) { Chef::PSTypeTester.new }
+  let(:test_class) { Chef::PSTypeTester.new }
 
   describe "#translate_type" do
     it "single quotes a string" do

--- a/spec/unit/mixin/subclass_directive_spec.rb
+++ b/spec/unit/mixin/subclass_directive_spec.rb
@@ -31,9 +31,9 @@ class ChildWithoutDirective < SubclassDirectiveParent
 end
 
 describe Chef::Mixin::Uris do
-  let (:child) { SubclassDirectiveChild.new }
+  let(:child) { SubclassDirectiveChild.new }
 
-  let (:other_child) { ChildWithoutDirective.new }
+  let(:other_child) { ChildWithoutDirective.new }
 
   it "the child instance has the directive set" do
     expect(child.behave_differently?).to be true

--- a/spec/unit/mixin/unformatter_spec.rb
+++ b/spec/unit/mixin/unformatter_spec.rb
@@ -27,8 +27,8 @@ class Chef::UnformatterTest
 end
 
 describe Chef::Mixin::Unformatter do
-  let (:unformatter) { Chef::UnformatterTest.new }
-  let (:message) { "Test Message" }
+  let(:unformatter) { Chef::UnformatterTest.new }
+  let(:message) { "Test Message" }
 
   describe "#write" do
     context "with a timestamp" do

--- a/spec/unit/mixin/uris_spec.rb
+++ b/spec/unit/mixin/uris_spec.rb
@@ -24,7 +24,7 @@ class Chef::UrisTest
 end
 
 describe Chef::Mixin::Uris do
-  let (:uris) { Chef::UrisTest.new }
+  let(:uris) { Chef::UrisTest.new }
 
   describe "#uri_scheme?" do
     it "matches 'scheme://foo.com'" do

--- a/spec/unit/provider/cron/unix_spec.rb
+++ b/spec/unit/provider/cron/unix_spec.rb
@@ -93,7 +93,7 @@ describe Chef::Provider::Cron::Unix do
     end
 
     context "when any other error occurs" do
-      let (:exitstatus) { 2 }
+      let(:exitstatus) { 2 }
 
       it "should raise an exception if another error occurs" do
         expect do

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -27,6 +27,12 @@ describe Chef::Provider::DscResource do
     Chef::Provider::DscResource.new(resource, run_context)
   end
 
+  let(:node) do
+    node = Chef::Node.new
+    node.automatic[:languages][:powershell][:version] = "5.0.10586.0"
+    node
+  end
+
   context "when PowerShell does not support Invoke-DscResource" do
     let (:node) do
       node = Chef::Node.new
@@ -170,10 +176,6 @@ describe Chef::Provider::DscResource do
   end
 
   describe "define_resource_requirements" do
-    let (:node) do
-      set_node_object
-    end
-
     context "module usage is valid" do
       before do
         allow(provider).to receive(:module_usage_valid?).and_return(true)
@@ -208,10 +210,6 @@ describe Chef::Provider::DscResource do
   end
 
   describe "module_usage_valid?" do
-    let (:node) do
-      set_node_object
-    end
-
     context "module_name and module_version both are not provided" do
       before do
         provider.instance_variable_set(:@module_name, nil)
@@ -262,10 +260,6 @@ describe Chef::Provider::DscResource do
   end
 
   describe "module_info_object" do
-    let (:node) do
-      set_node_object
-    end
-
     context "module_version is not given" do
       before do
         provider.instance_variable_set(:@module_version, nil)
@@ -292,10 +286,6 @@ describe Chef::Provider::DscResource do
   end
 
   describe "invoke_resource" do
-    let (:node) do
-      set_node_object
-    end
-
     let(:cmdlet) { double(run!: nil) }
 
     before(:each) do
@@ -337,10 +327,4 @@ describe Chef::Provider::DscResource do
       end
     end
   end
-end
-
-def set_node_object
-  node = Chef::Node.new
-  node.automatic[:languages][:powershell][:version] = "5.0.10586.0"
-  node
 end

--- a/spec/unit/provider/dsc_resource_spec.rb
+++ b/spec/unit/provider/dsc_resource_spec.rb
@@ -20,10 +20,10 @@ require "chef"
 require "spec_helper"
 
 describe Chef::Provider::DscResource do
-  let (:events) { Chef::EventDispatch::Dispatcher.new }
-  let (:run_context) { Chef::RunContext.new(node, {}, events) }
-  let (:resource) { Chef::Resource::DscResource.new("dscresource", run_context) }
-  let (:provider) do
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:resource) { Chef::Resource::DscResource.new("dscresource", run_context) }
+  let(:provider) do
     Chef::Provider::DscResource.new(resource, run_context)
   end
 
@@ -34,7 +34,7 @@ describe Chef::Provider::DscResource do
   end
 
   context "when PowerShell does not support Invoke-DscResource" do
-    let (:node) do
+    let(:node) do
       node = Chef::Node.new
       node.automatic[:languages][:powershell][:version] = "4.0"
       node
@@ -51,7 +51,7 @@ describe Chef::Provider::DscResource do
 
     context "when RefreshMode is not set to Disabled" do
       context "and the WMF 5 is a preview release" do
-        let (:node) do
+        let(:node) do
           node = Chef::Node.new
           node.automatic[:languages][:powershell][:version] = "5.0.10018.0"
           node
@@ -64,7 +64,7 @@ describe Chef::Provider::DscResource do
         end
       end
       context "and the WMF is 5 RTM or newer" do
-        let (:node) do
+        let(:node) do
           node = Chef::Node.new
           node.automatic[:languages][:powershell][:version] = "5.0.10586.0"
           node
@@ -80,15 +80,15 @@ describe Chef::Provider::DscResource do
   end
 
   context "when the LCM supports Invoke-DscResource" do
-    let (:node) do
+    let(:node) do
       node = Chef::Node.new
       node.automatic[:languages][:powershell][:version] = "5.0.10018.0"
       node
     end
-    let (:resource_result) { double("CmdletResult", return_value: { "InDesiredState" => true }, stream: "description") }
-    let (:invoke_dsc_resource) { double("cmdlet", run!: resource_result) }
-    let (:store) { double("ResourceStore", find: resource_records) }
-    let (:resource_records) { [] }
+    let(:resource_result) { double("CmdletResult", return_value: { "InDesiredState" => true }, stream: "description") }
+    let(:invoke_dsc_resource) { double("cmdlet", run!: resource_result) }
+    let(:store) { double("ResourceStore", find: resource_records) }
+    let(:resource_records) { [] }
 
     before do
       allow(Chef::Util::DSC::ResourceStore).to receive(:instance).and_return(store)
@@ -130,7 +130,7 @@ describe Chef::Provider::DscResource do
     end
 
     context "resource name cannot be found" do
-      let (:resource_records) { [] }
+      let(:resource_records) { [] }
 
       it "raises ResourceNotFound" do
         expect { provider.run_action(:run) }.to raise_error(Chef::Exceptions::ResourceNotFound)
@@ -139,7 +139,7 @@ describe Chef::Provider::DscResource do
 
     context "resource name is found" do
       context "no module name for resource found" do
-        let (:resource_records) { [{}] }
+        let(:resource_records) { [{}] }
 
         it "returns the default dsc resource module" do
           expect(Chef::Util::Powershell::Cmdlet).to receive(:new) do |node, cmdlet, format|
@@ -150,7 +150,7 @@ describe Chef::Provider::DscResource do
       end
 
       context "a module name for resource is found" do
-        let (:resource_records) { [{ "Module" => { "Name" => "ModuleName" } }] }
+        let(:resource_records) { [{ "Module" => { "Name" => "ModuleName" } }] }
 
         it "returns the default dsc resource module" do
           expect(Chef::Util::Powershell::Cmdlet).to receive(:new) do |node, cmdlet, format|
@@ -161,7 +161,7 @@ describe Chef::Provider::DscResource do
       end
 
       context "multiple resource are found" do
-        let (:resource_records) do
+        let(:resource_records) do
           [
           { "Module" => { "Name" => "ModuleName1", "Version" => "1.0.0.0" } },
           { "Module" => { "Name" => "ModuleName1", "Version" => "2.0.0.0" } },

--- a/spec/unit/provider/dsc_script_spec.rb
+++ b/spec/unit/provider/dsc_script_spec.rb
@@ -23,15 +23,15 @@ require "spec_helper"
 
 describe Chef::Provider::DscScript do
   context "when DSC is available" do
-    let (:node) do
+    let(:node) do
       node = Chef::Node.new
       node.automatic[:languages][:powershell][:version] = "4.0"
       node
     end
-    let (:events) { Chef::EventDispatch::Dispatcher.new }
-    let (:run_context) { Chef::RunContext.new(node, {}, events) }
-    let (:resource) { Chef::Resource::DscScript.new("script", run_context) }
-    let (:provider) do
+    let(:events) { Chef::EventDispatch::Dispatcher.new }
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:resource) { Chef::Resource::DscScript.new("script", run_context) }
+    let(:provider) do
       Chef::Provider::DscScript.new(resource, run_context)
     end
 
@@ -145,11 +145,11 @@ describe Chef::Provider::DscScript do
   end
 
   context "when Dsc is not available" do
-    let (:node) { Chef::Node.new }
-    let (:events) { Chef::EventDispatch::Dispatcher.new }
-    let (:run_context) { Chef::RunContext.new(node, {}, events) }
-    let (:resource) { Chef::Resource::DscScript.new("script", run_context) }
-    let (:provider) { Chef::Provider::DscScript.new(resource, run_context) }
+    let(:node) { Chef::Node.new }
+    let(:events) { Chef::EventDispatch::Dispatcher.new }
+    let(:run_context) { Chef::RunContext.new(node, {}, events) }
+    let(:resource) { Chef::Resource::DscScript.new("script", run_context) }
+    let(:provider) { Chef::Provider::DscScript.new(resource, run_context) }
 
     describe "action_run" do
       ["1.0", "2.0", "3.0"].each do |version|

--- a/spec/unit/provider/git_spec.rb
+++ b/spec/unit/provider/git_spec.rb
@@ -293,7 +293,7 @@ describe Chef::Provider::Git do
       end
     end
     context "with a timeout set" do
-      let (:seconds) { 10 }
+      let(:seconds) { 10 }
       before { @resource.timeout(seconds) }
       it "clones a repo with amended git options" do
         expect(@provider).to receive(:shell_out!).with(expected_cmd, default_options.merge(timeout: seconds))
@@ -301,7 +301,7 @@ describe Chef::Provider::Git do
       end
     end
     context "with a specific home" do
-      let (:override_home) do
+      let(:override_home) do
         { "HOME" => "/home/masterNinja" }
       end
       let(:overrided_options) do
@@ -337,7 +337,7 @@ describe Chef::Provider::Git do
       allow(Etc).to receive(:getpwuid).and_return(double("Struct::Passwd", name: @resource.user, dir: "/home/deployNinja"))
     end
     context "with a specific home" do
-      let (:override_home) do
+      let(:override_home) do
         { "HOME" => "/home/masterNinja" }
       end
       let(:overrided_options) do

--- a/spec/unit/provider/package/openbsd_spec.rb
+++ b/spec/unit/provider/package/openbsd_spec.rb
@@ -27,7 +27,7 @@ describe Chef::Provider::Package::Openbsd do
     node
   end
 
-  let (:provider) do
+  let(:provider) do
     events = Chef::EventDispatch::Dispatcher.new
     run_context = Chef::RunContext.new(node, {}, events)
     Chef::Provider::Package::Openbsd.new(new_resource, run_context)

--- a/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
+++ b/spec/unit/provider/package/windows/registry_uninstall_entry_spec.rb
@@ -8,7 +8,7 @@ describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
 
   describe "when QuietUninstallString key not present" do
     let(:quiet_uninstall_string) { nil }
-    let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
+    let(:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
     it "returns UninstallString key value" do
       expect(quiet_uninstall_string_key).to eql "UninstallStringPath"
     end
@@ -16,14 +16,14 @@ describe Chef::Provider::Package::Windows::RegistryUninstallEntry do
 
   describe "when QuietUninstallString key present" do
     let(:quiet_uninstall_string) { "QuietUninstallString" }
-    let (:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
+    let(:quiet_uninstall_string_key) { Chef::Provider::Package::Windows::RegistryUninstallEntry.quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry).uninstall_string }
     it "returns QuietUninstallString key value" do
       expect(quiet_uninstall_string_key).to eql "QuietUninstallStringPath"
     end
   end
 
   describe ".find_entries", :windows_only do
-    let (:registry_uninstall_entry) { Chef::Provider::Package::Windows::RegistryUninstallEntry }
+    let(:registry_uninstall_entry) { Chef::Provider::Package::Windows::RegistryUninstallEntry }
     before(:each) do
       allow_any_instance_of(::Win32::Registry).to receive(:open).and_return("::Win32::Registry::HKEY_CURRENT_USER")
     end

--- a/spec/unit/provider/user/dscl_spec.rb
+++ b/spec/unit/provider/user/dscl_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Provider::User::Dscl do
   let(:salt) { nil }
   let(:iterations) { nil }
 
-  let (:events) { Chef::EventDispatch::Dispatcher.new }
+  let(:events) { Chef::EventDispatch::Dispatcher.new }
 
   let(:node) do
     Chef::Node.new.tap do |node|
@@ -39,7 +39,7 @@ describe Chef::Provider::User::Dscl do
     end
   end
 
-  let (:run_context) { Chef::RunContext.new(node, {}, events) }
+  let(:run_context) { Chef::RunContext.new(node, {}, events) }
 
   let(:new_resource) do
     r = Chef::Resource::User::DsclUser.new("toor", run_context)

--- a/spec/unit/util/backup_spec.rb
+++ b/spec/unit/util/backup_spec.rb
@@ -21,7 +21,7 @@ require "tmpdir"
 
 describe Chef::Util::Backup do
 
-  let (:tempfile) do
+  let(:tempfile) do
     Tempfile.new("chef-util-backup-spec-test")
   end
 

--- a/spec/unit/util/powershell/ps_credential_spec.rb
+++ b/spec/unit/util/powershell/ps_credential_spec.rb
@@ -20,8 +20,8 @@ require "chef"
 require "chef/util/powershell/ps_credential"
 
 describe Chef::Util::Powershell::PSCredential do
-  let (:username) { "foo" }
-  let (:password) { "ThIsIsThEpAsSwOrD" }
+  let(:username) { "foo" }
+  let(:password) { "ThIsIsThEpAsSwOrD" }
 
   context "when username and password are provided" do
     let(:ps_credential) { Chef::Util::Powershell::PSCredential.new(username, password) }

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -114,7 +114,7 @@ describe Chef::Util::Selinux do
   end
 
   describe "when restorecon binary exists on the system" do
-    let (:path) { "/path/to/awesome directory" }
+    let(:path) { "/path/to/awesome directory" }
 
     before do
       @restorecon_enabled_path = File.join("/sbin", "restorecon")


### PR DESCRIPTION
While waiting for CI runs to finish for #10027, I looked for other methods added to the top-level scope and found a few. I also fixed an annoying whitespace pattern so reviewing this with whitespace changes off will make it easier to see the real changes.