### PR TITLE
Speed up our bundle installs by always running 3 jobs

### DIFF
--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -80,7 +80,7 @@ function Invoke-Build {
         $env:_BUNDER_WINDOWS_DLLS_COPIED = "1"
 
         Write-BuildLine " ** Using bundler to retrieve the Ruby dependencies"
-        bundle install
+        bundle install --jobs=3 --retry=3
         if (-not $?) { throw "unable to install gem dependencies" }
         Write-BuildLine " ** 'rake install' any gem sourced as a git reference so they'll look like regular gems."
         foreach($git_gem in (Get-ChildItem "$env:GEM_HOME/bundler/gems")) {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -93,7 +93,7 @@ do_prepare() {
 do_build() {
   ( cd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
     build_line "Installing gem dependencies ..."
-    bundle install
+    bundle install --jobs=3 --retry=3
     build_line "Installing this project's gems ..."
     bundle exec rake install
     for gem in $GEM_HOME/bundler/gems/*; do

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -156,6 +156,6 @@ fi
 CHEF_LICENSE=accept-no-persist
 
 cd "$chef_gem"
-sudo -E bundle install
+sudo -E bundle install --jobs=3 --retry=3
 # FIXME: we need to add back unit and integration tests here.  we have no coverage of those on e.g. AIX
 sudo -E bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f documentation spec/functional

--- a/tasks/bin/run_external_test
+++ b/tasks/bin/run_external_test
@@ -32,7 +32,7 @@ Dir.mktmpdir("chef-external-test") do |dir|
   Dir.chdir(dir) do
     shell_out!("git checkout #{git_thing}", live_stream: STDOUT)
     Bundler.with_unbundled_env do
-      shell_out!("bundle install", live_stream: STDOUT, env: env)
+      shell_out!("bundle install --jobs=3 --retry=3", live_stream: STDOUT, env: env)
       shell_out!("bundle exec #{ARGV.join(" ")}", live_stream: STDOUT, env: env)
     end
   end

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -30,7 +30,7 @@ begin
     %w{chef-utils chef-config}.each do |gem|
       Dir.chdir(gem) do
         Bundler.with_unbundled_env do
-          sh("bundle install")
+          sh("bundle install --jobs=3 --retry=3")
           sh("bundle exec rake spec")
         end
       end


### PR DESCRIPTION
multi-job bundle install is the default in the next release, but for now
we should make sure we set it everywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>