### PR TITLE
Clean up some interdependencies in script resource tests.

### DIFF
--- a/spec/support/shared/unit/script_resource.rb
+++ b/spec/support/shared/unit/script_resource.rb
@@ -47,21 +47,6 @@ shared_examples_for "a script resource" do
   end
 
   describe "when executing guards" do
-    let(:resource) do
-      resource = script_resource
-      resource.run_context = run_context
-      resource.code "echo hi"
-      resource
-    end
-    let(:node) do
-      node = Chef::Node.new
-      node.automatic[:platform] = "debian"
-      node.automatic[:platform_version] = "6.0"
-      node
-    end
-    let(:events) { Chef::EventDispatch::Dispatcher.new }
-    let(:run_context) { Chef::RunContext.new(node, {}, events) }
-
     it "inherits exactly the :cwd, :environment, :group, :path, :user, and :umask attributes from a parent resource class" do
       inherited_difference = Chef::Resource::Script.guard_inherited_attributes -
         %i{cwd environment group path user umask}
@@ -73,16 +58,17 @@ shared_examples_for "a script resource" do
       expect_any_instance_of(Chef::Resource::Conditional).not_to receive(:evaluate_block)
       expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).not_to receive(:evaluate_action)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).to receive(:evaluate).and_return(true)
-      resource.only_if "echo hi"
-      expect(resource.should_skip?(:run)).to eq(nil)
+      script_resource.only_if "echo hi"
+      expect(script_resource.should_skip?(:run)).to eq(nil)
     end
 
     it "when a valid guard_interpreter resource is specified, a block should be used to evaluate the guard" do
+      expect_any_instance_of(Chef::Resource::Conditional).not_to receive(:evaluate_block)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).not_to receive(:evaluate)
       expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
-      resource.guard_interpreter :script
-      resource.only_if "echo hi"
-      expect(resource.should_skip?(:run)).to eq(nil)
+      script_resource.guard_interpreter :script
+      script_resource.only_if "echo hi"
+      expect(script_resource.should_skip?(:run)).to eq(nil)
     end
   end
 end

--- a/spec/support/shared/unit/windows_script_resource.rb
+++ b/spec/support/shared/unit/windows_script_resource.rb
@@ -20,59 +20,46 @@ require "support/shared/unit/execute_resource"
 require "support/shared/unit/script_resource"
 
 shared_examples_for "a Windows script resource" do
-  before(:each) do
-    node = Chef::Node.new
-
-    node.default["kernel"] = {}
-    node.default["kernel"][:machine] = :x86_64.to_s
-
-    run_context = Chef::RunContext.new(node, nil, nil)
-
-    @resource = resource_instance
-
-  end
-
   it "should be a kind of Chef::Resource::WindowsScript" do
-    expect(@resource).to be_a_kind_of(Chef::Resource)
-    expect(@resource).to be_a_kind_of(Chef::Resource::WindowsScript)
+    expect(windows_script_resource).to be_a_kind_of(Chef::Resource)
+    expect(windows_script_resource).to be_a_kind_of(Chef::Resource::WindowsScript)
   end
 
   context "when evaluating guards" do
     it "should have a default_guard_interpreter attribute that is the same as the resource" do
-      expect(@resource.default_guard_interpreter).to eq(@resource.resource_name)
+      expect(windows_script_resource.default_guard_interpreter).to eq(windows_script_resource.resource_name)
     end
 
     it "should default to using guard_interpreter attribute that is the same as the resource" do
-      expect(@resource.guard_interpreter).to eq(@resource.resource_name)
+      expect(windows_script_resource.guard_interpreter).to eq(windows_script_resource.resource_name)
     end
 
     it "should use a resource to evaluate the guard when guard_interpreter is not specified" do
       expect_any_instance_of(Chef::GuardInterpreter::ResourceGuardInterpreter).to receive(:evaluate_action).and_return(true)
       expect_any_instance_of(Chef::GuardInterpreter::DefaultGuardInterpreter).not_to receive(:evaluate)
-      @resource.only_if "echo hi"
-      expect(@resource.should_skip?(:run)).to eq(nil)
+      windows_script_resource.only_if "echo hi"
+      expect(windows_script_resource.should_skip?(:run)).to eq(nil)
     end
 
     describe "when the guard is given a ruby block" do
       it "should evaluate the guard if the guard_interpreter is set to its default value" do
-        @resource.only_if { true }
-        expect(@resource.should_skip?(:run)).to eq(nil)
+        windows_script_resource.only_if { true }
+        expect(windows_script_resource.should_skip?(:run)).to eq(nil)
       end
 
       it "should raise an exception if the guard_interpreter is overridden from its default value" do
-        @resource.guard_interpreter :bash
-        @resource.only_if { true }
-        expect { @resource.should_skip?(:run) }.to raise_error(ArgumentError)
+        windows_script_resource.guard_interpreter :bash
+        windows_script_resource.only_if { true }
+        expect { windows_script_resource.should_skip?(:run) }.to raise_error(ArgumentError)
       end
     end
   end
 
   context "script with a default guard interpreter" do
