### PR TITLE
New render_json, render_toml, render_yaml helper methods

### DIFF
--- a/chef-utils/README.md
+++ b/chef-utils/README.md
@@ -187,6 +187,12 @@ Architecture Helpers allow you to determine the processor architecture of your n
 
 * `sanitized_path`
 
+### Content Rendering Helpers
+
+* `render_json`
+* `render_toml`
+* `render_yaml`
+
 ## Documentation for Cookbook library authors
 
 To use the helpers in a class or module in a cookbook library file you can include the ChefUtils DSL:

--- a/chef-utils/lib/chef-utils.rb
+++ b/chef-utils/lib/chef-utils.rb
@@ -23,12 +23,14 @@ require_relative "chef-utils/dsl/path_sanity"
 require_relative "chef-utils/dsl/platform"
 require_relative "chef-utils/dsl/platform_family"
 require_relative "chef-utils/dsl/platform_version"
+require_relative "chef-utils/dsl/render_helpers"
 require_relative "chef-utils/dsl/service"
 require_relative "chef-utils/dsl/train_helpers"
 require_relative "chef-utils/dsl/virtualization"
 require_relative "chef-utils/dsl/which"
 require_relative "chef-utils/dsl/windows"
 require_relative "chef-utils/mash"
+require_relative "chef-utils/toml"
 
 # This is the Chef Infra Client DSL, not everything needs to go in here
 module ChefUtils
@@ -40,6 +42,7 @@ module ChefUtils
   include ChefUtils::DSL::Platform
   include ChefUtils::DSL::PlatformFamily
   include ChefUtils::DSL::PlatformVersion
+  include ChefUtils::DSL::RenderHelpers
   include ChefUtils::DSL::TrainHelpers
   include ChefUtils::DSL::Virtualization
   include ChefUtils::DSL::Which

--- a/chef-utils/lib/chef-utils/dsl/render_helpers.rb
+++ b/chef-utils/lib/chef-utils/dsl/render_helpers.rb
@@ -1,0 +1,49 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative "../internal"
+require_relative "../toml"
+
+require 'json'
+require 'yaml'
+
+module ChefUtils
+  module DSL
+    module RenderHelpers
+      include Internal
+
+      # pretty-print a hash as a JSON string
+      def render_json(hash)
+        JSON.pretty_generate(hash) + "\n"
+      end
+
+      # pretty-print a hash as a TOML string
+      def render_toml(hash)
+        ChefUtils::Toml::Dumper.new(hash).toml_str
+      end
+
+      # pretty-print a hash as a YAML string
+      def render_yaml(hash)
+        yaml_content = hash.transform_keys(&:to_s).to_yaml
+        #above replaces first-level keys with strings, below the rest
+        yaml_content.gsub!(' :',' ')
+      end
+
+      extend self
+    end
+  end
+end

