### PR TITLE
windows_dns_record: add dns_server property with default of localhost

### DIFF
--- a/lib/chef/resource/windows_dns_record.rb
+++ b/lib/chef/resource/windows_dns_record.rb
@@ -42,18 +42,33 @@ class Chef
         description: "The type of record to create, can be either ARecord, CNAME or PTR.",
         default: "ARecord", equal_to: %w{ARecord CNAME PTR}
 
+      property :dns_server, String,
+        description: "The name of the DNS server on which to create the record.",
+        default: "localhost"
+
       action :create do
         description "Creates and updates the DNS entry."
 
+        windows_feature "RSAT-DNS-Server" do
+          not_if new_resource.dns_server.casecmp?("localhost")
+        end
+
         powershell_package "xDnsServer" do
         end
+
         do_it "Present"
       end
 
       action :delete do
         description "Deletes a DNS entry."
+
+        windows_feature "RSAT-DNS-Server" do
+          not_if new_resource.dns_server.casecmp?("localhost")
+        end
+
         powershell_package "xDnsServer" do
         end
+
         do_it "Absent"
       end
 
@@ -67,6 +82,7 @@ class Chef
             property :Zone, new_resource.zone
             property :Type, new_resource.record_type
             property :Target, new_resource.target
+            property :DnsServer, new_resource.dns_server
           end
         end
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This allows for managing DNS records on a remote DNS server

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#10119 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
