### PR TITLE
separate omnibus rspec path from options

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -107,13 +107,13 @@ $env:Path = $p
 # desktop heap exhaustion seems likely (https://docs.microsoft.com/en-us/archive/blogs/ntdebugging/desktop-heap-overview)
 $exit = 0
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile ./spec/unit
+bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/unit
 If ($lastexitcode -ne 0) { $exit = 1 }
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile ./spec/functional
+bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/functional
 If ($lastexitcode -ne 0) { $exit = 1 }
 
-bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile ./spec/integration
+bundle exec rspec -r rspec_junit_formatter -f RspecJunitFormatter -o test.xml -f progress --profile -- ./spec/integration
 If ($lastexitcode -ne 0) { $exit = 1 }
 
 Exit $exit


### PR DESCRIPTION
Signed-off-by: mwrock <matt@mattwrock.com>

I added the `--profile` arg at the last minute in #10339 and it thinks the path is the profile count and thus running all specs together 3 times.

The font test can only run once. Not sure why and may be worth investigating so the last 2 fail.