### PR TITLE
Update RuboCop config to Ruby 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.6
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"

--- a/kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb
@@ -33,11 +33,11 @@ end
 
 ruby_block "load vault item" do
   block do
-    begin
-      chef_vault_item("creds", "super_secret_1")
-    rescue ChefVault::Exceptions::SecretDecryption
-      puts "Not authorized for this key!"
-    end
+
+    chef_vault_item("creds", "super_secret_1")
+  rescue ChefVault::Exceptions::SecretDecryption
+    puts "Not authorized for this key!"
+
   end
   action :run
 end

--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -213,11 +213,11 @@ class Chef::Application::Apply < Chef::Application
     end
     runner = Chef::Runner.new(run_context)
     catch(:end_client_run_early) do
-      begin
-        runner.converge
-      ensure
-        @recipe_fh.close
-      end
+
+      runner.converge
+    ensure
+      @recipe_fh.close
+
     end
     Chef::Platform::Rebooter.reboot_if_needed!(runner)
   end

--- a/lib/chef/application/windows_service.rb
+++ b/lib/chef/application/windows_service.rb
@@ -78,33 +78,33 @@ class Chef
         while running?
           # Grab the service_action_mutex to make a chef-client run
           @service_action_mutex.synchronize do
-            begin
-              Chef::Log.info("Next #{Chef::Dist::CLIENT} run will happen in #{timeout} seconds")
-              @service_signal.wait(@service_action_mutex, timeout)
 
-              # Continue only if service is RUNNING
-              next if state != RUNNING
+            Chef::Log.info("Next #{Chef::Dist::CLIENT} run will happen in #{timeout} seconds")
+            @service_signal.wait(@service_action_mutex, timeout)
 
-              # Reconfigure each time through to pick up any changes in the client file
-              Chef::Log.info("Reconfiguring with startup parameters")
-              reconfigure(startup_parameters)
-              timeout = Chef::Config[:interval]
+            # Continue only if service is RUNNING
+            next if state != RUNNING
 
-              # Honor splay sleep config
-              timeout += rand Chef::Config[:splay]
+            # Reconfigure each time through to pick up any changes in the client file
+            Chef::Log.info("Reconfiguring with startup parameters")
+            reconfigure(startup_parameters)
+            timeout = Chef::Config[:interval]
 
-              # run chef-client only if service is in RUNNING state
-              next if state != RUNNING
+            # Honor splay sleep config
+            timeout += rand Chef::Config[:splay]
 
-              Chef::Log.info("#{Chef::Dist::CLIENT} service is starting a #{Chef::Dist::CLIENT} run...")
-              run_chef_client
-            rescue SystemExit => e
-              # Do not raise any of the errors here in order to
-              # prevent service crash
-              Chef::Log.error("#{e.class}: #{e}")
-            rescue Exception => e
-              Chef::Log.error("#{e.class}: #{e}")
-            end
+            # run chef-client only if service is in RUNNING state
+            next if state != RUNNING
+
+            Chef::Log.info("#{Chef::Dist::CLIENT} service is starting a #{Chef::Dist::CLIENT} run...")
+            run_chef_client
+          rescue SystemExit => e
+            # Do not raise any of the errors here in order to
+            # prevent service crash
+            Chef::Log.error("#{e.class}: #{e}")
+          rescue Exception => e
+            Chef::Log.error("#{e.class}: #{e}")
+
           end
         end
 

--- a/lib/chef/chef_fs/chef_fs_data_store.rb
+++ b/lib/chef/chef_fs/chef_fs_data_store.rb
@@ -172,11 +172,11 @@ class Chef
           @memory_store.create_dir(path, name, *options)
         else
           with_parent_dir(path + [name], *options) do |parent, name|
-            begin
-              parent.create_child(name, nil)
-            rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
-              raise ChefZero::DataStore::DataAlreadyExistsError.new(to_zero_path(e.entry), e)
-            end
+
+            parent.create_child(name, nil)
+          rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
+            raise ChefZero::DataStore::DataAlreadyExistsError.new(to_zero_path(e.entry), e)
+
           end
         end
       end
@@ -251,11 +251,11 @@ class Chef
           end
 
           with_parent_dir(path + [name], *options) do |parent, name|
-            begin
-              parent.create_child(name, data)
-            rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
-              raise ChefZero::DataStore::DataAlreadyExistsError.new(to_zero_path(e.entry), e)
-            end
+
+            parent.create_child(name, data)
+          rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
+            raise ChefZero::DataStore::DataAlreadyExistsError.new(to_zero_path(e.entry), e)
+
           end
         end
       end
@@ -349,11 +349,11 @@ class Chef
 
         else
           with_entry(path) do |entry|
-            begin
-              entry.read
-            rescue Chef::ChefFS::FileSystem::NotFoundError => e
-              raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
-            end
+
+            entry.read
+          rescue Chef::ChefFS::FileSystem::NotFoundError => e
+            raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+
           end
         end
       end
@@ -433,15 +433,15 @@ class Chef
 
         else
           with_entry(path) do |entry|
-            begin
-              if %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length >= 3
-                entry.delete(true)
-              else
-                entry.delete(false)
-              end
-            rescue Chef::ChefFS::FileSystem::NotFoundError => e
-              raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+
+            if %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length >= 3
+              entry.delete(true)
+            else
+              entry.delete(false)
             end
+          rescue Chef::ChefFS::FileSystem::NotFoundError => e
+            raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+
           end
         end
       end
@@ -471,11 +471,11 @@ class Chef
 
         else
           with_entry(path) do |entry|
-            begin
-              entry.delete(options.include?(:recursive))
-            rescue Chef::ChefFS::FileSystem::NotFoundError => e
-              raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
-            end
+
+            entry.delete(options.include?(:recursive))
+          rescue Chef::ChefFS::FileSystem::NotFoundError => e
+            raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
+
           end
         end
       end
@@ -487,11 +487,11 @@ class Chef
         # LIST /policies
         elsif path == [ "policies" ]
           with_entry([ path[0] ]) do |policies|
-            begin
-              policies.children.map { |policy| policy.name[0..-6].rpartition("-")[0] }.uniq
-            rescue Chef::ChefFS::FileSystem::NotFoundError
-              []
-            end
+
+            policies.children.map { |policy| policy.name[0..-6].rpartition("-")[0] }.uniq
+          rescue Chef::ChefFS::FileSystem::NotFoundError
+            []
+
           end
 
         # LIST /policies/POLICY/revisions
@@ -524,19 +524,19 @@ class Chef
 
         elsif %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length == 1
           with_entry(path) do |entry|
-            begin
-              if path[0] == "cookbook_artifacts"
-                entry.children.map { |child| child.name.rpartition("-")[0] }.uniq
-              elsif chef_fs.versioned_cookbooks
-                # /cookbooks/name-version -> /cookbooks/name
-                entry.children.map { |child| split_name_version(child.name)[0] }.uniq
-              else
-                entry.children.map(&:name)
-              end
-            rescue Chef::ChefFS::FileSystem::NotFoundError
-              # If the cookbooks dir doesn't exist, we have no cookbooks (not 404)
-              []
+
+            if path[0] == "cookbook_artifacts"
+              entry.children.map { |child| child.name.rpartition("-")[0] }.uniq
+            elsif chef_fs.versioned_cookbooks
+              # /cookbooks/name-version -> /cookbooks/name
+              entry.children.map { |child| split_name_version(child.name)[0] }.uniq
+            else
+              entry.children.map(&:name)
             end
+          rescue Chef::ChefFS::FileSystem::NotFoundError
+            # If the cookbooks dir doesn't exist, we have no cookbooks (not 404)
+            []
+
           end
 
         elsif %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length == 2
@@ -560,16 +560,16 @@ class Chef
 
         else
           result = with_entry(path) do |entry|
-            begin
-              entry.children.map { |c| zero_filename(c) }.sort
-            rescue Chef::ChefFS::FileSystem::NotFoundError => e
-              # /cookbooks, /data, etc. never return 404
-              if path_always_exists?(path)
-                []
-              else
-                raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
-              end
+
+            entry.children.map { |c| zero_filename(c) }.sort
+          rescue Chef::ChefFS::FileSystem::NotFoundError => e
+            # /cookbooks, /data, etc. never return 404
+            if path_always_exists?(path)
+              []
+            else
+              raise ChefZero::DataStore::DataNotFoundError.new(to_zero_path(e.entry), e)
             end
+
           end
 
           # Older versions of chef-zero do not understand policies and cookbook_artifacts,

--- a/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/acl_entry.rb
@@ -47,17 +47,17 @@ class Chef
             # ACL writes are fun.
             acls = data_handler.normalize(Chef::JSONCompat.parse(file_contents), self)
             PERMISSIONS.each do |permission|
-              begin
-                rest.put("#{api_path}/#{permission}", { permission => acls[permission] })
-              rescue Timeout::Error => e
-                raise Chef::ChefFS::FileSystem::OperationFailedError.new(:write, self, e, "Timeout writing: #{e}")
-              rescue Net::HTTPClientException => e
-                if e.response.code == "404"
-                  raise Chef::ChefFS::FileSystem::NotFoundError.new(self, e)
-                else
-                  raise Chef::ChefFS::FileSystem::OperationFailedError.new(:write, self, e, "HTTP error writing: #{e}")
-                end
+
+              rest.put("#{api_path}/#{permission}", { permission => acls[permission] })
+            rescue Timeout::Error => e
+              raise Chef::ChefFS::FileSystem::OperationFailedError.new(:write, self, e, "Timeout writing: #{e}")
+            rescue Net::HTTPClientException => e
+              if e.response.code == "404"
+                raise Chef::ChefFS::FileSystem::NotFoundError.new(self, e)
+              else
+                raise Chef::ChefFS::FileSystem::OperationFailedError.new(:write, self, e, "HTTP error writing: #{e}")
               end
