### PR TITLE
Use powershell_out vs. powershell_script in hostname

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -68,3 +68,7 @@ locale "set system locale" do
 end
 
 include_recipe "::_ohai_hint"
+
+hostname "new-hostname" do
+  windows_reboot false
+end

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -87,8 +87,7 @@ class Chef
         def updated_ec2_config_xml
           begin
             require "rexml/document" unless defined?(REXML::Document)
-            config_file = 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml'
-            config = REXML::Document.new(::File.read(config_file))
+            config = REXML::Document.new(::File.read(WINDOWS_EC2_CONFIG))
             # find an element named State with a sibling element whose value is Ec2SetComputerName
             REXML::XPath.each(config, "//Plugin/State[../Name/text() = 'Ec2SetComputerName']") do |element|
               element.text = "Disabled"
@@ -223,15 +222,17 @@ class Chef
           end
 
         else # windows
+          WINDOWS_EC2_CONFIG = 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml'.freeze
+
           raise "Windows hostnames cannot contain a period." if new_resource.hostname.match?(/\./)
 
           # suppress EC2 config service from setting our hostname
-          if ::File.exist?('C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml')
+          if ::File.exist?(WINDOWS_EC2_CONFIG)
             xml_contents = updated_ec2_config_xml
             if xml_contents.empty?
               Chef::Log.warn('Unable to properly parse and update C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml contents. Skipping file update.')
             else
-              file 'C:\Program Files\Amazon\Ec2ConfigService\Settings\config.xml' do
+              file WINDOWS_EC2_CONFIG do
                 content xml_contents
               end
             end

--- a/lib/chef/resource/hostname.rb
+++ b/lib/chef/resource/hostname.rb
@@ -248,8 +248,8 @@ class Chef
             # reboot because $windows
             reboot "setting hostname" do
               reason "#{Chef::Dist::PRODUCT} updated system hostname"
-              action :nothing
               only_if { new_resource.windows_reboot }
+              action :request_reboot
             end
           end
         end


### PR DESCRIPTION
This improves the log output and probably speeds up the run since we're
not writing out a temporary script file anymore and then executing it. I
also removed some delcare_resource uses since we enabled unified_mode
for this resource. There's a ton more to remove here.

Fixes #9823

Signed-off-by: Tim Smith <tsmith@chef.io>