### PR TITLE
Disable Naming/AsciiIdentifiers in our specs

### DIFF
--- a/spec/integration/recipes/recipe_dsl_spec.rb
+++ b/spec/integration/recipes/recipe_dsl_spec.rb
@@ -1221,7 +1221,7 @@ describe "Recipe DSL methods" do
 
       it "utf-8 dsl names work" do
         recipe = converge do
-          Straße("blah") {}
+          Straße("blah") {} # rubocop: disable Naming/AsciiIdentifiers
         end
         expect(recipe.logged_warnings).to eq ""
         expect(BaseThingy.created_resource).to eq(UTF8Thingy)

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -111,11 +111,11 @@ describe "Chef::Resource.property" do
 
   with_property ":Straße" do
     it "properties with UTF-8 in their name work" do
-      expect(resource.Straße).to eql(nil)
-      expect(resource.Straße "foo").to eql("foo")
-      expect(resource.Straße).to eql("foo")
-      expect(resource.Straße = "bar").to eql("bar")
-      expect(resource.Straße).to eql("bar")
+      expect(resource.Straße).to eql(nil) # rubocop: disable Naming/AsciiIdentifiers
+      expect(resource.Straße "foo").to eql("foo") # rubocop: disable Naming/AsciiIdentifiers
+      expect(resource.Straße).to eql("foo") # rubocop: disable Naming/AsciiIdentifiers
+      expect(resource.Straße = "bar").to eql("bar") # rubocop: disable Naming/AsciiIdentifiers
+      expect(resource.Straße).to eql("bar") # rubocop: disable Naming/AsciiIdentifiers
     end
   end
 


### PR DESCRIPTION
RuboCop 0.87 expanded this cop to detect these uses of non-ASCII
characters.

Signed-off-by: Tim Smith <tsmith@chef.io>