### PR TITLE
do not require source when removing powershell package source

### DIFF
--- a/lib/chef/resource/powershell_package_source.rb
+++ b/lib/chef/resource/powershell_package_source.rb
@@ -34,7 +34,7 @@ class Chef
 
       property :url, String,
         description: "The url to the package source.",
-        required: true
+        required: [:register]
 
       property :trusted, [TrueClass, FalseClass],
         description: "Whether or not to trust packages from this source.",


### PR DESCRIPTION
Signed-off-by: Jeremy Kimber <jeremykimberh@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
This removes the requirement for the `url` property to be defined within the `powershell_package_source` resource for all actions. Since the `remove` action doesn't have any interaction with the url, it doesn't make sense to require that property.

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