-    let(:script_resource) do
-      resource_instance.guard_interpreter :default
-      resource_instance
-    end
+    let(:script_resource) { windows_script_resource }
+
+    before { windows_script_resource.guard_interpreter :default }
+
     it_should_behave_like "a script resource"
   end
-
 end

--- a/spec/unit/resource/batch_spec.rb
+++ b/spec/unit/resource/batch_spec.rb
@@ -19,24 +19,24 @@
 require "spec_helper"
 
 describe Chef::Resource::Batch do
-  let(:node) { Chef::Node.new }
 
-  before(:each) do
+  let(:resource) do
+    node = Chef::Node.new
     node.default["kernel"] = {}
     node.default["kernel"][:machine] = :x86_64.to_s
     node.automatic[:os] = "windows"
 
     run_context = Chef::RunContext.new(node, nil, nil)
-    @resource = Chef::Resource::Batch.new("batch_unit_test", run_context)
+    Chef::Resource::Batch.new("batch_unit_test", run_context)
   end
 
   it "creates a new Chef::Resource::Batch" do
-    expect(@resource).to be_a_kind_of(Chef::Resource::Batch)
+    expect(resource).to be_a_kind_of(Chef::Resource::Batch)
   end
 
   context "windows script" do
-    let(:resource_instance) { @resource }
-    let(:resource_instance_name ) { @resource.command }
+    let(:windows_script_resource) { resource }
+    let(:resource_instance_name ) { resource.command }
     let(:resource_name) { :batch }
     let(:interpreter_file_name) { "cmd.exe" }
 

--- a/spec/unit/resource/powershell_script_spec.rb
+++ b/spec/unit/resource/powershell_script_spec.rb
@@ -20,7 +20,7 @@ require "spec_helper"
 
 describe Chef::Resource::PowershellScript do
 
-  before(:each) do
+  let(:resource) do
     node = Chef::Node.new
 
     node.default["kernel"] = {}
@@ -29,26 +29,25 @@ describe Chef::Resource::PowershellScript do
 
     run_context = Chef::RunContext.new(node, nil, nil)
 
-    @resource = Chef::Resource::PowershellScript.new("powershell_unit_test", run_context)
+    Chef::Resource::PowershellScript.new("powershell_unit_test", run_context)
   end
 
   it "creates a new Chef::Resource::PowershellScript" do
-    expect(@resource).to be_a_kind_of(Chef::Resource::PowershellScript)
+    expect(resource).to be_a_kind_of(Chef::Resource::PowershellScript)
   end
 
   it "sets convert_boolean_return to false by default" do
-    expect(@resource.convert_boolean_return).to eq(false)
+    expect(resource.convert_boolean_return).to eq(false)
   end
 
   it "returns the value for convert_boolean_return that was set" do
-    @resource.convert_boolean_return true
-    expect(@resource.convert_boolean_return).to eq(true)
-    @resource.convert_boolean_return false
-    expect(@resource.convert_boolean_return).to eq(false)
+    resource.convert_boolean_return true
+    expect(resource.convert_boolean_return).to eq(true)
+    resource.convert_boolean_return false
+    expect(resource.convert_boolean_return).to eq(false)
   end
 
   context "when using guards" do
-    let(:resource) { @resource }
     before(:each) do
       allow(resource).to receive(:run_action)
       allow(resource).to receive(:updated).and_return(true)
@@ -126,8 +125,8 @@ describe Chef::Resource::PowershellScript do
   end
 
   context "as a script running in Windows-based scripting language" do
-    let(:resource_instance) { @resource }
-    let(:resource_instance_name ) { @resource.command }
+    let(:windows_script_resource) { resource }
+    let(:resource_instance_name ) { resource.command }
     let(:resource_name) { :powershell_script }
     let(:interpreter_file_name) { "powershell.exe" }
 

--- a/spec/unit/resource/script_spec.rb
+++ b/spec/unit/resource/script_spec.rb
@@ -21,8 +21,13 @@ require "spec_helper"
 
 describe Chef::Resource::Script do
   let(:resource_instance_name) { "fakey_fakerton" }
-  let(:script_resource) { Chef::Resource::Script.new(resource_instance_name) }
   let(:resource_name) { :script }
+
+  let(:script_resource) do
+    run_context = Chef::RunContext.new(Chef::Node.new, nil, nil)
+
+    Chef::Resource::Script.new(resource_instance_name, run_context)
+  end
 
   it "sets the default action as :run" do
     expect(script_resource.action).to eql([:run])


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Followup to #10274. In these tests it is easy to introduce a recursive `let` reference because of all the shared context indirection going on. The big changes are to stop using instance variables and to use more specific variable names in the shared contexts.