### PR TITLE
Convert openssl resources to unified_mode

### DIFF
--- a/lib/chef/mixin/openssl_helper.rb
+++ b/lib/chef/mixin/openssl_helper.rb
@@ -412,7 +412,7 @@ class Chef
       # @param [string] cert_file path of the cert file or cert content
       # @param [integer] renew_before_expiry number of days before expiration
       # @return [true, false]
-      def cert_need_renewall?(cert_file, renew_before_expiry)
+      def cert_need_renewal?(cert_file, renew_before_expiry)
         resp = true
         cert_content = ::File.exist?(cert_file) ? File.read(cert_file) : cert_file
         begin
@@ -427,6 +427,8 @@ class Chef
 
         resp
       end
+
+      alias_method :cert_need_renewall?, :cert_need_renewal?
 
       private
 

--- a/lib/chef/resource/openssl_dhparam.rb
+++ b/lib/chef/resource/openssl_dhparam.rb
@@ -23,6 +23,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides(:openssl_dhparam) { true }
 
       description "Use the **openssl_dhparam** resource to generate dhparam.pem files. If a valid dhparam.pem file is found at the specified location, no new file will be created. If a file is found at the specified location but it is not a valid dhparam file, it will be overwritten."

--- a/lib/chef/resource/openssl_ec_private_key.rb
+++ b/lib/chef/resource/openssl_ec_private_key.rb
@@ -24,6 +24,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides :openssl_ec_private_key
 
       description "Use the **openssl_ec_private_key** resource to generate an elliptic curve (EC) private key file. If a valid EC key file can be opened at the specified location, no new file will be created. If the EC key file cannot be opened, either because it does not exist or because the password to the EC key file does not match the password in the recipe, then it will be overwritten."

--- a/lib/chef/resource/openssl_ec_public_key.rb
+++ b/lib/chef/resource/openssl_ec_public_key.rb
@@ -24,6 +24,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides :openssl_ec_public_key
 
       description "Use the **openssl_ec_public_key** resource to generate elliptic curve (EC) public key files from a given EC private key."

--- a/lib/chef/resource/openssl_rsa_private_key.rb
+++ b/lib/chef/resource/openssl_rsa_private_key.rb
@@ -23,6 +23,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides(:openssl_rsa_private_key) { true }
       provides(:openssl_rsa_key) { true } # legacy cookbook resource name
 

--- a/lib/chef/resource/openssl_rsa_public_key.rb
+++ b/lib/chef/resource/openssl_rsa_public_key.rb
@@ -23,6 +23,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides(:openssl_rsa_public_key) { true }
 
       examples <<~DOC

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -224,7 +224,7 @@ class Chef
             csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
             csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
             csr_subject.add_entry("CN", new_resource.common_name)
-            csr_subject.add_entry("emailcsr_subject.address", new_resource.email) unless new_resource.email.nil?
+            csr_subject.add_entry("emailAddress", new_resource.email) unless new_resource.email.nil?
           end
         end
 

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -189,14 +189,12 @@ class Chef
       action_class do
         def key_file
           @key_file ||=
-            begin
-              if new_resource.key_file
-                new_resource.key_file
-              else
-                path, file = ::File.split(new_resource.path)
-                filename = ::File.basename(file, ::File.extname(file))
-                path + "/" + filename + ".key"
-              end
+            if new_resource.key_file
+              new_resource.key_file
+            else
+              path, file = ::File.split(new_resource.path)
+              filename = ::File.basename(file, ::File.extname(file))
+              path + "/" + filename + ".key"
             end
         end
 

--- a/lib/chef/resource/openssl_x509_certificate.rb
+++ b/lib/chef/resource/openssl_x509_certificate.rb
@@ -24,6 +24,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides :openssl_x509_certificate
       provides(:openssl_x509) { true } # legacy cookbook name.
 
@@ -161,7 +163,7 @@ class Chef
           content cert.to_pem
         end
 
