### PR TITLE
Add a spellcheck exception for a word that snuck in.

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1327,6 +1327,7 @@
     "PWORD",
     "PWSTR",
     "PYTHONUNBUFFERED",
+    "pzstd",
     "qstr",
     "Quer",
     "queryformat",


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>