### PR TITLE
Use net/http and openssl instead of net/https

### DIFF
--- a/lib/chef/http.rb
+++ b/lib/chef/http.rb
@@ -22,7 +22,8 @@
 #
 
 require "tempfile" unless defined?(Tempfile)
-require "net/https"
+require "openssl" unless defined?(OpenSSL)
+require "net/http" unless defined?(Net::HTTP)
 require "uri" unless defined?(URI)
 require_relative "http/basic_client"
 require_relative "monkey_patches/net_http"


### PR DESCRIPTION
net/https just calls openssl and net/http. We can just do that ourselves
and avoid the extra layer

Signed-off-by: Tim Smith <tsmith@chef.io>