### PR TITLE
Remove cookbook uploader global state

### DIFF
--- a/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb
@@ -76,8 +76,7 @@ class Chef
             raise Chef::Exceptions::MetadataNotFound.new(cookbook.root_paths[0], cookbook.name) unless cookbook.has_metadata_file?
 
             if cookbook
-              begin
-                tmp_cl = Chef::CookbookLoader.copy_to_tmp_dir_from_array([cookbook])
+              Chef::CookbookLoader.copy_to_tmp_dir_from_array([cookbook]) do |tmp_cl|
                 tmp_cl.load_cookbooks
                 tmp_cl.compile_metadata
                 tmp_cl.freeze_versions if options[:freeze]
@@ -91,9 +90,6 @@ class Chef
                 with_actual_cookbooks_dir(other.parent.file_path) do
                   uploader.upload_cookbooks
                 end
-
-              ensure
-                tmp_cl.unlink!
               end
             end
           end

--- a/lib/chef/cookbook_loader.rb
+++ b/lib/chef/cookbook_loader.rb
@@ -44,14 +44,11 @@ class Chef
     # @return [Array<String>] the array of repo paths containing cookbook dirs
     attr_reader :repo_paths
 
-    attr_accessor :tmp_working_dir_path
-
     # XXX: this is highly questionable combined with the Hash-style each method
     include Enumerable
 
     # @param repo_paths [Array<String>] the array of repo paths containing cookbook dirs
     def initialize(*repo_paths)
-      @tmp_working_dir_path = nil
       @repo_paths = repo_paths.flatten.compact.map { |p| File.expand_path(p) }
       raise ArgumentError, "You must specify at least one cookbook repo path" if @repo_paths.empty?
     end
@@ -140,27 +137,23 @@ class Chef
 
     # This method creates tmp directory and copies all cookbooks into it and creates cookbook loader object which points to tmp directory
     def self.copy_to_tmp_dir_from_array(cookbooks)
-      tmp_cookbook_file = Tempfile.new("tmp_working_dir_path")
-      tmp_cookbook_file.close
-      @tmp_working_dir_path = tmp_cookbook_file.path
-      File.unlink(@tmp_working_dir_path)
-      FileUtils.mkdir_p(@tmp_working_dir_path)
-      cookbooks.each do |cookbook|
-        checksums_to_on_disk_paths = cookbook.checksums
-        cookbook.each_file do |manifest_record|
-          path_in_cookbook = manifest_record[:path]
-          on_disk_path = checksums_to_on_disk_paths[manifest_record[:checksum]]
-          dest = File.join(@tmp_working_dir_path, cookbook.name.to_s, path_in_cookbook)
-          FileUtils.mkdir_p(File.dirname(dest))
-          FileUtils.cp_r(on_disk_path, dest)
+      Dir.mktmpdir do |tmp_dir|
+        cookbooks.each do |cookbook|
+          checksums_to_on_disk_paths = cookbook.checksums
+          cookbook.each_file do |manifest_record|
+            path_in_cookbook = manifest_record[:path]
+            on_disk_path = checksums_to_on_disk_paths[manifest_record[:checksum]]
+            dest = File.join(tmp_dir, cookbook.name.to_s, path_in_cookbook)
+            FileUtils.mkdir_p(File.dirname(dest))
+            FileUtils.cp_r(on_disk_path, dest)
+          end
         end
+        tmp_cookbook_loader ||= begin
+          Chef::Cookbook::FileVendor.fetch_from_disk(tmp_dir)
+          CookbookLoader.new(tmp_dir)
+        end
+        yield tmp_cookbook_loader
       end
-      tmp_cookbook_loader ||= begin
-        Chef::Cookbook::FileVendor.fetch_from_disk(@tmp_working_dir_path)
-        CookbookLoader.new(@tmp_working_dir_path)
-      end
-      tmp_cookbook_loader.tmp_working_dir_path = @tmp_working_dir_path
-      tmp_cookbook_loader
     end
 
     # generates metadata.json adds it in the manifest
@@ -179,13 +172,6 @@ class Chef
       each do |cookbook_name, cookbook|
         cookbook.freeze_version
       end
