### PR TITLE
Extract shell_out helper method to chef-utils for reuse in ohai, etc

### DIFF
--- a/chef-utils/lib/chef-utils/dsl/path_sanity.rb
+++ b/chef-utils/lib/chef-utils/dsl/path_sanity.rb
@@ -30,27 +30,27 @@ module ChefUtils
         path_separator = ChefUtils.windows? ? ";" : ":"
         # ensure the Ruby and Gem bindirs are included for omnibus chef installs
         new_paths = env_path.split(path_separator)
-        [ ChefUtils::DSL::PathSanity.ruby_bindir, ChefUtils::DSL::PathSanity.gem_bindir ].compact.each do |path|
+        [ __ruby_bindir, __gem_bindir ].compact.each do |path|
           new_paths = [ path ] + new_paths unless new_paths.include?(path)
         end
-        ChefUtils::DSL::PathSanity.sane_paths.each do |path|
+        __sane_paths.each do |path|
           new_paths << path unless new_paths.include?(path)
         end
         new_paths.join(path_separator).encode("utf-8", invalid: :replace, undef: :replace)
       end
 
-      class << self
-        def sane_paths
-          ChefUtils.windows? ? %w{} : %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}
-        end
+      private
 
-        def ruby_bindir
-          RbConfig::CONFIG["bindir"]
-        end
+      def __sane_paths
+        ChefUtils.windows? ? %w{} : %w{/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin}
+      end
 
-        def gem_bindir
-          Gem.bindir
-        end
+      def __ruby_bindir
+        RbConfig::CONFIG["bindir"]
+      end
+
+      def __gem_bindir
+        Gem.bindir
       end
 
       extend self

--- a/chef-utils/lib/chef-utils/dsl/service.rb
+++ b/chef-utils/lib/chef-utils/dsl/service.rb
@@ -25,6 +25,7 @@ module ChefUtils
     module Service
       include Internal
       include TrainHelpers
+      include Introspection
 
       # Returns if debian's old rc.d manager is installed (not necessarily the primary init system).
       #
@@ -97,8 +98,8 @@ module ChefUtils
           file_exist?("/etc/rc.d/#{script}")
         when :systemd
           file_exist?("/etc/init.d/#{script}") ||
-            ChefUtils::DSL::Introspection.has_systemd_service_unit?(script) ||
-            ChefUtils::DSL::Introspection.has_systemd_unit?(script)
+            has_systemd_service_unit?(script) ||
+            has_systemd_unit?(script)
         else
           raise ArgumentError, "type of service must be one of :initd, :upstart, :xinetd, :etc_rcd, or :systemd"
         end

--- a/chef-utils/lib/chef-utils/internal.rb
+++ b/chef-utils/lib/chef-utils/internal.rb
@@ -75,9 +75,9 @@ module ChefUtils
       end
     end
 
-    # This should be set to a Train::FIXME instance.  You should wire this up to nil for not using a train transport connection.
+    # This should be set to a Train::Plugins::Transport instance.  You should wire this up to nil for not using a train transport connection.
     #
-    # @return [Train::FIXME]
+    # @return [Train::Plugins::Transport]
     #
     # @api private
     #

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -258,6 +258,13 @@ class Chef
       # ^^^^^^ NOTE: PLEASE DO NOT CONTINUE TO ADD THESE KINDS OF PLATFORM_VERSION APIS WITHOUT ^^^^^^^
       # ^^^^^^ GOING THROUGH THE DESIGN REVIEW PROCESS AND ADDRESS THE EXISTING CHEF-SUGAR ONES ^^^^^^^
       # ^^^^^^ DO "THE HARD RIGHT THING" AND ADDRESS THE BROADER PROBLEM AND FIX IT ALL.        ^^^^^^^
+
+      private
+
+      # dependency injection, see: ChefUtils::Internal
+      def __transport_connection
+        Chef.run_context.transport_connection
+      end
     end
   end
 end

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -17,6 +17,7 @@
 #
 
 require "chef-utils" unless defined?(ChefUtils::CANARY)
+require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   module DSL
@@ -25,6 +26,7 @@ class Chef
     # #value_for_platform.
     module PlatformIntrospection
       include ChefUtils
+      include Chef::Mixin::ChefUtilsWiring
 
       # Implementation class for determining platform dependent values
       class PlatformDependentValue
