### PR TITLE
Fix warning in test for redefined shared example group

### DIFF
--- a/spec/integration/knife/config_get_profile_spec.rb
+++ b/spec/integration/knife/config_get_profile_spec.rb
@@ -22,92 +22,93 @@ describe "knife config get-profile", :workstation do
   include KnifeSupport
 
   include_context "default config options"
-  include_context "with a chef repo"
 
   let(:cmd_args) { [] }
 
-  subject do
-    cmd = knife("config", "get-profile", *cmd_args, instance_filter: lambda { |instance|
-      # Fake the failsafe check because this command doesn't actually process knife.rb.
-      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
-    })
-    cmd.stdout
-  end
-
-  around do |ex|
-    # Store and reset the value of some env vars.
-    old_chef_home = ENV["CHEF_HOME"]
-    old_knife_home = ENV["KNIFE_HOME"]
-    old_home = ENV["HOME"]
-    old_wd = Dir.pwd
-    ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
-    # Clear these out because they are cached permanently.
-    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigGetProfile.reset_config_loader!
-    begin
-      ex.run
-    ensure
-      ENV["CHEF_HOME"] = old_chef_home
-      ENV["KNIFE_HOME"] = old_knife_home
-      ENV["HOME"] = old_home
-      Dir.chdir(old_wd)
-      ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-      ChefConfig::PathHelper.per_tool_home_environment = nil
+  when_the_repository("has a custom env") do
+    subject do
+      cmd = knife("config", "get-profile", *cmd_args, instance_filter: lambda { |instance|
+        # Fake the failsafe check because this command doesn't actually process knife.rb.
+        $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+      })
+      cmd.stdout
     end
-  end
 
-  before do
-    # Always run from the temp folder. This can't be in the `around` block above
-    # because it has to run after the before set in the "with a chef repo" shared context.
-    directory("repo")
-    Dir.chdir(path_to("repo"))
-    ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-    ENV["HOME"] = path_to(".")
-  end
-
-  context "with no configuration" do
-    it { is_expected.to eq "default\n" }
-  end
-
-  context "with --profile" do
-    let(:cmd_args) { %w{--profile production} }
-    it { is_expected.to eq "production\n" }
-  end
-
-  context "with an environment variable" do
     around do |ex|
-      old_chef_profile = ENV["CHEF_PROFILE"]
+      # Store and reset the value of some env vars.
+      old_chef_home = ENV["CHEF_HOME"]
+      old_knife_home = ENV["KNIFE_HOME"]
+      old_home = ENV["HOME"]
+      old_wd = Dir.pwd
+      ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
+      # Clear these out because they are cached permanently.
+      ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+      Chef::Knife::ConfigGetProfile.reset_config_loader!
       begin
-        ENV["CHEF_PROFILE"] = "staging"
         ex.run
       ensure
-        ENV["CHEF_PROFILE"] = old_chef_profile
+        ENV["CHEF_HOME"] = old_chef_home
+        ENV["KNIFE_HOME"] = old_knife_home
+        ENV["HOME"] = old_home
+        Dir.chdir(old_wd)
+        ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+        ChefConfig::PathHelper.per_tool_home_environment = nil
       end
     end
 
-    it { is_expected.to eq "staging\n" }
-  end
-
-  context "with a context file" do
-    before { file(".chef/context", "development\n") }
-    it { is_expected.to eq "development\n" }
-  end
-
-  context "with a context file under $CHEF_HOME" do
     before do
-      file("chefhome/.chef/context", "other\n")
-      ENV["CHEF_HOME"] = path_to("chefhome")
+      # Always run from the temp folder. This can't be in the `around` block above
+      # because it has to run after the before set in the "with a chef repo" shared context.
+      directory("repo")
+      Dir.chdir(path_to("repo"))
+      ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+      ENV["HOME"] = path_to(".")
     end
 
-    it { is_expected.to eq "other\n" }
-  end
-
-  context "with a context file under $KNIFE_HOME" do
-    before do
-      file("knifehome/.chef/context", "other\n")
-      ENV["KNIFE_HOME"] = path_to("knifehome")
+    context "with no configuration" do
+      it { is_expected.to eq "default\n" }
     end
 
-    it { is_expected.to eq "other\n" }
+    context "with --profile" do
+      let(:cmd_args) { %w{--profile production} }
+      it { is_expected.to eq "production\n" }
+    end
+
+    context "with an environment variable" do
+      around do |ex|
+        old_chef_profile = ENV["CHEF_PROFILE"]
+        begin
+          ENV["CHEF_PROFILE"] = "staging"
+          ex.run
+        ensure
+          ENV["CHEF_PROFILE"] = old_chef_profile
+        end
+      end
+
+      it { is_expected.to eq "staging\n" }
+    end
+
+    context "with a context file" do
+      before { file(".chef/context", "development\n") }
+      it { is_expected.to eq "development\n" }
+    end
+
+    context "with a context file under $CHEF_HOME" do
+      before do
+        file("chefhome/.chef/context", "other\n")
+        ENV["CHEF_HOME"] = path_to("chefhome")
+      end
+
+      it { is_expected.to eq "other\n" }
+    end
+
+    context "with a context file under $KNIFE_HOME" do
+      before do
+        file("knifehome/.chef/context", "other\n")
+        ENV["KNIFE_HOME"] = path_to("knifehome")
+      end
+
+      it { is_expected.to eq "other\n" }
+    end
   end
 end

