### PR TITLE
Remove unnecessary Mixin::ShellOut in providers

### DIFF
--- a/lib/chef/provider/cron/unix.rb
+++ b/lib/chef/provider/cron/unix.rb
@@ -26,8 +26,6 @@ class Chef
   class Provider
     class Cron
       class Unix < Chef::Provider::Cron
-        include Chef::Mixin::ShellOut
-
         provides :cron, os: "solaris2"
 
         private

--- a/lib/chef/provider/group.rb
+++ b/lib/chef/provider/group.rb
@@ -17,13 +17,11 @@
 #
 
 require_relative "../provider"
-require_relative "../mixin/shell_out"
 require "etc" unless defined?(Etc)
 
 class Chef
   class Provider
     class Group < Chef::Provider
-      include Chef::Mixin::ShellOut
       attr_accessor :group_exists
       attr_accessor :change_desc
 

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -17,7 +17,6 @@
 #
 
 require_relative "../log"
-require_relative "../mixin/shell_out"
 require_relative "../provider"
 require_relative "../resource/file"
 require_relative "../exceptions"
@@ -33,8 +32,6 @@ class Chef
     #   end
     class Ifconfig < Chef::Provider
       provides :ifconfig
-
-      include Chef::Mixin::ShellOut
 
       attr_accessor :config_template
       attr_accessor :config_path

--- a/lib/chef/provider/mount.rb
+++ b/lib/chef/provider/mount.rb
@@ -18,13 +18,11 @@
 #
 
 require_relative "../log"
-require_relative "../mixin/shell_out"
 require_relative "../provider"
 
 class Chef
   class Provider
     class Mount < Chef::Provider
-      include Chef::Mixin::ShellOut
 
       attr_accessor :unmount_retries
 

--- a/lib/chef/provider/package.rb
+++ b/lib/chef/provider/package.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require_relative "../mixin/shell_out"
 require_relative "../mixin/subclass_directive"
 require_relative "../log"
 require_relative "../file_cache"
@@ -27,7 +26,6 @@ require "shellwords" unless defined?(Shellwords)
 class Chef
   class Provider
     class Package < Chef::Provider
-      include Chef::Mixin::ShellOut
       extend Chef::Mixin::SubclassDirective
 
       # subclasses declare this if they want all their arguments as arrays of packages and names

--- a/lib/chef/provider/service/openbsd.rb
+++ b/lib/chef/provider/service/openbsd.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require_relative "../../mixin/shell_out"
 require_relative "init"
 require_relative "../../resource/service"
 
@@ -26,8 +25,6 @@ class Chef
       class Openbsd < Chef::Provider::Service::Init
 
         provides :service, os: "openbsd"
-
-        include Chef::Mixin::ShellOut
 
         attr_reader :init_command, :rc_conf, :rc_conf_local, :enabled_state_found
 

--- a/lib/chef/provider/systemd_unit.rb
+++ b/lib/chef/provider/systemd_unit.rb
@@ -18,7 +18,6 @@
 
 require_relative "../provider"
 require_relative "../mixin/which"
-require_relative "../mixin/shell_out"
 require_relative "../resource/file"
 require_relative "../resource/file/verification/systemd_unit"
 require "iniparse"
@@ -28,7 +27,6 @@ class Chef
   class Provider
     class SystemdUnit < Chef::Provider
       include Chef::Mixin::Which
-      include Chef::Mixin::ShellOut
 
       provides :systemd_unit
 

--- a/lib/chef/provider/windows_task.rb
+++ b/lib/chef/provider/windows_task.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-require_relative "../mixin/shell_out"
 require "rexml/document" unless defined?(REXML::Document)
 require "iso8601" if ChefUtils.windows?
 require_relative "../provider"
@@ -26,8 +25,6 @@ require "win32/taskscheduler" if ChefUtils.windows?
 class Chef
   class Provider
     class WindowsTask < Chef::Provider
-      include Chef::Mixin::ShellOut
-
       if ChefUtils.windows?
         include Win32
 


### PR DESCRIPTION
No need for this in the providers.

Signed-off-by: Tim Smith <tsmith@chef.io>