### PR TITLE
Update osx_profile description

### DIFF
--- a/lib/chef/resource/osx_profile.rb
+++ b/lib/chef/resource/osx_profile.rb
@@ -30,7 +30,7 @@ class Chef
       provides :osx_profile
       provides :osx_config_profile
 
-      description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on the macOS platform. The **osx_profile** resource installs profiles by using the uuidgen library to generate a unique `ProfileUUID`, and then using the `profiles` command to install the profile on the system."
+      description "Use the **osx_profile** resource to manage configuration profiles (`.mobileconfig` files) on the macOS platform. The **osx_profile** resource installs profiles by using the uuidgen library to generate a unique `ProfileUUID`, and then using the `profiles` command to install the profile on the system. Local profile installation is no longer supported by Apple on macOS 10.16+"
       introduced "12.7"
       examples <<~DOC
       **Install a profile from a cookbook file**


### PR DESCRIPTION
## Description
Apple no longer supports unattended local profile installation on macOS 10.16 (aka 11.0) or higher. This PR adds that information to the resource description.

## Related Issue
#10075 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
 n/a
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
 n/a
- [x] All new and existing tests passed.
n/a
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
"Obvious fix." 

Obvious fix.