### PR TITLE
Compensate for libyaml changes in yaml parsing test.

### DIFF
--- a/spec/unit/node/immutable_collections_spec.rb
+++ b/spec/unit/node/immutable_collections_spec.rb
@@ -73,7 +73,11 @@ shared_examples_for "Immutable#to_yaml" do
   end
 
   it "should create a YAML string with content" do
-    expect(copy).to eq(parsed_yaml)
+    # Roundtrip the test string through YAML to compensate for some changes in libyaml-0.2.5
+    # See: https://github.com/yaml/libyaml/pull/186
+    expected = YAML.dump(YAML.load(parsed_yaml))
+
+    expect(copy).to eq(expected)
   end
 end
 
@@ -241,7 +245,7 @@ describe Chef::Node::ImmutableArray do
 
   describe "to_yaml" do
     let(:copy) { @immutable_nested_array.to_yaml }
-    let(:parsed_yaml) { "---\n- level1\n- - foo\n  - bar\n  - baz\n  - 1\n  - 2\n  - 3\n  - \n  - true\n  - false\n  - - el\n    - 0\n    - \n- m: m\n" }
+    let(:parsed_yaml) { "---\n- level1\n- - foo\n  - bar\n  - baz\n  - 1\n  - 2\n  - 3\n  -\n  - true\n  - false\n  - - el\n    - 0\n    -\n- m: m\n" }
 
     include_examples "Immutable#to_yaml"
   end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

This test reliably fails in my local env after I did some system updates, most likely related to this change in the recent libyaml-0.2.5 release: https://github.com/yaml/libyaml/pull/186

```
Petes-MBP:chef pete$ rspec spec/unit/node/immutable_collections_spec.rb
WARNING: Shared example group 'with a chef repo' has been previously defined at:
  /Users/pete/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/cheffish-16.0.2/lib/cheffish/rspec/repository_support.rb:12
...and you are now defining it at:
  /Users/pete/work/chef/spec/support/shared/integration/integration_helper.rb:109
The new definition will overwrite the original one.
Run options:
  include {:focus=>true}
  exclude {:provider=>#<Proc:./spec/spec_helper.rb:211>, :arch=>#<Proc:./spec/spec_helper.rb:205>, :choco_installed=>true, :ruby=>"2.6.6", :chef=>"16.3.44", :not_intel_64bit=>true, :rhel_gte_8=>true, :rhel8=>true, :rhel7=>true, :rhel6=>true, :rhel=>true, :not_wpar=>true, :broken=>true, :openssl_lt_101=>true, :requires_root_or_running_windows=>true, :requires_root=>true, :selinux_only=>true, :debian_family_only=>true, :opensuse=>true, :suse_only=>true, :aix_only=>true, :linux_only=>true, :system_windows_service_gem_only=>true, :solaris_only=>true, :windows_service_requires_assign_token=>true, :windows_domain_joined_only=>true, :windows_powershell_dsc_only=>true, :ruby32_only=>true, :windows_gte_10=>true, :windows32_only=>true, :windows64_only=>true, :win2012r2_only=>true, :macos_1014=>true, :not_supported_on_macos=>true, :windows_only=>true, :volatile_from_verify=>false, :volatile=>true, :external=>true}

All examples were filtered out; ignoring {:focus=>true}
..........................................................................................F.

Failures:

  1) Chef::Node::ImmutableArray to_yaml should create a YAML string with content
     Failure/Error: expect(copy).to eq(parsed_yaml)

       expected: "---\n- level1\n- - foo\n  - bar\n  - baz\n  - 1\n  - 2\n  - 3\n  - \n  - true\n  - false\n  - - el\n    - 0\n    - \n- m: m\n"
            got: "---\n- level1\n- - foo\n  - bar\n  - baz\n  - 1\n  - 2\n  - 3\n  -\n  - true\n  - false\n  - - el\n    - 0\n    -\n- m: m\n"

       (compared using ==)

       Diff:

       @@ -6,11 +6,11 @@
          - 1
          - 2
          - 3
       -  -
       +  -
          - true
          - false
          - - el
            - 0
       -    -
       +    -
        - m: m

     Shared Example Group: "Immutable#to_yaml" called from ./spec/unit/node/immutable_collections_spec.rb:246
     # ./spec/unit/node/immutable_collections_spec.rb:76:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:301:in `block (2 levels) in <top (required)>'

Finished in 0.06133 seconds (files took 3.41 seconds to load)
92 examples, 1 failure

Failed examples:

rspec ./spec/unit/node/immutable_collections_spec.rb[2:35:2] # Chef::Node::ImmutableArray to_yaml should create a YAML string with content
```