### PR TITLE
Use Hash#transform_values

### DIFF
--- a/lib/chef/provider/template/content.rb
+++ b/lib/chef/provider/template/content.rb
@@ -40,14 +40,7 @@ class Chef
           visitor = lambda do |obj|
             case obj
             when Hash
-              # If this is an Attribute object, we need to change class otherwise
-              # we get the immutable behavior. This could probably be fixed by
-              # using Hash#transform_values once we only support Ruby 2.4.
-              obj_class = obj.is_a?(Chef::Node::ImmutableMash) ? Mash : obj.class
-              # Avoid mutating hashes in the resource in case we're changing anything.
-              obj.each_with_object(obj_class.new) do |(key, value), memo|
-                memo[key] = visitor.call(value)
-              end
+              obj.transform_values { |value| visitor.call(value) }
             when Array
               # Avoid mutating arrays in the resource in case we're changing anything.
               obj.map { |value| visitor.call(value) }


### PR DESCRIPTION
Use Hash#transform_values where makes sense

## Description
Now that the minimum Ruby ruby version is > 2.4, it's safe to use Hash#transform_values.

## Related Issue
https://github.com/chef/chef/commit/dbb339175b445bcd4dfd6c54bababf9dd7908993
https://github.com/chef/chef/pull/9247

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
