### PR TITLE
Move some Ruby omnibus cleanup to omnibus-software

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 6909d445b211528dc3c56b66813bca78dc22d213
+  revision: 9f74912a277f6fbf2d0bee1262188166ab6cfd12
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.343.0)
-    aws-sdk-core (3.104.1)
+    aws-partitions (1.344.0)
+    aws-sdk-core (3.104.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -41,8 +41,8 @@ GEM
     aws-sdk-kms (1.36.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.74.0)
-      aws-sdk-core (~> 3, >= 3.102.1)
+    aws-sdk-s3 (1.75.0)
+      aws-sdk-core (~> 3, >= 3.104.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.1)

--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -46,42 +46,16 @@ build do
     target_dir = "#{install_dir}/embedded/lib/ruby/gems/*/gems".tr('\\', "/")
     files = %w{
       *-public_cert.pem
-      *.blurb
-      *Upgrade.md
-      .dockerignore
-      autotest
-      autotest/*
-      bench
-      benchmark
-      benchmarks
-      design_rationale.rb
-      doc
-      doc-api
-      Dockerfile*
-      docs
-      ed25519.png
       example
       examples
       ext
-      features
-      frozen_old_spec
-      Gemfile.devtools
       Gemfile.lock
-      INSTALL.txt
-      man
-      minitest
-      on_what.rb
       rakelib
       sample
       samples
-      samus.json
       site
-      test
-      tests
       vendor
       VERSION
-      website
-      yard-template
     }
 
     Dir.glob(Dir.glob("#{target_dir}/*/{#{files.join(",")}}")).each do |f|


### PR DESCRIPTION
These are confirmed safe and we do them in omnibus now.

Signed-off-by: Tim Smith <tsmith@chef.io>