### PR TITLE
Fix windows habitat CI test script

### DIFF
--- a/habitat/tests/test.pester.ps1
+++ b/habitat/tests/test.pester.ps1
@@ -12,8 +12,21 @@ Describe "chef-infra-client" {
             $? | Should be $true
         }
 
+        <#
+          At some point hab's argument parsing changed and it started interpreting the trailing `--version` as being
+          an argument passed to hab instead of an argument to the command passed to `hab pkg exec`.
+
+          Powershell 5.1 and 7 appear to differ in how they treat following arguments as well, such that these two
+          versions of the command fail in powershell 5.1 (which is currently what is running in the windows machines
+          in Buildkite) but pass in powershell 7 (which is currently what is running in a stock Windows 10 VM).
+
+          $the_version = (hab pkg exec $PackageIdentifier chef-client.bat '--version' | Out-String).split(':')[1].Trim()
+          $the_version = (hab pkg exec $PackageIdentifier chef-client.bat --version | Out-String).split(':')[1].Trim()
+
+          This version of the command passes in powershell 5.1 but fails in powershell 7.
+        #>
         It "is the expected version" {
-            $the_version = (hab pkg exec $PackageIdentifier chef-client.bat --version | Out-String).split(':')[1].Trim()
+            $the_version = (hab pkg exec $PackageIdentifier chef-client.bat -- --version | Out-String).split(':')[1].Trim()
             $the_version | Should be $PackageVersion
         }
     }


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Followup to #10350.

Fixes this failure on the "Windows plan" CI job:

```
Describing chef-infra-client
   Context chef-client
    [+] is an executable 591ms
    [-] is the expected version 139ms
      RuntimeException: You cannot call a method on a null-valued expression.
      at <ScriptBlock>, C:\bk7f8d9d78\habitat\tests\test.pester.ps1: line 16
   Context ohai
    [+] is an executable 166ms
   Context chef-shell
    [+] is an executable 83ms
   Context chef-apply
    [+] is an executable 58ms
   Context knife
    [+] is an executable 61ms
   Context chef-solo
    [+] is an executable 58ms
Tests completed in 1.16s
Passed: 6 Failed: 1 Skipped: 0 Pending: 0 Inconclusive: 0
package didn't pass the test suite
At C:\bk7f8d9d78\scripts\ci\verify-plan.ps1:37 char:16
+ if (-not $?) { throw "package didn't pass the test suite" }
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (package didn't pass the test suite:String) [], RuntimeException
    + FullyQualifiedErrorId : package didn't pass the test suite
```