### PR TITLE
Pin dff-lcs, bump ohai, & misc omnibus updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 3c77e1ac8753552818ed2045bc17e6971fb86720
+  revision: 6a5391298d6fa2f2c2e8fa9a09c31f33a1497ae0
   branch: master
   specs:
-    ohai (16.2.2)
+    ohai (16.2.3)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 7bd12469af0ba7227d77124dce4cdf7b9051e331
+  revision: 3c77e1ac8753552818ed2045bc17e6971fb86720
   branch: master
   specs:
-    ohai (16.2.1)
+    ohai (16.2.2)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -36,7 +36,7 @@ PATH
       chef-utils (= 16.2.69)
       chef-vault
       chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
+      diff-lcs (>= 1.2.4, < 1.4.0)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (>= 1.9.25)
@@ -70,7 +70,7 @@ PATH
       chef-utils (= 16.2.69)
       chef-vault
       chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
+      diff-lcs (>= 1.2.4, < 1.4.0)
       ed25519 (~> 1.2)
       erubis (~> 2.7)
       ffi (>= 1.9.25)
@@ -166,7 +166,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
-    diff-lcs (1.4.2)
+    diff-lcs (1.3)
     ecma-re-validator (0.2.1)
       regexp_parser (~> 1.2)
     ed25519 (1.2.4)
@@ -227,7 +227,7 @@ GEM
       inspec-core (= 4.21.1)
     ipaddress (0.8.3)
     iso8601 (0.12.2)
-    json (2.3.0)
+    json (2.3.1)
     json_schemer (0.2.11)
       ecma-re-validator (~> 0.2)
       hana (~> 1.3)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "tty-screen", "~> 0.6" # knife list
   s.add_dependency "pastel" # knife ui.color
   s.add_dependency "erubis", "~> 2.7"
-  s.add_dependency "diff-lcs", "~> 1.2", ">= 1.2.4"
+  s.add_dependency "diff-lcs", ">= 1.2.4", "< 1.4.0" # 1.4 breaks output
   s.add_dependency "ffi-libarchive", "~> 1.0", ">= 1.0.3"
   s.add_dependency "chef-zero", ">= 14.0.11"
   s.add_dependency "chef-vault"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus
-  revision: d75718522deb9faeb3c21b50c60e94daf70ce9b6
+  revision: 320d9350cdf39abdcc4c37d5bc2971b3c222a0a0
   branch: master
   specs:
-    omnibus (7.0.13)
+    omnibus (7.0.14)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.335.0)
+    aws-partitions (1.337.0)
     aws-sdk-core (3.102.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.35.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.71.1)
+    aws-sdk-s3 (1.72.0)
       aws-sdk-core (~> 3, >= 3.102.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -164,7 +164,7 @@ GEM
     citrus (3.0.2)
     cleanroom (1.0.0)
     concurrent-ruby (1.1.6)
-    diff-lcs (1.4.2)
+    diff-lcs (1.4.3)
     ed25519 (1.2.4)
     equatable (0.6.1)
     erubi (1.9.0)
@@ -193,7 +193,7 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.12.2)
     jmespath (1.4.0)
-    json (2.3.0)
+    json (2.3.1)
     kitchen-vagrant (1.6.1)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -1,17 +1,16 @@
-# Client Tools Omnibus project
+# Chef Infra Client Omnibus project
 
 This project creates full-stack platform-specific packages for the following projects:
 
 - AngryChef
 - Chef
-- Chef with FIPS enabled
 
 ## Installation
 
 You must have a sane Ruby environment with Bundler installed. Ensure all the required gems are installed:
 
 ```shell
-$ bundle install --without development
+bundle install --without development
 ```
 
 ## Usage
@@ -117,7 +116,7 @@ For a complete list of all commands and platforms, run `kitchen list` or `kitche
 ## License
 
 ```text
-Copyright 2012-2018, Chef Software, Inc.
+Copyright:: Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -24,6 +24,8 @@ license :project_license
 
 source path: "#{project.files_path}/#{name}"
 
+dependency "ruby"
+
 build do
   block "Removing console and setup binaries" do
     Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/*/bin/{console,setup}").each do |f|
@@ -31,9 +33,14 @@ build do
       FileUtils.rm_rf(f)
     end
   end
-end
 
-build do
+  block "remove any .gitkeep files" do
+    Dir.glob("#{install_dir}/**/{.gitkeep,.keep}").each do |f|
+      puts "Deleting #{f}"
+      File.delete(f)
+    end
+  end
+
   block "Removing additional non-code files from installed gems" do
     # find the embedded ruby gems dir and clean it up for globbing
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -16,8 +16,8 @@
 #
 
 # This script sets the SSL_CERT_FILE environment variable to the CA cert bundle
-# that ships with omnibus packages of Chef and Chef DK. If this environment
-# variable is already configured, this script is a no-op.
+# that ships with omnibus packages of Chef Infra Client and Chef Workstation. If
+# this environment variable is already configured, this script is a no-op.
 #
 # This is required to make Chef tools use https URLs out of the box.
 

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -1,5 +1,5 @@
 #
-# This file is used to configure the Omnibus projects in this repo. It contains
+# This file is used to configure the chef infra client project. It contains
 # some minimal configuration examples for working with Omnibus. For a full list
 # of configurable options, please see the documentation for +omnibus/config.rb+.
 #

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -1,5 +1,5 @@
 #
-# This file is used to configure the chef infra client project. It contains
+# This file is used to configure the Chef Infra Client project. It contains
 # some minimal configuration examples for working with Omnibus. For a full list
 # of configurable options, please see the documentation for +omnibus/config.rb+.
 #


### PR DESCRIPTION
- Pin diff-lcs since 1.4 has changed the output.  
- Bump Ohai and other deps while here. 
- Update some omnibus docs and comments to make diffing with workstation better and the docs a bit more accurate.
- Bring in the .gitkeep cleanup from Workstation to nuke those files in the install