### PR TITLE
Fixed `knife cookbook upload -o` windows path issue

### DIFF
--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -34,10 +34,12 @@ class Chef
       banner "knife cookbook upload [COOKBOOKS...] (options)"
 
       option :cookbook_path,
-        short: "-o PATH:PATH",
-        long: "--cookbook-path PATH:PATH",
-        description: "A colon-separated path to look for cookbooks in.",
-        proc: lambda { |o| o.split(":") }
+        short: "-o 'PATH:PATH'",
+        long: "--cookbook-path 'PATH:PATH'",
+        description: "A colon-separated path to look for cookbooks in.
+                      Colon seprated path has been deprecated for Windows machine.
+                      In windows please use semicolon-separated path(For ex: 'PATH;PATH').",
+        proc: lambda { |o| o.split(File::PATH_SEPARATOR) }
 
       option :freeze,
         long: "--freeze",

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -36,9 +36,7 @@ class Chef
       option :cookbook_path,
         short: "-o 'PATH:PATH'",
         long: "--cookbook-path 'PATH:PATH'",
-        description: "A colon-separated path to look for cookbooks in.
-                      Colon seprated path has been deprecated for Windows machine.
-                      In windows please use semicolon-separated path(For ex: 'PATH;PATH').",
+        description: "A delimited path to search for cookbooks. On Unix the delimiter is ':', on Windows it is ';'.",
         proc: lambda { |o| o.split(File::PATH_SEPARATOR) }
 
       option :freeze,

--- a/spec/integration/knife/cookbook_upload_spec.rb
+++ b/spec/integration/knife/cookbook_upload_spec.rb
@@ -97,16 +97,17 @@ describe "knife cookbook upload", :workstation do
         expect { knife("cookbook upload x -o #{cb_dir}") }.to raise_error(Chef::Exceptions::MetadataNotValid)
       end
     end
-    
-    when_the_repository "have cookbooks at muliple paths" do
-      let(:cb_dir_first) do 
-        File.join(@repository_dir,"cookbooks")
-        .gsub(File::SEPARATOR,File::ALT_SEPARATOR || File::SEPARATOR)
+
+    when_the_repository "has cookbooks at multiple paths" do
+
+      let(:cb_dir_first) do
+        File.join(@repository_dir, "cookbooks")
+          .gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
       end
-      
+
       let(:cb_dir_second) do
-        File.join(@repository_dir,"test_cookbooks")
-        .gsub(File::SEPARATOR,File::ALT_SEPARATOR || File::SEPARATOR) 
+        File.join(@repository_dir, "test_cookbooks")
+          .gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
       end
 
       before(:each) do

--- a/spec/integration/knife/cookbook_upload_spec.rb
+++ b/spec/integration/knife/cookbook_upload_spec.rb
@@ -97,5 +97,31 @@ describe "knife cookbook upload", :workstation do
         expect { knife("cookbook upload x -o #{cb_dir}") }.to raise_error(Chef::Exceptions::MetadataNotValid)
       end
     end
+    
+    when_the_repository "have cookbooks at muliple paths" do
+      let(:cb_dir_first) do 
+        File.join(@repository_dir,"cookbooks")
+        .gsub(File::SEPARATOR,File::ALT_SEPARATOR || File::SEPARATOR)
+      end
+      
+      let(:cb_dir_second) do
+        File.join(@repository_dir,"test_cookbooks")
+        .gsub(File::SEPARATOR,File::ALT_SEPARATOR || File::SEPARATOR) 
+      end
+
+      before(:each) do
+        file "cookbooks/x/metadata.rb", cb_metadata("x", "1.0.0")
+        file "test_cookbooks/y/metadata.rb", cb_metadata("y", "1.0.0")
+      end
+
+      it "knife cookbook upload with -o or --cookbook-path" do
+        knife("cookbook upload x y -o #{cb_dir_first}#{File::PATH_SEPARATOR}#{cb_dir_second}").should_succeed stderr: <<~EOM
+          Uploading x            [1.0.0]
+          Uploading y            [1.0.0]
+          Uploaded 2 cookbooks.
+        EOM
+      end
+
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

## Description
- Fixed windows cookbooks upload issue.
- Updated cookbook_path option used  File::PATH_SEPARATOR to split path.
- Added rspec for upload multiple paths cookbooks.

## Related Issue
#10082 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
