### PR TITLE
Remove unnecessary require.

### DIFF
--- a/lib/chef/knife/search.rb
+++ b/lib/chef/knife/search.rb
@@ -26,7 +26,6 @@ class Chef
       include Knife::Core::MultiAttributeReturnOption
 
       deps do
-        require "addressable/uri" unless defined?(Addressable::URI)
         require_relative "../node"
         require_relative "../environment"
         require_relative "../api_client"


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Related to  #10464 and #10452. This file doesn't reference `Addressable::URI`.