+
             end
           end
         end

--- a/lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb
@@ -44,15 +44,15 @@ class Chef
             actual_invites = _read_json.inject({}) { |h, val| h[val["username"]] = val["id"]; h }
             invites = actual_invites.keys
             (desired_invites - invites).each do |invite|
-              begin
-                rest.post(api_path, { "user" => invite })
-              rescue Net::HTTPClientException => e
-                if e.response.code == "409"
-                  Chef::Log.warn("Could not invite #{invite} to organization #{org}: #{api_error_text(e.response)}")
-                else
-                  raise
-                end
+
+              rest.post(api_path, { "user" => invite })
+            rescue Net::HTTPClientException => e
+              if e.response.code == "409"
+                Chef::Log.warn("Could not invite #{invite} to organization #{org}: #{api_error_text(e.response)}")
+              else
+                raise
               end
+
             end
             (invites - desired_invites).each do |invite|
               rest.delete(File.join(api_path, actual_invites[invite]))

--- a/lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb
+++ b/lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb
@@ -43,15 +43,15 @@ class Chef
             desired_members = minimize_value(Chef::JSONCompat.parse(contents, create_additions: false))
             members = minimize_value(_read_json)
             (desired_members - members).each do |member|
-              begin
-                rest.post(api_path, "username" => member)
-              rescue Net::HTTPClientException => e
-                if %w{404 405}.include?(e.response.code)
-                  raise "Chef server at #{api_path} does not allow you to directly add members.  Please either upgrade your Chef server or move the users you want into invitations.json instead of members.json."
-                else
-                  raise
-                end
+
+              rest.post(api_path, "username" => member)
+            rescue Net::HTTPClientException => e
+              if %w{404 405}.include?(e.response.code)
+                raise "Chef server at #{api_path} does not allow you to directly add members.  Please either upgrade your Chef server or move the users you want into invitations.json instead of members.json."
+              else
+                raise
               end
+
             end
             (members - desired_members).each do |member|
               rest.delete(File.join(api_path, member))

--- a/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
+++ b/lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb
@@ -109,23 +109,23 @@ class Chef
               child = root_dir.create_child(name, file_contents)
             else
               child_paths[name].each do |path|
-                begin
-                  ::FileUtils.mkdir_p(path)
-                  ::FileUtils.chmod(0700, path)
-                  if ChefUtils.windows?
-                    all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
-                    administrators = Chef::ReservedNames::Win32::Security::SID.Administrators
-                    owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
-                    dacl = Chef::ReservedNames::Win32::Security::ACL.create([
-                      Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, all_mask),
-                      Chef::ReservedNames::Win32::Security::ACE.access_allowed(administrators, all_mask),
-                    ])
-                    so = Chef::ReservedNames::Win32::Security::SecurableObject.new(path)
-                    so.owner = owner
-                    so.set_dacl(dacl, false)
-                  end
-                rescue Errno::EEXIST
+
+                ::FileUtils.mkdir_p(path)
+                ::FileUtils.chmod(0700, path)
+                if ChefUtils.windows?
+                  all_mask = Chef::ReservedNames::Win32::API::Security::GENERIC_ALL
+                  administrators = Chef::ReservedNames::Win32::Security::SID.Administrators
+                  owner = Chef::ReservedNames::Win32::Security::SID.default_security_object_owner
+                  dacl = Chef::ReservedNames::Win32::Security::ACL.create([
+                    Chef::ReservedNames::Win32::Security::ACE.access_allowed(owner, all_mask),
+                    Chef::ReservedNames::Win32::Security::ACE.access_allowed(administrators, all_mask),
+                  ])
+                  so = Chef::ReservedNames::Win32::Security::SecurableObject.new(path)
+                  so.owner = owner
+                  so.set_dacl(dacl, false)
                 end
+              rescue Errno::EEXIST
+
               end
               child = make_child_entry(name)
             end

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -707,16 +707,16 @@ class Chef
     #
     def converge(run_context)
       catch(:end_client_run_early) do
-        begin
-          events.converge_start(run_context)
-          logger.debug("Converging node #{node_name}")
-          @runner = Chef::Runner.new(run_context)
-          @runner.converge
-          events.converge_complete
-        rescue Exception => e
-          events.converge_failed(e)
-          raise e
-        end
+
+        events.converge_start(run_context)
+        logger.debug("Converging node #{node_name}")
+        @runner = Chef::Runner.new(run_context)
+        @runner.converge
+        events.converge_complete
+      rescue Exception => e
+        events.converge_failed(e)
+        raise e
+
       end
     end
 

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -79,14 +79,14 @@ class Chef
           key_matches = []
           keys = @values[platform].keys
           keys.each do |k|
-            begin
-              if Chef::VersionConstraint::Platform.new(k).include?(node_version)
-                key_matches << k
-              end
-            rescue Chef::Exceptions::InvalidVersionConstraint => e
-              Chef::Log.trace "Caught InvalidVersionConstraint. This means that a key in value_for_platform cannot be interpreted as a Chef::VersionConstraint::Platform."
-              Chef::Log.trace(e)
+
+            if Chef::VersionConstraint::Platform.new(k).include?(node_version)
+              key_matches << k
             end
+          rescue Chef::Exceptions::InvalidVersionConstraint => e
+            Chef::Log.trace "Caught InvalidVersionConstraint. This means that a key in value_for_platform cannot be interpreted as a Chef::VersionConstraint::Platform."
+            Chef::Log.trace(e)
+
           end
           return @values[platform][version] if key_matches.include?(version)
 

--- a/lib/chef/file_content_management/tempfile.rb
+++ b/lib/chef/file_content_management/tempfile.rb
@@ -39,15 +39,15 @@ class Chef
         errors = [ ]
 
         tempfile_dirnames.each do |tempfile_dirname|
-          begin
-            # preserving the file extension of the target filename should be considered a public API
-            tf = ::Tempfile.open([tempfile_basename, tempfile_extension], tempfile_dirname)
-            break
-          rescue SystemCallError => e
-            message = "Creating temp file under '#{tempfile_dirname}' failed with: '#{e.message}'"
-            Chef::Log.trace(message)
-            errors << message
-          end
+
+          # preserving the file extension of the target filename should be considered a public API
+          tf = ::Tempfile.open([tempfile_basename, tempfile_extension], tempfile_dirname)
+          break
+        rescue SystemCallError => e
+          message = "Creating temp file under '#{tempfile_dirname}' failed with: '#{e.message}'"
+          Chef::Log.trace(message)
+          errors << message
+
         end
 
         raise Chef::Exceptions::FileContentStagingError, errors if tf.nil?

--- a/lib/chef/knife/cookbook_upload.rb
+++ b/lib/chef/knife/cookbook_upload.rb
@@ -132,20 +132,20 @@ class Chef
               end
             else
               tmp_cl.each do |cookbook_name, cookbook|
-                begin
-                  upload([cookbook], justify_width)
-                  upload_ok += 1
-                rescue Exceptions::CookbookNotFoundInRepo => e
-                  upload_failures += 1
-                  ui.error("Could not find cookbook #{cookbook_name} in your cookbook path, skipping it")
-                  Log.debug(e)
-                  upload_failures += 1
-                rescue Exceptions::CookbookFrozen
-                  ui.warn("Not updating version constraints for #{cookbook_name} in the environment as the cookbook is frozen.")
-                  upload_failures += 1
-                rescue SystemExit => e
-                  raise exit e.status
-                end
+
+                upload([cookbook], justify_width)
+                upload_ok += 1
+              rescue Exceptions::CookbookNotFoundInRepo => e
+                upload_failures += 1
+                ui.error("Could not find cookbook #{cookbook_name} in your cookbook path, skipping it")
+                Log.debug(e)
+                upload_failures += 1
+              rescue Exceptions::CookbookFrozen
+                ui.warn("Not updating version constraints for #{cookbook_name} in the environment as the cookbook is frozen.")
+                upload_failures += 1
+              rescue SystemExit => e
+                raise exit e.status
+
               end
 
               if upload_failures == 0
@@ -172,17 +172,17 @@ class Chef
           else
             upload_set = {}
             @name_args.each do |cookbook_name|
-              begin
-                unless upload_set.key?(cookbook_name)
-                  upload_set[cookbook_name] = cookbook_repo[cookbook_name]
-                  if config[:depends]
-                    upload_set[cookbook_name].metadata.dependencies.each_key { |dep| @name_args << dep }
-                  end
+
+              unless upload_set.key?(cookbook_name)
+                upload_set[cookbook_name] = cookbook_repo[cookbook_name]
+                if config[:depends]
+                  upload_set[cookbook_name].metadata.dependencies.each_key { |dep| @name_args << dep }
                 end
-              rescue Exceptions::CookbookNotFoundInRepo => e
-                ui.error(e.message)
-                Log.debug(e)
               end
+            rescue Exceptions::CookbookNotFoundInRepo => e
+              ui.error(e.message)
+              Log.debug(e)
+
             end
             upload_set
           end

--- a/lib/chef/knife/delete.rb
+++ b/lib/chef/knife/delete.rb
@@ -96,21 +96,21 @@ class Chef
         found_any = false
         error = false
         results.each do |result|
