### PR TITLE
Remove smartos detection / support in our package scripts

### DIFF
--- a/omnibus/package-scripts/angrychef/postinst
+++ b/omnibus/package-scripts/angrychef/postinst
@@ -26,14 +26,7 @@ is_darwin()
   uname -v | grep "^Darwin" 2>&1 >/dev/null
 }
 
-is_smartos()
-{
-  uname -v | grep "^joyent" 2>&1 >/dev/null
-}
-
-if is_smartos; then
-    PREFIX="/opt/local"
-elif is_darwin; then
+if is_darwin; then
     PREFIX="/usr/local"
     mkdir -p "$PREFIX/bin"
 else

--- a/omnibus/package-scripts/angrychef/postrm
+++ b/omnibus/package-scripts/angrychef/postrm
@@ -7,10 +7,6 @@
 #   this programming language.  do not touch.
 # - if you are under 40, get peer review from your elders.
 
-is_smartos() {
-  uname -v | grep "^joyent" 2>&1 >/dev/null
-}
-
 is_darwin() {
   uname -v | grep "^Darwin" 2>&1 >/dev/null
 }
@@ -24,9 +20,7 @@ is_suse() {
   fi
 }
 
-if is_smartos; then
-    PREFIX="/opt/local"
-elif is_darwin; then
+if is_darwin; then
     PREFIX="/usr/local"
 else
     PREFIX="/usr"

--- a/omnibus/package-scripts/chef/postinst
+++ b/omnibus/package-scripts/chef/postinst
@@ -26,14 +26,7 @@ is_darwin()
   uname -v | grep "^Darwin" 2>&1 >/dev/null
 }
 
-is_smartos()
-{
-  uname -v | grep "^joyent" 2>&1 >/dev/null
-}
-
-if is_smartos; then
-    PREFIX="/opt/local"
-elif is_darwin; then
+if is_darwin; then
     PREFIX="/usr/local"
     mkdir -p "$PREFIX/bin"
 else

--- a/omnibus/package-scripts/chef/postrm
+++ b/omnibus/package-scripts/chef/postrm
@@ -7,10 +7,6 @@
 #   this programming language.  do not touch.
 # - if you are under 40, get peer review from your elders.
 
-is_smartos() {
-  uname -v | grep "^joyent" 2>&1 >/dev/null
-}
-
 is_darwin() {
   uname -v | grep "^Darwin" 2>&1 >/dev/null
 }
@@ -24,9 +20,7 @@ is_suse() {
   fi
 }
 
-if is_smartos; then
-    PREFIX="/opt/local"
-elif is_darwin; then
+if is_darwin; then
     PREFIX="/usr/local"
 else
     PREFIX="/usr"


### PR DESCRIPTION
We don't produce smartos packages and we never have. There's no reason
to carry around this baggage.

Signed-off-by: Tim Smith <tsmith@chef.io>