### PR TITLE
Fix idempotency in the osx_profile resource and avoid writing data to disk

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,10 +72,6 @@ The `chef_client_cron` resource has been updated with a new `nice` property that
 
 The `chef_client_systemd_timer` resource has been updated with a new `cpu_quota` property that allows you to control the systemd `CPUQuota` value for the `chef-client` process. This allows you to ensure `chef-client` execution doesn't adversely impact performance on your systems.
 
-### osx_profile
-
-The `osx_profile` resource will now allow you to remove profiles from macOS 11 (Big Sur) systems. Due to security changes in macOS 11, it is no longer possible to locally install profiles, but this will allow you to cleanup existing profiles left over after an upgrade from an earlier macOS release. Thanks for reporting this issue [@chilcote](https://github.com/chilcote)!
-
 ### launchd
 
 The `launchd` resource has been updated to better validate inputs to the `nice` property so we can make sure these are acceptable nice values.
@@ -83,6 +79,10 @@ The `launchd` resource has been updated to better validate inputs to the `nice` 
 ### mount
 
 The `mount` resource on Linux has new improved idempotency in some scenarios by switching to `findmnt` to determine the current state of the system. Thanks for reporting this issue [@pollosp](https://github.com/pollosp)!
+
+### osx_profile
+
+The `osx_profile` resource will now allow you to remove profiles from macOS 11 (Big Sur) systems. Due to security changes in macOS 11, it is no longer possible to locally install profiles, but this will allow you to cleanup existing profiles left over after an upgrade from an earlier macOS release. The resource has been updated to resolve a regression introduced in Chef Infra Client 16.4 that caused the resource to attempt to update profiles on each converge. Thanks for reporting these issues [@chilcote](https://github.com/chilcote)!
 
 ### rhsm_register
 

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -308,12 +308,12 @@ class Chef
         #
 
         def get_installed_profiles(update = nil)
+          logger.trace("Saving profile data to node.run_state")
           if update
             node.run_state[:config_profiles] = query_installed_profiles
           else
             node.run_state[:config_profiles] ||= query_installed_profiles
           end
-          logger.trace("Saved profiles to run_state")
         end
 
         def query_installed_profiles

--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -317,10 +317,9 @@ class Chef
         end
 
         def query_installed_profiles
-          Tempfile.open("allprofiles.plist") do |tempfile|
-            shell_out( "/usr/bin/profiles", "-P", "-o", tempfile.path )
-            ::Plist.parse_xml(tempfile)
-          end
+          logger.trace("Running /usr/bin/profiles -P -o stdout-xml to determine profile state")
+          so = shell_out( "/usr/bin/profiles", "-P", "-o", "stdout-xml" )
+          ::Plist.parse_xml(so.stdout)
         end
 
         def profile_installed?

--- a/spec/unit/resource/osx_profile_spec.rb
+++ b/spec/unit/resource/osx_profile_spec.rb
@@ -102,6 +102,72 @@ describe Chef::Resource::OsxProfile do
           "ProfileVersion" => 1 }],
       }
     end
+    let(:profile_raw_xml) do
+      <<~OUT
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+            <key>tsmith</key>
+            <array>
+              <dict>
+                  <key>ProfileDisplayName</key>
+                  <string>Screensaver Settings</string>
+                  <key>ProfileIdentifier</key>
+                  <string>com.company.screensaver</string>
+                  <key>ProfileInstallDate</key>
+                  <string>2020-09-17 17:20:49 +0000</string>
+                  <key>ProfileItems</key>
+                  <array>
+                    <dict>
+                        <key>PayloadContent</key>
+                        <dict>
+                          <key>PayloadContentManagedPreferences</key>
+                          <dict>
+                              <key>com.apple.screensaver</key>
+                              <dict>
+                                <key>Forced</key>
+                                <array>
+                                    <dict>
+                                      <key>mcx_preference_settings</key>
+                                      <dict>
+                                          <key>idleTime</key>
+                                          <integer>0</integer>
+                                      </dict>
+                                    </dict>
+                                </array>
+                              </dict>
+                          </dict>
+                        </dict>
+                        <key>PayloadDisplayName</key>
+                        <string>com.apple.screensaver</string>
+                        <key>PayloadIdentifier</key>
+                        <string>com.company.screensaver</string>
+                        <key>PayloadType</key>
+                        <string>com.apple.ManagedClient.preferences</string>
+                        <key>PayloadUUID</key>
+                        <string>73fc30e0-1e57-0131-c32d-000c2944c108</string>
+                        <key>PayloadVersion</key>
+                        <integer>1</integer>
+                    </dict>
+                  </array>
+                  <key>ProfileOrganization</key>
+                  <string>Chef</string>
+                  <key>ProfileType</key>
+                  <string>Configuration</string>
+                  <key>ProfileUUID</key>
+                  <string>ed5e36c8-ea0b-5960-8f49-3c7d9121687e</string>
+                  <key>ProfileVersion</key>
+                  <integer>1</integer>
+              </dict>
+            </array>
+        </dict>
+      </plist>
+      OUT
+    end
+    let(:shell_out_profiles) do
+      double("shell_out", exitstatus: 0, error?: false, stdout: profile_raw_xml)
+    end
     # If anything is changed within this profile, be sure to update the
     # ProfileUUID in all_profiles to match the new config specific UUID
     let(:test_profile) do
@@ -155,7 +221,7 @@ describe Chef::Resource::OsxProfile do
       resource.profile_name profile_name
       allow(provider).to receive(:get_installed_profiles).and_call_original
       allow(provider).to receive(:read_plist).and_return(all_profiles)
-      expect(provider).to receive(:shell_out_compacted).with("/usr/bin/profiles", "-P", "-o", kind_of(String))
+      expect(provider).to receive(:shell_out_compacted).with("/usr/bin/profiles", "-P", "-o", "stdout-xml").and_return(shell_out_profiles)
       provider.load_current_resource
     end
 


### PR DESCRIPTION
This had 2 different issues that were causing it to not fetch the current resource state properly. The resource didn't fail, but it would converge each time because it believed the profile was not installed.

1) The profiles command was failing to write the profile state to disk because the temp file already existed. We don't actually need to write to disk and we can avoid that extra disk space / IO entirely by writing to stdout and parsing that.

2) Our fetching of the current profile state from node.state was always returning nil because of an extra logger at the end of the method. That has been moved to the top so that we return the objects correctly.