### PR TITLE
Fix openssl config tests on Windows

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -282,7 +282,9 @@ class Chef
           ef.issuer_certificate = info["issuer"]
         end
         ef.subject_certificate = cert
-        ef.config = ::OpenSSL::Config.load(::OpenSSL::Config::DEFAULT_CONFIG_FILE)
+        if openssl_config = __openssl_config
+          ef.config = openssl_config
+        end
 
         cert.extensions = extension
         cert.add_extension ef.create_extension("subjectKeyIdentifier", "hash")
@@ -313,7 +315,9 @@ class Chef
         crl.last_update = Time.now
         crl.next_update = Time.now + 3600 * 24 * info["validity"]
 
-        ef.config = ::OpenSSL::Config.load(::OpenSSL::Config::DEFAULT_CONFIG_FILE)
+        if openssl_config = __openssl_config
+          ef.config = openssl_config
+        end
         ef.issuer_certificate = info["issuer"]
 
         crl.add_extension ::OpenSSL::X509::Extension.new("crlNumber", ::OpenSSL::ASN1::Integer(1))
@@ -390,7 +394,9 @@ class Chef
         crl.next_update = crl.last_update + 3600 * 24 * info["validity"]
 
         ef = ::OpenSSL::X509::ExtensionFactory.new
-        ef.config = ::OpenSSL::Config.load(::OpenSSL::Config::DEFAULT_CONFIG_FILE)
+        if openssl_config = __openssl_config
+          ef.config = openssl_config
+        end
         ef.issuer_certificate = info["issuer"]
 
         crl.extensions = [ ::OpenSSL::X509::Extension.new("crlNumber",
@@ -420,6 +426,23 @@ class Chef
         end
 
         resp
+      end
+
+      private
+
+      def __openssl_config
+        path = if File.exist?(::OpenSSL::Config::DEFAULT_CONFIG_FILE)
+                 OpenSSL::Config::DEFAULT_CONFIG_FILE
+               else
+                 Dir[File.join(RbConfig::CONFIG["prefix"], "**", "openssl.cnf")].first
+               end
+
+        if File.exist?(path)
+          ::OpenSSL::Config.load(path)
+        else
+          Chef::Log.warn("Couldn't find OpenSSL config file")
+          nil
+        end
       end
     end
   end


### PR DESCRIPTION
Attempt to locate `openssl.cnf` if it isn't in the default location indicated by OpenSSL. This initially seemed like a much bigger deal, but is apparently not really an issue.

https://github.com/ruby/openssl/blob/016a4f8cc48f6ec62c6fac06f20e22e46e92a84f/test/openssl/test_config.rb#L28-L35
https://bugs.ruby-lang.org/issues/6830 

Signed-off-by: Pete Higgins <pete@peterhiggins.org>