### PR TITLE
Fix removing non-existent profile with osx_profile

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -253,7 +253,7 @@ class Chef
 
         def query_installed_profiles
           Tempfile.open("allprofiles.plist") do |tempfile|
-            shell_out!( "/usr/bin/profiles", "-P", "-o", tempfile.path )
+            shell_out( "/usr/bin/profiles", "-P", "-o", tempfile.path )
             ::Plist.parse_xml(tempfile)
           end
         end

--- a/spec/unit/resource/osx_profile_spec.rb
+++ b/spec/unit/resource/osx_profile_spec.rb
@@ -155,7 +155,7 @@ describe Chef::Resource::OsxProfile do
       resource.profile_name profile_name
       allow(provider).to receive(:get_installed_profiles).and_call_original
       allow(provider).to receive(:read_plist).and_return(all_profiles)
-      expect(provider).to receive(:shell_out_compacted!).with("/usr/bin/profiles", "-P", "-o", kind_of(String))
+      expect(provider).to receive(:shell_out_compacted).with("/usr/bin/profiles", "-P", "-o", kind_of(String))
       provider.load_current_resource
     end
 


### PR DESCRIPTION
I don't think this ever worked, but now it does
