### PR TITLE
Delete deprecated Fauxhai definitions

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -124,4 +124,14 @@ build do
       end
     end
   end
+
+  block "Remove deprecated fauxhai dumps we don't need for running chef-utils specs" do
+    require "json"
+    Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/fauxhai*/lib/fauxhai/platforms/**/*.json") do |file_path|
+      if JSON.parse(File.read(file_path))["deprecated"]
+        puts "Deleted deprecated Fauxhai definition at #{file_path}"
+        FileUtils.rm_f(file_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We're not bundling Fauxhai for cookbook testing by end users. We're bundling it to test our own chef-utils logic. We can remove all the deprecated definitions that we're not using anyways. This shaves 2 megs off our install in 22 files. Long term I'd like to just ship fauxhai w/o the definitions as fauxhai-lite, but this will get us what we need until that time.

Signed-off-by: Tim Smith <tsmith@chef.io>