-          begin
-            result.delete(config[:recurse])
-            deleted_any = true
-            found_any = true
-          rescue Chef::ChefFS::FileSystem::NotFoundError
-            # This is not an error unless *all* of them were not found
-          rescue Chef::ChefFS::FileSystem::MustDeleteRecursivelyError => e
-            ui.error "#{format_path_with_root(e.entry)} must be deleted recursively!  Pass -r to knife delete."
-            found_any = true
-            error = true
-          rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
-            ui.error "#{format_path_with_root(e.entry)} #{e.reason}."
-            found_any = true
-            error = true
-          end
+
+          result.delete(config[:recurse])
+          deleted_any = true
+          found_any = true
+        rescue Chef::ChefFS::FileSystem::NotFoundError
+          # This is not an error unless *all* of them were not found
+        rescue Chef::ChefFS::FileSystem::MustDeleteRecursivelyError => e
+          ui.error "#{format_path_with_root(e.entry)} must be deleted recursively!  Pass -r to knife delete."
+          found_any = true
+          error = true
+        rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
+          ui.error "#{format_path_with_root(e.entry)} #{e.reason}."
+          found_any = true
+          error = true
+
         end
         if deleted_any
           output("Deleted #{format_path(results[0])}")

--- a/lib/chef/knife/ssh.rb
+++ b/lib/chef/knife/ssh.rb
@@ -525,12 +525,12 @@ class Chef
       def cssh
         cssh_cmd = nil
         %w{csshX cssh}.each do |cmd|
-          begin
-            # Unix and Mac only
-            cssh_cmd = shell_out!("which #{cmd}").stdout.strip
-            break
-          rescue Mixlib::ShellOut::ShellCommandFailed
-          end
+
+          # Unix and Mac only
+          cssh_cmd = shell_out!("which #{cmd}").stdout.strip
+          break
+        rescue Mixlib::ShellOut::ShellCommandFailed
+
         end
         raise Chef::Exceptions::Exec, "no command found for cssh" unless cssh_cmd
 

--- a/lib/chef/knife/xargs.rb
+++ b/lib/chef/knife/xargs.rb
@@ -204,25 +204,25 @@ class Chef
         error = false
         # Create the temporary files
         tempfiles.each_pair do |tempfile, file|
-          begin
-            value = file[:file].read
-            file[:value] = value
-            tempfile.open
-            tempfile.write(value)
-            tempfile.close
-          rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
-            ui.error "#{format_path(e.entry)}: #{e.reason}."
-            error = true
-            tempfile.close!
-            tempfiles.delete(tempfile)
-            next
-          rescue Chef::ChefFS::FileSystem::NotFoundError => e
-            ui.error "#{format_path(e.entry)}: No such file or directory"
-            error = true
-            tempfile.close!
-            tempfiles.delete(tempfile)
-            next
-          end
+
+          value = file[:file].read
+          file[:value] = value
+          tempfile.open
+          tempfile.write(value)
+          tempfile.close
+        rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
+          ui.error "#{format_path(e.entry)}: #{e.reason}."
+          error = true
+          tempfile.close!
+          tempfiles.delete(tempfile)
+          next
+        rescue Chef::ChefFS::FileSystem::NotFoundError => e
+          ui.error "#{format_path(e.entry)}: No such file or directory"
+          error = true
+          tempfile.close!
+          tempfiles.delete(tempfile)
+          next
+
         end
 
         return error if error && tempfiles.size == 0

--- a/lib/chef/monkey_patches/webrick-utils.rb
+++ b/lib/chef/monkey_patches/webrick-utils.rb
@@ -33,16 +33,16 @@ module WEBrick
       last_error = nil
       sockets = []
       res.each do |ai|
-        begin
-          logger.debug("TCPServer.new(#{ai[3]}, #{port})") if logger
-          sock = TCPServer.new(ai[3], port)
-          port = sock.addr[1] if port == 0
-          Utils.set_close_on_exec(sock)
-          sockets << sock
-        rescue => ex
-          logger.warn("TCPServer Error: #{ex}") if logger
-          last_error = ex
-        end
+
+        logger.debug("TCPServer.new(#{ai[3]}, #{port})") if logger
+        sock = TCPServer.new(ai[3], port)
+        port = sock.addr[1] if port == 0
+        Utils.set_close_on_exec(sock)
+        sockets << sock
+      rescue => ex
+        logger.warn("TCPServer Error: #{ex}") if logger
+        last_error = ex
+
       end
       raise last_error if sockets.empty?
 

--- a/lib/chef/provider/git.rb
+++ b/lib/chef/provider/git.rb
@@ -44,11 +44,11 @@ class Chef
         unless new_resource.user.nil?
           requirements.assert(:all_actions) do |a|
             a.assertion do
-              begin
-                get_homedir(new_resource.user)
-              rescue ArgumentError
-                false
-              end
+
+              get_homedir(new_resource.user)
+            rescue ArgumentError
+              false
+
             end
             a.whyrun("User #{new_resource.user} does not exist, this run will fail unless it has been previously created. Assuming it would have been created.")
             a.failure_message(Chef::Exceptions::User, "#{new_resource.user} required by resource #{new_resource.name} does not exist")

--- a/lib/chef/provider/group/suse.rb
+++ b/lib/chef/provider/group/suse.rb
@@ -39,11 +39,11 @@ class Chef
 
           requirements.assert(:create, :manage, :modify) do |a|
             a.assertion do
-              begin
-                to_add(new_resource.members).all? { |member| Etc.getpwnam(member) }
-              rescue
-                false
-              end
+
+              to_add(new_resource.members).all? { |member| Etc.getpwnam(member) }
+            rescue
+              false
+
             end
             a.failure_message Chef::Exceptions::Group, "Could not add users #{to_add(new_resource.members).join(", ")} to #{new_resource.group_name}: one of these users does not exist"
             a.whyrun "Could not find one of these users: #{to_add(new_resource.members).join(", ")}. Assuming it will be created by a prior step"

--- a/lib/chef/provider/package/windows/registry_uninstall_entry.rb
+++ b/lib/chef/provider/package/windows/registry_uninstall_entry.rb
@@ -37,16 +37,16 @@ class Chef
               begin
                 ::Win32::Registry.open(hkey[0], UNINSTALL_SUBKEY, desired) do |reg|
                   reg.each_key do |key, _wtime|
-                    begin
-                      entry = reg.open(key, desired)
-                      display_name = read_registry_property(entry, "DisplayName")
-                      if display_name.to_s.rstrip == package_name
-                        quiet_uninstall_string = RegistryUninstallEntry.read_registry_property(entry, "QuietUninstallString")
-                        entries.push(quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry))
-                      end
-                    rescue ::Win32::Registry::Error => ex
-                      logger.trace("Registry error opening key '#{key}' on node #{desired}: #{ex}")
+
+                    entry = reg.open(key, desired)
+                    display_name = read_registry_property(entry, "DisplayName")
+                    if display_name.to_s.rstrip == package_name
+                      quiet_uninstall_string = RegistryUninstallEntry.read_registry_property(entry, "QuietUninstallString")
+                      entries.push(quiet_uninstall_string_key?(quiet_uninstall_string, hkey, key, entry))
                     end
+                  rescue ::Win32::Registry::Error => ex
+                    logger.trace("Registry error opening key '#{key}' on node #{desired}: #{ex}")
+
                   end
                 end
               rescue ::Win32::Registry::Error => ex

--- a/lib/chef/provider/service/windows.rb
+++ b/lib/chef/provider/service/windows.rb
@@ -95,17 +95,17 @@ class Chef::Provider::Service::Windows < Chef::Provider::Service
           shell_out!(@new_resource.start_command)
         else
           spawn_command_thread do
-            begin
-              Win32::Service.start(@new_resource.service_name)
-            rescue SystemCallError => ex
-              if ex.errno == ERROR_SERVICE_LOGON_FAILED
-                logger.error ex.message
-                raise Chef::Exceptions::Service,
-                  "Service #{@new_resource} did not start due to a logon failure (error #{ERROR_SERVICE_LOGON_FAILED}): possibly the specified user '#{@new_resource.run_as_user}' does not have the 'log on as a service' privilege, or the password is incorrect."
-              else
-                raise ex
-              end
+
+            Win32::Service.start(@new_resource.service_name)
+          rescue SystemCallError => ex
+            if ex.errno == ERROR_SERVICE_LOGON_FAILED
+              logger.error ex.message
+              raise Chef::Exceptions::Service,
+                "Service #{@new_resource} did not start due to a logon failure (error #{ERROR_SERVICE_LOGON_FAILED}): possibly the specified user '#{@new_resource.run_as_user}' does not have the 'log on as a service' privilege, or the password is incorrect."
+            else
+              raise ex
             end
+
           end
           wait_for_state(RUNNING)
         end

--- a/lib/chef/provider/user/mac.rb
+++ b/lib/chef/provider/user/mac.rb
@@ -583,16 +583,16 @@ class Chef
           timeout = Time.now + 5
 
           loop do
-            begin
-              run_dscl("read", "/Users/#{new_resource.username}", "ShadowHashData")
-              break
-            rescue Chef::Exceptions::DsclCommandFailed => e
-              if Time.now < timeout
-                sleep 0.1
-              else
-                raise Chef::Exceptions::User, e.message
-              end
+
+            run_dscl("read", "/Users/#{new_resource.username}", "ShadowHashData")
+            break
+          rescue Chef::Exceptions::DsclCommandFailed => e
+            if Time.now < timeout
+              sleep 0.1
+            else
+              raise Chef::Exceptions::User, e.message
             end
