### PR TITLE
Start building S390x packages again

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -27,6 +27,8 @@ builder-to-testers-map:
     - el-7-ppc64
   el-7-ppc64le:
     - el-7-ppc64le
+  el-7-s390x:
+    - el-7-s390x
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
@@ -38,6 +40,8 @@ builder-to-testers-map:
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
+  sles-12-s390x:
+    - sles-12-s390x
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
Testing if chef-16 builds okay on s390x.

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/345#0834c6ff-ac9e-487c-90c9-c210d84f1118

This reverts commit a7012bfe35dc3923537ee936417144a0328970ab.
