### PR TITLE
Don't run the dnf test that Windows doesn't like on Windows.

### DIFF
--- a/spec/unit/provider/package/dnf/python_helper_spec.rb
+++ b/spec/unit/provider/package/dnf/python_helper_spec.rb
@@ -22,7 +22,7 @@ require "spec_helper"
 describe Chef::Provider::Package::Dnf::PythonHelper do
   let(:helper) { Chef::Provider::Package::Dnf::PythonHelper.instance }
 
-  it "propagates stacktraces on stderr from the forked subprocess" do
+  it "propagates stacktraces on stderr from the forked subprocess", :rhel do
     allow(helper).to receive(:dnf_command).and_return("ruby -e 'raise \"your hands in the air\"'")
     expect { helper.package_query(:whatprovides, "tcpdump") }.to raise_error(/your hands in the air/)
   end


### PR DESCRIPTION
Running this unit test on Windows gives a strange error:

```
  3) Chef::Provider::Package::Dnf::PythonHelper propagates stacktraces on stderr from the forked subprocess
     Failure/Error: expect { helper.package_query(:whatprovides, "tcpdump") }.to raise_error(/your hands in the air/)
 
       expected /your hands in the air/, got #<ArgumentError: wrong file descriptor (5)> with backtrace:
         # ./lib/chef/provider/package/dnf/python_helper.rb:58:in `start'
         # ./lib/chef/provider/package/dnf/python_helper.rb:82:in `check'
         # ./lib/chef/provider/package/dnf/python_helper.rb:194:in `block in with_helper'
         # ./lib/chef/provider/package/dnf/python_helper.rb:193:in `with_helper'
         # ./lib/chef/provider/package/dnf/python_helper.rb:148:in `query'
         # ./lib/chef/provider/package/dnf/python_helper.rb:114:in `package_query'
         # ./spec/unit/provider/package/dnf/python_helper_spec.rb:27:in `block (3 levels) in <top (required)>'
         # ./spec/unit/provider/package/dnf/python_helper_spec.rb:27:in `block (2 levels) in <top (required)>'
         # ./spec/spec_helper.rb:295:in `block (2 levels) in <top (required)>'
     # ./spec/unit/provider/package/dnf/python_helper_spec.rb:27:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:295:in `block (2 levels) in <top (required)>'
```

While investigating trying to fix this test, I noticed that the code and spec for the yum version of this was very similar, except the yum version's spec is gated to only run on `:rhel`:

https://github.com/chef/chef/blob/master/spec/unit/provider/package/yum/python_helper_spec.rb#L25

Given that these two pieces of code are so similar, it seems likely that if one of them is only tested on RHEL the other should be as well.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>