### PR TITLE
chef_client_systemd_timer: Fix failures in the :remove action

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/linux.rb
@@ -102,6 +102,10 @@ chef_client_systemd_timer "Run chef-client as a systemd timer" do
   only_if { systemd? }
 end
 
+chef_client_systemd_timer "a timer that does not exist" do
+  action :remove
+end
+
 locale "set system locale" do
   lang "en_US.UTF-8"
   only_if { debian? }

--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -112,11 +112,11 @@ class Chef
 
       action :remove do
         systemd_unit "#{new_resource.job_name}.service" do
-          action :remove
+          action :delete
         end
 
         systemd_unit "#{new_resource.job_name}.timer" do
-          action :remove
+          action :delete
         end
       end
 


### PR DESCRIPTION
Get the actual systemd action right. Add a kitchen test for this as well.

Signed-off-by: Tim Smith <tsmith@chef.io>