-        if !new_resource.renew_before_expiry.nil? && cert_need_renewall?(new_resource.path, new_resource.renew_before_expiry)
+        if !new_resource.renew_before_expiry.nil? && cert_need_renewal?(new_resource.path, new_resource.renew_before_expiry)
           file new_resource.path do
             action :create
             owner new_resource.owner unless new_resource.owner.nil?
@@ -173,7 +175,7 @@ class Chef
         end
 
         if new_resource.csr_file.nil?
-          file new_resource.key_file do
+          file key_file do
             action :create_if_missing
             owner new_resource.owner unless new_resource.owner.nil?
             group new_resource.group unless new_resource.group.nil?
@@ -185,24 +187,27 @@ class Chef
       end
 
       action_class do
-        def generate_key_file
-          unless new_resource.key_file
-            path, file = ::File.split(new_resource.path)
-            filename = ::File.basename(file, ::File.extname(file))
-            new_resource.key_file path + "/" + filename + ".key"
-          end
-          new_resource.key_file
+        def key_file
+          @key_file ||=
+            begin
+              if new_resource.key_file
+                new_resource.key_file
+              else
+                path, file = ::File.split(new_resource.path)
+                filename = ::File.basename(file, ::File.extname(file))
+                path + "/" + filename + ".key"
+              end
+            end
         end
 
         def key
-          @key ||= if priv_key_file_valid?(generate_key_file, new_resource.key_pass)
-                     OpenSSL::PKey.read ::File.read(generate_key_file), new_resource.key_pass
+          @key ||= if priv_key_file_valid?(key_file, new_resource.key_pass)
+                     OpenSSL::PKey.read ::File.read(key_file), new_resource.key_pass
                    elsif new_resource.key_type == "rsa"
                      gen_rsa_priv_key(new_resource.key_length)
                    else
                      gen_ec_priv_key(new_resource.key_curve)
                    end
-          @key
         end
 
         def request
@@ -214,15 +219,15 @@ class Chef
         end
 
         def subject
-          subject = OpenSSL::X509::Name.new
-          subject.add_entry("C", new_resource.country) unless new_resource.country.nil?
-          subject.add_entry("ST", new_resource.state) unless new_resource.state.nil?
-          subject.add_entry("L", new_resource.city) unless new_resource.city.nil?
-          subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
-          subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
-          subject.add_entry("CN", new_resource.common_name)
-          subject.add_entry("emailAddress", new_resource.email) unless new_resource.email.nil?
-          subject
+          OpenSSL::X509::Name.new.tap do |csr_subject|
+            csr_subject.add_entry("C", new_resource.country) unless new_resource.country.nil?
+            csr_subject.add_entry("ST", new_resource.state) unless new_resource.state.nil?
+            csr_subject.add_entry("L", new_resource.city) unless new_resource.city.nil?
+            csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
+            csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
+            csr_subject.add_entry("CN", new_resource.common_name)
+            csr_subject.add_entry("emailcsr_subject.address", new_resource.email) unless new_resource.email.nil?
+          end
         end
 
         def ca_private_key

--- a/lib/chef/resource/openssl_x509_crl.rb
+++ b/lib/chef/resource/openssl_x509_crl.rb
@@ -24,6 +24,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides :openssl_x509_crl
 
       description "Use the **openssl_x509_crl** resource to generate PEM-formatted x509 certificate revocation list (CRL) files."

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -24,6 +24,8 @@ class Chef
       require_relative "../mixin/openssl_helper"
       include Chef::Mixin::OpenSSLHelper
 
+      unified_mode true
+
       provides :openssl_x509_request
 
       description "Use the **openssl_x509_request** resource to generate PEM-formatted x509 certificates requests. If no existing key is specified, the resource will automatically generate a passwordless key with the certificate."
@@ -132,7 +134,7 @@ class Chef
               action :create
             end
 
-            file new_resource.key_file do
+            file key_file do
               owner new_resource.owner unless new_resource.owner.nil?
               group new_resource.group unless new_resource.group.nil?
               mode new_resource.mode unless new_resource.mode.nil?