+
           end
         end
 

--- a/lib/chef/resource.rb
+++ b/lib/chef/resource.rb
@@ -663,11 +663,11 @@ class Chef
 
       all_props = {}
       self.class.state_properties.map do |p|
-        begin
-          all_props[p.name.to_s] = p.sensitive? ? '"*sensitive value suppressed*"' : value_to_text(p.get(self))
-        rescue Chef::Exceptions::ValidationFailed
-          # This space left intentionally blank, the property was probably required or had an invalid default.
-        end
+
+        all_props[p.name.to_s] = p.sensitive? ? '"*sensitive value suppressed*"' : value_to_text(p.get(self))
+      rescue Chef::Exceptions::ValidationFailed
+        # This space left intentionally blank, the property was probably required or had an invalid default.
+
       end
 
       ivars = instance_variables.map(&:to_sym) - HIDDEN_IVARS

--- a/lib/chef/resource/chef_vault_secret.rb
+++ b/lib/chef/resource/chef_vault_secret.rb
@@ -73,19 +73,19 @@ class Chef
         description: "The Chef environment of the data if storing per environment values."
 
       load_current_value do
-        begin
-          item = ChefVault::Item.load(data_bag, id)
-          raw_data item.raw_data
-          clients item.get_clients
-          admins item.get_admins
-          search item.search
-        rescue ChefVault::Exceptions::SecretDecryption
-          current_value_does_not_exist!
-        rescue ChefVault::Exceptions::KeysNotFound
-          current_value_does_not_exist!
-        rescue Net::HTTPClientException => e
-          current_value_does_not_exist! if e.response_code == "404"
-        end
+
+        item = ChefVault::Item.load(data_bag, id)
+        raw_data item.raw_data
+        clients item.get_clients
+        admins item.get_admins
+        search item.search
+      rescue ChefVault::Exceptions::SecretDecryption
+        current_value_does_not_exist!
+      rescue ChefVault::Exceptions::KeysNotFound
+        current_value_does_not_exist!
+      rescue Net::HTTPClientException => e
+        current_value_does_not_exist! if e.response_code == "404"
+
       end
 
       action :create do

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -128,11 +128,11 @@ class Chef
       end
 
       load_current_value do
-        begin
-          value get_sysctl_value(key)
-        rescue
-          current_value_does_not_exist!
-        end
+
+        value get_sysctl_value(key)
+      rescue
+        current_value_does_not_exist!
+
       end
 
       action :apply do

--- a/lib/chef/resource/windows_share.rb
+++ b/lib/chef/resource/windows_share.rb
@@ -59,7 +59,7 @@ class Chef
       # Specifies the path of the location of the folder to share. The path must be fully qualified. Relative paths or paths that contain wildcard characters are not permitted.
       property :path, String,
         description: "The path of the folder to share. Required when creating. If the share already exists on a different path then it is deleted and re-created.",
-        coerce: proc { |p| p.tr('/', "\\") || p }
+        coerce: proc { |p| p.tr("/", "\\") || p }
 
       # Specifies an optional description of the SMB share. A description of the share is displayed by running the Get-SmbShare cmdlet. The description may not contain more than 256 characters.
       property :description, String,

--- a/lib/chef/run_context/cookbook_compiler.rb
+++ b/lib/chef/run_context/cookbook_compiler.rb
@@ -169,17 +169,17 @@ class Chef
       def compile_recipes
         @events.recipe_load_start(run_list_expansion.recipes.size)
         run_list_expansion.recipes.each do |recipe|
-          begin
-            path = resolve_recipe(recipe)
-            @run_context.load_recipe(recipe)
-            @events.recipe_file_loaded(path, recipe)
-          rescue Chef::Exceptions::RecipeNotFound => e
-            @events.recipe_not_found(e)
-            raise
-          rescue Exception => e
-            @events.recipe_file_load_failed(path, e, recipe)
-            raise
-          end
+
+          path = resolve_recipe(recipe)
+          @run_context.load_recipe(recipe)
+          @events.recipe_file_loaded(path, recipe)
+        rescue Chef::Exceptions::RecipeNotFound => e
+          @events.recipe_not_found(e)
+          raise
+        rescue Exception => e
+          @events.recipe_file_load_failed(path, e, recipe)
+          raise
+
         end
         @events.recipe_load_complete
       end
@@ -231,14 +231,14 @@ class Chef
 
       def load_libraries_from_cookbook(cookbook_name, globs = "**/*.rb")
         each_file_in_cookbook_by_segment(cookbook_name, :libraries, globs) do |filename|
-          begin
-            logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")
-            Kernel.require(filename)
-            @events.library_file_loaded(filename)
-          rescue Exception => e
-            @events.library_file_load_failed(filename, e)
-            raise
-          end
+
+          logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")
+          Kernel.require(filename)
+          @events.library_file_loaded(filename)
+        rescue Exception => e
+          @events.library_file_load_failed(filename, e)
+          raise
+
         end
       end
 

--- a/lib/chef/util/diff.rb
+++ b/lib/chef/util/diff.rb
@@ -106,16 +106,16 @@ class Chef
         # join them. otherwise, print out the old one.
         old_hunk = hunk = nil
         diff_data.each do |piece|
-          begin
-            hunk = ::Diff::LCS::Hunk.new(old_data, new_data, piece, 3, file_length_difference)
-            file_length_difference = hunk.file_length_difference
-            next unless old_hunk
-            next if hunk.merge(old_hunk)
 
-            diff_str << old_hunk.diff(:unified) << "\n"
-          ensure
-            old_hunk = hunk
-          end
+          hunk = ::Diff::LCS::Hunk.new(old_data, new_data, piece, 3, file_length_difference)
+          file_length_difference = hunk.file_length_difference
+          next unless old_hunk
+          next if hunk.merge(old_hunk)
+
+          diff_str << old_hunk.diff(:unified) << "\n"
+        ensure
+          old_hunk = hunk
+
         end
         diff_str << old_hunk.diff(:unified) << "\n"
         diff_str

--- a/lib/chef/win32/file/version_info.rb
+++ b/lib/chef/win32/file/version_info.rb
@@ -49,11 +49,11 @@ class Chef
           SpecialBuild
         }.each do |method|
           define_method method do
-            begin
-              get_version_info_string(method.to_s)
-            rescue Chef::Exceptions::Win32APIError
-              return nil
-            end
+
+            get_version_info_string(method.to_s)
+          rescue Chef::Exceptions::Win32APIError
+            return nil
+
           end
         end
 

--- a/spec/functional/resource/group_spec.rb
+++ b/spec/functional/resource/group_spec.rb
@@ -307,12 +307,12 @@ describe Chef::Resource::Group, :requires_root_or_running_windows do
   let(:number) do
     # Loop until we pick a gid that is not in use.
     loop do
-      begin
-        gid = rand(2000..9999) # avoid low group numbers
-        return nil if Etc.getgrgid(gid).nil? # returns nil on windows
-      rescue ArgumentError # group does not exist
-        return gid
-      end
+
+      gid = rand(2000..9999) # avoid low group numbers
+      return nil if Etc.getgrgid(gid).nil? # returns nil on windows
+    rescue ArgumentError # group does not exist
+      return gid
+
     end
   end
 

--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -55,13 +55,13 @@ describe Chef::Resource::Link do
   end
 
   after(:each) do
-    begin
-      cleanup_link(to) if File.exists?(to)
-      cleanup_link(target_file) if File.exists?(target_file)
-      cleanup_link(CHEF_SPEC_BACKUP_PATH) if File.exists?(CHEF_SPEC_BACKUP_PATH)
-    rescue
-      puts "Could not remove a file: #{$!}"
-    end
+
+    cleanup_link(to) if File.exists?(to)
+    cleanup_link(target_file) if File.exists?(target_file)
+    cleanup_link(CHEF_SPEC_BACKUP_PATH) if File.exists?(CHEF_SPEC_BACKUP_PATH)
+  rescue
+    puts "Could not remove a file: #{$!}"
+
   end
 
   def user(user)

--- a/spec/functional/resource/powershell_script_spec.rb
+++ b/spec/functional/resource/powershell_script_spec.rb
@@ -273,10 +273,10 @@ describe Chef::Resource::WindowsScript::PowershellScript, :windows_only do
 
     context "when running on a 32-bit version of Windows", :windows32_only do
       it "raises an exception if :x86_64 process architecture is specified" do
