### PR TITLE
fix habitat based windows service tests

### DIFF
--- a/habitat/tests/spec.ps1
+++ b/habitat/tests/spec.ps1
@@ -10,6 +10,13 @@ $chef_gem_root = (hab pkg exec $PackageIdentifier gem.cmd which chef | Split-Pat
 try {
     Push-Location $chef_gem_root
     $env:PATH = "C:\hab\bin;$env:PATH"
+
+    # Put chef's GEM_PATH in the machine environment so that the windows service
+    # tests will be able to consume the win32-service gem
+    $pkgEnv = hab pkg env $PackageIdentifier
+    $gemPath = $pkgEnv | Where-Object { $_.StartsWith("`$env:GEM_PATH=") }
+    SETX GEM_PATH $($gemPath.Split("=")[1]) /m
+
     hab pkg binlink --force $PackageIdentifier
     /hab/bin/rspec --format progress --tag ~executables --tag ~choco_installed spec/functional
     if (-not $?) { throw "functional testing failed"}


### PR DESCRIPTION
The windows service that gets started in the windows service functional tests will not inherit the current shell's environment. So it fails because it's `GEM_PATH` is not set and therefore is unable to consume the `win32-service` gem. This adds the `chef-infra-client` packages `GEM_PATH` to the machine scoped `GEM_PATH`.
