### PR TITLE
Use .key? instead of keys.include

### DIFF
--- a/lib/chef/property.rb
+++ b/lib/chef/property.rb
@@ -706,7 +706,7 @@ class Chef
       # As of this writing, `name` is the only Chef::Resource property created with the
       # `property` definition, but this will allow for future properties to be extended
       # as needed.
-      !Chef::Resource.properties.keys.include?(name)
+      !Chef::Resource.properties.key?(name)
     end
 
     def exec_in_resource(resource, proc, *args)

--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -1,3 +1,4 @@
+# rubocop: disable Performance/InefficientHashSearch
 #
 # Author:: Lamont Granquist (<lamont@chef.io>)
 # Copyright:: Copyright (c) Chef Software Inc.

--- a/lib/chef/provider/user/dscl.rb
+++ b/lib/chef/provider/user/dscl.rb
@@ -562,7 +562,7 @@ in 'password', with the associated 'salt' and 'iterations'.")
         # Sets a value in user information hash using Chef attributes as keys.
         #
         def dscl_set(user_hash, key, value)
-          raise "Unknown dscl key #{key}" unless DSCL_PROPERTY_MAP.keys.include?(key)
+          raise "Unknown dscl key #{key}" unless DSCL_PROPERTY_MAP.key?(key)
 
           user_hash[DSCL_PROPERTY_MAP[key]] = [ value ]
           user_hash
@@ -572,7 +572,7 @@ in 'password', with the associated 'salt' and 'iterations'.")
         # Gets a value from user information hash using Chef attributes as keys.
         #
         def dscl_get(user_hash, key)
-          raise "Unknown dscl key #{key}" unless DSCL_PROPERTY_MAP.keys.include?(key)
+          raise "Unknown dscl key #{key}" unless DSCL_PROPERTY_MAP.key?(key)
 
           # DSCL values are set as arrays
           value = user_hash[DSCL_PROPERTY_MAP[key]]

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -673,7 +673,7 @@ class Chef
       ivars = instance_variables.map(&:to_sym) - HIDDEN_IVARS
       ivars.each do |ivar|
         iv = ivar.to_s.sub(/^@/, "")
-        if all_props.keys.include?(iv)
+        if all_props.key?(iv)
           text << "  #{iv} #{all_props[iv]}\n"
         elsif (value = instance_variable_get(ivar)) && !(value.respond_to?(:empty?) && value.empty?)
           text << "  #{iv} #{value_to_text(value)}\n"


### PR DESCRIPTION
We don't need to create an array that we then search when we can just search the hash.

Signed-off-by: Tim Smith <tsmith@chef.io>