### PR TITLE
Use sort.reverse instead of sort { |a, b| b <=> a }

### DIFF
--- a/lib/chef/util/backup.rb
+++ b/lib/chef/util/backup.rb
@@ -87,7 +87,7 @@ class Chef
       end
 
       def sorted_backup_files
-        unsorted_backup_files.sort { |a, b| b <=> a }
+        unsorted_backup_files.sort.reverse # faster than sort { |a, b| b <=> a }
       end
     end
   end


### PR DESCRIPTION
It's faster. See https://github.com/rubocop-hq/rubocop-performance/pull/130

Signed-off-by: Tim Smith <tsmith@chef.io>