### PR TITLE
Allow removing profiles in osx_profile on Big Sur

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -80,10 +80,6 @@ class Chef
         end
 
         def check_resource_semantics!
-          if mac? && node["platform_version"] =~ ">= 11.0"
-            raise "The osx_profile resource is not available on macOS Big Sur or above due to Apple's removal of support for CLI profile installation"
-          end
-
           if action == :remove
             if new_profile_identifier
               if invalid_profile_name?(new_profile_identifier)
@@ -97,6 +93,11 @@ class Chef
           end
 
           if action == :install
+            # we only do this check for the install action so that profiles can still be removed on macOS 11+
+            if mac? && node["platform_version"] =~ ">= 11.0"
+              raise "The osx_profile resource is not available on macOS Big Sur or above due to Apple's removal of support for CLI profile installation"
+            end
+
             if new_profile_hash.is_a?(Hash) && !new_profile_hash.include?("PayloadIdentifier")
               raise "The specified profile does not seem to be valid"
             end


### PR DESCRIPTION
Users may want to cleanup old profiles after upgrading a Catalina box to
Big Sur. We should allow for that. It's just installing new profiles
where we need to fail hard.

Signed-off-by: Tim Smith <tsmith@chef.io>