### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/chef/application.rb
+++ b/lib/chef/application.rb
@@ -25,7 +25,7 @@ require_relative "log"
 require_relative "platform"
 require "mixlib/cli" unless defined?(Mixlib::CLI)
 require "tmpdir" unless defined?(Dir.mktmpdir)
-require "rbconfig"
+require "rbconfig" unless defined?(RbConfig)
 require_relative "application/exit_code"
 require_relative "dist"
 require "license_acceptance/acceptor"

--- a/lib/chef/client.rb
+++ b/lib/chef/client.rb
@@ -54,7 +54,7 @@ require_relative "platform/rebooter"
 require_relative "mixin/deprecation"
 require "chef-utils" unless defined?(ChefUtils::CANARY)
 require "ohai" unless defined?(Ohai::System)
-require "rbconfig"
+require "rbconfig" unless defined?(RbConfig)
 require_relative "dist"
 require "forwardable" unless defined?(Forwardable)
 

--- a/lib/chef/dsl/platform_introspection.rb
+++ b/lib/chef/dsl/platform_introspection.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef-utils" unless defined?(ChefUtils::CANARY)
-require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
+require_relative "../mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   module DSL

--- a/lib/chef/encrypted_data_bag_item/decryptor.rb
+++ b/lib/chef/encrypted_data_bag_item/decryptor.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "yaml"
+require "yaml" unless defined?(YAML)
 require_relative "../json_compat"
 require "openssl" unless defined?(OpenSSL)
 require "base64"

--- a/lib/chef/json_compat.rb
+++ b/lib/chef/json_compat.rb
@@ -20,7 +20,7 @@
 require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "exceptions"
 # We're requiring this to prevent breaking consumers using Hash.to_json
-require "json"
+require "json" unless defined?(JSON)
 
 class Chef
   class JSONCompat

--- a/lib/chef/knife/core/generic_presenter.rb
+++ b/lib/chef/knife/core/generic_presenter.rb
@@ -87,7 +87,7 @@ class Chef
           when :json
             Chef::JSONCompat.to_json_pretty(data)
           when :yaml
-            require "yaml"
+            require "yaml" unless defined?(YAML)
             YAML.dump(data)
           when :pp
             require "stringio" unless defined?(StringIO)

--- a/lib/chef/knife/yaml_convert.rb
+++ b/lib/chef/knife/yaml_convert.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "yaml"
+require "yaml" unless defined?(YAML)
 require_relative "../knife"
 class Chef::Knife::YamlConvert < Chef::Knife
 

--- a/lib/chef/mixin/shell_out.rb
+++ b/lib/chef/mixin/shell_out.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require "mixlib/shellout/helper" unless defined?(Mixlib::ShellOut::Helper)
-require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
+require_relative "chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   module Mixin

--- a/lib/chef/mixin/which.rb
+++ b/lib/chef/mixin/which.rb
@@ -17,7 +17,7 @@
 
 require "chef-utils/dsl/which" unless defined?(ChefUtils::DSL::Which)
 require "chef-utils/dsl/default_paths" unless defined?(ChefUtils::DSL::DefaultPaths)
-require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
+require_relative "chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   module Mixin

--- a/lib/chef/platform/service_helpers.rb
+++ b/lib/chef/platform/service_helpers.rb
@@ -18,7 +18,7 @@
 
 require_relative "../chef_class"
 require "chef-utils" unless defined?(ChefUtils::CANARY)
-require "chef/mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
+require_relative "../mixin/chef_utils_wiring" unless defined?(Chef::Mixin::ChefUtilsWiring)
 
 class Chef
   class Platform

--- a/lib/chef/provider/ifconfig.rb
+++ b/lib/chef/provider/ifconfig.rb
@@ -20,7 +20,7 @@ require_relative "../log"
 require_relative "../provider"
 require_relative "../resource/file"
 require_relative "../exceptions"
-require "erb"
+require "erb" unless defined?(Erb)
 
 class Chef
   class Provider

--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -20,7 +20,7 @@ require_relative "../package"
 require_relative "../../resource/snap_package"
 require_relative "../../mixin/shell_out"
 require "socket" unless defined?(Socket)
-require "json"
+require "json" unless defined?(JSON)
 
 class Chef
   class Provider

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -19,7 +19,7 @@
 
 require_relative "../log"
 require_relative "../provider"
-require "ipaddr"
+require "ipaddr" unless defined?(IPAddr)
 
 class Chef
   class Provider

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "yaml"
+require "yaml" unless defined?(YAML)
 require_relative "dsl/recipe"
 require_relative "mixin/from_file"
 require_relative "mixin/deprecation"


### PR DESCRIPTION
Only require external libraries if we need to. Also use require_relative
everywhere we can.

Signed-off-by: Tim Smith <tsmith@chef.io>