-        begin
-          expect(resource.architecture(:x86_64)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
-        rescue Chef::Exceptions::Win32ArchitectureIncorrect
-        end
+
+        expect(resource.architecture(:x86_64)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
+      rescue Chef::Exceptions::Win32ArchitectureIncorrect
+
       end
     end
   end

--- a/spec/functional/run_lock_spec.rb
+++ b/spec/functional/run_lock_spec.rb
@@ -61,17 +61,17 @@ describe Chef::RunLock do
     let!(:p1) { ClientProcess.new(self, "p1") }
     let!(:p2) { ClientProcess.new(self, "p2") }
     after(:each) do |example|
-      begin
-        p1.stop
-        p2.stop
-      rescue
-        example.exception = $!
-        raise
-      ensure
-        if example.exception
-          print_events
-        end
+
+      p1.stop
+      p2.stop
+    rescue
+      example.exception = $!
+      raise
+    ensure
+      if example.exception
+        print_events
       end
+
     end
 
     def print_events
@@ -445,21 +445,21 @@ describe Chef::RunLock do
     def start
       example.log_event("#{name}.start")
       @pid = fork do
-        begin
-          Timeout.timeout(CLIENT_PROCESS_TIMEOUT) do
-            run_lock = TestRunLock.new(example.lockfile)
-            run_lock.client_process = self
-            fire_event("started")
-            run_lock.acquire
-            fire_event("acquired lock")
-            run_lock.save_pid
-            fire_event("saved pid")
-            exit!(0)
-          end
-        rescue
-          fire_event($!.message.lines.join(" // "))
-          raise
+
+        Timeout.timeout(CLIENT_PROCESS_TIMEOUT) do
+          run_lock = TestRunLock.new(example.lockfile)
+          run_lock.client_process = self
+          fire_event("started")
+          run_lock.acquire
+          fire_event("acquired lock")
+          run_lock.save_pid
+          fire_event("saved pid")
+          exit!(0)
         end
+      rescue
+        fire_event($!.message.lines.join(" // "))
+        raise
+
       end
       example.log_event("#{name}.start forked (pid #{pid})")
     end

--- a/spec/functional/win32/registry_spec.rb
+++ b/spec/functional/win32/registry_spec.rb
@@ -267,10 +267,10 @@ describe "Chef::Win32::Registry", :windows_only do
   describe "create_key" do
     before(:all) do
       ::Win32::Registry::HKEY_CURRENT_USER.open("Software\\Root") do |reg|
-        begin
-          reg.delete_key("Trunk", true)
-        rescue
-        end
+
+        reg.delete_key("Trunk", true)
+      rescue
+
       end
     end
 
@@ -362,10 +362,10 @@ describe "Chef::Win32::Registry", :windows_only do
     before(:all) do
       ::Win32::Registry::HKEY_CURRENT_USER.create "Software\\Root\\Trunk"
       ::Win32::Registry::HKEY_CURRENT_USER.open("Software\\Root\\Trunk") do |reg|
-        begin
-          reg.delete_key("Red", true)
-        rescue
-        end
+
+        reg.delete_key("Red", true)
+      rescue
+
       end
     end
 

--- a/spec/integration/knife/common_options_spec.rb
+++ b/spec/integration/knife/common_options_spec.rb
@@ -125,12 +125,12 @@ describe "knife common options", :workstation do
 
     context "when the default port (8889) is already bound" do
       before :each do
-        begin
-          @server = ChefZero::Server.new(host: "localhost", port: 8889)
-          @server.start_background
-        rescue Errno::EADDRINUSE
-          # OK.  Don't care who has it in use, as long as *someone* does.
-        end
+
+        @server = ChefZero::Server.new(host: "localhost", port: 8889)
+        @server.start_background
+      rescue Errno::EADDRINUSE
+        # OK.  Don't care who has it in use, as long as *someone* does.
+
       end
       after :each do
         @server.stop if @server
@@ -144,12 +144,12 @@ describe "knife common options", :workstation do
 
     context "when port 9999 is already bound" do
       before :each do
-        begin
-          @server = ChefZero::Server.new(host: "localhost", port: 9999)
-          @server.start_background
-        rescue Errno::EADDRINUSE
-          # OK.  Don't care who has it in use, as long as *someone* does.
-        end
+
+        @server = ChefZero::Server.new(host: "localhost", port: 9999)
+        @server.start_background
+      rescue Errno::EADDRINUSE
+        # OK.  Don't care who has it in use, as long as *someone* does.
+
       end
       after :each do
         @server.stop if @server

--- a/spec/integration/knife/serve_spec.rb
+++ b/spec/integration/knife/serve_spec.rb
@@ -26,11 +26,11 @@ describe "knife serve", :workstation do
   def with_knife_serve
     exception = nil
     t = Thread.new do
-      begin
-        knife("serve --chef-zero-port=8890")
-      rescue
-        exception = $!
-      end
+
+      knife("serve --chef-zero-port=8890")
+    rescue
+      exception = $!
+
     end
     begin
       Chef::Config.log_level = :debug

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -297,11 +297,11 @@ RSpec.configure do |config|
 
   # Protect Rspec from accidental exit(0) causing rspec to terminate without error
   config.around(:example) do |ex|
-    begin
-      ex.run
-    rescue SystemExit => e
-      raise UnexpectedSystemExit.from(e)
-    end
+
+    ex.run
+  rescue SystemExit => e
+    raise UnexpectedSystemExit.from(e)
+
   end
 end
 

--- a/spec/support/shared/functional/file_resource.rb
+++ b/spec/support/shared/functional/file_resource.rb
@@ -476,12 +476,12 @@ shared_examples_for "a configured file resource" do
         end
 
         it "issues a warning/assumption in whyrun mode" do
-          begin
-            Chef::Config[:why_run] = true
-            resource.run_action(:create) # should not raise
-          ensure
-            Chef::Config[:why_run] = false
-          end
+
+          Chef::Config[:why_run] = true
+          resource.run_action(:create) # should not raise
+        ensure
+          Chef::Config[:why_run] = false
+
         end
       end
 
@@ -504,12 +504,12 @@ shared_examples_for "a configured file resource" do
         end
 
         it "issues a warning/assumption in whyrun mode" do
-          begin
-            Chef::Config[:why_run] = true
-            resource.run_action(:create) # should not raise
-          ensure
-            Chef::Config[:why_run] = false
-          end
+
+          Chef::Config[:why_run] = true
+          resource.run_action(:create) # should not raise
+        ensure
+          Chef::Config[:why_run] = false
+
         end
       end
 
@@ -535,12 +535,12 @@ shared_examples_for "a configured file resource" do
         end
 
         it "issues a warning/assumption in whyrun mode" do
-          begin
-            Chef::Config[:why_run] = true
-            resource.run_action(:create) # should not raise
-          ensure
-            Chef::Config[:why_run] = false
-          end
+
+          Chef::Config[:why_run] = true
+          resource.run_action(:create) # should not raise
+        ensure
+          Chef::Config[:why_run] = false
+
         end
       end
 

--- a/spec/unit/mixin/template_spec.rb
+++ b/spec/unit/mixin/template_spec.rb
@@ -104,16 +104,16 @@ describe Chef::Mixin::Template, "render_template" do
     end
 
     it "should render local files" do
-      begin
-        tf = Tempfile.new("partial")
-        tf.write "test"
-        tf.rewind
 
-        output = @template_context.render_template_from_string("before {<%= render '#{tf.path}', :local => true %>} after")
-        expect(output).to eq("before {test} after")
-      ensure
-        tf.close
-      end
+      tf = Tempfile.new("partial")
+      tf.write "test"
+      tf.rewind
+
+      output = @template_context.render_template_from_string("before {<%= render '#{tf.path}', :local => true %>} after")
+      expect(output).to eq("before {test} after")
+    ensure
+      tf.close
+
     end
 
     it "should render partials from a different cookbook" do
@@ -124,16 +124,16 @@ describe Chef::Mixin::Template, "render_template" do
     end
 
     it "should render using the source argument if provided" do
-      begin
-        tf = Tempfile.new("partial")
-        tf.write "test"
-        tf.rewind
 
-        output = @template_context.render_template_from_string("before {<%= render 'something', :local => true, :source => '#{tf.path}' %>} after")
-        expect(output).to eq("before {test} after")
-      ensure
-        tf.close
-      end
+      tf = Tempfile.new("partial")
+      tf.write "test"
+      tf.rewind
+
+      output = @template_context.render_template_from_string("before {<%= render 'something', :local => true, :source => '#{tf.path}' %>} after")
+      expect(output).to eq("before {test} after")
+    ensure
+      tf.close
+
     end
 
     it "should pass the node to partials" do
@@ -195,11 +195,11 @@ describe Chef::Mixin::Template, "render_template" do
 
       describe "the raised TemplateError" do
         subject(:exception) do
-          begin
-            do_raise
-          rescue Chef::Mixin::Template::TemplateError => e
-            e
-          end
+
+          do_raise
+        rescue Chef::Mixin::Template::TemplateError => e
+          e
+
         end
 
         it "should contain template file and line numbers" do
@@ -274,11 +274,11 @@ describe Chef::Mixin::Template, "render_template" do
 
     describe "the raised TemplateError" do
       before :each do
-        begin
-          do_raise
-        rescue Chef::Mixin::Template::TemplateError => e
-          @exception = e
-        end
+
+        do_raise
+      rescue Chef::Mixin::Template::TemplateError => e
+        @exception = e
+
       end
 
       it "should have the original exception" do

--- a/spec/unit/mixin/windows_architecture_helper_spec.rb
+++ b/spec/unit/mixin/windows_architecture_helper_spec.rb
@@ -50,10 +50,10 @@ describe Chef::Mixin::WindowsArchitectureHelper do
 
   it "raises an error if an invalid architecture is passed to assert_valid_windows_architecture!" do
     @invalid_architectures.each do |architecture|
-      begin
-        expect(assert_valid_windows_architecture!(architecture)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
-      rescue Chef::Exceptions::Win32ArchitectureIncorrect
-      end
+
+      expect(assert_valid_windows_architecture!(architecture)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
+    rescue Chef::Exceptions::Win32ArchitectureIncorrect
+
     end
   end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1773,11 +1773,11 @@ describe Chef::Node do
           end
 
           let(:http_exception) do
-            begin
-              response.error!
-            rescue => e
-              e
-            end
+
+            response.error!
+          rescue => e
+            e
+
           end
 
           let(:trimmed_node) do

--- a/spec/unit/provider/remote_directory_spec.rb
+++ b/spec/unit/provider/remote_directory_spec.rb
@@ -201,17 +201,17 @@ describe Chef::Provider::RemoteDirectory do
         @fclass = Chef::CFCCheck.new
 
         Dir.mktmpdir do |tmp_dir|
-          begin
-            @fclass.file_class.symlink(tmp_dir.dup, symlinked_dir_path)
-            expect(::File.exist?(symlinked_dir_path)).to be_truthy
 
-            @provider.run_action
+          @fclass.file_class.symlink(tmp_dir.dup, symlinked_dir_path)
+          expect(::File.exist?(symlinked_dir_path)).to be_truthy
 
-            expect(::File.exist?(symlinked_dir_path)).to be_falsey
-            expect(::File.exist?(tmp_dir)).to be_truthy
-          rescue Chef::Exceptions::Win32APIError
-            skip "This must be run as an Administrator to create symlinks"
-          end
+          @provider.run_action
+
+          expect(::File.exist?(symlinked_dir_path)).to be_falsey
+          expect(::File.exist?(tmp_dir)).to be_truthy
+        rescue Chef::Exceptions::Win32APIError
+          skip "This must be run as an Administrator to create symlinks"
+
         end
       end
     end

--- a/spec/unit/provider_resolver_spec.rb
+++ b/spec/unit/provider_resolver_spec.rb
@@ -54,11 +54,11 @@ describe Chef::ProviderResolver do
 
     let(:provider_resolver) { Chef::ProviderResolver.new(node, resource, action) }
     let(:resolved_provider) do
-      begin
-        resource ? resource.provider_for_action(action).class : nil
-      rescue Chef::Exceptions::ProviderNotFound
-        nil
-      end
+
+      resource ? resource.provider_for_action(action).class : nil
+    rescue Chef::Exceptions::ProviderNotFound
+      nil
+
     end
 
     let(:service_name) { "test" }


### PR DESCRIPTION
This removes the redundant begins

```
kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb:36:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb:36:5: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
    begin
    ^^^^^
kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb:37:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
      chef_vault_item("creds", "super_secret_1")
  ^^^^
kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb:38:5: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 38, 4 is not aligned with block do at 35, 2.
    rescue ChefVault::Exceptions::SecretDecryption
    ^^^^^^
kitchen-tests/cookbooks/end_to_end/recipes/_chef-vault.rb:40:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/application/apply.rb:216:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/application/apply.rb:216:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
lib/chef/application/apply.rb:217:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        runner.converge
    ^^^^
lib/chef/application/apply.rb:218:7: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 218, 6 is not aligned with catch(:end_client_run_early) do at 215, 4.
      ensure
      ^^^^^^
lib/chef/application/apply.rb:220:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/application/windows_service.rb:81:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/application/windows_service.rb:81:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/application/windows_service.rb:82:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              Chef::Log.info("Next #{Chef::Dist::CLIENT} run will happen in #{timeout} seconds")
          ^^^^
lib/chef/application/windows_service.rb:101:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 101, 12 is not aligned with @service_action_mutex.synchronize do at 80, 10.
            rescue SystemExit => e
            ^^^^^^
lib/chef/application/windows_service.rb:105:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 105, 12 is not aligned with @service_action_mutex.synchronize do at 80, 10.
            rescue Exception => e
            ^^^^^^
lib/chef/application/windows_service.rb:107:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:175:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:175:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:176:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              parent.create_child(name, nil)
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:177:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 177, 12 is not aligned with with_parent_dir(path + [name], *options) do at 174, 10.
            rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:179:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:254:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:254:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:255:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              parent.create_child(name, data)
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:256:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 256, 12 is not aligned with with_parent_dir(path + [name], *options) do at 253, 10.
            rescue Chef::ChefFS::FileSystem::AlreadyExistsError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:258:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:352:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:352:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:353:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              entry.read
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:354:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 354, 12 is not aligned with with_entry(path) do at 351, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:356:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:436:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:436:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:437:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              if %w{cookbooks cookbook_artifacts}.include?(path[0]) && path.length >= 3
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:442:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 442, 12 is not aligned with with_entry(path) do at 435, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:444:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:474:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:474:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:475:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              entry.delete(options.include?(:recursive))
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:476:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 476, 12 is not aligned with with_entry(path) do at 473, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:478:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:490:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:490:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:491:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              policies.children.map { |policy| policy.name[0..-6].rpartition("-")[0] }.uniq
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:492:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 492, 12 is not aligned with with_entry([ path[0] ]) do at 489, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:494:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:527:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:527:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:528:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              if path[0] == "cookbook_artifacts"
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:536:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 536, 12 is not aligned with with_entry(path) do at 526, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:539:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:563:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/chef_fs_data_store.rb:563:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:564:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              entry.children.map { |c| zero_filename(c) }.sort
          ^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:565:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 565, 12 is not aligned with result at 562, 10.
            rescue Chef::ChefFS::FileSystem::NotFoundError => e
            ^^^^^^
lib/chef/chef_fs/chef_fs_data_store.rb:572:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:50:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:50:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:51:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                rest.put("#{api_path}/#{permission}", { permission => acls[permission] })
            ^^^^
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:52:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 52, 14 is not aligned with PERMISSIONS.each do at 49, 12.
              rescue Timeout::Error => e
              ^^^^^^
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:54:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 54, 14 is not aligned with PERMISSIONS.each do at 49, 12.
              rescue Net::HTTPClientException => e
              ^^^^^^
lib/chef/chef_fs/file_system/chef_server/acl_entry.rb:60:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb:47:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb:47:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb:48:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                rest.post(api_path, { "user" => invite })
            ^^^^
lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb:49:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 49, 14 is not aligned with (desired_invites - invites).each do at 46, 12.
              rescue Net::HTTPClientException => e
              ^^^^^^
lib/chef/chef_fs/file_system/chef_server/organization_invites_entry.rb:55:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb:46:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb:46:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb:47:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                rest.post(api_path, "username" => member)
            ^^^^
lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb:48:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 48, 14 is not aligned with (desired_members - members).each do at 45, 12.
              rescue Net::HTTPClientException => e
              ^^^^^^
lib/chef/chef_fs/file_system/chef_server/organization_members_entry.rb:54:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb:112:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb:112:17: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
                begin
                ^^^^^
lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb:113:15: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                  ::FileUtils.mkdir_p(path)
              ^^^^
lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb:127:17: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 127, 16 is not aligned with child_paths[name].each do at 111, 14.
                rescue Errno::EEXIST
                ^^^^^^
lib/chef/chef_fs/file_system/repository/chef_repository_file_system_root_dir.rb:128:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/client.rb:710:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/client.rb:710:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
lib/chef/client.rb:711:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          events.converge_start(run_context)
      ^^^^
lib/chef/client.rb:716:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 716, 8 is not aligned with catch(:end_client_run_early) do at 709, 6.
        rescue Exception => e
        ^^^^^^
lib/chef/client.rb:719:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/dsl/platform_introspection.rb:82:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/dsl/platform_introspection.rb:82:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/dsl/platform_introspection.rb:83:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              if Chef::VersionConstraint::Platform.new(k).include?(node_version)
          ^^^^
lib/chef/dsl/platform_introspection.rb:86:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 86, 12 is not aligned with keys.each do at 81, 10.
            rescue Chef::Exceptions::InvalidVersionConstraint => e
            ^^^^^^
lib/chef/dsl/platform_introspection.rb:89:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/file_content_management/tempfile.rb:42:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/file_content_management/tempfile.rb:42:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/file_content_management/tempfile.rb:43:13: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 12 instead of 10).
            # preserving the file extension of the target filename should be considered a public API
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/chef/file_content_management/tempfile.rb:44:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            tf = ::Tempfile.open([tempfile_basename, tempfile_extension], tempfile_dirname)
        ^^^^
lib/chef/file_content_management/tempfile.rb:46:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 46, 10 is not aligned with tempfile_dirnames.each do at 41, 8.
          rescue SystemCallError => e
          ^^^^^^
lib/chef/file_content_management/tempfile.rb:50:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/cookbook_upload.rb:135:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/cookbook_upload.rb:135:17: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
                begin
                ^^^^^
lib/chef/knife/cookbook_upload.rb:136:15: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                  upload([cookbook], justify_width)
              ^^^^
lib/chef/knife/cookbook_upload.rb:138:17: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 138, 16 is not aligned with tmp_cl.each do at 134, 14.
                rescue Exceptions::CookbookNotFoundInRepo => e
                ^^^^^^
lib/chef/knife/cookbook_upload.rb:143:17: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 143, 16 is not aligned with tmp_cl.each do at 134, 14.
                rescue Exceptions::CookbookFrozen
                ^^^^^^
lib/chef/knife/cookbook_upload.rb:146:17: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 146, 16 is not aligned with tmp_cl.each do at 134, 14.
                rescue SystemExit => e
                ^^^^^^
lib/chef/knife/cookbook_upload.rb:148:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/cookbook_upload.rb:175:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/cookbook_upload.rb:175:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/knife/cookbook_upload.rb:176:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                unless upload_set.key?(cookbook_name)
            ^^^^
lib/chef/knife/cookbook_upload.rb:182:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 182, 14 is not aligned with @name_args.each do at 174, 12.
              rescue Exceptions::CookbookNotFoundInRepo => e
              ^^^^^^
lib/chef/knife/cookbook_upload.rb:185:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/delete.rb:99:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/delete.rb:99:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/knife/delete.rb:100:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            result.delete(config[:recurse])
        ^^^^
lib/chef/knife/delete.rb:103:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 103, 10 is not aligned with results.each do at 98, 8.
          rescue Chef::ChefFS::FileSystem::NotFoundError
          ^^^^^^
lib/chef/knife/delete.rb:105:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 105, 10 is not aligned with results.each do at 98, 8.
          rescue Chef::ChefFS::FileSystem::MustDeleteRecursivelyError => e
          ^^^^^^
lib/chef/knife/delete.rb:109:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 109, 10 is not aligned with results.each do at 98, 8.
          rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
          ^^^^^^
lib/chef/knife/delete.rb:113:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/ssh.rb:528:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/ssh.rb:528:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/knife/ssh.rb:529:13: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 12 instead of 10).
            # Unix and Mac only
            ^^^^^^^^^^^^^^^^^^^
lib/chef/knife/ssh.rb:530:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            cssh_cmd = shell_out!("which #{cmd}").stdout.strip
        ^^^^
lib/chef/knife/ssh.rb:532:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 532, 10 is not aligned with %w{csshX cssh}.each do at 527, 8.
          rescue Mixlib::ShellOut::ShellCommandFailed
          ^^^^^^
lib/chef/knife/ssh.rb:533:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/xargs.rb:207:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/knife/xargs.rb:207:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/knife/xargs.rb:208:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            value = file[:file].read
        ^^^^
lib/chef/knife/xargs.rb:213:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 213, 10 is not aligned with tempfiles.each_pair do at 206, 8.
          rescue Chef::ChefFS::FileSystem::OperationNotAllowedError => e
          ^^^^^^
lib/chef/knife/xargs.rb:219:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 219, 10 is not aligned with tempfiles.each_pair do at 206, 8.
          rescue Chef::ChefFS::FileSystem::NotFoundError => e
          ^^^^^^
lib/chef/knife/xargs.rb:225:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/monkey_patches/webrick-utils.rb:36:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/monkey_patches/webrick-utils.rb:36:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
lib/chef/monkey_patches/webrick-utils.rb:37:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          logger.debug("TCPServer.new(#{ai[3]}, #{port})") if logger
      ^^^^
lib/chef/monkey_patches/webrick-utils.rb:42:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 42, 8 is not aligned with res.each do at 35, 6.
        rescue => ex
        ^^^^^^
lib/chef/monkey_patches/webrick-utils.rb:45:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/git.rb:47:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/git.rb:47:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/provider/git.rb:48:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                get_homedir(new_resource.user)
            ^^^^
lib/chef/provider/git.rb:49:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 49, 14 is not aligned with a.assertion do at 46, 12.
              rescue ArgumentError
              ^^^^^^
lib/chef/provider/git.rb:51:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/group/suse.rb:42:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/group/suse.rb:42:15: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
              begin
              ^^^^^
lib/chef/provider/group/suse.rb:43:13: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                to_add(new_resource.members).all? { |member| Etc.getpwnam(member) }
            ^^^^
lib/chef/provider/group/suse.rb:44:15: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 44, 14 is not aligned with a.assertion do at 41, 12.
              rescue
              ^^^^^^
lib/chef/provider/group/suse.rb:46:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/package/windows/registry_uninstall_entry.rb:40:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/package/windows/registry_uninstall_entry.rb:40:21: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
                    begin
                    ^^^^^
lib/chef/provider/package/windows/registry_uninstall_entry.rb:41:19: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
                      entry = reg.open(key, desired)
                  ^^^^
lib/chef/provider/package/windows/registry_uninstall_entry.rb:47:21: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 47, 20 is not aligned with reg.each_key do at 39, 18.
                    rescue ::Win32::Registry::Error => ex
                    ^^^^^^
lib/chef/provider/package/windows/registry_uninstall_entry.rb:49:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/service/windows.rb:98:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/service/windows.rb:98:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/provider/service/windows.rb:99:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              Win32::Service.start(@new_resource.service_name)
          ^^^^
lib/chef/provider/service/windows.rb:100:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 100, 12 is not aligned with spawn_command_thread do at 97, 10.
            rescue SystemCallError => ex
            ^^^^^^
lib/chef/provider/service/windows.rb:108:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/user/mac.rb:586:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/provider/user/mac.rb:586:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/provider/user/mac.rb:587:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              run_dscl("read", "/Users/#{new_resource.username}", "ShadowHashData")
          ^^^^
lib/chef/provider/user/mac.rb:589:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 589, 12 is not aligned with loop do at 585, 10.
            rescue Chef::Exceptions::DsclCommandFailed => e
            ^^^^^^
lib/chef/provider/user/mac.rb:595:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource.rb:666:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource.rb:666:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
lib/chef/resource.rb:667:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          all_props[p.name.to_s] = p.sensitive? ? '"*sensitive value suppressed*"' : value_to_text(p.get(self))
      ^^^^
lib/chef/resource.rb:668:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 668, 8 is not aligned with self.class.state_properties.map do at 665, 6.
        rescue Chef::Exceptions::ValidationFailed
        ^^^^^^
lib/chef/resource.rb:669:11: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 10 instead of 8).
          # This space left intentionally blank, the property was probably required or had an invalid default.
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/chef/resource.rb:670:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource/chef_vault_secret.rb:76:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource/chef_vault_secret.rb:76:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
lib/chef/resource/chef_vault_secret.rb:77:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          item = ChefVault::Item.load(data_bag, id)
      ^^^^
lib/chef/resource/chef_vault_secret.rb:82:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 82, 8 is not aligned with load_current_value do at 75, 6.
        rescue ChefVault::Exceptions::SecretDecryption
        ^^^^^^
lib/chef/resource/chef_vault_secret.rb:84:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 84, 8 is not aligned with load_current_value do at 75, 6.
        rescue ChefVault::Exceptions::KeysNotFound
        ^^^^^^
lib/chef/resource/chef_vault_secret.rb:86:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 86, 8 is not aligned with load_current_value do at 75, 6.
        rescue Net::HTTPClientException => e
        ^^^^^^
lib/chef/resource/chef_vault_secret.rb:88:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource/sysctl.rb:131:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/resource/sysctl.rb:131:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
lib/chef/resource/sysctl.rb:132:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          value get_sysctl_value(key)
      ^^^^
lib/chef/resource/sysctl.rb:133:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 133, 8 is not aligned with load_current_value do at 130, 6.
        rescue
        ^^^^^^
lib/chef/resource/sysctl.rb:135:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/run_context/cookbook_compiler.rb:172:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/run_context/cookbook_compiler.rb:172:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/run_context/cookbook_compiler.rb:173:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            path = resolve_recipe(recipe)
        ^^^^
lib/chef/run_context/cookbook_compiler.rb:176:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 176, 10 is not aligned with run_list_expansion.recipes.each do at 171, 8.
          rescue Chef::Exceptions::RecipeNotFound => e
          ^^^^^^
lib/chef/run_context/cookbook_compiler.rb:179:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 179, 10 is not aligned with run_list_expansion.recipes.each do at 171, 8.
          rescue Exception => e
          ^^^^^^
lib/chef/run_context/cookbook_compiler.rb:182:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/run_context/cookbook_compiler.rb:234:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/run_context/cookbook_compiler.rb:234:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/run_context/cookbook_compiler.rb:235:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            logger.trace("Loading cookbook #{cookbook_name}'s library file: #{filename}")
        ^^^^
lib/chef/run_context/cookbook_compiler.rb:238:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 238, 10 is not aligned with each_file_in_cookbook_by_segment(cookbook_name, :libraries, globs) do at 233, 8.
          rescue Exception => e
          ^^^^^^
lib/chef/run_context/cookbook_compiler.rb:241:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/util/diff.rb:109:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/util/diff.rb:109:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
lib/chef/util/diff.rb:110:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            hunk = ::Diff::LCS::Hunk.new(old_data, new_data, piece, 3, file_length_difference)
        ^^^^
lib/chef/util/diff.rb:116:11: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 116, 10 is not aligned with diff_data.each do at 108, 8.
          ensure
          ^^^^^^
lib/chef/util/diff.rb:118:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/win32/file/version_info.rb:52:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
lib/chef/win32/file/version_info.rb:52:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
lib/chef/win32/file/version_info.rb:53:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              get_version_info_string(method.to_s)
          ^^^^
lib/chef/win32/file/version_info.rb:54:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 54, 12 is not aligned with define_method method do at 51, 10.
            rescue Chef::Exceptions::Win32APIError
            ^^^^^^
lib/chef/win32/file/version_info.rb:56:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/group_spec.rb:310:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/group_spec.rb:310:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/functional/resource/group_spec.rb:311:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        gid = rand(2000..9999) # avoid low group numbers
    ^^^^
spec/functional/resource/group_spec.rb:313:7: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 313, 6 is not aligned with loop do at 309, 4.
      rescue ArgumentError # group does not exist
      ^^^^^^
spec/functional/resource/group_spec.rb:315:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/link_spec.rb:58:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/link_spec.rb:58:5: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
    begin
    ^^^^^
spec/functional/resource/link_spec.rb:59:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
      cleanup_link(to) if File.exists?(to)
  ^^^^
spec/functional/resource/link_spec.rb:62:5: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 62, 4 is not aligned with after(:each) do at 57, 2.
    rescue
    ^^^^^^
spec/functional/resource/link_spec.rb:64:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/powershell_script_spec.rb:276:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/resource/powershell_script_spec.rb:276:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/functional/resource/powershell_script_spec.rb:277:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          expect(resource.architecture(:x86_64)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
      ^^^^
spec/functional/resource/powershell_script_spec.rb:278:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 278, 8 is not aligned with it "raises an exception if :x86_64 process architecture is specified" do at 275, 6.
        rescue Chef::Exceptions::Win32ArchitectureIncorrect
        ^^^^^^
spec/functional/resource/powershell_script_spec.rb:279:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/run_lock_spec.rb:64:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/run_lock_spec.rb:64:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/functional/run_lock_spec.rb:65:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        p1.stop
    ^^^^
spec/functional/run_lock_spec.rb:67:7: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 67, 6 is not aligned with after(:each) do at 63, 4.
      rescue
      ^^^^^^
spec/functional/run_lock_spec.rb:70:7: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 70, 6 is not aligned with after(:each) do at 63, 4.
      ensure
      ^^^^^^
spec/functional/run_lock_spec.rb:74:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/run_lock_spec.rb:448:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/run_lock_spec.rb:448:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/functional/run_lock_spec.rb:449:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          Timeout.timeout(CLIENT_PROCESS_TIMEOUT) do
      ^^^^
spec/functional/run_lock_spec.rb:459:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 459, 8 is not aligned with @pid at 447, 6.
        rescue
        ^^^^^^
spec/functional/run_lock_spec.rb:462:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/win32/registry_spec.rb:270:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/win32/registry_spec.rb:270:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/functional/win32/registry_spec.rb:271:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          reg.delete_key("Trunk", true)
      ^^^^
spec/functional/win32/registry_spec.rb:272:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 272, 8 is not aligned with ::Win32::Registry::HKEY_CURRENT_USER.open("Software\\Root") do at 269, 6.
        rescue
        ^^^^^^
spec/functional/win32/registry_spec.rb:273:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/win32/registry_spec.rb:365:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/functional/win32/registry_spec.rb:365:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/functional/win32/registry_spec.rb:366:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          reg.delete_key("Red", true)
      ^^^^
spec/functional/win32/registry_spec.rb:367:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 367, 8 is not aligned with ::Win32::Registry::HKEY_CURRENT_USER.open("Software\\Root\\Trunk") do at 364, 6.
        rescue
        ^^^^^^
spec/functional/win32/registry_spec.rb:368:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/common_options_spec.rb:128:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/common_options_spec.rb:128:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/integration/knife/common_options_spec.rb:129:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          @server = ChefZero::Server.new(host: "localhost", port: 8889)
      ^^^^
spec/integration/knife/common_options_spec.rb:131:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 131, 8 is not aligned with before :each do at 127, 6.
        rescue Errno::EADDRINUSE
        ^^^^^^
spec/integration/knife/common_options_spec.rb:132:11: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 10 instead of 8).
          # OK.  Don't care who has it in use, as long as *someone* does.
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/integration/knife/common_options_spec.rb:133:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/common_options_spec.rb:147:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/common_options_spec.rb:147:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/integration/knife/common_options_spec.rb:148:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          @server = ChefZero::Server.new(host: "localhost", port: 9999)
      ^^^^
spec/integration/knife/common_options_spec.rb:150:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 150, 8 is not aligned with before :each do at 146, 6.
        rescue Errno::EADDRINUSE
        ^^^^^^
spec/integration/knife/common_options_spec.rb:151:11: C: [Corrected] Layout/CommentIndentation: Incorrect indentation detected (column 10 instead of 8).
          # OK.  Don't care who has it in use, as long as *someone* does.
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/integration/knife/common_options_spec.rb:152:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/serve_spec.rb:29:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/integration/knife/serve_spec.rb:29:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/integration/knife/serve_spec.rb:30:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        knife("serve --chef-zero-port=8890")
    ^^^^
spec/integration/knife/serve_spec.rb:31:7: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 31, 6 is not aligned with t at 28, 4.
      rescue
      ^^^^^^
spec/integration/knife/serve_spec.rb:33:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/spec_helper.rb:300:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/spec_helper.rb:300:5: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
    begin
    ^^^^^
spec/spec_helper.rb:301:3: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
      ex.run
  ^^^^
spec/spec_helper.rb:302:5: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 302, 4 is not aligned with config.around(:example) do at 299, 2.
    rescue SystemExit => e
    ^^^^^^
spec/spec_helper.rb:304:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:479:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:479:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
spec/support/shared/functional/file_resource.rb:480:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            Chef::Config[:why_run] = true
        ^^^^
spec/support/shared/functional/file_resource.rb:482:11: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 482, 10 is not aligned with it "issues a warning/assumption in whyrun mode" do at 478, 8.
          ensure
          ^^^^^^
spec/support/shared/functional/file_resource.rb:484:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:507:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:507:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
spec/support/shared/functional/file_resource.rb:508:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            Chef::Config[:why_run] = true
        ^^^^
spec/support/shared/functional/file_resource.rb:510:11: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 510, 10 is not aligned with it "issues a warning/assumption in whyrun mode" do at 506, 8.
          ensure
          ^^^^^^
spec/support/shared/functional/file_resource.rb:512:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:538:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/support/shared/functional/file_resource.rb:538:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
spec/support/shared/functional/file_resource.rb:539:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            Chef::Config[:why_run] = true
        ^^^^
spec/support/shared/functional/file_resource.rb:541:11: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 541, 10 is not aligned with it "issues a warning/assumption in whyrun mode" do at 537, 8.
          ensure
          ^^^^^^
spec/support/shared/functional/file_resource.rb:543:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:107:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:107:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/unit/mixin/template_spec.rb:108:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        tf = Tempfile.new("partial")
    ^^^^
spec/unit/mixin/template_spec.rb:114:7: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 114, 6 is not aligned with it "should render local files" do at 106, 4.
      ensure
      ^^^^^^
spec/unit/mixin/template_spec.rb:116:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:127:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:127:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/unit/mixin/template_spec.rb:128:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        tf = Tempfile.new("partial")
    ^^^^
spec/unit/mixin/template_spec.rb:134:7: C: [Corrected] Layout/RescueEnsureAlignment: ensure at 134, 6 is not aligned with it "should render using the source argument if provided" do at 126, 4.
      ensure
      ^^^^^^
spec/unit/mixin/template_spec.rb:136:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:198:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:198:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
spec/unit/mixin/template_spec.rb:199:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            do_raise
        ^^^^
spec/unit/mixin/template_spec.rb:200:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 200, 10 is not aligned with subject(:exception) do at 197, 8.
          rescue Chef::Mixin::Template::TemplateError => e
          ^^^^^^
spec/unit/mixin/template_spec.rb:202:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:277:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/template_spec.rb:277:9: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
        begin
        ^^^^^
spec/unit/mixin/template_spec.rb:278:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          do_raise
      ^^^^
spec/unit/mixin/template_spec.rb:279:9: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 279, 8 is not aligned with before :each do at 276, 6.
        rescue Chef::Mixin::Template::TemplateError => e
        ^^^^^^
spec/unit/mixin/template_spec.rb:281:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/windows_architecture_helper_spec.rb:53:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/mixin/windows_architecture_helper_spec.rb:53:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/unit/mixin/windows_architecture_helper_spec.rb:54:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        expect(assert_valid_windows_architecture!(architecture)).to raise_error Chef::Exceptions::Win32ArchitectureIncorrect
    ^^^^
spec/unit/mixin/windows_architecture_helper_spec.rb:55:7: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 55, 6 is not aligned with @invalid_architectures.each do at 52, 4.
      rescue Chef::Exceptions::Win32ArchitectureIncorrect
      ^^^^^^
spec/unit/mixin/windows_architecture_helper_spec.rb:56:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/node_spec.rb:1776:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/node_spec.rb:1776:13: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
            begin
            ^^^^^
spec/unit/node_spec.rb:1777:11: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
              response.error!
          ^^^^
spec/unit/node_spec.rb:1778:13: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 1778, 12 is not aligned with let(:http_exception) do at 1775, 10.
            rescue => e
            ^^^^^^
spec/unit/node_spec.rb:1780:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/provider/remote_directory_spec.rb:204:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/provider/remote_directory_spec.rb:204:11: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
          begin
          ^^^^^
spec/unit/provider/remote_directory_spec.rb:205:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
            @fclass.file_class.symlink(tmp_dir.dup, symlinked_dir_path)
        ^^^^
spec/unit/provider/remote_directory_spec.rb:212:11: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 212, 10 is not aligned with Dir.mktmpdir do at 203, 8.
          rescue Chef::Exceptions::Win32APIError
          ^^^^^^
spec/unit/provider/remote_directory_spec.rb:214:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/provider_resolver_spec.rb:57:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
spec/unit/provider_resolver_spec.rb:57:7: C: [Corrected] Style/RedundantBegin: Redundant begin block detected.
      begin
      ^^^^^
spec/unit/provider_resolver_spec.rb:58:5: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
        resource ? resource.provider_for_action(action).class : nil
    ^^^^
spec/unit/provider_resolver_spec.rb:59:7: C: [Corrected] Layout/RescueEnsureAlignment: rescue at 59, 6 is not aligned with let(:resolved_provider) do at 56, 4.
      rescue Chef::Exceptions::ProviderNotFound
      ^^^^^^
spec/unit/provider_resolver_spec.rb:61:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.

1783 files inspected, 306 offenses detected, 306 offenses corrected
```

Signed-off-by: Tim Smith <tsmith@chef.io>