### PR TITLE
Avoid requiring spec_helper more than once

### DIFF
--- a/spec/functional/resource/windows_user_privilege_spec.rb
+++ b/spec/functional/resource/windows_user_privilege_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require_relative "../../spec_helper"
+require "spec_helper"
 
 describe Chef::Resource::WindowsUserPrivilege, :windows_only do
   let(:principal) { nil }

--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/client"
 
 describe Chef::RunLock do

--- a/spec/functional/util/powershell/cmdlet_spec.rb
+++ b/spec/functional/util/powershell/cmdlet_spec.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef/json_compat"
-require_relative "../../../spec_helper"
+require "spec_helper"
 
 describe Chef::Util::Powershell::Cmdlet, :windows_powershell_dsc_only do
   before(:all) do

--- a/spec/functional/version_spec.rb
+++ b/spec/functional/version_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/mixin/shell_out"
 require "chef/version"
 require "ohai/version"

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/data_collector"
 require "socket"
 

--- a/spec/unit/json_compat_spec.rb
+++ b/spec/unit/json_compat_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/json_compat"
 
 describe Chef::JSONCompat do

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
+require "spec_helper"
 
 require "chef/cookbook_uploader"
 require "timeout"

--- a/spec/unit/provider/ifconfig_spec.rb
+++ b/spec/unit/provider/ifconfig_spec.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-# require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_helper"))
 require "spec_helper"
 require "chef/exceptions"
 

--- a/spec/unit/provider/package/smartos_spec.rb
+++ b/spec/unit/provider/package/smartos_spec.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "spec_helper"))
+require "spec_helper"
 require "ostruct"
 
 describe Chef::Provider::Package::SmartOS, "load_current_resource" do

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "spec_helper"))
+require "spec_helper"
 require "ostruct"
 
 shared_examples_for "define_resource_requirements_common" do

--- a/spec/unit/resource_reporter_spec.rb
+++ b/spec/unit/resource_reporter_spec.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/resource_reporter"
 require "socket"
 

--- a/spec/unit/run_lock_spec.rb
+++ b/spec/unit/run_lock_spec.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/client"
 
 describe Chef::RunLock do

--- a/spec/unit/scan_access_control_spec.rb
+++ b/spec/unit/scan_access_control_spec.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require_relative "../spec_helper"
+require "spec_helper"
 require "chef/scan_access_control"
 
 describe Chef::ScanAccessControl do


### PR DESCRIPTION
Running the unit tests on Windows I noticed that because of some funky ways used to require `spec_helper` that it was being loaded twice and I was getting warnings:

```
PS C:\vagrant\chef> bundle exec rspec .\spec\unit\provider\package\smartos_spec.rb .\spec\unit\provider\package\yum\python_hel
per_spec.rb
<internal:warning>:43:in `warn': opscode/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/cheffish-16.0.2/lib/cheffish/rspec
/repository_support.rb:12
...and you are now defining it at:
  //vboxsvr/vagrant/chef/spec/support/shared/integration/integration_helper.rb:109
The new definition will overwrite the original one. (StructuredWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:89:in `<top (required)>': already initialized constant OHAI_SYSTEM (StructuredWarni
ngs::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:89:in `<top (required)>': warning: previous definition of OHAI_SYSTEM was here (Str
ucturedWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:97:in `<top (required)>': already initialized constant TEST_NODE (StructuredWarning
s::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:97:in `<top (required)>': warning: previous definition of TEST_NODE was here (Struc
turedWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:98:in `<top (required)>': already initialized constant TEST_OS (StructuredWarnings:
:BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:98:in `<top (required)>': warning: previous definition of TEST_OS was here (Structu
redWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:99:in `<top (required)>': already initialized constant TEST_PLATFORM (StructuredWar
nings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:99:in `<top (required)>': warning: previous definition of TEST_PLATFORM was here (S
tructuredWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:100:in `<top (required)>': already initialized constant TEST_PLATFORM_VERSION (Stru
cturedWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:100:in `<top (required)>': warning: previous definition of TEST_PLATFORM_VERSION wa
s here (StructuredWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:101:in `<top (required)>': already initialized constant TEST_PLATFORM_FAMILY (Struc
turedWarnings::BuiltInWarning)
//vboxsvr/vagrant/chef/spec/spec_helper.rb:101:in `<top (required)>': warning: previous definition of TEST_PLATFORM_FAMILY was
 here (StructuredWarnings::BuiltInWarning)
Run options:
  include {:focus=>true}
  exclude {:provider=>#<Proc: ./spec/spec_helper.rb:210>, :arch=>#<Proc: ./spec/spec_helper.rb:204>, :requires_ifconfig=>true,
 :ruby=>"2.7.1", :chef=>"16.3.1", :not_intel_64bit=>true, :rhel_gte_8=>true, :rhel8=>true, :rhel7=>true, :rhel6=>true, :rhel=>
true, :not_wpar=>true, :broken=>true, :openssl_lt_101=>true, :requires_root=>true, :selinux_only=>true, :debian_family_only=>t
rue, :opensuse=>true, :suse_only=>true, :aix_only=>true, :linux_only=>true, :unix_only=>true, :solaris_only=>true, :windows_se
rvice_requires_assign_token=>true, :windows_domain_joined_only=>true, :windows_powershell_no_dsc_only=>true, :ruby32_only=>tru
e, :windows_lt_10=>true, :windows32_only=>true, :win2012r2_only=>true, :macos_1014=>true, :macos_only=>true, :not_supported_on
_windows=>true, :volatile_from_verify=>false, :volatile=>true, :external=>true}

All examples were filtered out; ignoring {:focus=>true}
........

Finished in 0.0404 seconds (files took 30.46 seconds to load)
8 examples, 0 failures
```

Rspec automatically puts `spec/` in the load path (I think?) so doing anything other than `require "spec_helper"` should never be necessary.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>