### PR TITLE
Fix protocol negotiation for unversioned objects

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -154,7 +154,7 @@ class Chef
     rescue Net::HTTPClientException => e
       http_attempts += 1
       response = e.response
-      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts > 0
+      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts >= 0
         Chef::Log.trace("Negotiating protocol version with #{url}, retry #{http_attempts}/#{version_retries}")
         retry
       else
@@ -193,7 +193,7 @@ class Chef
     rescue Net::HTTPClientException => e
       http_attempts += 1
       response = e.response
-      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts > 0
+      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts >= 0
         Chef::Log.trace("Negotiating protocol version with #{url}, retry #{http_attempts}/#{version_retries}")
         retry
       else
@@ -249,7 +249,7 @@ class Chef
     rescue Net::HTTPClientException => e
       http_attempts += 1
       response = e.response
-      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts > 0
+      if response.is_a?(Net::HTTPNotAcceptable) && version_retries - http_attempts >= 0
         Chef::Log.trace("Negotiating protocol version with #{url}, retry #{http_attempts}/#{version_retries}")
         retry
       else
@@ -470,11 +470,7 @@ class Chef
     end
 
     def version_retries
-      @version_retries ||= if options[:version_class]
-                             options[:version_class].possible_requests
-                           else
-                             0
-                           end
+      @version_retries ||= options[:version_class]&.possible_requests || 1
     end
 
     # @api private

--- a/lib/chef/http/authenticator.rb
+++ b/lib/chef/http/authenticator.rb
@@ -68,6 +68,8 @@ class Chef
           version_class.best_request_version
         elsif api_version
           api_version
+        elsif Chef::ServerAPIVersions.instance.negotiated?
+          Chef::ServerAPIVersions.instance.max_server_version.to_s
         else
           DEFAULT_SERVER_API_VERSION
         end

--- a/lib/chef/server_api_versions.rb
+++ b/lib/chef/server_api_versions.rb
@@ -51,6 +51,10 @@ class Chef
       @unversioned
     end
 
+    def negotiated?
+      !@versions.nil? || unversioned?
+    end
+
     def reset!
       @versions = nil
       @unversioned = false


### PR DESCRIPTION
We generally always do protocol negotiation on the get of the node
object and the Chef::Node is an unversioned API, so we need to
test that we backoff the API version to the highest version the server
offers and then retry again.
