### PR TITLE
Update tests and docs for umask on Windows.

### DIFF
--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -460,7 +460,7 @@ class Chef
     property :umask, String,
       desired_state: false,
       introduced: "16.2",
-      description: "Set a umask to be used for the duration of converging the resource. Defaults to `nil`, which means to use the system umask."
+      description: "Set a umask to be used for the duration of converging the resource. Defaults to `nil`, which means to use the system umask. Unsupported on Windows because Windows lacks a direct equivalent to UNIX's umask."
 
     # The time it took (in seconds) to run the most recently-run action.  Not
     # cumulative across actions.  This is set to 0 as soon as a new action starts

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -1255,19 +1255,36 @@ describe Chef::Resource do
       expect(block_value).to eq(original_umask)
     end
 
-    it "changes the umask in the block to the set value" do
-      resource.umask = "0123"
+    if windows?
+      it "is a no-op on Windows" do
+        resource.umask = "0123"
 
-      block_value = nil
+        block_value = nil
 
-      resource.with_umask do
-        block_value = ::File.umask
+        resource.with_umask do
+          block_value = ::File.umask
+        end
+
+        # Format the returned value so a potential error message is easier to understand.
+        actual_value = block_value.to_s(8).rjust(4, "0")
+
+        expect(actual_value).to eq("0000")
       end
+    else
+      it "changes the umask in the block to the set value" do
+        resource.umask = "0123"
 
-      # Format the returned value so a potential error message is easier to understand.
-      actual_value = block_value.to_s(8).rjust(4, "0")
+        block_value = nil
 
-      expect(actual_value).to eq("0123")
+        resource.with_umask do
+          block_value = ::File.umask
+        end
+
+        # Format the returned value so a potential error message is easier to understand.
+        actual_value = block_value.to_s(8).rjust(4, "0")
+
+        expect(actual_value).to eq("0123")
+      end
     end
 
     it "resets the umask afterwards" do


### PR DESCRIPTION
Followup to #10000. As we're finding out in #10068, `File.umask` is not supported on Windows and its causing a test failure there. FWIW, Ruby skips umask tests if they're run [on Windows](https://github.com/ruby/ruby/blob/5c276e1cc91c5ab2a41fbf7827af2fed914a2bc0/spec/ruby/core/file/umask_spec.rb#L19-L47) or [non-POSIX systems](https://github.com/ruby/ruby/blob/204dc3f39f12b4e2640555306bd1dd4530344277/test/ruby/test_file_exhaustive.rb#L787-L795).

I should have caught this in #10000. 😞 

Signed-off-by: Pete Higgins <pete@peterhiggins.org>