@@ -258,13 +260,6 @@ class Chef
       # ^^^^^^ NOTE: PLEASE DO NOT CONTINUE TO ADD THESE KINDS OF PLATFORM_VERSION APIS WITHOUT ^^^^^^^
       # ^^^^^^ GOING THROUGH THE DESIGN REVIEW PROCESS AND ADDRESS THE EXISTING CHEF-SUGAR ONES ^^^^^^^
       # ^^^^^^ DO "THE HARD RIGHT THING" AND ADDRESS THE BROADER PROBLEM AND FIX IT ALL.        ^^^^^^^
-
-      private
-
-      # dependency injection, see: ChefUtils::Internal
-      def __transport_connection
-        Chef.run_context.transport_connection
-      end
     end
   end
 end

--- a/lib/chef/mixin/chef_utils_wiring.rb
+++ b/lib/chef/mixin/chef_utils_wiring.rb
@@ -1,5 +1,4 @@
 #--
-# Author:: Lamont Granquist <lamont@chef.io>
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -15,24 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "chef-utils/dsl/which" unless defined?(ChefUtils::DSL::Which)
-require "chef-utils/dsl/path_sanity" unless defined?(ChefUtils::DSL::PathSanity)
-require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
+require_relative "../log"
+require_relative "../config"
+require_relative "../chef_class"
 
 class Chef
   module Mixin
-    module Which
-      include ChefUtils::DSL::Which
-      include ChefUtils::DSL::PathSanity
-      include ChefUtilsWiring
-
+    # Common Dependency Injection wiring for ChefUtils-related modules
+    module ChefUtilsWiring
       private
 
-      # we dep-inject path sanity into this API for historical reasons
-      #
-      # @api private
-      def __extra_path
-        __sane_paths
+      def __config
+        Chef::Config
+      end
+
+      def __log
+        Chef::Log
+      end
+
+      def __transport_connection
+        Chef.run_context&.transport_connection
       end
     end
   end

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -15,198 +15,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut::DEFAULT_READ_TIMEOUT)
-require "chef-utils/dsl/path_sanity" unless defined?(ChefUtils::DSL::PathSanity)
+require "mixlib/shellout/helper" unless defined?(Mixlib::ShellOut::Helper)
+require_relative "../log"
+require_relative "../config"
+require_relative "../chef_class"
 
 class Chef
   module Mixin
     module ShellOut
+      include Mixlib::ShellOut::Helper
 
-      # PREFERRED APIS:
-      #
-      # all consumers should now call shell_out!/shell_out.
-      #
-      # the shell_out_compacted/shell_out_compacted! APIs are private but are intended for use
-      # in rspec tests, and should ideally always be used to make code refactoring that do not
-      # change behavior easier:
-      #
-      # allow(provider).to receive(:shell_out_compacted!).with("foo", "bar", "baz")
-      # provider.shell_out!("foo", [ "bar", nil, "baz"])
-      # provider.shell_out!(["foo", nil, "bar" ], ["baz"])
-      #
-      # note that shell_out_compacted also includes adding the magical timeout option to force
-      # people to setup expectations on that value explicitly.  it does not include the default_env
-      # mangling in order to avoid users having to setup an expectation on anything other than
-      # setting `default_env: false` and allow us to make tweak to the default_env without breaking
-      # a thousand unit tests.
-      #
-
-      def shell_out(*args, **options)
-        options = options.dup
-        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
-        if options.empty?
-          shell_out_compacted(*Chef::Mixin::ShellOut.clean_array(*args))
-        else
-          shell_out_compacted(*Chef::Mixin::ShellOut.clean_array(*args), **options)
-        end
+      def __config
+        Chef::Config
       end
 
-      def shell_out!(*args, **options)
-        options = options.dup
-        options = Chef::Mixin::ShellOut.maybe_add_timeout(self, options)
-        if options.empty?
-          shell_out_compacted!(*Chef::Mixin::ShellOut.clean_array(*args))
-        else
-          shell_out_compacted!(*Chef::Mixin::ShellOut.clean_array(*args), **options)
-        end
+      def __log
+        Chef::Log
       end
 
