### PR TITLE
Update the windows_firewall_profile resource to fix NoMethodError

### DIFF
--- a/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
+++ b/kitchen-tests/cookbooks/end_to_end/recipes/windows.rb
@@ -32,6 +32,16 @@ windows_security_policy "EnableGuestAccount" do
   secvalue "1"
 end
 
+windows_firewall_profile "Domain" do
+  default_inbound_action "Allow"
+  default_outbound_action "Allow"
+  action :enable
+end
+
+windows_firewall_profile "Public" do
+  action :disable
+end
+
 users_manage "remove sysadmin" do
   group_name "sysadmin"
   group_id 2300

--- a/lib/chef/resource/windows_firewall_profile.rb
+++ b/lib/chef/resource/windows_firewall_profile.rb
@@ -161,24 +161,6 @@ class Chef
           cmd
         end
 
-        def load_firewall_state(profile_name)
-          <<-EOH
-            Remove-TypeData System.Array # workaround for PS bug here: https://bit.ly/2SRMQ8M
-            $#{profile_name} = Get-NetFirewallProfile -Profile #{profile_name}
-            ([PSCustomObject]@{
-              default_inbound_action = $#{profile_name}.DefaultInboundAction.ToString()
-              default_outbound_action = $#{profile_name}.DefaultOutboundAction.ToString()
-              allow_inbound_rules = $#{profile_name}.AllowInboundRules.ToString()
-              allow_local_firewall_rules = $#{profile_name}.AllowLocalFirewallRules.ToString()
-              allow_local_ipsec_rules = $#{profile_name}.AllowLocalIPsecRules.ToString()
-              allow_user_apps = $#{profile_name}.AllowUserApps.ToString()
-              allow_user_ports = $#{profile_name}.AllowUserPorts.ToString()
-              allow_unicast_response = $#{profile_name}.AllowUnicastResponseToMulticast.ToString()
-              display_notification = $#{profile_name}.NotifyOnListen.ToString()
-            }) | ConvertTo-Json
-          EOH
-        end
-
         def firewall_enabled?(profile_name)
           cmd = <<~CODE
             $#{profile_name} = Get-NetFirewallProfile -Profile #{profile_name}
@@ -193,6 +175,28 @@ class Chef
             false
           end
         end
+      end
+
+      private
+
+      # build the command to load the current resource
+      # @return [String] current firewall state
+      def load_firewall_state(profile_name)
+        <<-EOH
+          Remove-TypeData System.Array # workaround for PS bug here: https://bit.ly/2SRMQ8M
+          $#{profile_name} = Get-NetFirewallProfile -Profile #{profile_name}
+          ([PSCustomObject]@{
+            default_inbound_action = $#{profile_name}.DefaultInboundAction.ToString()
+            default_outbound_action = $#{profile_name}.DefaultOutboundAction.ToString()
+            allow_inbound_rules = $#{profile_name}.AllowInboundRules.ToString()
+            allow_local_firewall_rules = $#{profile_name}.AllowLocalFirewallRules.ToString()
+            allow_local_ipsec_rules = $#{profile_name}.AllowLocalIPsecRules.ToString()
+            allow_user_apps = $#{profile_name}.AllowUserApps.ToString()
+            allow_user_ports = $#{profile_name}.AllowUserPorts.ToString()
+            allow_unicast_response = $#{profile_name}.AllowUnicastResponseToMulticast.ToString()
+            display_notification = $#{profile_name}.NotifyOnListen.ToString()
+          }) | ConvertTo-Json
+        EOH
       end
     end
   end

--- a/lib/chef/resource/windows_firewall_profile.rb
+++ b/lib/chef/resource/windows_firewall_profile.rb
@@ -19,8 +19,6 @@
 class Chef
   class Resource
     class WindowsFirewallProfile < Chef::Resource
-      unified_mode true
-
       provides :windows_firewall_profile
       description "Use the **windows_firewall_profile** resource to enable, disable, and configure the Windows firewall."
       introduced "16.3"


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request should fix the NoMethodError being seen when using this resource.  Because the load_current_value section was using a method defined in the action_class, and therefore couldn't find it because it's not part of the action...  I've moved it into a private section (to mirror what's done in the windows_firewall_rule resource) which fixes the issue.

I've also added kitchen tests for this resource to ensure this is working correctly in both the enable and disable actions.
 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#10411 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
