### PR TITLE
Fix typo and macOS version evaluation logic in `osx_profile` resource

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -81,7 +81,7 @@ class Chef
 
         def check_resource_semantics!
           if mac? && node["platform_version"] =~ ">= 11.0"
-            raise "The osx_profile resource is not available on macOS Big Sur or above due to the removal of apple support for CLI installation of profiles"
+            raise "The osx_profile resource is not available on macOS Big Sur or above due to the removal of Apple support for CLI installation of profiles"
           end
 
           if action == :remove

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -80,8 +80,8 @@ class Chef
         end
 
         def check_resource_semantics!
-          if mac? && node["platform_version"] =~ "> 10.15"
-            raise "The osx_profile resource is not available on macOS Bug Sur or above due to the removal of apple support for CLI installation of profiles"
+          if mac? && node["platform_version"] =~ ">= 11.0"
+            raise "The osx_profile resource is not available on macOS Big Sur or above due to the removal of apple support for CLI installation of profiles"
           end
 
           if action == :remove


### PR DESCRIPTION
Typo: `Bug Sur` > `Big Sur`
macOS Eval Logic: Change `> 10.15` to `>= 11.0`

## Description
Currently this resource fails on 10.15.6 thinking that the node is on macOS Big Sur (11.0/10.16).

## Related Issue
#10318 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