-      # helper sugar for resources that support passing timeouts to shell_out
-      #
-      # module method to not pollute namespaces, but that means we need self injected as an arg
-      # @api private
-      def self.maybe_add_timeout(obj, options)
-        options = options.dup
-        # historically resources have not properly declared defaults on their timeouts, so a default default of 900s was enforced here
-        default_val = 900
-        return options if options.key?(:timeout)
-
-        # FIXME: need to nuke descendent tracker out of Chef::Provider so we can just define that class here without requiring the
-        # world, and then just use symbol lookup
-        if obj.class.ancestors.map(&:name).include?("Chef::Provider") && obj.respond_to?(:new_resource) && obj.new_resource.respond_to?(:timeout) && !options.key?(:timeout)
-          options[:timeout] = obj.new_resource.timeout ? obj.new_resource.timeout.to_f : default_val
-        end
-        options
-      end
-
-      # helper function to mangle options when `default_env` is true
-      #
-      # @api private
-      def self.apply_default_env(options)
-        options = options.dup
-        default_env = options.delete(:default_env)
-        default_env = true if default_env.nil?
-        if default_env
-          env_key = options.key?(:env) ? :env : :environment
-          options[env_key] = {
-            "LC_ALL" => Chef::Config[:internal_locale],
-            "LANGUAGE" => Chef::Config[:internal_locale],
-            "LANG" => Chef::Config[:internal_locale],
-            env_path => ChefUtils::DSL::PathSanity.sanitized_path,
-          }.update(options[env_key] || {})
-        end
-        options
-      end
-
-      private
-
-      # this SHOULD be used for setting up expectations in rspec, see banner comment at top.
-      #
-      # the private constraint is meant to avoid code calling this directly, rspec expectations are fine.
-      #
-      def shell_out_compacted(*args, **options)
-        options = Chef::Mixin::ShellOut.apply_default_env(options)
-        if options.empty?
-          Chef::Mixin::ShellOut.shell_out_command(*args)
-        else
-          Chef::Mixin::ShellOut.shell_out_command(*args, **options)
-        end
-      end
-
-      # this SHOULD be used for setting up expectations in rspec, see banner comment at top.
-      #
-      # the private constraint is meant to avoid code calling this directly, rspec expectations are fine.
-      #
-      def shell_out_compacted!(*args, **options)
-        options = Chef::Mixin::ShellOut.apply_default_env(options)
-        cmd = if options.empty?
-                Chef::Mixin::ShellOut.shell_out_command(*args)
-              else
-                Chef::Mixin::ShellOut.shell_out_command(*args, **options)
-              end
-        cmd.error!
-        cmd
-      end
-
-      # Helper for subclasses to reject nil out of an array.  It allows
-      # using the array form of shell_out (which avoids the need to surround arguments with
-      # quote marks to deal with shells).
-      #
-      # Usage:
-      #   shell_out!(*clean_array("useradd", universal_options, useradd_options, new_resource.username))
-      #
-      # universal_options and useradd_options can be nil, empty array, empty string, strings or arrays
-      # and the result makes sense.
-      #
-      # keeping this separate from shell_out!() makes it a bit easier to write expectations against the
-      # shell_out args and be able to omit nils and such in the tests (and to test that the nils are
-      # being rejected correctly).
-      #
-      # @param args [String] variable number of string arguments
-      # @return [Array] array of strings with nil and null string rejection
-
-      def self.clean_array(*args)
-        args.flatten.compact.map(&:to_s)
-      end
-
-      def self.transport_connection
-        Chef.run_context.transport_connection
-      end
-
-      def self.shell_out_command(*args, **options)
-        if Chef::Config.target_mode?
-          FakeShellOut.new(args, options, transport_connection.run_command(args.join(" "))) # FIXME: train should accept run_command(*args)
-        else
-          cmd = if options.empty?
-                  Mixlib::ShellOut.new(*args)
-                else
-                  Mixlib::ShellOut.new(*args, **options)
-                end
-          cmd.live_stream ||= io_for_live_stream
-          cmd.run_command
-          cmd
-        end
-      end
-
-      def self.io_for_live_stream
-        if STDOUT.tty? && !Chef::Config[:daemon] && Chef::Log.debug?
-          STDOUT
-        else
-          nil
-        end
-      end
-
-      def self.env_path
-        if ChefUtils.windows?
-          "Path"
-        else
-          "PATH"
-        end
-      end
-
-      class FakeShellOut
-        attr_reader :stdout, :stderr, :exitstatus, :status
-
-        def initialize(args, options, result)
-          @args = args
-          @options = options
-          @stdout = result.stdout
-          @stderr = result.stderr
-          @exitstatus = result.exit_status
-          @status = OpenStruct.new(success?: ( exitstatus == 0 ))
-        end
-
-        def error?
-          exitstatus != 0
-        end
-
-        def error!
-          raise Mixlib::ShellOut::ShellCommandFailed, "Unexpected exit status of #{exitstatus} running #{@args}" if error?
-        end
+      def __transport_connection
+        Chef.run_context&.transport_connection
       end
     end
   end
 end
