### PR TITLE
Fix spellcheck task on Windows.

### DIFF
--- a/tasks/spellcheck.rb
+++ b/tasks/spellcheck.rb
@@ -46,8 +46,13 @@ namespace :spellcheck do
   end
 
   task :cspell_check do
-    require "bundler"
-    Bundler.which("cspell") || abort(<<~INSTALL_CSPELL)
+    cspell_version = begin
+                       `cspell --version`
+                     rescue
+                       nil
+                     end
+
+    cspell_version.is_a?(String) || abort(<<~INSTALL_CSPELL)
           cspell is needed to run the spellcheck tasks. Run `npm install -g cspell` to install.
           For more information: https://www.npmjs.com/package/cspell
     INSTALL_CSPELL


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

`Bundler.which` did not detect cspell on Windows:

```
PS C:\vagrant\chef> ruby -rbundler -e "puts Bundler.which('cspell')"

PS C:\vagrant\chef> cspell --version
4.1.0
```

But it does work everywhere else:

```
Petes-MacBook-Pro:chef pete$ ruby -rbundler -e "puts Bundler.which('cspell')"
/Users/pete/.nvm/versions/node/v12.13.1/bin/cspell
Petes-MacBook-Pro:chef pete$ cspell --version
4.1.0
```