### PR TITLE
Remove unnecessary requires from ResourceReporter.

### DIFF
--- a/lib/chef/resource_reporter.rb
+++ b/lib/chef/resource_reporter.rb
@@ -19,8 +19,6 @@
 # limitations under the License.
 #
 
-require "uri" unless defined?(URI)
-require "securerandom" unless defined?(SecureRandom)
 require_relative "event_dispatch/base"
 
 class Chef


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

These libs are not used in this file, and no requires are faster than no requires.