### PR TITLE
Update spellcheck config with nice stuff from other repos.

### DIFF
--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -16,17 +16,19 @@
 #
 
 namespace :spellcheck do
-  task :fetch_common do
-    sh "wget -q https://raw.githubusercontent.com/chef/chef_dictionary/master/chef.txt -O chef_dictionary.txt"
-  end
-
-  task run: %i{config_check fetch_common} do
+  task run: :prereqs do
     sh 'cspell "**/*"'
   end
 
   desc "List the unique unrecognized words in the project."
-  task unknown_words: %i{config_check fetch_common} do
+  task unknown_words: :prereqs do
     sh 'cspell "**/*" --wordsOnly --no-summary | sort | uniq'
+  end
+
+  task prereqs: %i{cspell_check config_check fetch_common}
+
+  task :fetch_common do
+    sh "wget -q https://raw.githubusercontent.com/chef/chef_dictionary/master/chef.txt -O chef_dictionary.txt"
   end
 
   task :config_check do
@@ -41,6 +43,14 @@ namespace :spellcheck do
     unless (JSON.parse(File.read(config_file)) rescue false)
       abort "Failed to parse config file '#{config_file}', skipping spellcheck"
     end
+  end
+
+  task :cspell_check do
+    require 'chef-utils'
+    ChefUtils.which('cspell') || abort(<<~INSTALL_CSPELL)
+          cspell is needed to run the spellcheck tasks. Run `npm install -g cspell` to install.
+          For more information: https://www.npmjs.com/package/cspell
+    INSTALL_CSPELL
   end
 end
 

--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -46,8 +46,8 @@ namespace :spellcheck do
   end
 
   task :cspell_check do
-    require "chef-utils"
-    ChefUtils.which("cspell") || abort(<<~INSTALL_CSPELL)
+    require "bundler"
+    Bundler.which("cspell") || abort(<<~INSTALL_CSPELL)
           cspell is needed to run the spellcheck tasks. Run `npm install -g cspell` to install.
           For more information: https://www.npmjs.com/package/cspell
     INSTALL_CSPELL

--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -46,8 +46,8 @@ namespace :spellcheck do
   end
 
   task :cspell_check do
-    require 'chef-utils'
-    ChefUtils.which('cspell') || abort(<<~INSTALL_CSPELL)
+    require "chef-utils"
+    ChefUtils.which("cspell") || abort(<<~INSTALL_CSPELL)
           cspell is needed to run the spellcheck tasks. Run `npm install -g cspell` to install.
           For more information: https://www.npmjs.com/package/cspell
     INSTALL_CSPELL


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Gives a nicer error message when cspell is not installed:

```
Petes-MBP:chef pete$ npm uninstall -g cspell
removed 87 packages in 0.617s
Petes-MBP:chef pete$ rake spellcheck
cspell is needed to run the spellcheck tasks. Run `npm install -g cspell` to install.
For more information: https://www.npmjs.com/package/cspell
```