### PR TITLE
Update omnibus-software to slim our builds

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: d0427be1405e0a6230109fd51cd29e7967ffbdb5
+  revision: 1dd08b8d41b659206833c448dfdee1dfcdd1749c
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.346.0)
+    aws-partitions (1.348.0)
     aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -64,12 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.3.38)
+    chef (16.3.45)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.3.38)
-      chef-utils (= 16.3.38)
+      chef-config (= 16.3.45)
+      chef-utils (= 16.3.45)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -99,12 +99,12 @@ GEM
       tty-prompt (~> 0.21)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (16.3.38-universal-mingw32)
+    chef (16.3.45-universal-mingw32)
       addressable
       bcrypt_pbkdf (= 1.1.0.rc1)
       bundler (>= 1.10)
-      chef-config (= 16.3.38)
-      chef-utils (= 16.3.38)
+      chef-config (= 16.3.45)
+      chef-utils (= 16.3.45)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -147,15 +147,15 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (16.3.38)
+    chef-config (16.3.45)
       addressable
-      chef-utils (= 16.3.38)
+      chef-utils (= 16.3.45)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
-    chef-utils (16.3.38)
+    chef-utils (16.3.45)
     chef-vault (4.0.1)
     chef-zero (15.0.0)
       ffi-yajl (~> 2.2)
@@ -297,7 +297,7 @@ GEM
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.5.3)
+    test-kitchen (2.5.4)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       license-acceptance (~> 1.0, >= 1.0.11)


### PR DESCRIPTION
new ca-certs file
curl w/o support for imap,smtp,gopher etc
libarchive w/o bsdcat binary

Signed-off-by: Tim Smith <tsmith@chef.io>