### PR TITLE
Remove lzma and bzip binaries from our builds

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 399369c70d19eaf3ee035da1e4a14bd79b21381d
+  revision: e1c3d2839fe49e732aaf9edc8ebf708f12846ff3
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.350.0)
+    aws-partitions (1.351.0)
     aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)


### PR DESCRIPTION
We don't need these.

Signed-off-by: Tim Smith <tsmith@chef.io>