### PR TITLE
Use bash not execute in build_essential for better output

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/macos.rb
@@ -56,6 +56,8 @@ include_recipe "git"
   end
 end
 
+build_essential
+
 launchd "io.chef.testing.fake" do
   source "io.chef.testing.fake.plist"
   action "enable"

--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -146,8 +146,8 @@ class Chef
         def install_xcode_cli_tools(label)
           # This script was graciously borrowed and modified from Tim Sutton's
           # osx-vm-templates at https://github.com/timsutton/osx-vm-templates/blob/b001475df54a9808d3d56d06e71b8fa3001fff42/scripts/xcode-cli-tools.sh
-          execute "install Xcode Command Line tools" do
-            command <<-EOH
+          bash "install Xcode Command Line Tools" do
+            code <<-EOH
               # create the placeholder file that's checked by CLI updates' .dist code
               # in Apple's SUS catalog
               touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress


### PR DESCRIPTION
This avoids a giant output in logs that includes our comments

Signed-off-by: Tim Smith <tsmith@chef.io>