### PR TITLE
Use .match? when we don't need data from a regex match

### DIFF
--- a/lib/chef/resource/apt_repository.rb
+++ b/lib/chef/resource/apt_repository.rb
@@ -196,7 +196,7 @@ class Chef
 
           so = shell_out("apt-key", "list")
           so.stdout.split(/\n/).map do |t|
-            if t =~ %r{^\/#{key}.*\[expired: .*\]$}
+            if %r{^\/#{key}.*\[expired: .*\]$}.match?(t)
               logger.debug "Found expired key: #{t}"
               valid = false
               break

--- a/lib/chef/resource/windows_firewall_profile.rb
+++ b/lib/chef/resource/windows_firewall_profile.rb
@@ -185,9 +185,9 @@ class Chef
             } else {return $false}
           CODE
           firewall_status = powershell_out(cmd).stdout
-          if firewall_status =~ /True/
+          if /True/.match?(firewall_status)
             true
-          elsif firewall_status =~ /False/
+          elsif /False/.match?(firewall_status)
             false
           end
         end


### PR DESCRIPTION
We still had a few of these. Avoid creating the match object.

Signed-off-by: Tim Smith <tsmith@chef.io>