### PR TITLE
Fix syslog logging on Chef-16

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -194,14 +194,26 @@ class Chef
       chef_config[:log_location].map! do |log_location|
         case log_location
         when :syslog, "syslog"
+          force_force_logger
           logger::Syslog.new
         when :win_evt, "win_evt"
+          force_force_logger
           logger::WinEvt.new
         else
           # should be a path or STDOUT
           log_location
         end
       end
+    end
+
+    # Force the logger by default for the :winevt and :syslog loggers.  Since we do not and cannot
+    # support multiple log levels in a mix-and-match situation with formatters and loggers, and the
+    # formatters do not support syslog, we force the formatter off by default and the log level is
+    # thus info by default.  Users can add `--force-formatter -l info` to get back formatter output
+    # on STDOUT along with syslog logging.
+    #
+    def force_force_logger
+      chef_config[:force_logger] = true unless chef_config[:force_formatter]
     end
 
     # Use of output formatters is assumed if `force_formatter` is set or if `force_logger` is not set

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -343,7 +343,7 @@ class Chef
       formatters_for_run.map do |formatter_name, output_path|
         if output_path.nil?
           Chef::Formatters.new(formatter_name, STDOUT_FD, STDERR_FD)
-        else
+        elsif output_path.is_a?(String)
           io = File.open(output_path, "a+")
           io.sync = true
           Chef::Formatters.new(formatter_name, io, io)

--- a/spec/functional/resource/aix_service_spec.rb
+++ b/spec/functional/resource/aix_service_spec.rb
@@ -88,7 +88,6 @@ describe Chef::Resource::Service, :requires_root, :aix_only do
     Chef::RunContext.new(node, {}, events)
   end
 
-
   describe "When service is a subsystem" do
     before(:all) do
       script_dir = File.join(File.dirname(__FILE__), "/../assets/")


### PR DESCRIPTION
This forces the formatter output off for users that use the
winevt or syslog options to the log_location.

This changes nothing about the logging behavior from Chef-15, those
never supported formatter output.

It creates some more clear consistency with how STDOUT behaves when
those options are used.

- We do not have the ability (fairly fundamentally in the Chef::Log
  class itself) to have different log levels running at the same time
  so either you get :warn or you get :info and we'll likely never
  be able to support mix-and-match.

- Without mix-and-match if you're trying to use the formatter on
  STDOUT the syslog logger you have to either pick :warn -- which
  makes the syslog output totally useless, or else pick :info --
  which intersperses all of the info logger output with the
  formatter on STDOUT and leads to complaints and bug reports.

- So we force the logger on, although users can still get the old
  STDOUT logging behavior back with --force-formatter -l info

closes #9982