### PR TITLE
Introduce EXPEDITOR_VERSION for docker image tag

### DIFF
--- a/.expeditor/build.docker.yml
+++ b/.expeditor/build.docker.yml
@@ -1,3 +1,1 @@
 image_registry: chef
-env:
-  VERSION: "16.3.46"

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -18,9 +18,6 @@ sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"${VERSION}\"/" chef-bin/lib/ch
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"${VERSION}\"/" chef-utils/lib/chef-utils/version.rb
 sed -i -r "s/VersionString\.new\(\".+\"\)/VersionString.new(\"${VERSION}\")/" lib/chef/version.rb
 
-# Update the version for the dobi
-sed -i -r "s/^(\s*)VERSION: \".+\"/\1VERSION: \"${VERSION}\"/" .expeditor/build.docker.yml
-
 # Update the version inside Gemfile.lock
 bundle update chef chef-config chef-utils --jobs=7 --conservative
 

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -12,9 +12,9 @@ image=chef:
   image: '{env.IMAGE_REGISTRY}/chef'
   context: .
   tags:
-    - '{env.VERSION}'
+    - '{env.EXPEDITOR_VERSION}'
   args:
-    VERSION: '{env.VERSION}'
+    VERSION: '{env.EXPEDITOR_VERSION}'
     CHANNEL: unstable
   annotations:
     tags:


### PR DESCRIPTION
## Description
Chef used to use the EXPEDITOR_VERSION from the workload's metadata
when building images, reintroduce that so we can keep the same
functionality as before so that the VERSION of the repo can be bumped
but the docker images can be built off of the version being promoted.
Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
