### PR TITLE
Fix examples markdown in chef_handler resource.

### DIFF
--- a/lib/chef/resource/chef_handler.rb
+++ b/lib/chef/resource/chef_handler.rb
@@ -102,6 +102,7 @@ class Chef
 
       This recipe will generate report output similar to the following:
 
+      ```
       [2013-11-26T03:11:06+00:00] INFO: Chef Infra Client Run complete in 0.300029878 seconds
       [2013-11-26T03:11:06+00:00] INFO: Running report handlers
       [2013-11-26T03:11:06+00:00] INFO: Cookbooks and versions run: ["cookbook_versions_handler 1.0.0"]


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

There was a missing code fence causing some bad formatting.

![Screen Shot 2020-09-23 at 4 43 11 PM](https://user-images.githubusercontent.com/22962/94085140-1c60b400-fdbc-11ea-88ed-2cc47d34c426.png)
