### PR TITLE
Check for full names in Homebrew package info

### DIFF
--- a/lib/chef/provider/package/homebrew.rb
+++ b/lib/chef/provider/package/homebrew.rb
@@ -127,7 +127,7 @@ class Chef
 
           # check each item in the hash to see if we were passed an alias
           brew_info.each_value do |p|
-            return p if p["aliases"].include?(package_name)
+            return p if p["full_name"] == package_name || p["aliases"].include?(package_name)
           end
 
           {}


### PR DESCRIPTION
## Description
I was running into an issue where Homebrew formulae would fail to install using the full name, e.g. 
```
homebrew_package 'homebrew/core/vim'
homebrew_package 'derailed/k9s/k9s'
```

In the `package_info` method, I added an additional check for the `full_name` when the short-name isn't found and the method iterates over the entire hash.
Mostly a work-around, but seems to solve the issue without changing any existing behavior. This doesn't change the behavior of failure when the prefixed tap isn't previously installed (e.g. `derailed/k9s/k9s` will still fail if the tap doesn't exist locally).

I'm not really familiar with the Ruby/Chef ecosystem/internals. I wasn't able to successfully get the rspec unit tests running on my workstation. I planned to add some additional `context`s to the `homebrew_*_spec.rb` files. Happy to do that, but might need a little guidance with env expectations/commands (couldn't find docs, but know this is a deal in the contributing doc).

## Related Issue
I didn't create an issue for this - but can.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
