### PR TITLE
Change output to clearly show checksums are displayed incompletely

### DIFF
--- a/lib/chef/exceptions.rb
+++ b/lib/chef/exceptions.rb
@@ -423,7 +423,7 @@ class Chef
 
     class ChecksumMismatch < RuntimeError
       def initialize(res_cksum, cont_cksum)
-        super "Checksum on resource (#{res_cksum}) does not match checksum on content (#{cont_cksum})"
+        super "Checksum on resource (#{res_cksum}...) does not match checksum on content (#{cont_cksum}...)"
       end
     end
 

--- a/lib/chef/mixin/checksum.rb
+++ b/lib/chef/mixin/checksum.rb
@@ -32,6 +32,9 @@ class Chef
         checksum.slice(0, 6)
       end
 
+      def short_cksum_ellipsis(checksum)
+        short_cksum(checksum) + "..."
+      end
     end
   end
 end

--- a/lib/chef/mixin/checksum.rb
+++ b/lib/chef/mixin/checksum.rb
@@ -31,10 +31,6 @@ class Chef
 
         checksum.slice(0, 6)
       end
-
-      def short_cksum_ellipsis(checksum)
-        short_cksum(checksum) + "..."
-      end
     end
   end
 end

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -335,7 +335,7 @@ class Chef
 
       def do_validate_content
         if new_resource.checksum && tempfile && ( new_resource.checksum != tempfile_checksum )
-          raise Chef::Exceptions::ChecksumMismatch.new(short_cksum_ellipsis(new_resource.checksum), short_cksum_ellipsis(tempfile_checksum))
+          raise Chef::Exceptions::ChecksumMismatch.new(short_cksum(new_resource.checksum), short_cksum(tempfile_checksum))
         end
 
         if tempfile

--- a/lib/chef/provider/file.rb
+++ b/lib/chef/provider/file.rb
@@ -335,7 +335,7 @@ class Chef
 
       def do_validate_content
         if new_resource.checksum && tempfile && ( new_resource.checksum != tempfile_checksum )
-          raise Chef::Exceptions::ChecksumMismatch.new(short_cksum(new_resource.checksum), short_cksum(tempfile_checksum))
+          raise Chef::Exceptions::ChecksumMismatch.new(short_cksum_ellipsis(new_resource.checksum), short_cksum_ellipsis(tempfile_checksum))
         end
 
         if tempfile


### PR DESCRIPTION
## Description

When working with templates, people can get confused by a checksum mismatch displaying an apparently shorter hash and subsequently trying to add this one to the recipe:

```
Chef::Exceptions::ChecksumMismatch
----------------------------------
Checksum on resource (1de48f) does not match checksum on content (8222e7)
``` 

I propose to add ellipsis ("...") and the end to show this is a truncated hash instead.

## Related Issue

No filed issue, small usability improvement only

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