-    end
-
-    # removes the tmp_dir_path
-    def unlink!
-      raise "Invalid directory path." if @tmp_working_dir_path.nil?
-
-      FileUtils.rm_rf(@tmp_working_dir_path)
     end
 
     alias :cookbooks :values

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -107,8 +107,7 @@ class Chef
           cookbook_path = config[:cookbook_path].respond_to?(:join) ? config[:cookbook_path].join(", ") : config[:cookbook_path]
           ui.warn("Could not find any cookbooks in your cookbook path: '#{File.expand_path(cookbook_path)}'. Use --cookbook-path to specify the desired path.")
         else
-          begin
-            tmp_cl = Chef::CookbookLoader.copy_to_tmp_dir_from_array(cookbooks)
+          Chef::CookbookLoader.copy_to_tmp_dir_from_array(cookbooks) do |tmp_cl|
             tmp_cl.load_cookbooks
             tmp_cl.compile_metadata
             tmp_cl.freeze_versions if config[:freeze]
@@ -127,7 +126,6 @@ class Chef
                   ui.error("Uploading of some of the cookbooks must be failed. Remove cookbook whose version is frozen from your cookbooks repo OR use --force option.")
                   upload_failures += 1
                 rescue SystemExit => e
-                  tmp_cl.unlink!
                   raise exit e.status
                 end
                 ui.info("Uploaded all cookbooks.") if upload_failures == 0
@@ -146,7 +144,6 @@ class Chef
                   ui.warn("Not updating version constraints for #{cookbook_name} in the environment as the cookbook is frozen.")
                   upload_failures += 1
                 rescue SystemExit => e
-                  tmp_cl.unlink!
                   raise exit e.status
                 end
               end
@@ -164,8 +161,6 @@ class Chef
             unless version_constraints_to_update.empty?
               update_version_constraints(version_constraints_to_update) if config[:environment]
             end
-          ensure
-            tmp_cl.unlink!
           end
         end
       end

--- a/spec/unit/knife/cookbook_upload_spec.rb
+++ b/spec/unit/knife/cookbook_upload_spec.rb
@@ -40,7 +40,6 @@ describe Chef::Knife::CookbookUpload do
     allow(cookbook_loader).to receive(:load_cookbooks).and_return(cookbook_loader)
     allow(cookbook_loader).to receive(:compile_metadata).and_return(nil)
     allow(cookbook_loader).to receive(:freeze_versions).and_return(nil)
-    allow(cookbook_loader).to receive(:unlink!).and_return(nil)
     cookbook_loader
   end
 
@@ -60,7 +59,7 @@ describe Chef::Knife::CookbookUpload do
 
   before(:each) do
     allow(Chef::CookbookLoader).to receive(:new).and_return(cookbook_loader)
-    allow(Chef::CookbookLoader).to receive(:copy_to_tmp_dir_from_array).and_return(cookbook_loader)
+    allow(Chef::CookbookLoader).to receive(:copy_to_tmp_dir_from_array).and_yield(cookbook_loader)
   end
 
   describe "with --concurrency" do
@@ -70,7 +69,6 @@ describe Chef::Knife::CookbookUpload do
       test_cookbook = Chef::CookbookVersion.new("test_cookbook", "/tmp/blah")
       allow(cookbook_loader).to receive(:each).and_yield("test_cookbook", test_cookbook)
       allow(cookbook_loader).to receive(:cookbook_names).and_return(["test_cookbook"])
-      allow(cookbook_loader).to receive(:tmp_working_dir_path).and_return("/tmp/blah")
       expect(Chef::CookbookUploader).to receive(:new)
         .with( kind_of(Array), { force: nil, concurrency: 3 })
         .and_return(double("Chef::CookbookUploader", upload_cookbooks: true))


### PR DESCRIPTION
An attempt at fixing #9860.

Some of the cheffish tests fail intermittently on CI: https://buildkite.com/chef-oss/chef-chef-master-verify/builds/5295#cfb74720-f5be-455e-8ba4-3bde3ed4cd0a

Running these tests locally, the same 3 tests fail consistently (with an occasional success), either getting the 404 HTTP error or various errors about being unable to read files:

