### PR TITLE
Minor tweaks to the platform checks in the specs

### DIFF
--- a/spec/functional/resource/link_spec.rb
+++ b/spec/functional/resource/link_spec.rb
@@ -403,7 +403,7 @@ describe Chef::Resource::Link do
           it "create errors out" do
             if windows?
               expect { resource.run_action(:create) }.to raise_error(Errno::EACCES)
-            elsif os_x? || solaris? || freebsd? || aix?
+            elsif macos? || solaris? || freebsd? || aix?
               expect { resource.run_action(:create) }.to raise_error(Errno::EPERM)
             else
               expect { resource.run_action(:create) }.to raise_error(Errno::EISDIR)
@@ -606,7 +606,7 @@ describe Chef::Resource::Link do
           it "errors out" do
             if windows?
               expect { resource.run_action(:create) }.to raise_error(Errno::EACCES)
-            elsif os_x? || solaris? || freebsd? || aix?
+            elsif macos? || solaris? || freebsd? || aix?
               expect { resource.run_action(:create) }.to raise_error(Errno::EPERM)
             else
               expect { resource.run_action(:create) }.to raise_error(Errno::EISDIR)

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -134,19 +134,19 @@ def unix?
 end
 
 def linux?
-  !!(RUBY_PLATFORM =~ /linux/)
+  RUBY_PLATFORM.match?(/linux/)
 end
 
-def os_x?
-  !!(RUBY_PLATFORM =~ /darwin/)
+def macos?
+  RUBY_PLATFORM.match?(/darwin/)
 end
 
 def solaris?
-  !!(RUBY_PLATFORM =~ /solaris/)
+  RUBY_PLATFORM.match?(/solaris/)
 end
 
 def freebsd?
-  !!(RUBY_PLATFORM =~ /freebsd/)
+  RUBY_PLATFORM.match?(/freebsd/)
 end
 
 def intel_64bit?
@@ -182,7 +182,7 @@ def debian_family?
 end
 
 def aix?
-  !!(RUBY_PLATFORM =~ /aix/)
+  RUBY_PLATFORM.match?(/aix/)
 end
 
 def wpar?


### PR DESCRIPTION
Use match? to make sure we always get a bool back. Rename os_x? to
macos?

Signed-off-by: Tim Smith <tsmith@chef.io>