### PR TITLE
mixin/deep_merge: add support for optionally overwriting leaf hashes

### DIFF
--- a/lib/chef/mixin/deep_merge.rb
+++ b/lib/chef/mixin/deep_merge.rb
@@ -101,12 +101,24 @@ class Chef
       # `merge_onto` is the object that will "lose" in case of conflict.
       # `merge_with` is the object whose values will replace `merge_onto`s
       # values when there is a conflict.
-      def hash_only_merge!(merge_onto, merge_with)
+      # `overwrite_leaves` is a boolean to control whether Hash leaf objects
+      # in `merge_onto` will be overwritten (if set to true) or merged (if
+      # set to false, which is the default).
+      def hash_only_merge!(merge_onto, merge_with, overwrite_leaves = false)
         # If there are two Hashes, recursively merge.
         if merge_onto.is_a?(Hash) && merge_with.is_a?(Hash)
           merge_with.each do |key, merge_with_value|
+            is_leaf = false
+            if overwrite_leaves && merge_with_value.is_a?(Hash)
+              merge_with_value.each do |_k, v|
+                if v.is_a?(Hash)
+                  is_leaf = true
+                  break
+                end
+              end
+            end
             value =
-              if merge_onto.key?(key)
+              if merge_onto.key?(key) && !is_leaf
                 hash_only_merge(merge_onto[key], merge_with_value)
               else
                 merge_with_value

--- a/spec/unit/mixin/deep_merge_spec.rb
+++ b/spec/unit/mixin/deep_merge_spec.rb
@@ -338,5 +338,23 @@ describe Chef::Mixin::DeepMerge do
       merge_with_hash = { "top_level_a" => 2, "top_level_b" => true }
       @dm.hash_only_merge(merge_ee_hash, merge_with_hash)
     end
+
+    it "merges leaf Hashes by default" do
+      merge_ee_hash =   { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_a" => "foo" } } } }
+      merge_with_hash = { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_b" => "bar" } } } }
+
+      merged_result = @dm.hash_only_merge!(merge_ee_hash, merge_with_hash)
+
+      expect(merged_result).to eq({ "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_a" => "foo", "3_deep_b" => "bar" } } } })
+    end
+
+    it "overwrites leaf Hashes if requested" do
+      merge_ee_hash =   { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_a" => "foo" } } } }
+      merge_with_hash = { "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_b" => "bar" } } } }
+
+      merged_result = @dm.hash_only_merge!(merge_ee_hash, merge_with_hash, true)
+
+      expect(merged_result).to eq({ "top_level_a" => { "1_deep_a" => { "2_deep_a" => { "3_deep_b" => "bar" } } } })
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
By default `hash_only_merge!` will merge contents of all Hash objects recursively. I have a usecase that requires overwriting (and not merging) leaf Hash objects in a library, and I figured it would be better to extend this method rather than reimplementing it poorly or duplicating. This PR keeps the current behavior as the default and should be a noop for existing callers. My implementation is likely suboptimal, if you have suggestions for how to better implement this I'm all ears.=

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).