```
 1) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format chef_mirror :upload uploads everything
     Failure/Error:
       paths.collect!{|d| raise Errno::ENOENT, d unless File.exist?(d); d.dup}.each do |path|
         path = path.to_path if path.respond_to? :to_path
         enc = path.encoding == Encoding::US_ASCII ? fs_encoding : path.encoding
         ps = [path]
         while file = ps.shift
           catch(:prune) do
             yield file.dup.taint
             begin
               s = File.lstat(file)
             rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG

     Errno::ENOENT:
       chef_mirror[] (basic_chef_client::block line 242) had an error: Errno::ENOENT: No such file or directory - /var/folders/3d/kw7h7x0s39jdbhdyycl4jp_40000gn/T/tmp_working_dir_path20200721-75275-85siyh/y-3.0.0/metadata.rb
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:224:in `block in load_all_files'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:215:in `each'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:215:in `load_all_files'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:73:in `load!'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:98:in `load_cookbook'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:80:in `block in load_cookbooks'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:79:in `each_key'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:79:in `load_cookbooks'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:81:in `upload_cookbook'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:60:in `upload_cookbook_from'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:56:in `create_child_from'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system.rb:306:in `copy_entries'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system.rb:360:in `block in copy_entries'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:264:in `process_input'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:254:in `process_one'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer.rb:92:in `call'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer.rb:92:in `worker_loop'

  2) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.versioned_cookbooks is false chef_mirror :upload uploads everything
     Failure/Error: expect { get("cookbooks/x-1.0.0/2.0.0") }.not_to raise_error

       expected no Exception, got #<Net::HTTPServerException: 404 "Not Found "> with backtrace:
         # /Users/pete/work/chef/lib/chef/http.rb:152:in `request'
         # /Users/pete/work/chef/lib/chef/http.rb:115:in `get'
         # ./lib/cheffish/rspec/chef_run_support.rb:43:in `get'
         # ./spec/integration/chef_mirror_spec.rb:260:in `block (7 levels) in <top (required)>'
         # ./spec/integration/chef_mirror_spec.rb:260:in `block (6 levels) in <top (required)>'
     # ./spec/integration/chef_mirror_spec.rb:260:in `block (6 levels) in <top (required)>'

  3) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.chef_repo_path is not set but versioned_cookbooks is false chef_mirror :upload with chef_repo_path and versioned_cookbooks false uploads cookbooks with name including version
     Failure/Error: file_contents = File.open(file, "rb", &:read)

     TypeError:
       chef_mirror[] (basic_chef_client::block line 274) had an error: TypeError: no implicit conversion of nil into String
     # /Users/pete/work/chef/lib/chef/cookbook_uploader.rb:123:in `initialize'
     # /Users/pete/work/chef/lib/chef/cookbook_uploader.rb:123:in `open'
     # /Users/pete/work/chef/lib/chef/cookbook_uploader.rb:123:in `block in uploader_function_for'
     # /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:52:in `block (3 levels) in process'
     # /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:50:in `loop'
     # /Users/pete/work/chef/lib/chef/util/threaded_job_queue.rb:50:in `block (2 levels) in process'

Finished in 6.92 seconds (files took 1.91 seconds to load)
30 examples, 3 failures

Failed examples:

