### PR TITLE
Remove the Ubuntu azure pipeline test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,6 @@ jobs:
   - job:
     strategy:
       matrix:
-        ubuntu_kitchen_tests:
-          imageName: 'ubuntu-latest'
         mac_kitchen_tests:
           imageName: 'macos-latest'
 


### PR DESCRIPTION
We test this same stuff in the dokken based BK tests and this one is
failing outside of the Chef run.

Signed-off-by: Tim Smith <tsmith@chef.io>