### PR TITLE
Speed up a openssl helper specs

### DIFF
--- a/spec/unit/mixin/openssl_helper_spec.rb
+++ b/spec/unit/mixin/openssl_helper_spec.rb
@@ -99,7 +99,7 @@ describe Chef::Mixin::OpenSSLHelper do
 
     context "When the dhparam.pem file does exist, and does contain a vaild dhparam key" do
       it "returns true" do
-        @dhparam_file.puts(::OpenSSL::PKey::DH.new(1024).to_pem)
+        @dhparam_file.puts(::OpenSSL::PKey::DH.new(256).to_pem) # this is 256 to speed up specs
         @dhparam_file.close
         expect(instance.dhparam_pem_valid?(@dhparam_file.path)).to be_truthy
       end


### PR DESCRIPTION
This was one of our top 10 slow specs

Before:

```
  Chef::Mixin::OpenSSLHelper#dhparam_pem_valid? When the dhparam.pem file does exist, and does contain a vaild dhparam key returns true
    2.71 seconds ./spec/unit/mixin/openssl_helper_spec.rb:101
```

After:

```
  Chef::Mixin::OpenSSLHelper#dhparam_pem_valid? When the dhparam.pem file does exist, and does contain a vaild dhparam key returns true
    0.01844 seconds ./spec/unit/mixin/openssl_helper_spec.rb:101
```

Signed-off-by: Tim Smith <tsmith@chef.io>