--- a/spec/integration/knife/config_get_spec.rb
+++ b/spec/integration/knife/config_get_spec.rb
@@ -22,170 +22,171 @@ describe "knife config get", :workstation do
   include KnifeSupport
 
   include_context "default config options"
-  include_context "with a chef repo"
 
   let(:cmd_args) { [] }
 
-  subject do
-    cmd = knife("config", "get", *cmd_args, instance_filter: lambda { |instance|
-      # Clear the stub set up in KnifeSupport.
-      allow(File).to receive(:file?).and_call_original
-      # Lies, damn lies, and config files. We need to allow normal config loading
-      # behavior to be able to test stuff.
-      instance.config.delete(:config_file)
-      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
-    })
-    cmd.stdout
-  end
+  when_the_repository("has a custom env") do
+    subject do
+      cmd = knife("config", "get", *cmd_args, instance_filter: lambda { |instance|
+        # Clear the stub set up in KnifeSupport.
+        allow(File).to receive(:file?).and_call_original
+        # Lies, damn lies, and config files. We need to allow normal config loading
+        # behavior to be able to test stuff.
+        instance.config.delete(:config_file)
+        $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+      })
+      cmd.stdout
+    end
 
-  around do |ex|
-    # Store and reset the value of some env vars.
-    old_chef_home = ENV["CHEF_HOME"]
-    old_knife_home = ENV["KNIFE_HOME"]
-    old_home = ENV["HOME"]
-    old_wd = Dir.pwd
-    ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
-    # Clear these out because they are cached permanently.
-    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigGet.reset_config_loader!
-    begin
-      ex.run
-    ensure
-      ENV["CHEF_HOME"] = old_chef_home
-      ENV["KNIFE_HOME"] = old_knife_home
-      ENV["HOME"] = old_home
-      Dir.chdir(old_wd)
+    around do |ex|
+      # Store and reset the value of some env vars.
+      old_chef_home = ENV["CHEF_HOME"]
+      old_knife_home = ENV["KNIFE_HOME"]
+      old_home = ENV["HOME"]
+      old_wd = Dir.pwd
+      ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
+      # Clear these out because they are cached permanently.
+      ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+      Chef::Knife::ConfigGet.reset_config_loader!
+      begin
+        ex.run
+      ensure
+        ENV["CHEF_HOME"] = old_chef_home
+        ENV["KNIFE_HOME"] = old_knife_home
+        ENV["HOME"] = old_home
+        Dir.chdir(old_wd)
+        ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+        ChefConfig::PathHelper.per_tool_home_environment = nil
+      end
+    end
+
+    before do
+      # Always run from the temp folder. This can't be in the `around` block above
+      # because it has to run after the before set in the "with a chef repo" shared context.
+      directory("repo")
+      Dir.chdir(path_to("repo"))
       ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-      ChefConfig::PathHelper.per_tool_home_environment = nil
-    end
-  end
-
-  before do
-    # Always run from the temp folder. This can't be in the `around` block above
-    # because it has to run after the before set in the "with a chef repo" shared context.
-    directory("repo")
-    Dir.chdir(path_to("repo"))
-    ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-    ENV["HOME"] = path_to(".")
-  end
-
-  context "with a global knife.rb" do
-    before { file(".chef/knife.rb", "node_name 'one'\n") }
-
-    it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/.chef/knife.rb$}) }
-    it { is_expected.to match(/^node_name:\s+one$/) }
-  end
-
-  context "with a repo knife.rb" do
-    before { file("repo/.chef/knife.rb", "node_name 'two'\n") }
-
-    it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/repo/.chef/knife.rb$}) }
-    it { is_expected.to match(/^node_name:\s+two$/) }
-  end
-
-  context "with both knife.rb" do
-    before do
-      file(".chef/knife.rb", "node_name 'one'\n")
-      file("repo/.chef/knife.rb", "node_name 'two'\n")
+      ENV["HOME"] = path_to(".")
     end
 
-    it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/repo/.chef/knife.rb$}) }
-    it { is_expected.to match(/^node_name:\s+two$/) }
-  end
+    context "with a global knife.rb" do
+      before { file(".chef/knife.rb", "node_name 'one'\n") }
 
