### PR TITLE
Fix habitat test script

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -590,9 +590,6 @@ steps:
       linux:
         privileged: true
         single-use: true
-        environment:
-          - HAB_NONINTERACTIVE=true
-
 
 - label: ":habicat: Linux plan (kernel2)"
   commands:
@@ -604,8 +601,6 @@ steps:
       linux:
         privileged: true
         single-use: true
-        environment:
-          - HAB_NONINTERACTIVE=true
 
 - label: ":habicat: Windows plan"
   commands:
@@ -616,5 +611,3 @@ steps:
         privileged: true
         single-use: true
         shell: ["powershell", "-Command"]
-        environment:
-          - HAB_NONINTERACTIVE=true

--- a/scripts/ci/install-hab.sh
+++ b/scripts/ci/install-hab.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 export HAB_LICENSE="accept"
+export HAB_NONINTERACTIVE="true"
 
 hab_target="$1"
 

--- a/scripts/ci/verify-plan.sh
+++ b/scripts/ci/verify-plan.sh
@@ -6,6 +6,7 @@ export HAB_ORIGIN='ci'
 export PLAN='chef-infra-client'
 export CHEF_LICENSE="accept-no-persist"
 export HAB_LICENSE="accept-no-persist"
+export HAB_NONINTERACTIVE="true"
 
 # print error message followed by usage and exit
 error () {


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

With the extra debug information added, I could see that the failure was printing this message:

```
ERROR: chef-client is not the expected version. Expected '16.5.15', got 'hab-pkg-exec 1.6.139/20200824142405'
```

See: https://buildkite.com/chef-oss/chef-chef-master-verify/builds/6001#54bd468a-7edc-42fc-999d-c7ba90c380fa

That second string is the version of hab. Since these testing scripts pull the latest release of habitat, something must have changed in the way hab parses CLI flags that caused this to break.