### PR TITLE
client-run per resource error detail

### DIFF
--- a/lib/chef/action_collection.rb
+++ b/lib/chef/action_collection.rb
@@ -44,6 +44,9 @@ class Chef
       # @return [Exception] The exception that was thrown
       attr_accessor :exception
 
+      # @return [Hash] JSON-formatted error description from the Chef::Formatters::ErrorMapper
+      attr_accessor :error_description
+
       # @return [Numeric] The elapsed time in seconds with machine precision
       attr_accessor :elapsed_time
 
@@ -223,6 +226,7 @@ class Chef
 
       current_record.status = :failed
       current_record.exception = exception
+      current_record.error_description = Formatters::ErrorMapper.resource_failed(new_resource, action, exception).for_json
     end
 
     # Hook called after an action is completed.  This is always called, even if the action fails.

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -135,6 +135,8 @@ class Chef
           hash["conditional"] = action_record.conditional.to_text if action_record.status == :skipped
 
           unless action_record.exception.nil?
+            hash["error_message"] = action_record.exception.message
+
             hash["error"] = {
               "class" => action_record.exception.class,
               "message" => action_record.exception.message,

--- a/lib/chef/data_collector/run_end_message.rb
+++ b/lib/chef/data_collector/run_end_message.rb
@@ -133,7 +133,15 @@ class Chef
           end
 
           hash["conditional"] = action_record.conditional.to_text if action_record.status == :skipped
-          hash["error_message"] = action_record.exception.message unless action_record.exception.nil?
+
+          unless action_record.exception.nil?
+            hash["error"] = {
+              "class" => action_record.exception.class,
+              "message" => action_record.exception.message,
+              "backtrace" => action_record.exception.backtrace,
+              "description" => action_record.error_description,
+            }
+          end
 
           hash
         end

--- a/spec/unit/data_collector_spec.rb
+++ b/spec/unit/data_collector_spec.rb
@@ -39,6 +39,7 @@ describe Chef::DataCollector do
   let(:new_resource) do
     new_resource = Chef::Resource::File.new("/tmp/a-file.txt")
     new_resource.checksum nil
+    new_resource.path
     new_resource
   end
 
@@ -780,6 +781,13 @@ describe Chef::DataCollector do
         let(:resource_record) do
           rec = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
           rec["error_message"] = "imperial to metric conversion error"
+          rec["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
+          }
+
           [ rec ]
         end
         let(:status) { "failure" }
@@ -808,6 +816,13 @@ describe Chef::DataCollector do
           rec = resource_record_for(new_resource, nil, nil, :create, "failed", "1234")
           rec["before"] = {}
           rec["error_message"] = "imperial to metric conversion error"
+          rec["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
+          }
+
           [ rec ]
         end
         let(:status) { "failure" }
@@ -842,6 +857,13 @@ describe Chef::DataCollector do
         let(:resource_record) do
           rec1 = resource_record_for(new_resource, current_resource, nil, :create, "failed", "1234")
           rec1["error_message"] = "imperial to metric conversion error"
+          rec1["error"] = {
+            "class" => exception.class,
+            "message" => exception.message,
+            "backtrace" => exception.backtrace,
+            "description" => error_description,
+          }
+
           rec2 = resource_record_for(unprocessed_resource, nil, nil, :nothing, "unprocessed", "")
           [ rec1, rec2 ]
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Resources with `ignore_failure true` error backtrace and detail are not populating to A2.
- In order to solve this add error_description to action_collection of the resource-based object.
- Add error hash message class, message, and detail to end-run message resource object.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/10099


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>