-  context "with a credentials file" do
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
-
-    it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/.chef/credentials$}) }
-    it { is_expected.to match(/^node_name:\s+three$/) }
-  end
-
-  context "with a credentials file and knife.rb" do
-    before do
-      file(".chef/knife.rb", "node_name 'one'\n")
-      file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
+      it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/.chef/knife.rb$}) }
+      it { is_expected.to match(/^node_name:\s+one$/) }
     end
 
-    it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/.chef/knife.rb$}) }
-    it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/.chef/credentials$}) }
-    it { is_expected.to match(/^node_name:\s+one$/) }
-  end
+    context "with a repo knife.rb" do
+      before { file("repo/.chef/knife.rb", "node_name 'two'\n") }
 
-  context "with a config dot d files" do
-    before { file(".chef/config.d/abc.rb", "node_name 'one'\n") }
-
-    it { is_expected.to match(%r{^Loading from .d/ configuration file .*/#{File.basename(path_to("."))}/.chef/config.d/abc.rb$}) }
-    it { is_expected.to match(/^node_name:\s+one$/) }
-  end
-
-  context "with a credentials file and CHEF_HOME" do
-    before do
-      file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
-      file("foo/.chef/credentials", "[default]\nclient_name = \"four\"\n")
-      ENV["CHEF_HOME"] = path_to("foo")
+      it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/repo/.chef/knife.rb$}) }
+      it { is_expected.to match(/^node_name:\s+two$/) }
     end
 
-    it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/foo/.chef/credentials$}) }
-    it { is_expected.to match(/^node_name:\s+four$/) }
-  end
+    context "with both knife.rb" do
+      before do
+        file(".chef/knife.rb", "node_name 'one'\n")
+        file("repo/.chef/knife.rb", "node_name 'two'\n")
+      end
 
-  context "with a credentials file and KNIFE_HOME" do
-    before do
-      file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
-      file("bar/.chef/credentials", "[default]\nclient_name = \"four\"\n")
-      ENV["KNIFE_HOME"] = path_to("bar")
+      it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/repo/.chef/knife.rb$}) }
+      it { is_expected.to match(/^node_name:\s+two$/) }
     end
 
-    it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/bar/.chef/credentials$}) }
-    it { is_expected.to match(/^node_name:\s+four$/) }
-  end
+    context "with a credentials file" do
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
 
-  context "with single argument" do
-    let(:cmd_args) { %w{node_name} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+      it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/.chef/credentials$}) }
+      it { is_expected.to match(/^node_name:\s+three$/) }
+    end
 
-    it { is_expected.to match(/^node_name:\s+three\Z/) }
-  end
+    context "with a credentials file and knife.rb" do
+      before do
+        file(".chef/knife.rb", "node_name 'one'\n")
+        file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
+      end
 
-  context "with two arguments" do
-    let(:cmd_args) { %w{node_name client_key} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\nclient_key = \"three.pem\"") }
+      it { is_expected.to match(%r{^Loading from configuration file .*/#{File.basename(path_to("."))}/.chef/knife.rb$}) }
+      it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/.chef/credentials$}) }
+      it { is_expected.to match(/^node_name:\s+one$/) }
+    end
 
-    it { is_expected.to match(%r{^client_key:\s+\S*/.chef/three.pem\nnode_name:\s+three\Z}) }
-  end
+    context "with a config dot d files" do
+      before { file(".chef/config.d/abc.rb", "node_name 'one'\n") }
 