-
-# Break circular dep
-require_relative "../config"

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -16,26 +16,13 @@
 # limitations under the License.
 
 require "mixlib/shellout/helper" unless defined?(Mixlib::ShellOut::Helper)
-require_relative "../log"
-require_relative "../config"
-require_relative "../chef_class"
+require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   module Mixin
     module ShellOut
       include Mixlib::ShellOut::Helper
-
-      def __config
-        Chef::Config
-      end
-
-      def __log
-        Chef::Log
-      end
-
-      def __transport_connection
-        Chef.run_context&.transport_connection
-      end
+      include Chef::Mixin::ChefUtilsWiring
     end
   end
 end

--- a/lib/chef/mixin/which.rb
+++ b/lib/chef/mixin/which.rb
@@ -22,6 +22,7 @@ class Chef
   module Mixin
     module Which
       include ChefUtils::DSL::Which
+      include ChefUtils::DSL::PathSanity
 
       private
 
@@ -29,7 +30,12 @@ class Chef
       #
       # @api private
       def __extra_path
-        ChefUtils::DSL::PathSanity.sane_paths
+        __sane_paths
+      end
+
+      # dependency injection, see: ChefUtils::Internal
+      def __transport_connection
+        Chef.run_context&.transport_connection
       end
     end
   end

--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -17,38 +17,53 @@
 #
 
 require_relative "../chef_class"
-require "chef-utils" if defined?(ChefUtils::CANARY)
+require "chef-utils" unless defined?(ChefUtils::CANARY)
 
 class Chef
   class Platform
-    # @deprecated, use ChefUtils::DSL::Service instead (via the ChefUtils Universal DSL)
-    class ServiceHelpers
-      class << self
-        def service_resource_providers
-          providers = []
+    module ServiceHelpers
+      include ChefUtils::DSL::Service
 
-          providers << :debian if ChefUtils::DSL::Service.debianrcd?
-          providers << :invokercd if ChefUtils::DSL::Service.invokercd?
-          providers << :upstart if ChefUtils::DSL::Service.upstart?
-          providers << :insserv if ChefUtils::DSL::Service.insserv?
-          providers << :systemd if ChefUtils.systemd?
-          providers << :redhat if ChefUtils::DSL::Service.redhatrcd?
+      def service_resource_providers
+        providers = []
 
-          providers
-        end
+        providers << :debian if debianrcd?
+        providers << :invokercd if invokercd?
+        providers << :upstart if upstart?
+        providers << :insserv if insserv?
+        providers << :systemd if systemd?
+        providers << :redhat if redhatrcd?
 
-        def config_for_service(service_name)
-          configs = []
-
-          configs << :initd if ChefUtils::DSL::Service.service_script_exist?(:initd, service_name)
-          configs << :upstart if ChefUtils::DSL::Service.service_script_exist?(:upstart, service_name)
-          configs << :xinetd if ChefUtils::DSL::Service.service_script_exist?(:xinetd, service_name)
-          configs << :systemd if ChefUtils::DSL::Service.service_script_exist?(:systemd, service_name)
-          configs << :etc_rcd if ChefUtils::DSL::Service.service_script_exist?(:etc_rcd, service_name)
-
-          configs
-        end
+        providers
       end
+
+      def config_for_service(service_name)
+        configs = []
+
+        configs << :initd if service_script_exist?(:initd, service_name)
+        configs << :upstart if service_script_exist?(:upstart, service_name)
+        configs << :xinetd if service_script_exist?(:xinetd, service_name)
+        configs << :systemd if service_script_exist?(:systemd, service_name)
+        configs << :etc_rcd if service_script_exist?(:etc_rcd, service_name)
+
+        configs
+      end
+
+      private
+
+      def __config
+        Chef::Config
+      end
+
+      def __log
+        Chef::Log
+      end
+
+      def __transport_connection
+        Chef.run_context&.transport_connection
+      end
+
+      extend self
     end
   end
 end

--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -18,11 +18,13 @@
 
 require_relative "../chef_class"
 require "chef-utils" unless defined?(ChefUtils::CANARY)
+require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   class Platform
     module ServiceHelpers
       include ChefUtils::DSL::Service
+      include Chef::Mixin::ChefUtilsWiring
 
       def service_resource_providers
         providers = []
