### PR TITLE
Remove reference to deprecated option in test helper.

### DIFF
--- a/spec/support/shared/integration/knife_support.rb
+++ b/spec/support/shared/integration/knife_support.rb
@@ -39,10 +39,7 @@ module KnifeSupport
 
     # Work on machines where we can't access /var
     Dir.mktmpdir("checksums") do |checksums_cache_dir|
-      Chef::Config[:cache_options] = {
-        path: checksums_cache_dir,
-        skip_expires: true,
-      }
+      Chef::Config[:syntax_check_cache_path] = checksums_cache_dir
 
       # This is Chef::Knife.run without load_commands--we'll load stuff
       # ourselves, thank you very much
@@ -117,7 +114,7 @@ module KnifeSupport
       ensure
         Chef::Log.use_log_devices(old_loggers)
         Chef::Log.level = old_log_level
-        Chef::Config.delete(:cache_options)
+        Chef::Config.delete(:syntax_check_cache_path)
         Chef::Config.delete(:concurrency)
       end
 


### PR DESCRIPTION
`cache_options` is deprecated and this is one of the last few references to it in the code.

https://github.com/chef/chef/blob/master/chef-config/lib/chef-config/config.rb#L804-L813

Signed-off-by: Pete Higgins <pete@peterhiggins.org>