### PR TITLE
Fix execute resource with integer user parameter.

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -630,11 +630,11 @@ class Chef
         end
 
         # if domain is provided in both username and domain
-        if specified_user && ((specified_user.include? '\\') || (specified_user.include? "@")) && specified_domain
+        if specified_user.kind_of?(String) && ((specified_user.include? '\\') || (specified_user.include? "@")) && specified_domain
           raise ArgumentError, "The domain is provided twice. Username: `#{specified_user}`, Domain: `#{specified_domain}`. Please specify domain only once."
         end
 
-        if ! specified_user.nil? && specified_domain.nil?
+        if specified_user.kind_of?(String) && specified_domain.nil?
           # Splitting username of format: Domain\Username
           domain_and_user = user.split('\\')
 

--- a/spec/unit/resource/execute_spec.rb
+++ b/spec/unit/resource/execute_spec.rb
@@ -63,6 +63,16 @@ describe Chef::Resource::Execute do
         expect(identity[:user]).to eq("user")
       end
     end
+
+    context "when username is passed as an integer" do
+      let(:username) { 499 }
+
+      it "correctly parses the user and domain" do
+        identity = resource.qualify_user(username, password, domain)
+        expect(identity[:domain]).to eq(nil)
+        expect(identity[:user]).to eq(499)
+      end
+    end
   end
 
   shared_examples_for "it received valid credentials" do


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

The `execute` resource accepts an integer or string for the `user` parameter. There is some code that attempts to parse a domain name out of the `user` value that was blowing up if it was passed an integer.

With a simple resource like this:

```
bash "something" do
  user 501
  code "echo $(id)"
end
```

Running it would produce output like this:
```
Petes-MBP:chef pete$ sudo chef-apply test_bash_resource.rb  --log-level=debug
Password:
[2020-07-13T18:09:47-07:00] DEBUG: Reading products and relationships...
[2020-07-13T18:09:47-07:00] DEBUG: Successfully read products and relationships
[2020-07-13T18:09:47-07:00] DEBUG: Searching for the following licenses: ["infra-client", "inspec"]
[2020-07-13T18:09:47-07:00] DEBUG: Found license chef_infra_client at /etc/chef/accepted_licenses/chef_infra_client
[2020-07-13T18:09:47-07:00] DEBUG: Found license inspec at /etc/chef/accepted_licenses/inspec
[2020-07-13T18:09:47-07:00] DEBUG: Missing licenses remaining: []
[2020-07-13T18:09:47-07:00] DEBUG: All licenses present
[2020-07-13T18:09:47-07:00] DEBUG: Running Ohai with the following configuration: {:logger=>#<Mixlib::Log::Child:0x00007fc2061d92d0 @parent=Chef::Log, @metadata={:system=>"ohai", :version=>"16.2.4"}>}
[2020-07-13T18:09:47-07:00] DEBUG: Running Ohai with the following configuration: {:logger=>#<Mixlib::Log::Child:0x00007fc2061d92d0 @parent=Chef::Log, @metadata={:system=>"ohai", :version=>"16.2.4"}>}
[2020-07-13T18:09:52-07:00] DEBUG: Extracting run list from JSON attributes provided on command line
[2020-07-13T18:09:52-07:00] DEBUG: Applying attributes from json file
[2020-07-13T18:09:52-07:00] DEBUG: Platform is mac_os_x version 10.15.5
[2020-07-13T18:09:52-07:00] INFO: Run List is []
[2020-07-13T18:09:52-07:00] INFO: Run List expands to []
[2020-07-13T18:09:52-07:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2020-07-13T18:09:52-07:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2020-07-13T18:09:52-07:00] DEBUG: NoMethodError: undefined method `include?' for 501:Integer
/Users/pete/work/chef/lib/chef/resource/execute.rb:633:in `qualify_user'
/Users/pete/work/chef/lib/chef/resource/execute.rb:599:in `after_created'
/Users/pete/work/chef/lib/chef/resource_builder.rb:74:in `build'
/Users/pete/work/chef/lib/chef/dsl/declare_resource.rb:318:in `build_resource'
/Users/pete/work/chef/lib/chef/dsl/declare_resource.rb:273:in `declare_resource'
/Users/pete/work/chef/lib/chef/dsl/resources.rb:36:in `bash'
test_bash_resource.rb:1:in `run_chef_recipe'
/Users/pete/work/chef/lib/chef/application/apply.rb:212:in `instance_eval'
/Users/pete/work/chef/lib/chef/application/apply.rb:212:in `run_chef_recipe'
/Users/pete/work/chef/lib/chef/application/apply.rb:227:in `run_application'
/Users/pete/work/chef/lib/chef/application/apply.rb:240:in `run'
/Users/pete/work/chef/chef-bin/bin/chef-apply:24:in `<top (required)>'
.git/safe/../../.bin/chef-apply:29:in `load'
.git/safe/../../.bin/chef-apply:29:in `<main>'
[2020-07-13T18:09:52-07:00] FATAL: NoMethodError: undefined method `include?' for 501:Integer
```

After this PR I get this output:
```
Petes-MBP:chef pete$ sudo chef-apply test_bash_resource.rb  --log-level=debug
[2020-07-13T18:10:19-07:00] DEBUG: Reading products and relationships...
[2020-07-13T18:10:19-07:00] DEBUG: Successfully read products and relationships
[2020-07-13T18:10:19-07:00] DEBUG: Searching for the following licenses: ["infra-client", "inspec"]
[2020-07-13T18:10:19-07:00] DEBUG: Found license chef_infra_client at /etc/chef/accepted_licenses/chef_infra_client
[2020-07-13T18:10:19-07:00] DEBUG: Found license inspec at /etc/chef/accepted_licenses/inspec
[2020-07-13T18:10:19-07:00] DEBUG: Missing licenses remaining: []
[2020-07-13T18:10:19-07:00] DEBUG: All licenses present
[2020-07-13T18:10:19-07:00] DEBUG: Running Ohai with the following configuration: {:logger=>#<Mixlib::Log::Child:0x00007f9939127468 @parent=Chef::Log, @metadata={:system=>"ohai", :version=>"16.2.4"}>}
[2020-07-13T18:10:19-07:00] DEBUG: Running Ohai with the following configuration: {:logger=>#<Mixlib::Log::Child:0x00007f9939127468 @parent=Chef::Log, @metadata={:system=>"ohai", :version=>"16.2.4"}>}
[2020-07-13T18:10:24-07:00] DEBUG: Extracting run list from JSON attributes provided on command line
[2020-07-13T18:10:24-07:00] DEBUG: Applying attributes from json file
[2020-07-13T18:10:24-07:00] DEBUG: Platform is mac_os_x version 10.15.5
[2020-07-13T18:10:24-07:00] INFO: Run List is []
[2020-07-13T18:10:24-07:00] INFO: Run List expands to []
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * bash[something] action run[2020-07-13T18:10:24-07:00] INFO: Processing bash[something] action run ((chef-apply cookbook)::(chef-apply recipe) line 1)

    [execute] uid=501(pete) gid=20(staff) egid=0(wheel) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),264(_webdeveloper),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae)
[2020-07-13T18:10:24-07:00] INFO: bash[something] ran successfully
    - execute "bash"
[2020-07-13T18:10:24-07:00] DEBUG: Exiting
```

Found by @johnmccrae.