### PR TITLE
Resolve Lint/RedundantRequireStatement & Style/RedundantCondition warnings

### DIFF
--- a/lib/chef/chef_fs/parallelizer.rb
+++ b/lib/chef/chef_fs/parallelizer.rb
@@ -1,4 +1,3 @@
-require "thread"
 require_relative "parallelizer/parallel_enumerable"
 
 class Chef

--- a/lib/chef/cookbook_site_streaming_uploader.rb
+++ b/lib/chef/cookbook_site_streaming_uploader.rb
@@ -231,11 +231,7 @@ class Chef
           @part_no += 1
           @part_offset = 0
           next_part = read(how_much_next_part)
-          result = current_part + if next_part
-                                    next_part
-                                  else
-                                    ""
-                                  end
+          result = current_part + (next_part || "")
         else
           @part_offset += how_much_current_part
           result = current_part

--- a/lib/chef/knife/bootstrap/chef_vault_handler.rb
+++ b/lib/chef/knife/bootstrap/chef_vault_handler.rb
@@ -112,7 +112,7 @@ class Chef
               if bootstrap_vault_item
                 bootstrap_vault_item
               else
-                json = bootstrap_vault_json ? bootstrap_vault_json : File.read(bootstrap_vault_file)
+                json = bootstrap_vault_json || File.read(bootstrap_vault_file)
                 Chef::JSONCompat.from_json(json)
               end
             end

--- a/lib/chef/provider/launchd.rb
+++ b/lib/chef/provider/launchd.rb
@@ -209,7 +209,7 @@ class Chef
 
       # @api private
       def path
-        @path ||= new_resource.path ? new_resource.path : gen_path_from_type
+        @path ||= new_resource.path || gen_path_from_type
       end
     end
   end

--- a/lib/chef/provider/package/zypper.rb
+++ b/lib/chef/provider/package/zypper.rb
@@ -158,7 +158,7 @@ class Chef
         end
 
         def global_options
-          new_resource.global_options if new_resource.global_options
+          new_resource.global_options
         end
       end
     end

--- a/lib/chef/provider/route.rb
+++ b/lib/chef/provider/route.rb
@@ -169,11 +169,7 @@ class Chef
             next unless resource.is_a? Chef::Resource::Route
 
             # default to eth0
-            dev = if resource.device
-                    resource.device
-                  else
-                    "eth0"
-                  end
+            dev = resource.device || "eth0"
 
             conf[dev] = "" if conf[dev].nil?
             case @action

--- a/lib/chef/provider/service/macosx.rb
+++ b/lib/chef/provider/service/macosx.rb
@@ -47,7 +47,7 @@ class Chef
           @current_resource = Chef::Resource::MacosxService.new(@new_resource.name)
           @current_resource.service_name(@new_resource.service_name)
           @plist_size = 0
-          @plist = @new_resource.plist ? @new_resource.plist : find_service_plist
+          @plist = @new_resource.plist || find_service_plist
           @service_label = find_service_label
           # LaunchAgents should be loaded as the console user.
           @console_user = @plist ? @plist.include?("LaunchAgents") : false

--- a/lib/chef/provider/template_finder.rb
+++ b/lib/chef/provider/template_finder.rb
@@ -43,19 +43,11 @@ class Chef
       protected
 
       def template_source_name(name, options)
-        if options[:source]
-          options[:source]
-        else
-          name
-        end
+        options[:source] || name
       end
 
       def find_cookbook_name(options)
-        if options[:cookbook]
-          options[:cookbook]
-        else
-          @cookbook_name
-        end
+        options[:cookbook] || @cookbook_name
       end
     end
   end

--- a/lib/chef/provider_resolver.rb
+++ b/lib/chef/provider_resolver.rb
@@ -113,7 +113,7 @@ class Chef
 
     # if resource.provider is set, just return one of those objects
     def maybe_explicit_provider(resource)
-      resource.provider if resource.provider
+      resource.provider
     end
 
     # try dynamically finding a provider based on querying the providers to see what they support

--- a/lib/chef/recipe.rb
+++ b/lib/chef/recipe.rb
@@ -122,7 +122,7 @@ class Chef
     end
 
     def to_s
-      "cookbook: #{cookbook_name ? cookbook_name : "(none)"}, recipe: #{recipe_name ? recipe_name : "(none)"} "
+      "cookbook: #{cookbook_name || "(none)"}, recipe: #{recipe_name || "(none)"} "
     end
 
     def inspect

--- a/lib/chef/resource/execute.rb
+++ b/lib/chef/resource/execute.rb
@@ -587,7 +587,7 @@ class Chef
           ancestor_attributes = superclass.guard_inherited_attributes
         end
 
-        ancestor_attributes.concat(@class_inherited_attributes ? @class_inherited_attributes : []).uniq
+        ancestor_attributes.concat(@class_inherited_attributes || []).uniq
       end
 
       # post resource creation validation

--- a/lib/chef/util/threaded_job_queue.rb
+++ b/lib/chef/util/threaded_job_queue.rb
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "thread"
-
 class Chef
   class Util
     # A simple threaded job queue

--- a/spec/tiny_server.rb
+++ b/spec/tiny_server.rb
@@ -19,7 +19,6 @@
 require "webrick"
 require "webrick/https"
 require "rack"
-require "thread"
 require "singleton"
 require "open-uri"
 require "chef/config"

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -111,8 +111,7 @@ describe Chef::Runner do
 
     it "should use the provider specified by the resource (if it has one)" do
       provider = Chef::Provider::Easy.new(run_context.resource_collection[0], run_context)
-      # Expect provider to be called twice, because will fall back to old provider lookup
-      expect(run_context.resource_collection[0]).to receive(:provider).twice.and_return(Chef::Provider::Easy)
+      expect(run_context.resource_collection[0]).to receive(:provider).once.and_return(Chef::Provider::Easy)
       expect(Chef::Provider::Easy).to receive(:new).once.and_return(provider)
       runner.converge
     end


### PR DESCRIPTION
**Lint/RedundantRequireStatement:** These are required by Ruby out of the box so lets avoid trying to require them again.

**Style/RedundantCondition:** This lets us nuke a pile of ternary operators and other checks for values that weren't necessary

Signed-off-by: Tim Smith <tsmith@chef.io>
