### PR TITLE
Update the windows_user_privilege resource to have a `:clear` action

### DIFF
--- a/lib/chef/resource/windows_user_privilege.rb
+++ b/lib/chef/resource/windows_user_privilege.rb
@@ -141,7 +141,7 @@ class Chef
          }
 
       load_current_value do |new_resource|
-        unless new_resource.principal.nil? || new_resource.action.include?(:set) || new_resource.action.include?(:clear)
+        if new_resource.principal && (new_resource.action.include?(:add) || new_resource.action.include?(:remove))
           privilege Chef::ReservedNames::Win32::Security.get_account_right(new_resource.principal)
         end
       end


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
It would be useful to have an action in the windows_user_privilege resource that would allow you to easily remove all users from using a Windows user right.  This pull request adds a `:clear` action that does this, by looking for any users assigned a specific user right and then removing them.

It would work like this:
```ruby
windows_user_privilege 'Allow any user the Network Logon right' do
  privilege      'SeDenyNetworkLogonRight'
  action         :clear
end
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
