### PR TITLE
powershell_script: Use native properties and don't coerce user provided flags with powershell defaults

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -509,7 +509,6 @@ class Chef
       def initialize(name, run_context = nil)
         super
         @command = name
-        @backup = 5
         @default_guard_interpreter = :execute
         @is_guard_interpreter = false
       end

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -25,19 +25,7 @@ class Chef
       provides :powershell_script, os: "windows"
 
       property :flags, String,
-        description: "A string that is passed to the Windows PowerShell command",
-        default: lazy { default_flags },
-        coerce: proc { |input|
-          if input == default_flags
-            # Means there was no input provided,
-            # and should use defaults in this case
-            input
-          else
-            # The last occurrence of a flag would override its
-            # previous one at the time of command execution.
-            [default_flags, input].join(" ")
-          end
-        }
+        description: "A string that is passed to the Windows PowerShell command"
 
       property :convert_boolean_return, [true, false],
         default: false,
@@ -87,15 +75,6 @@ class Chef
       # same behavior.
       def self.get_default_attributes(opts)
         { convert_boolean_return: true }
-      end
-
-      # Options that will be passed to Windows PowerShell command
-      #
-      # @returns [String]
-      def default_flags
-        # Set InputFormat to None as PowerShell will hang if STDIN is redirected
-        # http://connect.microsoft.com/PowerShell/feedback/details/572313/powershell-exe-can-hang-if-stdin-is-redirected
-        "-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None"
       end
     end
   end

--- a/lib/chef/resource/powershell_script.rb
+++ b/lib/chef/resource/powershell_script.rb
@@ -39,6 +39,30 @@ class Chef
           end
         }
 
+      property :convert_boolean_return, [true, false],
+        default: false,
+        description: <<~DESC
+          Return `0` if the last line of a command is evaluated to be true or to return `1` if the last line is evaluated to be false.
+
+          When the `guard_interpreter` common attribute is set to `:powershell_script`, a string command will be evaluated as if this value were set to `true`. This is because the behavior of this attribute is similar to the value of the `"$?"` expression common in UNIX interpreters. For example, this:
+
+          ```ruby
+          powershell_script 'make_safe_backup' do
+            guard_interpreter :powershell_script
+            code 'cp ~/data/nodes.json ~/data/nodes.bak'
+            not_if 'test-path ~/data/nodes.bak'
+          end
+          ```
+
+          is similar to:
+          ```ruby
+          bash 'make_safe_backup' do
+            code 'cp ~/data/nodes.json ~/data/nodes.bak'
+            not_if 'test -e ~/data/nodes.bak'
+          end
+          ```
+        DESC
+
       description "Use the **powershell_script** resource to execute a script using the Windows PowerShell"\
                   " interpreter, much like how the script and script-based resources—bash, csh, perl, python,"\
                   " and ruby—are used. The powershell_script is specific to the Microsoft Windows platform"\
@@ -52,15 +76,6 @@ class Chef
         super
         @interpreter = "powershell.exe"
         @default_guard_interpreter = resource_name
-        @convert_boolean_return = false
-      end
-
-      def convert_boolean_return(arg = nil)
-        set_or_return(
-          :convert_boolean_return,
-          arg,
-          kind_of: [ FalseClass, TrueClass ]
-        )
       end
 
       # Allow callers evaluating guards to request default

--- a/spec/unit/provider/powershell_script_spec.rb
+++ b/spec/unit/provider/powershell_script_spec.rb
@@ -30,14 +30,20 @@ describe Chef::Provider::PowershellScript, "action_run" do
     Chef::Provider::PowershellScript.new(new_resource, run_context)
   end
 
-  context "when setting interpreter flags" do
+  describe "#command" do
     before(:each) do
-      allow(provider).to receive(:basepath).and_return("C:\\Windows\\system32")
+      allow(provider).to receive(:basepath).and_return("C:/Windows/system32")
     end
 
-    it "sets the -File flag as the last flag" do
-      flags = provider.command.split(" ").keep_if { |flag| flag =~ /^-/ }
-      expect(flags.pop).to eq("-File")
+    it "includes the user's flags after the default flags when building the command" do
+      new_resource.flags = "-InputFormat Fabulous"
+      provider.send(:script_file_path=, "C:/Temp/Script.ps1")
+
+      expected = <<~CMD.strip
+        "C:/Windows/system32/WindowsPowerShell/v1.0/powershell.exe" -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -InputFormat None -InputFormat Fabulous -File "C:/Temp/Script.ps1"
+      CMD
+
+      expect(provider.command).to eq(expected)
     end
   end
 end

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -130,24 +130,7 @@ describe Chef::Resource::PowershellScript do
     let(:resource_instance_name ) { @resource.command }
     let(:resource_name) { :powershell_script }
     let(:interpreter_file_name) { "powershell.exe" }
-    before do
-      allow(@resource).to receive(:default_flags).and_return(nil)
-    end
+
     it_behaves_like "a Windows script resource"
-  end
-
-  describe "#flags" do
-    let(:resource) { @resource }
-
-    it "appends user's flags to the defaults" do
-      flags = %q{-Lunch "tacos"}
-      resource.flags = flags
-
-      expect(resource.flags).to eq("#{resource.default_flags} #{flags}")
-    end
-
-    it "uses the defaults when user doesn't provide flags" do
-      expect(resource.flags).to eq(resource.default_flags)
-    end
   end
 end


### PR DESCRIPTION
Some code I had sitting in a local branch. If I remember right this was part of a bigger change that I abandoned and I forgot to PR the remainder.