### PR TITLE
build-essential: "libncurses-dev" on debian

### DIFF
--- a/lib/chef/resource/build_essential.rb
+++ b/lib/chef/resource/build_essential.rb
@@ -64,7 +64,7 @@ class Chef
 
         case
         when debian?
-          package %w{ autoconf binutils-doc bison build-essential flex gettext ncurses-dev }
+          package %w{ autoconf binutils-doc bison build-essential flex gettext libncurses-dev }
         when fedora_derived?
           package %w{ autoconf bison flex gcc gcc-c++ gettext kernel-devel make m4 ncurses-devel patch }
         when freebsd?


### PR DESCRIPTION
Signed-off-by: Isa Farnik <if_then@hey.com>

`ncurses-dev` on modern debian platforms is a virtual package that causes chef running the `build_essential` resource to choke.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
https://github.com/chef-boneyard/build-essential/issues/137

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
