### PR TITLE
Fix two warnings in tests.

### DIFF
--- a/spec/unit/win32/security_spec.rb
+++ b/spec/unit/win32/security_spec.rb
@@ -81,9 +81,10 @@ describe "Chef::Win32::Security", :windows_only do
 
     context "when the user has admin privileges" do
       it "returns true" do
-        allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token)
-        token = Chef::ReservedNames::Win32::Security.open_current_process_token
+        token = double(:process_token)
         allow(token).to receive_message_chain(:handle, :handle)
+
+        allow(Chef::ReservedNames::Win32::Security).to receive(:open_current_process_token).and_return(token)
         allow(Chef::ReservedNames::Win32::Security).to receive(:get_token_information_elevation_type)
         allow(Chef::ReservedNames::Win32::Security).to receive(:GetTokenInformation).and_return(true)
         allow_any_instance_of(FFI::Buffer).to receive(:read_ulong).and_return(1)
@@ -128,7 +129,7 @@ describe "Chef::Win32::Security", :windows_only do
     context "when FFI::LastError.error result is not ERROR_INSUFFICIENT_BUFFER and not NO_ERROR" do
       it "raises Chef::ReservedNames::Win32::Error.raise! exception" do
         expect(FFI::LastError).to receive(:error).and_return(123).at_least(:once)
-        expect { security_class.lookup_account_name "system" }.to raise_error
+        expect { security_class.lookup_account_name "system" }.to raise_error(Chef::Exceptions::Win32APIError)
       end
     end
   end


### PR DESCRIPTION
Fix two warnings that get logged while running this test:

```
<internal:warning>:43:in `warn': Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectati
ons on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`. Called from C:/vagrant/chef/spec/
unit/win32/security_spec.rb:86:in `block (4 levels) in <top (required)>'. (StructuredWarnings::BuiltInWarning)
```

and

```
<internal:warning>:43:in `warn': xceptions::Win32APIError: The filename, directory name, or volume label syntax is incorre
ct.
---- Begin Win32 API output ----
System Error Code: 123
System Error Message: The filename, directory name, or volume label syntax is incorrect.
---- End Win32 API output ----
>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectatio
ns.configuration.on_potential_false_positives = :nothing`. Called from C:/vagrant/chef/spec/unit/win32/security_spec.rb:131:in
 `block (4 levels) in <top (required)>'. (StructuredWarnings::BuiltInWarning)
```

Signed-off-by: Pete Higgins <pete@peterhiggins.org>