### PR TITLE
autoload license_acceptance/acceptor in knife loading

### DIFF
--- a/lib/chef/knife/bootstrap.rb
+++ b/lib/chef/knife/bootstrap.rb
@@ -20,7 +20,9 @@ require_relative "../knife"
 require_relative "data_bag_secret_options"
 require_relative "../dist"
 require "license_acceptance/cli_flags/mixlib_cli"
-require "license_acceptance/acceptor"
+module LicenseAcceptance
+  autoload :Acceptor, "license_acceptance/acceptor"
+end
 
 class Chef
   class Knife


### PR DESCRIPTION
I had previously done this for the `chef-client` scenario but missed this which is pulled in when loading knife commands. The deps of license_acceptance/acceptor are pretty heavy.

Signed-off-by: mwrock <matt@mattwrock.com>
