### PR TITLE
Define local test variables to avoid test load order bug.

### DIFF
--- a/spec/unit/http/api_versions_spec.rb
+++ b/spec/unit/http/api_versions_spec.rb
@@ -53,8 +53,26 @@ describe Chef::HTTP::APIVersions do
     m
   end
 
+  let(:version_class) do
+    Class.new do
+      extend Chef::Mixin::VersionedAPIFactory
+
+      version_class_v0 = Class.new do
+        extend Chef::Mixin::VersionedAPI
+        minimum_api_version 0
+      end
+      add_versioned_api_class version_class_v0
+
+      version_class_v2 = Class.new do
+        extend Chef::Mixin::VersionedAPI
+        minimum_api_version 2
+      end
+      add_versioned_api_class version_class_v2
+    end
+  end
+
   let(:client) do
-    TestVersionClient.new(url, { version_class: VersionedClassVersions })
+    TestVersionClient.new(url, { version_class: version_class })
   end
 
   let(:middleware) do

--- a/spec/unit/server_api_spec.rb
+++ b/spec/unit/server_api_spec.rb
@@ -59,20 +59,22 @@ describe Chef::ServerAPI do
   end
 
   context "versioned apis" do
-    class VersionedClassV0
-      extend Chef::Mixin::VersionedAPI
-      minimum_api_version 0
-    end
+    let(:version_class) do
+      Class.new do
+        extend Chef::Mixin::VersionedAPIFactory
 
-    class VersionedClassV2
-      extend Chef::Mixin::VersionedAPI
-      minimum_api_version 2
-    end
+        version_class_v0 = Class.new do
+          extend Chef::Mixin::VersionedAPI
+          minimum_api_version 0
+        end
+        add_versioned_api_class version_class_v0
 
-    class VersionedClassVersions
-      extend Chef::Mixin::VersionedAPIFactory
-      add_versioned_api_class VersionedClassV0
-      add_versioned_api_class VersionedClassV2
+        version_class_v2 = Class.new do
+          extend Chef::Mixin::VersionedAPI
+          minimum_api_version 2
+        end
+        add_versioned_api_class version_class_v2
+      end
     end
 
     before do
@@ -80,7 +82,7 @@ describe Chef::ServerAPI do
     end
 
     let(:versioned_client) do
-      Chef::ServerAPI.new(url, version_class: VersionedClassVersions)
+      Chef::ServerAPI.new(url, version_class: version_class)
     end
 
     it "on protocol negotiation it posts the same message body without doubly-encoding the json string" do


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

`spec/unit/http/api_versions_spec.rb` could not run by itself because it had an unspecified dependency on a class defined in `spec/unit/server_api_spec.rb`. The code is kinda ugly, but defining constants in your specs is a bad practice IMO.