### PR TITLE
Disable docker in Expeditor for now

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -86,17 +86,17 @@ merge_actions:
 
 subscriptions:
   # the omnibus/docker/gem chain
-  - workload: artifact_published:unstable:chef:{{version_constraint}}
-    actions:
-      - built_in:build_docker_image
-  - workload: artifact_published:current:chef:{{version_constraint}}
-    actions:
-      - built_in:tag_docker_image
+  # - workload: artifact_published:unstable:chef:{{version_constraint}}
+    # actions:
+    #   - built_in:build_docker_image
+  # - workload: artifact_published:current:chef:{{version_constraint}}
+    # actions:
+    #   - built_in:tag_docker_image
   - workload: artifact_published:stable:chef:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
-      - built_in:tag_docker_image
+      # - built_in:tag_docker_image
       - built_in:publish_rubygems
       - built_in:promote_habitat_packages
       - built_in:notify_chefio_slack_channels


### PR DESCRIPTION
This functionality currently does not work so we need to disable it.

Signed-off-by: Tim Smith <tsmith@chef.io>