### PR TITLE
Add a :reboot_delay property to the windows_ad_join resource

### DIFF
--- a/lib/chef/resource/windows_ad_join.rb
+++ b/lib/chef/resource/windows_ad_join.rb
@@ -80,6 +80,11 @@ class Chef
         description: "Controls the system reboot behavior post domain joining. Reboot immediately, after the #{Chef::Dist::PRODUCT} run completes, or never. Note that a reboot is necessary for changes to take effect.",
         default: :immediate
 
+      property :reboot_delay, Integer,
+        description: "The amount of time (in minutes) to delay a reboot request.",
+        default: 0,
+        introduced: "16.5"
+
       property :new_hostname, String,
         description: "Specifies a new hostname for the computer in the new domain.",
         introduced: "14.5"
@@ -116,6 +121,7 @@ class Chef
             unless new_resource.reboot == :never
               reboot "Reboot to join domain #{new_resource.domain_name}" do
                 action clarify_reboot(new_resource.reboot)
+                delay_mins new_resource.reboot_delay
                 reason "Reboot to join domain #{new_resource.domain_name}"
               end
             end
@@ -149,6 +155,7 @@ class Chef
             unless new_resource.reboot == :never
               reboot "Reboot to leave domain #{new_resource.domain_name}" do
                 action clarify_reboot(new_resource.reboot)
+                delay_mins new_resource.reboot_delay
                 reason "Reboot to leave domain #{new_resource.domain_name}"
               end
             end


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In many situations, when using the windows_ad_join resource, you can't utilize the build-in reboot functionality because the windows system reboots too quickly and the chef run can't close out with the proper error code. We often see this failure when in test-kitchen, where the appropriate chef exit codes don't get passed to test-kitchen in order for it to trigger a retry.

I've added a `:reboot_delay` property to the resource to leverage the `:delay_mins` property in the `reboot` resource.  This will allow users to leverage that `:delay_mins` property without having to use a `notify` call from their use of the `windows_ad_join` resource.

Example:

** Join a domain and reboot the system after a 2 minute delay **

```ruby
windows_ad_join 'ad.example.org' do
  domain_user 'nick'
  domain_password 'p@ssw0rd1'
  new_hostname 'win-workstation'
  reboot: :reboot_now
  reboot_delay: 2
end
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
This is allowing the fix for this [Test-Kitchen Issue](https://github.com/test-kitchen/test-kitchen/issues/1227) to be available to the windows_ad_join resource.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
