### PR TITLE
Support legacy DSS host keys with knife-ssh

### DIFF
--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -296,6 +296,10 @@ class Chef
             opts[:keepalive] = true
             opts[:keepalive_interval] = ssh_config[:keepalive_interval]
           end
+          # maintain support for legacy key types / ciphers / key exchange algorithms.
+          # most importantly this adds back support for DSS host keys
+          # See https://github.com/net-ssh/net-ssh/pull/709
+          opts[:append_all_supported_algorithms] = true
         end
       end
 

--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -278,7 +278,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", {})
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { append_all_supported_algorithms: true })
         @knife.run
         expect(@knife.config[:ssh_gateway]).to eq("user@ec2.public_hostname")
       end
@@ -291,7 +291,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", {})
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { append_all_supported_algorithms: true })
         @knife.run
         expect(@knife.config[:ssh_gateway]).to eq("user@ec2.public_hostname")
       end
@@ -305,7 +305,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { keys: File.expand_path("#{ENV["HOME"]}/.ssh/aws-gateway.rsa").squeeze("/"), keys_only: true })
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { append_all_supported_algorithms: true, keys: File.expand_path("#{ENV["HOME"]}/.ssh/aws-gateway.rsa").squeeze("/"), keys_only: true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end
@@ -319,7 +319,7 @@ describe Chef::Knife::Ssh do
       end
 
       it "uses the ssh_gateway_identity file" do
-        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { keys: File.expand_path("#{ENV["HOME"]}/.ssh/aws-gateway.rsa").squeeze("/"), keys_only: true })
+        expect(@knife.session).to receive(:via).with("ec2.public_hostname", "user", { append_all_supported_algorithms: true, keys: File.expand_path("#{ENV["HOME"]}/.ssh/aws-gateway.rsa").squeeze("/"), keys_only: true })
         @knife.run
         expect(@knife.config[:ssh_gateway_identity]).to eq("~/.ssh/aws-gateway.rsa")
       end


### PR DESCRIPTION
net-ssh 6.0 disabled these legacy keys by default. We need to enable the
support by passing this option.

Signed-off-by: Tim Smith <tsmith@chef.io>