### PR TITLE
Add --logfile to chef-apply command

### DIFF
--- a/lib/chef/application/apply.rb
+++ b/lib/chef/application/apply.rb
@@ -77,6 +77,11 @@ class Chef::Application::Apply < Chef::Application
     description: "Set the log level (trace, debug, info, warn, error, fatal).",
     proc: lambda { |l| l.to_sym }
 
+  option :log_location_cli,
+    short: "-L LOGLOCATION",
+    long: "--logfile LOGLOCATION",
+    description: "Set the log file location, defaults to STDOUT - recommended for daemonizing."
+
   option :always_dump_stacktrace,
     long: "--[no-]always-dump-stacktrace",
     boolean: true,


### PR DESCRIPTION
I needed this for testing and it just sorta seems like something we
should support. Yes that means people may be using chef-apply with some
sort of init system, but if that's something they wanna do then why not
just let them roll with that. This just copies the option from the
base.rb file and it works fine for me locally.

Signed-off-by: Tim Smith <tsmith@chef.io>