### PR TITLE
Shell test cleanup

### DIFF
--- a/spec/unit/shell/shell_ext_spec.rb
+++ b/spec/unit/shell/shell_ext_spec.rb
@@ -19,14 +19,57 @@
 require "spec_helper"
 
 describe Shell::Extensions do
+  let(:test_shell_session) do
+    Class.new(Shell::ShellSession) do
+      def rebuild_node
+        nil
+      end
+
+      def rebuild_collection
+        nil
+      end
+
+      def loading
+        nil
+      end
+
+      def loading_complete
+        nil
+      end
+    end
+  end
+
+  let(:test_job_manager) do
+    Class.new do
+      attr_accessor :jobs
+    end
+  end
+
+  let(:object_test_harness) do
+    Proc.new do
+      extend Shell::Extensions::ObjectCoreExtensions
+
+      def conf=(new_conf)
+        @conf = new_conf
+      end
+
+      def conf
+        @conf
+      end
+
+      desc "rspecin'"
+      def rspec_method; end
+    end
+  end
+
   describe "extending object for top level methods" do
 
     before do
-      @shell_client = TestableShellSession.instance
+      @shell_client = test_shell_session.instance
       allow(Shell).to receive(:session).and_return(@shell_client)
-      @job_manager = TestJobManager.new
+      @job_manager = test_job_manager.new
       @root_context = Object.new
-      @root_context.instance_eval(&ObjectTestHarness)
+      @root_context.instance_eval(&object_test_harness)
       Shell::Extensions.extend_context_object(@root_context)
       @root_context.conf = double("irbconf")
     end

--- a/spec/unit/shell/shell_session_spec.rb
+++ b/spec/unit/shell/shell_session_spec.rb
@@ -161,7 +161,7 @@ describe Shell::SoloLegacySession do
 
   before do
     Chef::Config[:shell_config] = { override_runlist: [Chef::RunList::RunListItem.new("shell::override")] }
-    Chef::Config[:shell_solo] = nil
+    Chef::Config[:solo_legacy_shell] = true
     session.node = node
     session.json_configuration = json_attribs
     session.run_context = run_context

--- a/spec/unit/shell/shell_session_spec.rb
+++ b/spec/unit/shell/shell_session_spec.rb
@@ -18,32 +18,10 @@
 require "spec_helper"
 require "ostruct"
 
-class TestableShellSession < Shell::ShellSession
-
-  def rebuild_node
-    nil
-  end
-
-  def rebuild_collection
-    nil
-  end
-
-  def loading
-    nil
-  end
-
-  def loading_complete
-    nil
-  end
-
-end
-
 describe Shell::ShellSession do
-
   it "is a singleton object" do
     expect(Shell::ShellSession).to include(Singleton)
   end
-
 end
 
 describe Shell::ClientSession do

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -18,26 +18,23 @@
 require "spec_helper"
 require "ostruct"
 
-ObjectTestHarness = Proc.new do
-  extend Shell::Extensions::ObjectCoreExtensions
-
-  def conf=(new_conf)
-    @conf = new_conf
-  end
-
-  def conf
-    @conf
-  end
-
-  desc "rspecin'"
-  def rspec_method; end
-end
-
-class TestJobManager
-  attr_accessor :jobs
-end
-
 describe Shell do
+  let(:object_test_harness) do
+    Proc.new do
+      extend Shell::Extensions::ObjectCoreExtensions
+
+      def conf=(new_conf)
+        @conf = new_conf
+      end
+
+      def conf
+        @conf
+      end
+
+      desc "rspecin'"
+      def rspec_method; end
+    end
+  end
 
   before do
     Shell.irb_conf = {}
@@ -66,7 +63,7 @@ describe Shell do
 
       conf = OpenStruct.new
       conf.main = Object.new
-      conf.main.instance_eval(&ObjectTestHarness)
+      conf.main.instance_eval(&object_test_harness)
       Shell.irb_conf[:IRB_RC].call(conf)
       expect(conf.prompt_c).to      eq("chef > ")
       expect(conf.return_format).to eq(" => %s \n")
@@ -107,7 +104,7 @@ describe Shell do
 
     before do
       @chef_object = Object.new
-      @chef_object.instance_eval(&ObjectTestHarness)
+      @chef_object.instance_eval(&object_test_harness)
     end
 
     it "creates help text for methods with descriptions" do


### PR DESCRIPTION
I recently noticed that one test was printing a lot of output in the unit tests, as can be seen in this recent buildkite output: https://buildkite.com/chef-oss/chef-chef-master-verify/builds/6053#4785c4cb-14f3-4937-b6ca-f42a83a6f3ec/86-886

The test was running ohai when it was supposed to be stubbed, meaning it was printing a lot of output and taking a lot longer than it should. In CI it was a few hundred lines and 1.5 seconds, but in my local environment it was several thousand lines of output and the test took ~15 seconds.

* The first commit is rearranging some test code to remove unspecified dependencies in the tests so that each file could be run separately.
* The second commit is cleaning up the test code to be more consistent to allow me to see the differences in test setup/assertions.
* The last commit is making the meaningful change to fix the test.