### PR TITLE
Fix for ssl_ca_file is only set on Windows, but not on any other platforms.

### DIFF
--- a/chef-config/lib/chef-config/config.rb
+++ b/chef-config/lib/chef-config/config.rb
@@ -634,7 +634,7 @@ module ChefConfig
     # Path to the default CA bundle files.
     default :ssl_ca_path, nil
     default(:ssl_ca_file) do
-      if ChefUtils.windows? && embedded_dir
+      if embedded_dir
         cacert_path = File.join(embedded_dir, "ssl/certs/cacert.pem")
         cacert_path if File.exist?(cacert_path)
       else

--- a/chef-config/spec/unit/config_spec.rb
+++ b/chef-config/spec/unit/config_spec.rb
@@ -644,12 +644,21 @@ RSpec.describe ChefConfig::Config do
 
         end
 
-        # On Windows, we'll detect an omnibus build and set this to the
-        # cacert.pem included in the package, but it's nil if you're on Windows
-        # w/o omnibus (e.g., doing development on Windows, custom build, etc.)
         unless is_windows
-          it "ChefConfig::Config[:ssl_ca_file] defaults to nil" do
-            expect(ChefConfig::Config[:ssl_ca_file]).to be_nil
+          describe "finding the Unix embedded dir" do
+            let(:default_config_location) { "/opt/chef/embedded/lib/ruby/gems/2.7.0/gems/chef-config-16.2.73/lib/chef-config/config.rb" }
+            let(:default_ca_file) { "/opt/chef/embedded/ssl/certs/cacert.pem" }
+
+            it "finds the embedded dir in the default location" do
+              allow(ChefConfig::Config).to receive(:_this_file).and_return(default_config_location)
+              expect(ChefConfig::Config.embedded_dir).to eq("/opt/chef/embedded")
+            end
+
+            it "sets the ssl_ca_cert path if the cert file is available" do
+              allow(ChefConfig::Config).to receive(:_this_file).and_return(default_config_location)
+              allow(File).to receive(:exist?).with(default_ca_file).and_return(true)
+              expect(ChefConfig::Config.ssl_ca_file).to eq(default_ca_file)
+            end
           end
         end
 


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

## Description
- Now Default configuration of `ssl_ca_file` will set for both types of platforms Windows and Unix.
- Added test cases.
- Ensured chef-style on the code changes made.

## Related Issue
Fixes: #10073 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
