### PR TITLE
Fix release build tests, part 3

### DIFF
--- a/spec/functional/resource/aix_service_spec.rb
+++ b/spec/functional/resource/aix_service_spec.rb
@@ -80,8 +80,14 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
   end
 
   let(:run_context) do
-    Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+    node = Chef::Node.new
+    node.default[:platform] = ohai[:platform]
+    node.default[:platform_version] = ohai[:platform_version]
+    node.default[:os] = ohai[:os]
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, {}, events)
   end
+
 
   describe "When service is a subsystem" do
     before(:all) do

--- a/spec/functional/resource/msu_package_spec.rb
+++ b/spec/functional/resource/msu_package_spec.rb
@@ -27,7 +27,12 @@ describe Chef::Resource::MsuPackage, :win2012r2_only do
   let(:timeout) { 3600 }
 
   let(:run_context) do
-    Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
+    node = Chef::Node.new
+    node.default[:platform] = ohai[:platform]
+    node.default[:platform_version] = ohai[:platform_version]
+    node.default[:os] = ohai[:os]
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, {}, events)
   end
 
   let(:new_resource) { Chef::Resource::CabPackage.new("windows_test_pkg") }


### PR DESCRIPTION
Followup to #10088 and #10089. Still seeing failures but a lot fewer this round.

https://buildkite.com/chef/chef-chef-master-omnibus-release/builds/616#0a82bdc2-3ce8-4936-acdc-b69b56dd8fe3/5428-13593

Signed-off-by: Pete Higgins <pete@peterhiggins.org>