--- a/chef-utils/lib/chef-utils/toml.rb
+++ b/chef-utils/lib/chef-utils/toml.rb
@@ -1,0 +1,114 @@
+require 'date'
+
+# imported from https://github.com/chef-cookbooks/habitat
+module ChefUtils
+  module Toml
+    class Dumper
+      attr_reader :toml_str
+
+      def initialize(hash)
+        @toml_str = ''
+
+        visit(hash, [])
+      end
+
+      private
+
+      def visit(hash, prefix, extra_brackets = false)
+        simple_pairs, nested_pairs, table_array_pairs = sort_pairs hash
+
+        if prefix.any? && (simple_pairs.any? || hash.empty?)
+          print_prefix prefix, extra_brackets
+        end
+
+        dump_pairs simple_pairs, nested_pairs, table_array_pairs, prefix
+      end
+
+      def sort_pairs(hash)
+        nested_pairs = []
+        simple_pairs = []
+        table_array_pairs = []
+
+        hash.keys.sort.each do |key|
+          val = hash[key]
+          element = [key, val]
+
+          if val.is_a? Hash
+            nested_pairs << element
+          elsif val.is_a?(Array) && val.first.is_a?(Hash)
+            table_array_pairs << element
+          else
+            simple_pairs << element
+          end
+        end
+
+        [simple_pairs, nested_pairs, table_array_pairs]
+      end
+
+      def dump_pairs(simple, nested, table_array, prefix = [])
+        # First add simple pairs, under the prefix
+        dump_simple_pairs simple
+        dump_nested_pairs nested, prefix
+        dump_table_array_pairs table_array, prefix
+      end
+
+      def dump_simple_pairs(simple_pairs)
+        simple_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+          @toml_str << "#{key} = #{to_toml(val)}\n"
+        end
+      end
+
+      def dump_nested_pairs(nested_pairs, prefix)
+        nested_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+
+          visit val, prefix + [key], false
+        end
+      end
+
+      def dump_table_array_pairs(table_array_pairs, prefix)
+        table_array_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+          aux_prefix = prefix + [key]
+
+          val.each do |child|
+            print_prefix aux_prefix, true
+            args = sort_pairs(child) << aux_prefix
+
+            dump_pairs(*args)
+          end
+        end
+      end
+
+      def print_prefix(prefix, array = false)
+        new_prefix = prefix.join('.')
+        new_prefix = "[#{new_prefix}]" if array
+
+        @toml_str += "[#{new_prefix}]\n"
+      end
+
+      def to_toml(obj)
+        if obj.is_a?(Time) || obj.is_a?(DateTime)
+          obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+        elsif obj.is_a?(Date)
+          obj.strftime('%Y-%m-%d')
+        elsif obj.is_a? Regexp
+          obj.inspect.inspect
+        elsif obj.is_a? String
+          obj.inspect.gsub(/\\(#[$@{])/, '\1')
+        else
+          obj.inspect
+        end
+      end
+
+      def bare_key?(key)
+        !!key.to_s.match(/^[a-zA-Z0-9_-]*$/)
+      end
+
+      def quote_key(key)
+        '"' + key.gsub('"', '\\"') + '"'
+      end
+    end
+  end
+end

--- a/chef-utils/spec/spec_helper.rb
+++ b/chef-utils/spec/spec_helper.rb
@@ -9,6 +9,7 @@ HELPER_MODULES = [
   ChefUtils::DSL::PathSanity,
   ChefUtils::DSL::Platform,
   ChefUtils::DSL::PlatformFamily,
+  ChefUtils::DSL::RenderHelpers,
   ChefUtils::DSL::Service,
   ChefUtils::DSL::Virtualization,
   ChefUtils::DSL::Which,
@@ -21,6 +22,7 @@ INTROSPECTION_HELPERS = (ChefUtils::DSL::Introspection.methods - Module.methods)
 OS_HELPERS = (ChefUtils::DSL::OS.methods - Module.methods).freeze
 PLATFORM_FAMILY_HELPERS = (ChefUtils::DSL::PlatformFamily.methods - Module.methods).freeze
 PLATFORM_HELPERS = (ChefUtils::DSL::Platform.methods - Module.methods).freeze
+RENDER_HELPERS = (ChefUtils::DSL::RenderHelpers.methods - Module.methods).freeze
 VIRTUALIZATION_HELPERS = (ChefUtils::DSL::Virtualization.methods - Module.methods).freeze
 WINDOWS_HELPERS = (ChefUtils::DSL::Windows.methods - Module.methods).freeze
 

--- a/chef-utils/spec/unit/dsl/render_helpers_spec.rb
+++ b/chef-utils/spec/unit/dsl/render_helpers_spec.rb
@@ -1,0 +1,113 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+RSpec.describe ChefUtils::DSL::RenderHelpers do
+
+  ( HELPER_MODULES - [ described_class ] ).each do |klass|
+    it "does not have methods that collide with #{klass}" do
+      expect((klass.methods - Module.methods) & RENDER_HELPERS).to be_empty
+    end
+  end
+
+  RENDER_HELPERS.each do |helper|
+    it "has the #{helper} in the ChefUtils module" do
+      expect(ChefUtils).to respond_to(helper)
+    end
+  end
+
+  hash = {
+          "golf": "hotel",
+          "kilo": ["lima", "mike"],
+          "india": {
+                    "juliett": "blue"
+                   },
+          "alpha": {
+                    "charlie": true,
+                    "bravo": 10,
+                   },
+          "echo": "foxtrot"
+         }
+
+  context "render_json" do
+    json = ChefUtils::DSL::RenderHelpers.render_json(hash)
+    describe "JSON content" do
+      it "expected JSON output" do
+        expected = <<-EXPECTED
+{
+  "golf": "hotel",
+  "kilo": [
+    "lima",
+    "mike"
+  ],
+  "india": {
+    "juliett": "blue"
+  },
+  "alpha": {
+    "charlie": true,
+    "bravo": 10
+  },
+  "echo": "foxtrot"
+}
+EXPECTED
+        expect(json).to eq(expected)
+      end
+    end
+  end
+
+  context "render_toml" do
+    toml = ChefUtils::DSL::RenderHelpers.render_toml(hash)
+    describe "TOML content" do
+      it "expected TOML output" do
+        expected = <<-EXPECTED
+echo = "foxtrot"
+golf = "hotel"
+kilo = ["lima", "mike"]
+[alpha]
+bravo = 10
+charlie = true
+[india]
+juliett = "blue"
+EXPECTED
+        expect(toml).to eq(expected)
+      end
+    end
+  end
+
+  context "render_yaml" do
+    yaml = ChefUtils::DSL::RenderHelpers.render_yaml(hash)
+    describe "YAML content" do
+      it "expected YAML output" do
+        expected = <<-EXPECTED
+---
+golf: hotel
+kilo:
+- lima
+- mike
+india:
+  juliett: blue
+alpha:
+  charlie: true
+  bravo: 10
+echo: foxtrot
+EXPECTED
+        expect(yaml).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provide new syntactic sugar methods for rendering JSON, TOML, and YAML content from hashes.

Related to 
https://github.com/chef/chef/issues/9911 
https://github.com/chef/chef/issues/9912 
https://github.com/chef/chef/issues/9913

The toml code is migrated from the Habitat cookbook: https://github.com/chef-cookbooks/habitat/blob/master/libraries/habitat_toml.rb

Signed-off-by: Matt Ray <github@mattray.dev>
