### PR TITLE
Fix second chef run hang for windows_font resource

### DIFF
--- a/lib/chef/resource/windows_font.rb
+++ b/lib/chef/resource/windows_font.rb
@@ -90,8 +90,9 @@ class Chef
         def font_exists?
           require "win32ole" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
           fonts_dir = WIN32OLE.new("WScript.Shell").SpecialFolders("Fonts")
+          fonts_dir_local = Chef::Util::PathHelper.join(ENV["home"], "AppData/Local/Microsoft/Windows/fonts")
           logger.trace("Seeing if the font at #{Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name)} exists")
-          ::File.exist?(Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name))
+          ::File.exist?(Chef::Util::PathHelper.join(fonts_dir, new_resource.font_name)) || ::File.exist?(Chef::Util::PathHelper.join(fonts_dir_local, new_resource.font_name))
         end
 
         # Parse out the schema provided to us to see if it's one we support via remote_file.

--- a/spec/functional/resource/windows_font_spec.rb
+++ b/spec/functional/resource/windows_font_spec.rb
@@ -1,0 +1,49 @@
+#
+# Author:: Dheeraj Singh Dubey (<ddubey@chef.io>)
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Chef::Resource::WindowsFont, :windows_only do
+  let(:resource_name) { "Playmaker.ttf" }
+  let(:resource_source) { "https://www.wfonts.com/download/data/2020/05/06/playmaker/Playmaker.ttf" }
+
+  let(:run_context) do
+    node = Chef::Node.new
+    node.default[:platform] = ohai[:platform]
+    node.default[:platform_version] = ohai[:platform_version]
+    node.default[:os] = ohai[:os]
+    events = Chef::EventDispatch::Dispatcher.new
+    Chef::RunContext.new(node, {}, events)
+  end
+
+  subject do
+    resource = Chef::Resource::WindowsFont.new(resource_name, run_context)
+    resource.source resource_source
+    resource
+  end
+
+  it "installs font on first install" do
+    subject.run_action(:install)
+    expect(subject).to be_updated_by_last_action
+  end
+
+  it "does not install font when already installed" do
+    subject.run_action(:install)
+    expect(subject).not_to be_updated_by_last_action
+  end
+end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
When using the `windows_font` resource the first pass works appropriately, but on the second pass it fails to detect the font is already installed. This causes windows to give a prompt stating
```
The <name> font is already installed. Do you want to replace it?
```
Over winrm this causes the run to just hang, but locally you can cancel or accept.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes https://github.com/chef/chef/issues/8779
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