rspec ./spec/integration/chef_mirror_spec.rb:240 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format chef_mirror :upload uploads everything
rspec ./spec/integration/chef_mirror_spec.rb:254 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.versioned_cookbooks is false chef_mirror :upload uploads everything
rspec ./spec/integration/chef_mirror_spec.rb:271 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.chef_repo_path is not set but versioned_cookbooks is false chef_mirror :upload with chef_repo_path and versioned_cookbooks false uploads cookbooks with name including version
```

```
 1) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format chef_mirror :upload uploads everything
     Failure/Error:
       paths.collect!{|d| raise Errno::ENOENT, d unless File.exist?(d); d.dup}.each do |path|
         path = path.to_path if path.respond_to? :to_path
         enc = path.encoding == Encoding::US_ASCII ? fs_encoding : path.encoding
         ps = [path]
         while file = ps.shift
           catch(:prune) do
             yield file.dup.taint
             begin
               s = File.lstat(file)
             rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG

     Errno::ENOENT:
       chef_mirror[] (basic_chef_client::block line 242) had an error: Errno::ENOENT: No such file or directory - /var/folders/3d/kw7h7x0s39jdbhdyycl4jp_40000gn/T/tmp_working_dir_path20200721-78307-1v6v8wr/y-3.0.0/..
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:224:in `block in load_all_files'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:215:in `each'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:215:in `load_all_files'
     # /Users/pete/work/chef/lib/chef/cookbook/cookbook_version_loader.rb:73:in `load!'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:98:in `load_cookbook'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:80:in `block in load_cookbooks'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:79:in `each_key'
     # /Users/pete/work/chef/lib/chef/cookbook_loader.rb:79:in `load_cookbooks'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:81:in `upload_cookbook'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:60:in `upload_cookbook_from'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system/chef_server/cookbooks_dir.rb:56:in `create_child_from'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system.rb:306:in `copy_entries'
     # /Users/pete/work/chef/lib/chef/chef_fs/file_system.rb:360:in `block in copy_entries'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:264:in `process_input'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer/parallel_enumerable.rb:254:in `process_one'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer.rb:92:in `call'
     # /Users/pete/work/chef/lib/chef/chef_fs/parallelizer.rb:92:in `worker_loop'

  2) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.versioned_cookbooks is false chef_mirror :upload uploads everything
     Failure/Error: expect { get("cookbooks/x-1.0.0/2.0.0") }.not_to raise_error

       expected no Exception, got #<Net::HTTPServerException: 404 "Not Found "> with backtrace:
         # /Users/pete/work/chef/lib/chef/http.rb:152:in `request'
         # /Users/pete/work/chef/lib/chef/http.rb:115:in `get'
         # ./lib/cheffish/rspec/chef_run_support.rb:43:in `get'
         # ./spec/integration/chef_mirror_spec.rb:260:in `block (7 levels) in <top (required)>'
         # ./spec/integration/chef_mirror_spec.rb:260:in `block (6 levels) in <top (required)>'
     # ./spec/integration/chef_mirror_spec.rb:260:in `block (6 levels) in <top (required)>'

  3) Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.chef_repo_path is not set but versioned_cookbooks is false chef_mirror :upload with chef_repo_path and versioned_cookbooks false uploads cookbooks with name including version
     Failure/Error: expect { get("cookbooks/x-1.0.0/2.0.0") }.not_to raise_error

       expected no Exception, got #<Net::HTTPServerException: 404 "Not Found "> with backtrace:
         # /Users/pete/work/chef/lib/chef/http.rb:152:in `request'
         # /Users/pete/work/chef/lib/chef/http.rb:115:in `get'
         # ./lib/cheffish/rspec/chef_run_support.rb:43:in `get'
         # ./spec/integration/chef_mirror_spec.rb:280:in `block (7 levels) in <top (required)>'
         # ./spec/integration/chef_mirror_spec.rb:280:in `block (6 levels) in <top (required)>'
     # ./spec/integration/chef_mirror_spec.rb:280:in `block (6 levels) in <top (required)>'

Finished in 6.94 seconds (files took 1.85 seconds to load)
30 examples, 3 failures

Failed examples:

rspec ./spec/integration/chef_mirror_spec.rb:240 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format chef_mirror :upload uploads everything
rspec ./spec/integration/chef_mirror_spec.rb:254 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.versioned_cookbooks is false chef_mirror :upload uploads everything
rspec ./spec/integration/chef_mirror_spec.rb:271 # Chef::Resource::ChefMirror When the Chef Zero server is in multi-org mode cookbook upload, chef_repo_path and versioned_cookbooks when the chef repo has cookbooks in non-versioned format and Chef::Config.chef_repo_path is not set but versioned_cookbooks is false chef_mirror :upload with chef_repo_path and versioned_cookbooks false uploads cookbooks with name including version
```

I'm not sure why specifically this global state was causing the failure, but after I tracked the failures down this location in the code and removed the global state on a hunch, the tests consistently passed for me. 

Signed-off-by: Pete Higgins <pete@peterhiggins.org>