### PR TITLE
Remove debug puts from snap_package

### DIFF
--- a/lib/chef/provider/package/snap.rb
+++ b/lib/chef/provider/package/snap.rb
@@ -218,7 +218,6 @@ class Chef
           waiting = true
           while waiting
             result = get_change_id(id)
-            puts "STATUS: #{result["result"]["status"]}"
             case result["result"]["status"]
             when "Do", "Doing", "Undoing", "Undo"
               # Continue


### PR DESCRIPTION
No need for this here. Thanks for pointing it out @jaymzh 

Signed-off-by: Tim Smith <tsmith@chef.io>