### PR TITLE
Use rspec constant stubbing.

### DIFF
--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -22,12 +22,8 @@ require "spec_helper"
 describe Chef::Provider::Service::Windows, "load_current_resource" do
   include_context "Win32"
 
-  before(:all) do
-    Chef::ReservedNames::Win32::Security = Class.new unless windows?
-  end
-
-  after(:all) do
-    Chef::ReservedNames::Win32.send(:remove_const, :Security) unless windows?
+  before do
+    stub_const("Chef::ReservedNames::Win32::Security", Class.new) unless windows?
   end
 
   let(:logger) { double("Mixlib::Log::Child").as_null_object }


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Saw this one on CI:

```
/workdir/spec/unit/provider/service/windows_spec.rb:26: warning: already initialized constant Chef::ReservedNames::Win32::Security
/workdir/vendor/bundle/ruby/2.6.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/mutate_const.rb:229: warning: previous definition of Security was here
```