### PR TITLE
Update sysctl resource description to match reality

### DIFF
--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -25,7 +25,7 @@ class Chef
       provides(:sysctl) { true }
       provides(:sysctl_param) { true }
 
-      description "Use the **sysctl** resource to set or remove kernel parameters using the `sysctl`  command line tool and configuration files in the system's `sysctl.d` directory. Configuration files managed by this resource are named `99-chef-KEYNAME.conf`."
+      description "Use the **sysctl** resource to set or remove kernel parameters using the `sysctl` command line tool and configuration files in the system's `sysctl.d` directory. Configuration files managed by this resource are named `99-chef-KEYNAME.conf`."
       examples <<~DOC
       **Set vm.swappiness**:
 

--- a/lib/chef/resource/sysctl.rb
+++ b/lib/chef/resource/sysctl.rb
@@ -25,11 +25,7 @@ class Chef
       provides(:sysctl) { true }
       provides(:sysctl_param) { true }
 
-      description "Use the **sysctl** resource to set or remove kernel parameters using the sysctl"\
-                  " command line tool and configuration files in the system's sysctl.d directory. "\
-                  "Configuration files managed by this resource are named 99-chef-KEYNAME.conf. If"\
-                  " an existing value was already set for the value it will be backed up to the node"\
-                  " and restored if the :remove action is used later."
+      description "Use the **sysctl** resource to set or remove kernel parameters using the `sysctl`  command line tool and configuration files in the system's `sysctl.d` directory. Configuration files managed by this resource are named `99-chef-KEYNAME.conf`."
       examples <<~DOC
       **Set vm.swappiness**:
 


### PR DESCRIPTION
We don't do the backup mess anymore and we never did when this resource was in chef-client itself.

Signed-off-by: Tim Smith <tsmith@chef.io>