@@ -47,20 +49,6 @@ class Chef
         configs << :etc_rcd if service_script_exist?(:etc_rcd, service_name)
 
         configs
-      end
-
-      private
-
-      def __config
-        Chef::Config
-      end
-
-      def __log
-        Chef::Log
-      end
-
-      def __transport_connection
-        Chef.run_context&.transport_connection
       end
 
       extend self

--- a/lib/chef/provider/service.rb
+++ b/lib/chef/provider/service.rb
@@ -23,8 +23,8 @@ require "chef-utils" unless defined?(ChefUtils::CANARY)
 class Chef
   class Provider
     class Service < Chef::Provider
-      include ChefUtils::DSL::Service
-      extend ChefUtils::DSL::Service
+      include Chef::Platform::ServiceHelpers
+      extend Chef::Platform::ServiceHelpers
 
       def supports
         @supports ||= new_resource.supports.dup

--- a/lib/chef/resource/service.rb
+++ b/lib/chef/resource/service.rb
@@ -25,8 +25,8 @@ require_relative "../dist"
 class Chef
   class Resource
     class Service < Chef::Resource
-      include ChefUtils::DSL::Service
-      extend ChefUtils::DSL::Service
+      include Chef::Platform::ServiceHelpers
+      extend Chef::Platform::ServiceHelpers
       unified_mode true
 
       provides :service, target_mode: true

--- a/spec/unit/mixin/shell_out_spec.rb
+++ b/spec/unit/mixin/shell_out_spec.rb
@@ -24,7 +24,6 @@ require "spec_helper"
 require "chef/mixin/path_sanity"
 
 describe Chef::Mixin::ShellOut do
-  include ChefUtils::DSL::PathSanity
   let(:shell_out_class) { Class.new { include Chef::Mixin::ShellOut } }
   subject(:shell_out_obj) { shell_out_class.new }
 
@@ -57,38 +56,38 @@ describe Chef::Mixin::ShellOut do
           describe "and environment is an option" do
             it "should not change environment language settings when they are set to nil" do
               options = { environment: { "LC_ALL" => nil, "LANGUAGE" => nil, "LANG" => nil, env_path => nil } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, **options).and_return(retobj)
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, **options).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should not change environment language settings when they are set to non-nil" do
               options = { environment: { "LC_ALL" => "en_US.UTF-8", "LANGUAGE" => "en_US.UTF-8", "LANG" => "en_US.UTF-8", env_path => "foo:bar:baz" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, **options).and_return(retobj)
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, **options).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should set environment language settings to the configured internal locale when they are not present" do
               options = { environment: { "HOME" => "/Users/morty" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
                 environment: {
                   "HOME" => "/Users/morty",
                   "LC_ALL" => Chef::Config[:internal_locale],
                   "LANG" => Chef::Config[:internal_locale],
                   "LANGUAGE" => Chef::Config[:internal_locale],
-                  env_path => sanitized_path,
+                  env_path => shell_out_obj.sanitized_path,
                 }).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should not mutate the options hash when it adds language settings" do
               options = { environment: { "HOME" => "/Users/morty" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
                 environment: {
                   "HOME" => "/Users/morty",
                   "LC_ALL" => Chef::Config[:internal_locale],
                   "LANG" => Chef::Config[:internal_locale],
                   "LANGUAGE" => Chef::Config[:internal_locale],
-                  env_path => sanitized_path,
+                  env_path => shell_out_obj.sanitized_path,
                 }).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
               expect(options[:environment].key?("LC_ALL")).to be false
@@ -98,38 +97,38 @@ describe Chef::Mixin::ShellOut do
           describe "and env is an option" do
             it "should not change env when langauge options are set to nil" do
               options = { env: { "LC_ALL" => nil, "LANG" => nil, "LANGUAGE" => nil, env_path => nil } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, **options).and_return(retobj)
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, **options).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should not change env when language options are set to non-nil" do
               options = { env: { "LC_ALL" => "de_DE.UTF-8", "LANG" => "de_DE.UTF-8", "LANGUAGE" => "de_DE.UTF-8", env_path => "foo:bar:baz" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, **options).and_return(retobj)
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, **options).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should set environment language settings to the configured internal locale when they are not present" do
               options = { env: { "HOME" => "/Users/morty" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
                 env: {
                   "HOME" => "/Users/morty",
                   "LC_ALL" => Chef::Config[:internal_locale],
                   "LANG" => Chef::Config[:internal_locale],
                   "LANGUAGE" => Chef::Config[:internal_locale],
-                  env_path => sanitized_path,
+                  env_path => shell_out_obj.sanitized_path,
                 }).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
 
             it "should not mutate the options hash when it adds language settings" do
               options = { env: { "HOME" => "/Users/morty" } }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
                 env: {
                   "HOME" => "/Users/morty",
                   "LC_ALL" => Chef::Config[:internal_locale],
                   "LANG" => Chef::Config[:internal_locale],
                   "LANGUAGE" => Chef::Config[:internal_locale],
-                  env_path => sanitized_path,
+                  env_path => shell_out_obj.sanitized_path,
                 }).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
               expect(options[:env].key?("LC_ALL")).to be false
@@ -139,13 +138,13 @@ describe Chef::Mixin::ShellOut do
           describe "and no env/environment option is present" do
             it "should set environment language settings to the configured internal locale" do
               options = { user: "morty" }
-              expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+              expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
                 user: "morty",
                 environment: {
                   "LC_ALL" => Chef::Config[:internal_locale],
                   "LANG" => Chef::Config[:internal_locale],
                   "LANGUAGE" => Chef::Config[:internal_locale],
-                  env_path => sanitized_path,
+                  env_path => shell_out_obj.sanitized_path,
                 }).and_return(retobj)
               shell_out_obj.send(method, cmd, **options)
             end
