### PR TITLE
Allow cpu_quota values > 100

### DIFF
--- a/lib/chef/resource/chef_client_systemd_timer.rb
+++ b/lib/chef/resource/chef_client_systemd_timer.rb
@@ -99,10 +99,10 @@ class Chef
         default: lazy { {} }
 
       property :cpu_quota, [Integer, String],
-        description: "The systemd CPUQuota to run the #{Chef::Dist::CLIENT} process with. This is a percentage value of the total CPU time available on the system.",
+        description: "The systemd CPUQuota to run the #{Chef::Dist::CLIENT} process with. This is a percentage value of the total CPU time available on the system. If the system has more than 1 core this may be a value greater than 100.",
         introduced: "16.5",
         coerce: proc { |x| Integer(x) },
-        callbacks: { "should be an Integer between 1 and 100" => proc { |v| v > 0 && v <= 100 } }
+        callbacks: { "should be a positive Integer" => proc { |v| v > 0 } }
 
       action :add do
         systemd_unit "#{new_resource.job_name}.service" do

--- a/spec/unit/resource/chef_client_systemd_timer_spec.rb
+++ b/spec/unit/resource/chef_client_systemd_timer_spec.rb
@@ -35,8 +35,8 @@ describe Chef::Resource::ChefClientSystemdTimer do
 
   it "validates the cpu_quota property input" do
     expect { resource.cpu_quota(0) }.to raise_error(Chef::Exceptions::ValidationFailed)
-    expect { resource.cpu_quota(101) }.to raise_error(Chef::Exceptions::ValidationFailed)
     expect { resource.cpu_quota(50) }.not_to raise_error
+    expect { resource.cpu_quota(101) }.not_to raise_error
   end
 
   it "builds a default value for chef_binary_path dist values" do


### PR DESCRIPTION
Turns out on multi-core boxes these are valid.

Signed-off-by: Tim Smith <tsmith@chef.io>