### PR TITLE
Remove the unused win32-dir dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/ohai.git
-  revision: 6d9bd5e5480f22035555a2adfbe69d171264e70e
+  revision: a61bba8887723c7c7dc7e0211a31af9dc6e84b2b
   branch: master
   specs:
     ohai (16.4.11)
@@ -100,7 +100,6 @@ PATH
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
       win32-certstore (~> 0.3)
-      win32-dir (~> 0.5.0)
       win32-event (~> 0.6.1)
       win32-eventlog (= 0.6.3)
       win32-mmap (~> 0.4.1)
@@ -185,7 +184,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.3)
       ffi
-    ffi-yajl (2.3.3)
+    ffi-yajl (2.3.4)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.3.0)
@@ -398,8 +397,6 @@ GEM
     win32-certstore (0.4.0)
       ffi
       mixlib-shellout
-    win32-dir (0.5.1)
-      ffi (>= 1.0.0)
     win32-event (0.6.3)
       win32-ipc (>= 0.6.0)
     win32-eventlog (0.6.3)
@@ -412,7 +409,7 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.5)
+    win32-service (2.1.6)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)

--- a/chef-universal-mingw32.gemspec
+++ b/chef-universal-mingw32.gemspec
@@ -3,7 +3,6 @@ gemspec = eval(IO.read(File.expand_path("chef.gemspec", __dir__)))
 gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 
 gemspec.add_dependency "win32-api", "~> 1.5.3"
-gemspec.add_dependency "win32-dir", "~> 0.5.0"
 gemspec.add_dependency "win32-event", "~> 0.6.1"
 # TODO: Relax this pin and make the necessary updaets. The issue originally
 # leading to this pin has been fixed in 0.6.5.

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 93208182830012d3e509ce0301edb6dd77464eed
+  revision: 379f9c7fe65e867af2b69b28b2ced739526f9842
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.355.0)
+    aws-partitions (1.356.0)
     aws-sdk-core (3.104.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -154,7 +154,7 @@ GEM
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
-    chef-sugar (5.1.9)
+    chef-sugar (5.1.11)
     chef-utils (16.3.45)
     chef-vault (4.0.6)
     chef-zero (15.0.1)
@@ -179,7 +179,7 @@ GEM
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.3)
       ffi
-    ffi-yajl (2.3.3)
+    ffi-yajl (2.3.4)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
     gssapi (1.3.0)
@@ -249,7 +249,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (16.3.2)
+    ohai (16.4.11)
       chef-config (>= 12.8, < 17)
       chef-utils (>= 16.0, < 17)
       ffi (~> 1.9)
@@ -260,7 +260,6 @@ GEM
       mixlib-log (>= 2.0.1, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       plist (~> 3.1)
-      systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     pastel (0.8.0)
       tty-color (~> 0.5)
@@ -293,7 +292,6 @@ GEM
     strings-ansi (0.2.0)
     structured_warnings (0.4.0)
     syslog-logger (1.6.8)
-    systemu (2.6.5)
     test-kitchen (2.6.0)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
@@ -356,7 +354,7 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.5)
+    win32-service (2.1.6)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)


### PR DESCRIPTION
I'm not seeing this being required anywhere in our kit.

Signed-off-by: Tim Smith <tsmith@chef.io>