@@ -154,12 +153,12 @@ describe Chef::Mixin::ShellOut do
 
         describe "when the last argument is not a Hash" do
           it "should set environment language settings to the configured internal locale" do
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd,
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd,
               environment: {
                 "LC_ALL" => Chef::Config[:internal_locale],
                 "LANG" => Chef::Config[:internal_locale],
                 "LANGUAGE" => Chef::Config[:internal_locale],
-                env_path => sanitized_path,
+                env_path => shell_out_obj.sanitized_path,
               }).and_return(retobj)
             shell_out_obj.send(method, cmd)
           end
@@ -173,19 +172,19 @@ describe Chef::Mixin::ShellOut do
         describe "and environment is an option" do
           it "should not change environment['LC_ALL'] when set to nil" do
             options = { environment: { "LC_ALL" => nil } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should not change environment['LC_ALL'] when set to non-nil" do
             options = { environment: { "LC_ALL" => "en_US.UTF-8" } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should no longer set environment['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { environment: { "HOME" => "/Users/morty" } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -193,19 +192,19 @@ describe Chef::Mixin::ShellOut do
         describe "and env is an option" do
           it "should not change env when set to nil" do
             options = { env: { "LC_ALL" => nil } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should not change env when set to non-nil" do
             options = { env: { "LC_ALL" => "en_US.UTF-8" } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
 
           it "should no longer set env['LC_ALL'] to nil when 'LC_ALL' not present" do
             options = { env: { "HOME" => "/Users/morty" } }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -213,7 +212,7 @@ describe Chef::Mixin::ShellOut do
         describe "and no env/environment option is present" do
           it "should no longer add environment option and set environment['LC_ALL'] to nil" do
             options = { user: "morty" }
-            expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd, options).and_return(true)
+            expect(shell_out_obj).to receive(:__shell_out_command).with(cmd, options).and_return(true)
             shell_out_obj.shell_out(cmd, **options, default_env: false)
           end
         end
@@ -221,7 +220,7 @@ describe Chef::Mixin::ShellOut do
 
       describe "when the last argument is not a Hash" do
         it "should no longer add environment options and set environment['LC_ALL'] to nil" do
-          expect(Chef::Mixin::ShellOut).to receive(:shell_out_command).with(cmd).and_return(true)
+          expect(shell_out_obj).to receive(:__shell_out_command).with(cmd).and_return(true)
           shell_out_obj.shell_out(cmd, default_env: false)
         end
       end


### PR DESCRIPTION
Okay I think I made some improvements which make this whole framework bound a lot less tightly bound to "global state" and calling class methods.  The `ChefUtils.systemd?` calling convention may be somewhat of a bad idea, but after ripping some of that out I put it back in due to not wanting to break public APIs, and I believe that this does not break public APIs.

What I did do though is in some of the modules that referenced class names, I instead switched to mixin in those modules and then calling the methods, which I believe (going forwards) is the more correct way of writing these -- it makes it easier to include those methods into external classes and override things like the __transport_connection, whereas if they call class methods then external software consumers would need to directly monkeypatch into ChefUtils classes to override those methods (which is clearly a poor API).