### PR TITLE
double quotes in example for string interpolation

### DIFF
--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -161,11 +161,11 @@ class Chef
 
         ```ruby
         execute 'test_rule' do
-          command 'command_to_run
+          command "command_to_run
             --option value
             --option value
             --source \#{node[:name_of_node][:ipsec][:local][:subnet]}
-            -j test_rule'
+            -j test_rule"
 
           action :nothing
         end


### PR DESCRIPTION
In the example on line 163,
```
execute 'test_rule' do
          command 'command_to_run
            --option value
            --option value
            --source #{node[:name_of_node][:ipsec][:local][:subnet]}
            -j test_rule'
          action :nothing
        end
```

that example command would not run correctly because the variable #{node{node[:name_of_node][:ipsec][:local][:subnet]}
would not be evaluated.  

changing to double quotes fixes the example.  

Obvious fix.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
