### PR TITLE
Add missing requires to chef/policy_builder/dynamic

### DIFF
--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -24,7 +24,7 @@ require_relative "../config"
 require_relative "../node"
 require_relative "../exceptions"
 require_relative "expand_node_object"
-require_relative "policefile"
+require_relative "policyfile"
 
 class Chef
   module PolicyBuilder

--- a/lib/chef/policy_builder/dynamic.rb
+++ b/lib/chef/policy_builder/dynamic.rb
@@ -23,6 +23,8 @@ require_relative "../run_context"
 require_relative "../config"
 require_relative "../node"
 require_relative "../exceptions"
+require_relative "expand_node_object"
+require_relative "policefile"
 
 class Chef
   module PolicyBuilder


### PR DESCRIPTION
This was coming in for free before somehow, but now it's causing
failures in the Chef Workstation specs.

ERROR: Chef Infra failed to converge: uninitialized constant Chef::PolicyBuilder::Dynamic::ExpandNodeObject from file /opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/chef-16.5.64/lib/chef/policy_builder/dynamic.rb:158:in `select_implementation'
Caused by: (NameError) uninitialized constant Chef::PolicyBuilder::Dynamic::ExpandNodeObject

Signed-off-by: Tim Smith <tsmith@chef.io>