### PR TITLE
Set log level to :fatal in test to prevent excess logging.

### DIFF
--- a/spec/functional/knife/ssh_spec.rb
+++ b/spec/functional/knife/ssh_spec.rb
@@ -36,17 +36,6 @@ describe Chef::Knife::Ssh do
     allow(Net::SSH).to receive(:configuration_for).and_return(ssh_config)
   end
 
-  # Force log level to info.
-  around do |ex|
-    old_level = Chef::Log.level
-    begin
-      Chef::Log.level = :info
-      ex.run
-    ensure
-      Chef::Log.level = old_level
-    end
-  end
-
   describe "identity file" do
     context "when knife[:ssh_identity_file] is set" do
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -243,6 +243,9 @@ RSpec.configure do |config|
 
     Chef::Log.setup!
 
+    Chef::Config[:log_level] = :fatal
+    Chef::Log.level(Chef::Config[:log_level])
+
     # By default, treat deprecation warnings as errors in tests.
     Chef::Config.treat_deprecation_warnings_as_errors(true)
 

--- a/spec/support/chef_helpers.rb
+++ b/spec/support/chef_helpers.rb
@@ -18,14 +18,6 @@ CHEF_SPEC_DATA = File.expand_path(File.dirname(__FILE__) + "/../data/")
 CHEF_SPEC_ASSETS = File.expand_path(File.dirname(__FILE__) + "/../functional/assets/")
 CHEF_SPEC_BACKUP_PATH = File.join(Dir.tmpdir, "test-backup-path")
 
-Chef::Config[:log_level] = :fatal
-Chef::Config[:persistent_queue] = false
-Chef::Config[:file_backup_path] = CHEF_SPEC_BACKUP_PATH
-
-Chef::Log.init(StringIO.new)
-Chef::Log.level(Chef::Config.log_level)
-Chef::Config.solo(false)
-
 def sha256_checksum(path)
   OpenSSL::Digest.hexdigest("SHA256", File.read(path))
 end

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -366,7 +366,6 @@ shared_examples_for "a configured file resource" do
   include_context "diff disabled"
 
   before do
-    Chef::Log.level = :info
     Chef::Config[:ssl_verify_mode] = :verify_none
   end
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -26,7 +26,6 @@ describe Chef::Application do
     allow(@app).to receive(:trap)
     allow(Dir).to receive(:chdir).and_return(0)
     allow(@app).to receive(:reconfigure)
-    Chef::Log.init(STDERR)
   end
 
   after do
@@ -253,6 +252,10 @@ describe Chef::Application do
       end
 
       context "when log_level is not set" do
+        before do
+          Chef::Config.delete(:log_level)
+        end
+
         it_behaves_like "log_level_is_auto"
       end
 


### PR DESCRIPTION
Set the log level to :fatal for all tests after resetting the logger. Attempted fix for #10186.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>