### PR TITLE
chef_client_launchd: create a launchd daemon to handle the client restart

### DIFF
--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -122,6 +122,11 @@ class Chef
           action :enable
         end
 
+        # Launchd doesn't have the concept of a reload aka restart. Instead to update a daemon config you have
+        # to unload it and then reload the new plist. That's usually fine, but not if chef-client is trying
+        # to restart itself. If the chef-client process uses launchd or macosx_service resources to restart itself
+        # we'll end up with a stopped service that will never get started back up. Instead we use this daemon
+        # that triggers when the chef-client plist file is updated, and handles the restart outside the run.
         launchd "com.#{Chef::Dist::SHORT}.restarter" do
           username "root"
           watch_paths ["/Library/LaunchDaemons/com.#{Chef::Dist::SHORT}.#{Chef::Dist::CLIENT}.plist"]

--- a/lib/chef/resource/chef_client_launchd.rb
+++ b/lib/chef/resource/chef_client_launchd.rb
@@ -133,6 +133,10 @@ class Chef
           action :enable
         end
 
+        # We want to make sure that after we update the chef-client launchd config that we don't move on to another recipe
+        # before the restarter daemon can do its thing. This sleep avoids killing the client while it's doing something like
+        # installing a package, which could be problematic. It also makes it a bit more clear in the log that the killed process
+        # was intentional.
         chef_sleep "Sleep before client restart" do
           seconds 10
           action :nothing


### PR DESCRIPTION
Launchd doesn't have the concept of a reload aka restart. Instead to update a daemon config you have to unload it and then reload the new plist. That's usually fine (actually just like upstart), but not if Chef is trying to restart itself. Currently if you change the nice level or interval the client will unload its own config which kills the run and it never gets started back up.  So to work around this we're going to install a launchd daemon that has a watcher on the chef-client daemon plist file. It's only job to to unload and reload the client. That way when the daemonized chef-client process updates the plist the restarter job will handle the restart. To ensure we're not in the middle of the next recipe we use a chef_sleep resource to sleep a bit post launchd update.

I also updated the resource to work better with cinc while I was in here.

Signed-off-by: Tim Smith <tsmith@chef.io>