### PR TITLE
Implement ENFORCE_LICENSE dist constant for knife bootstrap

### DIFF
--- a/chef-config/lib/chef-config/dist.rb
+++ b/chef-config/lib/chef-config/dist.rb
@@ -19,5 +19,8 @@ module ChefConfig
     # The legacy conf folder: C:/opscode/chef. Specifically the "opscode" part
     # DIR_SUFFIX is appended to it in code where relevant
     LEGACY_CONF_DIR = "opscode".freeze
+
+    # Enable forcing Chef EULA
+    ENFORCE_LICENSE = true
   end
 end

--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -555,7 +555,7 @@ class Chef
       end
 
       def run
-        check_license
+        check_license if ChefConfig::Dist::ENFORCE_LICENSE
 
         plugin_setup!
         validate_name_args!


### PR DESCRIPTION
As a user of a community Chef distribution, I would like to be able to use knife
bootstrap without requiring the license check [1]. It's expected that that user
would not be installing a licensed version of Chef Infra Client, but instead a
community distribution.

This provides a similar feature as used in other places which makes it much
easier to disable the license check.

[1] https://gitlab.com/cinc-project/distribution/workstation/-/issues/3

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
This is a backport for Chef 15 based on #9992.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