@@ -145,36 +147,39 @@ class Chef
       end
 
       action_class do
-        def generate_key_file
-          unless new_resource.key_file
-            path, file = ::File.split(new_resource.path)
-            filename = ::File.basename(file, ::File.extname(file))
-            new_resource.key_file path + "/" + filename + ".key"
-          end
-          new_resource.key_file
+        def key_file
+          @key_file ||=
+            begin
+              if new_resource.key_file
+                new_resource.key_file
+              else
+                path, file = ::File.split(new_resource.path)
+                filename = ::File.basename(file, ::File.extname(file))
+                path + "/" + filename + ".key"
+              end
+            end
         end
 
         def key
-          @key ||= if priv_key_file_valid?(generate_key_file, new_resource.key_pass)
-                     OpenSSL::PKey.read ::File.read(generate_key_file), new_resource.key_pass
+          @key ||= if priv_key_file_valid?(key_file, new_resource.key_pass)
+                     OpenSSL::PKey.read ::File.read(key_file), new_resource.key_pass
                    elsif new_resource.key_type == "rsa"
                      gen_rsa_priv_key(new_resource.key_length)
                    else
                      gen_ec_priv_key(new_resource.key_curve)
                    end
-          @key
         end
 
         def subject
-          csr_subject = OpenSSL::X509::Name.new
-          csr_subject.add_entry("C", new_resource.country) unless new_resource.country.nil?
-          csr_subject.add_entry("ST", new_resource.state) unless new_resource.state.nil?
-          csr_subject.add_entry("L", new_resource.city) unless new_resource.city.nil?
-          csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
-          csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
-          csr_subject.add_entry("CN", new_resource.common_name)
-          csr_subject.add_entry("emailAddress", new_resource.email) unless new_resource.email.nil?
-          csr_subject
+          OpenSSL::X509::Name.new.tap do |csr_subject|
+            csr_subject.add_entry("C", new_resource.country) unless new_resource.country.nil?
+            csr_subject.add_entry("ST", new_resource.state) unless new_resource.state.nil?
+            csr_subject.add_entry("L", new_resource.city) unless new_resource.city.nil?
+            csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
+            csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
+            csr_subject.add_entry("CN", new_resource.common_name)
+            csr_subject.add_entry("emailcsr_subject.address", new_resource.email) unless new_resource.email.nil?
+          end
         end
 
         def csr

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -149,14 +149,12 @@ class Chef
       action_class do
         def key_file
           @key_file ||=
-            begin
-              if new_resource.key_file
-                new_resource.key_file
-              else
-                path, file = ::File.split(new_resource.path)
-                filename = ::File.basename(file, ::File.extname(file))
-                path + "/" + filename + ".key"
-              end
+            if new_resource.key_file
+              new_resource.key_file
+            else
+              path, file = ::File.split(new_resource.path)
+              filename = ::File.basename(file, ::File.extname(file))
+              path + "/" + filename + ".key"
             end
         end
 

--- a/lib/chef/resource/openssl_x509_request.rb
+++ b/lib/chef/resource/openssl_x509_request.rb
@@ -176,7 +176,7 @@ class Chef
             csr_subject.add_entry("O", new_resource.org) unless new_resource.org.nil?
             csr_subject.add_entry("OU", new_resource.org_unit) unless new_resource.org_unit.nil?
             csr_subject.add_entry("CN", new_resource.common_name)
-            csr_subject.add_entry("emailcsr_subject.address", new_resource.email) unless new_resource.email.nil?
+            csr_subject.add_entry("emailAddress", new_resource.email) unless new_resource.email.nil?
           end
         end
 


### PR DESCRIPTION
Mostly does what the title says, there wasn't much that depended on
compile/converge ordering and mostly this might fix a bug or two
in intention.

Renamed a method that had a misspelling.

Used tap in two places.

Removed the mutation of the new_resource in two places which is
the most disruptive part of this change.
