### PR TITLE
fix chocolatey and x86 windows omnibus builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -54,8 +54,8 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
-#  windows-2012r2-i386:
-#    - windows-2012r2-i386
+  windows-2012r2-i386:
+    - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64


### PR DESCRIPTION
Signed-off-by: mwrock <matt@mattwrock.com>

This fixes two build failure classes:

1. Chocolatey tests were chocking on building its environment variable hash complaining of a duplicate `Path` entry. This is because there was an entry for `Path` but it was trying to add `PATH`. Something in the buildkite setup recases the `Path` variable to `PATH`. While Windows itself treats environment vars in a case insensitive manner, choco code is sensitive. So this simply removes the `path` vaeiable and re adds it ensuring it is cased `Path`.

2. The 2012R2-i386 tests had a bunch of failures where shelling out in functional tests was returning an exit code of `-1073741502`. This is a `STATUS_DLL_INIT_FAILED` error. Note that this is not reproducible locally or even on an ec2 instance using the buildkite AMI. I was only able to repro on a instance terraformed by releng. The failure can then only be reproduced if you run the entire set of tests. If you just run the failing tests alone, they succeed. Examining the environment variables during a failure, none were any different than during success when testing the individual failing spec.  Finally `pry`ing into a failing test, it turns out that shelling out to ANYTHING (like `git --version`) fails with the same exit code. The failure was occuring just after the spawned process opened user32.dll and kernel32.dll. It had not yet tried to access any of the application specific binaries like `x86-msvcrt-ruby270.dll`. After doing research the biggest candidate appears to be exceeding the allocated memory of the desktop heap. See https://docs.microsoft.com/en-us/archive/blogs/ntdebugging/desktop-heap-overview. So the fix here was splitting up the unit, integration and functional tests.