### PR TITLE
Move the rehash methods into the subcommand loader

### DIFF
--- a/lib/chef/knife/core/subcommand_loader.rb
+++ b/lib/chef/knife/core/subcommand_loader.rb
@@ -75,6 +75,25 @@ class Chef
         Chef::Util::PathHelper.home(".chef", "plugin_manifest.json")
       end
 
+      def self.generate_hash
+        output = if plugin_manifest?
+                   plugin_manifest
+                 else
+                   { Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY => {} }
+                 end
+        output[Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY]["plugins_paths"] = Chef::Knife.subcommand_files
+        output[Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY]["plugins_by_category"] = Chef::Knife.subcommands_by_category
+        output
+      end
+
+      def self.write_hash(data)
+        plugin_manifest_dir = File.expand_path("..", plugin_manifest_path)
+        FileUtils.mkdir_p(plugin_manifest_dir) unless File.directory?(plugin_manifest_dir)
+        File.open(plugin_manifest_path, "w") do |f|
+          f.write(Chef::JSONCompat.to_json_pretty(data))
+        end
+      end
+
       def initialize(chef_config_dir)
         @chef_config_dir = chef_config_dir
       end

--- a/lib/chef/knife/rehash.rb
+++ b/lib/chef/knife/rehash.rb
@@ -34,7 +34,9 @@ class Chef
         else
           reload_plugins
         end
-        write_hash(generate_hash)
+
+        ui.msg "Knife subcommands are cached in #{Chef::Knife::SubcommandLoader.plugin_manifest_path}. Delete this file to disable the caching."
+        Chef::Knife::SubcommandLoader.write_hash(Chef::Knife::SubcommandLoader.generate_hash)
       end
 
       def reload_plugins
@@ -42,26 +44,6 @@ class Chef
         # plugins from disc and ensures the hash we write is always correct.  By this point it should also already have
         # loaded plugins and `load_commands` shouldn't have an effect.
         Chef::Knife.subcommand_loader.load_commands
-      end
-
-      def generate_hash
-        output = if Chef::Knife::SubcommandLoader.plugin_manifest?
-                   Chef::Knife::SubcommandLoader.plugin_manifest
-                 else
-                   { Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY => {} }
-                 end
-        output[Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY]["plugins_paths"] = Chef::Knife.subcommand_files
-        output[Chef::Knife::SubcommandLoader::HashedCommandLoader::KEY]["plugins_by_category"] = Chef::Knife.subcommands_by_category
-        output
-      end
-
-      def write_hash(data)
-        plugin_manifest_dir = File.expand_path("..", Chef::Knife::SubcommandLoader.plugin_manifest_path)
-        FileUtils.mkdir_p(plugin_manifest_dir) unless File.directory?(plugin_manifest_dir)
-        File.open(Chef::Knife::SubcommandLoader.plugin_manifest_path, "w") do |f|
-          f.write(Chef::JSONCompat.to_json_pretty(data))
-          ui.msg "Knife subcommands are cached in #{Chef::Knife::SubcommandLoader.plugin_manifest_path}. Delete this file to disable the caching."
-        end
       end
     end
   end


### PR DESCRIPTION
This way we can use them in chef-cli to rehash any time we install a
gem.

Signed-off-by: Tim Smith <tsmith@chef.io>