### PR TITLE
Add global list option in knife user list

### DIFF
--- a/knife/lib/chef/knife/user_list.rb
+++ b/knife/lib/chef/knife/user_list.rb
@@ -34,8 +34,19 @@ class Chef
         long: "--with-uri",
         description: "Show corresponding URIs."
 
+      option :global,
+        short: "-g",
+        long: "--global",
+        description: "List all global users."
+
       def run
-        output(format_list_for_display(Chef::UserV1.list))
+        if config[:global]
+          results = format_list_for_display(root_rest.get("users"))
+        else
+          user_arr = rest.get("users")
+          results = user_arr.map { |user| user["user"]["username"] }
+        end
+        output(results)
       end
 
     end

--- a/knife/spec/unit/knife/user_list_spec.rb
+++ b/knife/spec/unit/knife/user_list_spec.rb
@@ -30,15 +30,21 @@ describe Chef::Knife::UserList do
     }
   end
 
+  let(:users1) do
+    [{ "user" => { "username" => "user3" } },
+     { "user" => { "username" => "user4" } },
+     { "user" => { "username" => "user5" } }]
+  end
+
   before :each do
     @rest = double("Chef::ServerAPI")
     allow(Chef::ServerAPI).to receive(:new).and_return(@rest)
-    allow(@rest).to receive(:get).with("users").and_return(users)
   end
 
   describe "with no arguments" do
     it "lists all non users" do
-      expect(knife.ui).to receive(:output).with(%w{user1 user2})
+      allow(@rest).to receive(:get).with("users").and_return(users1)
+      expect(knife.ui).to receive(:output).with(%w{user3 user4 user5})
       knife.run
     end
 
@@ -47,26 +53,29 @@ describe Chef::Knife::UserList do
   describe "with all_users argument" do
     before do
       knife.config[:all_users] = true
+      allow(@rest).to receive(:get).with("users").and_return(users1)
     end
 
     it "lists all users including hidden users" do
-      expect(knife.ui).to receive(:output).with(%w{user1 user2})
+      expect(knife.ui).to receive(:output).with(%w{user3 user4 user5})
       knife.run
     end
   end
 
-  it "lists the users" do
-    expect(knife).to receive(:format_list_for_display)
-    knife.run
-  end
-
-  describe "with options with_uri argument" do
+  describe "with options with_uri argument and global" do
     before do
       knife.config[:with_uri] = true
+      knife.config[:global] = true
+      allow(@rest).to receive(:get).with("users").and_return(users)
     end
 
     it "lists all users including hidden users" do
       expect(knife.ui).to receive(:output).with(users)
+      knife.run
+    end
+
+    it "lists the users" do
+      expect(knife).to receive(:format_list_for_display)
       knife.run
     end
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
 Added a option to list global users `--global` in `knife user list` command

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/chef/issues/3517
https://github.com/chef/chef/issues/3513

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
