### PR TITLE
require mixlib-shellout 3.1.1+ and pull in new ohai

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 0a6530f2b7fdf225a7ca0ae54459cfce9b8d3b4c
+  revision: 3f0489d2cbcfbb49a9b9655cea6d3e5ef8da24dc
   branch: master
   specs:
-    ohai (16.2.4)
+    ohai (16.2.5)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -49,7 +49,7 @@ PATH
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
       net-ssh (>= 4.2, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -85,7 +85,7 @@ PATH
       mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 3.0.3, < 4.0)
+      mixlib-shellout (>= 3.1.1, < 4.0)
       net-sftp (>= 2.1.2, < 4.0)
       net-ssh (>= 4.2, < 7)
       net-ssh-multi (~> 1.2, >= 1.2.1)

--- a/chef.gemspec
+++ b/chef.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-cli", ">= 2.1.1", "< 3.0"
   s.add_dependency "mixlib-log", ">= 2.0.3", "< 4.0"
   s.add_dependency "mixlib-authentication", ">= 2.1", "< 4"
-  s.add_dependency "mixlib-shellout", ">= 3.0.3", "< 4.0"
+  s.add_dependency "mixlib-shellout", ">= 3.1.1", "< 4.0"
   s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "ohai", "~> 16.0"
 


### PR DESCRIPTION
The refactoring to chef-utils requires this new mixlib-shellout.

Signed-off-by: Tim Smith <tsmith@chef.io>