### PR TITLE
Fix chef-resource-inspector to handle classes in equal_to

### DIFF
--- a/lib/chef/resource_inspector.rb
+++ b/lib/chef/resource_inspector.rb
@@ -59,9 +59,15 @@ module ResourceInspector
                required: opts[:required] || false,
                default: opts[:default_description] || get_default(opts[:default]),
                name_property: opts[:name_property] || false,
-               equal_to: Array(opts[:equal_to]).sort.map(&:inspect) }
+               equal_to: sort_equal_to(opts[:equal_to]) }
     end
     data
+  end
+
+  def self.sort_equal_to(equal_to)
+    Array(equal_to).sort.map(&:inspect)
+  rescue ArgumentError
+    Array(equal_to).map(&:inspect)
   end
 
   def self.extract_cookbook(path, complete)


### PR DESCRIPTION
Rescue argumenterrors and just return the array unsorted.

I'd flip the inspect and sort, but that would result in incorrectly
sorted data.

Signed-off-by: Tim Smith <tsmith@chef.io>