-  context "with a dotted argument" do
-    let(:cmd_args) { %w{knife.ssh_user} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n[default.knife]\nssh_user = \"foo\"\n") }
+      it { is_expected.to match(%r{^Loading from .d/ configuration file .*/#{File.basename(path_to("."))}/.chef/config.d/abc.rb$}) }
+      it { is_expected.to match(/^node_name:\s+one$/) }
+    end
 
-    it { is_expected.to match(/^knife.ssh_user:\s+foo\Z/) }
-  end
+    context "with a credentials file and CHEF_HOME" do
+      before do
+        file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
+        file("foo/.chef/credentials", "[default]\nclient_name = \"four\"\n")
+        ENV["CHEF_HOME"] = path_to("foo")
+      end
 
-  context "with regex argument" do
-    let(:cmd_args) { %w{/name/} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+      it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/foo/.chef/credentials$}) }
+      it { is_expected.to match(/^node_name:\s+four$/) }
+    end
 
-    it { is_expected.to match(/^node_name:\s+three\Z/) }
-  end
+    context "with a credentials file and KNIFE_HOME" do
+      before do
+        file(".chef/credentials", "[default]\nclient_name = \"three\"\n")
+        file("bar/.chef/credentials", "[default]\nclient_name = \"four\"\n")
+        ENV["KNIFE_HOME"] = path_to("bar")
+      end
 
-  context "with --all" do
-    let(:cmd_args) { %w{-a /key_contents/} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+      it { is_expected.to match(%r{^Loading from credentials file .*/#{File.basename(path_to("."))}/bar/.chef/credentials$}) }
+      it { is_expected.to match(/^node_name:\s+four$/) }
+    end
 
-    it { is_expected.to match(/^client_key_contents:\s+\nvalidation_key_contents:\s+\Z/) }
-  end
+    context "with single argument" do
+      let(:cmd_args) { %w{node_name} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
 
-  context "with --raw" do
-    let(:cmd_args) { %w{-r node_name} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+      it { is_expected.to match(/^node_name:\s+three\Z/) }
+    end
 
-    it { is_expected.to eq("three\n") }
-  end
+    context "with two arguments" do
+      let(:cmd_args) { %w{node_name client_key} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\nclient_key = \"three.pem\"") }
 
-  context "with --format=json" do
-    let(:cmd_args) { %w{--format=json node_name} }
-    before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+      it { is_expected.to match(%r{^client_key:\s+\S*/.chef/three.pem\nnode_name:\s+three\Z}) }
+    end
 
-    it { expect(JSON.parse(subject)).to eq({ "node_name" => "three" }) }
+    context "with a dotted argument" do
+      let(:cmd_args) { %w{knife.ssh_user} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n[default.knife]\nssh_user = \"foo\"\n") }
+
+      it { is_expected.to match(/^knife.ssh_user:\s+foo\Z/) }
+    end
+
+    context "with regex argument" do
+      let(:cmd_args) { %w{/name/} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+
+      it { is_expected.to match(/^node_name:\s+three\Z/) }
+    end
+
+    context "with --all" do
+      let(:cmd_args) { %w{-a /key_contents/} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+
+      it { is_expected.to match(/^client_key_contents:\s+\nvalidation_key_contents:\s+\Z/) }
+    end
+
+    context "with --raw" do
+      let(:cmd_args) { %w{-r node_name} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+
+      it { is_expected.to eq("three\n") }
+    end
+
+    context "with --format=json" do
+      let(:cmd_args) { %w{--format=json node_name} }
+      before { file(".chef/credentials", "[default]\nclient_name = \"three\"\n") }
+
+      it { expect(JSON.parse(subject)).to eq({ "node_name" => "three" }) }
+    end
   end
 end

--- a/spec/integration/knife/config_list_profiles_spec.rb
+++ b/spec/integration/knife/config_list_profiles_spec.rb
@@ -22,197 +22,198 @@ describe "knife config list-profiles", :workstation do
   include KnifeSupport
 
   include_context "default config options"
-  include_context "with a chef repo"
 
-  let(:cmd_args) { [] }
-  let(:knife_list_profiles) do
-    knife("config", "list-profiles", *cmd_args, instance_filter: lambda { |instance|
-      # Fake the failsafe check because this command doesn't actually process knife.rb.
-      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
-      allow(File).to receive(:file?).and_call_original
-    })
-  end
-  subject { knife_list_profiles.stdout }
-
-  around do |ex|
-    # Store and reset the value of some env vars.
-    old_home = ENV["HOME"]
-    old_wd = Dir.pwd
-    # Clear these out because they are cached permanently.
-    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigListProfiles.reset_config_loader!
-    begin
-      ex.run
-    ensure
-      ENV["HOME"] = old_home
-      Dir.chdir(old_wd)
-      ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+  when_the_repository("has a custom env") do
+    let(:cmd_args) { [] }
+    let(:knife_list_profiles) do
+      knife("config", "list-profiles", *cmd_args, instance_filter: lambda { |instance|
+        # Fake the failsafe check because this command doesn't actually process knife.rb.
+        $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+        allow(File).to receive(:file?).and_call_original
+      })
     end
-  end
+    subject { knife_list_profiles.stdout }
 
-  before do
-    # Always run from the temp folder. This can't be in the `around` block above
-    # because it has to run after the before set in the "with a chef repo" shared context.
-    directory("repo")
-    Dir.chdir(path_to("repo"))
-    ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-    ENV["HOME"] = path_to(".")
-  end
+    around do |ex|
+      # Store and reset the value of some env vars.
+      old_home = ENV["HOME"]
+      old_wd = Dir.pwd
+      # Clear these out because they are cached permanently.
+      ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+      Chef::Knife::ConfigListProfiles.reset_config_loader!
+      begin
+        ex.run
+      ensure
+        ENV["HOME"] = old_home
+        Dir.chdir(old_wd)
+        ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+      end
+    end
 
-  # NOTE: The funky formatting with # at the end of the line of some of the
-  # output examples are because of how the format strings are built, there is
-  # substantial trailing whitespace in most cases which many editors "helpfully" remove.
+    before do
+      # Always run from the temp folder. This can't be in the `around` block above
+      # because it has to run after the before set in the "with a chef repo" shared context.
+      directory("repo")
+      Dir.chdir(path_to("repo"))
+      ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+      ENV["HOME"] = path_to(".")
+    end
 
-  context "with no credentials file" do
-    subject { knife_list_profiles.stderr }
-    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
-  end
+    # NOTE: The funky formatting with # at the end of the line of some of the
+    # output examples are because of how the format strings are built, there is
+    # substantial trailing whitespace in most cases which many editors "helpfully" remove.
 
-  context "with an empty credentials file" do
-    before { file(".chef/credentials", "") }
-    subject { knife_list_profiles.stderr }
-    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
-  end
+    context "with no credentials file" do
+      subject { knife_list_profiles.stderr }
+      it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
+    end
 
-  context "with a simple default profile" do
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to eq <<~EOH.delete("#") }
-       Profile  Client    Key                  Server                                   #
-      ----------------------------------------------------------------------------------#
-      *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-    EOH
-  end
+    context "with an empty credentials file" do
+      before { file(".chef/credentials", "") }
+      subject { knife_list_profiles.stderr }
+      it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
+    end
 
-  context "with multiple profiles" do
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+    context "with a simple default profile" do
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to eq <<~EOH.delete("#") }
+         Profile  Client    Key                  Server                                   #
+        ----------------------------------------------------------------------------------#
+        *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+      EOH
+    end
 
-      [prod]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/prod"
+    context "with multiple profiles" do
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
 
-      [qa]
-      client_name = "qauser"
-      client_key = "~/src/qauser.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to eq <<~EOH.delete("#") }
-       Profile  Client    Key                  Server                                   #
-      ----------------------------------------------------------------------------------#
-      *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-       prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
-       qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
-    EOH
-  end
+        [prod]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/prod"
 
-  context "with a non-default active profile" do
-    let(:cmd_args) { %w{--profile prod} }
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+        [qa]
+        client_name = "qauser"
+        client_key = "~/src/qauser.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to eq <<~EOH.delete("#") }
+         Profile  Client    Key                  Server                                   #
+        ----------------------------------------------------------------------------------#
+        *default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+         prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+         qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+      EOH
+    end
 
-      [prod]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/prod"
+    context "with a non-default active profile" do
+      let(:cmd_args) { %w{--profile prod} }
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
 
-      [qa]
-      client_name = "qauser"
-      client_key = "~/src/qauser.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to eq <<~EOH.delete("#") }
-       Profile  Client    Key                  Server                                   #
-      ----------------------------------------------------------------------------------#
-       default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-      *prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
-       qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
-    EOH
-  end
+        [prod]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/prod"
 
-  context "with a bad profile as an active profile" do
-    let(:cmd_args) { %w{--profile production} }
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+        [qa]
+        client_name = "qauser"
+        client_key = "~/src/qauser.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to eq <<~EOH.delete("#") }
+         Profile  Client    Key                  Server                                   #
+        ----------------------------------------------------------------------------------#
+         default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+        *prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+         qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+      EOH
+    end
 
-      [prod]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/prod"
+    context "with a bad profile as an active profile" do
+      let(:cmd_args) { %w{--profile production} }
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
 
-      [qa]
-      client_name = "qauser"
-      client_key = "~/src/qauser.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to eq <<~EOH.delete("#") }
-       Profile  Client    Key                  Server                                   #
-       ---------------------------------------------------------------------------------#
-       default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
-       prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
-       qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
-    EOH
-  end
+        [prod]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/prod"
 
-  context "with a minimal profile" do
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to match %r{^*default .*? https://example.com/organizations/testorg$} }
-  end
+        [qa]
+        client_name = "qauser"
+        client_key = "~/src/qauser.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to eq <<~EOH.delete("#") }
+         Profile  Client    Key                  Server                                   #
+         ---------------------------------------------------------------------------------#
+         default  testuser  ~/.chef/testkey.pem  https://example.com/organizations/testorg#
+         prod     testuser  ~/.chef/testkey.pem  https://example.com/organizations/prod   #
+         qa       qauser    ~/src/qauser.pem     https://example.com/organizations/testorg#
+      EOH
+    end
 
-  context "with -i" do
-    let(:cmd_args) { %w{-i} }
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it { is_expected.to eq <<~EOH.delete("#") }
-       Profile  Client  Key  Server                                   #
-      ----------------------------------------------------------------#
-      *default               https://example.com/organizations/testorg#
-    EOH
-  end
+    context "with a minimal profile" do
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to match %r{^*default .*? https://example.com/organizations/testorg$} }
+    end
 
-  context "with --format=json" do
-    let(:cmd_args) { %w{--format=json node_name} }
-    before { file(".chef/credentials", <<~EOH) }
-      [default]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+    context "with -i" do
+      let(:cmd_args) { %w{-i} }
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it { is_expected.to eq <<~EOH.delete("#") }
+         Profile  Client  Key  Server                                   #
+        ----------------------------------------------------------------#
+        *default               https://example.com/organizations/testorg#
+      EOH
+    end
 
-      [prod]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/prod"
+    context "with --format=json" do
+      let(:cmd_args) { %w{--format=json node_name} }
+      before { file(".chef/credentials", <<~EOH) }
+        [default]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
 
-      [qa]
-      client_name = "qauser"
-      client_key = "~/src/qauser.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it {
-      expect(JSON.parse(subject)).to eq [
-      { "profile" => "default", "active" => true, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/testorg" },
-      { "profile" => "prod", "active" => false, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/prod" },
-      { "profile" => "qa", "active" => false, "client_name" => "qauser", "client_key" => path_to("src/qauser.pem"), "server_url" => "https://example.com/organizations/testorg" },
-    ]
-    }
+        [prod]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/prod"
+
+        [qa]
+        client_name = "qauser"
+        client_key = "~/src/qauser.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+      EOH
+      it {
+        expect(JSON.parse(subject)).to eq [
+        { "profile" => "default", "active" => true, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/testorg" },
+        { "profile" => "prod", "active" => false, "client_name" => "testuser", "client_key" => path_to(".chef/testkey.pem"), "server_url" => "https://example.com/organizations/prod" },
+        { "profile" => "qa", "active" => false, "client_name" => "qauser", "client_key" => path_to("src/qauser.pem"), "server_url" => "https://example.com/organizations/testorg" },
+      ]
+      }
+    end
   end
 end

--- a/spec/integration/knife/config_use_profile_spec.rb
+++ b/spec/integration/knife/config_use_profile_spec.rb
@@ -22,133 +22,134 @@ describe "knife config use-profile", :workstation do
   include KnifeSupport
 
   include_context "default config options"
-  include_context "with a chef repo"
 
   let(:cmd_args) { [] }
 
-  let(:knife_use_profile) do
-    knife("config", "use-profile", *cmd_args, instance_filter: lambda { |instance|
-      # Fake the failsafe check because this command doesn't actually process knife.rb.
-      $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
-      allow(File).to receive(:file?).and_call_original
-    })
-  end
+  when_the_repository("has a custom env") do
+    let(:knife_use_profile) do
+      knife("config", "use-profile", *cmd_args, instance_filter: lambda { |instance|
+        # Fake the failsafe check because this command doesn't actually process knife.rb.
+        $__KNIFE_INTEGRATION_FAILSAFE_CHECK << " ole"
+        allow(File).to receive(:file?).and_call_original
+      })
+    end
 
-  subject { knife_use_profile.stdout }
+    subject { knife_use_profile.stdout }
 
-  around do |ex|
-    # Store and reset the value of some env vars.
-    old_chef_home = ENV["CHEF_HOME"]
-    old_knife_home = ENV["KNIFE_HOME"]
-    old_home = ENV["HOME"]
-    old_wd = Dir.pwd
-    ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
-    # Clear these out because they are cached permanently.
-    ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
-    Chef::Knife::ConfigUseProfile.reset_config_loader!
-    begin
-      ex.run
-    ensure
-      ENV["CHEF_HOME"] = old_chef_home
-      ENV["KNIFE_HOME"] = old_knife_home
-      ENV["HOME"] = old_home
-      Dir.chdir(old_wd)
+    around do |ex|
+      # Store and reset the value of some env vars.
+      old_chef_home = ENV["CHEF_HOME"]
+      old_knife_home = ENV["KNIFE_HOME"]
+      old_home = ENV["HOME"]
+      old_wd = Dir.pwd
+      ChefConfig::PathHelper.per_tool_home_environment = "KNIFE_HOME"
+      # Clear these out because they are cached permanently.
+      ChefConfig::PathHelper.class_exec { remove_class_variable(:@@home_dir) }
+      Chef::Knife::ConfigUseProfile.reset_config_loader!
+      begin
+        ex.run
+      ensure
+        ENV["CHEF_HOME"] = old_chef_home
+        ENV["KNIFE_HOME"] = old_knife_home
+        ENV["HOME"] = old_home
+        Dir.chdir(old_wd)
+        ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
+        ChefConfig::PathHelper.per_tool_home_environment = nil
+      end
+    end
+
+    before do
+      # Always run from the temp folder. This can't be in the `around` block above
+      # because it has to run after the before set in the "with a chef repo" shared context.
+      directory("repo")
+      Dir.chdir(path_to("repo"))
       ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-      ChefConfig::PathHelper.per_tool_home_environment = nil
+      ENV["HOME"] = path_to(".")
     end
-  end
 
-  before do
-    # Always run from the temp folder. This can't be in the `around` block above
-    # because it has to run after the before set in the "with a chef repo" shared context.
-    directory("repo")
-    Dir.chdir(path_to("repo"))
-    ENV[ChefUtils.windows? ? "CD" : "PWD"] = Dir.pwd
-    ENV["HOME"] = path_to(".")
-  end
-
-  context "with no argument" do
-    subject { knife_use_profile.stderr }
-    it { is_expected.to eq "FATAL: You must specify a profile\n" }
-  end
-
-  context "with an argument" do
-    let(:cmd_args) { %w{production} }
-    before { file(".chef/credentials", <<~EOH) }
-      [production]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    it do
-      is_expected.to eq "Set default profile to production\n"
-      expect(File.read(path_to(".chef/context"))).to eq "production\n"
+    context "with no argument" do
+      subject { knife_use_profile.stderr }
+      it { is_expected.to eq "FATAL: You must specify a profile\n" }
     end
-  end
 
-  context "with no credentials file" do
-    let(:cmd_args) { %w{production} }
-    subject { knife_use_profile.stderr }
-    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
-  end
-
-  context "with an empty credentials file" do
-    let(:cmd_args) { %w{production} }
-    before { file(".chef/credentials", "") }
-    subject { knife_use_profile.stderr }
-    it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
-  end
-
-  context "with an wrong argument" do
-    let(:cmd_args) { %w{staging} }
-    before { file(".chef/credentials", <<~EOH) }
-      [production]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
-    EOH
-    subject { knife_use_profile }
-    it { expect { subject }.to raise_error ChefConfig::ConfigurationError, "Profile staging doesn't exist. Please add it to #{path_to(".chef/credentials")} and if it is profile with DNS name check that you are not missing single quotes around it as per docs https://docs.chef.io/workstation/knife_setup/#knife-profiles." }
-  end
-
-  context "with $CHEF_HOME" do
-    let(:cmd_args) { %w{staging} }
-    before do
-      ENV["CHEF_HOME"] = path_to("chefhome"); file("chefhome/tmp", "")
-      file("chefhome/.chef/credentials", <<~EOH
-      [staging]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+    context "with an argument" do
+      let(:cmd_args) { %w{production} }
+      before { file(".chef/credentials", <<~EOH) }
+        [production]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
       EOH
-      )
+      it do
+        is_expected.to eq "Set default profile to production\n"
+        expect(File.read(path_to(".chef/context"))).to eq "production\n"
+      end
     end
 
-    it do
-      is_expected.to eq "Set default profile to staging\n"
-      expect(File.read(path_to("chefhome/.chef/context"))).to eq "staging\n"
-      expect(File.exist?(path_to(".chef/context"))).to be_falsey
+    context "with no credentials file" do
+      let(:cmd_args) { %w{production} }
+      subject { knife_use_profile.stderr }
+      it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
     end
-  end
 
-  context "with $KNIFE_HOME" do
-    let(:cmd_args) { %w{development} }
+    context "with an empty credentials file" do
+      let(:cmd_args) { %w{production} }
+      before { file(".chef/credentials", "") }
+      subject { knife_use_profile.stderr }
+      it { is_expected.to eq "FATAL: No profiles found, #{path_to(".chef/credentials")} does not exist or is empty\n" }
+    end
 
-    before do
-      ENV["KNIFE_HOME"] = path_to("knifehome"); file("knifehome/tmp", "")
-      file("knifehome/.chef/credentials", <<~EOH
-      [development]
-      client_name = "testuser"
-      client_key = "testkey.pem"
-      chef_server_url = "https://example.com/organizations/testorg"
+    context "with an wrong argument" do
+      let(:cmd_args) { %w{staging} }
+      before { file(".chef/credentials", <<~EOH) }
+        [production]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
       EOH
-      )
+      subject { knife_use_profile }
+      it { expect { subject }.to raise_error ChefConfig::ConfigurationError, "Profile staging doesn't exist. Please add it to #{path_to(".chef/credentials")} and if it is profile with DNS name check that you are not missing single quotes around it as per docs https://docs.chef.io/workstation/knife_setup/#knife-profiles." }
     end
 
-    it do
-      is_expected.to eq "Set default profile to development\n"
-      expect(File.read(path_to("knifehome/.chef/context"))).to eq "development\n"
-      expect(File.exist?(path_to(".chef/context"))).to be_falsey
+    context "with $CHEF_HOME" do
+      let(:cmd_args) { %w{staging} }
+      before do
+        ENV["CHEF_HOME"] = path_to("chefhome"); file("chefhome/tmp", "")
+        file("chefhome/.chef/credentials", <<~EOH
+        [staging]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+        EOH
+        )
+      end
+
+      it do
+        is_expected.to eq "Set default profile to staging\n"
+        expect(File.read(path_to("chefhome/.chef/context"))).to eq "staging\n"
+        expect(File.exist?(path_to(".chef/context"))).to be_falsey
+      end
+    end
+
+    context "with $KNIFE_HOME" do
+      let(:cmd_args) { %w{development} }
+
+      before do
+        ENV["KNIFE_HOME"] = path_to("knifehome"); file("knifehome/tmp", "")
+        file("knifehome/.chef/credentials", <<~EOH
+        [development]
+        client_name = "testuser"
+        client_key = "testkey.pem"
+        chef_server_url = "https://example.com/organizations/testorg"
+        EOH
+        )
+      end
+
+      it do
+        is_expected.to eq "Set default profile to development\n"
+        expect(File.read(path_to("knifehome/.chef/context"))).to eq "development\n"
+        expect(File.exist?(path_to(".chef/context"))).to be_falsey
+      end
     end
   end
 end

--- a/spec/integration/knife/diff_spec.rb
+++ b/spec/integration/knife/diff_spec.rb
@@ -318,7 +318,9 @@ describe "knife diff", :workstation do
     end
   end # without versioned cookbooks
 
-  with_versioned_cookbooks do
+  context "with versioned cookbooks" do
+    before { Chef::Config[:versioned_cookbooks] = true }
+
     when_the_chef_server "has one of each thing" do
       before do
         client "x", "{}"

--- a/spec/integration/knife/download_spec.rb
+++ b/spec/integration/knife/download_spec.rb
@@ -594,7 +594,9 @@ describe "knife download", :workstation do
     end
   end # without versioned cookbooks
 
-  with_versioned_cookbooks do
+  context "with versioned cookbooks" do
+    before { Chef::Config[:versioned_cookbooks] = true }
+
     when_the_chef_server "has one of each thing" do
       before do
         client "x", {}

--- a/spec/integration/knife/upload_spec.rb
+++ b/spec/integration/knife/upload_spec.rb
@@ -800,7 +800,9 @@ describe "knife upload", :workstation do
     end
   end # without versioned cookbooks
 
-  with_versioned_cookbooks do
+  context "with versioned cookbooks" do
+    before { Chef::Config[:versioned_cookbooks] = true }
+
     when_the_chef_server "has one of each thing" do
 
       before do

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -49,13 +49,6 @@ module IntegrationSupport
         module_eval(&block)
       end
     end
-
-    def with_versioned_cookbooks(&block)
-      context("with versioned cookbooks") do
-        include_context "with versioned cookbooks"
-        module_eval(&block)
-      end
-    end
   end
 
   def api
@@ -131,11 +124,5 @@ module IntegrationSupport
       Dir.chdir(@old_cwd) if @old_cwd
     end
 
-  end
-
-  # Versioned cookbooks
-
-  RSpec.shared_context "with versioned cookbooks", versioned_cookbooks: true do
-    before(:each) { Chef::Config[:versioned_cookbooks] = true }
   end
 end

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -143,11 +143,4 @@ module IntegrationSupport
     before(:each) { Chef::Config[:versioned_cookbooks] = true }
     after(:each)  { Chef::Config.delete(:versioned_cookbooks) }
   end
-
-  RSpec.shared_context "without versioned cookbooks", versioned_cookbooks: false do
-    # Just make sure this goes back to default
-    before(:each) { Chef::Config[:versioned_cookbooks] = false }
-    after(:each)  { Chef::Config.delete(:versioned_cookbooks) }
-  end
-
 end

--- a/spec/support/shared/integration/integration_helper.rb
+++ b/spec/support/shared/integration/integration_helper.rb
@@ -120,10 +120,6 @@ module IntegrationSupport
     after :each do
       if @repository_dir
         begin
-          %w{client cookbook data_bag environment node role user}.each do |object_name|
-            Chef::Config.delete("#{object_name}_path".to_sym)
-          end
-          Chef::Config.delete(:chef_repo_path)
           # TODO: "force" actually means "silence all exceptions". this
           # silences a weird permissions error on Windows that we should track
           # down, but for now there's no reason for it to blow up our CI.
@@ -141,6 +137,5 @@ module IntegrationSupport
 
   RSpec.shared_context "with versioned cookbooks", versioned_cookbooks: true do
     before(:each) { Chef::Config[:versioned_cookbooks] = true }
-    after(:each)  { Chef::Config.delete(:versioned_cookbooks) }
   end
 end


### PR DESCRIPTION
Because I get annoyed seeing this warning whenever I run tests:

```
WARNING: Shared example group 'with a chef repo' has been previously defined at:
  /Users/pete/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/cheffish-16.0.2/lib/cheffish/rspec/repository_support.rb:12
...and you are now defining it at:
  /Users/pete/work/chef/spec/support/shared/integration/integration_helper.rb:109
The new definition will overwrite the original one.
```

90% of the lines changed in this PR are indentation changes so viewing this with whitespace changes turned off will likely make this much more readable: https://github.com/chef/chef/pull/10232/files?w=1