### PR TITLE
Fix `powershell_exec!` test.

### DIFF
--- a/spec/unit/mixin/powershell_exec_spec.rb
+++ b/spec/unit/mixin/powershell_exec_spec.rb
@@ -47,7 +47,7 @@ describe Chef::Mixin::PowershellExec, :windows_only do
     end
 
     it "raises an error if the command fails" do
-      expect(object.powershell_exec!("$PSVersionTable")).to be_kind_of(Chef::PowerShell::CommandFailed)
+      expect { object.powershell_exec!("this-should-error") }.to raise_error(Chef::PowerShell::CommandFailed)
     end
   end
 end


### PR DESCRIPTION
This test was running the same code as the one right above it and expecting a different result.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>

