### PR TITLE
Cleanup more files from our package's gem installs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1530,6 +1530,7 @@
     "singleline",
     "Singleuser",
     "SINGLEUSERTS",
+    "sitearchdir",
     "SITENAME",
     "skipkeys",
     "skippyj",


### PR DESCRIPTION
Nuke more useless files in gems
Remove all the empty gem dirs for the ruby built in gems so we can skip shipping 41 empty folders

Signed-off-by: Tim Smith <tsmith@chef.io>