### PR TITLE
Allow iso8601 gem version 0.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 8028951abb141fef97a9b2ddc5e2120f63fbc16a
+  revision: 0a6530f2b7fdf225a7ca0ae54459cfce9b8d3b4c
   branch: master
   specs:
-    ohai (16.2.3)
+    ohai (16.2.4)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -78,7 +78,7 @@ PATH
       ffi-yajl (~> 2.2)
       highline (>= 1.6.9, < 3)
       iniparse (~> 1.4)
-      iso8601 (~> 0.12.1)
+      iso8601 (>= 0.12.1, < 0.14)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
       mixlib-authentication (>= 2.1, < 4)
@@ -226,7 +226,7 @@ GEM
     inspec-core-bin (4.21.3)
       inspec-core (= 4.21.3)
     ipaddress (0.8.3)
-    iso8601 (0.12.3)
+    iso8601 (0.13.0)
     json (2.3.1)
     json_schemer (0.2.11)
       ecma-re-validator (~> 0.2)

--- a/chef-config/lib/chef-config/version.rb
+++ b/chef-config/lib/chef-config/version.rb
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 module ChefConfig
-  CHEFCONFIG_ROOT = File.expand_path('..', __dir__)
+  CHEFCONFIG_ROOT = File.expand_path("..", __dir__)
   VERSION = "16.2.87".freeze
 end

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -14,7 +14,7 @@ gemspec.add_dependency "win32-process", "~> 0.8.2"
 gemspec.add_dependency "win32-service", ">= 2.1.5", "< 3.0"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 gemspec.add_dependency "win32-taskscheduler", "~> 2.0"
-gemspec.add_dependency "iso8601", "~> 0.12.1"
+gemspec.add_dependency "iso8601", ">= 0.12.1", "< 0.14" # validate 0.14 when it comes out
 gemspec.add_dependency "win32-certstore", "~> 0.3"
 gemspec.extensions << "ext/win32-eventlog/Rakefile"
 gemspec.files += Dir.glob("{distro,ext}/**/*")

--- a/chef-utils/lib/chef-utils/version.rb
+++ b/chef-utils/lib/chef-utils/version.rb
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 module ChefUtils
-  CHEFUTILS_ROOT = File.expand_path('..', __dir__)
+  CHEFUTILS_ROOT = File.expand_path("..", __dir__)
   VERSION = "16.2.87".freeze
 end

--- a/lib/chef/version.rb
+++ b/lib/chef/version.rb
@@ -22,7 +22,7 @@
 require_relative "version_string"
 
 class Chef
-  CHEF_ROOT = File.expand_path('..', __dir__)
+  CHEF_ROOT = File.expand_path("..", __dir__)
   VERSION = Chef::VersionString.new("16.2.87")
 end
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.338.0)
+    aws-partitions (1.339.0)
     aws-sdk-core (3.103.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
This release just drops Ruby 2.4 support and resolves Rubocop warnings.

Signed-off-by: Tim Smith <tsmith@chef.io>